### PR TITLE
Fix building of openshift/origin-keepalived-ipfailover

### DIFF
--- a/images/ipfailover/keepalived/Dockerfile
+++ b/images/ipfailover/keepalived/Dockerfile
@@ -5,6 +5,10 @@
 #
 FROM openshift/origin-base
 
+# TODO: systemd update from centos 7.1 -> 7.2 is broken, remove this once 7.2
+# base images land
+RUN yum swap -y -- remove systemd-container\* -- install systemd systemd-libs
+
 RUN yum -y install kmod keepalived iproute psmisc nc net-tools && \
     yum clean all
 


### PR DESCRIPTION
Add workaround for conflict between files from `systemd-container` and `systemd` packages like @sdodson did in 429eddc8ce910ea28cf9a2601261da7892dafd12 commit.

@sdodson @bparees PTAL

Fix #6895 