### PR TITLE
Rename system:humans group to system:authenticated:oauth

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -35,17 +35,17 @@ const (
 const (
 	UnauthenticatedUsername = "system:anonymous"
 
-	AuthenticatedGroup   = "system:authenticated"
-	UnauthenticatedGroup = "system:unauthenticated"
-	HumanGroup           = "system:humans"
-	ClusterAdminGroup    = "system:cluster-admins"
-	ClusterReaderGroup   = "system:cluster-readers"
-	MastersGroup         = "system:masters"
-	NodesGroup           = "system:nodes"
-	NodeAdminsGroup      = "system:node-admins"
-	NodeReadersGroup     = "system:node-readers"
-	RouterGroup          = "system:routers"
-	RegistryGroup        = "system:registries"
+	AuthenticatedGroup      = "system:authenticated"
+	AuthenticatedOAuthGroup = "system:authenticated:oauth"
+	UnauthenticatedGroup    = "system:unauthenticated"
+	ClusterAdminGroup       = "system:cluster-admins"
+	ClusterReaderGroup      = "system:cluster-readers"
+	MastersGroup            = "system:masters"
+	NodesGroup              = "system:nodes"
+	NodeAdminsGroup         = "system:node-admins"
+	NodeReadersGroup        = "system:node-readers"
+	RouterGroup             = "system:routers"
+	RegistryGroup           = "system:registries"
 )
 
 // Roles

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -641,7 +641,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: SelfProvisionerRoleName,
 			},
-			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: HumanGroup}},
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedOAuthGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -317,7 +317,7 @@ func newAuthenticator(config configapi.MasterConfig, etcdHelper storage.Interfac
 
 		authenticators = append(authenticators,
 			// if you have a bearer token, you're a human (usually)
-			group.NewGroupAdder(unionrequest.NewUnionAuthentication(tokenRequestAuthenticators...), []string{bootstrappolicy.HumanGroup}))
+			group.NewGroupAdder(unionrequest.NewUnionAuthentication(tokenRequestAuthenticators...), []string{bootstrappolicy.AuthenticatedOAuthGroup}))
 	}
 
 	if configapi.UseTLS(config.ServingInfo.ServingInfo) {

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -70,7 +70,7 @@ items:
   userNames: null
 - apiVersion: v1
   groupNames:
-  - system:humans
+  - system:authenticated:oauth
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
@@ -79,7 +79,7 @@ items:
     name: self-provisioner
   subjects:
   - kind: SystemGroup
-    name: system:humans
+    name: system:authenticated:oauth
   userNames: null
 - apiVersion: v1
   groupNames:


### PR DESCRIPTION
Fixes #7052

@smarterclayton PTAL

Chose "system:authenticated:oauth", given that it's a subset of all authenticated users, and we might want to do the same for x509 auth in the future