### PR TITLE
E2e bindings dev pr rebase candidate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ all build:
 	hack/build-go.sh $(WHAT)
 .PHONY: all build
 
+# Build Code with E2E tests artifact.
+# Example:
+# make e2e
+e2e:
+	hack/build-go.sh test/e2e/e2e.test
+.PHONY: e2e
+
 # Run core verification and all self contained tests.
 #
 # Example:
@@ -38,7 +45,6 @@ all build:
 check: | build verify
 	$(MAKE) test-unit test-cmd -o build -o verify
 .PHONY: check
-
 
 # Verify code conventions are properly setup.
 #

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,25 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	ke2e "k8s.io/kubernetes/test/e2e"
+)
+
+var _ = Describe("Custom Extension", func() {
+	It("Should be extensible", func() {
+		By("Adding a new test on top of the other E2Es")
+		if 1 == 0 {
+			ke2e.Failf("example test, will never fail.")
+		}
+	})
+})
+
+func init() {
+	ke2e.RegisterFlags()
+}
+
+func TestE2E(t *testing.T) {
+	ke2e.RunE2ETests(t)
+}


### PR DESCRIPTION
This is the updated PR modification needed for e2e publishing which expects e2e.go to be in test/e2e/ based on the upstream https://github.com/kubernetes/kubernetes/commit/ef5f1012f687cd633f29b5e9b2b1c7ded2145195.
  
- patched it against the most up-to-date rebase that i could find, which is in @deads2k 's fork.  
- For provenance it currently includes all the commits which will flow in from the upcoming rebase,
- these extra commits will need to be rebased  away the rebase lands.