### PR TITLE
WIP: allow either iptables-based or userspace-based proxy

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -15,8 +15,11 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	proxy "k8s.io/kubernetes/pkg/proxy"
 	pconfig "k8s.io/kubernetes/pkg/proxy/config"
-	proxy "k8s.io/kubernetes/pkg/proxy/iptables"
+	ipproxy "k8s.io/kubernetes/pkg/proxy/iptables"
+	usproxy "k8s.io/kubernetes/pkg/proxy/userspace"
+	"k8s.io/kubernetes/pkg/util"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/iptables"
@@ -223,7 +226,21 @@ func (c *NodeConfig) RunProxy() {
 	exec := kexec.New()
 	dbus := utildbus.New()
 	iptables := iptables.New(exec, dbus, protocol)
-	proxier, err := proxy.NewProxier(iptables, exec, syncPeriod, false)
+
+	var proxier proxy.ProxyProvider
+	var endpointsHandler pconfig.EndpointsConfigHandler
+	if /* FIXME */ true {
+		var ipproxier *ipproxy.Proxier
+		ipproxier, err = ipproxy.NewProxier(iptables, exec, syncPeriod, false)
+		proxier = ipproxier
+		endpointsHandler = ipproxier
+	} else {
+		var usproxier *usproxy.Proxier
+		loadBalancer := usproxy.NewLoadBalancerRR()
+		usproxier, err = usproxy.NewProxier(loadBalancer, ip, iptables, util.PortRange{}, syncPeriod, /* FIXME? */ 250 * time.Millisecond)
+		proxier = usproxier
+		endpointsHandler = loadBalancer
+	}
 	if err != nil {
 		// This should be fatal, but that would break the integration tests
 		glog.Warningf("WARNING: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
@@ -239,9 +256,9 @@ func (c *NodeConfig) RunProxy() {
 
 	serviceConfig.RegisterHandler(proxier)
 	if c.FilteringEndpointsHandler == nil {
-		endpointsConfig.RegisterHandler(proxier)
+		endpointsConfig.RegisterHandler(endpointsHandler)
 	} else {
-		c.FilteringEndpointsHandler.SetBaseEndpointsHandler(proxier)
+		c.FilteringEndpointsHandler.SetBaseEndpointsHandler(endpointsHandler)
 		endpointsConfig.RegisterHandler(c.FilteringEndpointsHandler)
 	}
 	recorder.Eventf(nodeRef, kapi.EventTypeNormal, "Starting", "Starting kube-proxy.")


### PR DESCRIPTION
For #6908. This adds the code to use the userspace proxy again, but it's not actually configurable yet. @liggitt asked me to file a PR anyway.

There's also another configurable option in the userspace proxy now, UDPIdleTimeout, --udp-timeout, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace". I just hardcoded the default value.
