### PR TITLE
UI API groups

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -26,6 +26,7 @@
     "HawtioCore": false,
     "Logger" : false,
     "LabelSelector": false,
+    "ResourceGroupVersion": false,
     "moment": false,
     "Messenger" : false,
     "URI": false,

--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -110,6 +110,7 @@
         <script src="scripts/services/logger.js"></script>
         <script src="scripts/services/ws.js"></script>
         <script src="scripts/services/userstore.js"></script>
+        <script src="scripts/services/api.js"></script>
         <script src="scripts/services/auth.js"></script>
         <script src="scripts/services/data.js"></script>
         <script src="scripts/services/discovery.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -266,6 +266,7 @@ angular
       });
   })
   .constant("API_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).api))
+  .constant("APIS_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).apis))
   .constant("AUTH_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).auth))
   .constant("LOGGING_URL", (window.OPENSHIFT_CONFIG || {}).loggingURL)
   .constant("METRICS_URL", (window.OPENSHIFT_CONFIG || {}).metricsURL)

--- a/assets/app/scripts/controllers/about.js
+++ b/assets/app/scripts/controllers/about.js
@@ -11,10 +11,6 @@ angular.module('openshiftConsole')
     AuthService.withUser();
     
     $scope.version = {
-      api: {
-        openshift: DataService.oApiVersion,
-        kubernetes: DataService.k8sApiVersion,
-      },
       master: {
         openshift: Constants.VERSION.openshift,
         kubernetes: Constants.VERSION.kubernetes,

--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -5,6 +5,7 @@ angular.module("openshiftConsole")
       Logger,
       $q,
       $routeParams,
+      APIService,
       DataService,
       ProjectsService,
       Navigate,
@@ -122,11 +123,11 @@ angular.module("openshiftConsole")
 
         initAndValidate($scope);
 
-        var ifResourcesDontExist = function(resources, namespace, scope){
+        var ifResourcesDontExist = function(apiObjects, namespace, scope){
           var result = $q.defer();
           var successResults = [];
           var failureResults = [];
-          var remaining = resources.length;
+          var remaining = apiObjects.length;
 
           function _checkDone() {
             if (remaining === 0) {
@@ -136,19 +137,25 @@ angular.module("openshiftConsole")
               }
               else
                 //means no resources exist with the given nanme
-                result.resolve(resources);
+                result.resolve(apiObjects);
             }
           }
 
-          resources.forEach(function(resource) {
-            var resourceName = DataService.kindToResource(resource.kind);
-            if (!resourceName) {
-              failureResults.push({data: {message: "Unrecognized kind: " + resource.kind + "."}});
+          apiObjects.forEach(function(apiObject) {
+            var resource = APIService.objectToResourceGroupVersion(apiObject);
+            if (!resource) {
+              failureResults.push({data: {message: APIService.invalidObjectKindOrVersion(apiObject)}});
               remaining--;
               _checkDone();
               return;
             }
-            DataService.get(resourceName, resource.metadata.name, {namespace: (namespace || $routeParams.project)}, {errorNotification: false}).then(
+            if (!APIService.apiInfo(resource)) {
+              failureResults.push({data: {message: APIService.unsupportedObjectKindOrVersion(apiObject)}});
+              remaining--;
+              _checkDone();
+              return;
+            }
+            DataService.get(resource, apiObject.metadata.name, {namespace: (namespace || $routeParams.project)}, {errorNotification: false}).then(
               function (data) {
                 successResults.push(data);
                 remaining--;
@@ -184,10 +191,9 @@ angular.module("openshiftConsole")
                       hasErrors = true;
                       result.failure.forEach(
                         function(failure) {
-                          var objectName = failureObjectNameFilter(failure) || "object";
                           alerts.push({
                             type: "error",
-                            message: "Cannot create " + humanize(objectName).toLowerCase() + ". ",
+                            message: "Cannot create " + humanize(failure.object.kind).toLowerCase() + " \"" + failure.object.metadata.name + "\". ",
                             details: failure.data.message
                           });
                         }

--- a/assets/app/scripts/controllers/modals/editModal.js
+++ b/assets/app/scripts/controllers/modals/editModal.js
@@ -8,7 +8,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('EditModalController', function ($scope, $filter, $uibModalInstance, DataService) {
+  .controller('EditModalController', function ($scope, $filter, $uibModalInstance, APIService, DataService) {
     // Use angular.copy to avoid $$hashKey properties inserted by ng-repeat.
     var resource = angular.copy($scope.resource);
 
@@ -79,6 +79,21 @@ angular.module('openshiftConsole')
         $scope.error = {
           message: 'Cannot change resource kind (original: ' + resource.kind + ', modified: ' + (updatedResource.kind || '<unspecified>') + ').'
         };
+        return;
+      }
+      
+      var groupVersion = APIService.objectToResourceGroupVersion(resource);
+      var updatedGroupVersion = APIService.objectToResourceGroupVersion(updatedResource);
+      if (!updatedGroupVersion) {
+        $scope.error = { message: APIService.invalidObjectKindOrVersion(updatedResource) };
+        return;
+      }
+      if (updatedGroupVersion.group !== groupVersion.group) {
+        $scope.error = { message: 'Cannot change resource group (original: ' + (groupVersion.group || '<none>') + ', modified: ' + (updatedGroupVersion.group || '<none>') + ').' };
+        return;
+      }
+      if (!APIService.apiInfo(updatedGroupVersion)) {
+        $scope.error = { message: APIService.unsupportedObjectKindOrVersion(updatedResource) };
         return;
       }
 

--- a/assets/app/scripts/controllers/newfromtemplate.js
+++ b/assets/app/scripts/controllers/newfromtemplate.js
@@ -132,10 +132,9 @@ angular.module('openshiftConsole')
                       hasErrors = true;
                       result.failure.forEach(
                         function(failure) {
-                          var objectName = failureObjectNameFilter(failure) || "object";
                           alerts.push({
                             type: "error",
-                            message: "Cannot create " + humanize(objectName).toLowerCase() + ". ",
+                            message: "Cannot create " + humanize(failure.object.kind).toLowerCase() + " \"" + failure.object.metadata.name + "\". ",
                             details: failure.data.message
                           });
                         }

--- a/assets/app/scripts/services/api.js
+++ b/assets/app/scripts/services/api.js
@@ -1,0 +1,246 @@
+'use strict';
+
+// ResourceGroupVersion represents a fully qualified resource
+function ResourceGroupVersion(resource, group, version) {
+  this.resource = resource;
+  this.group    = group;
+  this.version  = version;
+  return this;
+}
+// toString() includes the group and version information if present
+ResourceGroupVersion.prototype.toString = function() {
+  var s = this.resource;
+  if (this.group)   { s += "/" + this.group;   }
+  if (this.version) { s += "/" + this.version; }
+  return s;
+};
+// primaryResource() returns the resource with any subresources removed
+ResourceGroupVersion.prototype.primaryResource = function() {
+  if (!this.resource) { return ""; }
+  var i = this.resource.indexOf('/');
+  if (i === -1) { return this.resource; }
+  return this.resource.substring(0,i);
+};
+// subresources() returns a (possibly empty) list of subresource segments
+ResourceGroupVersion.prototype.subresources = function() {
+  var segments = (this.resource || '').split("/");
+  segments.shift();
+  return segments;
+};
+// equals() returns true if the given resource, group, and version match.
+// If omitted, group and version are not compared.
+ResourceGroupVersion.prototype.equals = function(resource, group, version) {
+  if (this.resource !== resource) { return false; }
+  if (arguments.length === 1)     { return true;  }
+  if (this.group !== group)       { return false; }
+  if (arguments.length === 2)     { return true;  }
+  if (this.version !== version)   { return false; }
+  return true;
+};
+
+
+angular.module('openshiftConsole')
+.factory('APIService', function(API_CFG, APIS_CFG, Logger) {
+  
+  // Set the default api versions the console will use if otherwise unspecified
+  var defaultVersion = {
+    "":           "v1",
+    "extensions": "v1beta1"
+  };
+
+  // toResourceGroupVersion() returns a ResourceGroupVersion.
+  // If resource is already a ResourceGroupVersion, returns itself.
+  //
+  // if r is a string, the empty group and default version for the empty group are assumed.
+  //
+  // if r is an object, the resource, group, and version attributes are read.
+  // a missing group attribute defaults to the legacy group.
+  // a missing version attribute defaults to the default version for the group, or undefined if the group is unknown.
+  //
+  // if r is already a ResourceGroupVersion, it is returned as-is
+  var toResourceGroupVersion = function(r) {
+    if (r instanceof ResourceGroupVersion) {
+      return r;
+    }
+    var resource, group, version;
+    if (angular.isString(r)) {
+      resource = normalizeResource(r);
+      group = '';
+      version = defaultVersion[group];
+    } else if (r && r.resource) {
+      resource = normalizeResource(r.resource);
+      group = r.group || '';
+      version = r.version || defaultVersion[group];
+    }
+    return new ResourceGroupVersion(resource, group, version);
+  };
+  
+  // normalizeResource lowercases the first segment of the given resource. subresources can be case-sensitive.
+  var normalizeResource = function(resource) {
+    if (!resource) {
+      return resource;
+    }
+    var i = resource.indexOf('/');
+    if (i === -1) {
+      return resource.toLowerCase();
+    }
+    return resource.substring(0, i).toLowerCase() + resource.substring(i);
+  };
+  
+  // port of group_version.go#ParseGroupVersion
+  var parseGroupVersion = function(apiVersion) {
+    if (!apiVersion) {
+      return undefined;
+    }
+    var parts = apiVersion.split("/");
+    if (parts.length === 1) {
+      return {group:'', version: parts[0]};
+    }
+    if (parts.length === 2) {
+      return {group:parts[0], version: parts[1]};
+    }
+    Logger.warn('Invalid apiVersion "' + apiVersion + '"');
+    return undefined;
+  };
+  
+  var objectToResourceGroupVersion = function(apiObject) {
+    if (!apiObject || !apiObject.kind || !apiObject.apiVersion) {
+      return undefined;
+    }
+    var resource = kindToResource(apiObject.kind);
+    if (!resource) {
+      return undefined;
+    }
+    var groupVersion = parseGroupVersion(apiObject.apiVersion);
+    if (!groupVersion) {
+      return undefined;
+    }
+    return new ResourceGroupVersion(resource, groupVersion.group, groupVersion.version);
+  };
+  
+  // deriveTargetResource figures out the fully qualified destination to submit the object to.
+  // if resource is a string, and the object's kind matches the resource, the object's group/version are used.
+  // if resource is a ResourceGroupVersion, and the object's kind and group match, the object's version is used.
+  // otherwise, resource is used as-is.
+  var deriveTargetResource = function(resource, object) {
+    if (!resource || !object) {
+      return undefined;
+    }
+    var objectResource = kindToResource(object.kind);
+    var objectGroupVersion = parseGroupVersion(object.apiVersion);
+    var resourceGroupVersion = toResourceGroupVersion(resource);
+    if (!objectResource || !objectGroupVersion || !resourceGroupVersion) {
+      return undefined;
+    }
+    
+    // We specified something like "pods"
+    if (angular.isString(resource)) {
+      // If the object had a matching kind {"kind":"Pod","apiVersion":"v1"}, use the group/version from the object
+      if (resourceGroupVersion.equals(objectResource)) {
+        resourceGroupVersion.group = objectGroupVersion.group;
+        resourceGroupVersion.version = objectGroupVersion.version;
+      }
+      return resourceGroupVersion;
+    }
+    
+    // If the resource was already a fully specified object,
+    // require the group to match as well before taking the version from the object
+    if (resourceGroupVersion.equals(objectResource, objectGroupVersion.group)) {
+      resourceGroupVersion.version = objectGroupVersion.version;
+    }
+    return resourceGroupVersion;
+  };  
+  
+  // port of restmapper.go#kindToResource
+  var kindToResource = function(kind) {
+    if (!kind) {
+      return "";
+    }
+    var resource = String(kind).toLowerCase();
+    if (resource === 'endpoints' || resource === 'securitycontextconstraints') {
+      // no-op, plural is the singular
+    }
+    else if (resource[resource.length-1] === 's') {
+      resource = resource + 'es';
+    }
+    else if (resource[resource.length-1] === 'y') {
+      resource = resource.substring(0, resource.length-1) + 'ies';
+    }
+    else {
+      resource = resource + 's';
+    }
+
+    return resource;
+  };
+  
+  // apiInfo returns the host/port, prefix, group, and version for the given resource,
+  // or undefined if the specified resource/group/version is known not to exist.
+  var apiInfo = function(resource) {
+    resource = toResourceGroupVersion(resource);
+    var primaryResource = resource.primaryResource();
+    
+    // API info for resources in an API group can just be derived
+    // TODO: use API discovery to determine available groups, versions, and resources
+    // If this is called before discovery loads, just return the derived data, but if we know from discovery that a group/version/resource is invalid, return undefined.
+    if (resource.group) {
+      return {
+        hostPort: APIS_CFG.hostPort,
+        prefix:   APIS_CFG.prefix,
+        group:    resource.group,
+        version:  resource.version
+      };
+    }
+    
+    // Resources without an API group could be legacy k8s or origin resources.
+    // Scan through resources to determine which this is.
+    var api, prefix;
+    for (var apiName in API_CFG) {
+      api = API_CFG[apiName];
+      if (!api.resources[primaryResource]) {
+        continue;
+      }
+      prefix = api.prefixes[resource.version];
+      if (!prefix) {
+        continue;
+      }
+      return {
+        hostPort: api.hostPort,
+        prefix:   prefix,
+        version:  resource.version
+      };
+    }
+    return undefined;
+  };  
+  
+  var invalidObjectKindOrVersion = function(apiObject) {
+    var kind = "<none>";
+    var version = "<none>";
+    if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
+    if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
+    return "Invalid kind ("+kind+") or API version ("+version+")";
+  };
+  var unsupportedObjectKindOrVersion = function(apiObject) {
+    var kind = "<none>";
+    var version = "<none>";
+    if (apiObject && apiObject.kind)       { kind    = apiObject.kind;       }
+    if (apiObject && apiObject.apiVersion) { version = apiObject.apiVersion; }
+    return "The API version "+version+" for kind " + kind + " is not supported by this server";
+  };
+    
+  return {
+    toResourceGroupVersion: toResourceGroupVersion,
+    
+    parseGroupVersion: parseGroupVersion,
+    
+    objectToResourceGroupVersion: objectToResourceGroupVersion,
+    
+    deriveTargetResource: deriveTargetResource,
+    
+    kindToResource: kindToResource,
+    
+    apiInfo: apiInfo,
+    
+    invalidObjectKindOrVersion: invalidObjectKindOrVersion,
+    unsupportedObjectKindOrVersion: unsupportedObjectKindOrVersion
+  };
+});

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -3,8 +3,6 @@
 angular.module("openshiftConsole")
 
   .service("ApplicationGenerator", function(DataService, Logger, $parse){
-    var oApiVersion = DataService.oApiVersion;
-    var k8sApiVersion = DataService.k8sApiVersion;
 
     var scope = {};
 
@@ -111,7 +109,7 @@ angular.module("openshiftConsole")
 
       var route = {
         kind: "Route",
-        apiVersion: oApiVersion,
+        apiVersion: "v1",
         metadata: {
           name: name,
           labels: input.labels,
@@ -184,7 +182,7 @@ angular.module("openshiftConsole")
       };
 
       var deploymentConfig = {
-        apiVersion: oApiVersion,
+        apiVersion: "v1",
         kind: "DeploymentConfig",
         metadata: {
           name: input.name,
@@ -274,7 +272,7 @@ angular.module("openshiftConsole")
       var sourceUrl = uri.href();
 
       var bc = {
-        apiVersion: oApiVersion,
+        apiVersion: "v1",
         kind: "BuildConfig",
         metadata: {
           name: input.name,
@@ -320,7 +318,7 @@ angular.module("openshiftConsole")
 
     scope._generateImageStream = function(input){
       return {
-        apiVersion: oApiVersion,
+        apiVersion: "v1",
         kind: "ImageStream",
         metadata: {
           name: input.name,
@@ -337,7 +335,7 @@ angular.module("openshiftConsole")
 
       var service = {
         kind: "Service",
-        apiVersion: k8sApiVersion,
+        apiVersion: "v1",
         metadata: {
           name: serviceName,
           labels: input.labels,

--- a/assets/app/views/about.html
+++ b/assets/app/views/about.html
@@ -30,10 +30,6 @@
                         <dd>{{version.master.openshift || 'unknown'}}</dd>
                         <dt>Kubernetes Master:</dt>
                         <dd>{{version.master.kubernetes || 'unknown'}}</dd>
-                        <dt>OpenShift API:</dt>
-                        <dd>{{version.api.openshift}}</dd>
-                        <dt>Kubernetes API:</dt>
-                        <dd>{{version.api.kubernetes}}</dd>
                       </dl>
 
                       <h2 id="cli">Command Line Tools</h2>
@@ -58,7 +54,7 @@
                       <p>
                         After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
                         <div class="code prettyprint ng-binding" ng-if="sessionToken">
-                          oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="showSessionToken = !showSessionToken" ng-show="!showSessionToken">show</a>
+                          oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="showSessionToken = !showSessionToken" ng-show="!showSessionToken">...click to show token...</a>
                         </div>
                         <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
         oc login {{loginBaseURL}}

--- a/assets/test/spec/services/apiServiceSpec.js
+++ b/assets/test/spec/services/apiServiceSpec.js
@@ -1,0 +1,239 @@
+"use strict";
+
+describe("APIService", function(){
+  var APIService;
+
+  beforeEach(function(){
+    inject(function(_APIService_){
+      APIService = _APIService_;
+    });
+  });
+
+  describe("#toResourceGroupVersion", function(){
+
+    var tc = [
+      // string args
+      // simple
+      ['pods',         {r:'pods',g:'',v:'v1'}],
+      // normalization
+      ['Pods',         {r:'pods',g:'',v:'v1'}],
+      // normalization preserves subresources
+      ['PODS/FOO',     {r:'pods/FOO',g:'',v:'v1'}],
+      
+      // structured, resource only
+      // simple
+      [{resource:'pods'},         {r:'pods',g:'',v:'v1'}],
+      // normalization
+      [{resource:'Pods'},         {r:'pods',g:'',v:'v1'}],
+      // normalization preserves subresources
+      [{resource:'PODS/FOO'},     {r:'pods/FOO',g:'',v:'v1'}],
+
+      // structured, with group
+      // groups default version if known
+      [{resource:'pods',group:''},           {r:'pods',g:'',          v:'v1'     }],
+      [{resource:'jobs',group:'extensions'}, {r:'jobs',g:'extensions',v:'v1beta1'}],
+      // unknown groups do not default version
+      [{resource:'foos',group:'unknown'},    {r:'foos',g:'unknown',   v:undefined}],
+      
+      // structured, with version
+      // groups default
+      [{resource:'pods',version:'v1'},      {r:'pods',g:'',v:'v1'     }],
+      [{resource:'pods',version:'v1beta3'}, {r:'pods',g:'',v:'v1beta3'}],
+      
+      // structured, fully specified
+      [{resource:'pods',group:'',          version:'v1'},      {r:'pods',g:'',          v:'v1'     }],
+      [{resource:'pods',group:'',          version:'v1beta3'}, {r:'pods',g:'',          v:'v1beta3'}],
+      [{resource:'jobs',group:'extensions',version:'v1'},      {r:'jobs',g:'extensions',v:'v1'     }],
+      [{resource:'jobs',group:'extensions',version:'v1beta1'}, {r:'jobs',g:'extensions',v:'v1beta1'}],
+      [{resource:'foos',group:'unknown',   version:'v1'},      {r:'foos',g:'unknown',   v:'v1'     }],
+      [{resource:'foos',group:'unknown',   version:'v1beta1'}, {r:'foos',g:'unknown',   v:'v1beta1'}]
+    ];
+
+    angular.forEach(tc, _.spread(function(input, expectedRGV) {
+      it('should result in ' + JSON.stringify(expectedRGV) + ' when called with ' + JSON.stringify(input), function() {
+        // Call once and compare the components
+        var actualRGV = APIService.toResourceGroupVersion(input);
+        expect(actualRGV.resource).toEqual(expectedRGV.r);
+        expect(actualRGV.group   ).toEqual(expectedRGV.g);
+        expect(actualRGV.version ).toEqual(expectedRGV.v);
+        
+        // Call again with the result and make sure it is returns the same thing
+        var actualRGV2 = APIService.toResourceGroupVersion(actualRGV);
+        expect(actualRGV).toEqual(actualRGV2);
+      });
+    }));
+
+  });
+  
+  describe("#parseGroupVersion", function(){
+    var tc = [
+      // invalid cases
+      [null,          undefined],
+      ["",            undefined],
+      ['foo/bar/baz', undefined],
+      // legacy
+      ['v1',      {group:'',version:'v1'     }],
+      ['v1beta3', {group:'',version:'v1beta3'}],
+      // groups
+      ['foo/bar',      {group:'foo',version:'bar'}],
+      ['FOO/BAR',      {group:'FOO',version:'BAR'}]
+    ];
+    angular.forEach(tc, _.spread(function(input, expectedGroupVersion) {
+      it('should result in ' + JSON.stringify(expectedGroupVersion) + ' when called with ' + JSON.stringify(input), function() {
+        expect(APIService.parseGroupVersion(input)).toEqual(expectedGroupVersion);
+      });
+    }));
+  });  
+  
+  describe("#objectToResourceGroupVersion", function(){
+    var tc = [
+      // invalid cases
+      [null,              undefined],
+      ["",                undefined],
+      [{},                undefined],
+      [{kind:"Pod"},      undefined],
+      [{apiVersion:"v1"}, undefined],
+      
+      // legacy
+      [{kind:"Pod",      apiVersion:"v1"}, {g:'',v:'v1',r:'pods'}],
+
+      // extensions
+      [{kind:"Job",apiVersion:"extensions/v1beta1"}, {g:'extensions',v:'v1beta1',r:'jobs'}],
+      [{kind:"Foo",apiVersion:"unknown/v1beta6"},    {g:'unknown',   v:'v1beta6',r:'foos'}],
+    ];
+    angular.forEach(tc, _.spread(function(input, expectedRGV) {
+      it('should result in ' + JSON.stringify(expectedRGV) + ' when called with ' + JSON.stringify(input), function() {
+        // Call once and compare the components
+        var actualRGV = APIService.objectToResourceGroupVersion(input);
+        if (expectedRGV) {
+          expect(actualRGV.resource).toEqual(expectedRGV.r);
+          expect(actualRGV.group   ).toEqual(expectedRGV.g);
+          expect(actualRGV.version ).toEqual(expectedRGV.v);
+        } else {
+          expect(actualRGV).toEqual(expectedRGV);
+        }
+      });
+    }));
+  });  
+  
+  describe("#kindToResource", function(){
+    var tc = [
+      // invalid cases
+      [null,              ""],
+      ["",                ""],
+      
+      // pluralization
+      ["foo",             "foos"],
+      // pluralization with s
+      ["foos",            "fooses"],
+      // pluralization with y
+      ["Policy",          "policies"],
+      // special cases
+      ["Endpoints",                  "endpoints"],
+      ["SecurityContextConstraints", "securitycontextconstraints"],
+    ];
+    angular.forEach(tc, _.spread(function(kind, resource) {
+      it('should result in ' + JSON.stringify(resource) + ' when called with ' + JSON.stringify(kind), function() {
+        expect(APIService.kindToResource(kind)).toEqual(resource);
+      });
+    }));
+  });  
+
+  describe("#deriveTargetResource", function(){
+    var tc = [
+      // invalid cases
+      [null,null,              undefined],
+      ["","",                  undefined],
+      [{},{},                  undefined],
+      
+      // simple resource, matching object overrides group/version
+      ['pods', {kind:"Pod",apiVersion:"v1"},                 {r:'pods',g:'',          v:'v1'     }],
+      ['pods', {kind:"Pod",apiVersion:"v2"},                 {r:'pods',g:'',          v:'v2'     }],
+      ['jobs', {kind:"Job",apiVersion:"extensions/v1beta1"}, {r:'jobs',g:'extensions',v:'v1beta1'}],
+      ['jobs', {kind:"Job",apiVersion:"extensions/v1beta2"}, {r:'jobs',g:'extensions',v:'v1beta2'}],
+
+      // simple resource, non-matching object leaves group/version alone
+      ['pods', {kind:"Foo",apiVersion:"v1"},                 {r:'pods',g:'',v:'v1'}],
+      ['pods', {kind:"Foo",apiVersion:"v2"},                 {r:'pods',g:'',v:'v1'}],
+      ['jobs', {kind:"Foo",apiVersion:"extensions/v1beta1"}, {r:'jobs',g:'',v:'v1'}],
+      ['jobs', {kind:"Foo",apiVersion:"extensions/v1beta2"}, {r:'jobs',g:'',v:'v1'}],
+      // actual use:
+      ['deploymentconfigs/scale', {kind:"Scale",apiVersion:"extensions/v1beta1"}, {r:'deploymentconfigs/scale',g:'',v:'v1'}],
+
+      // complex resource, matching object kind and group overrides version
+      [{resource:'pods',group:''                        }, {kind:"Pod",apiVersion:"v3"},                 {r:'pods',g:'',          v:'v3'     }],
+      [{resource:'pods',group:'',           version:'v2'}, {kind:"Pod",apiVersion:"v3"},                 {r:'pods',g:'',          v:'v3'     }],
+      [{resource:'jobs',group:'extensions'              }, {kind:"Job",apiVersion:"extensions/v1beta3"}, {r:'jobs',g:'extensions',v:'v1beta3'}],
+      [{resource:'jobs',group:'extensions', version:'v2'}, {kind:"Job",apiVersion:"extensions/v1beta3"}, {r:'jobs',g:'extensions',v:'v1beta3'}],
+
+      // complex resource, non-matching object group leaves group/version alone
+      [{resource:'pods',                                }, {kind:"Pod",apiVersion:"othergroup/v3"},      {r:'pods',g:'',          v:'v1'     }],
+      [{resource:'pods',group:''                        }, {kind:"Pod",apiVersion:"othergroup/v3"},      {r:'pods',g:'',          v:'v1'     }],
+      [{resource:'pods',group:'',           version:'v2'}, {kind:"Pod",apiVersion:"othergroup/v3"},      {r:'pods',g:'',          v:'v2'     }],
+      [{resource:'jobs',group:'extensions'              }, {kind:"Job",apiVersion:"othergroup/v1beta3"}, {r:'jobs',g:'extensions',v:'v1beta1'}],
+      [{resource:'jobs',group:'extensions', version:'v2'}, {kind:"Job",apiVersion:"othergroup/v1beta3"}, {r:'jobs',g:'extensions',v:'v2'     }],
+      // complex resource, non-matching object kind leaves group/version alone 
+      [{resource:'pods',group:''                        }, {kind:"Foo",apiVersion:"v3"},                 {r:'pods',g:'',          v:'v1'     }],
+      [{resource:'pods',group:'',           version:'v2'}, {kind:"Foo",apiVersion:"v3"},                 {r:'pods',g:'',          v:'v2'     }],
+      // actual use:
+      [{resource:'deploymentconfigs/scale'},               {kind:"Scale",apiVersion:"extensions/v1beta1"}, {r:'deploymentconfigs/scale',g:'',v:'v1'}],
+    ];
+    angular.forEach(tc, _.spread(function(resource, apiObject, expectedRGV) {
+      it('should result in ' + JSON.stringify(expectedRGV) + ' when called with ' + JSON.stringify(resource)+","+JSON.stringify(apiObject), function() {
+        // Call once and compare the components
+        var actualRGV = APIService.deriveTargetResource(resource, apiObject);
+        if (expectedRGV) {
+          expect(actualRGV.resource).toEqual(expectedRGV.r);
+          expect(actualRGV.group   ).toEqual(expectedRGV.g);
+          expect(actualRGV.version ).toEqual(expectedRGV.v);
+        } else {
+          expect(actualRGV).toEqual(expectedRGV);
+        }
+      });
+    }));
+  });  
+
+  describe("#primaryResource", function(){
+    var tc = [
+      // invalid cases
+      [null,              ""],
+      ["",                ""],
+
+      // no subresources
+      ["foo",             "foo"],
+      ["FOO",             "foo"],
+      
+      // subresource cases
+      ["foo/bar",         "foo"],
+      ["FOO/bar/baz",     "foo"]
+    ];
+    angular.forEach(tc, _.spread(function(resource, primaryResource) {
+      it('should result in ' + JSON.stringify(primaryResource) + ' when called with ' + JSON.stringify(resource), function() {
+        expect(APIService.toResourceGroupVersion(resource).primaryResource()).toEqual(primaryResource);
+      });
+    }));
+  });  
+  
+  describe("#subresources", function(){
+    var tc = [
+      // invalid cases
+      [null,              []],
+      ["",                []],
+
+      // no subresources
+      ["foo",             []],
+      ["FOO",             []],
+      
+      // subresource cases
+      ["foo/bar",         ["bar"]],
+      ["FOO/bar/baz",     ["bar","baz"]],
+      ["FOO/Bar/Baz",     ["Bar","Baz"]]
+    ];
+    angular.forEach(tc, _.spread(function(resource, subresources) {
+      it('should result in ' + JSON.stringify(subresources) + ' when called with ' + JSON.stringify(resource), function() {
+        expect(APIService.toResourceGroupVersion(resource).subresources()).toEqual(subresources);
+      });
+    }));
+  });    
+  
+});

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -5,12 +5,6 @@ describe("ApplicationGenerator", function(){
   var input;
 
   beforeEach(function(){
-    module('openshiftConsole', function($provide){
-      $provide.value("DataService",{
-        oApiVersion: "v1",
-        k8sApiVersion: "v1"
-      });
-    });
 
     inject(function(_ApplicationGenerator_){
       ApplicationGenerator = _ApplicationGenerator_;

--- a/assets/test/spec/services/dataServiceSpec.js
+++ b/assets/test/spec/services/dataServiceSpec.js
@@ -72,13 +72,16 @@ describe("DataService", function(){
       [{resource:'pods/proxy', name:"mypod", namespace:"myns", myparam1:"myvalue"}, "http://localhost:8443/api/v1/namespaces/myns/pods/mypod/proxy?myparam1=myvalue"],
 
       // Different API versions
-      [{resource:'builds',apiVersion:'v1beta3'}, null],
-      [{resource:'builds',apiVersion:'v1'     }, "http://localhost:8443/oapi/v1/builds"],
-      [{resource:'builds',apiVersion:'unknown'}, null],
+      [{resource:'builds',version:'v1beta3'}, null],
+      [{resource:'builds',version:'v1'     }, "http://localhost:8443/oapi/v1/builds"],
+      [{resource:'builds',version:'unknown'}, null],
 
-      [{resource:'pods',  apiVersion:'v1beta3'}, null],
-      [{resource:'pods',  apiVersion:'v1'     }, "http://localhost:8443/api/v1/pods"],
-      [{resource:'pods',  apiVersion:'unknown'}, null]
+      [{resource:'pods',  version:'v1beta3'}, null],
+      [{resource:'pods',  version:'v1'     }, "http://localhost:8443/api/v1/pods"],
+      [{resource:'pods',  version:'unknown'}, null],
+
+      // Different API groups
+      [{resource:'jobs',  group: 'extensions', version:'v1beta1'}, "http://localhost:8443/apis/extensions/v1beta1/jobs"]
     ];
 
     angular.forEach(tc, function(item) {

--- a/test/fixtures/invalid-api-version-template.yaml
+++ b/test/fixtures/invalid-api-version-template.yaml
@@ -1,0 +1,81 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: invalid-api-version-template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      description: v1 Secret - used to test v1 negotiation of k8s objects
+    name: v1-secret
+- apiVersion: v1beta3
+  kind: Secret
+  metadata:
+    annotations:
+      description: v1beta3 Secret - used to test v1beta3 negotiation of k8s objects
+    name: v1beta3-secret
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      description: v1 Route - used to test v1 negotiation of origin objects
+    name: v1-route
+  spec:
+    to:
+      kind: Service
+      name: test
+- apiVersion: v1beta3
+  kind: Route
+  metadata:
+    annotations:
+      description: v1beta3 Route - used to test v1beta3 negotiation of origin objects
+    name: v1beta3-route
+  spec:
+    to:
+      kind: Service
+      name: test
+- apiVersion: extensions/v1beta1
+  kind: Job
+  metadata:
+    annotations:
+      description: v1beta1 Job - used to test v1beta1 negotation of group k8s objects
+    name: v1beta1-job
+  spec:
+    selector:
+      matchLabels:
+        run: v1beta1-job
+    template:
+      metadata:
+        labels:
+          run: v1beta1-job
+      spec:
+        containers:
+        - image: openshift/hello-openshift
+          name: hello-container
+        restartPolicy: Never
+- apiVersion: extensions/v1beta2
+  kind: Job
+  metadata:
+    annotations:
+      description: v1beta1 Job - used to test v1beta1 negotation of group k8s objects
+    name: v1beta2-job
+  spec:
+    selector:
+      matchLabels:
+        run: v1beta1-job
+    template:
+      metadata:
+        labels:
+          run: v1beta1-job
+      spec:
+        containers:
+        - image: openshift/hello-openshift
+          name: hello-container
+        restartPolicy: Never
+- apiVersion: othergroup/v2
+  kind: Foo
+  metadata:
+    annotations:
+      description: used to test how clients handle API groups they do not know about, and which fail when posted to the server
+    name: othergroup-v2-foo


### PR DESCRIPTION
- [x] unit tests for APIService
- [x] test editing YAML, changing API version, then submitting
- [x] test submitting template with v1beta3, see error
- [x] test submitting {"kind":"Scale","apiVersion":"extensions/v1beta1"} to "oapi/v1/deploymentconfigs/foo/scale"
- [x] fix up `DataService.url`
- [x] test submitting template with Job in extensions/v1beta1 - works
- [x] test submitting template with Job in extensions/v1beta2 - policy passes, API endpoint not found
- [x] test submitting template with extensions/invalidversion, see error - policy fails
- [x] remove `toResourceGroupVersionWithWarning` after ensuring all callers already have ResourceGroupVersion objects
