### PR TITLE
Allow values as arguments in oc process

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -718,6 +718,9 @@ Process a template into list of resources
   # Convert stored template into resource list
   $ oc process foo
 
+  # Convert stored template into resource list by setting/overriding parameter values
+  $ oc process foo PARM1=VALUE1 PARM2=VALUE2
+
   # Convert template stored in different namespace into a resource list
   $ oc process openshift//foo
 

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -33,6 +33,14 @@ os::cmd::expect_success_and_text 'oc process -f test/templates/fixtures/guestboo
 # Individually specified parameter values are honored
 os::cmd::expect_success_and_text 'oc process -f test/templates/fixtures/guestbook.json -v ADMIN_USERNAME=myuser -v ADMIN_PASSWORD=mypassword' '"myuser"'
 os::cmd::expect_success_and_text 'oc process -f test/templates/fixtures/guestbook.json -v ADMIN_USERNAME=myuser -v ADMIN_PASSWORD=mypassword' '"mypassword"'
+# Argument values are honored
+os::cmd::expect_success_and_text 'oc process ADMIN_USERNAME=myuser ADMIN_PASSWORD=mypassword -f test/templates/fixtures/guestbook.json'       '"myuser"'
+os::cmd::expect_success_and_text 'oc process -f test/templates/fixtures/guestbook.json ADMIN_USERNAME=myuser ADMIN_PASSWORD=mypassword'       '"mypassword"'
+# Argument values with commas are honored
+os::cmd::expect_success 'oc create -f examples/sample-app/application-template-stibuild.json'
+os::cmd::expect_success_and_text 'oc process ruby-helloworld-sample MYSQL_USER=myself MYSQL_PASSWORD=my,1%pass'  '"myself"'
+os::cmd::expect_success_and_text 'oc process MYSQL_USER=myself MYSQL_PASSWORD=my,1%pass ruby-helloworld-sample'  '"my,1%pass"'
+os::cmd::expect_success 'oc delete template ruby-helloworld-sample'
 echo "template+parameters: ok"
 
 # Run as cluster-admin to allow choosing any supplemental groups we want


### PR DESCRIPTION
Makes `oc process` support `KEY=VALUE` template values as arguments, which makes it conform with `oc env`.

Also allows you to have argument values with commas (like `PASS=pass,%123`), which fixes https://bugzilla.redhat.com/show_bug.cgi?id=1264500.