### PR TITLE
Remove transition, no longer needed, that causes Safari mobile menu flicker

### DIFF
--- a/assets/app/styles/_substructure.less
+++ b/assets/app/styles/_substructure.less
@@ -47,7 +47,6 @@ html,body {
     background: @sidebar-os-bg;
     padding: 0;
     position:relative;
-    transition:@sidebar-os-transition;
     @media (max-width: @screen-xs-max) {
       border-top: 0;
       padding-left: 0;

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -10,7 +10,6 @@
             <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
             <alerts alerts="alerts"></alerts>
             <div ng-if="!loaded">Loading...</div>
-            <alerts alerts="alerts"></alerts>
             <h1>
               {{build.metadata.name}}
               <span ng-if="build.status.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="right" data-trigger="hover" dynamic-content="{{build.status.message}}"></span>

--- a/assets/app/views/browse/image.html
+++ b/assets/app/views/browse/image.html
@@ -2,55 +2,53 @@
   <project-page>
 
   <!-- Middle section -->
-  <div class="middle-section">
+  <div class="middle-section" ng-if="imageStream">
     <div id="scrollable-content" class="middle-container has-scroll">
       <div class="middle-header">
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded">Loading...</div>
+          <h1>
+            {{imageStream.metadata.name}}
+            <div class="pull-right dropdown">
+              <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+              <ul class="dropdown-menu actions action-button">
+                <li>
+                  <edit-link
+                    resource="imageStream"
+                    kind="imagestreams"
+                    alerts="alerts">
+                  </edit-link>
+                </li>
+                <li>
+                  <delete-link
+                    resource-type="imagestream"
+                    resource-name="{{imageStream.metadata.name}}"
+                    project-name="{{imageStream.metadata.namespace}}"
+                    alerts="alerts">
+                  </delete-link>
+                </li>
+              </ul>
+            </div>
+            <small class="meta">created <relative-timestamp timestamp="imageStream.metadata.creationTimestamp"></relative-timestamp></small>
+          </h1>
+          <labels labels="imageStream.metadata.labels" clickable="true" kind="images" project-name="{{imageStream.metadata.namespace}}" limit="3"></labels>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content">
+      <div class="middle-content gutter-top">
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-12">
-              <div ng-if="imageStream">
-                <h1>
-                  {{imageStream.metadata.name}}
-                  <div class="pull-right dropdown">
-                    <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
-                    <ul class="dropdown-menu actions action-button">
-                      <li>
-                        <edit-link
-                          resource="imageStream"
-                          kind="imagestreams"
-                          alerts="alerts">
-                        </edit-link>
-                      </li>
-                      <li>
-                        <delete-link
-                          resource-type="imagestream"
-                          resource-name="{{imageStream.metadata.name}}"
-                          project-name="{{imageStream.metadata.namespace}}"
-                          alerts="alerts">
-                        </delete-link>
-                      </li>
-                    </ul>
-                  </div>
-                  <small class="meta">created <relative-timestamp timestamp="imageStream.metadata.creationTimestamp"></relative-timestamp></small>
-                </h1>
-                <labels labels="imageStream.metadata.labels" clickable="true" kind="images" project-name="{{imageStream.metadata.namespace}}" limit="3"></labels>
-                <div class="resource-details">
-                  <dl class="dl-horizontal left">
-                    <dt ng-if-start="imageStream.spec.dockerImageRepository">Follows docker repo:</dt>
-                    <dd ng-if-end>{{imageStream.spec.dockerImageRepository}}</dd>
-                    <dt>Docker pull spec:</dt>
-                    <dd>{{imageStream.status.dockerImageRepository}}</dd>
-                  </dl>
-                  <annotations annotations="imageStream.metadata.annotations"></annotations>
-                </div>
-              </div><!-- /imageStream -->
+              <div class="resource-details">
+                <dl class="dl-horizontal left">
+                  <dt ng-if-start="imageStream.spec.dockerImageRepository">Follows docker repo:</dt>
+                  <dd ng-if-end>{{imageStream.spec.dockerImageRepository}}</dd>
+                  <dt>Docker pull spec:</dt>
+                  <dd>{{imageStream.status.dockerImageRepository}}</dd>
+                </dl>
+                <annotations annotations="imageStream.metadata.annotations"></annotations>
+              </div>
               <div class="table-responsive">
                 <table class="table table-bordered">
                   <thead>

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -2,45 +2,44 @@
   <project-page>
 
   <!-- Middle section -->
-  <div class="middle-section">
+  <div class="middle-section" ng-if="service">
     <div id="scrollable-content" class="middle-container has-scroll">
       <div class="middle-header">
         <div class="container-fluid">
           <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
           <alerts alerts="alerts"></alerts>
           <div ng-if="!loaded">Loading...</div>
+          <h1>
+            {{service.metadata.name}}
+            <div class="pull-right dropdown">
+              <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+              <ul class="dropdown-menu actions action-link">
+                <li>
+                  <edit-link
+                    resource="service"
+                    kind="services"
+                    alerts="alerts">
+                  </edit-link>
+                </li>
+                <li>
+                  <delete-link
+                    resource-type="service"
+                    resource-name="{{service.metadata.name}}"
+                    project-name="{{service.metadata.namespace}}"
+                    alerts="alerts">
+                  </delete-link>
+                </li>
+              </ul>
+            </div>
+            <small class="meta">created <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></small>
+          </h1>
+          <labels labels="service.metadata.labels" clickable="true" kind="services" project-name="{{service.metadata.namespace}}" limit="3"></labels>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content">
+      <div class="middle-content gutter-top">
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-12">
-              <div ng-if="service">
-                <h1>
-                  {{service.metadata.name}}
-                  <div class="pull-right dropdown">
-                    <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
-                    <ul class="dropdown-menu actions action-link">
-                      <li>
-                        <edit-link
-                          resource="service"
-                          kind="services"
-                          alerts="alerts">
-                        </edit-link>
-                      </li>
-                      <li>
-                        <delete-link
-                          resource-type="service"
-                          resource-name="{{service.metadata.name}}"
-                          project-name="{{service.metadata.namespace}}"
-                          alerts="alerts">
-                        </delete-link>
-                      </li>
-                    </ul>
-                  </div>
-                  <small class="meta">created <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></small>
-                </h1>
-                <labels labels="service.metadata.labels" clickable="true" kind="services" project-name="{{service.metadata.namespace}}" limit="3"></labels>
                 <div class="resource-details">
                   <dl class="dl-horizontal left">
                     <dt>Selectors:</dt>
@@ -107,7 +106,6 @@
                   </div>
                   <annotations annotations="service.metadata.annotations"></annotations>
                 </div>
-              </div><!-- /service -->
             </div><!-- /col-* -->
           </div>
         </div>

--- a/assets/app/views/directives/_copy-to-clipboard.html
+++ b/assets/app/views/directives/_copy-to-clipboard.html
@@ -1,1 +1,1 @@
-<button data-clipboard-text="{{clipboardText}}"><i class="fa fa-clipboard"/></button>
+<button data-clipboard-text="{{clipboardText}}" class="btn btn-default"><i class="fa fa-clipboard"/></button>


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/6958
Remove extra alert from builds page
Make spacing consistent by moving ```<h1>```, actions, and labels into middle-header beneath breadcrumb
Add missing btn default styling to copy-to-clipboard