### PR TITLE
Add GitLab OAuth identity provider

### DIFF
--- a/pkg/auth/oauth/external/gitlab/gitlab.go
+++ b/pkg/auth/oauth/external/gitlab/gitlab.go
@@ -1,0 +1,127 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/RangelReale/osincli"
+	"github.com/golang/glog"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/auth/oauth/external"
+)
+
+const (
+	// Uses the GitLab User-API (http://doc.gitlab.com/ce/api/users.html#current-user)
+	// and OAuth-Provider (http://doc.gitlab.com/ce/integration/oauth_provider.html)
+	// with default OAuth scope (http://doc.gitlab.com/ce/api/users.html#current-user)
+	// Requires GitLab 7.7.0 or higher
+	gitlabAuthorizePath = "/oauth/authorize"
+	gitlabTokenPath     = "/oauth/token"
+	gitlabUserApiPath   = "/api/v3/user"
+	gitlabOAuthScope    = "api"
+)
+
+type provider struct {
+	providerName string
+	transport    http.RoundTripper
+	authorizeUrl string
+	tokenUrl     string
+	userApiUrl   string
+	clientID     string
+	clientSecret string
+}
+
+type gitlabUser struct {
+	ID       uint64
+	Username string
+	Email    string
+	Name     string
+}
+
+func NewProvider(providerName string, transport http.RoundTripper, URL, clientID, clientSecret string) (external.Provider, error) {
+	// Create service URLs
+	u, err := url.Parse(URL)
+	if err != nil {
+		return nil, errors.New("Host URL is invalid")
+	}
+	authorizePath := path.Join(u.Path, gitlabAuthorizePath)
+	tokenPath := path.Join(u.Path, gitlabTokenPath)
+	userApiPath := path.Join(u.Path, gitlabUserApiPath)
+	u.Path = authorizePath
+	authorizeUrl := u.String()
+	u.Path = tokenPath
+	tokenUrl := u.String()
+	u.Path = userApiPath
+	userApiUrl := u.String()
+
+	return provider{providerName, transport, authorizeUrl, tokenUrl, userApiUrl, clientID, clientSecret}, nil
+}
+
+func (p provider) GetTransport() (http.RoundTripper, error) {
+	return p.transport, nil
+}
+
+// NewConfig implements external/interfaces/Provider.NewConfig
+func (p provider) NewConfig() (*osincli.ClientConfig, error) {
+	config := &osincli.ClientConfig{
+		ClientId:                 p.clientID,
+		ClientSecret:             p.clientSecret,
+		ErrorsInStatusCode:       true,
+		SendClientSecretInParams: true,
+		AuthorizeUrl:             p.authorizeUrl,
+		TokenUrl:                 p.tokenUrl,
+		Scope:                    gitlabOAuthScope,
+	}
+	return config, nil
+}
+
+// AddCustomParameters implements external/interfaces/Provider.AddCustomParameters
+func (p provider) AddCustomParameters(req *osincli.AuthorizeRequest) {
+}
+
+// GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
+func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
+	req, _ := http.NewRequest("GET", p.userApiUrl, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", data.AccessToken))
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, false, err
+	}
+
+	userdata := gitlabUser{}
+	err = json.Unmarshal(body, &userdata)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if userdata.ID == 0 {
+		return nil, false, errors.New("Could not retrieve GitLab id")
+	}
+
+	identity := authapi.NewDefaultUserIdentityInfo(p.providerName, fmt.Sprintf("%d", userdata.ID))
+	if len(userdata.Name) > 0 {
+		identity.Extra[authapi.IdentityDisplayNameKey] = userdata.Name
+	}
+	if len(userdata.Username) > 0 {
+		identity.Extra[authapi.IdentityPreferredUsernameKey] = userdata.Username
+	}
+	if len(userdata.Email) > 0 {
+		identity.Extra[authapi.IdentityEmailKey] = userdata.Email
+	}
+	glog.V(4).Infof("Got identity=%#v", identity)
+
+	return identity, true, nil
+}

--- a/pkg/auth/oauth/external/gitlab/gitlab_test.go
+++ b/pkg/auth/oauth/external/gitlab/gitlab_test.go
@@ -1,0 +1,15 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/auth/oauth/external"
+)
+
+func TestGitLab(t *testing.T) {
+	p, err := NewProvider("gitlab", nil, "https://gitlab.com/", "clientid", "clientsecret")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	_ = external.Provider(p)
+}

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -187,6 +187,9 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 				refs = append(refs, &provider.RemoteConnectionInfo.ClientCert.CertFile)
 				refs = append(refs, &provider.RemoteConnectionInfo.ClientCert.KeyFile)
 
+			case (*GitLabIdentityProvider):
+				refs = append(refs, &provider.CA)
+
 			case (*OpenIDIdentityProvider):
 				refs = append(refs, &provider.CA)
 
@@ -475,6 +478,7 @@ func IsIdentityProviderType(provider runtime.EmbeddedObject) bool {
 		(*KeystonePasswordIdentityProvider),
 		(*OpenIDIdentityProvider),
 		(*GitHubIdentityProvider),
+		(*GitLabIdentityProvider),
 		(*GoogleIdentityProvider):
 
 		return true
@@ -488,6 +492,7 @@ func IsOAuthIdentityProvider(provider IdentityProvider) bool {
 	case
 		(*OpenIDIdentityProvider),
 		(*GitHubIdentityProvider),
+		(*GitLabIdentityProvider),
 		(*GoogleIdentityProvider):
 
 		return true

--- a/pkg/cmd/server/api/register.go
+++ b/pkg/cmd/server/api/register.go
@@ -36,6 +36,7 @@ func init() {
 		&KeystonePasswordIdentityProvider{},
 		&RequestHeaderIdentityProvider{},
 		&GitHubIdentityProvider{},
+		&GitLabIdentityProvider{},
 		&GoogleIdentityProvider{},
 		&OpenIDIdentityProvider{},
 		&GrantConfig{},
@@ -54,6 +55,7 @@ func (*LDAPPasswordIdentityProvider) IsAnAPIObject()      {}
 func (*KeystonePasswordIdentityProvider) IsAnAPIObject()  {}
 func (*RequestHeaderIdentityProvider) IsAnAPIObject()     {}
 func (*GitHubIdentityProvider) IsAnAPIObject()            {}
+func (*GitLabIdentityProvider) IsAnAPIObject()            {}
 func (*GoogleIdentityProvider) IsAnAPIObject()            {}
 func (*OpenIDIdentityProvider) IsAnAPIObject()            {}
 func (*GrantConfig) IsAnAPIObject()                       {}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -673,6 +673,20 @@ type GitHubIdentityProvider struct {
 	ClientSecret string
 }
 
+type GitLabIdentityProvider struct {
+	unversioned.TypeMeta
+
+	// CA is the optional trusted certificate authority bundle to use when making requests to the server
+	// If empty, the default system roots are used
+	CA string
+	// URL is the oauth server base URL
+	URL string
+	// ClientID is the oauth client ID
+	ClientID string
+	// ClientSecret is the oauth client secret
+	ClientSecret string
+}
+
 type GoogleIdentityProvider struct {
 	unversioned.TypeMeta
 

--- a/pkg/cmd/server/api/v1/register.go
+++ b/pkg/cmd/server/api/v1/register.go
@@ -28,6 +28,7 @@ func init() {
 		&KeystonePasswordIdentityProvider{},
 		&RequestHeaderIdentityProvider{},
 		&GitHubIdentityProvider{},
+		&GitLabIdentityProvider{},
 		&GoogleIdentityProvider{},
 		&OpenIDIdentityProvider{},
 		&GrantConfig{},
@@ -48,6 +49,7 @@ func (*LDAPPasswordIdentityProvider) IsAnAPIObject()      {}
 func (*KeystonePasswordIdentityProvider) IsAnAPIObject()  {}
 func (*RequestHeaderIdentityProvider) IsAnAPIObject()     {}
 func (*GitHubIdentityProvider) IsAnAPIObject()            {}
+func (*GitLabIdentityProvider) IsAnAPIObject()            {}
 func (*GoogleIdentityProvider) IsAnAPIObject()            {}
 func (*OpenIDIdentityProvider) IsAnAPIObject()            {}
 func (*GrantConfig) IsAnAPIObject()                       {}

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -626,6 +626,20 @@ type GitHubIdentityProvider struct {
 	ClientSecret string `json:"clientSecret"`
 }
 
+type GitLabIdentityProvider struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// CA is the optional trusted certificate authority bundle to use when making requests to the server
+	// If empty, the default system roots are used
+	CA string `json:"ca"`
+	// URL is the oauth server base URL
+	URL string `json:"url"`
+	// ClientID is the oauth client ID
+	ClientID string `json:"clientID"`
+	// ClientSecret is the oauth client secret
+	ClientSecret string `json:"clientSecret"`
+}
+
 type GoogleIdentityProvider struct {
 	unversioned.TypeMeta `json:",inline"`
 

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -267,6 +267,17 @@ oauthConfig:
     name: ""
     provider:
       apiVersion: v1
+      ca: ""
+      clientID: ""
+      clientSecret: ""
+      kind: GitLabIdentityProvider
+      url: ""
+  - challenge: false
+    login: false
+    mappingMethod: ""
+    name: ""
+    provider:
+      apiVersion: v1
       clientID: ""
       clientSecret: ""
       hostedDomain: ""
@@ -388,6 +399,7 @@ func TestMasterConfig(t *testing.T) {
 				{Provider: runtime.EmbeddedObject{Object: &internal.RequestHeaderIdentityProvider{}}},
 				{Provider: runtime.EmbeddedObject{Object: &internal.KeystonePasswordIdentityProvider{}}},
 				{Provider: runtime.EmbeddedObject{Object: &internal.GitHubIdentityProvider{}}},
+				{Provider: runtime.EmbeddedObject{Object: &internal.GitLabIdentityProvider{}}},
 				{Provider: runtime.EmbeddedObject{Object: &internal.GoogleIdentityProvider{}}},
 				{Provider: runtime.EmbeddedObject{Object: &internal.OpenIDIdentityProvider{}}},
 			},

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/oauth/external"
 	"github.com/openshift/origin/pkg/auth/oauth/external/github"
+	"github.com/openshift/origin/pkg/auth/oauth/external/gitlab"
 	"github.com/openshift/origin/pkg/auth/oauth/external/google"
 	"github.com/openshift/origin/pkg/auth/oauth/external/openid"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
@@ -446,6 +447,13 @@ func (c *AuthConfig) getOAuthProvider(identityProvider configapi.IdentityProvide
 	switch provider := identityProvider.Provider.Object.(type) {
 	case (*configapi.GitHubIdentityProvider):
 		return github.NewProvider(identityProvider.Name, provider.ClientID, provider.ClientSecret), nil
+
+	case (*configapi.GitLabIdentityProvider):
+		transport, err := cmdutil.TransportFor(provider.CA, "", "")
+		if err != nil {
+			return nil, err
+		}
+		return gitlab.NewProvider(identityProvider.Name, transport, provider.URL, provider.ClientID, provider.ClientSecret)
 
 	case (*configapi.GoogleIdentityProvider):
 		return google.NewProvider(identityProvider.Name, provider.ClientID, provider.ClientSecret, provider.HostedDomain)


### PR DESCRIPTION
Adds [GitLab](http://gitlab.com) as additional OAuth identity provider with configurable URL. Supports GitLab Online and self hosted GitLab instances which are used in various companies as central OAuth providers.