### PR TITLE
made login fail with bad token

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -211,6 +211,8 @@ fi
 
 
 # login and logout tests
+# bad token should error
+os::cmd::expect_failure_and_text "oc login ${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' --token=badvalue" 'The token provided is invalid or expired'
 # bad --api-version should error
 os::cmd::expect_failure_and_text "oc login ${KUBERNETES_MASTER} -u test-user -p test-password --api-version=foo/bar/baz" 'error.*foo/bar/baz'
 # --token and --username are mutually exclusive

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -217,7 +217,7 @@ func (o *LoginOptions) gatherAuthInfo() error {
 				return err
 			}
 
-			fmt.Fprint(o.Out, "The token provided is invalid (probably expired).\n\n")
+			return fmt.Errorf("The token provided is invalid or expired.\n\n")
 		}
 	}
 


### PR DESCRIPTION
This PR makes logging in with a bad token (`oc login --token=`) fail straight away instead of interactively asking for credentials.

@liggitt PTAL

fixes #7000 