### PR TITLE
Tag current deployed image into an image stream on deployment success

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -18877,6 +18877,13 @@
      "execNewPod": {
       "$ref": "v1.ExecNewPodHook",
       "description": "options for an ExecNewPodHook"
+     },
+     "tagImages": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.TagImageHook"
+      },
+      "description": "a list of image stream tags that should be updated to the latest value on this deployment if the deployment succeeds"
      }
     }
    },
@@ -18911,6 +18918,23 @@
        "type": "string"
       },
       "description": "the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"
+     }
+    }
+   },
+   "v1.TagImageHook": {
+    "id": "v1.TagImageHook",
+    "required": [
+     "containerName",
+     "to"
+    ],
+    "properties": {
+     "containerName": {
+      "type": "string",
+      "description": "the name of a container in this deployment config whose image will be used as the tag destination; if only one container is defined it will default to that value"
+     },
+     "to": {
+      "$ref": "v1.ObjectReference",
+      "description": "the name of an ImageStreamTag in the current namespace that will be updated with the image value"
      }
     }
    },

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20590,6 +20590,7 @@
     "id": "v1.TagReference",
     "required": [
      "name",
+     "annotations",
      "generation"
     ],
     "properties": {
@@ -20909,6 +20910,8 @@
    "v1.ImageStreamTag": {
     "id": "v1.ImageStreamTag",
     "required": [
+     "tag",
+     "generation",
      "image"
     ],
     "properties": {
@@ -20922,6 +20925,22 @@
      },
      "metadata": {
       "$ref": "v1.ObjectMeta"
+     },
+     "tag": {
+      "$ref": "v1.TagReference",
+      "description": "the spec tag (optional) that is associated with this ImageStream"
+     },
+     "generation": {
+      "type": "integer",
+      "format": "int64",
+      "description": "the generation of the tagged image, if not equal to the tag generation or the latest condition generation, there is an image import pending"
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.TagEventCondition"
+      },
+      "description": "the set of conditions that apply to this tag"
      },
      "image": {
       "$ref": "v1.Image",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -2260,6 +2260,25 @@ func deepCopy_api_ImageStreamTag(in imageapi.ImageStreamTag, out *imageapi.Image
 	} else {
 		out.ObjectMeta = newVal.(pkgapi.ObjectMeta)
 	}
+	if in.Tag != nil {
+		out.Tag = new(imageapi.TagReference)
+		if err := deepCopy_api_TagReference(*in.Tag, out.Tag, c); err != nil {
+			return err
+		}
+	} else {
+		out.Tag = nil
+	}
+	out.Generation = in.Generation
+	if in.Conditions != nil {
+		out.Conditions = make([]imageapi.TagEventCondition, len(in.Conditions))
+		for i := range in.Conditions {
+			if err := deepCopy_api_TagEventCondition(in.Conditions[i], &out.Conditions[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Conditions = nil
+	}
 	if err := deepCopy_api_Image(in.Image, &out.Image, c); err != nil {
 		return err
 	}

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1729,6 +1729,16 @@ func deepCopy_api_LifecycleHook(in deployapi.LifecycleHook, out *deployapi.Lifec
 	} else {
 		out.ExecNewPod = nil
 	}
+	if in.TagImages != nil {
+		out.TagImages = make([]deployapi.TagImageHook, len(in.TagImages))
+		for i := range in.TagImages {
+			if err := deepCopy_api_TagImageHook(in.TagImages[i], &out.TagImages[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.TagImages = nil
+	}
 	return nil
 }
 
@@ -1816,6 +1826,16 @@ func deepCopy_api_RollingDeploymentStrategyParams(in deployapi.RollingDeployment
 		}
 	} else {
 		out.Post = nil
+	}
+	return nil
+}
+
+func deepCopy_api_TagImageHook(in deployapi.TagImageHook, out *deployapi.TagImageHook, c *conversion.Cloner) error {
+	out.ContainerName = in.ContainerName
+	if newVal, err := c.DeepCopy(in.To); err != nil {
+		return err
+	} else {
+		out.To = newVal.(pkgapi.ObjectReference)
 	}
 	return nil
 }
@@ -3310,6 +3330,7 @@ func init() {
 		deepCopy_api_LifecycleHook,
 		deepCopy_api_RecreateDeploymentStrategyParams,
 		deepCopy_api_RollingDeploymentStrategyParams,
+		deepCopy_api_TagImageHook,
 		deepCopy_api_DockerConfig,
 		deepCopy_api_DockerImage,
 		deepCopy_api_Image,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2985,6 +2985,16 @@ func autoConvert_api_LifecycleHook_To_v1_LifecycleHook(in *deployapi.LifecycleHo
 	} else {
 		out.ExecNewPod = nil
 	}
+	if in.TagImages != nil {
+		out.TagImages = make([]deployapiv1.TagImageHook, len(in.TagImages))
+		for i := range in.TagImages {
+			if err := Convert_api_TagImageHook_To_v1_TagImageHook(&in.TagImages[i], &out.TagImages[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.TagImages = nil
+	}
 	return nil
 }
 
@@ -3089,6 +3099,21 @@ func autoConvert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStra
 		out.Post = nil
 	}
 	return nil
+}
+
+func autoConvert_api_TagImageHook_To_v1_TagImageHook(in *deployapi.TagImageHook, out *deployapiv1.TagImageHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.TagImageHook))(in)
+	}
+	out.ContainerName = in.ContainerName
+	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.To, &out.To, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_api_TagImageHook_To_v1_TagImageHook(in *deployapi.TagImageHook, out *deployapiv1.TagImageHook, s conversion.Scope) error {
+	return autoConvert_api_TagImageHook_To_v1_TagImageHook(in, out, s)
 }
 
 func autoConvert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in *deployapiv1.CustomDeploymentStrategyParams, out *deployapi.CustomDeploymentStrategyParams, s conversion.Scope) error {
@@ -3527,6 +3552,16 @@ func autoConvert_v1_LifecycleHook_To_api_LifecycleHook(in *deployapiv1.Lifecycle
 	} else {
 		out.ExecNewPod = nil
 	}
+	if in.TagImages != nil {
+		out.TagImages = make([]deployapi.TagImageHook, len(in.TagImages))
+		for i := range in.TagImages {
+			if err := Convert_v1_TagImageHook_To_api_TagImageHook(&in.TagImages[i], &out.TagImages[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.TagImages = nil
+	}
 	return nil
 }
 
@@ -3627,6 +3662,21 @@ func autoConvert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStra
 		out.Post = nil
 	}
 	return nil
+}
+
+func autoConvert_v1_TagImageHook_To_api_TagImageHook(in *deployapiv1.TagImageHook, out *deployapi.TagImageHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.TagImageHook))(in)
+	}
+	out.ContainerName = in.ContainerName
+	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.To, &out.To, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_TagImageHook_To_api_TagImageHook(in *deployapiv1.TagImageHook, out *deployapi.TagImageHook, s conversion.Scope) error {
+	return autoConvert_v1_TagImageHook_To_api_TagImageHook(in, out, s)
 }
 
 func autoConvert_api_Image_To_v1_Image(in *imageapi.Image, out *imageapiv1.Image, s conversion.Scope) error {
@@ -8727,6 +8777,7 @@ func init() {
 		autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		autoConvert_api_TLSConfig_To_v1_TLSConfig,
 		autoConvert_api_TagEventCondition_To_v1_TagEventCondition,
+		autoConvert_api_TagImageHook_To_v1_TagImageHook,
 		autoConvert_api_TagImportPolicy_To_v1_TagImportPolicy,
 		autoConvert_api_TagReference_To_v1_TagReference,
 		autoConvert_api_TemplateList_To_v1_TemplateList,
@@ -8900,6 +8951,7 @@ func init() {
 		autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		autoConvert_v1_TLSConfig_To_api_TLSConfig,
 		autoConvert_v1_TagEventCondition_To_api_TagEventCondition,
+		autoConvert_v1_TagImageHook_To_api_TagImageHook,
 		autoConvert_v1_TagImportPolicy_To_api_TagImportPolicy,
 		autoConvert_v1_TagReference_To_api_TagReference,
 		autoConvert_v1_TemplateList_To_api_TemplateList,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -3924,6 +3924,26 @@ func autoConvert_api_ImageStreamTag_To_v1_ImageStreamTag(in *imageapi.ImageStrea
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for api.TagReference -> v1.TagReference
+	if in.Tag != nil {
+		out.Tag = new(imageapiv1.TagReference)
+		if err := Convert_api_TagReference_To_v1_TagReference(in.Tag, out.Tag, s); err != nil {
+			return err
+		}
+	} else {
+		out.Tag = nil
+	}
+	out.Generation = in.Generation
+	if in.Conditions != nil {
+		out.Conditions = make([]imageapiv1.TagEventCondition, len(in.Conditions))
+		for i := range in.Conditions {
+			if err := Convert_api_TagEventCondition_To_v1_TagEventCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Conditions = nil
+	}
 	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
 		return err
 	}
@@ -4008,6 +4028,25 @@ func Convert_api_RepositoryImportStatus_To_v1_RepositoryImportStatus(in *imageap
 	return autoConvert_api_RepositoryImportStatus_To_v1_RepositoryImportStatus(in, out, s)
 }
 
+func autoConvert_api_TagEventCondition_To_v1_TagEventCondition(in *imageapi.TagEventCondition, out *imageapiv1.TagEventCondition, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*imageapi.TagEventCondition))(in)
+	}
+	out.Type = imageapiv1.TagEventConditionType(in.Type)
+	out.Status = apiv1.ConditionStatus(in.Status)
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
+		return err
+	}
+	out.Reason = in.Reason
+	out.Message = in.Message
+	out.Generation = in.Generation
+	return nil
+}
+
+func Convert_api_TagEventCondition_To_v1_TagEventCondition(in *imageapi.TagEventCondition, out *imageapiv1.TagEventCondition, s conversion.Scope) error {
+	return autoConvert_api_TagEventCondition_To_v1_TagEventCondition(in, out, s)
+}
+
 func autoConvert_api_TagImportPolicy_To_v1_TagImportPolicy(in *imageapi.TagImportPolicy, out *imageapiv1.TagImportPolicy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*imageapi.TagImportPolicy))(in)
@@ -4019,6 +4058,45 @@ func autoConvert_api_TagImportPolicy_To_v1_TagImportPolicy(in *imageapi.TagImpor
 
 func Convert_api_TagImportPolicy_To_v1_TagImportPolicy(in *imageapi.TagImportPolicy, out *imageapiv1.TagImportPolicy, s conversion.Scope) error {
 	return autoConvert_api_TagImportPolicy_To_v1_TagImportPolicy(in, out, s)
+}
+
+func autoConvert_api_TagReference_To_v1_TagReference(in *imageapi.TagReference, out *imageapiv1.TagReference, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*imageapi.TagReference))(in)
+	}
+	out.Name = in.Name
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	// unable to generate simple pointer conversion for api.ObjectReference -> v1.ObjectReference
+	if in.From != nil {
+		out.From = new(apiv1.ObjectReference)
+		if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.From, out.From, s); err != nil {
+			return err
+		}
+	} else {
+		out.From = nil
+	}
+	out.Reference = in.Reference
+	if in.Generation != nil {
+		out.Generation = new(int64)
+		*out.Generation = *in.Generation
+	} else {
+		out.Generation = nil
+	}
+	if err := Convert_api_TagImportPolicy_To_v1_TagImportPolicy(&in.ImportPolicy, &out.ImportPolicy, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_api_TagReference_To_v1_TagReference(in *imageapi.TagReference, out *imageapiv1.TagReference, s conversion.Scope) error {
+	return autoConvert_api_TagReference_To_v1_TagReference(in, out, s)
 }
 
 func autoConvert_v1_Image_To_api_Image(in *imageapiv1.Image, out *imageapi.Image, s conversion.Scope) error {
@@ -4315,6 +4393,26 @@ func autoConvert_v1_ImageStreamTag_To_api_ImageStreamTag(in *imageapiv1.ImageStr
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
+	// unable to generate simple pointer conversion for v1.TagReference -> api.TagReference
+	if in.Tag != nil {
+		out.Tag = new(imageapi.TagReference)
+		if err := Convert_v1_TagReference_To_api_TagReference(in.Tag, out.Tag, s); err != nil {
+			return err
+		}
+	} else {
+		out.Tag = nil
+	}
+	out.Generation = in.Generation
+	if in.Conditions != nil {
+		out.Conditions = make([]imageapi.TagEventCondition, len(in.Conditions))
+		for i := range in.Conditions {
+			if err := Convert_v1_TagEventCondition_To_api_TagEventCondition(&in.Conditions[i], &out.Conditions[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Conditions = nil
+	}
 	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
 		return err
 	}
@@ -4399,6 +4497,25 @@ func Convert_v1_RepositoryImportStatus_To_api_RepositoryImportStatus(in *imageap
 	return autoConvert_v1_RepositoryImportStatus_To_api_RepositoryImportStatus(in, out, s)
 }
 
+func autoConvert_v1_TagEventCondition_To_api_TagEventCondition(in *imageapiv1.TagEventCondition, out *imageapi.TagEventCondition, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*imageapiv1.TagEventCondition))(in)
+	}
+	out.Type = imageapi.TagEventConditionType(in.Type)
+	out.Status = api.ConditionStatus(in.Status)
+	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastTransitionTime, &out.LastTransitionTime, s); err != nil {
+		return err
+	}
+	out.Reason = in.Reason
+	out.Message = in.Message
+	out.Generation = in.Generation
+	return nil
+}
+
+func Convert_v1_TagEventCondition_To_api_TagEventCondition(in *imageapiv1.TagEventCondition, out *imageapi.TagEventCondition, s conversion.Scope) error {
+	return autoConvert_v1_TagEventCondition_To_api_TagEventCondition(in, out, s)
+}
+
 func autoConvert_v1_TagImportPolicy_To_api_TagImportPolicy(in *imageapiv1.TagImportPolicy, out *imageapi.TagImportPolicy, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*imageapiv1.TagImportPolicy))(in)
@@ -4410,6 +4527,45 @@ func autoConvert_v1_TagImportPolicy_To_api_TagImportPolicy(in *imageapiv1.TagImp
 
 func Convert_v1_TagImportPolicy_To_api_TagImportPolicy(in *imageapiv1.TagImportPolicy, out *imageapi.TagImportPolicy, s conversion.Scope) error {
 	return autoConvert_v1_TagImportPolicy_To_api_TagImportPolicy(in, out, s)
+}
+
+func autoConvert_v1_TagReference_To_api_TagReference(in *imageapiv1.TagReference, out *imageapi.TagReference, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*imageapiv1.TagReference))(in)
+	}
+	out.Name = in.Name
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	// unable to generate simple pointer conversion for v1.ObjectReference -> api.ObjectReference
+	if in.From != nil {
+		out.From = new(api.ObjectReference)
+		if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.From, out.From, s); err != nil {
+			return err
+		}
+	} else {
+		out.From = nil
+	}
+	out.Reference = in.Reference
+	if in.Generation != nil {
+		out.Generation = new(int64)
+		*out.Generation = *in.Generation
+	} else {
+		out.Generation = nil
+	}
+	if err := Convert_v1_TagImportPolicy_To_api_TagImportPolicy(&in.ImportPolicy, &out.ImportPolicy, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_TagReference_To_api_TagReference(in *imageapiv1.TagReference, out *imageapi.TagReference, s conversion.Scope) error {
+	return autoConvert_v1_TagReference_To_api_TagReference(in, out, s)
 }
 
 func autoConvert_api_OAuthAccessToken_To_v1_OAuthAccessToken(in *oauthapi.OAuthAccessToken, out *oauthapiv1.OAuthAccessToken, s conversion.Scope) error {
@@ -8570,7 +8726,9 @@ func init() {
 		autoConvert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
 		autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		autoConvert_api_TLSConfig_To_v1_TLSConfig,
+		autoConvert_api_TagEventCondition_To_v1_TagEventCondition,
 		autoConvert_api_TagImportPolicy_To_v1_TagImportPolicy,
+		autoConvert_api_TagReference_To_v1_TagReference,
 		autoConvert_api_TemplateList_To_v1_TemplateList,
 		autoConvert_api_Template_To_v1_Template,
 		autoConvert_api_UserIdentityMapping_To_v1_UserIdentityMapping,
@@ -8741,7 +8899,9 @@ func init() {
 		autoConvert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
 		autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		autoConvert_v1_TLSConfig_To_api_TLSConfig,
+		autoConvert_v1_TagEventCondition_To_api_TagEventCondition,
 		autoConvert_v1_TagImportPolicy_To_api_TagImportPolicy,
+		autoConvert_v1_TagReference_To_api_TagReference,
 		autoConvert_v1_TemplateList_To_api_TemplateList,
 		autoConvert_v1_Template_To_api_Template,
 		autoConvert_v1_UserIdentityMapping_To_api_UserIdentityMapping,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1752,6 +1752,16 @@ func deepCopy_v1_LifecycleHook(in deployapiv1.LifecycleHook, out *deployapiv1.Li
 	} else {
 		out.ExecNewPod = nil
 	}
+	if in.TagImages != nil {
+		out.TagImages = make([]deployapiv1.TagImageHook, len(in.TagImages))
+		for i := range in.TagImages {
+			if err := deepCopy_v1_TagImageHook(in.TagImages[i], &out.TagImages[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.TagImages = nil
+	}
 	return nil
 }
 
@@ -1847,6 +1857,16 @@ func deepCopy_v1_RollingDeploymentStrategyParams(in deployapiv1.RollingDeploymen
 		}
 	} else {
 		out.Post = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_TagImageHook(in deployapiv1.TagImageHook, out *deployapiv1.TagImageHook, c *conversion.Cloner) error {
+	out.ContainerName = in.ContainerName
+	if newVal, err := c.DeepCopy(in.To); err != nil {
+		return err
+	} else {
+		out.To = newVal.(pkgapiv1.ObjectReference)
 	}
 	return nil
 }
@@ -3199,6 +3219,7 @@ func init() {
 		deepCopy_v1_LifecycleHook,
 		deepCopy_v1_RecreateDeploymentStrategyParams,
 		deepCopy_v1_RollingDeploymentStrategyParams,
+		deepCopy_v1_TagImageHook,
 		deepCopy_v1_Image,
 		deepCopy_v1_ImageImportSpec,
 		deepCopy_v1_ImageImportStatus,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -2146,6 +2146,25 @@ func deepCopy_v1_ImageStreamTag(in imageapiv1.ImageStreamTag, out *imageapiv1.Im
 	} else {
 		out.ObjectMeta = newVal.(pkgapiv1.ObjectMeta)
 	}
+	if in.Tag != nil {
+		out.Tag = new(imageapiv1.TagReference)
+		if err := deepCopy_v1_TagReference(*in.Tag, out.Tag, c); err != nil {
+			return err
+		}
+	} else {
+		out.Tag = nil
+	}
+	out.Generation = in.Generation
+	if in.Conditions != nil {
+		out.Conditions = make([]imageapiv1.TagEventCondition, len(in.Conditions))
+		for i := range in.Conditions {
+			if err := deepCopy_v1_TagEventCondition(in.Conditions[i], &out.Conditions[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Conditions = nil
+	}
 	if err := deepCopy_v1_Image(in.Image, &out.Image, c); err != nil {
 		return err
 	}

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2669,6 +2669,21 @@ func autoConvert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymen
 	return nil
 }
 
+func autoConvert_api_TagImageHook_To_v1beta3_TagImageHook(in *deployapi.TagImageHook, out *deployapiv1beta3.TagImageHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.TagImageHook))(in)
+	}
+	out.ContainerName = in.ContainerName
+	if err := Convert_api_ObjectReference_To_v1beta3_ObjectReference(&in.To, &out.To, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_api_TagImageHook_To_v1beta3_TagImageHook(in *deployapi.TagImageHook, out *deployapiv1beta3.TagImageHook, s conversion.Scope) error {
+	return autoConvert_api_TagImageHook_To_v1beta3_TagImageHook(in, out, s)
+}
+
 func autoConvert_v1beta3_DeploymentCause_To_api_DeploymentCause(in *deployapiv1beta3.DeploymentCause, out *deployapi.DeploymentCause, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*deployapiv1beta3.DeploymentCause))(in)
@@ -2926,6 +2941,21 @@ func autoConvert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymen
 		out.Post = nil
 	}
 	return nil
+}
+
+func autoConvert_v1beta3_TagImageHook_To_api_TagImageHook(in *deployapiv1beta3.TagImageHook, out *deployapi.TagImageHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.TagImageHook))(in)
+	}
+	out.ContainerName = in.ContainerName
+	if err := Convert_v1beta3_ObjectReference_To_api_ObjectReference(&in.To, &out.To, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1beta3_TagImageHook_To_api_TagImageHook(in *deployapiv1beta3.TagImageHook, out *deployapi.TagImageHook, s conversion.Scope) error {
+	return autoConvert_v1beta3_TagImageHook_To_api_TagImageHook(in, out, s)
 }
 
 func autoConvert_api_Image_To_v1beta3_Image(in *imageapi.Image, out *imageapiv1beta3.Image, s conversion.Scope) error {
@@ -6873,6 +6903,7 @@ func init() {
 		autoConvert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
 		autoConvert_api_TCPSocketAction_To_v1beta3_TCPSocketAction,
 		autoConvert_api_TLSConfig_To_v1beta3_TLSConfig,
+		autoConvert_api_TagImageHook_To_v1beta3_TagImageHook,
 		autoConvert_api_TemplateList_To_v1beta3_TemplateList,
 		autoConvert_api_Template_To_v1beta3_Template,
 		autoConvert_api_UserIdentityMapping_To_v1beta3_UserIdentityMapping,
@@ -7016,6 +7047,7 @@ func init() {
 		autoConvert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
 		autoConvert_v1beta3_TCPSocketAction_To_api_TCPSocketAction,
 		autoConvert_v1beta3_TLSConfig_To_api_TLSConfig,
+		autoConvert_v1beta3_TagImageHook_To_api_TagImageHook,
 		autoConvert_v1beta3_TemplateList_To_api_TemplateList,
 		autoConvert_v1beta3_Template_To_api_Template,
 		autoConvert_v1beta3_UserIdentityMapping_To_api_UserIdentityMapping,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -3075,6 +3075,9 @@ func autoConvert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(in *imageapi.Image
 	if err := Convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
+	// in.Tag has no peer in out
+	out.Generation = in.Generation
+	// in.Conditions has no peer in out
 	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
 		return err
 	}

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1760,6 +1760,16 @@ func deepCopy_v1beta3_LifecycleHook(in deployapiv1beta3.LifecycleHook, out *depl
 	} else {
 		out.ExecNewPod = nil
 	}
+	if in.TagImages != nil {
+		out.TagImages = make([]deployapiv1beta3.TagImageHook, len(in.TagImages))
+		for i := range in.TagImages {
+			if err := deepCopy_v1beta3_TagImageHook(in.TagImages[i], &out.TagImages[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.TagImages = nil
+	}
 	return nil
 }
 
@@ -1855,6 +1865,16 @@ func deepCopy_v1beta3_RollingDeploymentStrategyParams(in deployapiv1beta3.Rollin
 		}
 	} else {
 		out.Post = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_TagImageHook(in deployapiv1beta3.TagImageHook, out *deployapiv1beta3.TagImageHook, c *conversion.Cloner) error {
+	out.ContainerName = in.ContainerName
+	if newVal, err := c.DeepCopy(in.To); err != nil {
+		return err
+	} else {
+		out.To = newVal.(pkgapiv1beta3.ObjectReference)
 	}
 	return nil
 }
@@ -3017,6 +3037,7 @@ func init() {
 		deepCopy_v1beta3_LifecycleHook,
 		deepCopy_v1beta3_RecreateDeploymentStrategyParams,
 		deepCopy_v1beta3_RollingDeploymentStrategyParams,
+		deepCopy_v1beta3_TagImageHook,
 		deepCopy_v1beta3_Image,
 		deepCopy_v1beta3_ImageLayer,
 		deepCopy_v1beta3_ImageList,

--- a/pkg/client/imagestreamtags.go
+++ b/pkg/client/imagestreamtags.go
@@ -14,6 +14,7 @@ type ImageStreamTagsNamespacer interface {
 // ImageStreamTagInterface exposes methods on ImageStreamTag resources.
 type ImageStreamTagInterface interface {
 	Get(name, tag string) (*api.ImageStreamTag, error)
+	Update(tag *api.ImageStreamTag) (*api.ImageStreamTag, error)
 	Delete(name, tag string) error
 }
 
@@ -35,6 +36,13 @@ func newImageStreamTags(c *Client, namespace string) *imageStreamTags {
 func (c *imageStreamTags) Get(name, tag string) (result *api.ImageStreamTag, err error) {
 	result = &api.ImageStreamTag{}
 	err = c.r.Get().Namespace(c.ns).Resource("imageStreamTags").Name(fmt.Sprintf("%s:%s", name, tag)).Do().Into(result)
+	return
+}
+
+// Update updates an image stream tag (creating it if it does not exist).
+func (c *imageStreamTags) Update(tag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
+	err = c.r.Put().Namespace(c.ns).Resource("imageStreamTags").Name(tag.Name).Body(tag).Do().Into(result)
 	return
 }
 

--- a/pkg/client/testclient/fake_imagestreamtags.go
+++ b/pkg/client/testclient/fake_imagestreamtags.go
@@ -26,6 +26,15 @@ func (c *FakeImageStreamTags) Get(name, tag string) (*imageapi.ImageStreamTag, e
 	return obj.(*imageapi.ImageStreamTag), err
 }
 
+func (c *FakeImageStreamTags) Update(inObj *imageapi.ImageStreamTag) (*imageapi.ImageStreamTag, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewUpdateAction("imagestreamtags", c.Namespace, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*imageapi.ImageStreamTag), err
+}
+
 func (c *FakeImageStreamTags) Delete(name, tag string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewDeleteAction("imagestreamtags", c.Namespace, imageapi.JoinImageStreamTag(name, tag)), &imageapi.ImageStreamTag{})
 	return err

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -132,7 +132,7 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 		}
 	}
 	existingDeployerPods := []kapi.Pod{
-		mkpod("prehook"), mkpod("posthook"), mkpod("deployerpod"),
+		mkpod("hook-pre"), mkpod("hook-post"), mkpod("deployerpod"),
 	}
 
 	kubeClient := &ktc.Fake{}
@@ -171,7 +171,7 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 	}
 
 	sort.Strings(deletedPods)
-	expectedDeletions := []string{"deployerpod", "posthook", "prehook"}
+	expectedDeletions := []string{"deployerpod", "hook-post", "hook-pre"}
 	if e, a := expectedDeletions, deletedPods; !reflect.DeepEqual(e, a) {
 		t.Fatalf("Not all deployer pods for the failed deployment were deleted.\nEXPECTED: %v\nACTUAL: %v", e, a)
 	}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -294,6 +294,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("get"),
 					Resources: sets.NewString("pods/log"),
 				},
+				{
+					// Deployer.After.TagImages
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("imagestreamtags"),
+				},
 			},
 		},
 		{

--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -95,6 +95,11 @@ func EachTemplateImage(pod *kapi.PodSpec, triggerFn TriggeredByFunc, fn func(Tem
 // TriggeredByFunc returns a TemplateImage or error from the provided container
 type TriggeredByFunc func(container *kapi.Container) (TemplateImage, bool)
 
+// IgnoreTriggers ignores the triggers
+func IgnoreTriggers(container *kapi.Container) (TemplateImage, bool) {
+	return TemplateImage{}, false
+}
+
 // DeploymentConfigHasTrigger returns a function that can identify the image for each container.
 func DeploymentConfigHasTrigger(config *DeploymentConfig) TriggeredByFunc {
 	return func(container *kapi.Container) (TemplateImage, bool) {

--- a/pkg/deploy/api/v1/defaults_test.go
+++ b/pkg/deploy/api/v1/defaults_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -14,6 +15,10 @@ import (
 	_ "github.com/openshift/origin/pkg/deploy/api/install"
 	deployv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 )
+
+func mkintp(i int64) *int64 {
+	return &i
+}
 
 func TestDefaults(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
@@ -51,8 +56,23 @@ func TestDefaults(t *testing.T) {
 						Type: deployv1.DeploymentStrategyTypeRecreate,
 						RecreateParams: &deployv1.RecreateDeploymentStrategyParams{
 							TimeoutSeconds: newInt64(deployapi.DefaultRollingTimeoutSeconds),
+							Pre: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{}, {}},
+							},
+							Mid: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{}, {}},
+							},
+							Post: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{}, {}},
+							},
 						},
 						RollingParams: &deployv1.RollingDeploymentStrategyParams{
+							Pre: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{}, {}},
+							},
+							Post: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{}, {}},
+							},
 							UpdatePeriodSeconds: newInt64(5),
 							IntervalSeconds:     newInt64(6),
 							TimeoutSeconds:      newInt64(7),
@@ -63,6 +83,15 @@ func TestDefaults(t *testing.T) {
 					Triggers: []deployv1.DeploymentTriggerPolicy{
 						{
 							Type: deployv1.DeploymentTriggerOnImageChange,
+						},
+					},
+					Template: &kapiv1.PodTemplateSpec{
+						Spec: kapiv1.PodSpec{
+							Containers: []kapiv1.Container{
+								{
+									Name: "test",
+								},
+							},
 						},
 					},
 				},
@@ -73,8 +102,23 @@ func TestDefaults(t *testing.T) {
 						Type: deployv1.DeploymentStrategyTypeRecreate,
 						RecreateParams: &deployv1.RecreateDeploymentStrategyParams{
 							TimeoutSeconds: newInt64(deployapi.DefaultRollingTimeoutSeconds),
+							Pre: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{ContainerName: "test"}, {ContainerName: "test"}},
+							},
+							Mid: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{ContainerName: "test"}, {ContainerName: "test"}},
+							},
+							Post: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{ContainerName: "test"}, {ContainerName: "test"}},
+							},
 						},
 						RollingParams: &deployv1.RollingDeploymentStrategyParams{
+							Pre: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{ContainerName: "test"}, {ContainerName: "test"}},
+							},
+							Post: &deployv1.LifecycleHook{
+								TagImages: []deployv1.TagImageHook{{ContainerName: "test"}, {ContainerName: "test"}},
+							},
 							UpdatePeriodSeconds: newInt64(5),
 							IntervalSeconds:     newInt64(6),
 							TimeoutSeconds:      newInt64(7),
@@ -85,6 +129,21 @@ func TestDefaults(t *testing.T) {
 					Triggers: []deployv1.DeploymentTriggerPolicy{
 						{
 							Type: deployv1.DeploymentTriggerOnImageChange,
+						},
+					},
+					Template: &kapiv1.PodTemplateSpec{
+						Spec: kapiv1.PodSpec{
+							SecurityContext:               &kapiv1.PodSecurityContext{},
+							RestartPolicy:                 kapiv1.RestartPolicyAlways,
+							TerminationGracePeriodSeconds: mkintp(30),
+							DNSPolicy:                     kapiv1.DNSClusterFirst,
+							Containers: []kapiv1.Container{
+								{
+									Name: "test",
+									TerminationMessagePath: "/dev/termination-log",
+									ImagePullPolicy:        kapiv1.PullAlways,
+								},
+							},
 						},
 					},
 				},

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -28,13 +28,15 @@ const (
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
 	Type DeploymentStrategyType `json:"type,omitempty" description:"the name of a deployment strategy"`
+
 	// CustomParams are the input to the Custom deployment strategy.
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty" description:"input to the Custom deployment strategy"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty" description:"input to the Recreate deployment strategy"`
 	// RollingParams are the input to the Rolling deployment strategy.
 	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty" description:"input to the Rolling deployment strategy"`
-	// Resources contains resource requirements to execute the deployment
+
+	// Resources contains resource requirements to execute the deployment and any hooks
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"resource requirements to execute the deployment"`
 	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
 	Labels map[string]string `json:"labels,omitempty" description:"labels for deployer and hook pods"`
@@ -77,17 +79,20 @@ type RecreateDeploymentStrategyParams struct {
 	// pod is created. All LifecycleHookFailurePolicy values are supported.
 	Mid *LifecycleHook `json:"mid,omitempty" description:"a hook executed after the strategy scales down the deployment and before it scales up"`
 	// Post is a lifecycle hook which is executed after the strategy has
-	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
-	// is NOT supported.
+	// finished all deployment logic. All LifecycleHookFailurePolicy values are supported.
 	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the deployment"`
 }
 
-// LifecycleHook defines a specific deployment lifecycle action.
+// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
 type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
 	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy" description:"what action to take if the hook fails"`
+
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
 	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty" description:"options for an ExecNewPodHook"`
+
+	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.
+	TagImages []TagImageHook `json:"tagImages,omitempty" description:"a list of image stream tags that should be updated to the latest value on this deployment if the deployment succeeds"`
 }
 
 // LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
@@ -117,6 +122,15 @@ type ExecNewPodHook struct {
 	// copied to the hook pod. Volumes names not found in pod spec are ignored.
 	// An empty list means no volumes will be copied.
 	Volumes []string `json:"volumes,omitempty" description:"the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"`
+}
+
+// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
+type TagImageHook struct {
+	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single
+	// container this value will be defaulted to the name of that container.
+	ContainerName string `json:"containerName" description:"the name of a container in this deployment config whose image will be used as the tag destination; if only one container is defined it will default to that value"`
+	// To is the target ImageStreamTag to set the container's image onto.
+	To kapi.ObjectReference `json:"to" description:"the name of an ImageStreamTag in the current namespace that will be updated with the image value"`
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -28,12 +28,14 @@ const (
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
 	Type DeploymentStrategyType `json:"type,omitempty" description:"the name of a deployment strategy"`
+
 	// CustomParams are the input to the Custom deployment strategy.
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty" description:"input to the Custom deployment strategy"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty" description:"input to the Recreate deployment strategy"`
 	// RollingParams are the input to the Rolling deployment strategy.
 	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty" description:"input to the Rolling deployment strategy"`
+
 	// Compute resource requirements to execute the deployment
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"resource requirements to execute the deployment"`
 	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
@@ -82,12 +84,16 @@ type RecreateDeploymentStrategyParams struct {
 	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the deployment"`
 }
 
-// Handler defines a specific deployment lifecycle action.
+// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
 type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
 	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy" description:"what action to take if the hook fails"`
+
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
 	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty" description:"options for an ExecNewPodHook"`
+
+	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag if the deployment succeeds.
+	TagImages []TagImageHook `json:"tagImages,omitempty" description:"a list of image stream tags that should be updated to the latest value on this deployment if the deployment succeeds"`
 }
 
 // HandlerFailurePolicy describes possibles actions to take if a hook fails.
@@ -117,6 +123,14 @@ type ExecNewPodHook struct {
 	// copied to the hook pod. Volumes names not found in pod spec are ignored.
 	// An empty list means no volumes will be copied.
 	Volumes []string `json:"volumes,omitempty" description:"the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"`
+}
+
+// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
+type TagImageHook struct {
+	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag
+	ContainerName string `json:"containerName" description:"the name of a container in this deployment config whose image will be used as the tag destination"`
+	// To is the target ImageStreamTag to set the image of
+	To kapi.ObjectReference `json:"to" description:"the name of an ImageStreamTag in the current namespace that will be updated with the image value"`
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment

--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -236,8 +236,8 @@ func TestRecreate_deploymentPostHookFail(t *testing.T) {
 	}
 
 	err := strategy.Deploy(nil, deployment, 2)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
+	if err == nil {
+		t.Fatalf("unexpected non deploy error: %#v", err)
 	}
 	if !hookExecuted {
 		t.Fatalf("expected hook execution")

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -187,7 +187,7 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 	}{
 		{rollingParams(deployapi.LifecycleHookFailurePolicyAbort, ""), true, true},
 		{rollingParams(deployapi.LifecycleHookFailurePolicyAbort, ""), false, false},
-		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), true, false},
+		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), true, true},
 		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), false, false},
 	}
 
@@ -205,10 +205,10 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 			t.Logf("got expected error: %v", err)
 		}
 		if err == nil && tc.deploymentShouldFail {
-			t.Errorf("expected an error for case: %v", tc)
+			t.Errorf("expected an error for case: %#v", tc)
 		}
 		if err != nil && !tc.deploymentShouldFail {
-			t.Errorf("unexpected error for case: %v: %v", tc, err)
+			t.Errorf("unexpected error for case: %#v: %v", tc, err)
 		}
 	}
 }
@@ -246,11 +246,11 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 	}{
 		{rollingParams(deployapi.LifecycleHookFailurePolicyAbort, ""), true, true},
 		{rollingParams(deployapi.LifecycleHookFailurePolicyAbort, ""), false, false},
-		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), true, false},
+		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), true, true},
 		{rollingParams("", deployapi.LifecycleHookFailurePolicyAbort), false, false},
 	}
 
-	for _, tc := range cases {
+	for i, tc := range cases {
 		config := deploytest.OkDeploymentConfig(2)
 		config.Spec.Strategy.RollingParams = tc.params
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codecs.LegacyCodec(registered.GroupOrDie(kapi.GroupName).GroupVersions[0]))
@@ -263,10 +263,10 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 			t.Logf("got expected error: %v", err)
 		}
 		if err == nil && tc.deploymentShouldFail {
-			t.Errorf("expected an error for case: %v", tc)
+			t.Errorf("%d: expected an error for case: %v", i, tc)
 		}
 		if err != nil && !tc.deploymentShouldFail {
-			t.Errorf("unexpected error for case: %v: %v", tc, err)
+			t.Errorf("%d: unexpected error for case: %v: %v", i, tc, err)
 		}
 	}
 }

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -194,6 +194,19 @@ type ImageStreamTag struct {
 	unversioned.TypeMeta
 	kapi.ObjectMeta
 
+	// Tag is the spec tag associated with this image stream tag, and it may be null
+	// if only pushes have occured to this image stream.
+	Tag *TagReference
+
+	// Generation is the current generation of the tagged image - if tag is provided
+	// and this value is not equal to the tag generation, a user has requested an
+	// import that has not completed, or Conditions will be filled out indicating any
+	// error.
+	Generation int64
+
+	// Conditions is an array of conditions that apply to the image stream tag.
+	Conditions []TagEventCondition
+
 	// The Image associated with the ImageStream and tag.
 	Image Image
 }

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -75,7 +75,7 @@ type TagReference struct {
 	// Name of the tag
 	Name string `json:"name" description:"name of tag"`
 	// Annotations associated with images using this tag
-	Annotations map[string]string `json:"annotations,omitempty" description:"annotations associated with images using this tag"`
+	Annotations map[string]string `json:"annotations" description:"annotations associated with images using this tag"`
 	// From is a reference to an image stream tag or image stream this tag should track
 	From *kapi.ObjectReference `json:"from,omitempty" description:"a reference to an image stream tag or image stream this tag should track"`
 	// Reference states if the tag will be imported. Default value is false, which means the tag will be imported.
@@ -164,6 +164,19 @@ type ImageStreamMapping struct {
 type ImageStreamTag struct {
 	unversioned.TypeMeta `json:",inline"`
 	kapi.ObjectMeta      `json:"metadata,omitempty"`
+
+	// Tag is the spec tag associated with this image stream tag, and it may be null
+	// if only pushes have occured to this image stream.
+	Tag *TagReference `json:"tag" description:"the spec tag (optional) that is associated with this ImageStream"`
+
+	// Generation is the current generation of the tagged image - if tag is provided
+	// and this value is not equal to the tag generation, a user has requested an
+	// import that has not completed, or Conditions will be filled out indicating any
+	// error.
+	Generation int64 `json:"generation" description:"the generation of the tagged image, if not equal to the tag generation or the latest condition generation, there is an image import pending"`
+
+	// Conditions is an array of conditions that apply to the image stream tag.
+	Conditions []TagEventCondition `json:"conditions,omitempty" description:"the set of conditions that apply to this tag"`
 
 	// Image associated with the ImageStream and tag.
 	Image Image `json:"image" description:"the image associated with the ImageStream and tag"`

--- a/pkg/image/api/v1beta3/types.go
+++ b/pkg/image/api/v1beta3/types.go
@@ -71,7 +71,7 @@ type ImageStreamSpec struct {
 // TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
 type TagReference struct {
 	Name        string                `json:"name"`
-	Annotations map[string]string     `json:"annotations,omitempty"`
+	Annotations map[string]string     `json:"annotations"`
 	From        *kapi.ObjectReference `json:"from,omitempty"`
 	// Reference states if the tag will be imported. Default value is false, which means the tag will be imported.
 	Reference bool `json:"reference,omitempty" description:"if true consider this tag a reference only and do not attempt to import metadata about the image"`

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -137,7 +137,7 @@ func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, boo
 		istag.ResourceVersion = imageStream.ResourceVersion
 	}
 	if imageStream.ResourceVersion != istag.ResourceVersion {
-		return nil, false, kapierrors.NewConflict("imageStreamTag", istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
+		return nil, false, kapierrors.NewConflict(api.Resource("imagestreamtags"), istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
 	}
 
 	// create the synthetic old istag
@@ -220,7 +220,7 @@ func (r *REST) Delete(ctx kapi.Context, id string) (runtime.Object, error) {
 	}
 
 	if notFound {
-		return nil, kapierrors.NewNotFound(api.Resource("imagestreamtag"), tag)
+		return nil, kapierrors.NewNotFound(api.Resource("imagestreamtags"), tag)
 	}
 
 	if _, err = r.imageStreamRegistry.UpdateImageStream(ctx, stream); err != nil {
@@ -234,7 +234,7 @@ func (r *REST) Delete(ctx kapi.Context, id string) (runtime.Object, error) {
 func (r *REST) imageFor(ctx kapi.Context, tag string, imageStream *api.ImageStream) (*api.Image, error) {
 	event := api.LatestTaggedImage(imageStream, tag)
 	if event == nil || len(event.Image) == 0 {
-		return nil, kapierrors.NewNotFound(api.Resource("imagestreamtag"), api.JoinImageStreamTag(imageStream.Name, tag))
+		return nil, kapierrors.NewNotFound(api.Resource("imagestreamtags"), api.JoinImageStreamTag(imageStream.Name, tag))
 	}
 
 	return r.imageRegistry.GetImage(ctx, event.Image)
@@ -248,7 +248,7 @@ func newISTag(tag string, imageStream *api.ImageStream, image *api.Image, allowE
 	event := api.LatestTaggedImage(imageStream, tag)
 	if event == nil || len(event.Image) == 0 {
 		if !allowEmptyEvent {
-			return nil, kapierrors.NewNotFound("imagestreamtag", istagName)
+			return nil, kapierrors.NewNotFound(api.Resource("imagestreamtags"), istagName)
 		}
 		event = &api.TagEvent{
 			Created: imageStream.CreationTimestamp,

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -66,8 +66,11 @@ func (r *REST) List(ctx kapi.Context, options *kapi.ListOptions) (runtime.Object
 	list := &api.ImageStreamTagList{}
 	for _, currIS := range imageStreams.Items {
 		for currTag := range currIS.Status.Tags {
-			istag, err := newISTag(currTag, &currIS, nil)
+			istag, err := newISTag(currTag, &currIS, nil, false)
 			if err != nil {
+				if kapierrors.IsNotFound(err) {
+					continue
+				}
 				return nil, err
 			}
 			matches, err := matcher.Matches(istag)
@@ -101,7 +104,7 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 		return nil, err
 	}
 
-	return newISTag(tag, imageStream, image)
+	return newISTag(tag, imageStream, image, false)
 }
 
 func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
@@ -110,41 +113,82 @@ func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, boo
 		return nil, false, kapierrors.NewBadRequest(fmt.Sprintf("obj is not an ImageStreamTag: %#v", obj))
 	}
 
-	old, err := r.Get(ctx, istag.Name)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if err := rest.BeforeUpdate(Strategy, ctx, obj, old); err != nil {
-		return nil, false, err
-	}
-
-	// we only allow updates of annotations, so lets find the correct image stream and update it.
 	name, tag, err := nameAndTag(istag.Name)
 	if err != nil {
 		return nil, false, err
 	}
 
 	imageStream, err := r.imageStreamRegistry.GetImageStream(ctx, name)
+	if err != nil {
+		if !kapierrors.IsNotFound(err) || len(istag.ResourceVersion) != 0 {
+			return nil, false, err
+		}
+		namespace, ok := kapi.NamespaceFrom(ctx)
+		if !ok {
+			return nil, false, kapierrors.NewBadRequest("namespace is required on ImageStreamTags")
+		}
+		imageStream = &api.ImageStream{
+			ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name},
+		}
+	}
+
+	// check for conflict
+	if len(istag.ResourceVersion) == 0 {
+		istag.ResourceVersion = imageStream.ResourceVersion
+	}
+	if imageStream.ResourceVersion != istag.ResourceVersion {
+		return nil, false, kapierrors.NewConflict("imageStreamTag", istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
+	}
+
+	// create the synthetic old istag
+	old, err := newISTag(tag, imageStream, nil, true)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(istag.ResourceVersion) == 0 {
+		if err := rest.BeforeCreate(Strategy, ctx, obj); err != nil {
+			return nil, false, err
+		}
+	} else {
+		if err := rest.BeforeUpdate(Strategy, ctx, obj, old); err != nil {
+			return nil, false, err
+		}
+	}
+
+	// update the spec tag
 	if imageStream.Spec.Tags == nil {
 		imageStream.Spec.Tags = map[string]api.TagReference{}
 	}
-	tagRef := imageStream.Spec.Tags[tag]
+	tagRef, exists := imageStream.Spec.Tags[tag]
+	// if the caller set tag, override the spec tag
+	if istag.Tag != nil {
+		tagRef = *istag.Tag
+		tagRef.Name = tag
+	}
 	tagRef.Annotations = istag.Annotations
 	imageStream.Spec.Tags[tag] = tagRef
 
-	newImageStream, err := r.imageStreamRegistry.UpdateImageStream(ctx, imageStream)
+	// mutate the image stream
+	var newImageStream *api.ImageStream
+	if imageStream.CreationTimestamp.IsZero() {
+		newImageStream, err = r.imageStreamRegistry.CreateImageStream(ctx, imageStream)
+	} else {
+		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, imageStream)
+	}
 	if err != nil {
 		return nil, false, err
 	}
 
 	image, err := r.imageFor(ctx, tag, newImageStream)
 	if err != nil {
-		return nil, false, err
+		if !kapierrors.IsNotFound(err) {
+			return nil, false, err
+		}
 	}
 
-	newISTag, err := newISTag(tag, newImageStream, image)
-	return newISTag, false, err
+	newISTag, err := newISTag(tag, newImageStream, image, true)
+	return newISTag, !exists, err
 }
 
 // Delete removes a tag from a stream. `id` is of the format <stream name>:<tag>.
@@ -196,12 +240,19 @@ func (r *REST) imageFor(ctx kapi.Context, tag string, imageStream *api.ImageStre
 	return r.imageRegistry.GetImage(ctx, event.Image)
 }
 
-func newISTag(tag string, imageStream *api.ImageStream, image *api.Image) (*api.ImageStreamTag, error) {
+// newISTag initializes an image stream tag from an image stream and image. The allowEmptyEvent will create a tag even
+// in the event that the status tag does does not exist yet (no image has successfully been tagged) or the image is nil.
+func newISTag(tag string, imageStream *api.ImageStream, image *api.Image, allowEmptyEvent bool) (*api.ImageStreamTag, error) {
 	istagName := api.JoinImageStreamTag(imageStream.Name, tag)
 
 	event := api.LatestTaggedImage(imageStream, tag)
 	if event == nil || len(event.Image) == 0 {
-		return nil, kapierrors.NewNotFound(api.Resource("imagestreamtag"), istagName)
+		if !allowEmptyEvent {
+			return nil, kapierrors.NewNotFound("imagestreamtag", istagName)
+		}
+		event = &api.TagEvent{
+			Created: imageStream.CreationTimestamp,
+		}
 	}
 
 	ist := &api.ImageStreamTag{
@@ -212,12 +263,25 @@ func newISTag(tag string, imageStream *api.ImageStream, image *api.Image) (*api.
 			Annotations:       map[string]string{},
 			ResourceVersion:   imageStream.ResourceVersion,
 		},
+		Generation: event.Generation,
+		Conditions: imageStream.Status.Tags[tag].Conditions,
 	}
 
-	// if the imageStream has Spec.Tags[tag].Annotations[k] = v, copy it to the image's annotations
-	// and add them to the istag's annotations
 	if imageStream.Spec.Tags != nil {
 		if tagRef, ok := imageStream.Spec.Tags[tag]; ok {
+			// copy the spec tag
+			ist.Tag = &tagRef
+			if from := ist.Tag.From; from != nil {
+				copied := *from
+				ist.Tag.From = &copied
+			}
+			if gen := ist.Tag.Generation; gen != nil {
+				copied := *gen
+				ist.Tag.Generation = &copied
+			}
+
+			// if the imageStream has Spec.Tags[tag].Annotations[k] = v, copy it to the image's annotations
+			// and add them to the istag's annotations
 			if image != nil && image.Annotations == nil {
 				image.Annotations = make(map[string]string)
 			}

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -177,7 +177,7 @@ func TestGetImageStreamTag(t *testing.T) {
 					},
 				}},
 			expectError:     true,
-			errorTargetKind: "imagestreamtag",
+			errorTargetKind: "imagestreamtags",
 			errorTargetID:   "test:latest",
 		},
 		"missing image": {
@@ -205,7 +205,7 @@ func TestGetImageStreamTag(t *testing.T) {
 					},
 				}},
 			expectError:     true,
-			errorTargetKind: "imagestreamtag",
+			errorTargetKind: "imagestreamtags",
 			errorTargetID:   "test:latest",
 		},
 	}

--- a/pkg/image/registry/imagestreamtag/strategy.go
+++ b/pkg/image/registry/imagestreamtag/strategy.go
@@ -28,6 +28,14 @@ func (s *strategy) NamespaceScoped() bool {
 }
 
 func (s *strategy) PrepareForCreate(obj runtime.Object) {
+	newIST := obj.(*api.ImageStreamTag)
+
+	newIST.Conditions = nil
+	newIST.Image = api.Image{}
+}
+
+func (s *strategy) GenerateName(base string) string {
+	return base
 }
 
 func (s *strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
@@ -52,6 +60,12 @@ func (s *strategy) PrepareForUpdate(obj, old runtime.Object) {
 	newIST := obj.(*api.ImageStreamTag)
 	oldIST := old.(*api.ImageStreamTag)
 
+	// for backwards compatibility, callers can't be required to set both annotation locations when
+	// doing a GET and then update.
+	if newIST.Tag != nil {
+		newIST.Tag.Annotations = newIST.Annotations
+	}
+	newIST.Conditions = oldIST.Conditions
 	newIST.SelfLink = oldIST.SelfLink
 	newIST.Image = oldIST.Image
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -224,7 +224,7 @@ oc logs buildconfigs/ruby-sample-build --loglevel=6
 oc logs buildconfig/ruby-sample-build --loglevel=6
 echo "logs: ok"
 
-echo "[INFO] Starting a deployment to test scaling..."
+echo "[INFO] Starting a deployment to test scaling and image tag..."
 oc create -f test/integration/fixtures/test-deployment-config.yaml
 # scaling which might conflict with the deployment should work
 oc scale dc/test-deployment-config --replicas=2
@@ -232,6 +232,8 @@ tryuntil '[ "$(oc get rc/test-deployment-config-1 -o yaml | grep Complete)" ]'
 # scale rc via deployment configuration
 oc scale dc/test-deployment-config --replicas=3 --timeout=1m
 oc delete dc/test-deployment-config
+# expect the post deployment action to set a tag
+oc get istag/origin-ruby-sample:deployed
 echo "scale: ok"
 
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} with non-existing commit..."

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -637,6 +637,12 @@ items:
     - pods/log
     verbs:
     - get
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - imagestreamtags
+    verbs:
+    - update
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/integration/fixtures/test-deployment-config.yaml
+++ b/test/integration/fixtures/test-deployment-config.yaml
@@ -10,6 +10,13 @@ spec:
     type: Recreate
     recreateParams:
       timeoutSeconds: 10
+      post:
+        failurePolicy: Ignore
+        tagImages:
+        - containerName: ruby-helloworld
+          to:
+            kind: ImageStreamTag
+            name: origin-ruby-sample:deployed
   template:
     metadata:
       labels:


### PR DESCRIPTION
Add an "after" action set that can tag the deployed image into an image stream tag after the deployment succeeds. Allows an e2e style test to tag a :dev image into a :tested or :qe-ready tag (see transient PR #6930).

Use case: you run a deployment - if it succeeds, you tag the image into a "stable" branch for someone else to trigger on.

TODO:

* [x] tests for imagestreamtag update
* [x] e2e tests for tagging
* [x] decision on abort policy
* [x] structure of the after type - might be better as an array of after actions in order
* [x] better factoring of the code in deployer - should it be treated like a hook?  what abstraction do we need for future growth

@kargakis @ironcladlou @bparees