### PR TITLE
Make clean up before test runs more consistent

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -9,7 +9,7 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
-#Cleanup cluster resources created by this test
+# Cleanup cluster resources created by this test
 (
   set +e
   oc delete project/example project/ui-test-project project/recreated-project
@@ -24,7 +24,8 @@ os::log::install_errexit
   oc delete identities/anypassword:cascaded-user
   oadm policy reconcile-cluster-roles --confirm
   oadm policy reconcile-cluster-role-bindings --confirm
-) 2>/dev/null 1>&2
+) &>/dev/null
+
 
 defaultimage="openshift/origin-\${component}:latest"
 USE_IMAGES=${USE_IMAGES:-$defaultimage}
@@ -318,4 +319,3 @@ os::cmd::expect_success_and_not_text "oc get clusterrolebindings/cluster-admins 
 os::cmd::expect_success_and_not_text "oc get rolebindings/cluster-admin         --output-version=v1 --template='{{.subjects}}' -n default" 'cascaded-group'
 os::cmd::expect_success_and_not_text "oc get scc/restricted                     --output-version=v1 --template='{{.groups}}'"              'cascaded-group'
 echo "user-group-cascade: ok"
-

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates basic resource retrieval and command interaction
 
 os::cmd::expect_success_and_text 'oc types' 'Deployment Configuration'
@@ -82,7 +90,7 @@ os::cmd::expect_success 'oc create -f test/integration/fixtures/test-service.jso
 os::cmd::expect_failure 'oc expose service frontend --create-external-load-balancer'
 os::cmd::expect_failure 'oc expose service frontend --port=40 --type=NodePort'
 os::cmd::expect_success 'oc expose service frontend --path=/test'
-os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.path}}'" "/test"  
+os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.path}}'" "/test"
 os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.to.name}}'" "frontend"           # routes to correct service
 os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.port.targetPort}}'" "<no value>" # no target port for services with unnamed ports
 os::cmd::expect_success 'oc delete svc,route -l name=frontend'

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 url=":${API_PORT:-8443}"
 project="$(oc project -q)"
 

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates deployments and the env command
 
 os::cmd::expect_success 'oc get deploymentConfigs'

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates the edit command
 
 os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
@@ -18,4 +26,3 @@ os::cmd::expect_success_and_text 'OC_EDITOR=cat oc edit pod/hello-openshift' 'na
 os::cmd::expect_success_and_text 'OC_EDITOR=cat oc edit --windows-line-endings pod/hello-openshift | file -' 'CRLF'
 os::cmd::expect_success_and_not_text 'OC_EDITOR=cat oc edit --windows-line-endings=false pod/hello-openshift | file -' 'CRFL'
 echo "edit: ok"
-

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates the export command
 
 os::cmd::expect_success 'oc new-app -f examples/sample-app/application-template-stibuild.json --name=sample'

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -12,9 +12,10 @@ os::log::install_errexit
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete images test
+  oc delete all,templates --all
   exit 0
-) 2>/dev/null 1>&2
+) &>/dev/null
+
 
 defaultimage="openshift/origin-\${component}:latest"
 USE_IMAGES=${USE_IMAGES:-$defaultimage}

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates,secrets --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates secret interaction
 os::cmd::expect_failure_and_text 'oc secrets new foo --type=blah makefile=Makefile' 'error: unknown secret type "blah"'
 os::cmd::expect_success 'oc secrets new foo --type=blah makefile=Makefile --confirm'

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates template commands
 
 os::cmd::expect_success 'oc get templates'

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -9,6 +9,14 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates,pv,pvc --all
+  exit 0
+) &>/dev/null
+
+
 # This test validates the 'volume' command
 
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.yaml'


### PR DESCRIPTION
Add clean up of resources similar to what `test/cmd/newapp.sh` had to all other `test/cmd` tests.

This enables a developer to run tests against a running cluster multiple times in a row as documented in HACKING.md and test/cmd/README.md.