### PR TITLE
ClusterResourceOverride: overcommit admission controller

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -279,7 +279,7 @@ angular
   .constant("AUTH_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).auth))
   .constant("LOGGING_URL", (window.OPENSHIFT_CONFIG || {}).loggingURL)
   .constant("METRICS_URL", (window.OPENSHIFT_CONFIG || {}).metricsURL)
-  .constant("LIMIT_REQUEST_OVERRIDES", _.get(window.OPENSHIFT_CONFIG, "limitRequestOverrides", {}))
+  .constant("LIMIT_REQUEST_OVERRIDES", _.get(window.OPENSHIFT_CONFIG, "limitRequestOverrides"))
   // Sometimes we need to know the css breakpoints, make sure to update this
   // if they ever change!
   .constant("BREAKPOINTS", {

--- a/assets/app/scripts/services/limits.js
+++ b/assets/app/scripts/services/limits.js
@@ -34,30 +34,30 @@ angular.module("openshiftConsole")
     };
 
     var hideCPUComputeResources = function() {
-      return LIMIT_REQUEST_OVERRIDES.enabled &&
-             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryRatio &&
-             LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitRatio;
+      return LIMIT_REQUEST_OVERRIDES &&
+             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryPercent &&
+             LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitPercent;
     };
 
     var isRequestCalculated = function(computeResource) {
-      if (!LIMIT_REQUEST_OVERRIDES.enabled) {
+      if (!LIMIT_REQUEST_OVERRIDES) {
         return false;
       }
 
       switch (computeResource) {
       case "cpu":
-        return LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitRatio;
+        return LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitPercent;
       case "memory":
-        return LIMIT_REQUEST_OVERRIDES.memoryRequestToLimitRatio;
+        return LIMIT_REQUEST_OVERRIDES.memoryRequestToLimitPercent;
       default:
         return false;
       }
     };
 
     var isLimitCalculated = function(computeResource) {
-      return LIMIT_REQUEST_OVERRIDES.enabled &&
+      return LIMIT_REQUEST_OVERRIDES &&
              computeResource === 'cpu' &&
-             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryRatio;
+             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryPercent;
     };
 
     // Reconciles multiple limit range resources for a compute resource ('cpu'

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -142,7 +142,7 @@ os::cmd::expect_success_and_text "openshift ex validate master-config ${MASTER_C
 os::cmd::expect_success_and_text "openshift ex validate node-config ${NODE_CONFIG_DIR}/node-config.yaml" 'SUCCESS'
 # breaking the config fails the validation check
 cp ${MASTER_CONFIG_DIR}/master-config.yaml ${BASETMPDIR}/master-config-broken.yaml
-os::util::sed '7,12d' ${BASETMPDIR}/master-config-broken.yaml
+echo "kubernetesMasterConfig: {}" >> ${BASETMPDIR}/master-config-broken.yaml
 os::cmd::expect_failure_and_text "openshift ex validate master-config ${BASETMPDIR}/master-config-broken.yaml" 'ERROR'
 
 cp ${NODE_CONFIG_DIR}/node-config.yaml ${BASETMPDIR}/node-config-broken.yaml

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	"k8s.io/kubernetes/pkg/util"
 )
 
@@ -187,6 +188,13 @@ window.OPENSHIFT_CONFIG = {
   	oauth_client_id: "{{ .OAuthClientID | js}}",
   	logout_uri: "{{ .LogoutURI | js}}"
   },
+  {{ with .LimitRequestOverrides }}
+  limitRequestOverrides: {
+	limitCPUToMemoryPercent: {{ .LimitCPUToMemoryPercent }},
+	cpuRequestToLimitPercent: {{ .CPURequestToLimitPercent }},
+	memoryRequestToLimitPercent: {{ .MemoryRequestToLimitPercent }}
+  },
+  {{ end }}
   loggingURL: "{{ .LoggingURL | js}}",
   metricsURL: "{{ .MetricsURL | js}}"
 };
@@ -222,6 +230,12 @@ type WebConsoleConfig struct {
 	LoggingURL string
 	// MetricsURL is the endpoint for metrics (optional)
 	MetricsURL string
+	// LimitRequestOverrides contains the ratios for overriding request/limit on containers.
+	// Applied in order:
+	//   LimitCPUToMemoryPercent
+	//   CPURequestToLimitPercent
+	//   MemoryRequestToLimitPercent
+	LimitRequestOverrides *api.ClusterResourceOverrideConfig
 }
 
 func GeneratedConfigHandler(config WebConsoleConfig, version WebConsoleVersion) (http.Handler, error) {

--- a/pkg/cmd/server/api/install/install.go
+++ b/pkg/cmd/server/api/install/install.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/build/admission/defaults/api/install"
 	_ "github.com/openshift/origin/pkg/build/admission/overrides/api/install"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit/api/install"
+	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/install"
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration/api/install"
 )
 

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -198,20 +198,21 @@ func (c *AssetConfig) addHandlers(mux *http.ServeMux) error {
 
 	// Generated web console config and server version
 	config := assets.WebConsoleConfig{
-		APIGroupAddr:        masterURL.Host,
-		APIGroupPrefix:      KubernetesAPIGroupPrefix,
-		MasterAddr:          masterURL.Host,
-		MasterPrefix:        OpenShiftAPIPrefix,
-		MasterResources:     originResources.List(),
-		KubernetesAddr:      masterURL.Host,
-		KubernetesPrefix:    KubernetesAPIPrefix,
-		KubernetesResources: k8sResources.List(),
-		OAuthAuthorizeURI:   OpenShiftOAuthAuthorizeURL(masterURL.String()),
-		OAuthRedirectBase:   c.Options.PublicURL,
-		OAuthClientID:       OpenShiftWebConsoleClientID,
-		LogoutURI:           c.Options.LogoutURL,
-		LoggingURL:          c.Options.LoggingPublicURL,
-		MetricsURL:          c.Options.MetricsPublicURL,
+		APIGroupAddr:          masterURL.Host,
+		APIGroupPrefix:        KubernetesAPIGroupPrefix,
+		MasterAddr:            masterURL.Host,
+		MasterPrefix:          OpenShiftAPIPrefix,
+		MasterResources:       originResources.List(),
+		KubernetesAddr:        masterURL.Host,
+		KubernetesPrefix:      KubernetesAPIPrefix,
+		KubernetesResources:   k8sResources.List(),
+		OAuthAuthorizeURI:     OpenShiftOAuthAuthorizeURL(masterURL.String()),
+		OAuthRedirectBase:     c.Options.PublicURL,
+		OAuthClientID:         OpenShiftWebConsoleClientID,
+		LogoutURI:             c.Options.LogoutURL,
+		LoggingURL:            c.Options.LoggingPublicURL,
+		MetricsURL:            c.Options.MetricsPublicURL,
+		LimitRequestOverrides: c.LimitRequestOverrides,
 	}
 	kVersionInfo := kversion.Get()
 	oVersionInfo := oversion.Get()

--- a/pkg/cmd/server/origin/asset_config.go
+++ b/pkg/cmd/server/origin/asset_config.go
@@ -1,15 +1,17 @@
 package origin
 
 import (
-	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	oapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 )
 
 // AssetConfig defines the required parameters for starting the OpenShift master
 type AssetConfig struct {
-	Options configapi.AssetConfig
+	Options               oapi.AssetConfig
+	LimitRequestOverrides *api.ClusterResourceOverrideConfig
 }
 
-// BuildAssetConfig returns a new AssetConfig
-func BuildAssetConfig(options configapi.AssetConfig) (*AssetConfig, error) {
-	return &AssetConfig{options}, nil
+// NewAssetConfig returns a new AssetConfig
+func NewAssetConfig(options oapi.AssetConfig, limitRequestOverrides *api.ClusterResourceOverrideConfig) (*AssetConfig, error) {
+	return &AssetConfig{options, limitRequestOverrides}, nil
 }

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"
+	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride"
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/security/admission"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -30,6 +30,9 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
+	override "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride"
+	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -451,7 +454,22 @@ func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 
 	var standaloneAssetConfig *origin.AssetConfig
 	if oc.WebConsoleEnabled() {
-		config, err := origin.BuildAssetConfig(*oc.Options.AssetConfig)
+		var overrideConfig *overrideapi.ClusterResourceOverrideConfig = nil
+		if oc.Options.KubernetesMasterConfig != nil { // external kube gets you a nil pointer here
+			if overridePluginConfigFile, err := pluginconfig.GetPluginConfigFile(oc.Options.KubernetesMasterConfig.AdmissionConfig.PluginConfig, overrideapi.PluginName, ""); err != nil {
+				return err
+			} else if overridePluginConfigFile != "" {
+				configFile, err := os.Open(overridePluginConfigFile)
+				if err != nil {
+					return err
+				}
+				if overrideConfig, err = override.ReadConfig(configFile); err != nil {
+					return err
+				}
+			}
+		}
+
+		config, err := origin.NewAssetConfig(*oc.Options.AssetConfig, overrideConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/util/pluginconfig/config.go
+++ b/pkg/cmd/util/pluginconfig/config.go
@@ -29,3 +29,18 @@ func GetPluginConfig(cfg configapi.AdmissionPluginConfig) (string, error) {
 	}
 	return configFile.Name(), nil
 }
+
+// GetPluginConfigFile translates from the master plugin config to a file name containing
+// a particular plugin's config (the file may be a temp file if config is embedded)
+func GetPluginConfigFile(pluginConfig map[string]configapi.AdmissionPluginConfig, pluginName string, defaultConfigFilePath string) (string, error) {
+	// Check whether a config is specified for this plugin. If not, default to the
+	// global plugin config file (if any).
+	if cfg, hasConfig := pluginConfig[pluginName]; hasConfig {
+		configFilePath, err := GetPluginConfig(cfg)
+		if err != nil {
+			return "", err
+		}
+		return configFilePath, nil
+	}
+	return defaultConfigFilePath, nil
+}

--- a/pkg/quota/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission.go
@@ -1,0 +1,181 @@
+package clusterresourceoverride
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/validation"
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
+
+	"github.com/golang/glog"
+	"speter.net/go/exp/math/dec/inf"
+)
+
+const (
+	clusterResourceOverrideAnnotation = "quota.openshift.io/cluster-resource-override-enabled"
+	cpuBaseScaleFactor                = 1000.0 / (1024.0 * 1024.0 * 1024.0) // 1000 milliCores per 1GiB
+)
+
+var (
+	zeroDec = inf.NewDec(0, 0)
+)
+
+func init() {
+	admission.RegisterPlugin(api.PluginName, func(client kclient.Interface, config io.Reader) (admission.Interface, error) {
+		return newClusterResourceOverride(client, config)
+	})
+}
+
+type internalConfig struct {
+	limitCPUToMemoryRatio     *inf.Dec
+	cpuRequestToLimitRatio    *inf.Dec
+	memoryRequestToLimitRatio *inf.Dec
+}
+type clusterResourceOverridePlugin struct {
+	*admission.Handler
+	config       *internalConfig
+	ProjectCache *cache.ProjectCache
+	LimitRanger  admission.Interface
+}
+
+var _ = oadmission.WantsProjectCache(&clusterResourceOverridePlugin{})
+var _ = oadmission.Validator(&clusterResourceOverridePlugin{})
+
+// newClusterResourceOverride returns an admission controller for containers that
+// configurably overrides container resource request/limits
+func newClusterResourceOverride(client kclient.Interface, config io.Reader) (admission.Interface, error) {
+	parsed, err := ReadConfig(config)
+	if err != nil {
+		glog.V(5).Infof("%s admission controller loaded with error: (%T) %[2]v", api.PluginName, err)
+		return nil, err
+	}
+	if errs := validation.Validate(parsed); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	glog.V(5).Infof("%s admission controller loaded with config: %v", api.PluginName, parsed)
+	var internal *internalConfig
+	if parsed != nil {
+		internal = &internalConfig{
+			limitCPUToMemoryRatio:     inf.NewDec(parsed.LimitCPUToMemoryPercent, 2),
+			cpuRequestToLimitRatio:    inf.NewDec(parsed.CPURequestToLimitPercent, 2),
+			memoryRequestToLimitRatio: inf.NewDec(parsed.MemoryRequestToLimitPercent, 2),
+		}
+	}
+	return &clusterResourceOverridePlugin{
+		Handler:     admission.NewHandler(admission.Create),
+		config:      internal,
+		LimitRanger: limitranger.NewLimitRanger(client, wrapLimit),
+	}, nil
+}
+
+func wrapLimit(limitRange *kapi.LimitRange, resourceName string, obj runtime.Object) error {
+	limitranger.Limit(limitRange, resourceName, obj)
+	// always return success so that all defaults will be applied.
+	// validation will occur after the overrides.
+	return nil
+}
+
+func (a *clusterResourceOverridePlugin) SetProjectCache(projectCache *cache.ProjectCache) {
+	a.ProjectCache = projectCache
+}
+
+func ReadConfig(configFile io.Reader) (*api.ClusterResourceOverrideConfig, error) {
+	if configFile == nil || reflect.ValueOf(configFile).IsNil() /* pointer to nil */ {
+		glog.V(5).Infof("%s has no config to read.", api.PluginName)
+		return nil, nil
+	}
+	configBytes, err := ioutil.ReadAll(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &api.ClusterResourceOverrideConfig{}
+	err = configlatest.ReadYAML(configBytes, config)
+	if err != nil {
+		glog.V(5).Infof("%s error reading config: %v", api.PluginName, err)
+		return nil, err
+	}
+	glog.V(5).Infof("%s config is: %v", api.PluginName, config)
+	return config, nil
+}
+
+func (a *clusterResourceOverridePlugin) Validate() error {
+	if a.ProjectCache == nil {
+		return fmt.Errorf("%s did not get a project cache", api.PluginName)
+	}
+	return nil
+}
+
+// TODO this will need to update when we have pod requests/limits
+func (a *clusterResourceOverridePlugin) Admit(attr admission.Attributes) error {
+	glog.V(6).Infof("%s admission controller is invoked", api.PluginName)
+	if a.config == nil || attr.GetResource() != kapi.Resource("pods") || attr.GetSubresource() != "" {
+		return nil // not applicable
+	}
+	pod, ok := attr.GetObject().(*kapi.Pod)
+	if !ok {
+		return admission.NewForbidden(attr, fmt.Errorf("unexpected object: %#v", attr.GetObject()))
+	}
+	glog.V(5).Infof("%s is looking at creating pod %s in project %s", api.PluginName, pod.Name, attr.GetNamespace())
+
+	// allow annotations on project to override
+	if ns, err := a.ProjectCache.GetNamespace(attr.GetNamespace()); err != nil {
+		glog.Warningf("%s got an error retrieving namespace: %v", api.PluginName, err)
+		return admission.NewForbidden(attr, err) // this should not happen though
+	} else {
+		projectEnabledPlugin, exists := ns.Annotations[clusterResourceOverrideAnnotation]
+		if exists && projectEnabledPlugin != "true" {
+			glog.V(5).Infof("%s is disabled for project %s", api.PluginName, attr.GetNamespace())
+			return nil // disabled for this project, do nothing
+		}
+	}
+
+	// Reuse LimitRanger logic to apply limit/req defaults from the project. Ignore validation
+	// errors, assume that LimitRanger will run after this plugin to validate.
+	glog.V(5).Infof("%s: initial pod limits are: %#v", api.PluginName, pod.Spec.Containers[0].Resources)
+	if err := a.LimitRanger.Admit(attr); err != nil {
+		glog.V(5).Infof("%s: error from LimitRanger: %#v", api.PluginName, err)
+	}
+	glog.V(5).Infof("%s: pod limits after LimitRanger are: %#v", api.PluginName, pod.Spec.Containers[0].Resources)
+	for _, container := range pod.Spec.Containers {
+		resources := container.Resources
+		memLimit, memFound := resources.Limits[kapi.ResourceMemory]
+		if memFound && a.config.memoryRequestToLimitRatio.Cmp(zeroDec) != 0 {
+			resources.Requests[kapi.ResourceMemory] = resource.Quantity{
+				Amount: multiply(memLimit.Amount, a.config.memoryRequestToLimitRatio),
+				Format: resource.BinarySI,
+			}
+		}
+		if memFound && a.config.limitCPUToMemoryRatio.Cmp(zeroDec) != 0 {
+			resources.Limits[kapi.ResourceCPU] = resource.Quantity{
+				// float math is necessary here as there is no way to create an inf.Dec to represent cpuBaseScaleFactor < 0.001
+				Amount: multiply(inf.NewDec(int64(float64(memLimit.Value())*cpuBaseScaleFactor), 3), a.config.limitCPUToMemoryRatio),
+				Format: resource.DecimalSI,
+			}
+		}
+		cpuLimit, cpuFound := resources.Limits[kapi.ResourceCPU]
+		if cpuFound && a.config.cpuRequestToLimitRatio.Cmp(zeroDec) != 0 {
+			resources.Requests[kapi.ResourceCPU] = resource.Quantity{
+				Amount: multiply(cpuLimit.Amount, a.config.cpuRequestToLimitRatio),
+				Format: resource.DecimalSI,
+			}
+		}
+	}
+	glog.V(5).Infof("%s: pod limits after overrides are: %#v", api.PluginName, pod.Spec.Containers[0].Resources)
+	return nil
+}
+
+func multiply(x *inf.Dec, y *inf.Dec) *inf.Dec {
+	return inf.NewDec(0, 0).Mul(x, y)
+}

--- a/pkg/quota/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission_test.go
@@ -1,0 +1,282 @@
+package clusterresourceoverride
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/client/cache"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/validation"
+
+	_ "github.com/openshift/origin/pkg/api/install"
+)
+
+const (
+	yamlConfig = `
+apiVersion: v1
+kind: ClusterResourceOverrideConfig
+limitCPUToMemoryPercent: 100
+cpuRequestToLimitPercent: 10
+memoryRequestToLimitPercent: 25
+`
+	invalidConfig = `
+apiVersion: v1
+kind: ClusterResourceOverrideConfig
+cpuRequestToLimitPercent: 200
+`
+	invalidConfig2 = ``
+)
+
+var (
+	deserializedYamlConfig = &api.ClusterResourceOverrideConfig{
+		LimitCPUToMemoryPercent:     100,
+		CPURequestToLimitPercent:    10,
+		MemoryRequestToLimitPercent: 25,
+	}
+)
+
+func TestConfigReader(t *testing.T) {
+	initialConfig := testConfig(10, 20, 30)
+	serializedConfig, serializationErr := configapilatest.WriteYAML(initialConfig)
+	if serializationErr != nil {
+		t.Fatalf("WriteYAML: config serialize failed: %v", serializationErr)
+	}
+
+	tests := []struct {
+		name           string
+		config         io.Reader
+		expectErr      bool
+		expectNil      bool
+		expectInvalid  bool
+		expectedConfig *api.ClusterResourceOverrideConfig
+	}{
+		{
+			name:      "process nil config",
+			config:    nil,
+			expectNil: true,
+		}, {
+			name:           "deserialize initialConfig yaml",
+			config:         bytes.NewReader(serializedConfig),
+			expectedConfig: initialConfig,
+		}, {
+			name:      "completely broken config",
+			config:    bytes.NewReader([]byte("asdfasdfasdF")),
+			expectErr: true,
+		}, {
+			name:           "deserialize yamlConfig",
+			config:         bytes.NewReader([]byte(yamlConfig)),
+			expectedConfig: deserializedYamlConfig,
+		}, {
+			name:          "choke on out-of-bounds ratio",
+			config:        bytes.NewReader([]byte(invalidConfig)),
+			expectInvalid: true,
+		}, {
+			name:          "complain about no settings",
+			config:        bytes.NewReader([]byte(invalidConfig2)),
+			expectInvalid: true,
+		},
+	}
+	for _, test := range tests {
+		config, err := ReadConfig(test.config)
+		if test.expectErr && err == nil {
+			t.Errorf("%s: expected error", test.name)
+		} else if !test.expectErr && err != nil {
+			t.Errorf("%s: expected no error, saw %v", test.name, err)
+		}
+		if err == nil {
+			if test.expectNil && config != nil {
+				t.Errorf("%s: expected nil config, but saw: %v", test.name, config)
+			} else if !test.expectNil && config == nil {
+				t.Errorf("%s: expected config, but got nil", test.name)
+			}
+		}
+		if config != nil {
+			if test.expectedConfig != nil && *test.expectedConfig != *config {
+				t.Errorf("%s: expected %v from reader, but got %v", test.name, test.expectErr, config)
+			}
+			if err := validation.Validate(config); test.expectInvalid && len(err) == 0 {
+				t.Errorf("%s: expected validation to fail, but it passed", test.name)
+			} else if !test.expectInvalid && len(err) > 0 {
+				t.Errorf("%s: expected validation to pass, but it failed with %v", test.name, err)
+			}
+		}
+	}
+}
+
+func TestLimitRequestAdmission(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             *api.ClusterResourceOverrideConfig
+		object             runtime.Object
+		expectedMemRequest resource.Quantity
+		expectedCpuLimit   resource.Quantity
+		expectedCpuRequest resource.Quantity
+		namespace          *kapi.Namespace
+	}{
+		{
+			name:               "this thing even runs",
+			config:             testConfig(100, 50, 50),
+			object:             testPod("0", "0", "0", "0"),
+			expectedMemRequest: resource.MustParse("0"),
+			expectedCpuLimit:   resource.MustParse("0"),
+			expectedCpuRequest: resource.MustParse("0"),
+			namespace:          fakeNamespace(true),
+		},
+		{
+			name:               "nil config",
+			config:             nil,
+			object:             testPod("1", "1", "1", "1"),
+			expectedMemRequest: resource.MustParse("1"),
+			expectedCpuLimit:   resource.MustParse("1"),
+			expectedCpuRequest: resource.MustParse("1"),
+			namespace:          fakeNamespace(true),
+		},
+		{
+			name:               "all values are adjusted",
+			config:             testConfig(100, 50, 50),
+			object:             testPod("1Gi", "0", "2000m", "0"),
+			expectedMemRequest: resource.MustParse("512Mi"),
+			expectedCpuLimit:   resource.MustParse("1"),
+			expectedCpuRequest: resource.MustParse("500m"),
+			namespace:          fakeNamespace(true),
+		},
+		{
+			name:               "just requests are adjusted",
+			config:             testConfig(0, 50, 50),
+			object:             testPod("10Mi", "0", "50m", "0"),
+			expectedMemRequest: resource.MustParse("5Mi"),
+			expectedCpuLimit:   resource.MustParse("50m"),
+			expectedCpuRequest: resource.MustParse("25m"),
+			namespace:          fakeNamespace(true),
+		},
+		{
+			name:               "project annotation disables overrides",
+			config:             testConfig(0, 50, 50),
+			object:             testPod("10Mi", "0", "50m", "0"),
+			expectedMemRequest: resource.MustParse("0"),
+			expectedCpuLimit:   resource.MustParse("50m"),
+			expectedCpuRequest: resource.MustParse("0"),
+			namespace:          fakeNamespace(false),
+		},
+		{
+			name:               "large values don't overflow",
+			config:             testConfig(100, 50, 50),
+			object:             testPod("1Ti", "0", "0", "0"),
+			expectedMemRequest: resource.MustParse("512Gi"),
+			expectedCpuLimit:   resource.MustParse("1024"),
+			expectedCpuRequest: resource.MustParse("512"),
+			namespace:          fakeNamespace(true),
+		},
+		{
+			name:               "little values don't get lost",
+			config:             testConfig(500, 10, 10),
+			object:             testPod("1.024Mi", "0", "0", "0"),
+			expectedMemRequest: resource.MustParse(".0001Gi"),
+			expectedCpuLimit:   resource.MustParse("5m"),
+			expectedCpuRequest: resource.MustParse(".5m"),
+			namespace:          fakeNamespace(true),
+		},
+	}
+
+	for _, test := range tests {
+		var reader io.Reader
+		if test.config != nil { // we would get nil with the plugin un-configured
+			config, _ := json.Marshal(test.config)
+			reader = bytes.NewReader(config)
+		}
+		c, err := newClusterResourceOverride(&ktestclient.Fake{}, reader)
+		if err != nil {
+			t.Errorf("%s: config de/serialize failed: %v", test.name, err)
+		}
+		c.(*clusterResourceOverridePlugin).SetProjectCache(fakeProjectCache(test.namespace))
+		attrs := admission.NewAttributesRecord(test.object, unversioned.GroupKind{}, test.namespace.Name, "name", kapi.Resource("pods"), "", admission.Create, fakeUser())
+		if err := c.Admit(attrs); err != nil {
+			t.Errorf("%s: admission controller should not return error", test.name)
+		}
+		// if it's a pod, test that the resources are as expected
+		pod, ok := test.object.(*kapi.Pod)
+		if !ok {
+			continue
+		}
+		resources := pod.Spec.Containers[0].Resources // only test one container
+		if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
+			t.Errorf("%s: memory requests do not match; %s should be %s", test.name, actual, test.expectedMemRequest)
+		}
+		if actual := resources.Requests[kapi.ResourceCPU]; test.expectedCpuRequest.Cmp(actual) != 0 {
+			t.Errorf("%s: cpu requests do not match; %s should be %s", test.name, actual, test.expectedCpuRequest)
+		}
+		if actual := resources.Limits[kapi.ResourceCPU]; test.expectedCpuLimit.Cmp(actual) != 0 {
+			t.Errorf("%s: cpu limits do not match; %s should be %s", test.name, actual, test.expectedCpuLimit)
+		}
+	}
+}
+
+func testPod(memLimit string, memRequest string, cpuLimit string, cpuRequest string) *kapi.Pod {
+	return &kapi.Pod{
+		Spec: kapi.PodSpec{
+			Containers: []kapi.Container{
+				{
+					Resources: kapi.ResourceRequirements{
+						Limits: kapi.ResourceList{
+							kapi.ResourceCPU:    resource.MustParse(cpuLimit),
+							kapi.ResourceMemory: resource.MustParse(memLimit),
+						},
+						Requests: kapi.ResourceList{
+							kapi.ResourceCPU:    resource.MustParse(cpuRequest),
+							kapi.ResourceMemory: resource.MustParse(memRequest),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fakeUser() user.Info {
+	return &user.DefaultInfo{
+		Name: "testuser",
+	}
+}
+
+var nsIndex = 0
+
+func fakeNamespace(pluginEnabled bool) *kapi.Namespace {
+	nsIndex++
+	ns := &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:        fmt.Sprintf("fakeNS%d", nsIndex),
+			Annotations: map[string]string{},
+		},
+	}
+	if !pluginEnabled {
+		ns.Annotations[clusterResourceOverrideAnnotation] = "false"
+	}
+	return ns
+}
+
+func fakeProjectCache(ns *kapi.Namespace) *projectcache.ProjectCache {
+	store := projectcache.NewCacheStore(cache.MetaNamespaceKeyFunc)
+	store.Add(ns)
+	return projectcache.NewFake((&ktestclient.Fake{}).Namespaces(), store, "")
+}
+
+func testConfig(lc2mr int64, cr2lr int64, mr2lr int64) *api.ClusterResourceOverrideConfig {
+	return &api.ClusterResourceOverrideConfig{
+		LimitCPUToMemoryPercent:     lc2mr,
+		CPURequestToLimitPercent:    cr2lr,
+		MemoryRequestToLimitPercent: mr2lr,
+	}
+}

--- a/pkg/quota/admission/clusterresourceoverride/api/install/install.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/install/install.go
@@ -1,0 +1,41 @@
+package install
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/v1"
+)
+
+// availableVersions lists all known external versions for this group from most preferred to least preferred
+var availableVersions = []unversioned.GroupVersion{v1.SchemeGroupVersion}
+
+func init() {
+	if err := enableVersions(availableVersions); err != nil {
+		panic(err)
+	}
+}
+
+// TODO: enableVersions should be centralized rather than spread in each API group.
+func enableVersions(externalVersions []unversioned.GroupVersion) error {
+	addVersionsToScheme(externalVersions...)
+	return nil
+}
+
+func addVersionsToScheme(externalVersions ...unversioned.GroupVersion) {
+	// add the internal version to Scheme
+	api.AddToScheme(configapi.Scheme)
+	// add the enabled external versions to Scheme
+	for _, v := range externalVersions {
+		switch v {
+		case v1.SchemeGroupVersion:
+			v1.AddToScheme(configapi.Scheme)
+		default:
+			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
+			continue
+		}
+	}
+}

--- a/pkg/quota/admission/clusterresourceoverride/api/name.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/name.go
@@ -1,0 +1,4 @@
+package api
+
+const PluginName = "ClusterResourceOverride"
+const ConfigKind = "ClusterResourceOverrideConfig"

--- a/pkg/quota/admission/clusterresourceoverride/api/register.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/register.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
+
+// Adds the list of known types to api.Scheme.
+func AddToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&ClusterResourceOverrideConfig{},
+	)
+}
+
+func (obj *ClusterResourceOverrideConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/quota/admission/clusterresourceoverride/api/types.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/types.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// ClusterResourceOverrideConfig is the configuration for the ClusterResourceOverride
+// admission controller which overrides user-provided container request/limit values.
+type ClusterResourceOverrideConfig struct {
+	unversioned.TypeMeta
+	// For each of the following, if a non-zero ratio is specified then the initial
+	// value (if any) in the pod spec is overwritten according to the ratio.
+	// LimitRange defaults are merged prior to the override.
+	//
+	// LimitCPUToMemoryPercent (if > 0) overrides the CPU limit to a ratio of the memory limit;
+	// 100% overrides CPU to 1 core per 1GiB of RAM. This is done before overriding the CPU request.
+	LimitCPUToMemoryPercent int64
+	// CPURequestToLimitPercent (if > 0) overrides CPU request to a percentage of CPU limit
+	CPURequestToLimitPercent int64
+	// MemoryRequestToLimitPercent (if > 0) overrides memory request to a percentage of memory limit
+	MemoryRequestToLimitPercent int64
+}

--- a/pkg/quota/admission/clusterresourceoverride/api/v1/register.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/v1/register.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: "v1"}
+
+// Adds the list of known types to api.Scheme.
+func AddToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&ClusterResourceOverrideConfig{},
+	)
+}
+
+func (obj *ClusterResourceOverrideConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/quota/admission/clusterresourceoverride/api/v1/types.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/v1/types.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// ClusterResourceOverrideConfig is the configuration for the ClusterResourceOverride
+// admission controller which overrides user-provided container request/limit values.
+type ClusterResourceOverrideConfig struct {
+	unversioned.TypeMeta `json:",inline"`
+	// For each of the following, if a non-zero ratio is specified then the initial
+	// value (if any) in the pod spec is overwritten according to the ratio.
+	// LimitRange defaults are merged prior to the override.
+	//
+	// LimitCPUToMemoryPercent (if > 0) overrides the CPU limit to a ratio of the memory limit;
+	// 100% overrides CPU to 1 core per 1GiB of RAM. This is done before overriding the CPU request.
+	LimitCPUToMemoryPercent int64 `json:"limitCPUToMemoryPercent"`
+	// CPURequestToLimitPercent (if > 0) overrides CPU request to a percentage of CPU limit
+	CPURequestToLimitPercent int64 `json:"cpuRequestToLimitPercent"`
+	// MemoryRequestToLimitPercent (if > 0) overrides memory request to a percentage of memory limit
+	MemoryRequestToLimitPercent int64 `json:"memoryRequestToLimitPercent"`
+}

--- a/pkg/quota/admission/clusterresourceoverride/api/validation/validation.go
+++ b/pkg/quota/admission/clusterresourceoverride/api/validation/validation.go
@@ -1,0 +1,27 @@
+package validation
+
+import (
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+)
+
+func Validate(config *api.ClusterResourceOverrideConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if config == nil {
+		return allErrs
+	}
+	if config.LimitCPUToMemoryPercent == 0 && config.CPURequestToLimitPercent == 0 && config.MemoryRequestToLimitPercent == 0 {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath(api.PluginName), "plugin enabled but no percentages were specified"))
+	}
+	if config.LimitCPUToMemoryPercent < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath(api.PluginName, "LimitCPUToMemoryPercent"), config.LimitCPUToMemoryPercent, "must be positive"))
+	}
+	if config.CPURequestToLimitPercent < 0 || config.CPURequestToLimitPercent > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath(api.PluginName, "CPURequestToLimitPercent"), config.CPURequestToLimitPercent, "must be between 0 and 100"))
+	}
+	if config.MemoryRequestToLimitPercent < 0 || config.MemoryRequestToLimitPercent > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath(api.PluginName, "MemoryRequestToLimitPercent"), config.MemoryRequestToLimitPercent, "must be between 0 and 100"))
+	}
+	return allErrs
+}

--- a/pkg/quota/admission/clusterresourceoverride/doc.go
+++ b/pkg/quota/admission/clusterresourceoverride/doc.go
@@ -1,0 +1,8 @@
+package clusterresourceoverride
+
+// The ClusterResourceOverride plugin is only active when admission control config is supplied for it.
+// The plugin allows administrators to override user-provided container request/limit values
+// in order to control overcommit and optionally pin CPU to memory.
+// The plugin's actions can be disabled per-project with the project annotation
+// quota.openshift.io/cluster-resource-override-enabled="false", so cluster admins
+// can exempt infrastructure projects and such from the overrides.

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -1,0 +1,140 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+	kapi "k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/install"
+)
+
+func TestClusterResourceOverridePlugin(t *testing.T) {
+	config := &overrideapi.ClusterResourceOverrideConfig{
+		LimitCPUToMemoryPercent:     100,
+		CPURequestToLimitPercent:    50,
+		MemoryRequestToLimitPercent: 50,
+	}
+	kubeClient := setupClusterResourceOverrideTest(t, config)
+	podHandler := kubeClient.Pods(testutil.Namespace())
+	limitHandler := kubeClient.LimitRanges(testutil.Namespace())
+
+	// test with no limits object present
+
+	podCreated, err := podHandler.Create(testClusterResourceOverridePod("limitless", "2Gi", "1"))
+	checkErr(t, err)
+	if memory := podCreated.Spec.Containers[0].Resources.Requests.Memory(); memory.Cmp(resource.MustParse("1Gi")) != 0 {
+		t.Errorf("limitlesspod: Memory did not match expected 1Gi: %#v", memory)
+	}
+	if cpu := podCreated.Spec.Containers[0].Resources.Limits.Cpu(); cpu.Cmp(resource.MustParse("2")) != 0 {
+		t.Errorf("limitlesspod: CPU limit did not match expected 2 core: %#v", cpu)
+	}
+	if cpu := podCreated.Spec.Containers[0].Resources.Requests.Cpu(); cpu.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("limitlesspod: CPU req did not match expected 1 core: %#v", cpu)
+	}
+
+	// test with limits object with defaults;
+	// I wanted to test with a limits object without defaults to see limits forbid an empty resource spec,
+	// but found that if defaults aren't set in the limit object, something still fills them in.
+	// note: defaults are only used when quantities are *missing*, not when they are 0
+	limitItem := kapi.LimitRangeItem{
+		Type:                 kapi.LimitTypeContainer,
+		Max:                  testResourceList("2Gi", "2"),
+		Min:                  testResourceList("128Mi", "200m"),
+		Default:              testResourceList("512Mi", "500m"), // note: auto-filled from max if we set that;
+		DefaultRequest:       testResourceList("128Mi", "200m"), // filled from max if set, or min if that is set
+		MaxLimitRequestRatio: kapi.ResourceList{},
+	}
+	limit := &kapi.LimitRange{
+		ObjectMeta: kapi.ObjectMeta{Name: "limit"},
+		Spec:       kapi.LimitRangeSpec{Limits: []kapi.LimitRangeItem{limitItem}},
+	}
+	_, err = limitHandler.Create(limit)
+	checkErr(t, err)
+	podCreated, err = podHandler.Create(testClusterResourceOverridePod("limit-with-default", "", "1"))
+	checkErr(t, err)
+	if memory := podCreated.Spec.Containers[0].Resources.Limits.Memory(); memory.Cmp(resource.MustParse("512Mi")) != 0 {
+		t.Errorf("limit-with-default: Memory limit did not match default 512Mi: %v", memory)
+	}
+	if memory := podCreated.Spec.Containers[0].Resources.Requests.Memory(); memory.Cmp(resource.MustParse("256Mi")) != 0 {
+		t.Errorf("limit-with-default: Memory req did not match expected 256Mi: %v", memory)
+	}
+	if cpu := podCreated.Spec.Containers[0].Resources.Limits.Cpu(); cpu.Cmp(resource.MustParse("500m")) != 0 {
+		t.Errorf("limit-with-default: CPU limit did not match expected 500 mcore: %v", cpu)
+	}
+	if cpu := podCreated.Spec.Containers[0].Resources.Requests.Cpu(); cpu.Cmp(resource.MustParse("250m")) != 0 {
+		t.Errorf("limit-with-default: CPU req did not match expected 250 mcore: %v", cpu)
+	}
+
+	// set it up so that the overrides create resources that fail validation
+	_, err = podHandler.Create(testClusterResourceOverridePod("limit-with-default-fail", "128Mi", "1"))
+	if err == nil {
+		t.Errorf("limit-with-default-fail: expected to be forbidden")
+	} else if !apierrors.IsForbidden(err) {
+		t.Errorf("limit-with-default-fail: unexpected error: %v", err)
+	}
+}
+
+func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.ClusterResourceOverrideConfig) kclient.Interface {
+	masterConfig, err := testserver.DefaultMasterOptions()
+	checkErr(t, err)
+	// fill in possibly-empty config values
+	if masterConfig.KubernetesMasterConfig == nil {
+		masterConfig.KubernetesMasterConfig = &api.KubernetesMasterConfig{}
+	}
+	kubeMaster := masterConfig.KubernetesMasterConfig
+	if kubeMaster.AdmissionConfig.PluginConfig == nil {
+		kubeMaster.AdmissionConfig.PluginConfig = map[string]api.AdmissionPluginConfig{}
+	}
+	// set our config as desired
+	kubeMaster.AdmissionConfig.PluginConfig[overrideapi.PluginName] =
+		api.AdmissionPluginConfig{Configuration: pluginConfig}
+
+	// start up a server and return useful clients to that server
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterConfig)
+	checkErr(t, err)
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	checkErr(t, err)
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	checkErr(t, err)
+	// need to create a project and return client for project admin
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	checkErr(t, err)
+	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), "peon")
+	checkErr(t, err)
+	checkErr(t, testserver.WaitForServiceAccounts(clusterAdminKubeClient, testutil.Namespace(), []string{bootstrappolicy.DefaultServiceAccountName}))
+	return clusterAdminKubeClient
+}
+
+func testClusterResourceOverridePod(name string, memory string, cpu string) *kapi.Pod {
+	resources := kapi.ResourceRequirements{
+		Limits:   testResourceList(memory, cpu),
+		Requests: kapi.ResourceList{},
+	}
+	container := kapi.Container{Name: name, Image: "scratch", Resources: resources}
+	pod := &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{Name: name},
+		Spec:       kapi.PodSpec{Containers: []kapi.Container{container}},
+	}
+	return pod
+}
+
+func testResourceList(memory string, cpu string) kapi.ResourceList {
+	list := kapi.ResourceList{}
+	if memory != "" {
+		list[kapi.ResourceMemory] = resource.MustParse(memory)
+	}
+	if cpu != "" {
+		list[kapi.ResourceCPU] = resource.MustParse(cpu)
+	}
+	return list
+}


### PR DESCRIPTION
Allows master config to override request and limit on submitted pods in order to control "request" overcommit and peg cpu limit to memory limit.

https://trello.com/c/rRN7m0zv/546-5-override-container-resource-request-based-on-limit

