### PR TITLE
remove unused e2e option

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -14,7 +14,6 @@ os::log::install_errexit
 source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::util::environment::setup_time_vars
 
-ROUTER_TESTS_ENABLED="${ROUTER_TESTS_ENABLED:-true}"
 TEST_ASSETS="${TEST_ASSETS:-false}"
 
 


### PR DESCRIPTION
This used to gate the router response validation.  Not used anymore