### PR TITLE
Replace TagReference with NamedTagReference

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -19947,14 +19947,14 @@
      "tags": {
       "type": "array",
       "items": {
-       "$ref": "v1.NamedTagReference"
+       "$ref": "v1.TagReference"
       },
       "description": "map arbitrary string values to specific image locators"
      }
     }
    },
-   "v1.NamedTagReference": {
-    "id": "v1.NamedTagReference",
+   "v1.TagReference": {
+    "id": "v1.TagReference",
     "required": [
      "name",
      "generation"

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -2357,6 +2357,7 @@ func deepCopy_api_TagImportPolicy(in imageapi.TagImportPolicy, out *imageapi.Tag
 }
 
 func deepCopy_api_TagReference(in imageapi.TagReference, out *imageapi.TagReference, c *conversion.Cloner) error {
+	out.Name = in.Name
 	if in.Annotations != nil {
 		out.Annotations = make(map[string]string)
 		for key, val := range in.Annotations {

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -165,6 +165,10 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 			if j.Tags == nil {
 				j.Tags = make(map[string]image.TagReference)
 			}
+			for k, v := range j.Tags {
+				v.Name = k
+				j.Tags[k] = v
+			}
 		},
 		func(j *image.ImageStreamStatus, c fuzz.Continue) {
 			c.FuzzNoCustom(j)

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -2082,9 +2082,9 @@ func deepCopy_v1_ImageStreamMapping(in imageapiv1.ImageStreamMapping, out *image
 func deepCopy_v1_ImageStreamSpec(in imageapiv1.ImageStreamSpec, out *imageapiv1.ImageStreamSpec, c *conversion.Cloner) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	if in.Tags != nil {
-		out.Tags = make([]imageapiv1.NamedTagReference, len(in.Tags))
+		out.Tags = make([]imageapiv1.TagReference, len(in.Tags))
 		for i := range in.Tags {
-			if err := deepCopy_v1_NamedTagReference(in.Tags[i], &out.Tags[i], c); err != nil {
+			if err := deepCopy_v1_TagReference(in.Tags[i], &out.Tags[i], c); err != nil {
 				return err
 			}
 		}
@@ -2175,38 +2175,6 @@ func deepCopy_v1_NamedTagEventList(in imageapiv1.NamedTagEventList, out *imageap
 	return nil
 }
 
-func deepCopy_v1_NamedTagReference(in imageapiv1.NamedTagReference, out *imageapiv1.NamedTagReference, c *conversion.Cloner) error {
-	out.Name = in.Name
-	if in.Annotations != nil {
-		out.Annotations = make(map[string]string)
-		for key, val := range in.Annotations {
-			out.Annotations[key] = val
-		}
-	} else {
-		out.Annotations = nil
-	}
-	if in.From != nil {
-		if newVal, err := c.DeepCopy(in.From); err != nil {
-			return err
-		} else {
-			out.From = newVal.(*pkgapiv1.ObjectReference)
-		}
-	} else {
-		out.From = nil
-	}
-	out.Reference = in.Reference
-	if in.Generation != nil {
-		out.Generation = new(int64)
-		*out.Generation = *in.Generation
-	} else {
-		out.Generation = nil
-	}
-	if err := deepCopy_v1_TagImportPolicy(in.ImportPolicy, &out.ImportPolicy, c); err != nil {
-		return err
-	}
-	return nil
-}
-
 func deepCopy_v1_RepositoryImportSpec(in imageapiv1.RepositoryImportSpec, out *imageapiv1.RepositoryImportSpec, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.From); err != nil {
 		return err
@@ -2276,6 +2244,38 @@ func deepCopy_v1_TagEventCondition(in imageapiv1.TagEventCondition, out *imageap
 func deepCopy_v1_TagImportPolicy(in imageapiv1.TagImportPolicy, out *imageapiv1.TagImportPolicy, c *conversion.Cloner) error {
 	out.Insecure = in.Insecure
 	out.Scheduled = in.Scheduled
+	return nil
+}
+
+func deepCopy_v1_TagReference(in imageapiv1.TagReference, out *imageapiv1.TagReference, c *conversion.Cloner) error {
+	out.Name = in.Name
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	if in.From != nil {
+		if newVal, err := c.DeepCopy(in.From); err != nil {
+			return err
+		} else {
+			out.From = newVal.(*pkgapiv1.ObjectReference)
+		}
+	} else {
+		out.From = nil
+	}
+	out.Reference = in.Reference
+	if in.Generation != nil {
+		out.Generation = new(int64)
+		*out.Generation = *in.Generation
+	} else {
+		out.Generation = nil
+	}
+	if err := deepCopy_v1_TagImportPolicy(in.ImportPolicy, &out.ImportPolicy, c); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3128,12 +3128,12 @@ func init() {
 		deepCopy_v1_ImageStreamTag,
 		deepCopy_v1_ImageStreamTagList,
 		deepCopy_v1_NamedTagEventList,
-		deepCopy_v1_NamedTagReference,
 		deepCopy_v1_RepositoryImportSpec,
 		deepCopy_v1_RepositoryImportStatus,
 		deepCopy_v1_TagEvent,
 		deepCopy_v1_TagEventCondition,
 		deepCopy_v1_TagImportPolicy,
+		deepCopy_v1_TagReference,
 		deepCopy_v1_OAuthAccessToken,
 		deepCopy_v1_OAuthAccessTokenList,
 		deepCopy_v1_OAuthAuthorizeToken,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1968,9 +1968,9 @@ func deepCopy_v1beta3_ImageStreamMapping(in imageapiv1beta3.ImageStreamMapping, 
 func deepCopy_v1beta3_ImageStreamSpec(in imageapiv1beta3.ImageStreamSpec, out *imageapiv1beta3.ImageStreamSpec, c *conversion.Cloner) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	if in.Tags != nil {
-		out.Tags = make([]imageapiv1beta3.NamedTagReference, len(in.Tags))
+		out.Tags = make([]imageapiv1beta3.TagReference, len(in.Tags))
 		for i := range in.Tags {
-			if err := deepCopy_v1beta3_NamedTagReference(in.Tags[i], &out.Tags[i], c); err != nil {
+			if err := deepCopy_v1beta3_TagReference(in.Tags[i], &out.Tags[i], c); err != nil {
 				return err
 			}
 		}
@@ -2052,38 +2052,6 @@ func deepCopy_v1beta3_NamedTagEventList(in imageapiv1beta3.NamedTagEventList, ou
 	return nil
 }
 
-func deepCopy_v1beta3_NamedTagReference(in imageapiv1beta3.NamedTagReference, out *imageapiv1beta3.NamedTagReference, c *conversion.Cloner) error {
-	out.Name = in.Name
-	if in.Annotations != nil {
-		out.Annotations = make(map[string]string)
-		for key, val := range in.Annotations {
-			out.Annotations[key] = val
-		}
-	} else {
-		out.Annotations = nil
-	}
-	if in.From != nil {
-		if newVal, err := c.DeepCopy(in.From); err != nil {
-			return err
-		} else {
-			out.From = newVal.(*pkgapiv1beta3.ObjectReference)
-		}
-	} else {
-		out.From = nil
-	}
-	out.Reference = in.Reference
-	if in.Generation != nil {
-		out.Generation = new(int64)
-		*out.Generation = *in.Generation
-	} else {
-		out.Generation = nil
-	}
-	if err := deepCopy_v1beta3_TagImportPolicy(in.ImportPolicy, &out.ImportPolicy, c); err != nil {
-		return err
-	}
-	return nil
-}
-
 func deepCopy_v1beta3_TagEvent(in imageapiv1beta3.TagEvent, out *imageapiv1beta3.TagEvent, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.Created); err != nil {
 		return err
@@ -2113,6 +2081,38 @@ func deepCopy_v1beta3_TagEventCondition(in imageapiv1beta3.TagEventCondition, ou
 func deepCopy_v1beta3_TagImportPolicy(in imageapiv1beta3.TagImportPolicy, out *imageapiv1beta3.TagImportPolicy, c *conversion.Cloner) error {
 	out.Insecure = in.Insecure
 	out.Scheduled = in.Scheduled
+	return nil
+}
+
+func deepCopy_v1beta3_TagReference(in imageapiv1beta3.TagReference, out *imageapiv1beta3.TagReference, c *conversion.Cloner) error {
+	out.Name = in.Name
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	if in.From != nil {
+		if newVal, err := c.DeepCopy(in.From); err != nil {
+			return err
+		} else {
+			out.From = newVal.(*pkgapiv1beta3.ObjectReference)
+		}
+	} else {
+		out.From = nil
+	}
+	out.Reference = in.Reference
+	if in.Generation != nil {
+		out.Generation = new(int64)
+		*out.Generation = *in.Generation
+	} else {
+		out.Generation = nil
+	}
+	if err := deepCopy_v1beta3_TagImportPolicy(in.ImportPolicy, &out.ImportPolicy, c); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2960,10 +2960,10 @@ func init() {
 		deepCopy_v1beta3_ImageStreamTag,
 		deepCopy_v1beta3_ImageStreamTagList,
 		deepCopy_v1beta3_NamedTagEventList,
-		deepCopy_v1beta3_NamedTagReference,
 		deepCopy_v1beta3_TagEvent,
 		deepCopy_v1beta3_TagEventCondition,
 		deepCopy_v1beta3_TagImportPolicy,
+		deepCopy_v1beta3_TagReference,
 		deepCopy_v1beta3_OAuthAccessToken,
 		deepCopy_v1beta3_OAuthAccessTokenList,
 		deepCopy_v1beta3_OAuthAuthorizeToken,

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -89,6 +89,8 @@ type ImageStreamSpec struct {
 // TagReference specifies optional annotations for images using this tag and an optional reference to
 // an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
 type TagReference struct {
+	// Name of the tag
+	Name string
 	// Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.
 	Annotations map[string]string
 	// Optional; if specified, a reference to another image that this tag should point to. Valid values

--- a/pkg/image/api/v1/conversion.go
+++ b/pkg/image/api/v1/conversion.go
@@ -104,7 +104,7 @@ func convert_api_ImageStreamSpec_To_v1_ImageStreamSpec(in *newer.ImageStreamSpec
 			}
 		}
 	}
-	out.Tags = make([]NamedTagReference, 0, 0)
+	out.Tags = make([]TagReference, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
@@ -189,28 +189,17 @@ func init() {
 
 			return nil
 		},
-		func(in *[]NamedTagReference, out *map[string]newer.TagReference, s conversion.Scope) error {
+		func(in *[]TagReference, out *map[string]newer.TagReference, s conversion.Scope) error {
 			for _, curr := range *in {
-				r := newer.TagReference{
-					Annotations: curr.Annotations,
-					Reference:   curr.Reference,
-					ImportPolicy: newer.TagImportPolicy{
-						Insecure:  curr.ImportPolicy.Insecure,
-						Scheduled: curr.ImportPolicy.Scheduled,
-					},
-				}
-				if curr.Generation != nil {
-					gen := *curr.Generation
-					r.Generation = &gen
-				}
-				if err := s.Convert(&curr.From, &r.From, 0); err != nil {
+				r := newer.TagReference{}
+				if err := s.Convert(&curr, &r, 0); err != nil {
 					return err
 				}
 				(*out)[curr.Name] = r
 			}
 			return nil
 		},
-		func(in *map[string]newer.TagReference, out *[]NamedTagReference, s conversion.Scope) error {
+		func(in *map[string]newer.TagReference, out *[]TagReference, s conversion.Scope) error {
 			allTags := make([]string, 0, len(*in))
 			for tag := range *in {
 				allTags = append(allTags, tag)
@@ -219,22 +208,11 @@ func init() {
 
 			for _, tag := range allTags {
 				newTagReference := (*in)[tag]
-				oldTagReference := NamedTagReference{
-					Name:        tag,
-					Annotations: newTagReference.Annotations,
-					Reference:   newTagReference.Reference,
-					ImportPolicy: TagImportPolicy{
-						Insecure:  newTagReference.ImportPolicy.Insecure,
-						Scheduled: newTagReference.ImportPolicy.Scheduled,
-					},
-				}
-				if newTagReference.Generation != nil {
-					gen := *newTagReference.Generation
-					oldTagReference.Generation = &gen
-				}
-				if err := s.Convert(&newTagReference.From, &oldTagReference.From, 0); err != nil {
+				oldTagReference := TagReference{}
+				if err := s.Convert(&newTagReference, &oldTagReference, 0); err != nil {
 					return err
 				}
+				oldTagReference.Name = tag
 				*out = append(*out, oldTagReference)
 			}
 			return nil

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -67,11 +67,11 @@ type ImageStreamSpec struct {
 	// DockerImageRepository is optional, if specified this stream is backed by a Docker repository on this server
 	DockerImageRepository string `json:"dockerImageRepository,omitempty" description:"optional field if specified this stream is backed by a Docker repository on this server"`
 	// Tags map arbitrary string values to specific image locators
-	Tags []NamedTagReference `json:"tags,omitempty" description:"map arbitrary string values to specific image locators"`
+	Tags []TagReference `json:"tags,omitempty" description:"map arbitrary string values to specific image locators"`
 }
 
-// NamedTagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
-type NamedTagReference struct {
+// TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
+type TagReference struct {
 	// Name of the tag
 	Name string `json:"name" description:"name of tag"`
 	// Annotations associated with images using this tag

--- a/pkg/image/api/v1beta3/conversion.go
+++ b/pkg/image/api/v1beta3/conversion.go
@@ -81,7 +81,7 @@ func convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec,
 
 func convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec(in *newer.ImageStreamSpec, out *ImageStreamSpec, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
-	out.Tags = make([]NamedTagReference, 0, 0)
+	out.Tags = make([]TagReference, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
@@ -237,28 +237,17 @@ func init() {
 
 			return nil
 		},
-		func(in *[]NamedTagReference, out *map[string]newer.TagReference, s conversion.Scope) error {
+		func(in *[]TagReference, out *map[string]newer.TagReference, s conversion.Scope) error {
 			for _, curr := range *in {
-				r := newer.TagReference{
-					Annotations: curr.Annotations,
-					Reference:   curr.Reference,
-					ImportPolicy: newer.TagImportPolicy{
-						Insecure:  curr.ImportPolicy.Insecure,
-						Scheduled: curr.ImportPolicy.Scheduled,
-					},
-				}
-				if curr.Generation != nil {
-					gen := *curr.Generation
-					r.Generation = &gen
-				}
-				if err := s.Convert(&curr.From, &r.From, 0); err != nil {
+				r := newer.TagReference{}
+				if err := s.Convert(&curr, &r, 0); err != nil {
 					return err
 				}
 				(*out)[curr.Name] = r
 			}
 			return nil
 		},
-		func(in *map[string]newer.TagReference, out *[]NamedTagReference, s conversion.Scope) error {
+		func(in *map[string]newer.TagReference, out *[]TagReference, s conversion.Scope) error {
 			allTags := make([]string, 0, len(*in))
 			for tag := range *in {
 				allTags = append(allTags, tag)
@@ -267,22 +256,11 @@ func init() {
 
 			for _, tag := range allTags {
 				newTagReference := (*in)[tag]
-				oldTagReference := NamedTagReference{
-					Name:        tag,
-					Annotations: newTagReference.Annotations,
-					Reference:   newTagReference.Reference,
-					ImportPolicy: TagImportPolicy{
-						Insecure:  newTagReference.ImportPolicy.Insecure,
-						Scheduled: newTagReference.ImportPolicy.Scheduled,
-					},
-				}
-				if newTagReference.Generation != nil {
-					gen := *newTagReference.Generation
-					oldTagReference.Generation = &gen
-				}
-				if err := s.Convert(&newTagReference.From, &oldTagReference.From, 0); err != nil {
+				oldTagReference := TagReference{}
+				if err := s.Convert(&newTagReference, &oldTagReference, 0); err != nil {
 					return err
 				}
+				oldTagReference.Name = tag
 				*out = append(*out, oldTagReference)
 			}
 			return nil

--- a/pkg/image/api/v1beta3/types.go
+++ b/pkg/image/api/v1beta3/types.go
@@ -65,11 +65,11 @@ type ImageStreamSpec struct {
 	// Optional, if specified this stream is backed by a Docker repository on this server
 	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
 	// Tags map arbitrary string values to specific image locators
-	Tags []NamedTagReference `json:"tags,omitempty"`
+	Tags []TagReference `json:"tags,omitempty"`
 }
 
-// NamedTagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
-type NamedTagReference struct {
+// TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.
+type TagReference struct {
 	Name        string                `json:"name"`
 	Annotations map[string]string     `json:"annotations,omitempty"`
 	From        *kapi.ObjectReference `json:"from,omitempty"`

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -75,10 +75,6 @@ func ValidateImageStream(stream *api.ImageStream) field.ErrorList {
 		result = append(result, field.Invalid(field.NewPath("metadata", "name"), stream.Name, fmt.Sprintf("'namespace/name' cannot be longer than %d characters", reference.NameTotalLengthMax)))
 	}
 
-	if stream.Spec.Tags == nil {
-		stream.Spec.Tags = make(map[string]api.TagReference)
-	}
-
 	if len(stream.Spec.DockerImageRepository) != 0 {
 		dockerImageRepositoryPath := field.NewPath("spec", "dockerImageRepository")
 		if ref, err := api.ParseDockerImageReference(stream.Spec.DockerImageRepository); err != nil {

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -426,6 +426,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 		three := int64(3)
 		expectedStreamSpec := map[string]api.TagReference{
 			"another": {
+				Name: "another",
 				From: &kapi.ObjectReference{
 					Kind: "ImageStreamTag",
 					Name: "test:foo",


### PR DESCRIPTION
Having two different types internally and externally was not useful, and
made it harder to keep the types in sync and reason about their
conversions.

Extracted from #6925

[test]