### PR TITLE
Fix problem with iOS zoom using the YAML editor

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -15,7 +15,7 @@
   input[type="search"],
   input[type="url"],
   textarea,
-  .ace_editor {
+  .console-os .ace_editor {
     font-size: 16px;
   }
 


### PR DESCRIPTION
Increase specificity of `font-size` editor style. The style is no longer applied to the editor.