### PR TITLE
Test deployments

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -18170,7 +18170,8 @@
     "required": [
      "strategy",
      "triggers",
-     "replicas"
+     "replicas",
+     "test"
     ],
     "properties": {
      "strategy": {
@@ -18188,6 +18189,10 @@
       "type": "integer",
       "format": "int32",
       "description": "the desired number of replicas"
+     },
+     "test": {
+      "type": "boolean",
+      "description": "if true, this deployment config will always be scaled to 0 except while a deployment is running"
      },
      "selector": {
       "type": "any",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1491,6 +1491,7 @@ func deepCopy_api_DeploymentConfigSpec(in deployapi.DeploymentConfigSpec, out *d
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2847,6 +2847,7 @@ func autoconvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deploya
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {
@@ -3374,6 +3375,7 @@ func autoconvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *deploya
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1518,6 +1518,7 @@ func deepCopy_v1_DeploymentConfigSpec(in deployapiv1.DeploymentConfigSpec, out *
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2856,6 +2856,7 @@ func autoconvert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec(in *de
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {
@@ -3383,6 +3384,7 @@ func autoconvert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *de
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1526,6 +1526,7 @@ func deepCopy_v1beta3_DeploymentConfigSpec(in deployapiv1beta3.DeploymentConfigS
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.Test = in.Test
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -246,9 +246,15 @@ func printTriggers(triggers []deployapi.DeploymentTriggerPolicy, w *tabwriter.Wr
 func printDeploymentConfigSpec(spec deployapi.DeploymentConfigSpec, w io.Writer) error {
 	fmt.Fprint(w, "Template:\n")
 
-	fmt.Fprintf(w, "  Selector:\t%s\n  Replicas:\t%d\n",
-		formatLabels(spec.Selector),
-		spec.Replicas)
+	if spec.Test {
+		fmt.Fprintf(w, "  Selector:\t%s\n  Replicas:\t%d (test, will be scaled down between deployments)\n",
+			formatLabels(spec.Selector),
+			spec.Replicas)
+	} else {
+		fmt.Fprintf(w, "  Selector:\t%s\n  Replicas:\t%d\n",
+			formatLabels(spec.Selector),
+			spec.Replicas)
+	}
 
 	fmt.Fprintf(w, "  Containers:\n  NAME\tIMAGE\tENV\n")
 	for _, container := range spec.Template.Spec.Containers {

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -289,6 +289,7 @@ func (c *MasterConfig) RunDeployerPodController() {
 	_, kclient := c.DeployerPodControllerClients()
 	factory := deployerpodcontroller.DeployerPodControllerFactory{
 		KubeClient: kclient,
+		Codec:      c.EtcdHelper.Codec(),
 	}
 
 	controller := factory.Create()

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -150,3 +150,8 @@ func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
 		Status: OkDeploymentConfigStatus(version),
 	}
 }
+
+func TestDeploymentConfig(config *deployapi.DeploymentConfig) *deployapi.DeploymentConfig {
+	config.Spec.Test = true
+	return config
+}

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -266,6 +266,11 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int
 
+	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
+	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
+	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+	Test bool
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string
 

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -237,6 +237,11 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int `json:"replicas" description:"the desired number of replicas"`
 
+	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
+	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
+	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+	Test bool `json:"test" description:"if true, this deployment config will always be scaled to 0 except while a deployment is running"`
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -254,6 +254,11 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int `json:"replicas" description:"the desired number of replicas"`
 
+	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
+	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
+	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+	Test bool `json:"test" description:"if true, this deployment config will always be scaled to 0 except while a deployment is running"`
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 

--- a/test/extended/deployments/test_deployments.go
+++ b/test/extended/deployments/test_deployments.go
@@ -1,0 +1,101 @@
+package deployments
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("deployments: parallel: test deployment", func() {
+	defer g.GinkgoRecover()
+	var (
+		deploymentFixture = exutil.FixturePath("..", "extended", "fixtures", "test-deployment-test.yaml")
+		oc                = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
+	)
+
+	g.Describe("test deployment", func() {
+		g.It("should run a deployment to completion and then scale to zero", func() {
+			out, err := oc.Run("create").Args("-f", deploymentFixture).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			out, err = oc.Run("logs").Args("-f", "dc/deployment-test").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
+			o.Expect(out).To(o.ContainSubstring("deployment-test-1 to 2"))
+			o.Expect(out).To(o.ContainSubstring("Pre hook finished"))
+			o.Expect(out).To(o.ContainSubstring("Deployment deployment-test-1 successfully made active"))
+
+			g.By("verifying the deployment is marked complete and scaled to zero")
+			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get("deployment-test-1")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
+				if deployapi.DeploymentStatus(status) != deployapi.DeploymentStatusComplete {
+					return false, nil
+				}
+				if rc.Spec.Replicas != 0 {
+					return false, nil
+				}
+				if rc.Status.Replicas != 0 {
+					return false, nil
+				}
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that scaling does not result in new pods")
+			out, err = oc.Run("scale").Args("dc/deployment-test", "--replicas=1").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring no scale up of the deployment happens")
+			wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get("deployment-test-1")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(rc.Spec.Replicas).Should(o.BeEquivalentTo(0))
+				o.Expect(rc.Status.Replicas).Should(o.BeEquivalentTo(0))
+				return false, nil
+			})
+
+			g.By("verifying the scale is updated on the deployment config")
+			config, err := oc.REST().DeploymentConfigs(oc.Namespace()).Get("deployment-test")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(config.Spec.Replicas).Should(o.BeEquivalentTo(1))
+			o.Expect(config.Spec.Test).Should(o.BeTrue())
+
+			g.By("deploying a second time")
+			out, err = oc.Run("deploy").Args("--latest", "deployment-test").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			out, err = oc.Run("logs").Args("-f", "dc/deployment-test").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
+			o.Expect(out).To(o.ContainSubstring("deployment-test-2 up to 1"))
+			o.Expect(out).To(o.ContainSubstring("Pre hook finished"))
+
+			g.By("verifying the second deployment is marked complete and scaled to zero")
+			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get("deployment-test-2")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
+				if deployapi.DeploymentStatus(status) != deployapi.DeploymentStatusComplete {
+					return false, nil
+				}
+				if rc.Spec.Replicas != 0 {
+					return false, nil
+				}
+				if rc.Status.Replicas != 0 {
+					return false, nil
+				}
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+	})
+})

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -5,6 +5,7 @@ import (
 
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
+	_ "github.com/openshift/origin/test/extended/deployments"
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/jenkins"
 	_ "github.com/openshift/origin/test/extended/job"

--- a/test/extended/fixtures/test-deployment-test.yaml
+++ b/test/extended/fixtures/test-deployment-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: deployment-test
+spec:
+  replicas: 2
+  selector:
+    name: deployment-test
+  strategy:
+    type: Rolling
+    rollingParams:
+      pre:
+        failurePolicy: Abort
+        execNewPod:
+          containerName: myapp
+          command:
+          - /bin/echo
+          - test pre hook executed
+  template:
+    metadata:
+      labels:
+        name: deployment-test
+    spec:
+      containers:
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        command:
+        - /bin/sleep
+        - "100"
+  test: true
+  triggers:
+  - type: ConfigChange


### PR DESCRIPTION
A deployment is a deployment that is scaled to zero when it is
not running. Once the deployment reaches a terminal state its RC is
scaled to zero, and any pods are deleted. This allows the deployment to
be a test or validation environment - triggering each time a new image
is created, and ensuring that everything goes smoothly. Hooks can be
added to test function, or can pause for arbitrary periods of time in
order give the user time to test the function.

The scale number on the deployment config is considered primary - during
reconciliation of transient deployment configs any changes to individual
RCs are ignored.

TODO:

* [x] e2e test / example
* [ ] UI impact
* [x] settle on terminology

Extracted from #6925