### PR TITLE
theme-f1 chromeless logs template updates

### DIFF
--- a/assets/app/scripts/directives/affix.js
+++ b/assets/app/scripts/directives/affix.js
@@ -1,38 +1,29 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
-  .directive('affix', function() {
+  .directive('affix', function($window) {
     return {
       restrict: 'AE',
       scope: {
-        offsetTop: '=',
-        offsetBottom: '='
+        offsetTop: '@',
+        offsetBottom: '@'
       },
-      controller: [
-        function() {
-        //'$window',
-        //function($window) {
-          this.init = function(/* affixedEl */) {
-            // FOR DEBUGGING
-            // angular
-            // .element($window)
-            // .bind("scroll", function() {
-            //   var pos = affixedEl.affix('checkPosition')[0];
-            //     console.log('affix position', pos.offsetWidth, pos.offsetHeight, pos.offsetTop, pos.offsetBottom);
-            //     //scope.$apply();
-            // });
-          };
-        }
-      ],
       link: function($scope, $elem, $attrs, ctrl) {
-        ctrl.init(
-            $elem.affix({
-              offset: {
-                top: $attrs.offsetTop,
-                bottom: $attrs.offsetBottom
-              }
-            }));
+        // for debugging
+        // angular
+        // .element($window)
+        // .bind("scroll", function() {
+        //   var pos = $elem.affix('checkPosition')[0];
+        //     console.log('affix position', pos.offsetWidth, pos.offsetHeight, pos.offsetTop, pos.offsetBottom);
+        //     //$scope.$apply();
+        // });
+        $elem.affix({
+          offset: {
+            top: $attrs.offsetTop,
+            bottom: $attrs.offsetBottom
+          }
+        });
       }
     };
   });
-

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -34,6 +34,8 @@ angular.module('openshiftConsole')
         transclude: true,
         templateUrl: 'views/directives/logs/_log-viewer.html',
         scope: {
+          followAffixTop: '=?',
+          followAffixBottom: '=?',
           kind: '@',
           name: '=',
           context: '=',
@@ -48,29 +50,42 @@ angular.module('openshiftConsole')
           '$scope',
           function($scope) {
             // cached node's are set by the directive's postLink fn after render (see link: func below)
+            // A jQuery wrapped verison is cached in var of same name w/$
             var cachedLogNode;
             var cachedScrollableNode;
+            var $cachedScrollableNode;
             var scrollableDOMNode;
+            var $affixableNode;
+            var html = document.documentElement;
 
 
-            angular.extend($scope, {
-              loading: true,
-              autoScroll: false
-            });
+
+            // are we going to scroll the window, or the DOM node?
+            var detectScrollableNode = function() {
+              if(window.innerWidth < BREAKPOINTS.screenSmMin) {
+                scrollableDOMNode = null;
+              } else {
+                scrollableDOMNode = cachedScrollableNode;
+              }
+            };
+
+
 
 
             var updateScrollLinks = function() {
               $scope.$apply(function() {
                 // Show scroll links if the top or bottom of the log is off screen.
-                var html = document.documentElement, r = cachedLogNode.getBoundingClientRect();
+                var r = cachedLogNode.getBoundingClientRect();
                 $scope.showScrollLinks = r && ((r.top < 0) || (r.bottom > html.clientHeight));
               });
             };
 
 
+
             // Set to true before auto-scrolling.
             var autoScrollingNow = false;
             var onScroll = function() {
+
               // Determine if the user scrolled or we auto-scrolled.
               if (autoScrollingNow) {
                 // Reset the value.
@@ -82,11 +97,66 @@ angular.module('openshiftConsole')
                 });
               }
             };
-            $win.scroll(onScroll);
 
 
-            var onResize = _.debounce(updateScrollLinks, 50);
+
+            var attachScrollEvents = function() {
+              if(window.innerWidth < BREAKPOINTS.screenSmMin) {
+                $win.on('scroll', onScroll);
+                $cachedScrollableNode.off('scroll', onScroll);
+              } else {
+                $win.off('scroll', onScroll);
+                $cachedScrollableNode.on('scroll', onScroll);
+              }
+            };
+
+
+            // the class .target-logger-node is needed to adjust some
+            // css when the target is not the window.
+            // TODO: resize event breaks the affix, even with this if/else.
+            // however, on first load of either mobile or non this works fine.
+            var affix = function() {
+              if(window.innerWidth < BREAKPOINTS.screenSmMin) {
+                $affixableNode
+                  .removeClass('target-logger-node')
+                  .affix({
+                    target:  window,
+                    offset: {
+                        top:  $scope.followAffixTop || 0, // 390,
+                        bottom: $scope.followAffixBottom || 0 // 90
+                    }
+                  });
+              } else {
+                $affixableNode
+                  .addClass('target-logger-node')
+                  .affix({
+                    target:  $cachedScrollableNode,
+                    offset: {
+                        top: $scope.followAffixTop || 0, // 390,
+                        bottom: $scope.followAffixBottom || 0 // 90
+                    }
+                  });
+              }
+            };
+
+
+            // roll up & debounce the various fns to call on resize
+            var onResize = _.debounce(function() {
+              // toggle off the follow behavior if the user resizes the window
+              onScroll();
+              // and udpate scroll handlers
+              detectScrollableNode();
+              attachScrollEvents();
+              updateScrollLinks();
+              affix();
+            }, 100);
+
+
             $win.on('resize', onResize);
+
+
+
+            // STREAMER & DOM NODE HANDLING ------------------------------------
 
 
             var autoScrollBottom = function() {
@@ -96,6 +166,7 @@ angular.module('openshiftConsole')
               logLinks.scrollBottom(scrollableDOMNode);
             };
 
+
             var toggleAutoScroll = function() {
               $scope.autoScroll = !$scope.autoScroll;
               if ($scope.autoScroll) {
@@ -103,7 +174,6 @@ angular.module('openshiftConsole')
                 autoScrollBottom();
               }
             };
-
 
             var buffer = document.createDocumentFragment();
 
@@ -164,8 +234,7 @@ angular.module('openshiftConsole')
                 tailLines: 1000,
                 limitBytes: 10 * 1024 * 1024 // Limit log size to 10 MiB
               }, $scope.options);
-              streamer =
-                DataService.createStream($scope.kind, $scope.name, $scope.context, options);
+              streamer = DataService.createStream($scope.kind, $scope.name, $scope.context, options);
 
               var lastLineNumber = 0;
               var addLine = function(text) {
@@ -220,20 +289,16 @@ angular.module('openshiftConsole')
               streamer.start();
             };
 
-            $scope.$watchGroup(['name', 'options.container', 'run'], streamLogs);
 
-            $scope.$on('$destroy', function() {
-              // Close streamer if open. (No-op if not streaming.)
-              stopStreaming();
 
-              // Stop listening for scroll and resize events.
-              $win.off('scroll', onScroll);
-              $win.off('resize', onResize);
-            });
 
+
+            // initial $scope setup --------------------------------------------
 
             angular.extend($scope, {
               ready: true,
+              loading: true,
+              autoScroll: false,
               onScrollBottom: function() {
                 logLinks.scrollBottom(scrollableDOMNode);
               },
@@ -246,7 +311,26 @@ angular.module('openshiftConsole')
               restartLogs: streamLogs
             });
 
+            $scope.$watchGroup(['name', 'options.container', 'run'], streamLogs);
 
+
+
+
+            // tear down -------------------------------------------------------
+
+            $scope.$on('$destroy', function() {
+              // close streamer or no-op
+              stopStreaming();
+              // clean up all the listeners
+              $win.off('resize', onResize);
+              $win.off('scroll', onScroll);
+              $cachedScrollableNode.off('scroll', onScroll);
+            });
+
+
+
+
+            // Kibana archives -------------------------------------------------
 
             APIDiscovery
               .getLoggingURL()
@@ -281,31 +365,29 @@ angular.module('openshiftConsole')
 
 
 
-              // scrollable node is window if mobile, else a particular DOM node.
-              var detectScrollableNode = function() {
-                if(window.innerWidth < BREAKPOINTS.screenSmMin) {
-                  scrollableDOMNode = null;
-                } else {
-                  scrollableDOMNode = cachedScrollableNode;
-                }
-              };
 
-              var debounceScrollable = _.debounce(detectScrollableNode, 200);
+              // PUBLIC API ----------------------------------------------------
 
-              // API to share w/link fn
+              // scrollable node is a parent div#scrollable-content, but may be window
+              // if we are currently mobile
               this.cacheScollableNode = function(node) {
                 cachedScrollableNode = node;
-                detectScrollableNode();
+                $cachedScrollableNode = $(cachedScrollableNode);
               };
 
               this.cacheLogNode = function(node) {
-                cachedLogNode = node;
+                cachedLogNode = node; // no jQuery, optimized
               };
-              // maintain the correct scrollable node
-              $win.on('resize', debounceScrollable);
-              $scope.$on('$destroy', function() {
-                $win.off('resize', debounceScrollable);
-              });
+
+              this.cacheAffixable = function(node) {
+                $affixableNode = $(node); // jQuery is fine
+              };
+
+              this.start = function() {
+                detectScrollableNode();
+                attachScrollEvents();
+                affix();
+              };
           }
         ],
         require: 'logViewer',
@@ -316,6 +398,8 @@ angular.module('openshiftConsole')
           // and we were sending it messages telling it when to scroll.
           ctrl.cacheScollableNode(document.getElementById('scrollable-content'));
           ctrl.cacheLogNode(document.getElementById('logContent'));
+          ctrl.cacheAffixable(document.getElementById('affixedFollow'));
+          ctrl.start();
         }
       };
     }

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -42,19 +42,27 @@
     border-right: 0;
     border-top: 0;
   }
-  .log-scroll-top.affix {
-    position: fixed;
-    right: 40px;
-    top: 0;
-  }
+  // starting position
   .log-scroll-top.affix-top {
     position: absolute;
     right: 0;
     top: 0;
   }
-  .log-scroll-top.affix-bottom {
-
+  // once affixed, has this position
+  .log-scroll-top.affix {
+    position: fixed;
+    right: 20px;
+    top: 0;
   }
+  // TODO: hacky, need to encapsulate this better
+  // '.target-logger-node' is a class indicating the target is not 'window'
+  // this is toggled in JS
+  .log-scroll-top.affix.target-logger-node {
+    position: fixed;
+    right: 42px;
+    top: 60px !important;
+  }
+
   .log-scroll-bottom {
     position: absolute;
     border-bottom: 0;
@@ -74,6 +82,14 @@
       width: 100%;
     }
   }
+}
+
+// TODO: need to encapsulate this better
+.chromeless .log-scroll-top.affix {
+  right: 0px; // override
+}
+.chromeless .log-scroll-top.affix.target-logger-node {
+  right: 10px;  // override
 }
 
 .log-link-external {
@@ -107,17 +123,6 @@
   white-space: pre-wrap;
   width: 100%;
   .word-break();
-}
-.log-chromeless {
-  margin-top: -1px;
-  .log-size-warning {
-    margin: 10px;
-  }
-  .log-view {
-    .log-scroll-top.affix {
-      right: 0;
-    }
-  }
 }
 
 .table-log-pods {

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -61,6 +61,8 @@
                       <uib-tab-heading>Logs</uib-tab-heading>
                       <log-viewer
                         ng-if="selectedTab.logs"
+                        follow-affix-top="390"
+                        follow-affix-bottom="90"
                         kind="builds/log"
                         name="build.metadata.name"
                         context="logContext"

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -73,6 +73,8 @@
                     <uib-tab-heading>Logs</uib-tab-heading>
                     <log-viewer
                       ng-if="selectedTab.logs"
+                      follow-affix-top="390"
+                      follow-affix-bottom="90"
                       kind="deploymentconfigs/log"
                       name="deploymentConfigName"
                       context="logContext"

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -86,6 +86,8 @@
 
                     <log-viewer
                         ng-if="selectedTab.logs"
+                        follow-affix-top="390"
+                        follow-affix-bottom="90"
                         kind="pods/log"
                         name="pod.metadata.name"
                         context="logContext"

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -48,10 +48,8 @@
   <div flex height-max class="log-view">
     <div
       ng-show="showScrollLinks"
-      class="log-scroll log-scroll-top"
-      affix
-      offset-top="445"
-      offset-bottom="90">
+      id="affixedFollow"
+      class="log-scroll log-scroll-top">
       <a ng-if="loading" href="" ng-click="toggleAutoScroll()">
         <span ng-if="!autoScroll">Follow</span>
         <span ng-if="autoScroll">Stop following</span>

--- a/assets/app/views/logs/chromeless-build-log.html
+++ b/assets/app/views/logs/chromeless-build-log.html
@@ -1,17 +1,30 @@
 <default-header class="top-header"></default-header>
-<div column flex class="content">
-  <div flex class="log-chromeless">
-    <alerts alerts="alerts"></alerts>
-    <log-viewer
-      kind="builds/log"
-      name="build.metadata.name"
-      context="logContext"
-      status="build.status.phase"
-      start="build.status.startTimestamp | date : 'short'"
-      end="build.status.completionTimestamp | date : 'short'"
-      chromeless="true"
-      run="logCanRun"
-      flex>
-    </log-viewer>
+<div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+  <navbar-utility-mobile></navbar-utility-mobile>
+</div>
+<div class="wrap chromeless"><!-- flex row -->
+  <div class="middle"><!-- flex -->
+    <div class="middle-section"><!-- absolute position, height 100%, width 100% fill parent -->
+      <div id="scrollable-content" class="middle-container has-scroll"><!-- flex column, height 100% -->
+        <div class="middle-header">
+          <div class="container-fluid">
+            <alerts alerts="alerts"></alerts>
+          </div>
+        </div>
+        <div class="middle-content"><!-- flex item (fill the parent) -->
+          <log-viewer
+            kind="builds/log"
+            name="build.metadata.name"
+            context="logContext"
+            status="build.status.phase"
+            start="build.status.startTimestamp | date : 'short'"
+            end="build.status.completionTimestamp | date : 'short'"
+            chromeless="true"
+            run="logCanRun"
+            flex>
+          </log-viewer>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/assets/app/views/logs/chromeless-deployment-log.html
+++ b/assets/app/views/logs/chromeless-deployment-log.html
@@ -1,16 +1,29 @@
 <default-header class="top-header"></default-header>
-<div column flex class="content">
-  <div flex class="log-chromeless">
-    <alerts alerts="alerts"></alerts>
-    <log-viewer
-      ng-if="deploymentConfigName && logOptions.version"
-      kind="deploymentconfigs/log"
-      name="deploymentConfigName"
-      context="logContext"
-      options="logOptions"
-      chromeless="true"
-      run="logCanRun"
-      flex>
-    </log-viewer>
+<div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+  <navbar-utility-mobile></navbar-utility-mobile>
+</div>
+<div class="wrap chromeless">
+  <div class="middle">
+    <div class="middle-section">
+      <div id="scrollable-content" class="middle-container has-scroll">
+        <div class="middle-header">
+          <div class="container-fluid">
+            <alerts alerts="alerts"></alerts>
+          </div>
+        </div>
+        <div class="middle-content">
+          <log-viewer
+            ng-if="deploymentConfigName && logOptions.version"
+            kind="deploymentconfigs/log"
+            name="deploymentConfigName"
+            context="logContext"
+            options="logOptions"
+            chromeless="true"
+            run="logCanRun"
+            flex>
+          </log-viewer>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/assets/app/views/logs/chromeless-pod-log.html
+++ b/assets/app/views/logs/chromeless-pod-log.html
@@ -1,17 +1,30 @@
 <default-header class="top-header"></default-header>
-<div column flex class="content">
-  <div flex class="log-chromeless">
-    <alerts alerts="alerts"></alerts>
-    <log-viewer
-        kind="pods/log"
-        name="pod.metadata.name"
-        context="logContext"
-        options="logOptions"
-        status="pod.status.phase"
-        start="pod.status.startTime | date : 'short'"
-        chromeless="true"
-        run="logCanRun"
-        flex>
-    </log-viewer>
+<div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+  <navbar-utility-mobile></navbar-utility-mobile>
+</div>
+<div class="wrap chromeless">
+  <div class="middle">
+    <div class="middle-section">
+      <div id="scrollable-content" class="middle-container has-scroll">
+        <div class="middle-header">
+          <div class="container-fluid">
+            <alerts alerts="alerts"></alerts>
+          </div>
+        </div>
+        <div class="middle-content">
+          <log-viewer
+            kind="pods/log"
+            name="pod.metadata.name"
+            context="logContext"
+            options="logOptions"
+            status="pod.status.phase"
+            start="pod.status.startTime | date : 'short'"
+            chromeless="true"
+            run="logCanRun"
+            flex>
+          </log-viewer>
+        </div>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
- Update markup in chromeless templates to fix log scrolling issues.

At some point in the near future we should encapsulate the scrolling functionality better.  It's fairly brittle & prone to breaking w/o being noticed.  I left comments in the `chromeless-build-log.html` file for future reference.

Checklist of bugs intending to addressed:
- [x] bug 6956 scroll top & bottom broken on chromeless logs
- [x] bug 6985 log keeps following on manual scroll
- [x] bug 6957 hamburger menu on chromeless
- [x] bug 7003 affix while scrolling 
- [x] fix broken alignment of follow link (right aligned)
- [x] fix alerts on the chromeless log page
- [x] remove log-chromeless class

So to let github handle closing issues when merged:
fixes #6956 
fixes #6985 
fixes #6957 
fixes #7003 

@sg00dwin @spadgett 