### PR TITLE
Import the AlwaysPullImages admission controller

### DIFF
--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -16,6 +16,7 @@ import (
 var admissionPluginsNotUsedByKube = sets.NewString(
 	"AlwaysAdmit",            // from kube, no need for this by default
 	"AlwaysDeny",             // from kube, no need for this by default
+	"AlwaysPullImages",       // from kube, not enabled by default.  This is only applicable to some environments.  This will ensure that containers cannot use pre-pulled copies of images without authorization.
 	"NamespaceAutoProvision", // from kube, it creates a namespace if a resource is created in a non-existent namespace.  We don't want this behavior
 	"SecurityContextDeny",    // from kube, it denies pods that want to use SCC capabilities.  We have different rules to allow this in openshift.
 	"DenyExecOnPrivileged",   // from kube (deprecated, see below), it denies exec to pods that have certain privileges.  This is superceded in origin by SCCExecRestrictions that checks against SCC rules.
@@ -32,7 +33,6 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"InitialResources", // do we want this? https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/initial-resources.md
 
 	"PersistentVolumeLabel", // do we want this? disable by default
-	"AlwaysPullImages",      // do we want this? disable by default
 )
 
 func TestKubeAdmissionControllerUsage(t *testing.T) {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/security/admission"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"


### PR DESCRIPTION
Import the AlwaysPullImages admission controller but do not enable it by default

@ncdc @abhgupta 

You can ignore the upstream commit in this pull, just wanted to get it submitted and through dev testing before the rebase was done so the card isn't hanging out.