### PR TITLE
fix multiple component error handling

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -1046,12 +1046,11 @@ func (c *AppConfig) run(acceptors app.Acceptors) (*AppResult, error) {
 		}
 	}
 
-	imageRefs := components.ImageComponentRefs()
-	if len(imageRefs) > 1 && len(c.Name) > 0 {
+	if len(components.ImageComponentRefs().Group()) > 1 && len(c.Name) > 0 {
 		return nil, fmt.Errorf("only one component or source repository can be used when specifying a name")
 	}
-	if len(imageRefs) > 1 && len(c.To) > 0 {
-		return nil, fmt.Errorf("only one component or source repository can be used when specifying an output image reference")
+	if len(components.UseSource()) > 1 && len(c.To) > 0 {
+		return nil, fmt.Errorf("only one component with source can be used when specifying an output image reference")
 	}
 
 	env := app.Environment(environment)
@@ -1071,7 +1070,7 @@ func (c *AppConfig) run(acceptors app.Acceptors) (*AppResult, error) {
 		}, nil
 	}
 
-	pipelines, err := c.buildPipelines(imageRefs, env)
+	pipelines, err := c.buildPipelines(components.ImageComponentRefs(), env)
 	if err != nil {
 		if err == app.ErrNameRequired {
 			return nil, fmt.Errorf("can't suggest a valid name, please specify a name with --name")

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -81,6 +81,13 @@ func (r ComponentReferences) NeedsSource() (refs ComponentReferences) {
 	})
 }
 
+// UseSource returns all the components that use source repositories
+func (r ComponentReferences) UseSource() (refs ComponentReferences) {
+	return r.filter(func(ref ComponentReference) bool {
+		return ref.Input().Uses != nil
+	})
+}
+
 // ImageComponentRefs returns the list of component references to images
 func (r ComponentReferences) ImageComponentRefs() (refs ComponentReferences) {
 	return r.filter(func(ref ComponentReference) bool {

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -57,7 +57,7 @@ os::cmd::expect_success "oc new-build -D \$'FROM openshift/origin:v1.1\nENV ok=1
 os::cmd::expect_success_and_text "oc get bc/origin-test2 --template '${template}'" '^ImageStreamTag origin-name-test:latest$'
 
 os::cmd::try_until_text 'oc get is ruby-22-centos7' 'latest'
-os::cmd::expect_failure_and_text 'oc new-build ruby-22-centos7~https://github.com/openshift/ruby-ex ruby-22-centos7~https://github.com/openshift/ruby-ex --to invalid/argument' 'error: only one component or source repository can be used when specifying an output image reference'
+os::cmd::expect_failure_and_text 'oc new-build ruby-22-centos7~https://github.com/openshift/ruby-ex ruby-22-centos7~https://github.com/openshift/ruby-ex --to invalid/argument' 'error: only one component with source can be used when specifying an output image reference'
 
 os::cmd::expect_success 'oc delete all --all'
 

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -146,6 +146,14 @@ os::cmd::expect_failure_and_text 'oc new-app --dry-run mysq' 'error: only a part
 os::cmd::expect_failure_and_text 'oc new-app --dry-run mysq' 'The argument "mysq" only partially matched'
 os::cmd::expect_failure_and_text 'oc new-app --dry-run mysq' "Image stream \"mysql\" \\(tag \"5.6\"\\) in project"
 
+# Allow setting --name when specifying grouping
+os::cmd::expect_success "oc new-app mysql+ruby~https://github.com/openshift/ruby-ex --name foo -o yaml"
+# but not with multiple components
+os::cmd::expect_failure_and_text "oc new-app mysql ruby~https://github.com/openshift/ruby-ex --name foo -o yaml" "error: only one component or source repository can be used when specifying a name"
+# do not allow specifying output image when specifying multiple input repos
+os::cmd::expect_failure_and_text 'oc new-build https://github.com/openshift/nodejs-ex https://github.com/openshift/ruby-ex --to foo' 'error: only one component with source can be used when specifying an output image reference'
+# but succeed with multiple intput repos and no output image specified
+os::cmd::expect_success 'oc new-build https://github.com/openshift/nodejs-ex https://github.com/openshift/ruby-ex -o yaml'
 
 os::cmd::expect_success 'oc delete imageStreams --all'
 
@@ -164,6 +172,7 @@ os::cmd::expect_success 'oc delete all -l app=ruby'
 # check for error when template JSON file has errors
 jsonfile="${OS_ROOT}/test/fixtures/invalid.json"
 os::cmd::expect_failure_and_text "oc new-app '${jsonfile}'" "error: unable to load template file \"${jsonfile}\": invalid character '}' after object key"
+
 
 # check new-build
 os::cmd::expect_failure_and_text 'oc new-build mysql -o yaml' 'you must specify at least one source repository URL'


### PR DESCRIPTION
disallow --to only when multiple source components are specified
disallow --name only when multiple DCs will be created

fixes https://github.com/openshift/origin/issues/6372