### PR TITLE
tar extract cannot hard link on vboxfs filesystem

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -18,9 +18,9 @@ if [[ -z "$@" ]]; then
     platform=$(os::build::host_platform)
     echo "++ Using release artifacts from ${OS_RELEASE_COMMIT} for ${platform} instead of building"
     mkdir -p "${OS_OUTPUT_BINPATH}/${platform}"
-    tar mxzf "${OS_PRIMARY_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/${platform}"
-    tar mxzf "${OS_CLIENT_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/${platform}"
-    tar mxzf "${OS_IMAGE_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/${platform}"
+    os::build::extract_tar "${OS_PRIMARY_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/${platform}"
+    os::build::extract_tar "${OS_CLIENT_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/${platform}"
+    os::build::extract_tar "${OS_IMAGE_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/${platform}"
 
     os::build::make_openshift_binary_symlinks
 

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -18,8 +18,8 @@ cd "${OS_ROOT}"
 os::build::detect_local_release_tars $(os::build::host_platform_friendly)
 
 mkdir -p "${OS_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${OS_PRIMARY_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${OS_CLIENT_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${OS_IMAGE_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/linux/amd64"
+os::build::extract_tar "${OS_PRIMARY_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/linux/amd64"
+os::build::extract_tar "${OS_CLIENT_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/linux/amd64"
+os::build::extract_tar "${OS_IMAGE_RELEASE_TAR}" "${OS_OUTPUT_BINPATH}/linux/amd64"
 
 os::build::make_openshift_binary_symlinks


### PR DESCRIPTION
Some filesystems are not supporting hard links and tar can not extract the content from the release archives. 

The change Fixes #6900 by first checking if a hard link can be created on the destination filesystem. The check is done by trial and error, as checking only for the filesystem type (vboxfs) is not reliable.

If the file system is not supporting hard links then the archive is extracted in a ramfs (/dev/shm) and then dereferenced using tar to replace hard links with files.  
