### PR TITLE
Clean up test scripts

### DIFF
--- a/hack/lib/log.sh
+++ b/hack/lib/log.sh
@@ -200,16 +200,13 @@ function os::log::start_system_logger() {
     readonly SAR_LOGFILE="${LOG_DIR}/sar.log"
     export SAR_LOGFILE
 
-    ( os::log::internal::run_system_logger "${SAR_LOGFILE}" "${LOG_DIR}/sar_stderr.log" ) &
-    LOGGER_PID=$!
-    readonly LOGGER_PID
-    export LOGGER_PID
+    os::log::internal::run_system_logger "${SAR_LOGFILE}" "${LOG_DIR}/sar_stderr.log"
 
     os::log::install_system_logger_cleanup
 }
 
 
-# os::log::internal::run_system_logger runs the system logger. This function should be run in the background.
+# os::log::internal::run_system_logger runs the system logger in the background.
 # 'sar' is configured to run once a second for 24 hours, so the cleanup trap should be installed to ensure that
 # the process is killed once the parent script is finished.
 #
@@ -224,5 +221,9 @@ function os::log::internal::run_system_logger() {
     local binary_logfile=$1
     local stderr_logfile=$2
 
-    sar -A -o "${binary_logfile}" 1 86400 1>/dev/null 2>"${stderr_logfile}"
+    sar -A -o "${binary_logfile}" 1 86400 1>/dev/null 2>"${stderr_logfile}" &
+    
+    LOGGER_PID=$!
+    readonly LOGGER_PID
+    export LOGGER_PID
 }

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -95,7 +95,7 @@ function exectest() {
 
 		# dump etcd for failing test
 		echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/$1-etcd_dump.json"
-		curl -L "${API_SCHEME}://${API_HOST}:${ETCD_PORT}/v2/keys/?recursive=true" > "${ARTIFACT_DIR}/$1-etcd_dump.json"
+		curl -L -s "${API_SCHEME}://${API_HOST}:${ETCD_PORT}/v2/keys/?recursive=true" > "${ARTIFACT_DIR}/$1-etcd_dump.json"
 		echo
 
 		exit 1


### PR DESCRIPTION
Add conditionals around cleanup things that assume docker is running
Use `pgrep -P` instead of `ps --pid`
Launch logger in background, clean up child processes as well