### PR TITLE
Fix bug #6897, logViewer navigate to logs tab directly

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -216,7 +216,7 @@ angular.module('openshiftConsole')
               streamer.start();
             };
 
-            $scope.$watchGroup(['name', 'options.container'], streamLogs);
+            $scope.$watchGroup(['name', 'options.container', 'run'], streamLogs);
 
             $scope.$on('$destroy', function() {
               // Close streamer if open. (No-op if not streaming.)


### PR DESCRIPTION
Fixes [this bug](https://github.com/openshift/origin/issues/6897).

Adds 'run' to the `$watchGroup` in logViewer.

@jwforres @spadgett 