### PR TITLE
Admission control plugin to override run-once pod ActiveDeadlineSeconds

### DIFF
--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -26,6 +26,7 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"BuildOverrides",           // from origin, only needed for managing builds, not kubernetes resources
 	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube
 	"ProjectRequestLimit",      // from origin, used for limiting project requests by user (online use case)
+	"RunOnceDuration",          // from origin, used for overriding the ActiveDeadlineSeconds for run-once pods
 
 	"NamespaceExists",  // superceded by NamespaceLifecycle
 	"InitialResources", // do we want this? https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/initial-resources.md

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"
+	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/security/admission"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"

--- a/pkg/quota/admission/runonceduration/admission.go
+++ b/pkg/quota/admission/runonceduration/admission.go
@@ -1,0 +1,130 @@
+package runonceduration
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strconv"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
+	"github.com/openshift/origin/pkg/quota/admission/runonceduration/api/validation"
+)
+
+func init() {
+	admission.RegisterPlugin("RunOnceDuration", func(client kclient.Interface, config io.Reader) (admission.Interface, error) {
+		pluginConfig, err := readConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		return NewRunOnceDuration(pluginConfig), nil
+	})
+}
+
+func readConfig(reader io.Reader) (*api.RunOnceDurationConfig, error) {
+	config := &api.RunOnceDurationConfig{}
+	if reader == nil || reflect.ValueOf(reader).IsNil() {
+		return config, nil
+	}
+	configBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	err = configlatest.ReadYAML(configBytes, config)
+	if err != nil {
+		return nil, err
+	}
+	errs := validation.ValidateRunOnceDurationConfig(config)
+	if len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+	return config, nil
+}
+
+func NewRunOnceDuration(config *api.RunOnceDurationConfig) admission.Interface {
+	return &runOnceDuration{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		config:  config,
+	}
+}
+
+type runOnceDuration struct {
+	*admission.Handler
+	config *api.RunOnceDurationConfig
+	cache  *projectcache.ProjectCache
+}
+
+var _ = oadmission.WantsProjectCache(&runOnceDuration{})
+var _ = oadmission.Validator(&runOnceDuration{})
+
+func (a *runOnceDuration) Admit(attributes admission.Attributes) error {
+	switch {
+	case a.config == nil,
+		!a.config.Enabled,
+		attributes.GetResource() != kapi.Resource("pods"),
+		len(attributes.GetSubresource()) > 0:
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*kapi.Pod)
+	if !ok {
+		return admission.NewForbidden(attributes, fmt.Errorf("unexpected object: %#v", attributes.GetObject()))
+	}
+
+	// Only update pods with a restart policy of Never or OnFailure
+	switch pod.Spec.RestartPolicy {
+	case kapi.RestartPolicyNever,
+		kapi.RestartPolicyOnFailure:
+		// continue
+	default:
+		return nil
+	}
+
+	appliedProjectOverride, err := a.applyProjectAnnotationOverride(attributes.GetNamespace(), pod)
+	if err != nil {
+		return admission.NewForbidden(attributes, err)
+	}
+
+	if !appliedProjectOverride && a.config.ActiveDeadlineSecondsOverride != nil {
+		pod.Spec.ActiveDeadlineSeconds = a.config.ActiveDeadlineSecondsOverride
+	}
+	return nil
+}
+
+func (a *runOnceDuration) SetProjectCache(cache *projectcache.ProjectCache) {
+	a.cache = cache
+}
+
+func (a *runOnceDuration) Validate() error {
+	if a.cache == nil {
+		return errors.New("RunOnceDuration plugin requires a project cache")
+	}
+	return nil
+}
+
+func (a *runOnceDuration) applyProjectAnnotationOverride(namespace string, pod *kapi.Pod) (bool, error) {
+	ns, err := a.cache.GetNamespace(namespace)
+	if err != nil {
+		return false, fmt.Errorf("error looking up pod namespace: %v", err)
+	}
+	if ns.Annotations == nil {
+		return false, nil
+	}
+	override, hasOverride := ns.Annotations[api.ActiveDeadlineSecondsOverrideAnnotation]
+	if !hasOverride {
+		return false, nil
+	}
+	overrideInt64, err := strconv.ParseInt(override, 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("cannot parse the ActiveDeadlineSeconds override (%s) for project %s: %v", override, ns.Name, err)
+	}
+	pod.Spec.ActiveDeadlineSeconds = &overrideInt64
+	return true, nil
+}

--- a/pkg/quota/admission/runonceduration/admission_test.go
+++ b/pkg/quota/admission/runonceduration/admission_test.go
@@ -1,0 +1,169 @@
+package runonceduration
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
+)
+
+func testCache(projectAnnotations map[string]string) *projectcache.ProjectCache {
+	kclient := &ktestclient.Fake{}
+	pCache := projectcache.NewFake(kclient.Namespaces(), projectcache.NewCacheStore(cache.MetaNamespaceKeyFunc), "")
+	ns := &kapi.Namespace{}
+	ns.Name = "default"
+	ns.Annotations = projectAnnotations
+	pCache.Store.Add(ns)
+	return pCache
+}
+
+func testConfig(n *int64) *api.RunOnceDurationConfig {
+	return &api.RunOnceDurationConfig{
+		ActiveDeadlineSecondsOverride: n,
+		Enabled: true,
+	}
+}
+
+func testRunOncePod() *kapi.Pod {
+	pod := &kapi.Pod{}
+	pod.Spec.RestartPolicy = kapi.RestartPolicyNever
+	return pod
+}
+
+func testRestartOnFailurePod() *kapi.Pod {
+	pod := &kapi.Pod{}
+	pod.Spec.RestartPolicy = kapi.RestartPolicyOnFailure
+	return pod
+}
+
+func testRunOncePodWithDuration(n int64) *kapi.Pod {
+	pod := testRunOncePod()
+	pod.Spec.ActiveDeadlineSeconds = &n
+	return pod
+}
+
+func testRestartAlwaysPod() *kapi.Pod {
+	pod := &kapi.Pod{}
+	pod.Spec.RestartPolicy = kapi.RestartPolicyAlways
+	return pod
+}
+
+func int64p(n int64) *int64 {
+	return &n
+}
+
+func TestRunOnceDurationAdmit(t *testing.T) {
+	tests := []struct {
+		name                          string
+		config                        *api.RunOnceDurationConfig
+		pod                           *kapi.Pod
+		projectAnnotations            map[string]string
+		expectedActiveDeadlineSeconds *int64
+	}{
+		{
+			name:   "expect globally configured duration to be set",
+			config: testConfig(int64p(10)),
+			pod:    testRunOncePod(),
+			expectedActiveDeadlineSeconds: int64p(10),
+		},
+		{
+			name:   "empty config, no duration to be set",
+			config: testConfig(nil),
+			pod:    testRunOncePod(),
+			expectedActiveDeadlineSeconds: nil,
+		},
+		{
+			name:   "expect configured duration to override existing duration",
+			config: testConfig(int64p(10)),
+			pod:    testRunOncePodWithDuration(5),
+			expectedActiveDeadlineSeconds: int64p(10),
+		},
+		{
+			name:   "expect empty config to not override existing duration",
+			config: testConfig(nil),
+			pod:    testRunOncePodWithDuration(5),
+			expectedActiveDeadlineSeconds: int64p(5),
+		},
+		{
+			name:   "expect project override to be used with nil global value",
+			config: testConfig(nil),
+			pod:    testRunOncePodWithDuration(5),
+			projectAnnotations: map[string]string{
+				api.ActiveDeadlineSecondsOverrideAnnotation: "1000",
+			},
+			expectedActiveDeadlineSeconds: int64p(1000),
+		},
+		{
+			name:   "expect project override to have priority over global config value",
+			config: testConfig(int64p(10)),
+			pod:    testRunOncePodWithDuration(5),
+			projectAnnotations: map[string]string{
+				api.ActiveDeadlineSecondsOverrideAnnotation: "1000",
+			},
+			expectedActiveDeadlineSeconds: int64p(1000),
+		},
+		{
+			name:   "make no change to a pod that is not a run-once pod",
+			config: testConfig(int64p(10)),
+			pod:    testRestartAlwaysPod(),
+			expectedActiveDeadlineSeconds: nil,
+		},
+		{
+			name:   "update a pod that has a RestartOnFailure policy",
+			config: testConfig(int64p(10)),
+			pod:    testRestartOnFailurePod(),
+			expectedActiveDeadlineSeconds: int64p(10),
+		},
+	}
+
+	for _, tc := range tests {
+		runOnceDuration := NewRunOnceDuration(tc.config)
+		runOnceDuration.(oadmission.WantsProjectCache).SetProjectCache(testCache(tc.projectAnnotations))
+		pod := tc.pod
+		attrs := admission.NewAttributesRecord(pod, kapi.Kind("Pod"), "default", "test", kapi.Resource("pods"), "", admission.Create, nil)
+		err := runOnceDuration.Admit(attrs)
+		if err != nil {
+			t.Errorf("%s: unexpected admission error: %v", tc.name, err)
+			continue
+		}
+		switch {
+		case tc.expectedActiveDeadlineSeconds == nil && pod.Spec.ActiveDeadlineSeconds == nil:
+			// continue
+		case tc.expectedActiveDeadlineSeconds == nil && pod.Spec.ActiveDeadlineSeconds != nil:
+			t.Errorf("%s: expected nil ActiveDeadlineSeconds. Got: %d", tc.name, *pod.Spec.ActiveDeadlineSeconds)
+		case tc.expectedActiveDeadlineSeconds != nil && pod.Spec.ActiveDeadlineSeconds == nil:
+			t.Errorf("%s: unexpected nil ActiveDeadlineSeconds.", tc.name)
+		case *pod.Spec.ActiveDeadlineSeconds != *tc.expectedActiveDeadlineSeconds:
+			t.Errorf("%s: unexpected active deadline seconds: %d", tc.name, *pod.Spec.ActiveDeadlineSeconds)
+		}
+	}
+}
+
+func TestReadConfig(t *testing.T) {
+	configStr := `apiVersion: v1
+kind: RunOnceDurationConfig
+activeDeadlineSecondsOverride: 3600
+enabled: true
+`
+	buf := bytes.NewBufferString(configStr)
+	config, err := readConfig(buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading config: %v", err)
+	}
+	if config.ActiveDeadlineSecondsOverride == nil {
+		t.Fatalf("nil value for ActiveDeadlineSecondsOverride")
+	}
+	if *config.ActiveDeadlineSecondsOverride != 3600 {
+		t.Errorf("unexpected value for ActiveDeadlineSecondsOverride: %d", config.ActiveDeadlineSecondsOverride)
+	}
+	if !config.Enabled {
+		t.Errorf("unexpected value for Enabled")
+	}
+}

--- a/pkg/quota/admission/runonceduration/api/latest/register.go
+++ b/pkg/quota/admission/runonceduration/api/latest/register.go
@@ -1,0 +1,5 @@
+package latest
+
+import (
+	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration/api/v1"
+)

--- a/pkg/quota/admission/runonceduration/api/register.go
+++ b/pkg/quota/admission/runonceduration/api/register.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration/api/latest"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: ""}
+
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+func Kind(kind string) unversioned.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+// Resource takes an unqualified resource and returns back a Group qualified GroupResource
+func Resource(resource string) unversioned.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+func init() {
+	api.Scheme.AddKnownTypes(SchemeGroupVersion,
+		&RunOnceDurationConfig{},
+	)
+}
+
+func (*RunOnceDurationConfig) IsAnAPIObject() {}

--- a/pkg/quota/admission/runonceduration/api/types.go
+++ b/pkg/quota/admission/runonceduration/api/types.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// RunOnceDurationConfig is the configuration for the RunOnceDuration plugin.
+// It specifies a default override value for ActiveDeadlineSeconds for a run-once pod.
+// The project that contains the pod may specify a different setting. That setting will
+// take precedence over the one configured for the plugin here.
+type RunOnceDurationConfig struct {
+	unversioned.TypeMeta
+
+	// Enabled if false disables the effect of this plugin. A global override will
+	// not be applied and projects will not be checked for an override annotation.
+	Enabled bool
+
+	// ActiveDeadlineSecondsOverride is the value to set on containers of run-once pods
+	// Only a positive value is valid. Absence of a value means that the plugin
+	// won't make any changes to the pod
+	ActiveDeadlineSecondsOverride *int64
+}
+
+const ActiveDeadlineSecondsOverrideAnnotation = "openshift.io/active-deadline-seconds-override"

--- a/pkg/quota/admission/runonceduration/api/v1/register.go
+++ b/pkg/quota/admission/runonceduration/api/v1/register.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: "v1"}
+
+func init() {
+	api.Scheme.AddKnownTypes(SchemeGroupVersion,
+		&RunOnceDurationConfig{},
+	)
+}
+
+func (*RunOnceDurationConfig) IsAnAPIObject() {}

--- a/pkg/quota/admission/runonceduration/api/v1/types.go
+++ b/pkg/quota/admission/runonceduration/api/v1/types.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// RunOnceDurationConfig is the configuration for the RunOnceDuration plugin.
+// It specifies a default override value for ActiveDeadlineSeconds for a run-once pod.
+// The project that contains the pod may specify a different setting. That setting will
+// take precedence over the one configured for the plugin here.
+type RunOnceDurationConfig struct {
+	unversioned.TypeMeta
+
+	// Enabled if false disables the effect of this plugin. A global override will
+	// not be applied and projects will not be checked for an override annotation.
+	Enabled bool `json:"enabled",description:"set to true to enable the plugin"`
+
+	// ActiveDeadlineSecondsOverride is the value to set on containers of run-once pods
+	// Only a positive value is valid. Absence of a value means that the plugin
+	// won't make any changes to the pod
+	ActiveDeadlineSecondsOverride *int64 `json:"activeDeadlineSecondsOverride,omitempty",description:"value to override activeDeadlineSeconds in run-once pods"`
+}

--- a/pkg/quota/admission/runonceduration/api/validation/validation.go
+++ b/pkg/quota/admission/runonceduration/api/validation/validation.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	"github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
+)
+
+// ValidateRunOnceDurationConfig validates the RunOnceDuration plugin configuration
+func ValidateRunOnceDurationConfig(config *api.RunOnceDurationConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if config == nil || config.ActiveDeadlineSecondsOverride == nil {
+		return allErrs
+	}
+	if *config.ActiveDeadlineSecondsOverride <= 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("activeDeadlineSecondsOverride"), config.ActiveDeadlineSecondsOverride, "must be greater than 0"))
+	}
+	return allErrs
+}

--- a/pkg/quota/admission/runonceduration/api/validation/validation_test.go
+++ b/pkg/quota/admission/runonceduration/api/validation/validation_test.go
@@ -1,0 +1,29 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
+)
+
+func TestRunOnceDurationConfigValidation(t *testing.T) {
+	// Check invalid duration returns an error
+	var invalidSecs int64 = -1
+	invalidConfig := &api.RunOnceDurationConfig{
+		ActiveDeadlineSecondsOverride: &invalidSecs,
+	}
+	errs := ValidateRunOnceDurationConfig(invalidConfig)
+	if len(errs) == 0 {
+		t.Errorf("Did not get expected error on invalid config")
+	}
+
+	// Check that valid duration returns no error
+	var validSecs int64 = 5
+	validConfig := &api.RunOnceDurationConfig{
+		ActiveDeadlineSecondsOverride: &validSecs,
+	}
+	errs = ValidateRunOnceDurationConfig(validConfig)
+	if len(errs) > 0 {
+		t.Errorf("Unexpected error on valid config")
+	}
+}

--- a/pkg/quota/admission/runonceduration/doc.go
+++ b/pkg/quota/admission/runonceduration/doc.go
@@ -1,0 +1,23 @@
+/*
+Package runonceduration contains the RunOnceDuration admission control plugin.
+The plugin allows overriding the ActiveDeadlineSeconds for pods that have a
+RestartPolicy of RestartPolicyNever (run once). If configured to allow a project
+annotation override, and an annotation exists in the pod's namespace of:
+
+ openshift.io/active-deadline-seconds-override
+
+the value of the annotation will take precedence over the globally configured
+value in the plugin's configuration.
+
+
+Configuration
+
+The plugin is configured via a RunOnceDurationConfig object:
+
+ apiVersion: v1
+ kind: RunOnceDurationConfig
+ enabled: true
+ activeDeadlineSecondsOverride: 3600
+*/
+
+package runonceduration

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -1,0 +1,101 @@
+//  +build integration
+
+package integration
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	kubemaster "github.com/openshift/origin/pkg/cmd/server/kubernetes"
+	pluginapi "github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func testRunOnceDurationPod() *kapi.Pod {
+	pod := &kapi.Pod{}
+	pod.Name = "testpod"
+	pod.Spec.RestartPolicy = kapi.RestartPolicyNever
+	pod.Spec.Containers = []kapi.Container{
+		{
+			Name:  "container",
+			Image: "test/image",
+		},
+	}
+	return pod
+}
+
+func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
+	var secs int64 = 3600
+	config := &pluginapi.RunOnceDurationConfig{
+		ActiveDeadlineSecondsOverride: &secs,
+		Enabled: true,
+	}
+	kclient := setupRunOnceDurationTest(t, config, nil)
+	pod, err := kclient.Pods(testutil.Namespace()).Create(testRunOnceDurationPod())
+	if err != nil {
+		t.Fatalf("Unexpected: %v", err)
+	}
+	if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != 3600 {
+		t.Errorf("Unexpected value for pod.ActiveDeadlineSeconds %v", pod.Spec.ActiveDeadlineSeconds)
+	}
+}
+
+func TestRunOnceDurationAdmissionPluginProjectOverride(t *testing.T) {
+	var secs int64 = 3600
+	config := &pluginapi.RunOnceDurationConfig{
+		ActiveDeadlineSecondsOverride: &secs,
+		Enabled: true,
+	}
+	nsAnnotations := map[string]string{
+		pluginapi.ActiveDeadlineSecondsOverrideAnnotation: "100",
+	}
+	kclient := setupRunOnceDurationTest(t, config, nsAnnotations)
+	pod, err := kclient.Pods(testutil.Namespace()).Create(testRunOnceDurationPod())
+	if err != nil {
+		t.Fatalf("Unexpected: %v", err)
+	}
+	if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != 100 {
+		t.Errorf("Unexpected value for pod.ActiveDeadlineSeconds %v", pod.Spec.ActiveDeadlineSeconds)
+	}
+}
+
+func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurationConfig, nsAnnotations map[string]string) kclient.Interface {
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("error creating config: %v", err)
+	}
+	plugins := append([]string{"RunOnceDuration"}, kubemaster.AdmissionPlugins...)
+	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = plugins
+	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		"RunOnceDuration": {
+			Configuration: runtime.EmbeddedObject{
+				Object: pluginConfig,
+			},
+		},
+	}
+	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("error starting server: %v", err)
+	}
+	kubeClient, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting client: %v", err)
+	}
+	ns := &kapi.Namespace{}
+	ns.Name = testutil.Namespace()
+	ns.Annotations = nsAnnotations
+	_, err = kubeClient.Namespaces().Create(ns)
+	if err != nil {
+		t.Fatalf("error creating namespace: %v", err)
+	}
+	if err := testserver.WaitForServiceAccounts(kubeClient, testutil.Namespace(), []string{bootstrappolicy.DefaultServiceAccountName}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	return kubeClient
+}


### PR DESCRIPTION
Allows forcing a globally configured time limit on run once pods.

Needs:
- [x] Allow override of config per project annotations
- [x] Integration test