### PR TITLE
Update java console to 1.0.42

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPENSHIFT_JVM_VERSION=v1.0.40
+OPENSHIFT_JVM_VERSION=v1.0.42
 
 STARTTIME=$(date +%s)
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..


### PR DESCRIPTION
Updates the java console to fix the following issues:

* Camel Hawt.io console hangs in Firefox with karaf-camel-amq quickstart https://bugzilla.redhat.com/show_bug.cgi?id=1287078
* A-MQ hawt.io console deleting queue does not remove it from the tree view https://bugzilla.redhat.com/show_bug.cgi?id=1287094

@jwforres FYI, thanks!