### PR TITLE
Move build "Rebuild" and "Cancel" buttons to primary actions

### DIFF
--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -88,6 +88,7 @@ angular.module('openshiftConsole')
           }
         );
 
+        var hashSize = $filter('hashSize');
         watches.push(DataService.watch("builds", context, function(builds, action, build) {
           $scope.builds = {};
           // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
@@ -119,17 +120,19 @@ angular.module('openshiftConsole')
               delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
             }
           }
+
+          $scope.canBuild = !hashSize($scope.buildConfigBuildsInProgress[buildConfigName]);
         }));
-        $scope.startBuild = function(buildConfigName) {
-          BuildsService.startBuild(buildConfigName, context, $scope);
+
+        $scope.cancelBuild = function() {
+          BuildsService.cancelBuild($scope.build, $scope.buildConfigName, context, $scope);
         };
 
-        $scope.cancelBuild = function(build, buildConfigName) {
-          BuildsService.cancelBuild(build, buildConfigName, context, $scope);
-        };
-
-        $scope.cloneBuild = function(buildName) {
-          BuildsService.cloneBuild(buildName, context, $scope);
+        $scope.cloneBuild = function() {
+          var name = _.get($scope, 'build.metadata.name');
+          if (name && $scope.canBuild) {
+            BuildsService.cloneBuild(name, context, $scope);
+          }
         };
 
         $scope.$on('$destroy', function(){

--- a/assets/app/views/browse/_build-details.html
+++ b/assets/app/views/browse/_build-details.html
@@ -7,9 +7,6 @@
         <dd>
           <status-icon status="build.status.phase"></status-icon>
           {{build.status.phase}}
-
-        <button class="btn btn-default build-status-button btn-xs" ng-click="cancelBuild(build, buildConfigName)" ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel</button>
-        <button class="btn btn-default build-status-button btn-xs" ng-click="cloneBuild(build.metadata.name)" ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)" ng-disabled="(buildConfigBuildsInProgress[buildConfigName] | hashSize) !== 0">Rebuild</button>
         </dd>
         <dt>Started:</dt>
         <dd>

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -15,8 +15,35 @@
               <span ng-if="build.status.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="right" data-trigger="hover" dynamic-content="{{build.status.message}}"></span>
               <small class="meta">created <relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
+                <!-- Primary Actions -->
+                <button class="btn btn-default hidden-xs"
+                        ng-click="cancelBuild()"
+                        ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel</button>
+                <button class="btn btn-default hidden-xs"
+                        ng-click="cloneBuild()"
+                        ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)"
+                        ng-disabled="!canBuild">Rebuild</button>
+
+                <!-- Secondary Actions -->
                 <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
+                  <li ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)"
+                      class="visible-xs-inline">
+                    <a href=""
+                       role="button"
+                       ng-click="cancelBuild()"
+                    ><i class="fa fa-ban fa-fw" aria-hidden="true"></i> Cancel</a>
+                  </li>
+                  <li class="visible-xs-inline"
+                      ng-class="{ disabled: !canBuild }"
+                      ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)">
+                    <a href=""
+                       role="button"
+                       ng-click="cloneBuild()"
+                       ng-attr-aria-disabled="{{canBuild ? undefined : 'true'}}"
+                       ng-class="{ 'disabled-link': !canBuild }"
+                    ><i class="fa fa-refresh fa-fw"></i> Rebuild</a>
+                  </li>
                   <li>
                     <edit-link
                       resource="build"


### PR DESCRIPTION
Moves the "Rebuild" and "Cancel" buttons from inside the tab content to the primary actions for consistency with other pages. The buttons move into the kebab dropdown on mobile.

Desktop:

<img width="791" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/12816373/2078d114-cb1a-11e5-9841-6684b6fda407.png">

Mobile:

![screen shot 2016-02-04 at 8 34 51 am](https://cloud.githubusercontent.com/assets/1167259/12816406/5bffee02-cb1a-11e5-93ec-1c9a7481ec13.png)
