### PR TITLE
Move graph helpers to deploy/api

### DIFF
--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"fmt"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // DeploymentToPodLogOptions builds a PodLogOptions object out of a DeploymentLogOptions.
@@ -27,5 +31,91 @@ func ScaleFromConfig(dc *DeploymentConfig) *extensions.Scale {
 			Namespace:         dc.Namespace,
 			CreationTimestamp: dc.CreationTimestamp,
 		},
+	}
+}
+
+// TemplateImage is a structure for helping a caller iterate over a PodSpec
+type TemplateImage struct {
+	Image string
+
+	Ref *imageapi.DockerImageReference
+
+	From *kapi.ObjectReference
+
+	Container *kapi.Container
+}
+
+// TemplateImageForContainer locates the requested container in a pod spec, returning information about the
+// trigger (if it exists), or an error.
+func TemplateImageForContainer(pod *kapi.PodSpec, triggerFn TriggeredByFunc, containerName string) (TemplateImage, error) {
+	for i := range pod.Containers {
+		container := &pod.Containers[i]
+		if container.Name != containerName {
+			continue
+		}
+		var ref imageapi.DockerImageReference
+		if trigger, ok := triggerFn(container); ok {
+			trigger.Image = container.Image
+			trigger.Container = container
+			return trigger, nil
+		}
+		ref, err := imageapi.ParseDockerImageReference(container.Image)
+		if err != nil {
+			return TemplateImage{Image: container.Image, Container: container}, err
+		}
+		return TemplateImage{Image: container.Image, Ref: &ref, Container: container}, nil
+	}
+	return TemplateImage{}, fmt.Errorf("no container %q found", containerName)
+}
+
+// EachTemplateImage iterates a pod spec, looking for triggers that match each container and invoking
+// fn with each located image.
+func EachTemplateImage(pod *kapi.PodSpec, triggerFn TriggeredByFunc, fn func(TemplateImage, error)) {
+	for i := range pod.Containers {
+		container := &pod.Containers[i]
+		var ref imageapi.DockerImageReference
+		if trigger, ok := triggerFn(container); ok {
+			trigger.Image = container.Image
+			trigger.Container = container
+			fn(trigger, nil)
+			continue
+		}
+		ref, err := imageapi.ParseDockerImageReference(container.Image)
+		if err != nil {
+			fn(TemplateImage{Image: container.Image, Container: container}, err)
+			continue
+		}
+		fn(TemplateImage{Image: container.Image, Ref: &ref, Container: container}, nil)
+	}
+}
+
+// TriggeredByFunc returns a TemplateImage or error from the provided container
+type TriggeredByFunc func(container *kapi.Container) (TemplateImage, bool)
+
+// DeploymentConfigHasTrigger returns a function that can identify the image for each container.
+func DeploymentConfigHasTrigger(config *DeploymentConfig) TriggeredByFunc {
+	return func(container *kapi.Container) (TemplateImage, bool) {
+		for _, trigger := range config.Spec.Triggers {
+			params := trigger.ImageChangeParams
+			if params == nil {
+				continue
+			}
+			for _, name := range params.ContainerNames {
+				if container.Name == name {
+					if len(params.From.Name) == 0 {
+						continue
+					}
+					from := params.From
+					if len(from.Namespace) == 0 {
+						from.Namespace = config.Namespace
+					}
+					return TemplateImage{
+						Image: container.Image,
+						From:  &from,
+					}, true
+				}
+			}
+		}
+		return TemplateImage{}, false
 	}
 }

--- a/pkg/deploy/graph/edges.go
+++ b/pkg/deploy/graph/edges.go
@@ -5,6 +5,7 @@ import (
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
@@ -23,10 +24,10 @@ func AddTriggerEdges(g osgraph.MutableUniqueGraph, node *deploygraph.DeploymentC
 		return node
 	}
 
-	EachTemplateImage(
+	deployapi.EachTemplateImage(
 		&podTemplate.Spec,
-		DeploymentConfigHasTrigger(node.DeploymentConfig),
-		func(image TemplateImage, err error) {
+		deployapi.DeploymentConfigHasTrigger(node.DeploymentConfig),
+		func(image deployapi.TemplateImage, err error) {
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
This will allow their reuse from other deployment code.

Extracted from #6925