### PR TITLE
Support 'oc explain' for Origin types

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/explain.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/explain.go
@@ -98,7 +98,7 @@ func RunExplain(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 		}
 	}
 
-	schema, err := f.SwaggerSchema(apiVersion)
+	schema, err := f.SwaggerSchema(apiVersion.WithKind(gvk.Kind))
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -95,8 +95,8 @@ type Factory struct {
 	LogsForObject func(object, options runtime.Object) (*client.Request, error)
 	// Returns a schema that can validate objects stored on disk.
 	Validator func(validate bool, cacheDir string) (validation.Schema, error)
-	// SwaggerSchema returns the schema declaration for the provided group version.
-	SwaggerSchema func(unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	// SwaggerSchema returns the schema declaration for the provided group version kind.
+	SwaggerSchema func(unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error)
 	// Returns the default namespace to use in cases where no
 	// other namespace is specified and whether the namespace was
 	// overriden.
@@ -335,7 +335,8 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 			}
 			return validation.NullSchema{}, nil
 		},
-		SwaggerSchema: func(version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+		SwaggerSchema: func(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
+			version := gvk.GroupVersion()
 			client, err := clients.ClientForVersion(&version)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Will now explain Origin types, and @stevekuznetsov's changes will enhance this as well.