### PR TITLE
Bug 1293578 - The Router liveness/readiness probes should always use …

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -344,6 +344,13 @@ func generateProbeConfigForRouter(cfg *RouterConfig, ports []kapi.ContainerPort)
 				IntVal: int32(healthzPort),
 			},
 		}
+
+		// Workaround for misconfigured environments where the Node's InternalIP is
+		// physically present on the Node.  In those environments the probes will
+		// fail unless a host firewall port is opened
+		if cfg.HostNetwork {
+			probe.Handler.HTTPGet.Host = "localhost"
+		}
 	}
 
 	return probe

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -209,6 +209,10 @@ os::cmd::expect_success_and_text "oadm router -o yaml --credentials=${KUBECONFIG
 os::cmd::expect_success "oadm router --credentials=${KUBECONFIG} --images='${USE_IMAGES}' --service-account=router -n default"
 os::cmd::expect_success_and_text 'oadm router -n default' 'service exists'
 os::cmd::expect_success_and_text 'oc get dc/router -o yaml -n default' 'readinessProbe'
+os::cmd::expect_success_and_text 'oc get dc/router -o yaml -n default' 'host: localhost'
+
+# only when using hostnetwork should we force the probes to use localhost
+os::cmd::expect_success_and_not_text "oadm router -o yaml --credentials=${KUBECONFIG} --service-account=router -n default --host-network=false" 'host: localhost'
 echo "router: ok"
 
 # Test running a registry


### PR DESCRIPTION
…localhost

Pods using the hostNetwork are getting the default IP from the Node entry for
their liveness probe today.  In some common misconfigurations this IP will not
actually be physically present on the Node running the probes and therefore
will not be short-circuited to use the loopback interface.  In those cases the
probes will fail unless an admin manually opens up port that allows the probe
to pass.

We're putting checks in place for this situation but this seems like a
reasonable safeguard to make sure a critical piece of infrastructure comes up
the first time.