### PR TITLE
[WIP] CARRY: Don't add clusterDNS if it's already there

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1567,7 +1567,7 @@ func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 	}
 	var dns, dnsSearch []string
 
-	if kl.clusterDNS != nil {
+	if kl.clusterDNS != nil && !sets.NewString(hostDNS...).Has(kl.clusterDNS.String()) {
 		dns = append([]string{kl.clusterDNS.String()}, hostDNS...)
 	} else {
 		dns = hostDNS


### PR DESCRIPTION
This will happen when we start adding kubernetes svc ip to the host's
/etc/resolv.conf. Upstream currently does not add the host's nameservers to pod
resolv.conf so this is not an issue upstream. If we change to upstream behavior
this change is unnecessary.