### PR TITLE
Repository and image quota support

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/distribution/errors.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/errors.go
@@ -8,6 +8,10 @@ import (
 	"github.com/docker/distribution/digest"
 )
 
+// ErrAccessDenied is returned when an access to a requested resource is
+// denied.
+var ErrAccessDenied = errors.New("access denied")
+
 // ErrManifestNotModified is returned when a conditional manifest GetByTag
 // returns nil due to the client indicating it has the latest version
 var ErrManifestNotModified = errors.New("manifest not modified")

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/blobupload.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/blobupload.go
@@ -221,12 +221,18 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 		return
 	}
 
+	size := buh.State.Offset
+	if offset, err := buh.Upload.Seek(0, os.SEEK_CUR); err == nil {
+		size = offset
+	}
+
 	desc, err := buh.Upload.Commit(buh, distribution.Descriptor{
 		Digest: dgst,
+		Size:   size,
 
 		// TODO(stevvooe): This isn't wildly important yet, but we should
-		// really set the length and mediatype. For now, we can let the
-		// backend take care of this.
+		// really set the mediatype. For now, we can let the backend take care
+		// of this.
 	})
 
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/blobupload.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/blobupload.go
@@ -241,6 +241,8 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 			buh.Errors = append(buh.Errors, v2.ErrorCodeDigestInvalid.WithDetail(err))
 		default:
 			switch err {
+			case distribution.ErrAccessDenied:
+				buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied)
 			case distribution.ErrUnsupported:
 				buh.Errors = append(buh.Errors, errcode.ErrorCodeUnsupported)
 			case distribution.ErrBlobInvalidLength, distribution.ErrBlobDigestUnsupported:

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/images.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/images.go
@@ -163,6 +163,10 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnsupported)
 			return
 		}
+		if err == distribution.ErrAccessDenied {
+			imh.Errors = append(imh.Errors, errcode.ErrorCodeDenied)
+			return
+		}
 		switch err := err.(type) {
 		case distribution.ErrManifestVerification:
 			for _, verificationError := range err {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -16579,8 +16579,19 @@
      "hard": {
       "type": "any",
       "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+     },
+     "scopes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ResourceQuotaScope"
+      },
+      "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects."
      }
     }
+   },
+   "v1.ResourceQuotaScope": {
+    "id": "v1.ResourceQuotaScope",
+    "properties": {}
    },
    "v1.ResourceQuotaStatus": {
     "id": "v1.ResourceQuotaStatus",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -60,6 +60,7 @@ import (
 	servicecontroller "k8s.io/kubernetes/pkg/controller/service"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/healthz"
+	quotainstall "k8s.io/kubernetes/pkg/quota/install"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -217,9 +218,23 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 		glog.Infof("allocate-node-cidrs set to %v, node controller not creating routes", s.AllocateNodeCIDRs)
 	}
 
-	go resourcequotacontroller.NewResourceQuotaController(
-		clientset.NewForConfigOrDie(client.AddUserAgent(kubeconfig, "resourcequota-controller")),
-		controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod)).Run(s.ConcurrentResourceQuotaSyncs, wait.NeverStop)
+	resourceQuotaControllerClient := clientset.NewForConfigOrDie(client.AddUserAgent(kubeconfig, "resourcequota-controller"))
+	resourceQuotaRegistry := quotainstall.NewRegistry(resourceQuotaControllerClient)
+	groupKindsToReplenish := []unversioned.GroupKind{
+		api.Kind("Pod"),
+		api.Kind("Service"),
+		api.Kind("ReplicationController"),
+		api.Kind("PersistentVolumeClaim"),
+		api.Kind("Secret"),
+	}
+	resourceQuotaControllerOptions := &resourcequotacontroller.ResourceQuotaControllerOptions{
+		KubeClient:            resourceQuotaControllerClient,
+		ResyncPeriod:          controller.StaticResyncPeriodFunc(s.ResourceQuotaSyncPeriod),
+		Registry:              resourceQuotaRegistry,
+		GroupKindsToReplenish: groupKindsToReplenish,
+		ControllerFactory:     resourcequotacontroller.NewReplenishmentControllerFactory(resourceQuotaControllerClient),
+	}
+	go resourcequotacontroller.NewResourceQuotaController(resourceQuotaControllerOptions).Run(s.ConcurrentResourceQuotaSyncs, wait.NeverStop)
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2457,6 +2457,15 @@ func DeepCopy_api_ResourceQuotaSpec(in ResourceQuotaSpec, out *ResourceQuotaSpec
 	} else {
 		out.Hard = nil
 	}
+	if in.Scopes != nil {
+		in, out := in.Scopes, &out.Scopes
+		*out = make([]ResourceQuotaScope, len(in))
+		for i := range in {
+			(*out)[i] = in[i]
+		}
+	} else {
+		out.Scopes = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/helpers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/helpers.go
@@ -79,9 +79,82 @@ var Semantic = conversion.EqualitiesOrDie(
 	},
 )
 
+var standardResourceQuotaScopes = sets.NewString(
+	string(ResourceQuotaScopeTerminating),
+	string(ResourceQuotaScopeNotTerminating),
+	string(ResourceQuotaScopeBestEffort),
+	string(ResourceQuotaScopeNotBestEffort),
+)
+
+// IsStandardResourceQuotaScope returns true if the scope is a standard value
+func IsStandardResourceQuotaScope(str string) bool {
+	return standardResourceQuotaScopes.Has(str)
+}
+
+var podObjectCountQuotaResources = sets.NewString(
+	string(ResourcePods),
+)
+
+var podComputeQuotaResources = sets.NewString(
+	string(ResourceCPU),
+	string(ResourceMemory),
+	string(ResourceLimitsCPU),
+	string(ResourceLimitsMemory),
+	string(ResourceRequestsCPU),
+	string(ResourceRequestsMemory),
+)
+
+// IsResourceQuotaScopeValidForResource returns true if the resource applies to the specified scope
+func IsResourceQuotaScopeValidForResource(scope ResourceQuotaScope, resource string) bool {
+	switch scope {
+	case ResourceQuotaScopeTerminating, ResourceQuotaScopeNotTerminating, ResourceQuotaScopeNotBestEffort:
+		return podObjectCountQuotaResources.Has(resource) || podComputeQuotaResources.Has(resource)
+	case ResourceQuotaScopeBestEffort:
+		return podObjectCountQuotaResources.Has(resource)
+	default:
+		return true
+	}
+}
+
+var standardContainerResources = sets.NewString(
+	string(ResourceCPU),
+	string(ResourceMemory),
+)
+
+// IsStandardContainerResourceName returns true if the container can make a resource request
+// for the specified resource
+func IsStandardContainerResourceName(str string) bool {
+	return standardContainerResources.Has(str)
+}
+
+var standardQuotaResources = sets.NewString(
+	string(ResourceCPU),
+	string(ResourceMemory),
+	string(ResourceRequestsCPU),
+	string(ResourceRequestsMemory),
+	string(ResourceLimitsCPU),
+	string(ResourceLimitsMemory),
+	string(ResourcePods),
+	string(ResourceQuotas),
+	string(ResourceServices),
+	string(ResourceReplicationControllers),
+	string(ResourceSecrets),
+	string(ResourcePersistentVolumeClaims),
+)
+
+// IsStandardQuotaResourceName returns true if the resource is known to
+// the quota tracking system
+func IsStandardQuotaResourceName(str string) bool {
+	return standardQuotaResources.Has(str)
+}
+
 var standardResources = sets.NewString(
 	string(ResourceCPU),
 	string(ResourceMemory),
+	string(ResourceRequestsCPU),
+	string(ResourceRequestsMemory),
+	string(ResourceLimitsCPU),
+	string(ResourceLimitsMemory),
 	string(ResourcePods),
 	string(ResourceQuotas),
 	string(ResourceServices),

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2135,12 +2135,37 @@ const (
 	ResourceSecrets ResourceName = "secrets"
 	// ResourcePersistentVolumeClaims, number
 	ResourcePersistentVolumeClaims ResourceName = "persistentvolumeclaims"
+	// CPU request, in cores. (500m = .5 cores)
+	ResourceRequestsCPU ResourceName = "requests.cpu"
+	// Memory request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceRequestsMemory ResourceName = "requests.memory"
+	// CPU limit, in cores. (500m = .5 cores)
+	ResourceLimitsCPU ResourceName = "limits.cpu"
+	// Memory limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceLimitsMemory ResourceName = "limits.memory"
+)
+
+// A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+type ResourceQuotaScope string
+
+const (
+	// Match all pod objects where spec.activeDeadlineSeconds
+	ResourceQuotaScopeTerminating ResourceQuotaScope = "Terminating"
+	// Match all pod objects where !spec.activeDeadlineSeconds
+	ResourceQuotaScopeNotTerminating ResourceQuotaScope = "NotTerminating"
+	// Match all pod objects that have best effort quality of service
+	ResourceQuotaScopeBestEffort ResourceQuotaScope = "BestEffort"
+	// Match all pod objects that do not have best effort quality of service
+	ResourceQuotaScopeNotBestEffort ResourceQuotaScope = "NotBestEffort"
 )
 
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota
 type ResourceQuotaSpec struct {
 	// Hard is the set of desired hard limits for each named resource
 	Hard ResourceList `json:"hard,omitempty"`
+	// A collection of filters that must match each object tracked by a quota.
+	// If not specified, the quota matches all objects.
+	Scopes []ResourceQuotaScope `json:"scopes,omitempty"`
 }
 
 // ResourceQuotaStatus defines the enforced hard limits and observed use

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2652,6 +2652,14 @@ func autoConvert_api_ResourceQuotaSpec_To_v1_ResourceQuotaSpec(in *api.ResourceQ
 	} else {
 		out.Hard = nil
 	}
+	if in.Scopes != nil {
+		out.Scopes = make([]ResourceQuotaScope, len(in.Scopes))
+		for i := range in.Scopes {
+			out.Scopes[i] = ResourceQuotaScope(in.Scopes[i])
+		}
+	} else {
+		out.Scopes = nil
+	}
 	return nil
 }
 
@@ -6007,6 +6015,14 @@ func autoConvert_v1_ResourceQuotaSpec_To_api_ResourceQuotaSpec(in *ResourceQuota
 	}
 	if err := s.Convert(&in.Hard, &out.Hard, 0); err != nil {
 		return err
+	}
+	if in.Scopes != nil {
+		out.Scopes = make([]api.ResourceQuotaScope, len(in.Scopes))
+		for i := range in.Scopes {
+			out.Scopes[i] = api.ResourceQuotaScope(in.Scopes[i])
+		}
+	} else {
+		out.Scopes = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2097,6 +2097,14 @@ func deepCopy_v1_ResourceQuotaSpec(in ResourceQuotaSpec, out *ResourceQuotaSpec,
 	} else {
 		out.Hard = nil
 	}
+	if in.Scopes != nil {
+		out.Scopes = make([]ResourceQuotaScope, len(in.Scopes))
+		for i := range in.Scopes {
+			out.Scopes[i] = in.Scopes[i]
+		}
+	} else {
+		out.Scopes = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2599,6 +2599,28 @@ const (
 	ResourceSecrets ResourceName = "secrets"
 	// ResourcePersistentVolumeClaims, number
 	ResourcePersistentVolumeClaims ResourceName = "persistentvolumeclaims"
+	// CPU request, in cores. (500m = .5 cores)
+	ResourceCPURequest ResourceName = "cpu.request"
+	// CPU limit, in cores. (500m = .5 cores)
+	ResourceCPULimit ResourceName = "cpu.limit"
+	// Memory request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceMemoryRequest ResourceName = "memory.request"
+	// Memory limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceMemoryLimit ResourceName = "memory.limit"
+)
+
+// A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+type ResourceQuotaScope string
+
+const (
+	// Match all pod objects where spec.activeDeadlineSeconds
+	ResourceQuotaScopeTerminating ResourceQuotaScope = "Terminating"
+	// Match all pod objects where !spec.activeDeadlineSeconds
+	ResourceQuotaScopeNotTerminating ResourceQuotaScope = "NotTerminating"
+	// Match all pod objects that have best effort quality of service
+	ResourceQuotaScopeBestEffort ResourceQuotaScope = "BestEffort"
+	// Match all pod objects that do not have best effort quality of service
+	ResourceQuotaScopeNotBestEffort ResourceQuotaScope = "NotBestEffort"
 )
 
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
@@ -2606,6 +2628,9 @@ type ResourceQuotaSpec struct {
 	// Hard is the set of desired hard limits for each named resource.
 	// More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
 	Hard ResourceList `json:"hard,omitempty"`
+	// A collection of filters that must match each object tracked by a quota.
+	// If not specified, the quota matches all objects.
+	Scopes []ResourceQuotaScope `json:"scopes,omitempty"`
 }
 
 // ResourceQuotaStatus defines the enforced hard limits and observed use.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -1364,8 +1364,9 @@ func (ResourceQuotaList) SwaggerDoc() map[string]string {
 }
 
 var map_ResourceQuotaSpec = map[string]string{
-	"":     "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
-	"hard": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+	"":       "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
+	"hard":   "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+	"scopes": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
 }
 
 func (ResourceQuotaSpec) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -44,6 +44,7 @@ import (
 var RepairMalformedUpdates bool = true
 
 const isNegativeErrorMsg string = `must be greater than or equal to 0`
+const isInvalidQuotaResource string = `must be a standard resource for quota`
 const fieldImmutableErrorMsg string = `field is immutable`
 const cIdentifierErrorMsg string = `must be a C identifier (matching regex ` + validation.CIdentifierFmt + `): e.g. "my_name" or "MyName"`
 const isNotIntegerErrorMsg string = `must be an integer`
@@ -1934,6 +1935,30 @@ func validateResourceName(value string, fldPath *field.Path) field.ErrorList {
 	return field.ErrorList{}
 }
 
+// Validate container resource name
+// Refer to docs/design/resources.md for more details.
+func validateContainerResourceName(value string, fldPath *field.Path) field.ErrorList {
+	allErrs := validateResourceName(value, fldPath)
+	if len(strings.Split(value, "/")) == 1 {
+		if !api.IsStandardContainerResourceName(value) {
+			return append(allErrs, field.Invalid(fldPath, value, "must be a standard resource for containers"))
+		}
+	}
+	return field.ErrorList{}
+}
+
+// Validate resource names that can go in a resource quota
+// Refer to docs/design/resources.md for more details.
+func validateResourceQuotaResourceName(value string, fldPath *field.Path) field.ErrorList {
+	allErrs := validateResourceName(value, fldPath)
+	if len(strings.Split(value, "/")) == 1 {
+		if !api.IsStandardQuotaResourceName(value) {
+			return append(allErrs, field.Invalid(fldPath, value, isInvalidQuotaResource))
+		}
+	}
+	return field.ErrorList{}
+}
+
 // ValidateLimitRange tests if required fields in the LimitRange are set.
 func ValidateLimitRange(limitRange *api.LimitRange) field.ErrorList {
 	allErrs := ValidateObjectMeta(&limitRange.ObjectMeta, true, ValidateLimitRangeName, field.NewPath("metadata"))
@@ -1958,12 +1983,12 @@ func ValidateLimitRange(limitRange *api.LimitRange) field.ErrorList {
 		maxLimitRequestRatios := map[string]resource.Quantity{}
 
 		for k, q := range limit.Max {
-			allErrs = append(allErrs, validateResourceName(string(k), idxPath.Child("max").Key(string(k)))...)
+			allErrs = append(allErrs, validateContainerResourceName(string(k), idxPath.Child("max").Key(string(k)))...)
 			keys.Insert(string(k))
 			max[string(k)] = q
 		}
 		for k, q := range limit.Min {
-			allErrs = append(allErrs, validateResourceName(string(k), idxPath.Child("min").Key(string(k)))...)
+			allErrs = append(allErrs, validateContainerResourceName(string(k), idxPath.Child("min").Key(string(k)))...)
 			keys.Insert(string(k))
 			min[string(k)] = q
 		}
@@ -1977,19 +2002,19 @@ func ValidateLimitRange(limitRange *api.LimitRange) field.ErrorList {
 			}
 		} else {
 			for k, q := range limit.Default {
-				allErrs = append(allErrs, validateResourceName(string(k), idxPath.Child("default").Key(string(k)))...)
+				allErrs = append(allErrs, validateContainerResourceName(string(k), idxPath.Child("default").Key(string(k)))...)
 				keys.Insert(string(k))
 				defaults[string(k)] = q
 			}
 			for k, q := range limit.DefaultRequest {
-				allErrs = append(allErrs, validateResourceName(string(k), idxPath.Child("defaultRequest").Key(string(k)))...)
+				allErrs = append(allErrs, validateContainerResourceName(string(k), idxPath.Child("defaultRequest").Key(string(k)))...)
 				keys.Insert(string(k))
 				defaultRequests[string(k)] = q
 			}
 		}
 
 		for k, q := range limit.MaxLimitRequestRatio {
-			allErrs = append(allErrs, validateResourceName(string(k), idxPath.Child("maxLimitRequestRatio").Key(string(k)))...)
+			allErrs = append(allErrs, validateContainerResourceName(string(k), idxPath.Child("maxLimitRequestRatio").Key(string(k)))...)
 			keys.Insert(string(k))
 			maxLimitRequestRatios[string(k)] = q
 		}
@@ -2212,7 +2237,7 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 	for resourceName, quantity := range requirements.Limits {
 		fldPath := limPath.Key(string(resourceName))
 		// Validate resource name.
-		allErrs = append(allErrs, validateResourceName(string(resourceName), fldPath)...)
+		allErrs = append(allErrs, validateContainerResourceName(string(resourceName), fldPath)...)
 		if api.IsStandardResourceName(string(resourceName)) {
 			allErrs = append(allErrs, validateBasicResource(quantity, fldPath.Key(string(resourceName)))...)
 		}
@@ -2236,9 +2261,44 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 	for resourceName, quantity := range requirements.Requests {
 		fldPath := reqPath.Key(string(resourceName))
 		// Validate resource name.
-		allErrs = append(allErrs, validateResourceName(string(resourceName), fldPath)...)
+		allErrs = append(allErrs, validateContainerResourceName(string(resourceName), fldPath)...)
 		if api.IsStandardResourceName(string(resourceName)) {
 			allErrs = append(allErrs, validateBasicResource(quantity, fldPath.Key(string(resourceName)))...)
+		}
+	}
+	return allErrs
+}
+
+// validateResourceQuotaScopes ensures that each enumerated hard resource constraint is valid for set of scopes
+func validateResourceQuotaScopes(resourceQuota *api.ResourceQuota) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(resourceQuota.Spec.Scopes) == 0 {
+		return allErrs
+	}
+	hardLimits := sets.NewString()
+	for k := range resourceQuota.Spec.Hard {
+		hardLimits.Insert(string(k))
+	}
+	fldPath := field.NewPath("spec", "scopes")
+	scopeSet := sets.NewString()
+	for _, scope := range resourceQuota.Spec.Scopes {
+		if !api.IsStandardResourceQuotaScope(string(scope)) {
+			allErrs = append(allErrs, field.Invalid(fldPath, resourceQuota.Spec.Scopes, "unsupported scope"))
+		}
+		for _, k := range hardLimits.List() {
+			if api.IsStandardQuotaResourceName(k) && !api.IsResourceQuotaScopeValidForResource(scope, k) {
+				allErrs = append(allErrs, field.Invalid(fldPath, resourceQuota.Spec.Scopes, "unsupported scope applied to resource"))
+			}
+		}
+		scopeSet.Insert(string(scope))
+	}
+	invalidScopePairs := []sets.String{
+		sets.NewString(string(api.ResourceQuotaScopeBestEffort), string(api.ResourceQuotaScopeNotBestEffort)),
+		sets.NewString(string(api.ResourceQuotaScopeTerminating), string(api.ResourceQuotaScopeNotTerminating)),
+	}
+	for _, invalidScopePair := range invalidScopePairs {
+		if scopeSet.HasAll(invalidScopePair.List()...) {
+			allErrs = append(allErrs, field.Invalid(fldPath, resourceQuota.Spec.Scopes, "conflicting scopes"))
 		}
 	}
 	return allErrs
@@ -2251,21 +2311,24 @@ func ValidateResourceQuota(resourceQuota *api.ResourceQuota) field.ErrorList {
 	fldPath := field.NewPath("spec", "hard")
 	for k, v := range resourceQuota.Spec.Hard {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
+	allErrs = append(allErrs, validateResourceQuotaScopes(resourceQuota)...)
+
 	fldPath = field.NewPath("status", "hard")
 	for k, v := range resourceQuota.Status.Hard {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
 	fldPath = field.NewPath("status", "used")
 	for k, v := range resourceQuota.Status.Used {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
+
 	return allErrs
 }
 
@@ -2288,9 +2351,25 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *api.Resourc
 	fldPath := field.NewPath("spec", "hard")
 	for k, v := range newResourceQuota.Spec.Hard {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
+
+	// ensure scopes cannot change, and that resources are still valid for scope
+	fldPath = field.NewPath("spec", "scopes")
+	oldScopes := sets.NewString()
+	newScopes := sets.NewString()
+	for _, scope := range newResourceQuota.Spec.Scopes {
+		newScopes.Insert(string(scope))
+	}
+	for _, scope := range oldResourceQuota.Spec.Scopes {
+		oldScopes.Insert(string(scope))
+	}
+	if !oldScopes.Equal(newScopes) {
+		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, "field is immutable"))
+	}
+	allErrs = append(allErrs, validateResourceQuotaScopes(newResourceQuota)...)
+
 	newResourceQuota.Status = oldResourceQuota.Status
 	return allErrs
 }
@@ -2305,13 +2384,13 @@ func ValidateResourceQuotaStatusUpdate(newResourceQuota, oldResourceQuota *api.R
 	fldPath := field.NewPath("status", "hard")
 	for k, v := range newResourceQuota.Status.Hard {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
 	fldPath = field.NewPath("status", "used")
 	for k, v := range newResourceQuota.Status.Used {
 		resPath := fldPath.Key(string(k))
-		allErrs = append(allErrs, validateResourceName(string(k), resPath)...)
+		allErrs = append(allErrs, validateResourceQuotaResourceName(string(k), resPath)...)
 		allErrs = append(allErrs, validateResourceQuantityValue(string(k), v, resPath)...)
 	}
 	newResourceQuota.Spec = oldResourceQuota.Spec

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
@@ -3953,10 +3953,50 @@ func TestValidateResourceQuota(t *testing.T) {
 		Hard: api.ResourceList{
 			api.ResourceCPU:                    resource.MustParse("100"),
 			api.ResourceMemory:                 resource.MustParse("10000"),
+			api.ResourceRequestsCPU:            resource.MustParse("100"),
+			api.ResourceRequestsMemory:         resource.MustParse("10000"),
+			api.ResourceLimitsCPU:              resource.MustParse("100"),
+			api.ResourceLimitsMemory:           resource.MustParse("10000"),
 			api.ResourcePods:                   resource.MustParse("10"),
 			api.ResourceServices:               resource.MustParse("0"),
 			api.ResourceReplicationControllers: resource.MustParse("10"),
 			api.ResourceQuotas:                 resource.MustParse("10"),
+		},
+	}
+
+	terminatingSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceCPU:       resource.MustParse("100"),
+			api.ResourceLimitsCPU: resource.MustParse("200"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeTerminating},
+	}
+
+	nonTerminatingSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceCPU: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeNotTerminating},
+	}
+
+	bestEffortSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourcePods: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeBestEffort},
+	}
+
+	nonBestEffortSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceCPU: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeNotBestEffort},
+	}
+
+	// storage is not yet supported as a quota tracked resource
+	invalidQuotaResourceSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceStorage: resource.MustParse("10"),
 		},
 	}
 
@@ -3986,6 +4026,27 @@ func TestValidateResourceQuota(t *testing.T) {
 		},
 	}
 
+	invalidTerminatingScopePairsSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceCPU: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeTerminating, api.ResourceQuotaScopeNotTerminating},
+	}
+
+	invalidBestEffortScopePairsSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourcePods: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeBestEffort, api.ResourceQuotaScopeNotBestEffort},
+	}
+
+	invalidScopeNameSpec := api.ResourceQuotaSpec{
+		Hard: api.ResourceList{
+			api.ResourceCPU: resource.MustParse("100"),
+		},
+		Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScope("foo")},
+	}
+
 	successCases := []api.ResourceQuota{
 		{
 			ObjectMeta: api.ObjectMeta{
@@ -4000,6 +4061,34 @@ func TestValidateResourceQuota(t *testing.T) {
 				Namespace: "foo",
 			},
 			Spec: fractionalComputeSpec,
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "abc",
+				Namespace: "foo",
+			},
+			Spec: terminatingSpec,
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "abc",
+				Namespace: "foo",
+			},
+			Spec: nonTerminatingSpec,
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "abc",
+				Namespace: "foo",
+			},
+			Spec: bestEffortSpec,
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "abc",
+				Namespace: "foo",
+			},
+			Spec: nonBestEffortSpec,
 		},
 	}
 
@@ -4036,6 +4125,22 @@ func TestValidateResourceQuota(t *testing.T) {
 		"fractional-api-resource": {
 			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: fractionalPodSpec},
 			isNotIntegerErrorMsg,
+		},
+		"invalid-quota-resource": {
+			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: invalidQuotaResourceSpec},
+			isInvalidQuotaResource,
+		},
+		"invalid-quota-terminating-pair": {
+			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: invalidTerminatingScopePairsSpec},
+			"conflicting scopes",
+		},
+		"invalid-quota-besteffort-pair": {
+			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: invalidBestEffortScopePairsSpec},
+			"conflicting scopes",
+		},
+		"invalid-quota-scope-name": {
+			api.ResourceQuota{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: invalidScopeNameSpec},
+			"unsupported scope",
 		},
 	}
 	for k, v := range errorCases {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/replenishment_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/replenishment_controller.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/cache"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/quota/evaluator/core"
+	"k8s.io/kubernetes/pkg/runtime"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ReplenishmentFunc is a function that is invoked when controller sees a change
+// that may require a quota to be replenished (i.e. object deletion, or object moved to terminal state)
+type ReplenishmentFunc func(groupKind unversioned.GroupKind, namespace string, object runtime.Object)
+
+// ReplenishmentControllerOptions is an options struct that tells a factory
+// how to configure a controller that can inform the quota system it should
+// replenish quota
+type ReplenishmentControllerOptions struct {
+	// The kind monitored for replenishment
+	GroupKind unversioned.GroupKind
+	// The period that should be used to re-sync the monitored resource
+	ResyncPeriod controller.ResyncPeriodFunc
+	// The function to invoke when a change is observed that should trigger
+	// replenishment
+	ReplenishmentFunc ReplenishmentFunc
+}
+
+// PodReplenishmentUpdateFunc will replenish if the old pod was quota tracked but the new is not
+func PodReplenishmentUpdateFunc(options *ReplenishmentControllerOptions) func(oldObj, newObj interface{}) {
+	return func(oldObj, newObj interface{}) {
+		oldPod := oldObj.(*api.Pod)
+		newPod := newObj.(*api.Pod)
+		if core.QuotaPod(oldPod) && !core.QuotaPod(newPod) {
+			options.ReplenishmentFunc(options.GroupKind, newPod.Namespace, newPod)
+		}
+	}
+}
+
+// ObjectReplenenishmentDeleteFunc will replenish on every delete
+func ObjectReplenishmentDeleteFunc(options *ReplenishmentControllerOptions) func(obj interface{}) {
+	return func(obj interface{}) {
+		metaObject, err := meta.Accessor(obj)
+		if err != nil {
+			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				glog.Errorf("replenishment controller could not get object from tombstone %+v, could take up to %v before quota is replenished", obj, options.ResyncPeriod())
+				utilruntime.HandleError(err)
+				return
+			}
+			metaObject, err = meta.Accessor(tombstone.Obj)
+			if err != nil {
+				glog.Errorf("replenishment controller tombstone contained object that is not a meta %+v, could take up to %v before quota is replenished", tombstone.Obj, options.ResyncPeriod())
+				utilruntime.HandleError(err)
+				return
+			}
+		}
+		options.ReplenishmentFunc(options.GroupKind, metaObject.GetNamespace(), nil)
+	}
+}
+
+// ReplenishmentControllerFactory knows how to build replenishment controllers
+type ReplenishmentControllerFactory interface {
+	// NewController returns a controller configured with the specified options
+	NewController(options *ReplenishmentControllerOptions) (*framework.Controller, error)
+}
+
+// replenishmentControllerFactory implements ReplenishmentControllerFactory
+type replenishmentControllerFactory struct {
+	kubeClient clientset.Interface
+}
+
+// NewReplenishmentControllerFactory returns a factory that knows how to build controllers
+// to replenish resources when updated or deleted
+func NewReplenishmentControllerFactory(kubeClient clientset.Interface) ReplenishmentControllerFactory {
+	return &replenishmentControllerFactory{
+		kubeClient: kubeClient,
+	}
+}
+
+func (r *replenishmentControllerFactory) NewController(options *ReplenishmentControllerOptions) (*framework.Controller, error) {
+	var result *framework.Controller
+	switch options.GroupKind {
+	case api.Kind("Pod"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.kubeClient.Core().Pods(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.kubeClient.Core().Pods(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.Pod{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				UpdateFunc: PodReplenishmentUpdateFunc(options),
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	case api.Kind("Service"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.kubeClient.Core().Services(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.kubeClient.Core().Services(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.Service{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	case api.Kind("ReplicationController"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.kubeClient.Core().ReplicationControllers(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.kubeClient.Core().ReplicationControllers(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.ReplicationController{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	case api.Kind("PersistentVolumeClaim"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.kubeClient.Core().PersistentVolumeClaims(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.kubeClient.Core().PersistentVolumeClaims(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.PersistentVolumeClaim{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	case api.Kind("Secret"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.kubeClient.Core().Secrets(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.kubeClient.Core().Secrets(api.NamespaceAll).Watch(options)
+				},
+			},
+			&api.PersistentVolumeClaim{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				DeleteFunc: ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	default:
+		return nil, fmt.Errorf("no replenishment controller available for %s", options.GroupKind)
+	}
+	return result, nil
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/replenishment_controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/replenishment_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcequota
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// testReplenishment lets us test replenishment functions are invoked
+type testReplenishment struct {
+	groupKind unversioned.GroupKind
+	namespace string
+}
+
+// mock function that holds onto the last kind that was replenished
+func (t *testReplenishment) Replenish(groupKind unversioned.GroupKind, namespace string, object runtime.Object) {
+	t.groupKind = groupKind
+	t.namespace = namespace
+}
+
+func TestPodReplenishmentUpdateFunc(t *testing.T) {
+	mockReplenish := &testReplenishment{}
+	options := ReplenishmentControllerOptions{
+		GroupKind:         api.Kind("Pod"),
+		ReplenishmentFunc: mockReplenish.Replenish,
+		ResyncPeriod:      controller.NoResyncPeriodFunc,
+	}
+	oldPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{Namespace: "test", Name: "pod"},
+		Status:     api.PodStatus{Phase: api.PodRunning},
+	}
+	newPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{Namespace: "test", Name: "pod"},
+		Status:     api.PodStatus{Phase: api.PodFailed},
+	}
+	updateFunc := PodReplenishmentUpdateFunc(&options)
+	updateFunc(oldPod, newPod)
+	if mockReplenish.groupKind != api.Kind("Pod") {
+		t.Errorf("Unexpected group kind %v", mockReplenish.groupKind)
+	}
+	if mockReplenish.namespace != oldPod.Namespace {
+		t.Errorf("Unexpected namespace %v", mockReplenish.namespace)
+	}
+}
+
+func TestObjectReplenishmentDeleteFunc(t *testing.T) {
+	mockReplenish := &testReplenishment{}
+	options := ReplenishmentControllerOptions{
+		GroupKind:         api.Kind("Pod"),
+		ReplenishmentFunc: mockReplenish.Replenish,
+		ResyncPeriod:      controller.NoResyncPeriodFunc,
+	}
+	oldPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{Namespace: "test", Name: "pod"},
+		Status:     api.PodStatus{Phase: api.PodRunning},
+	}
+	deleteFunc := ObjectReplenishmentDeleteFunc(&options)
+	deleteFunc(oldPod)
+	if mockReplenish.groupKind != api.Kind("Pod") {
+		t.Errorf("Unexpected group kind %v", mockReplenish.groupKind)
+	}
+	if mockReplenish.namespace != oldPod.Namespace {
+		t.Errorf("Unexpected namespace %v", mockReplenish.namespace)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/resource_quota_controller.go
@@ -17,22 +17,38 @@ limitations under the License.
 package resourcequota
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/runtime"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 )
+
+// ResourceQuotaControllerOptions holds options for creating a quota controller
+type ResourceQuotaControllerOptions struct {
+	// Must have authority to list all quotas, and update quota status
+	KubeClient clientset.Interface
+	// Controls full recalculation of quota usage
+	ResyncPeriod controller.ResyncPeriodFunc
+	// Knows how to calculate usage
+	Registry quota.Registry
+	// Knows how to build controllers that notify replenishment events
+	ControllerFactory ReplenishmentControllerFactory
+	// List of GroupKind objects that should be monitored for replenishment at
+	// a faster frequency than the quota controller recalculation interval
+	GroupKindsToReplenish []unversioned.GroupKind
+}
 
 // ResourceQuotaController is responsible for tracking quota usage status in the system
 type ResourceQuotaController struct {
@@ -42,27 +58,32 @@ type ResourceQuotaController struct {
 	rqIndexer cache.Indexer
 	// Watches changes to all resource quota
 	rqController *framework.Controller
-	// A store of pods, populated by the podController
-	podStore cache.StoreToPodLister
-	// Watches changes to all pods (so we can optimize release of compute resources)
-	podController *framework.Controller
 	// ResourceQuota objects that need to be synchronized
 	queue *workqueue.Type
 	// To allow injection of syncUsage for testing.
 	syncHandler func(key string) error
 	// function that controls full recalculation of quota usage
 	resyncPeriod controller.ResyncPeriodFunc
+	// knows how to calculate usage
+	registry quota.Registry
+	// controllers monitoring to notify for replenishment
+	replenishmentControllers []*framework.Controller
 }
 
-// NewResourceQuotaController creates a new ResourceQuotaController
-func NewResourceQuotaController(kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc) *ResourceQuotaController {
-
+func NewResourceQuotaController(options *ResourceQuotaControllerOptions) *ResourceQuotaController {
+	// build the resource quota controller
 	rq := &ResourceQuotaController{
-		kubeClient:   kubeClient,
-		queue:        workqueue.New(),
-		resyncPeriod: resyncPeriod,
+		kubeClient:               options.KubeClient,
+		queue:                    workqueue.New(),
+		resyncPeriod:             options.ResyncPeriod,
+		registry:                 options.Registry,
+		replenishmentControllers: []*framework.Controller{},
 	}
 
+	// set the synchronization handler
+	rq.syncHandler = rq.syncResourceQuotaFromKey
+
+	// build the controller that observes quota
 	rq.rqIndexer, rq.rqController = framework.NewIndexerInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
@@ -73,7 +94,7 @@ func NewResourceQuotaController(kubeClient clientset.Interface, resyncPeriod con
 			},
 		},
 		&api.ResourceQuota{},
-		resyncPeriod(),
+		rq.resyncPeriod(),
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: rq.enqueueResourceQuota,
 			UpdateFunc: func(old, cur interface{}) {
@@ -87,10 +108,9 @@ func NewResourceQuotaController(kubeClient clientset.Interface, resyncPeriod con
 				// responsible for enqueue of all resource quotas when doing a full resync (enqueueAll)
 				oldResourceQuota := old.(*api.ResourceQuota)
 				curResourceQuota := cur.(*api.ResourceQuota)
-				if api.Semantic.DeepEqual(oldResourceQuota.Spec.Hard, curResourceQuota.Status.Hard) {
+				if quota.Equals(curResourceQuota.Spec.Hard, oldResourceQuota.Spec.Hard) {
 					return
 				}
-				glog.V(4).Infof("Observed updated quota spec for %v/%v", curResourceQuota.Namespace, curResourceQuota.Name)
 				rq.enqueueResourceQuota(curResourceQuota)
 			},
 			// This will enter the sync loop and no-op, because the controller has been deleted from the store.
@@ -101,26 +121,19 @@ func NewResourceQuotaController(kubeClient clientset.Interface, resyncPeriod con
 		cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc},
 	)
 
-	// We use this pod controller to rapidly observe when a pod deletion occurs in order to
-	// release compute resources from any associated quota.
-	rq.podStore.Store, rq.podController = framework.NewInformer(
-		&cache.ListWatch{
-			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
-				return rq.kubeClient.Core().Pods(api.NamespaceAll).List(options)
-			},
-			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
-				return rq.kubeClient.Core().Pods(api.NamespaceAll).Watch(options)
-			},
-		},
-		&api.Pod{},
-		resyncPeriod(),
-		framework.ResourceEventHandlerFuncs{
-			DeleteFunc: rq.deletePod,
-		},
-	)
-
-	// set the synchronization handler
-	rq.syncHandler = rq.syncResourceQuotaFromKey
+	for _, groupKindToReplenish := range options.GroupKindsToReplenish {
+		controllerOptions := &ReplenishmentControllerOptions{
+			GroupKind:         groupKindToReplenish,
+			ResyncPeriod:      options.ResyncPeriod,
+			ReplenishmentFunc: rq.replenishQuota,
+		}
+		replenishmentController, err := options.ControllerFactory.NewController(controllerOptions)
+		if err != nil {
+			glog.Warningf("quota controller unable to replenish %s due to %v, changes only accounted during full resync", groupKindToReplenish, err)
+		} else {
+			rq.replenishmentControllers = append(rq.replenishmentControllers, replenishmentController)
+		}
+	}
 	return rq
 }
 
@@ -155,6 +168,7 @@ func (rq *ResourceQuotaController) worker() {
 			err := rq.syncHandler(key.(string))
 			if err != nil {
 				utilruntime.HandleError(err)
+				rq.queue.Add(key)
 			}
 		}()
 	}
@@ -164,43 +178,19 @@ func (rq *ResourceQuotaController) worker() {
 func (rq *ResourceQuotaController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	go rq.rqController.Run(stopCh)
-	go rq.podController.Run(stopCh)
+	// the controllers that replenish other resources to respond rapidly to state changes
+	for _, replenishmentController := range rq.replenishmentControllers {
+		go replenishmentController.Run(stopCh)
+	}
+	// the workers that chug through the quota calculation backlog
 	for i := 0; i < workers; i++ {
 		go wait.Until(rq.worker, time.Second, stopCh)
 	}
+	// the timer for how often we do a full recalculation across all quotas
 	go wait.Until(func() { rq.enqueueAll() }, rq.resyncPeriod(), stopCh)
 	<-stopCh
 	glog.Infof("Shutting down ResourceQuotaController")
 	rq.queue.ShutDown()
-}
-
-// FilterQuotaPods eliminates pods that no longer have a cost against the quota
-// pods that have a restart policy of always are always returned
-// pods that are in a failed state, but have a restart policy of on failure are always returned
-// pods that are not in a success state or a failure state are included in quota
-func FilterQuotaPods(pods []api.Pod) []*api.Pod {
-	var result []*api.Pod
-	for i := range pods {
-		value := &pods[i]
-		// a pod that has a restart policy always no matter its state counts against usage
-		if value.Spec.RestartPolicy == api.RestartPolicyAlways {
-			result = append(result, value)
-			continue
-		}
-		// a failed pod with a restart policy of on failure will count against usage
-		if api.PodFailed == value.Status.Phase &&
-			value.Spec.RestartPolicy == api.RestartPolicyOnFailure {
-			result = append(result, value)
-			continue
-		}
-		// if the pod is not succeeded or failed, then we count it against quota
-		if api.PodSucceeded != value.Status.Phase &&
-			api.PodFailed != value.Status.Phase {
-			result = append(result, value)
-			continue
-		}
-	}
-	return result
 }
 
 // syncResourceQuotaFromKey syncs a quota key
@@ -224,115 +214,68 @@ func (rq *ResourceQuotaController) syncResourceQuotaFromKey(key string) (err err
 	return rq.syncResourceQuota(quota)
 }
 
-// syncResourceQuota runs a complete sync of current status
-func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (err error) {
-
+// syncResourceQuota runs a complete sync of resource quota status across all known kinds
+func (rq *ResourceQuotaController) syncResourceQuota(resourceQuota api.ResourceQuota) (err error) {
 	// quota is dirty if any part of spec hard limits differs from the status hard limits
-	dirty := !api.Semantic.DeepEqual(quota.Spec.Hard, quota.Status.Hard)
+	dirty := !api.Semantic.DeepEqual(resourceQuota.Spec.Hard, resourceQuota.Status.Hard)
 
 	// dirty tracks if the usage status differs from the previous sync,
 	// if so, we send a new usage with latest status
 	// if this is our first sync, it will be dirty by default, since we need track usage
-	dirty = dirty || (quota.Status.Hard == nil || quota.Status.Used == nil)
+	dirty = dirty || (resourceQuota.Status.Hard == nil || resourceQuota.Status.Used == nil)
 
-	// Create a usage object that is based on the quota resource version
+	// Create a usage object that is based on the quota resource version that will handle updates
+	// by default, we preserve the past usage observation, and set hard to the current spec
+	previousUsed := api.ResourceList{}
+	if resourceQuota.Status.Used != nil {
+		previousUsed = quota.Add(api.ResourceList{}, resourceQuota.Status.Used)
+	}
 	usage := api.ResourceQuota{
 		ObjectMeta: api.ObjectMeta{
-			Name:            quota.Name,
-			Namespace:       quota.Namespace,
-			ResourceVersion: quota.ResourceVersion,
-			Labels:          quota.Labels,
-			Annotations:     quota.Annotations},
+			Name:            resourceQuota.Name,
+			Namespace:       resourceQuota.Namespace,
+			ResourceVersion: resourceQuota.ResourceVersion,
+			Labels:          resourceQuota.Labels,
+			Annotations:     resourceQuota.Annotations},
 		Status: api.ResourceQuotaStatus{
-			Hard: api.ResourceList{},
-			Used: api.ResourceList{},
+			Hard: quota.Add(api.ResourceList{}, resourceQuota.Spec.Hard),
+			Used: previousUsed,
 		},
 	}
 
-	// set the hard values supported on the quota
-	for k, v := range quota.Spec.Hard {
-		usage.Status.Hard[k] = *v.Copy()
+	// find the intersection between the hard resources on the quota
+	// and the resources this controller can track to know what we can
+	// look to measure updated usage stats for
+	hardResources := quota.ResourceNames(usage.Status.Hard)
+	potentialResources := []api.ResourceName{}
+	evaluators := rq.registry.Evaluators()
+	for _, evaluator := range evaluators {
+		potentialResources = append(potentialResources, evaluator.MatchesResources()...)
 	}
-	// set any last known observed status values for usage
-	for k, v := range quota.Status.Used {
-		usage.Status.Used[k] = *v.Copy()
-	}
+	matchedResources := quota.Intersection(hardResources, potentialResources)
 
-	set := map[api.ResourceName]bool{}
-	for k := range usage.Status.Hard {
-		set[k] = true
-	}
-
-	pods := &api.PodList{}
-	if set[api.ResourcePods] || set[api.ResourceMemory] || set[api.ResourceCPU] {
-		pods, err = rq.kubeClient.Core().Pods(usage.Namespace).List(api.ListOptions{})
+	// sum the observed usage from each evaluator
+	newUsage := api.ResourceList{}
+	usageStatsOptions := quota.UsageStatsOptions{Namespace: resourceQuota.Namespace, Scopes: resourceQuota.Spec.Scopes}
+	for _, evaluator := range evaluators {
+		stats, err := evaluator.UsageStats(usageStatsOptions)
 		if err != nil {
 			return err
 		}
+		newUsage = quota.Add(newUsage, stats.Used)
 	}
 
-	filteredPods := FilterQuotaPods(pods.Items)
-
-	// iterate over each resource, and update observation
-	for k := range usage.Status.Hard {
-
-		// look if there is a used value, if none, we are definitely dirty
-		prevQuantity, found := usage.Status.Used[k]
-		if !found {
-			dirty = true
-		}
-
-		var value *resource.Quantity
-
-		switch k {
-		case api.ResourcePods:
-			value = resource.NewQuantity(int64(len(filteredPods)), resource.DecimalSI)
-		case api.ResourceServices:
-			items, err := rq.kubeClient.Core().Services(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceReplicationControllers:
-			items, err := rq.kubeClient.Core().ReplicationControllers(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceQuotas:
-			items, err := rq.kubeClient.Core().ResourceQuotas(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceSecrets:
-			items, err := rq.kubeClient.Core().Secrets(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourcePersistentVolumeClaims:
-			items, err := rq.kubeClient.Core().PersistentVolumeClaims(usage.Namespace).List(api.ListOptions{})
-			if err != nil {
-				return err
-			}
-			value = resource.NewQuantity(int64(len(items.Items)), resource.DecimalSI)
-		case api.ResourceMemory:
-			value = PodsRequests(filteredPods, api.ResourceMemory)
-		case api.ResourceCPU:
-			value = PodsRequests(filteredPods, api.ResourceCPU)
-		}
-
-		// ignore fields we do not understand (assume another controller is tracking it)
-		if value != nil {
-			// see if the value has changed
-			dirty = dirty || (value.Value() != prevQuantity.Value())
-			// just update the value
-			usage.Status.Used[k] = *value
-		}
+	// mask the observed usage to only the set of resources tracked by this quota
+	// merge our observed usage with the quota usage status
+	// if the new usage is different than the last usage, we will need to do an update
+	newUsage = quota.Mask(newUsage, matchedResources)
+	for key, value := range newUsage {
+		usage.Status.Used[key] = value
 	}
 
-	// update the usage only if it changed
+	dirty = dirty || !quota.Equals(usage.Status.Used, resourceQuota.Status.Used)
+
+	// there was a change observed by this controller that requires we update quota
 	if dirty {
 		_, err = rq.kubeClient.Core().ResourceQuotas(usage.Namespace).UpdateStatus(&usage)
 		return err
@@ -340,102 +283,20 @@ func (rq *ResourceQuotaController) syncResourceQuota(quota api.ResourceQuota) (e
 	return nil
 }
 
-// PodsRequests returns sum of each resource request for each pod in list
-// If a given pod in the list does not have a request for the named resource, we log the error
-// but still attempt to get the most representative count
-func PodsRequests(pods []*api.Pod, resourceName api.ResourceName) *resource.Quantity {
-	var sum *resource.Quantity
-	for i := range pods {
-		pod := pods[i]
-		podQuantity, err := PodRequests(pod, resourceName)
-		if err != nil {
-			// log the error, but try to keep the most accurate count possible in log
-			// rationale here is that you may have had pods in a namespace that did not have
-			// explicit requests prior to adding the quota
-			glog.Infof("No explicit request for resource, pod %s/%s, %s", pod.Namespace, pod.Name, resourceName)
-		} else {
-			if sum == nil {
-				sum = podQuantity
-			} else {
-				sum.Add(*podQuantity)
-			}
-		}
-	}
-	// if list is empty
-	if sum == nil {
-		q := resource.MustParse("0")
-		sum = &q
-	}
-	return sum
-}
-
-// PodRequests returns sum of each resource request across all containers in pod
-func PodRequests(pod *api.Pod, resourceName api.ResourceName) (*resource.Quantity, error) {
-	if !PodHasRequests(pod, resourceName) {
-		return nil, fmt.Errorf("Each container in pod %s/%s does not have an explicit request for resource %s.", pod.Namespace, pod.Name, resourceName)
-	}
-	var sum *resource.Quantity
-	for j := range pod.Spec.Containers {
-		value, _ := pod.Spec.Containers[j].Resources.Requests[resourceName]
-		if sum == nil {
-			sum = value.Copy()
-		} else {
-			err := sum.Add(value)
-			if err != nil {
-				return sum, err
-			}
-		}
-	}
-	// if list is empty
-	if sum == nil {
-		q := resource.MustParse("0")
-		sum = &q
-	}
-	return sum, nil
-}
-
-// PodHasRequests verifies that each container in the pod has an explicit request that is non-zero for a named resource
-func PodHasRequests(pod *api.Pod, resourceName api.ResourceName) bool {
-	for j := range pod.Spec.Containers {
-		value, valueSet := pod.Spec.Containers[j].Resources.Requests[resourceName]
-		if !valueSet || value.Value() == int64(0) {
-			return false
-		}
-	}
-	return true
-}
-
-// When a pod is deleted, enqueue the quota that manages the pod and update its expectations.
-// obj could be an *api.Pod, or a DeletionFinalStateUnknown marker item.
-func (rq *ResourceQuotaController) deletePod(obj interface{}) {
-	pod, ok := obj.(*api.Pod)
-	// When a delete is dropped, the relist will notice a pod in the store not
-	// in the list, leading to the insertion of a tombstone object which contains
-	// the deleted key/value. Note that this value might be stale. If the pod
-	// changed labels the new rc will not be woken up till the periodic resync.
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			glog.Errorf("Couldn't get object from tombstone %+v, could take up to %v before a quota records the deletion", obj, rq.resyncPeriod())
-			return
-		}
-		pod, ok = tombstone.Obj.(*api.Pod)
-		if !ok {
-			glog.Errorf("Tombstone contained object that is not a pod %+v, could take up to %v before quota records the deletion", obj, rq.resyncPeriod())
-			return
-		}
-	}
-
-	quotas, err := rq.rqIndexer.Index("namespace", pod)
+// replenishQuota is a replenishment function invoked by a controller to notify that a quota should be recalculated
+func (rq *ResourceQuotaController) replenishQuota(groupKind unversioned.GroupKind, namespace string, object runtime.Object) {
+	// TODO: make this support targeted replenishment to a specific kind, right now it does a full replenish
+	indexKey := &api.ResourceQuota{}
+	indexKey.Namespace = namespace
+	resourceQuotas, err := rq.rqIndexer.Index("namespace", indexKey)
 	if err != nil {
-		glog.Errorf("Couldn't find resource quota associated with pod %+v, could take up to %v before a quota records the deletion", obj, rq.resyncPeriod())
+		glog.Errorf("quota controller could not find ResourceQuota associated with namespace: %s, could take up to %v before a quota replenishes", namespace, rq.resyncPeriod())
 	}
-	if len(quotas) == 0 {
-		glog.V(4).Infof("No resource quota associated with namespace %q", pod.Namespace)
+	if len(resourceQuotas) == 0 {
 		return
 	}
-	for i := range quotas {
-		quota := quotas[i].(*api.ResourceQuota)
-		rq.enqueueResourceQuota(quota)
+	for i := range resourceQuotas {
+		resourceQuota := resourceQuotas[i].(*api.ResourceQuota)
+		rq.enqueueResourceQuota(resourceQuota)
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright 2015 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,15 +17,16 @@ limitations under the License.
 package resourcequota
 
 import (
-	"strconv"
+	"strings"
 	"testing"
-	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/testing/fake"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/quota/install"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -47,85 +48,11 @@ func getResourceRequirements(requests, limits api.ResourceList) api.ResourceRequ
 	return res
 }
 
-func validPod(name string, numContainers int, resources api.ResourceRequirements) *api.Pod {
-	pod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{Name: name, Namespace: "test"},
-		Spec:       api.PodSpec{},
-	}
-	pod.Spec.Containers = make([]api.Container, 0, numContainers)
-	for i := 0; i < numContainers; i++ {
-		pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
-			Image:     "foo:V" + strconv.Itoa(i),
-			Resources: resources,
-		})
-	}
-	return pod
-}
-
-func TestFilterQuotaPods(t *testing.T) {
-	pods := []api.Pod{
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-running"},
-			Status:     api.PodStatus{Phase: api.PodRunning},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-pending"},
-			Status:     api.PodStatus{Phase: api.PodPending},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-succeeded"},
-			Status:     api.PodStatus{Phase: api.PodSucceeded},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-unknown"},
-			Status:     api.PodStatus{Phase: api.PodUnknown},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-failed"},
-			Status:     api.PodStatus{Phase: api.PodFailed},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-failed-with-restart-always"},
-			Spec: api.PodSpec{
-				RestartPolicy: api.RestartPolicyAlways,
-			},
-			Status: api.PodStatus{Phase: api.PodFailed},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-failed-with-restart-on-failure"},
-			Spec: api.PodSpec{
-				RestartPolicy: api.RestartPolicyOnFailure,
-			},
-			Status: api.PodStatus{Phase: api.PodFailed},
-		},
-		{
-			ObjectMeta: api.ObjectMeta{Name: "pod-failed-with-restart-never"},
-			Spec: api.PodSpec{
-				RestartPolicy: api.RestartPolicyNever,
-			},
-			Status: api.PodStatus{Phase: api.PodFailed},
-		},
-	}
-	expectedResults := sets.NewString("pod-running",
-		"pod-pending", "pod-unknown", "pod-failed-with-restart-always",
-		"pod-failed-with-restart-on-failure")
-
-	actualResults := sets.String{}
-	result := FilterQuotaPods(pods)
-	for i := range result {
-		actualResults.Insert(result[i].Name)
-	}
-
-	if len(expectedResults) != len(actualResults) || !actualResults.HasAll(expectedResults.List()...) {
-		t.Errorf("Expected results %v, Actual results %v", expectedResults, actualResults)
-	}
-}
-
 func TestSyncResourceQuota(t *testing.T) {
 	podList := api.PodList{
 		Items: []api.Pod{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "pod-running"},
+				ObjectMeta: api.ObjectMeta{Name: "pod-running", Namespace: "testing"},
 				Status:     api.PodStatus{Phase: api.PodRunning},
 				Spec: api.PodSpec{
 					Volumes:    []api.Volume{{Name: "vol"}},
@@ -133,7 +60,7 @@ func TestSyncResourceQuota(t *testing.T) {
 				},
 			},
 			{
-				ObjectMeta: api.ObjectMeta{Name: "pod-running-2"},
+				ObjectMeta: api.ObjectMeta{Name: "pod-running-2", Namespace: "testing"},
 				Status:     api.PodStatus{Phase: api.PodRunning},
 				Spec: api.PodSpec{
 					Volumes:    []api.Volume{{Name: "vol"}},
@@ -141,7 +68,7 @@ func TestSyncResourceQuota(t *testing.T) {
 				},
 			},
 			{
-				ObjectMeta: api.ObjectMeta{Name: "pod-failed"},
+				ObjectMeta: api.ObjectMeta{Name: "pod-failed", Namespace: "testing"},
 				Status:     api.PodStatus{Phase: api.PodFailed},
 				Spec: api.PodSpec{
 					Volumes:    []api.Volume{{Name: "vol"}},
@@ -150,7 +77,8 @@ func TestSyncResourceQuota(t *testing.T) {
 			},
 		},
 	}
-	quota := api.ResourceQuota{
+	resourceQuota := api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: "testing"},
 		Spec: api.ResourceQuotaSpec{
 			Hard: api.ResourceList{
 				api.ResourceCPU:    resource.MustParse("3"),
@@ -174,15 +102,43 @@ func TestSyncResourceQuota(t *testing.T) {
 		},
 	}
 
-	kubeClient := fake.NewSimpleClientset(&podList, &quota)
-
-	ResourceQuotaController := NewResourceQuotaController(kubeClient, controller.StaticResyncPeriodFunc(time.Second))
-	err := ResourceQuotaController.syncResourceQuota(quota)
+	kubeClient := fake.NewSimpleClientset(&podList, &resourceQuota)
+	resourceQuotaControllerOptions := &ResourceQuotaControllerOptions{
+		KubeClient:   kubeClient,
+		ResyncPeriod: controller.NoResyncPeriodFunc,
+		Registry:     install.NewRegistry(kubeClient),
+		GroupKindsToReplenish: []unversioned.GroupKind{
+			api.Kind("Pod"),
+			api.Kind("Service"),
+			api.Kind("ReplicationController"),
+			api.Kind("PersistentVolumeClaim"),
+		},
+		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+	}
+	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
+	err := quotaController.syncResourceQuota(resourceQuota)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
+		strings.Join([]string{"list", "services", ""}, "-"),
+		strings.Join([]string{"list", "pods", ""}, "-"),
+		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
+		strings.Join([]string{"list", "secrets", ""}, "-"),
+		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
+		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
+	}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
+	}
 
-	usage := kubeClient.Actions()[1].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
+	lastActionIndex := len(kubeClient.Actions()) - 1
+	usage := kubeClient.Actions()[lastActionIndex].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
 
 	// ensure hard and used limits are what we expected
 	for k, v := range expectedUsage.Status.Hard {
@@ -204,7 +160,7 @@ func TestSyncResourceQuota(t *testing.T) {
 }
 
 func TestSyncResourceQuotaSpecChange(t *testing.T) {
-	quota := api.ResourceQuota{
+	resourceQuota := api.ResourceQuota{
 		Spec: api.ResourceQuotaSpec{
 			Hard: api.ResourceList{
 				api.ResourceCPU: resource.MustParse("4"),
@@ -231,15 +187,44 @@ func TestSyncResourceQuotaSpecChange(t *testing.T) {
 		},
 	}
 
-	kubeClient := fake.NewSimpleClientset(&quota)
-
-	ResourceQuotaController := NewResourceQuotaController(kubeClient, controller.StaticResyncPeriodFunc(time.Second))
-	err := ResourceQuotaController.syncResourceQuota(quota)
+	kubeClient := fake.NewSimpleClientset(&resourceQuota)
+	resourceQuotaControllerOptions := &ResourceQuotaControllerOptions{
+		KubeClient:   kubeClient,
+		ResyncPeriod: controller.NoResyncPeriodFunc,
+		Registry:     install.NewRegistry(kubeClient),
+		GroupKindsToReplenish: []unversioned.GroupKind{
+			api.Kind("Pod"),
+			api.Kind("Service"),
+			api.Kind("ReplicationController"),
+			api.Kind("PersistentVolumeClaim"),
+		},
+		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+	}
+	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
+	err := quotaController.syncResourceQuota(resourceQuota)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
 
-	usage := kubeClient.Actions()[1].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
+		strings.Join([]string{"list", "services", ""}, "-"),
+		strings.Join([]string{"list", "pods", ""}, "-"),
+		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
+		strings.Join([]string{"list", "secrets", ""}, "-"),
+		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
+		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
+	}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
+	}
+
+	lastActionIndex := len(kubeClient.Actions()) - 1
+	usage := kubeClient.Actions()[lastActionIndex].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
 
 	// ensure hard and used limits are what we expected
 	for k, v := range expectedUsage.Status.Hard {
@@ -262,7 +247,7 @@ func TestSyncResourceQuotaSpecChange(t *testing.T) {
 }
 
 func TestSyncResourceQuotaNoChange(t *testing.T) {
-	quota := api.ResourceQuota{
+	resourceQuota := api.ResourceQuota{
 		Spec: api.ResourceQuotaSpec{
 			Hard: api.ResourceList{
 				api.ResourceCPU: resource.MustParse("4"),
@@ -278,165 +263,37 @@ func TestSyncResourceQuotaNoChange(t *testing.T) {
 		},
 	}
 
-	kubeClient := fake.NewSimpleClientset(&api.PodList{}, &quota)
-
-	ResourceQuotaController := NewResourceQuotaController(kubeClient, controller.StaticResyncPeriodFunc(time.Second))
-	err := ResourceQuotaController.syncResourceQuota(quota)
+	kubeClient := fake.NewSimpleClientset(&api.PodList{}, &resourceQuota)
+	resourceQuotaControllerOptions := &ResourceQuotaControllerOptions{
+		KubeClient:   kubeClient,
+		ResyncPeriod: controller.NoResyncPeriodFunc,
+		Registry:     install.NewRegistry(kubeClient),
+		GroupKindsToReplenish: []unversioned.GroupKind{
+			api.Kind("Pod"),
+			api.Kind("Service"),
+			api.Kind("ReplicationController"),
+			api.Kind("PersistentVolumeClaim"),
+		},
+		ControllerFactory: NewReplenishmentControllerFactory(kubeClient),
+	}
+	quotaController := NewResourceQuotaController(resourceQuotaControllerOptions)
+	err := quotaController.syncResourceQuota(resourceQuota)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
-
-	actions := kubeClient.Actions()
-	if len(actions) != 1 && !actions[0].Matches("list", "pods") {
-		t.Errorf("SyncResourceQuota made an unexpected client action when state was not dirty: %v", kubeClient.Actions)
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
+		strings.Join([]string{"list", "services", ""}, "-"),
+		strings.Join([]string{"list", "pods", ""}, "-"),
+		strings.Join([]string{"list", "resourcequotas", ""}, "-"),
+		strings.Join([]string{"list", "secrets", ""}, "-"),
+		strings.Join([]string{"list", "persistentvolumeclaims", ""}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
 	}
-}
-
-func TestPodHasRequests(t *testing.T) {
-	type testCase struct {
-		pod            *api.Pod
-		resourceName   api.ResourceName
-		expectedResult bool
-	}
-	testCases := []testCase{
-		{
-			pod:            validPod("request-cpu", 2, getResourceRequirements(getResourceList("100m", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: true,
-		},
-		{
-			pod:            validPod("no-request-cpu", 2, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: false,
-		},
-		{
-			pod:            validPod("request-zero-cpu", 2, getResourceRequirements(getResourceList("0", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: false,
-		},
-		{
-			pod:            validPod("request-memory", 2, getResourceRequirements(getResourceList("", "2Mi"), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: true,
-		},
-		{
-			pod:            validPod("no-request-memory", 2, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: false,
-		},
-		{
-			pod:            validPod("request-zero-memory", 2, getResourceRequirements(getResourceList("", "0"), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: false,
-		},
-	}
-	for _, item := range testCases {
-		if actual := PodHasRequests(item.pod, item.resourceName); item.expectedResult != actual {
-			t.Errorf("Pod %s for resource %s expected %v actual %v", item.pod.Name, item.resourceName, item.expectedResult, actual)
-		}
-	}
-}
-
-func TestPodRequests(t *testing.T) {
-	type testCase struct {
-		pod            *api.Pod
-		resourceName   api.ResourceName
-		expectedResult string
-		expectedError  bool
-	}
-	testCases := []testCase{
-		{
-			pod:            validPod("request-cpu", 2, getResourceRequirements(getResourceList("100m", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: "200m",
-			expectedError:  false,
-		},
-		{
-			pod:            validPod("no-request-cpu", 2, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: "",
-			expectedError:  true,
-		},
-		{
-			pod:            validPod("request-zero-cpu", 2, getResourceRequirements(getResourceList("0", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceCPU,
-			expectedResult: "",
-			expectedError:  true,
-		},
-		{
-			pod:            validPod("request-memory", 2, getResourceRequirements(getResourceList("", "500Mi"), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: "1000Mi",
-			expectedError:  false,
-		},
-		{
-			pod:            validPod("no-request-memory", 2, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: "",
-			expectedError:  true,
-		},
-		{
-			pod:            validPod("request-zero-memory", 2, getResourceRequirements(getResourceList("", "0"), getResourceList("", ""))),
-			resourceName:   api.ResourceMemory,
-			expectedResult: "",
-			expectedError:  true,
-		},
-	}
-	for _, item := range testCases {
-		actual, err := PodRequests(item.pod, item.resourceName)
-		if item.expectedError != (err != nil) {
-			t.Errorf("Unexpected error result for pod %s for resource %s expected error %v got %v", item.pod.Name, item.resourceName, item.expectedError, err)
-		}
-		if item.expectedResult != "" && (item.expectedResult != actual.String()) {
-			t.Errorf("Expected %s, Actual %s, pod %s for resource %s", item.expectedResult, actual.String(), item.pod.Name, item.resourceName)
-		}
-	}
-}
-
-func TestPodsRequests(t *testing.T) {
-	type testCase struct {
-		pods           []*api.Pod
-		resourceName   api.ResourceName
-		expectedResult string
-	}
-	testCases := []testCase{
-		{
-			pods: []*api.Pod{
-				validPod("request-cpu-1", 1, getResourceRequirements(getResourceList("100m", ""), getResourceList("", ""))),
-				validPod("request-cpu-2", 1, getResourceRequirements(getResourceList("1", ""), getResourceList("", ""))),
-			},
-			resourceName:   api.ResourceCPU,
-			expectedResult: "1100m",
-		},
-		{
-			pods: []*api.Pod{
-				validPod("no-request-cpu-1", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-				validPod("no-request-cpu-2", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			},
-			resourceName:   api.ResourceCPU,
-			expectedResult: "",
-		},
-		{
-			pods: []*api.Pod{
-				validPod("request-zero-cpu-1", 1, getResourceRequirements(getResourceList("0", ""), getResourceList("", ""))),
-				validPod("request-zero-cpu-1", 1, getResourceRequirements(getResourceList("0", ""), getResourceList("", ""))),
-			},
-			resourceName:   api.ResourceCPU,
-			expectedResult: "",
-		},
-		{
-			pods: []*api.Pod{
-				validPod("request-memory-1", 1, getResourceRequirements(getResourceList("", "500Mi"), getResourceList("", ""))),
-				validPod("request-memory-2", 1, getResourceRequirements(getResourceList("", "1Gi"), getResourceList("", ""))),
-			},
-			resourceName:   api.ResourceMemory,
-			expectedResult: "1524Mi",
-		},
-	}
-	for _, item := range testCases {
-		actual := PodsRequests(item.pods, item.resourceName)
-		if item.expectedResult != "" && (item.expectedResult != actual.String()) {
-			t.Errorf("Expected %s, Actual %s, pod %s for resource %s", item.expectedResult, actual.String(), item.pods[0].Name, item.resourceName)
-		}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
@@ -261,35 +261,40 @@ func DescribeResourceQuotas(quotas *api.ResourceQuotaList, w io.Writer) {
 		fmt.Fprint(w, "No resource quota.\n")
 		return
 	}
-	resources := []api.ResourceName{}
-	hard := map[api.ResourceName]resource.Quantity{}
-	used := map[api.ResourceName]resource.Quantity{}
+	sort.Sort(SortableResourceQuotas(quotas.Items))
+
+	fmt.Fprint(w, "Resource Quotas")
 	for _, q := range quotas.Items {
+		fmt.Fprintf(w, "\n Name:\t%s\n", q.Name)
+		if len(q.Spec.Scopes) > 0 {
+			scopes := []string{}
+			for _, scope := range q.Spec.Scopes {
+				scopes = append(scopes, string(scope))
+			}
+			sort.Strings(scopes)
+			fmt.Fprintf(w, " Scopes:\t%s\n", strings.Join(scopes, ", "))
+			for _, scope := range scopes {
+				helpText := helpTextForResourceQuotaScope(api.ResourceQuotaScope(scope))
+				if len(helpText) > 0 {
+					fmt.Fprintf(w, "  * %s\n", helpText)
+				}
+			}
+		}
+
+		fmt.Fprintf(w, " Resource\tUsed\tHard\n")
+		fmt.Fprint(w, " --------\t---\t---\n")
+
+		resources := []api.ResourceName{}
 		for resource := range q.Status.Hard {
 			resources = append(resources, resource)
+		}
+		sort.Sort(SortableResourceNames(resources))
+
+		for _, resource := range resources {
 			hardQuantity := q.Status.Hard[resource]
 			usedQuantity := q.Status.Used[resource]
-
-			// if for some reason there are multiple quota documents, we take least permissive
-			prevQuantity, ok := hard[resource]
-			if ok {
-				if hardQuantity.Value() < prevQuantity.Value() {
-					hard[resource] = hardQuantity
-				}
-			} else {
-				hard[resource] = hardQuantity
-			}
-			used[resource] = usedQuantity
+			fmt.Fprintf(w, " %s\t%s\t%s\n", string(resource), usedQuantity.String(), hardQuantity.String())
 		}
-	}
-
-	sort.Sort(SortableResourceNames(resources))
-	fmt.Fprint(w, "Resource Quotas\n Resource\tUsed\tHard\n")
-	fmt.Fprint(w, " ---\t---\t---\n")
-	for _, resource := range resources {
-		hardQuantity := hard[resource]
-		usedQuantity := used[resource]
-		fmt.Fprintf(w, " %s\t%s\t%s\n", string(resource), usedQuantity.String(), hardQuantity.String())
 	}
 }
 
@@ -396,10 +401,38 @@ func (d *ResourceQuotaDescriber) Describe(namespace, name string) (string, error
 	return describeQuota(resourceQuota)
 }
 
+func helpTextForResourceQuotaScope(scope api.ResourceQuotaScope) string {
+	switch scope {
+	case api.ResourceQuotaScopeTerminating:
+		return "Matches all pods that have an active deadline."
+	case api.ResourceQuotaScopeNotTerminating:
+		return "Matches all pods that do not have an active deadline."
+	case api.ResourceQuotaScopeBestEffort:
+		return "Matches all pods that have best effort quality of service."
+	case api.ResourceQuotaScopeNotBestEffort:
+		return "Matches all pods that do not have best effort quality of service."
+	default:
+		return ""
+	}
+}
 func describeQuota(resourceQuota *api.ResourceQuota) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "Name:\t%s\n", resourceQuota.Name)
 		fmt.Fprintf(out, "Namespace:\t%s\n", resourceQuota.Namespace)
+		if len(resourceQuota.Spec.Scopes) > 0 {
+			scopes := []string{}
+			for _, scope := range resourceQuota.Spec.Scopes {
+				scopes = append(scopes, string(scope))
+			}
+			sort.Strings(scopes)
+			fmt.Fprintf(out, "Scopes:\t%s\n", strings.Join(scopes, ", "))
+			for _, scope := range scopes {
+				helpText := helpTextForResourceQuotaScope(api.ResourceQuotaScope(scope))
+				if len(helpText) > 0 {
+					fmt.Fprintf(out, " * %s\n", helpText)
+				}
+			}
+		}
 		fmt.Fprintf(out, "Resource\tUsed\tHard\n")
 		fmt.Fprintf(out, "--------\t----\t----\n")
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/sorted_resource_name_list.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/sorted_resource_name_list.go
@@ -33,3 +33,17 @@ func (list SortableResourceNames) Swap(i, j int) {
 func (list SortableResourceNames) Less(i, j int) bool {
 	return list[i] < list[j]
 }
+
+type SortableResourceQuotas []api.ResourceQuota
+
+func (list SortableResourceQuotas) Len() int {
+	return len(list)
+}
+
+func (list SortableResourceQuotas) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableResourceQuotas) Less(i, j int) bool {
+	return list[i].Name < list[j].Name
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// core contains modules that interface with the core api group
+package core

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/persistent_volume_claims.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/persistent_volume_claims.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// NewPersistentVolumeClaimEvaluator returns an evaluator that can evaluate persistent volume claims
+func NewPersistentVolumeClaimEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	allResources := []api.ResourceName{api.ResourcePersistentVolumeClaims}
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.PersistentVolumeClaim",
+		InternalGroupKind: api.Kind("PersistentVolumeClaim"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+		},
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
+		ConstraintsFunc:      generic.ObjectCountConstraintsFunc(api.ResourcePersistentVolumeClaims),
+		UsageFunc:            generic.ObjectCountUsageFunc(api.ResourcePersistentVolumeClaims),
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().PersistentVolumeClaims(namespace).List(options)
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/pods.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/pods.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/kubelet/qos/util"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// NewPodEvaluator returns an evaluator that can evaluate pods
+func NewPodEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	computeResources := []api.ResourceName{
+		api.ResourceCPU,
+		api.ResourceMemory,
+		api.ResourceRequestsCPU,
+		api.ResourceRequestsMemory,
+		api.ResourceLimitsCPU,
+		api.ResourceLimitsMemory,
+	}
+	allResources := append(computeResources, api.ResourcePods)
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.Pod",
+		InternalGroupKind: api.Kind("Pod"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+			admission.Update: computeResources,
+		},
+		GetFuncByNamespace: func(namespace, name string) (runtime.Object, error) {
+			return kubeClient.Core().Pods(namespace).Get(name)
+		},
+		ConstraintsFunc:      PodConstraintsFunc,
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     PodMatchesScopeFunc,
+		UsageFunc:            PodUsageFunc,
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().Pods(namespace).List(options)
+		},
+	}
+}
+
+// PodConstraintsFunc verifies that all required resources are present on the pod
+func PodConstraintsFunc(required []api.ResourceName, object runtime.Object) error {
+	pod, ok := object.(*api.Pod)
+	if !ok {
+		return fmt.Errorf("Unexpected input object %v", object)
+	}
+
+	// TODO: fix this when we have pod level cgroups
+	// since we do not yet pod level requests/limits, we need to ensure each
+	// container makes an explict request or limit for a quota tracked resource
+	requiredSet := quota.ToSet(required)
+	missingSet := sets.NewString()
+	for i := range pod.Spec.Containers {
+		requests := pod.Spec.Containers[i].Resources.Requests
+		limits := pod.Spec.Containers[i].Resources.Limits
+		containerUsage := podUsageHelper(requests, limits)
+		containerSet := quota.ToSet(quota.ResourceNames(containerUsage))
+		if !containerSet.Equal(requiredSet) {
+			difference := requiredSet.Difference(containerSet)
+			missingSet.Insert(difference.List()...)
+		}
+	}
+	if len(missingSet) == 0 {
+		return nil
+	}
+	return fmt.Errorf("must specify %s", strings.Join(missingSet.List(), ","))
+}
+
+// podUsageHelper can summarize the pod quota usage based on requests and limits
+func podUsageHelper(requests api.ResourceList, limits api.ResourceList) api.ResourceList {
+	result := api.ResourceList{}
+	result[api.ResourcePods] = resource.MustParse("1")
+	if request, found := requests[api.ResourceCPU]; found {
+		result[api.ResourceCPU] = request
+		result[api.ResourceRequestsCPU] = request
+	}
+	if limit, found := limits[api.ResourceCPU]; found {
+		result[api.ResourceLimitsCPU] = limit
+	}
+	if request, found := requests[api.ResourceMemory]; found {
+		result[api.ResourceMemory] = request
+		result[api.ResourceRequestsMemory] = request
+	}
+	if limit, found := limits[api.ResourceMemory]; found {
+		result[api.ResourceLimitsMemory] = limit
+	}
+	return result
+}
+
+// PodUsageFunc knows how to measure usage associated with pods
+func PodUsageFunc(object runtime.Object) api.ResourceList {
+	pod, ok := object.(*api.Pod)
+	if !ok {
+		return api.ResourceList{}
+	}
+
+	// by convention, we do not quota pods that have reached an end-of-life state
+	if !QuotaPod(pod) {
+		return api.ResourceList{}
+	}
+
+	// TODO: fix this when we have pod level cgroups
+	// when we have pod level cgroups, we can just read pod level requests/limits
+	requests := api.ResourceList{}
+	limits := api.ResourceList{}
+	for i := range pod.Spec.Containers {
+		requests = quota.Add(requests, pod.Spec.Containers[i].Resources.Requests)
+		limits = quota.Add(limits, pod.Spec.Containers[i].Resources.Limits)
+	}
+
+	return podUsageHelper(requests, limits)
+}
+
+// PodMatchesScopeFunc is a function that knows how to evaluate if a pod matches a scope
+func PodMatchesScopeFunc(scope api.ResourceQuotaScope, object runtime.Object) bool {
+	pod, ok := object.(*api.Pod)
+	if !ok {
+		return false
+	}
+	switch scope {
+	case api.ResourceQuotaScopeTerminating:
+		return isTerminating(pod)
+	case api.ResourceQuotaScopeNotTerminating:
+		return !isTerminating(pod)
+	case api.ResourceQuotaScopeBestEffort:
+		return isBestEffort(pod)
+	case api.ResourceQuotaScopeNotBestEffort:
+		return !isBestEffort(pod)
+	}
+	return false
+}
+
+func isBestEffort(pod *api.Pod) bool {
+	// TODO: when we have request/limits on a pod scope, we need to revisit this
+	for _, container := range pod.Spec.Containers {
+		qosPerResource := util.GetQoS(&container)
+		for _, qos := range qosPerResource {
+			if util.BestEffort == qos {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isTerminating(pod *api.Pod) bool {
+	if pod.Spec.ActiveDeadlineSeconds != nil && *pod.Spec.ActiveDeadlineSeconds >= int64(0) {
+		return true
+	}
+	return false
+}
+
+// QuotaPod returns true if the pod is eligible to track against a quota
+// if it's not in a terminal state according to its phase.
+func QuotaPod(pod *api.Pod) bool {
+	// see GetPhase in kubelet.go for details on how it covers all restart policy conditions
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L3001
+	return !(api.PodFailed == pod.Status.Phase || api.PodSucceeded == pod.Status.Phase)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/registry.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/registry.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+)
+
+// NewRegistry returns a registry that knows how to deal with core kubernetes resources
+func NewRegistry(kubeClient clientset.Interface) quota.Registry {
+	pod := NewPodEvaluator(kubeClient)
+	service := NewServiceEvaluator(kubeClient)
+	replicationController := NewReplicationControllerEvaluator(kubeClient)
+	resourceQuota := NewResourceQuotaEvaluator(kubeClient)
+	secret := NewSecretEvaluator(kubeClient)
+	persistentVolumeClaim := NewPersistentVolumeClaimEvaluator(kubeClient)
+	return &generic.GenericRegistry{
+		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
+			pod.GroupKind():                   pod,
+			service.GroupKind():               service,
+			replicationController.GroupKind(): replicationController,
+			secret.GroupKind():                secret,
+			resourceQuota.GroupKind():         resourceQuota,
+			persistentVolumeClaim.GroupKind(): persistentVolumeClaim,
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/replication_controllers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/replication_controllers.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// NewReplicationControllerEvaluator returns an evaluator that can evaluate replication controllers
+func NewReplicationControllerEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	allResources := []api.ResourceName{api.ResourceReplicationControllers}
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.ReplicationController",
+		InternalGroupKind: api.Kind("ReplicationController"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+		},
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
+		ConstraintsFunc:      generic.ObjectCountConstraintsFunc(api.ResourceReplicationControllers),
+		UsageFunc:            generic.ObjectCountUsageFunc(api.ResourceReplicationControllers),
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().ReplicationControllers(namespace).List(options)
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/resource_quotas.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/resource_quotas.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// NewResourceQuotaEvaluator returns an evaluator that can evaluate resource quotas
+func NewResourceQuotaEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	allResources := []api.ResourceName{api.ResourceQuotas}
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.ResourceQuota",
+		InternalGroupKind: api.Kind("ResourceQuota"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+		},
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
+		ConstraintsFunc:      generic.ObjectCountConstraintsFunc(api.ResourceQuotas),
+		UsageFunc:            generic.ObjectCountUsageFunc(api.ResourceQuotas),
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().ResourceQuotas(namespace).List(options)
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/secrets.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/secrets.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// NewSecretEvaluator returns an evaluator that can evaluate secrets
+func NewSecretEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	allResources := []api.ResourceName{api.ResourceSecrets}
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.Secret",
+		InternalGroupKind: api.Kind("Secret"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+		},
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
+		ConstraintsFunc:      generic.ObjectCountConstraintsFunc(api.ResourceSecrets),
+		UsageFunc:            generic.ObjectCountUsageFunc(api.ResourceSecrets),
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().Secrets(namespace).List(options)
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/services.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/evaluator/core/services.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// NewServiceEvaluator returns an evaluator that can evaluate service quotas
+func NewServiceEvaluator(kubeClient clientset.Interface) quota.Evaluator {
+	allResources := []api.ResourceName{api.ResourceServices}
+	return &generic.GenericEvaluator{
+		Name:              "Evaluator.Service",
+		InternalGroupKind: api.Kind("Service"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: allResources,
+		},
+		MatchedResourceNames: allResources,
+		MatchesScopeFunc:     generic.MatchesNoScopeFunc,
+		ConstraintsFunc:      generic.ObjectCountConstraintsFunc(api.ResourceServices),
+		UsageFunc:            generic.ObjectCountUsageFunc(api.ResourceServices),
+		ListFuncByNamespace: func(namespace string, options api.ListOptions) (runtime.Object, error) {
+			return kubeClient.Core().Services(namespace).List(options)
+		},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/generic/evaluator.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/generic/evaluator.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// ConstraintsFunc takes a list of required resources that must match on the input item
+type ConstraintsFunc func(required []api.ResourceName, item runtime.Object) error
+
+// GetFuncByNamespace knows how to get a resource with specified namespace and name
+type GetFuncByNamespace func(namespace, name string) (runtime.Object, error)
+
+// ListFuncByNamespace knows how to list resources in a namespace
+type ListFuncByNamespace func(namespace string, options api.ListOptions) (runtime.Object, error)
+
+// MatchesScopeFunc knows how to evaluate if an object matches a scope
+type MatchesScopeFunc func(scope api.ResourceQuotaScope, object runtime.Object) bool
+
+// UsageFunc knows how to measure usage associated with an object
+type UsageFunc func(object runtime.Object) api.ResourceList
+
+// MatchesNoScopeFunc returns false on all match checks
+func MatchesNoScopeFunc(scope api.ResourceQuotaScope, object runtime.Object) bool {
+	return false
+}
+
+// ObjectCountConstraintsFunc returns true if the specified resource name is in
+// the required set of resource names
+func ObjectCountConstraintsFunc(resourceName api.ResourceName) ConstraintsFunc {
+	return func(required []api.ResourceName, item runtime.Object) error {
+		if !quota.Contains(required, resourceName) {
+			return fmt.Errorf("missing %s", resourceName)
+		}
+		return nil
+	}
+}
+
+// ObjectCountUsageFunc is useful if you are only counting your object
+// It always returns 1 as the usage for the named resource
+func ObjectCountUsageFunc(resourceName api.ResourceName) UsageFunc {
+	return func(object runtime.Object) api.ResourceList {
+		return api.ResourceList{
+			resourceName: resource.MustParse("1"),
+		}
+	}
+}
+
+// GenericEvaluator provides an implementation for quota.Evaluator
+type GenericEvaluator struct {
+	// Name used for logging
+	Name string
+	// The GroupKind that this evaluator tracks
+	InternalGroupKind unversioned.GroupKind
+	// The set of resources that are pertinent to the mapped operation
+	InternalOperationResources map[admission.Operation][]api.ResourceName
+	// The set of resource names this evaluator matches
+	MatchedResourceNames []api.ResourceName
+	// A function that knows how to evaluate a matches scope request
+	MatchesScopeFunc MatchesScopeFunc
+	// A function that knows how to return usage for an object
+	UsageFunc UsageFunc
+	// A function that knows how to list resources by namespace
+	ListFuncByNamespace ListFuncByNamespace
+	// A function that knows how to get resource in a namespace
+	// This function must be specified if the evaluator needs to handle UPDATE
+	GetFuncByNamespace GetFuncByNamespace
+	// A function that checks required constraints are satisfied
+	ConstraintsFunc ConstraintsFunc
+}
+
+// Ensure that GenericEvaluator implements quota.Evaluator
+var _ quota.Evaluator = &GenericEvaluator{}
+
+// Constraints checks required constraints are satisfied on the input object
+func (g *GenericEvaluator) Constraints(required []api.ResourceName, item runtime.Object) error {
+	return g.ConstraintsFunc(required, item)
+}
+
+// Get returns the object by namespace and name
+func (g *GenericEvaluator) Get(namespace, name string) (runtime.Object, error) {
+	return g.GetFuncByNamespace(namespace, name)
+}
+
+// OperationResources returns the set of resources that could be updated for the
+// specified operation for this kind.  If empty, admission control will ignore
+// quota processing for the operation.
+func (g *GenericEvaluator) OperationResources(operation admission.Operation) []api.ResourceName {
+	return g.InternalOperationResources[operation]
+}
+
+// GroupKind that this evaluator tracks
+func (g *GenericEvaluator) GroupKind() unversioned.GroupKind {
+	return g.InternalGroupKind
+}
+
+// MatchesResources is the list of resources that this evaluator matches
+func (g *GenericEvaluator) MatchesResources() []api.ResourceName {
+	return g.MatchedResourceNames
+}
+
+// Matches returns true if the evaluator matches the specified quota with the provided input item
+func (g *GenericEvaluator) Matches(resourceQuota *api.ResourceQuota, item runtime.Object) bool {
+	if resourceQuota == nil {
+		return false
+	}
+
+	// verify the quota matches on resource, by default its false
+	matchResource := false
+	for resourceName := range resourceQuota.Status.Hard {
+		if g.MatchesResource(resourceName) {
+			matchResource = true
+		}
+	}
+	// by default, no scopes matches all
+	matchScope := true
+	for _, scope := range resourceQuota.Spec.Scopes {
+		matchScope = matchScope && g.MatchesScope(scope, item)
+	}
+	return matchResource && matchScope
+}
+
+// MatchesResource returns true if this evaluator can match on the specified resource
+func (g *GenericEvaluator) MatchesResource(resourceName api.ResourceName) bool {
+	for _, matchedResourceName := range g.MatchedResourceNames {
+		if resourceName == matchedResourceName {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesScope returns true if the input object matches the specified scope
+func (g *GenericEvaluator) MatchesScope(scope api.ResourceQuotaScope, object runtime.Object) bool {
+	return g.MatchesScopeFunc(scope, object)
+}
+
+// Usage returns the resource usage for the specified object
+func (g *GenericEvaluator) Usage(object runtime.Object) api.ResourceList {
+	return g.UsageFunc(object)
+}
+
+// UsageStats calculates latest observed usage stats for all objects
+func (g *GenericEvaluator) UsageStats(options quota.UsageStatsOptions) (quota.UsageStats, error) {
+	// default each tracked resource to zero
+	result := quota.UsageStats{Used: api.ResourceList{}}
+	for _, resourceName := range g.MatchedResourceNames {
+		result.Used[resourceName] = resource.MustParse("0")
+	}
+	list, err := g.ListFuncByNamespace(options.Namespace, api.ListOptions{})
+	if err != nil {
+		return result, fmt.Errorf("%s: Failed to list %v: %v", g.Name, g.GroupKind, err)
+	}
+	_, err = meta.Accessor(list)
+	if err != nil {
+		return result, fmt.Errorf("%s: Unable to understand list result %#v", g.Name, list)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return result, fmt.Errorf("%s: Unable to understand list result %#v (%v)", g.Name, list, err)
+	}
+	for _, item := range items {
+		// need to verify that the item matches the set of scopes
+		matchesScopes := true
+		for _, scope := range options.Scopes {
+			if !g.MatchesScope(scope, item) {
+				matchesScopes = false
+			}
+		}
+		// only count usage if there was a match
+		if matchesScopes {
+			result.Used = quota.Add(result.Used, g.Usage(item))
+		}
+	}
+	return result, nil
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/generic/registry.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/generic/registry.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/quota"
+)
+
+// Ensure it implements the required interface
+var _ quota.Registry = &GenericRegistry{}
+
+// GenericRegistry implements Registry
+type GenericRegistry struct {
+	// internal evaluators by group kind
+	InternalEvaluators map[unversioned.GroupKind]quota.Evaluator
+}
+
+// Evaluators returns the map of evaluators by groupKind
+func (r *GenericRegistry) Evaluators() map[unversioned.GroupKind]quota.Evaluator {
+	return r.InternalEvaluators
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/install/registry.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/install/registry.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/evaluator/core"
+)
+
+// NewRegistry returns a registry that knows how to deal kubernetes resources
+// across API groups
+func NewRegistry(kubeClient clientset.Interface) quota.Registry {
+	// TODO: when quota supports resources in other api groups, we will need to merge
+	return core.NewRegistry(kubeClient)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/interfaces.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/interfaces.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// UsageStatsOptions is an options structs that describes how stats should be calculated
+type UsageStatsOptions struct {
+	// Namespace where stats should be calculate
+	Namespace string
+	// Scopes that must match counted objects
+	Scopes []api.ResourceQuotaScope
+}
+
+// UsageStats is result of measuring observed resource use in the system
+type UsageStats struct {
+	// Used maps resource to quantity used
+	Used api.ResourceList
+}
+
+// Evaluator knows how to evaluate quota usage for a particular group kind
+type Evaluator interface {
+	// Constraints ensures that each required resource is present on item
+	Constraints(required []api.ResourceName, item runtime.Object) error
+	// Get returns the object with specified namespace and name
+	Get(namespace, name string) (runtime.Object, error)
+	// GroupKind returns the groupKind that this object knows how to evaluate
+	GroupKind() unversioned.GroupKind
+	// MatchesResources is the list of resources that this evaluator matches
+	MatchesResources() []api.ResourceName
+	// Matches returns true if the specified quota matches the input item
+	Matches(resourceQuota *api.ResourceQuota, item runtime.Object) bool
+	// OperationResources returns the set of resources that could be updated for the
+	// specified operation for this kind.  If empty, admission control will ignore
+	// quota processing for the operation.
+	OperationResources(operation admission.Operation) []api.ResourceName
+	// Usage returns the resource usage for the specified object
+	Usage(object runtime.Object) api.ResourceList
+	// UsageStats calculates latest observed usage stats for all objects
+	UsageStats(options UsageStatsOptions) (UsageStats, error)
+}
+
+// Registry holds the list of evaluators associated to a particular group kind
+type Registry interface {
+	// Evaluators returns the set Evaluator objects registered to a groupKind
+	Evaluators() map[unversioned.GroupKind]Evaluator
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/resources.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/resources.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// Equals returns true if the two lists are equivalent
+func Equals(a api.ResourceList, b api.ResourceList) bool {
+	for key, value1 := range a {
+		value2, found := b[key]
+		if !found {
+			return false
+		}
+		if value1.Cmp(value2) != 0 {
+			return false
+		}
+	}
+	for key, value1 := range b {
+		value2, found := a[key]
+		if !found {
+			return false
+		}
+		if value1.Cmp(value2) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// LessThanOrEqual returns true if a < b for each key in b
+// If false, it returns the keys in a that exceeded b
+func LessThanOrEqual(a api.ResourceList, b api.ResourceList) (bool, []api.ResourceName) {
+	result := true
+	resourceNames := []api.ResourceName{}
+	for key, value := range b {
+		if other, found := a[key]; found {
+			if other.Cmp(value) > 0 {
+				result = false
+				resourceNames = append(resourceNames, key)
+			}
+		}
+	}
+	return result, resourceNames
+}
+
+// Add returns the result of a + b for each named resource
+func Add(a api.ResourceList, b api.ResourceList) api.ResourceList {
+	result := api.ResourceList{}
+	for key, value := range a {
+		quantity := *value.Copy()
+		if other, found := b[key]; found {
+			quantity.Add(other)
+		}
+		result[key] = quantity
+	}
+	for key, value := range b {
+		if _, found := result[key]; !found {
+			quantity := *value.Copy()
+			result[key] = quantity
+		}
+	}
+	return result
+}
+
+// Subtract returns the result of a - b for each named resource
+func Subtract(a api.ResourceList, b api.ResourceList) api.ResourceList {
+	result := api.ResourceList{}
+	for key, value := range a {
+		quantity := *value.Copy()
+		if other, found := b[key]; found {
+			quantity.Sub(other)
+		}
+		result[key] = quantity
+	}
+	for key, value := range b {
+		if _, found := result[key]; !found {
+			quantity := *value.Copy()
+			quantity.Neg(value)
+			result[key] = quantity
+		}
+	}
+	return result
+}
+
+// Mask returns a new resource list that only has the values with the specified names
+func Mask(resources api.ResourceList, names []api.ResourceName) api.ResourceList {
+	nameSet := ToSet(names)
+	result := api.ResourceList{}
+	for key, value := range resources {
+		if nameSet.Has(string(key)) {
+			result[key] = *value.Copy()
+		}
+	}
+	return result
+}
+
+// ResourceNames returns a list of all resource names in the ResourceList
+func ResourceNames(resources api.ResourceList) []api.ResourceName {
+	result := []api.ResourceName{}
+	for resourceName := range resources {
+		result = append(result, resourceName)
+	}
+	return result
+}
+
+// Contains returns true if the specified item is in the list of items
+func Contains(items []api.ResourceName, item api.ResourceName) bool {
+	return ToSet(items).Has(string(item))
+}
+
+// Intersection returns the intersection of both list of resources
+func Intersection(a []api.ResourceName, b []api.ResourceName) []api.ResourceName {
+	setA := ToSet(a)
+	setB := ToSet(b)
+	setC := setA.Intersection(setB)
+	result := []api.ResourceName{}
+	for _, resourceName := range setC.List() {
+		result = append(result, api.ResourceName(resourceName))
+	}
+	return result
+}
+
+// IsZero returns true if each key maps to the quantity value 0
+func IsZero(a api.ResourceList) bool {
+	zero := resource.MustParse("0")
+	for _, v := range a {
+		if v.Cmp(zero) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// ToSet takes a list of resource names and converts to a string set
+func ToSet(resourceNames []api.ResourceName) sets.String {
+	result := sets.NewString()
+	for _, resourceName := range resourceNames {
+		result.Insert(string(resourceName))
+	}
+	return result
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/resources_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/quota/resources_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+func TestEquals(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		b        api.ResourceList
+		expected bool
+	}{
+		"isEqual": {
+			a:        api.ResourceList{},
+			b:        api.ResourceList{},
+			expected: true,
+		},
+		"isEqualWithKeys": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			b: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: true,
+		},
+		"isNotEqualSameKeys": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("200m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			b: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: false,
+		},
+		"isNotEqualDiffKeys": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			b: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+				api.ResourcePods:   resource.MustParse("1"),
+			},
+			expected: false,
+		},
+	}
+	for testName, testCase := range testCases {
+		if result := Equals(testCase.a, testCase.b); result != testCase.expected {
+			t.Errorf("%s expected: %v, actual: %v, a=%v, b=%v", testName, testCase.expected, result, testCase.a, testCase.b)
+		}
+	}
+}
+
+func TestAdd(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		b        api.ResourceList
+		expected api.ResourceList
+	}{
+		"noKeys": {
+			a:        api.ResourceList{},
+			b:        api.ResourceList{},
+			expected: api.ResourceList{},
+		},
+		"toEmpty": {
+			a:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			b:        api.ResourceList{},
+			expected: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+		},
+		"matching": {
+			a:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			b:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			expected: api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
+		},
+	}
+	for testName, testCase := range testCases {
+		sum := Add(testCase.a, testCase.b)
+		if result := Equals(testCase.expected, sum); !result {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, sum)
+		}
+	}
+}
+
+func TestSubtract(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		b        api.ResourceList
+		expected api.ResourceList
+	}{
+		"noKeys": {
+			a:        api.ResourceList{},
+			b:        api.ResourceList{},
+			expected: api.ResourceList{},
+		},
+		"value-empty": {
+			a:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			b:        api.ResourceList{},
+			expected: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+		},
+		"empty-value": {
+			a:        api.ResourceList{},
+			b:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			expected: api.ResourceList{api.ResourceCPU: resource.MustParse("-100m")},
+		},
+		"value-value": {
+			a:        api.ResourceList{api.ResourceCPU: resource.MustParse("200m")},
+			b:        api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+			expected: api.ResourceList{api.ResourceCPU: resource.MustParse("100m")},
+		},
+	}
+	for testName, testCase := range testCases {
+		sub := Subtract(testCase.a, testCase.b)
+		if result := Equals(testCase.expected, sub); !result {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, sub)
+		}
+	}
+}
+
+func TestResourceNames(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		expected []api.ResourceName
+	}{
+		"empty": {
+			a:        api.ResourceList{},
+			expected: []api.ResourceName{},
+		},
+		"values": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("100m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: []api.ResourceName{api.ResourceMemory, api.ResourceCPU},
+		},
+	}
+	for testName, testCase := range testCases {
+		actualSet := ToSet(ResourceNames(testCase.a))
+		expectedSet := ToSet(testCase.expected)
+		if !actualSet.Equal(expectedSet) {
+			t.Errorf("%s expected: %v, actual: %v", testName, expectedSet, actualSet)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	testCases := map[string]struct {
+		a        []api.ResourceName
+		b        api.ResourceName
+		expected bool
+	}{
+		"does-not-contain": {
+			a:        []api.ResourceName{api.ResourceMemory},
+			b:        api.ResourceCPU,
+			expected: false,
+		},
+		"does-contain": {
+			a:        []api.ResourceName{api.ResourceMemory, api.ResourceCPU},
+			b:        api.ResourceCPU,
+			expected: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		if actual := Contains(testCase.a, testCase.b); actual != testCase.expected {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, actual)
+		}
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceList
+		expected bool
+	}{
+		"empty": {
+			a:        api.ResourceList{},
+			expected: true,
+		},
+		"zero": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("0"),
+				api.ResourceMemory: resource.MustParse("0"),
+			},
+			expected: true,
+		},
+		"non-zero": {
+			a: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("200m"),
+				api.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			expected: false,
+		},
+	}
+	for testName, testCase := range testCases {
+		if result := IsZero(testCase.a); result != testCase.expected {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
@@ -18,16 +18,20 @@ package resourcequota
 
 import (
 	"strconv"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/hashicorp/golang-lru"
 
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/testing/fake"
-	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
-	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/quota/install"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func getResourceList(cpu, memory string) api.ResourceList {
@@ -63,386 +67,502 @@ func validPod(name string, numContainers int, resources api.ResourceRequirements
 	return pod
 }
 
+// TestAdmissionIgnoresDelete verifies that the admission controller ignores delete operations
 func TestAdmissionIgnoresDelete(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	handler, err := NewResourceQuota(kubeClient, install.NewRegistry(kubeClient))
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
 	namespace := "default"
-	handler := createResourceQuota(&fake.Clientset{}, nil)
-	err := handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod"), namespace, "name", api.Resource("pods"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod"), namespace, "name", api.Resource("pods"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("ResourceQuota should admit all deletes: %v", err)
 	}
 }
 
+// TestAdmissionIgnoresSubresources verifies that the admission controller ignores subresources
+// It verifies that creation of a pod that would have exceeded quota is properly failed
+// It verifies that create operations to a subresource that would have exceeded quota would succeed
 func TestAdmissionIgnoresSubresources(t *testing.T) {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
-	handler := createResourceQuota(&fake.Clientset{}, indexer)
-
-	quota := &api.ResourceQuota{}
-	quota.Name = "quota"
-	quota.Namespace = "test"
-	quota.Status = api.ResourceQuotaStatus{
+	resourceQuota := &api.ResourceQuota{}
+	resourceQuota.Name = "quota"
+	resourceQuota.Namespace = "test"
+	resourceQuota.Status = api.ResourceQuotaStatus{
 		Hard: api.ResourceList{},
 		Used: api.ResourceList{},
 	}
-	quota.Status.Hard[api.ResourceMemory] = resource.MustParse("2Gi")
-	quota.Status.Used[api.ResourceMemory] = resource.MustParse("1Gi")
-
-	indexer.Add(quota)
-
+	resourceQuota.Status.Hard[api.ResourceMemory] = resource.MustParse("2Gi")
+	resourceQuota.Status.Used[api.ResourceMemory] = resource.MustParse("1Gi")
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
+	}
+	handler.indexer.Add(resourceQuota)
 	newPod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
 	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod exceeded allowed quota")
 	}
-
 	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "subresource", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error because the action went to a subresource: %v", err)
 	}
-
 }
 
-func TestIncrementUsagePodResources(t *testing.T) {
-	type testCase struct {
-		testName      string
-		existing      *api.Pod
-		input         *api.Pod
-		resourceName  api.ResourceName
-		hard          resource.Quantity
-		expectedUsage resource.Quantity
-		expectedError bool
-	}
-	testCases := []testCase{
-		{
-			testName:      "memory-allowed",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100Mi"), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("", "100Mi"), getResourceList("", ""))),
-			resourceName:  api.ResourceMemory,
-			hard:          resource.MustParse("500Mi"),
-			expectedUsage: resource.MustParse("200Mi"),
-			expectedError: false,
-		},
-		{
-			testName:      "memory-not-allowed",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100Mi"), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("", "450Mi"), getResourceList("", ""))),
-			resourceName:  api.ResourceMemory,
-			hard:          resource.MustParse("500Mi"),
-			expectedError: true,
-		},
-		{
-			testName:      "memory-not-allowed-with-different-format",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100M"), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("", "450Mi"), getResourceList("", ""))),
-			resourceName:  api.ResourceMemory,
-			hard:          resource.MustParse("500Mi"),
-			expectedError: true,
-		},
-		{
-			testName:      "memory-no-request",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100Mi"), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:  api.ResourceMemory,
-			hard:          resource.MustParse("500Mi"),
-			expectedError: true,
-		},
-		{
-			testName:      "cpu-allowed",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("1", ""), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("1", ""), getResourceList("", ""))),
-			resourceName:  api.ResourceCPU,
-			hard:          resource.MustParse("2"),
-			expectedUsage: resource.MustParse("2"),
-			expectedError: false,
-		},
-		{
-			testName:      "cpu-not-allowed",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("1", ""), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("600m", ""), getResourceList("", ""))),
-			resourceName:  api.ResourceCPU,
-			hard:          resource.MustParse("1500m"),
-			expectedError: true,
-		},
-		{
-			testName:      "cpu-no-request",
-			existing:      validPod("a", 1, getResourceRequirements(getResourceList("1", ""), getResourceList("", ""))),
-			input:         validPod("b", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),
-			resourceName:  api.ResourceCPU,
-			hard:          resource.MustParse("1500m"),
-			expectedError: true,
+// TestAdmitBelowQuotaLimit verifies that a pod when created has its usage reflected on the quota
+func TestAdmitBelowQuotaLimit(t *testing.T) {
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: "test", ResourceVersion: "124"},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1"),
+				api.ResourceMemory: resource.MustParse("50Gi"),
+				api.ResourcePods:   resource.MustParse("3"),
+			},
 		},
 	}
-	for _, item := range testCases {
-		podList := &api.PodList{Items: []api.Pod{*item.existing}}
-		client := fake.NewSimpleClientset(podList)
-		status := &api.ResourceQuotaStatus{
-			Hard: api.ResourceList{},
-			Used: api.ResourceList{},
-		}
-		used, err := resourcequotacontroller.PodRequests(item.existing, item.resourceName)
-		if err != nil {
-			t.Errorf("Test %s, unexpected error %v", item.testName, err)
-		}
-		status.Hard[item.resourceName] = item.hard
-		status.Used[item.resourceName] = *used
-
-		dirty, err := IncrementUsage(admission.NewAttributesRecord(item.input, api.Kind("Pod"), item.input.Namespace, item.input.Name, api.Resource("pods"), "", admission.Create, nil), status, client)
-		if err == nil && item.expectedError {
-			t.Errorf("Test %s, expected error", item.testName)
-		}
-		if err != nil && !item.expectedError {
-			t.Errorf("Test %s, unexpected error", err)
-		}
-		if !item.expectedError {
-			if !dirty {
-				t.Errorf("Test %s, expected the quota to be dirty", item.testName)
-			}
-			quantity := status.Used[item.resourceName]
-			if quantity.String() != item.expectedUsage.String() {
-				t.Errorf("Test %s, expected usage %s, actual usage %s", item.testName, item.expectedUsage.String(), quantity.String())
-			}
-		}
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
 	}
-}
-
-func TestIncrementUsagePods(t *testing.T) {
-	pod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
-	podList := &api.PodList{Items: []api.Pod{*pod}}
-	client := fake.NewSimpleClientset(podList)
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
-	}
-	r := api.ResourcePods
-	status.Hard[r] = resource.MustParse("2")
-	status.Used[r] = resource.MustParse("1")
-	dirty, err := IncrementUsage(admission.NewAttributesRecord(&api.Pod{}, api.Kind("Pod"), pod.Namespace, "new-pod", api.Resource("pods"), "", admission.Create, nil), status, client)
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if !dirty {
-		t.Errorf("Expected the status to get incremented, therefore should have been dirty")
+	if len(kubeClient.Actions()) == 0 {
+		t.Errorf("Expected a client action")
 	}
-	quantity := status.Used[r]
-	if quantity.Value() != int64(2) {
-		t.Errorf("Expected new item count to be 2, but was %s", quantity.String())
-	}
-}
 
-func TestExceedUsagePods(t *testing.T) {
-	pod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
-	podList := &api.PodList{Items: []api.Pod{*pod}}
-	client := fake.NewSimpleClientset(podList)
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
 	}
-	r := api.ResourcePods
-	status.Hard[r] = resource.MustParse("1")
-	status.Used[r] = resource.MustParse("1")
-	_, err := IncrementUsage(admission.NewAttributesRecord(&api.Pod{}, api.Kind("Pod"), pod.Namespace, "name", api.Resource("pods"), "", admission.Create, nil), status, client)
-	if err == nil {
-		t.Errorf("Expected error because this would exceed your quota")
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
 	}
-}
 
-func TestIncrementUsageServices(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.ServiceList{
-		Items: []api.Service{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+	lastActionIndex := len(kubeClient.Actions()) - 1
+	usage := kubeClient.Actions()[lastActionIndex].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
+	expectedUsage := api.ResourceQuota{
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1100m"),
+				api.ResourceMemory: resource.MustParse("52Gi"),
+				api.ResourcePods:   resource.MustParse("4"),
 			},
 		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
 	}
-	r := api.ResourceServices
-	status.Hard[r] = resource.MustParse("2")
-	status.Used[r] = resource.MustParse("1")
-	dirty, err := IncrementUsage(admission.NewAttributesRecord(&api.Service{}, api.Kind("Service"), namespace, "name", api.Resource("services"), "", admission.Create, nil), status, client)
+	for k, v := range expectedUsage.Status.Used {
+		actual := usage.Status.Used[k]
+		actualValue := actual.String()
+		expectedValue := v.String()
+		if expectedValue != actualValue {
+			t.Errorf("Usage Used: Key: %v, Expected: %v, Actual: %v", k, expectedValue, actualValue)
+		}
+	}
+}
+
+// TestAdmitExceedQuotaLimit verifies that if a pod exceeded allowed usage that its rejected during admission.
+func TestAdmitExceedQuotaLimit(t *testing.T) {
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: "test", ResourceVersion: "124"},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1"),
+				api.ResourceMemory: resource.MustParse("50Gi"),
+				api.ResourcePods:   resource.MustParse("3"),
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
+	}
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Expected an error exceeding quota")
+	}
+}
+
+// TestAdmitEnforceQuotaConstraints verifies that if a quota tracks a particular resource that that resource is
+// specified on the pod.  In this case, we create a quota that tracks cpu request, memory request, and memory limit.
+// We ensure that a pod that does not specify a memory limit that it fails in admission.
+func TestAdmitEnforceQuotaConstraints(t *testing.T) {
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: "test", ResourceVersion: "124"},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:          resource.MustParse("3"),
+				api.ResourceMemory:       resource.MustParse("100Gi"),
+				api.ResourceLimitsMemory: resource.MustParse("200Gi"),
+				api.ResourcePods:         resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:          resource.MustParse("1"),
+				api.ResourceMemory:       resource.MustParse("50Gi"),
+				api.ResourceLimitsMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:         resource.MustParse("3"),
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
+	}
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	if err == nil {
+		t.Errorf("Expected an error because the pod does not specify a memory limit")
+	}
+}
+
+// TestAdmitPodInNamespaceWithoutQuota ensures that if a namespace has no quota, that a pod can get in
+func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: "other", ResourceVersion: "124"},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:          resource.MustParse("3"),
+				api.ResourceMemory:       resource.MustParse("100Gi"),
+				api.ResourceLimitsMemory: resource.MustParse("200Gi"),
+				api.ResourcePods:         resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:          resource.MustParse("1"),
+				api.ResourceMemory:       resource.MustParse("50Gi"),
+				api.ResourceLimitsMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:         resource.MustParse("3"),
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	liveLookupCache, err := lru.New(100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := &quotaAdmission{
+		Handler:         admission.NewHandler(admission.Create, admission.Update),
+		client:          kubeClient,
+		indexer:         indexer,
+		registry:        install.NewRegistry(kubeClient),
+		liveLookupCache: liveLookupCache,
+	}
+	// Add to the index
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
+	// Add to the lru cache so we do not do a live client lookup
+	liveLookupCache.Add(newPod.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(30 * time.Second)), items: []*api.ResourceQuota{}})
+	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Did not expect an error because the pod is in a different namespace than the quota")
+	}
+}
+
+// TestAdmitBelowTerminatingQuotaLimit ensures that terminating pods are charged to the right quota.
+// It creates a terminating and non-terminating quota, and creates a terminating pod.
+// It ensures that the terminating quota is incremented, and the non-terminating quota is not.
+func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
+	resourceQuotaNonTerminating := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota-non-terminating", Namespace: "test", ResourceVersion: "124"},
+		Spec: api.ResourceQuotaSpec{
+			Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeNotTerminating},
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1"),
+				api.ResourceMemory: resource.MustParse("50Gi"),
+				api.ResourcePods:   resource.MustParse("3"),
+			},
+		},
+	}
+	resourceQuotaTerminating := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota-terminating", Namespace: "test", ResourceVersion: "124"},
+		Spec: api.ResourceQuotaSpec{
+			Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeTerminating},
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1"),
+				api.ResourceMemory: resource.MustParse("50Gi"),
+				api.ResourcePods:   resource.MustParse("3"),
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(resourceQuotaTerminating, resourceQuotaNonTerminating)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
+	}
+	handler.indexer.Add(resourceQuotaNonTerminating)
+	handler.indexer.Add(resourceQuotaTerminating)
+
+	// create a pod that has an active deadline
+	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
+	activeDeadlineSeconds := int64(30)
+	newPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if !dirty {
-		t.Errorf("Expected the status to get incremented, therefore should have been dirty")
+	if len(kubeClient.Actions()) == 0 {
+		t.Errorf("Expected a client action")
 	}
-	quantity := status.Used[r]
-	if quantity.Value() != int64(2) {
-		t.Errorf("Expected new item count to be 2, but was %s", quantity.String())
+
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
+	}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
+	}
+
+	lastActionIndex := len(kubeClient.Actions()) - 1
+	usage := kubeClient.Actions()[lastActionIndex].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
+
+	// ensure only the quota-terminating was updated
+	if usage.Name != resourceQuotaTerminating.Name {
+		t.Errorf("Incremented the wrong quota, expected %v, actual %v", resourceQuotaTerminating.Name, usage.Name)
+	}
+
+	expectedUsage := api.ResourceQuota{
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("3"),
+				api.ResourceMemory: resource.MustParse("100Gi"),
+				api.ResourcePods:   resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1100m"),
+				api.ResourceMemory: resource.MustParse("52Gi"),
+				api.ResourcePods:   resource.MustParse("4"),
+			},
+		},
+	}
+	for k, v := range expectedUsage.Status.Used {
+		actual := usage.Status.Used[k]
+		actualValue := actual.String()
+		expectedValue := v.String()
+		if expectedValue != actualValue {
+			t.Errorf("Usage Used: Key: %v, Expected: %v, Actual: %v", k, expectedValue, actualValue)
+		}
 	}
 }
 
-func TestExceedUsageServices(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.ServiceList{
-		Items: []api.Service{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+// TestAdmitBelowBestEffortQuotaLimit creates a best effort and non-best effort quota.
+// It verifies that best effort pods are properly scoped to the best effort quota document.
+func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
+	resourceQuotaBestEffort := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota-besteffort", Namespace: "test", ResourceVersion: "124"},
+		Spec: api.ResourceQuotaSpec{
+			Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeBestEffort},
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourcePods: resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourcePods: resource.MustParse("3"),
 			},
 		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
 	}
-	r := api.ResourceServices
-	status.Hard[r] = resource.MustParse("1")
-	status.Used[r] = resource.MustParse("1")
-	_, err := IncrementUsage(admission.NewAttributesRecord(&api.Service{}, api.Kind("Service"), namespace, "name", api.Resource("services"), "", admission.Create, nil), status, client)
-	if err == nil {
-		t.Errorf("Expected error because this would exceed usage")
+	resourceQuotaNotBestEffort := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota-not-besteffort", Namespace: "test", ResourceVersion: "124"},
+		Spec: api.ResourceQuotaSpec{
+			Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeNotBestEffort},
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourcePods: resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourcePods: resource.MustParse("3"),
+			},
+		},
 	}
-}
+	kubeClient := fake.NewSimpleClientset(resourceQuotaBestEffort, resourceQuotaNotBestEffort)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
+	}
+	handler.indexer.Add(resourceQuotaBestEffort)
+	handler.indexer.Add(resourceQuotaNotBestEffort)
 
-func TestIncrementUsageReplicationControllers(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.ReplicationControllerList{
-		Items: []api.ReplicationController{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
-			},
-		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
-	}
-	r := api.ResourceReplicationControllers
-	status.Hard[r] = resource.MustParse("2")
-	status.Used[r] = resource.MustParse("1")
-	dirty, err := IncrementUsage(admission.NewAttributesRecord(&api.ReplicationController{}, api.Kind("ReplicationController"), namespace, "name", api.Resource("replicationcontrollers"), "", admission.Create, nil), status, client)
+	// create a pod that is best effort because it does not make a request for anything
+	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if !dirty {
-		t.Errorf("Expected the status to get incremented, therefore should have been dirty")
+	expectedActionSet := sets.NewString(
+		strings.Join([]string{"update", "resourcequotas", "status"}, "-"),
+	)
+	actionSet := sets.NewString()
+	for _, action := range kubeClient.Actions() {
+		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
 	}
-	quantity := status.Used[r]
-	if quantity.Value() != int64(2) {
-		t.Errorf("Expected new item count to be 2, but was %s", quantity.String())
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", expectedActionSet, actionSet, expectedActionSet.Difference(actionSet))
 	}
-}
+	lastActionIndex := len(kubeClient.Actions()) - 1
+	usage := kubeClient.Actions()[lastActionIndex].(testclient.UpdateAction).GetObject().(*api.ResourceQuota)
 
-func TestExceedUsageReplicationControllers(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.ReplicationControllerList{
-		Items: []api.ReplicationController{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+	if usage.Name != resourceQuotaBestEffort.Name {
+		t.Errorf("Incremented the wrong quota, expected %v, actual %v", resourceQuotaBestEffort.Name, usage.Name)
+	}
+
+	expectedUsage := api.ResourceQuota{
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourcePods: resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourcePods: resource.MustParse("4"),
 			},
 		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
 	}
-	r := api.ResourceReplicationControllers
-	status.Hard[r] = resource.MustParse("1")
-	status.Used[r] = resource.MustParse("1")
-	_, err := IncrementUsage(admission.NewAttributesRecord(&api.ReplicationController{}, api.Kind("ReplicationController"), namespace, "name", api.Resource("replicationcontrollers"), "", admission.Create, nil), status, client)
-	if err == nil {
-		t.Errorf("Expected error for exceeding hard limits")
+	for k, v := range expectedUsage.Status.Used {
+		actual := usage.Status.Used[k]
+		actualValue := actual.String()
+		expectedValue := v.String()
+		if expectedValue != actualValue {
+			t.Errorf("Usage Used: Key: %v, Expected: %v, Actual: %v", k, expectedValue, actualValue)
+		}
 	}
 }
 
-func TestExceedUsageSecrets(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.SecretList{
-		Items: []api.Secret{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
+// TestAdmitBestEffortQuotaLimitIgnoresBurstable validates that a besteffort quota does not match a resource
+// guaranteed pod.
+func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota-besteffort", Namespace: "test", ResourceVersion: "124"},
+		Spec: api.ResourceQuotaSpec{
+			Scopes: []api.ResourceQuotaScope{api.ResourceQuotaScopeBestEffort},
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourcePods: resource.MustParse("5"),
+			},
+			Used: api.ResourceList{
+				api.ResourcePods: resource.MustParse("3"),
 			},
 		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
 	}
-	r := api.ResourceSecrets
-	status.Hard[r] = resource.MustParse("1")
-	status.Used[r] = resource.MustParse("1")
-	_, err := IncrementUsage(admission.NewAttributesRecord(&api.Secret{}, api.Kind("Secret"), namespace, "name", api.Resource("secrets"), "", admission.Create, nil), status, client)
-	if err == nil {
-		t.Errorf("Expected error for exceeding hard limits")
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: install.NewRegistry(kubeClient),
 	}
-}
-
-func TestExceedUsagePersistentVolumeClaims(t *testing.T) {
-	namespace := "default"
-	client := fake.NewSimpleClientset(&api.PersistentVolumeClaimList{
-		Items: []api.PersistentVolumeClaim{
-			{
-				ObjectMeta: api.ObjectMeta{Name: "123", Namespace: namespace},
-			},
-		},
-	})
-	status := &api.ResourceQuotaStatus{
-		Hard: api.ResourceList{},
-		Used: api.ResourceList{},
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
-	r := api.ResourcePersistentVolumeClaims
-	status.Hard[r] = resource.MustParse("1")
-	status.Used[r] = resource.MustParse("1")
-	_, err := IncrementUsage(admission.NewAttributesRecord(&api.PersistentVolumeClaim{}, api.Kind("PersistentVolumeClaim"), namespace, "name", api.Resource("persistentvolumeclaims"), "", admission.Create, nil), status, client)
-	if err == nil {
-		t.Errorf("Expected error for exceeding hard limits")
+	if len(kubeClient.Actions()) != 0 {
+		t.Errorf("Expected no client actions because the incoming pod did not match best effort quota")
 	}
 }
 
-func TestIncrementUsageOnUpdateIgnoresNonPodResources(t *testing.T) {
-	testCase := []struct {
-		kind        unversioned.GroupKind
-		resource    unversioned.GroupResource
-		subresource string
-		object      runtime.Object
+func TestHasUsageStats(t *testing.T) {
+	testCases := map[string]struct {
+		a        api.ResourceQuota
+		expected bool
 	}{
-		{
-			kind:     api.Kind("Service"),
-			resource: api.Resource("services"),
-			object:   &api.Service{},
+		"empty": {
+			a:        api.ResourceQuota{Status: api.ResourceQuotaStatus{Hard: api.ResourceList{}}},
+			expected: true,
 		},
-		{
-			kind:     api.Kind("ReplicationController"),
-			resource: api.Resource("replicationcontrollers"),
-			object:   &api.ReplicationController{},
+		"hard-only": {
+			a: api.ResourceQuota{
+				Status: api.ResourceQuotaStatus{
+					Hard: api.ResourceList{
+						api.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Used: api.ResourceList{},
+				},
+			},
+			expected: false,
 		},
-		{
-			kind:     api.Kind("ResourceQuota"),
-			resource: api.Resource("resourcequotas"),
-			object:   &api.ResourceQuota{},
-		},
-		{
-			kind:     api.Kind("Secret"),
-			resource: api.Resource("secrets"),
-			object:   &api.Secret{},
-		},
-		{
-			kind:     api.Kind("PersistentVolumeClaim"),
-			resource: api.Resource("persistentvolumeclaims"),
-			object:   &api.PersistentVolumeClaim{},
+		"hard-used": {
+			a: api.ResourceQuota{
+				Status: api.ResourceQuotaStatus{
+					Hard: api.ResourceList{
+						api.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Used: api.ResourceList{
+						api.ResourceMemory: resource.MustParse("500Mi"),
+					},
+				},
+			},
+			expected: true,
 		},
 	}
-
-	for _, testCase := range testCase {
-		client := fake.NewSimpleClientset()
-		status := &api.ResourceQuotaStatus{
-			Hard: api.ResourceList{},
-			Used: api.ResourceList{},
-		}
-		r := resourceToResourceName[testCase.resource]
-		status.Hard[r] = resource.MustParse("2")
-		status.Used[r] = resource.MustParse("1")
-
-		attributesRecord := admission.NewAttributesRecord(testCase.object, testCase.kind, "my-ns", "new-thing",
-			testCase.resource, testCase.subresource, admission.Update, nil)
-		dirty, err := IncrementUsage(attributesRecord, status, client)
-		if err != nil {
-			t.Errorf("Increment usage of resource %v had unexpected error: %v", testCase.resource, err)
-		}
-		if dirty {
-			t.Errorf("Increment usage of resource %v should not result in a dirty quota on update", testCase.resource)
+	for testName, testCase := range testCases {
+		if result := hasUsageStats(&testCase.a); result != testCase.expected {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, result)
 		}
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/resource_quota.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/resource_quota.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// how long to wait for a resource quota update to occur
+	resourceQuotaTimeout = 30 * time.Second
+)
+
+var _ = Describe("ResourceQuota", func() {
+	f := NewFramework("resourcequota")
+
+	It("should create a ResourceQuota and ensure its status is promptly calculated.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create a ResourceQuota and capture the life of a service.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a Service")
+		service := newTestServiceForQuota("test-service")
+		service, err = f.Client.Services(f.Namespace.Name).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status captures service creation")
+		usedResources = api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourceServices] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting a Service")
+		err = f.Client.Services(f.Namespace.Name).Delete(service.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released usage")
+		usedResources[api.ResourceServices] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create a ResourceQuota and capture the life of a pod.", func() {
+		By("Creating a ResourceQuota")
+		quotaName := "test-quota"
+		resourceQuota := newTestResourceQuota(quotaName)
+		resourceQuota, err := createResourceQuota(f.Client, f.Namespace.Name, resourceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a Pod that fits quota")
+		podName := "test-pod"
+		requests := api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("500m")
+		requests[api.ResourceMemory] = resource.MustParse("252Mi")
+		pod := newTestPodForQuota(podName, requests, api.ResourceList{})
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring ResourceQuota status captures the pod usage")
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		usedResources[api.ResourceCPU] = requests[api.ResourceCPU]
+		usedResources[api.ResourceMemory] = requests[api.ResourceMemory]
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Not allowing a pod to be created that exceeds remaining quota")
+		requests = api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("600m")
+		requests[api.ResourceMemory] = resource.MustParse("100Mi")
+		pod = newTestPodForQuota("fail-pod", requests, api.ResourceList{})
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).To(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(podName, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourceQuotas] = resource.MustParse("1")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceCPU] = resource.MustParse("0")
+		usedResources[api.ResourceMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, quotaName, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should verify ResourceQuota with terminating scopes.", func() {
+		By("Creating a ResourceQuota with terminating scope")
+		quotaTerminatingName := "quota-terminating"
+		resourceQuotaTerminating, err := createResourceQuota(f.Client, f.Namespace.Name, newTestResourceQuotaWithScope(quotaTerminatingName, api.ResourceQuotaScopeTerminating))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring ResourceQuota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a ResourceQuota with not terminating scope")
+		quotaNotTerminatingName := "quota-not-terminating"
+		resourceQuotaNotTerminating, err := createResourceQuota(f.Client, f.Namespace.Name, newTestResourceQuotaWithScope(quotaNotTerminatingName, api.ResourceQuotaScopeNotTerminating))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring ResourceQuota status is calculated")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a long running pod")
+		podName := "test-pod"
+		requests := api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("500m")
+		requests[api.ResourceMemory] = resource.MustParse("200Mi")
+		limits := api.ResourceList{}
+		limits[api.ResourceCPU] = resource.MustParse("1")
+		limits[api.ResourceMemory] = resource.MustParse("400Mi")
+		pod := newTestPodForQuota(podName, requests, limits)
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with not terminating scope captures the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		usedResources[api.ResourceRequestsCPU] = requests[api.ResourceCPU]
+		usedResources[api.ResourceRequestsMemory] = requests[api.ResourceMemory]
+		usedResources[api.ResourceLimitsCPU] = limits[api.ResourceCPU]
+		usedResources[api.ResourceLimitsMemory] = limits[api.ResourceMemory]
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with terminating scope ignored the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsMemory] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(podName, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsMemory] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a terminating pod")
+		podName = "terminating-pod"
+		pod = newTestPodForQuota(podName, requests, limits)
+		activeDeadlineSeconds := int64(3600)
+		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with terminating scope captures the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		usedResources[api.ResourceRequestsCPU] = requests[api.ResourceCPU]
+		usedResources[api.ResourceRequestsMemory] = requests[api.ResourceMemory]
+		usedResources[api.ResourceLimitsCPU] = limits[api.ResourceCPU]
+		usedResources[api.ResourceLimitsMemory] = limits[api.ResourceMemory]
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with not terminating scope ignored the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsMemory] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(podName, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceRequestsMemory] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsCPU] = resource.MustParse("0")
+		usedResources[api.ResourceLimitsMemory] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should verify ResourceQuota with best effort scope.", func() {
+		By("Creating a ResourceQuota with best effort scope")
+		resourceQuotaBestEffort, err := createResourceQuota(f.Client, f.Namespace.Name, newTestResourceQuotaWithScope("quota-besteffort", api.ResourceQuotaScopeBestEffort))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring ResourceQuota status is calculated")
+		usedResources := api.ResourceList{}
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a ResourceQuota with not best effort scope")
+		resourceQuotaNotBestEffort, err := createResourceQuota(f.Client, f.Namespace.Name, newTestResourceQuotaWithScope("quota-not-besteffort", api.ResourceQuotaScopeNotBestEffort))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring ResourceQuota status is calculated")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a best-effort pod")
+		pod := newTestPodForQuota(podName, api.ResourceList{}, api.ResourceList{})
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with best effort scope captures the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with not best effort ignored the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(pod.Name, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a not best-effort pod")
+		requests := api.ResourceList{}
+		requests[api.ResourceCPU] = resource.MustParse("500m")
+		requests[api.ResourceMemory] = resource.MustParse("200Mi")
+		limits := api.ResourceList{}
+		limits[api.ResourceCPU] = resource.MustParse("1")
+		limits[api.ResourceMemory] = resource.MustParse("400Mi")
+		pod = newTestPodForQuota("burstable-pod", requests, limits)
+		pod, err = f.Client.Pods(f.Namespace.Name).Create(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with not best effort scope captures the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("1")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota with best effort scope ignored the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the pod")
+		err = f.Client.Pods(f.Namespace.Name).Delete(pod.Name, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring resource quota status released the pod usage")
+		usedResources[api.ResourcePods] = resource.MustParse("0")
+		err = waitForResourceQuota(f.Client, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+// newTestResourceQuotaWithScope returns a quota that enforces default constraints for testing with scopes
+func newTestResourceQuotaWithScope(name string, scope api.ResourceQuotaScope) *api.ResourceQuota {
+	hard := api.ResourceList{}
+	hard[api.ResourcePods] = resource.MustParse("5")
+	switch scope {
+	case api.ResourceQuotaScopeTerminating, api.ResourceQuotaScopeNotTerminating:
+		hard[api.ResourceRequestsCPU] = resource.MustParse("1")
+		hard[api.ResourceRequestsMemory] = resource.MustParse("500Mi")
+		hard[api.ResourceLimitsCPU] = resource.MustParse("2")
+		hard[api.ResourceLimitsMemory] = resource.MustParse("1Gi")
+	}
+	return &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: name},
+		Spec:       api.ResourceQuotaSpec{Hard: hard, Scopes: []api.ResourceQuotaScope{scope}},
+	}
+}
+
+// newTestResourceQuota returns a quota that enforces default constraints for testing
+func newTestResourceQuota(name string) *api.ResourceQuota {
+	hard := api.ResourceList{}
+	hard[api.ResourcePods] = resource.MustParse("5")
+	hard[api.ResourceServices] = resource.MustParse("10")
+	hard[api.ResourceReplicationControllers] = resource.MustParse("10")
+	hard[api.ResourceQuotas] = resource.MustParse("1")
+	hard[api.ResourceCPU] = resource.MustParse("1")
+	hard[api.ResourceMemory] = resource.MustParse("500Mi")
+	return &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: name},
+		Spec:       api.ResourceQuotaSpec{Hard: hard},
+	}
+}
+
+// newTestPodForQuota returns a pod that has the specified requests and limits
+func newTestPodForQuota(name string, requests api.ResourceList, limits api.ResourceList) *api.Pod {
+	return &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  "nginx",
+					Image: "gcr.io/google_containers/pause:2.0",
+					Resources: api.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
+		},
+	}
+}
+
+// newTestServiceForQuota returns a simple service
+func newTestServiceForQuota(name string) *api.Service {
+	return &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{{
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+			}},
+		},
+	}
+}
+
+// createResourceQuota in the specified namespace
+func createResourceQuota(c *client.Client, namespace string, resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	return c.ResourceQuotas(namespace).Create(resourceQuota)
+}
+
+// deleteResourceQuota with the specified name
+func deleteResourceQuota(c *client.Client, namespace, name string) error {
+	return c.ResourceQuotas(namespace).Delete(name)
+}
+
+// wait for resource quota status to show the expected used resources value
+func waitForResourceQuota(c *client.Client, ns, quotaName string, used api.ResourceList) error {
+	return wait.Poll(poll, resourceQuotaTimeout, func() (bool, error) {
+		resourceQuota, err := c.ResourceQuotas(ns).Get(quotaName)
+		if err != nil {
+			return false, err
+		}
+		// used may not yet be calculated
+		if resourceQuota.Status.Used == nil {
+			return false, nil
+		}
+		// verify that the quota shows the expected used resource values
+		for k, v := range used {
+			if actualValue, found := resourceQuota.Status.Used[k]; !found || (actualValue.Cmp(v) != 0) {
+				Logf("resource %s, expected %s, actual %s", k, v.String(), actualValue.String())
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -17621,8 +17621,19 @@
      "hard": {
       "type": "any",
       "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+     },
+     "scopes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ResourceQuotaScope"
+      },
+      "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects."
      }
     }
+   },
+   "v1.ResourceQuotaScope": {
+    "id": "v1.ResourceQuotaScope",
+    "properties": {}
    },
    "v1.ResourceQuotaStatus": {
     "id": "v1.ResourceQuotaStatus",

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -361,6 +361,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("create"),
 					Resources: sets.NewString("imagestreammappings"),
 				},
+				{
+					Verbs:     sets.NewString("list"),
+					Resources: sets.NewString("resourcequotas"),
+				},
 			},
 		},
 		{

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -171,7 +171,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{"OriginNamespaceLifecycle", "BuildByStrategy"}
+	admissionControlPluginNames := []string{"OriginNamespaceLifecycle", "BuildByStrategy", "OriginResourceQuota"}
 	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
 		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
 	}
@@ -180,6 +180,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		OpenshiftClient: privilegedLoopbackOpenShiftClient,
 		ProjectCache:    projectCache,
 	}
+
 	plugins := []admission.Interface{}
 	clientsetClient := internalclientset.FromUnversionedClient(privilegedLoopbackKubeClient)
 	for _, pluginName := range admissionControlPluginNames {
@@ -532,6 +533,12 @@ func (c *MasterConfig) ImageStreamSecretClient() *kclient.Client {
 // ImageStreamImportSecretClient returns the client capable of retrieving image secrets for a namespace
 func (c *MasterConfig) ImageStreamImportSecretClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
+}
+
+// ResourceQuotaManagerClients returns the client capable of retrieving resources needed for resource quota
+// evaluation
+func (c *MasterConfig) ResourceQuotaManagerClients() (*osclient.Client, *internalclientset.Clientset) {
+	return c.PrivilegedLoopbackOpenShiftClient, internalclientset.FromUnversionedClient(c.PrivilegedLoopbackKubernetesClient)
 }
 
 // WebConsoleEnabled says whether web ui is not a disabled feature and asset service is configured.

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/golang/glog"
 
+	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	"k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
 	sacontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/registry/service/allocator"
 	etcdallocator "k8s.io/kubernetes/pkg/registry/service/allocator/etcd"
@@ -41,8 +44,16 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/factory"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	quota "github.com/openshift/origin/pkg/quota"
+	quotacontroller "github.com/openshift/origin/pkg/quota/controller"
 	serviceaccountcontrollers "github.com/openshift/origin/pkg/serviceaccounts/controllers"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+)
+
+const (
+	defaultConcurrentResourceQuotaSyncs int           = 5
+	defaultResourceQuotaSyncPeriod      time.Duration = 5 * time.Minute
 )
 
 // RunProjectAuthorizationCache starts the project authorization cache
@@ -424,4 +435,26 @@ func (c *MasterConfig) RunSecurityAllocationController() {
 // RunGroupCache starts the group cache
 func (c *MasterConfig) RunGroupCache() {
 	c.GroupCache.Run()
+}
+
+// RunResourceQuotaManager starts resource quota controller for OpenShift resources
+func (c *MasterConfig) RunResourceQuotaManager(cm *cmapp.CMServer) {
+	concurrentResourceQuotaSyncs := defaultConcurrentResourceQuotaSyncs
+	resourceQuotaSyncPeriod := defaultResourceQuotaSyncPeriod
+	if cm != nil {
+		// TODO: should these be part of os master config?
+		concurrentResourceQuotaSyncs = cm.ConcurrentResourceQuotaSyncs
+		resourceQuotaSyncPeriod = cm.ResourceQuotaSyncPeriod
+	}
+
+	osClient, kClient := c.ResourceQuotaManagerClients()
+	resourceQuotaRegistry := quota.NewRegistry(osClient)
+	resourceQuotaControllerOptions := &kresourcequota.ResourceQuotaControllerOptions{
+		KubeClient:            kClient,
+		ResyncPeriod:          controller.StaticResyncPeriodFunc(resourceQuotaSyncPeriod),
+		Registry:              resourceQuotaRegistry,
+		GroupKindsToReplenish: []unversioned.GroupKind{imageapi.Kind("ImageStream")},
+		ControllerFactory:     quotacontroller.NewReplenishmentControllerFactory(osClient),
+	}
+	go kresourcequota.NewResourceQuotaController(resourceQuotaControllerOptions).Run(concurrentResourceQuotaSyncs, utilwait.NeverStop)
 }

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -19,8 +19,8 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"AlwaysPullImages",       // from kube, not enabled by default.  This is only applicable to some environments.  This will ensure that containers cannot use pre-pulled copies of images without authorization.
 	"NamespaceAutoProvision", // from kube, it creates a namespace if a resource is created in a non-existent namespace.  We don't want this behavior
 	"SecurityContextDeny",    // from kube, it denies pods that want to use SCC capabilities.  We have different rules to allow this in openshift.
-	"DenyExecOnPrivileged",   // from kube (deprecated, see below), it denies exec to pods that have certain privileges.  This is superceded in origin by SCCExecRestrictions that checks against SCC rules.
-	"DenyEscalatingExec",     // from kube, it denies exec to pods that have certain privileges.  This is superceded in origin by SCCExecRestrictions that checks against SCC rules.
+	"DenyExecOnPrivileged",   // from kube (deprecated, see below), it denies exec to pods that have certain privileges.  This is superseded in origin by SCCExecRestrictions that checks against SCC rules.
+	"DenyEscalatingExec",     // from kube, it denies exec to pods that have certain privileges.  This is superseded in origin by SCCExecRestrictions that checks against SCC rules.
 
 	"BuildByStrategy",          // from origin, only needed for managing builds, not kubernetes resources
 	"BuildDefaults",            // from origin, only needed for managing builds, not kubernetes resources
@@ -28,8 +28,9 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube
 	"ProjectRequestLimit",      // from origin, used for limiting project requests by user (online use case)
 	"RunOnceDuration",          // from origin, used for overriding the ActiveDeadlineSeconds for run-once pods
+	"OriginResourceQuota",      // from origin, used for quota abuse checks of openshift resources
 
-	"NamespaceExists",  // superceded by NamespaceLifecycle
+	"NamespaceExists",  // superseded by NamespaceLifecycle
 	"InitialResources", // do we want this? https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/initial-resources.md
 
 	"PersistentVolumeLabel", // do we want this? disable by default

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"
 	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride"
+	_ "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/security/admission"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -564,6 +564,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 
 		// called by admission control
 		kc.RunResourceQuotaManager()
+		oc.RunResourceQuotaManager(kc.ControllerManager)
 
 		// no special order
 		kc.RunNodeController()
@@ -581,6 +582,8 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunPersistentVolumeClaimRecycler(oc.ImageFor("recycler"), recyclerClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
 
 		glog.Infof("Started Kubernetes Controllers")
+	} else {
+		oc.RunResourceQuotaManager(nil)
 	}
 
 	// no special order

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -117,14 +117,14 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 		return nil, ac.wrapErr(err)
 	}
 
-	client, err := NewUserOpenShiftClient(bearerToken)
+	_, osClient, err := NewUserOpenShiftClients(bearerToken)
 	if err != nil {
 		return nil, ac.wrapErr(err)
 	}
 
 	// In case of docker login, hits endpoint /v2
 	if len(accessRecords) == 0 {
-		if err := verifyOpenShiftUser(ctx, client); err != nil {
+		if err := verifyOpenShiftUser(ctx, osClient); err != nil {
 			return nil, ac.wrapErr(err)
 		}
 	}
@@ -160,12 +160,12 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 				if verifiedPrune {
 					continue
 				}
-				if err := verifyPruneAccess(ctx, client); err != nil {
+				if err := verifyPruneAccess(ctx, osClient); err != nil {
 					return nil, ac.wrapErr(err)
 				}
 				verifiedPrune = true
 			default:
-				if err := verifyImageStreamAccess(ctx, imageStreamNS, imageStreamName, verb, client); err != nil {
+				if err := verifyImageStreamAccess(ctx, imageStreamNS, imageStreamName, verb, osClient); err != nil {
 					return nil, ac.wrapErr(err)
 				}
 			}
@@ -176,7 +176,7 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 				if verifiedPrune {
 					continue
 				}
-				if err := verifyPruneAccess(ctx, client); err != nil {
+				if err := verifyPruneAccess(ctx, osClient); err != nil {
 					return nil, ac.wrapErr(err)
 				}
 				verifiedPrune = true
@@ -188,7 +188,7 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 		}
 	}
 
-	return WithUserClient(ctx, client), nil
+	return WithUserClient(ctx, osClient), nil
 }
 
 func getNamespaceName(resourceName string) (string, string, error) {

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -64,7 +64,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 	for _, test := range tests {
 		ctx := context.Background()
 		server, _ := simulateOpenShiftMaster([]response{test.openshiftResponse})
-		client, err := NewUserOpenShiftClient("magic bearer token")
+		_, client, err := NewUserOpenShiftClients("magic bearer token")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/dockerregistry/server/openshiftclient.go
+++ b/pkg/dockerregistry/server/openshiftclient.go
@@ -9,43 +9,39 @@ import (
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
-func NewUserOpenShiftClient(bearerToken string) (*osclient.Client, error) {
+// NewUserOpenShiftClients returns clients for Kubernetes and OpenShift master api servers with given bearer
+// token.
+func NewUserOpenShiftClients(bearerToken string) (*kclient.Client, *osclient.Client, error) {
 	config, err := openShiftClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	config.BearerToken = bearerToken
-	client, err := osclient.New(config)
-	if err != nil {
-		return nil, fmt.Errorf("error creating Origin client: %s", err)
-	}
-	return client, nil
+	return getClientsForConfig(config)
 }
 
-func NewRegistryOpenShiftClient() (*osclient.Client, error) {
+// NewRegistryOpenShiftClients returns clients for Kubernetes and OpenShift master api servers.
+func NewRegistryOpenShiftClients() (*kclient.Client, *osclient.Client, error) {
 	config, err := openShiftClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if !config.Insecure {
 		certData := os.Getenv("OPENSHIFT_CERT_DATA")
 		if len(certData) == 0 {
-			return nil, errors.New("OPENSHIFT_CERT_DATA is required")
+			return nil, nil, errors.New("OPENSHIFT_CERT_DATA is required")
 		}
 		certKeyData := os.Getenv("OPENSHIFT_KEY_DATA")
 		if len(certKeyData) == 0 {
-			return nil, errors.New("OPENSHIFT_KEY_DATA is required")
+			return nil, nil, errors.New("OPENSHIFT_KEY_DATA is required")
 		}
 		config.TLSClientConfig.CertData = []byte(certData)
 		config.TLSClientConfig.KeyData = []byte(certKeyData)
 	}
-	client, err := osclient.New(config)
-	if err != nil {
-		return nil, fmt.Errorf("error creating Origin client: %s", err)
-	}
-	return client, nil
+	return getClientsForConfig(config)
 }
 
+// openShiftClientConfig creates a config for instantiation of clients out of environment variables.
 func openShiftClientConfig() (*kclient.Config, error) {
 	openshiftAddr := os.Getenv("OPENSHIFT_MASTER")
 	if len(openshiftAddr) == 0 {
@@ -69,4 +65,17 @@ func openShiftClientConfig() (*kclient.Config, error) {
 		TLSClientConfig: tlsClientConfig,
 		Insecure:        insecure,
 	}, nil
+}
+
+// getClientsForConfig creates Kubernetes and OpenShift master api clients from given config.
+func getClientsForConfig(config *kclient.Config) (*kclient.Client, *osclient.Client, error) {
+	kClient, err := kclient.New(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating Kube client: %s", err)
+	}
+	osClient, err := osclient.New(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating Origin client: %s", err)
+	}
+	return kClient, osClient, nil
 }

--- a/pkg/dockerregistry/server/quotarestrictedblobstore.go
+++ b/pkg/dockerregistry/server/quotarestrictedblobstore.go
@@ -1,0 +1,159 @@
+// Package server wraps repository and blob store objects of docker/distribution upstream. Most significantly,
+// the wrappers cause manifests to be stored in OpenShift's etcd store instead of registry's storage.
+// Registry's middleware API is utilized to register the object factories.
+//
+// Module with quotaRestrictedBlobStore defines a wrapper for upstream blob store that does an image quota
+// check before committing image layer to a registry. Master server contains admission check that will refuse
+// the manifest if the image exceeds whatever quota set. But the check occurs too late (after the layers are
+// written). This addition allows us to refuse the layers and thus keep the storage clean.
+//
+// There are few things to keep in mind:
+//
+//   1. Origin master calculates image sizes from the contents of the layers. Registry, on the other hand,
+//      deals with layers themselves that contain some overhead required to store file attributes, and the
+//      layers are compressed. Thus we compare apples with pears. The check is primarily useful when the quota
+//      is already almost reached.
+//
+//   2. During a push, multiple layers are uploaded. Uploaded layer does not raise the usage of any resource.
+//      The usage will be raised during admission check once the manifest gets uploaded.
+//
+//   3. Here, we take into account just a single layer, not the image as a whole because the layers are
+//      uploaded before the manifest.
+//
+//      This leads to a situation where several layers can be written until a big enough layer will be
+//      received that exceeds quota limit.
+//
+//   3. Image stream size quota doesn't accumulate. Iow, its usage is NOT permanently stored in a resource
+//      quota object. It's updated just for a very short period of time between an ImageStreamMapping object
+//      is allowed by admission plugin to be created and subsequent quota refresh triggered by resource quota
+//      controller. Therefore its check will probably not ever trigger unless uploaded layer is really big. We
+//      could compute the usage here from corresponding image stream. We don't do so to keep the push
+//      efficient.
+package server
+
+import (
+	"fmt"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"strings"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/quota"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// quotaRestrictedBlobStore wraps upstream blob store with a guard preventing big layers exceeding image quotas
+// from being saved.
+type quotaRestrictedBlobStore struct {
+	distribution.BlobStore
+
+	repo *repository
+}
+
+var _ distribution.BlobStore = &quotaRestrictedBlobStore{}
+
+func (bs *quotaRestrictedBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	context.GetLogger(ctx).Debug("(*quotaRestrictedBlobStore).Put: starting")
+
+	if err := admitBlobWrite(ctx, bs.repo, int64(len(p))); err != nil {
+		context.GetLogger(ctx).Error(err.Error())
+		return distribution.Descriptor{}, err
+	}
+
+	return bs.BlobStore.Put(ctx, mediaType, p)
+}
+
+// Create wraps returned blobWriter with quota guard wrapper.
+func (bs *quotaRestrictedBlobStore) Create(ctx context.Context) (distribution.BlobWriter, error) {
+	context.GetLogger(ctx).Debug("(*quotaRestrictedBlobStore).Create: starting")
+
+	bw, err := bs.BlobStore.Create(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := (*bs.repo)
+	repo.ctx = ctx
+	return &quotaRestrictedBlobWriter{
+		BlobWriter: bw,
+		repo:       &repo,
+	}, nil
+}
+
+// Resume wraps returned blobWriter with quota guard wrapper.
+func (bs *quotaRestrictedBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	context.GetLogger(ctx).Debug("(*quotaRestrictedBlobStore).Resume: starting")
+
+	bw, err := bs.BlobStore.Resume(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := (*bs.repo)
+	repo.ctx = ctx
+	return &quotaRestrictedBlobWriter{
+		BlobWriter: bw,
+		repo:       &repo,
+	}, nil
+}
+
+// quotaRestrictedBlobWriter wraps upstream blob writer with a guard preventig big layers exceeding image
+// quotas from being written.
+type quotaRestrictedBlobWriter struct {
+	distribution.BlobWriter
+
+	repo *repository
+}
+
+func (bw *quotaRestrictedBlobWriter) Commit(ctx context.Context, provisional distribution.Descriptor) (canonical distribution.Descriptor, err error) {
+	context.GetLogger(ctx).Debug("(*quotaRestrictedBlobWriter).Commit: starting")
+
+	if err := admitBlobWrite(ctx, bw.repo, provisional.Size); err != nil {
+		context.GetLogger(ctx).Error(err.Error())
+		return distribution.Descriptor{}, err
+	}
+
+	can, err := bw.BlobWriter.Commit(ctx, provisional)
+	return can, err
+}
+
+// admitBlobWrite checks whether the blob of given size does not exceed image quota, if set. Returns
+// ErrAccessDenied error if the quota is exceeded.
+func admitBlobWrite(ctx context.Context, repo *repository, size int64) error {
+	if size < 1 {
+		return nil
+	}
+	rqs, err := repo.registryKubeClient.ResourceQuotas(repo.namespace).List(kapi.ListOptions{})
+	if err != nil {
+		context.GetLogger(ctx).Errorf("Failed to list resourcequotas: %v", err)
+		return err
+	}
+
+	usage := kapi.ResourceList{
+		imageapi.ResourceProjectImagesSize: *resource.NewQuantity(size, resource.BinarySI),
+		imageapi.ResourceImageStreamSize:   *resource.NewQuantity(size, resource.BinarySI),
+		imageapi.ResourceImageSize:         *resource.NewQuantity(size, resource.BinarySI),
+	}
+	resources := quota.ResourceNames(usage)
+
+	for _, rq := range rqs.Items {
+		newUsage := quota.Add(usage, rq.Status.Used)
+		newUsage = quota.Mask(newUsage, resources)
+		requested := quota.Mask(rq.Spec.Hard, resources)
+
+		allowed, exceeded := quota.LessThanOrEqual(newUsage, requested)
+		if !allowed {
+			details := make([]string, len(exceeded))
+			by := quota.Subtract(newUsage, requested)
+			for i, r := range exceeded {
+				details[i] = fmt.Sprintf("%s limited to %s by %s", r, requested[r], by[r])
+			}
+			context.GetLogger(ctx).Error("Refusing to write blob exceeding quota: " + strings.Join(details, ", "))
+			return distribution.ErrAccessDenied
+		}
+	}
+
+	return nil
+}

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -331,6 +331,12 @@ func ImageWithMetadata(image *Image) error {
 		return nil
 	}
 
+	if len(image.DockerImageLayers) > 0 && image.DockerImageMetadata.Size > 0 {
+		glog.V(5).Infof("Image metadata already filled for %s", image.Name)
+		// don't update image already filled
+		return nil
+	}
+
 	manifestData := image.DockerImageManifest
 
 	manifest := DockerImageManifest{}

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -30,6 +30,16 @@ const (
 
 	// DefaultImageTag is used when an image tag is needed and the configuration does not specify a tag to use.
 	DefaultImageTag = "latest"
+
+	// ResourceProjectImagesSize stands for a sum of sizes of all images stored in an internal registry under
+	// a single namespace. Used as a resource quota key.
+	ResourceProjectImagesSize kapi.ResourceName = "openshift.io/projectimagessize"
+	// ResourceImageStreamSize stands for a sum of sizes of all images stored in an internal registry within
+	// a single image stream (aka. repository). Used as a resource quota key.
+	ResourceImageStreamSize kapi.ResourceName = "openshift.io/imagestreamsize"
+	// ResourceImageSize stands for a size of an image stored in an internal registry. Used as a resource
+	// quota key. If set, bigger images will be refused during a push.
+	ResourceImageSize kapi.ResourceName = "openshift.io/imagesize"
 )
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.

--- a/pkg/quota/admission/resourcequota/admission.go
+++ b/pkg/quota/admission/resourcequota/admission.go
@@ -1,0 +1,70 @@
+// This plugin supplements upstream ResourceQuota admission plugin.
+// It takes care of OpenShift specific resources that may be abusing resource quota limits.
+
+package admission
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/admission"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	"github.com/openshift/origin/pkg/quota"
+)
+
+const pluginName = "OriginResourceQuota"
+
+func init() {
+	admission.RegisterPlugin(pluginName,
+		func(kClient clientset.Interface, config io.Reader) (admission.Interface, error) {
+			return NewOriginResourceQuota(kClient), nil
+		})
+}
+
+// originQuotaAdmission implements an admission controller that can enforce quota constraints on images and image
+// streams
+type originQuotaAdmission struct {
+	*admission.Handler
+	kQuotaAdmission admission.Interface
+	// must be able to read/write ResourceQuota
+	kClient clientset.Interface
+}
+
+var _ = oadmission.WantsOpenshiftClient(&originQuotaAdmission{})
+var _ = oadmission.Validator(&originQuotaAdmission{})
+
+// NewOriginResourceQuota creates a new OriginResourceQuota admission plugin that takes care of admission of
+// origin resources abusing resource quota.
+func NewOriginResourceQuota(kClient clientset.Interface) admission.Interface {
+	// defer an initialization of upstream controller until os client is set
+	return &originQuotaAdmission{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		kClient: kClient,
+	}
+}
+
+func (a *originQuotaAdmission) Admit(as admission.Attributes) error {
+	return a.kQuotaAdmission.Admit(as)
+}
+
+func (a *originQuotaAdmission) SetOpenshiftClient(osClient osclient.Interface) {
+	registry := quota.NewRegistry(osClient)
+	quotaAdmission, err := resourcequota.NewResourceQuota(a.kClient, registry)
+	if err != nil {
+		glog.Fatalf("failed to initialize %s plugin: %v", pluginName, err)
+	}
+	a.kQuotaAdmission = quotaAdmission
+}
+
+func (a *originQuotaAdmission) Validate() error {
+	if a.kQuotaAdmission == nil {
+		return fmt.Errorf("%s requires an openshift client", pluginName)
+	}
+	return nil
+}

--- a/pkg/quota/controller/replenishment_controller.go
+++ b/pkg/quota/controller/replenishment_controller.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// replenishmentControllerFactory implements ReplenishmentControllerFactory
+type replenishmentControllerFactory struct {
+	osClient osclient.Interface
+}
+
+var _ kresourcequota.ReplenishmentControllerFactory = &replenishmentControllerFactory{}
+
+// NewReplenishmentControllerFactory returns a factory that knows how to build controllers
+// to replenish resources when updated or deleted
+func NewReplenishmentControllerFactory(osClient osclient.Interface) kresourcequota.ReplenishmentControllerFactory {
+	return &replenishmentControllerFactory{
+		osClient: osClient,
+	}
+}
+
+func (r *replenishmentControllerFactory) NewController(options *kresourcequota.ReplenishmentControllerOptions) (*framework.Controller, error) {
+	var result *framework.Controller
+	switch options.GroupKind {
+	case imageapi.Kind("ImageStream"):
+		_, result = framework.NewInformer(
+			&cache.ListWatch{
+				ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+					return r.osClient.ImageStreams(api.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+					return r.osClient.ImageStreams(api.NamespaceAll).Watch(options)
+				},
+			},
+			&imageapi.ImageStream{},
+			options.ResyncPeriod(),
+			framework.ResourceEventHandlerFuncs{
+				UpdateFunc: ImageStreamReplenishmentUpdateFunc(options),
+				DeleteFunc: kresourcequota.ObjectReplenishmentDeleteFunc(options),
+			},
+		)
+	default:
+		return nil, fmt.Errorf("no replenishment controller available for %s", options.GroupKind)
+	}
+	return result, nil
+}
+
+// ImageStreamReplenishmentUpdateFunc will replenish if the old image stream was quota tracked but the new is not
+func ImageStreamReplenishmentUpdateFunc(options *kresourcequota.ReplenishmentControllerOptions) func(oldObj, newObj interface{}) {
+	return func(oldObj, newObj interface{}) {
+		oldIS := oldObj.(*imageapi.ImageStream)
+		newIS := newObj.(*imageapi.ImageStream)
+		if !reflect.DeepEqual(oldIS.Status.Tags, newIS.Status.Tags) {
+			options.ReplenishmentFunc(options.GroupKind, newIS.Namespace, newIS)
+		}
+	}
+}

--- a/pkg/quota/controller/replenishment_controller_test.go
+++ b/pkg/quota/controller/replenishment_controller_test.go
@@ -1,0 +1,127 @@
+package controller
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// testReplenishment lets us test replenishment functions are invoked
+type testReplenishment struct {
+	groupKind unversioned.GroupKind
+	namespace string
+}
+
+// mock function that holds onto the last kind that was replenished
+func (t *testReplenishment) Replenish(groupKind unversioned.GroupKind, namespace string, object runtime.Object) {
+	t.groupKind = groupKind
+	t.namespace = namespace
+}
+
+func TestImageStreamReplenishmentUpdateFunc(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		oldISStatus    imageapi.ImageStreamStatus
+		newISStatus    imageapi.ImageStreamStatus
+		expectedUpdate bool
+	}{
+		{
+			name:           "empty",
+			expectedUpdate: false,
+		},
+		{
+			name: "no change",
+			oldISStatus: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"foo": {
+						Items: []imageapi.TagEvent{
+							{DockerImageReference: "foo-ref"},
+						},
+					},
+				},
+			},
+			newISStatus: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"foo": {
+						Items: []imageapi.TagEvent{
+							{DockerImageReference: "foo-ref"},
+						},
+					},
+				},
+			},
+			expectedUpdate: false,
+		},
+		{
+			name: "first image stream tag",
+			newISStatus: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"latest": {
+						Items: []imageapi.TagEvent{
+							{DockerImageReference: "latest-ref"},
+							{DockerImageReference: "older"},
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+		},
+		{
+			name: "image stream tag event deleted",
+			oldISStatus: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"latest": {
+						Items: []imageapi.TagEvent{
+							{DockerImageReference: "latest-ref"},
+							{DockerImageReference: "older"},
+						},
+					},
+				},
+			},
+			newISStatus: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"latest": {
+						Items: []imageapi.TagEvent{
+							{DockerImageReference: "latest-ref"},
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+		},
+	} {
+		mockReplenish := &testReplenishment{}
+		options := kresourcequota.ReplenishmentControllerOptions{
+			GroupKind:         kapi.Kind("ImageStream"),
+			ReplenishmentFunc: mockReplenish.Replenish,
+			ResyncPeriod:      controller.NoResyncPeriodFunc,
+		}
+		oldIS := &imageapi.ImageStream{
+			ObjectMeta: kapi.ObjectMeta{Namespace: "test", Name: "is"},
+			Status:     tc.oldISStatus,
+		}
+		newIS := &imageapi.ImageStream{
+			ObjectMeta: kapi.ObjectMeta{Namespace: "test", Name: "is"},
+			Status:     tc.newISStatus,
+		}
+		updateFunc := ImageStreamReplenishmentUpdateFunc(&options)
+		updateFunc(oldIS, newIS)
+		if tc.expectedUpdate {
+			if mockReplenish.groupKind != kapi.Kind("ImageStream") {
+				t.Errorf("[%s]: Unexpected group kind %v", tc.name, mockReplenish.groupKind)
+			}
+			if mockReplenish.namespace != oldIS.Namespace {
+				t.Errorf("[%s]: Unexpected namespace %v", tc.name, mockReplenish.namespace)
+			}
+		} else {
+			if mockReplenish.groupKind.Group != "" || mockReplenish.groupKind.Kind != "" || mockReplenish.namespace != "" {
+				t.Errorf("[%s]: Update function unexpectedly called on %s in namespace %s", tc.name, mockReplenish.groupKind, mockReplenish.namespace)
+			}
+		}
+	}
+}

--- a/pkg/quota/image/imagestream_evaluator.go
+++ b/pkg/quota/image/imagestream_evaluator.go
@@ -1,0 +1,94 @@
+package image
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	quotautil "github.com/openshift/origin/pkg/quota/util"
+)
+
+// NewImageStreamEvaluator computes resource usage of ImageStreams. Instantiating this is necessary for image
+// resource quota admission controller to properly work on ImageStreamMapping objects. Project image size
+// usage must be evaluated in quota's usage status before a CREATE operation on ImageStreamMapping can be
+// allowed.
+func NewImageStreamEvaluator(osClient osclient.Interface) kquota.Evaluator {
+	computeResources := []kapi.ResourceName{
+		imageapi.ResourceProjectImagesSize,
+		//  Used values need to be set on resource quota before admission controller can handle requests.
+		//  Therefor we return following resources as well. Even though we evaluate them always to 0.
+		imageapi.ResourceImageStreamSize,
+		imageapi.ResourceImageSize,
+	}
+
+	matchesScopeFunc := func(kapi.ResourceQuotaScope, runtime.Object) bool { return true }
+	getFuncByNamespace := func(namespace, name string) (runtime.Object, error) {
+		return osClient.ImageStreams(namespace).Get(name)
+	}
+	listFuncByNamespace := func(namespace string, options kapi.ListOptions) (runtime.Object, error) {
+		return osClient.ImageStreams(namespace).List(options)
+	}
+
+	return quotautil.NewSharedContextEvaluator(
+		"ImageStream evaluator",
+		kapi.Kind("ImageStream"),
+		map[admission.Operation][]kapi.ResourceName{
+			admission.Create: computeResources,
+			admission.Update: computeResources,
+		},
+		matchesScopeFunc,
+		getFuncByNamespace,
+		listFuncByNamespace,
+		imageStreamConstraintsFunc,
+		makeImageStreamUsageComputerFactory(osClient))
+}
+
+// imageStreamConstraintsFunc checks that given object is an image stream
+func imageStreamConstraintsFunc(required []kapi.ResourceName, object runtime.Object) error {
+	if _, ok := object.(*imageapi.ImageStream); !ok {
+		return fmt.Errorf("Unexpected input object %v", object)
+	}
+	return nil
+}
+
+// makeImageStreamUsageComputerFactory returns an object used during computation of image quota across all
+// repositories in a namespace.
+func makeImageStreamUsageComputerFactory(osClient osclient.Interface) quotautil.UsageComputerFactory {
+	return func() quotautil.UsageComputer {
+		return &imageStreamUsageComputer{
+			osClient:   osClient,
+			imageCache: make(map[string]*imageapi.Image),
+		}
+	}
+}
+
+// imageStreamUsageComputer is a context object for use in SharedContextEvaluator.
+type imageStreamUsageComputer struct {
+	osClient osclient.Interface
+	// imageCache maps image name to a an image object. It holds only images
+	// stored in the registry to avoid multiple fetches of the same object.
+	imageCache map[string]*imageapi.Image
+}
+
+// Usage returns a usage for an image stream. The only resource computed is
+// ResourceProjectImagesSize which is the only resource scoped to a namespace.
+func (c *imageStreamUsageComputer) Usage(object runtime.Object) kapi.ResourceList {
+	is, ok := object.(*imageapi.ImageStream)
+	if !ok {
+		return kapi.ResourceList{}
+	}
+
+	res := map[kapi.ResourceName]resource.Quantity{
+		imageapi.ResourceProjectImagesSize: *GetImageStreamSize(c.osClient, is, c.imageCache),
+		imageapi.ResourceImageStreamSize:   *resource.NewQuantity(0, resource.BinarySI),
+		imageapi.ResourceImageSize:         *resource.NewQuantity(0, resource.BinarySI),
+	}
+
+	return res
+}

--- a/pkg/quota/image/imagestream_evaluator_test.go
+++ b/pkg/quota/image/imagestream_evaluator_test.go
@@ -1,0 +1,649 @@
+package image
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+var (
+	expectedResources = []kapi.ResourceName{
+		imageapi.ResourceProjectImagesSize,
+		imageapi.ResourceImageStreamSize,
+		imageapi.ResourceImageSize,
+	}
+)
+
+func TestImageStreamEvaluatorUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		is           imageapi.ImageStream
+		expectedSize int64
+	}{
+		{
+			"empty image stream",
+			imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "empty",
+				},
+				Status: imageapi.ImageStreamStatus{},
+			},
+			0,
+		},
+
+		{
+			"image stream with one tag",
+			imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is",
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"latest": {
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is@%s", baseImageWith1LayerDigest),
+									Image:                baseImageWith1LayerDigest,
+								},
+							},
+						},
+					},
+				},
+			},
+			128,
+		},
+
+		{
+			"image stream with two references with shared layer",
+			imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "sharedlayer",
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"latest": {
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", baseImageWith1LayerDigest),
+									Image:                baseImageWith1LayerDigest,
+								},
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", baseImageWith2LayersDigest),
+									Image:                baseImageWith2LayersDigest,
+								},
+							},
+						},
+					},
+				},
+			},
+			240, // 128 (twice) + 112 (once)
+		},
+
+		{
+			"image stream with two tags with shared layer",
+			imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "sharedlayer",
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"foo": {
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", baseImageWith2LayersDigest),
+									Image:                baseImageWith2LayersDigest,
+								},
+							},
+						},
+						"bar": {
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", childImageWith3LayersDigest),
+									Image:                childImageWith3LayersDigest,
+								},
+							},
+						},
+					},
+				},
+			},
+			310, // 128 (twice) + 112 (twice) + 70 (once)
+		},
+
+		{
+			"image stream with two items without a shared layer",
+			imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "noshared",
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"latest": {
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/noshared@%s", childImageWith2LayersDigest),
+									Image:                childImageWith2LayersDigest,
+								},
+								{
+									DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/noshared@%s", miscImageDigest),
+									Image:                miscImageDigest,
+								},
+							},
+						},
+					},
+				},
+			},
+			808, // 128 (once) + 126 (once) + 554 (once)
+		},
+	} {
+
+		fakeClient := &testclient.Fake{}
+		fakeClient.AddReactor("get", "imagestreams", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			switch a := action.(type) {
+			case ktestclient.GetAction:
+				if a.GetName() != tc.is.Name {
+					err := fmt.Errorf("image stream %s not found", a.GetName())
+					t.Errorf(err.Error())
+					return true, nil, err
+				}
+
+				t.Logf("imagestream get handler: returning image stream %s/%s", tc.is.Namespace, tc.is.Name)
+				return true, &tc.is, nil
+			}
+			return false, nil, nil
+		})
+		fakeClient.AddReactor("get", "imagestreamimages", getFakeImageStreamImageGetHandler(t, tc.is.Namespace, tc.is))
+
+		evaluator := NewImageStreamEvaluator(fakeClient)
+
+		is, err := evaluator.Get(tc.is.Namespace, tc.is.Name)
+		if err != nil {
+			t.Errorf("[%s]: could not get image stream %q: %v", tc.name, tc.is.Name, err)
+			continue
+		}
+		usage := evaluator.Usage(is)
+
+		if len(usage) != len(expectedResources) {
+			t.Errorf("[%s]: got unexpected number of computed resources: %d != %d", tc.name, len(usage), len(expectedResources))
+		}
+
+		masked := kquota.Mask(usage, expectedResources)
+
+		if len(masked) != len(expectedResources) {
+			for k := range usage {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: got unexpected resource %q from Usage() method", tc.name, k)
+				}
+			}
+
+			for _, k := range expectedResources {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: expected resource %q not computed", tc.name, k)
+				}
+			}
+		}
+
+		for rname, expectedValue := range map[kapi.ResourceName]resource.Quantity{
+			imageapi.ResourceImageSize:         *resource.NewQuantity(0, resource.BinarySI),
+			imageapi.ResourceImageStreamSize:   *resource.NewQuantity(0, resource.BinarySI),
+			imageapi.ResourceProjectImagesSize: *resource.NewQuantity(tc.expectedSize, resource.BinarySI),
+		} {
+			if v, exists := masked[rname]; exists {
+				if v.Cmp(expectedValue) != 0 {
+					t.Errorf("[%s]: got unexpected usage for %q: %s != %s", tc.name, rname, v.String(), expectedValue.String())
+				}
+			}
+		}
+	}
+}
+
+func TestImageStreamEvaluatorUsageStats(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		iss          []imageapi.ImageStream
+		namespace    string
+		expectedSize int64
+	}{
+		{
+			"no image stream",
+			[]imageapi.ImageStream{},
+			"test",
+			0,
+		},
+
+		{
+			"one image stream with one tag",
+			[]imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "onetag",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"test",
+			128,
+		},
+
+		{
+			"image stream with two references with shared layer",
+			[]imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "sharedlayer",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/sharedlayer@%s", baseImageWith2LayersDigest),
+										Image:                baseImageWith2LayersDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"test",
+			240, // 128 (twice) + 112 (once)
+		},
+
+		{
+			"two image streams with shared layer",
+			[]imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is1",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is1@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is2",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", baseImageWith2LayersDigest),
+										Image:                baseImageWith2LayersDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"test",
+			368, // 128*2 + 112 (once)
+		},
+
+		{
+			"two image streams in different namespaces",
+			[]imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is1",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is1@%s", childImageWith2LayersDigest),
+										Image:                childImageWith2LayersDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "other",
+						Name:      "is2",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", miscImageDigest),
+										Image:                miscImageDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"test",
+			254, // 128 + 126
+		},
+	} {
+		fakeClient := &testclient.Fake{}
+		fakeClient.AddReactor("list", "imagestreams", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			switch a := action.(type) {
+			case ktestclient.ListAction:
+				res := &imageapi.ImageStreamList{
+					Items: []imageapi.ImageStream{},
+				}
+				for _, is := range tc.iss {
+					if is.Namespace == a.GetNamespace() {
+						res.Items = append(res.Items, is)
+					}
+				}
+
+				return true, res, nil
+			}
+			return false, nil, nil
+		})
+		fakeClient.AddReactor("get", "imagestreamimages", getFakeImageStreamImageGetHandler(t, tc.namespace, tc.iss...))
+
+		evaluator := NewImageStreamEvaluator(fakeClient)
+
+		stats, err := evaluator.UsageStats(kquota.UsageStatsOptions{Namespace: tc.namespace})
+		if err != nil {
+			t.Errorf("[%s]: could not get usage stats for namespace %q: %v", tc.name, tc.namespace, err)
+			continue
+		}
+
+		if len(stats.Used) != len(expectedResources) {
+			t.Errorf("[%s]: got unexpected number of computed resources: %d != %d", tc.name, len(stats.Used), len(expectedResources))
+		}
+
+		masked := kquota.Mask(stats.Used, expectedResources)
+
+		if len(masked) != len(expectedResources) {
+			for k := range stats.Used {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: got unexpected resource %q from Usage() method", tc.name, k)
+				}
+			}
+
+			for _, k := range expectedResources {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: expected resource %q not computed", tc.name, k)
+				}
+			}
+		}
+
+		for rname, expectedValue := range map[kapi.ResourceName]resource.Quantity{
+			imageapi.ResourceImageSize:         *resource.NewQuantity(0, resource.BinarySI),
+			imageapi.ResourceImageStreamSize:   *resource.NewQuantity(0, resource.BinarySI),
+			imageapi.ResourceProjectImagesSize: *resource.NewQuantity(tc.expectedSize, resource.BinarySI),
+		} {
+			if v, exists := masked[rname]; exists {
+				if v.Cmp(expectedValue) != 0 {
+					t.Errorf("[%s]: got unexpected usage for %q: %s != %s", tc.name, rname, v.String(), expectedValue.String())
+				}
+			}
+		}
+	}
+}
+
+func getFakeImageStreamImageGetHandler(t *testing.T, namespace string, iss ...imageapi.ImageStream) ktestclient.ReactionFunc {
+	return func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		switch a := action.(type) {
+		case ktestclient.GetAction:
+			if a.GetNamespace() != namespace {
+				err := fmt.Errorf("namespace %q not found", a.GetNamespace())
+				t.Error(err.Error())
+				return true, nil, err
+			}
+			for _, is := range iss {
+				if !strings.HasPrefix(a.GetName(), is.Name+"@") {
+					continue
+				}
+				name := strings.TrimPrefix(a.GetName(), is.Name+"@")
+
+				res := &imageapi.ImageStreamImage{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: namespace,
+						Name:      a.GetName(),
+					},
+					Image: imageapi.Image{
+						ObjectMeta: kapi.ObjectMeta{
+							Name:        name,
+							Annotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+						},
+						DockerImageReference: fmt.Sprintf("registry.example.org/%s/%s", namespace, a.GetName()),
+					},
+				}
+
+				switch name {
+				case baseImageWith1LayerDigest:
+					res.Image.DockerImageManifest = baseImageWith1Layer
+				case baseImageWith2LayersDigest:
+					res.Image.DockerImageManifest = baseImageWith2Layers
+				case childImageWith2LayersDigest:
+					res.Image.DockerImageManifest = childImageWith2Layers
+				case childImageWith3LayersDigest:
+					res.Image.DockerImageManifest = childImageWith3Layers
+				case miscImageDigest:
+					res.Image.DockerImageManifest = miscImage
+				default:
+					err := fmt.Errorf("image %q not found", name)
+					t.Error(err.Error())
+					return true, nil, err
+				}
+
+				t.Logf("imagestreamimage get handler: returning %q", res.Name)
+				return true, res, nil
+			}
+
+			err := fmt.Errorf("imagestreamimage %q not found", a.GetName())
+			t.Error(err.Error())
+			return true, nil, err
+		}
+		return false, nil, nil
+	}
+}
+
+// 1 data layer of 128 B
+const baseImageWith1LayerDigest = `sha256:c5207ce0f38da269ad2e58f143b5ea4b314c75ce1121384369f0db9015e10e82`
+const baseImageWith1Layer = `{
+   "schemaVersion": 1,
+   "name": "miminar/baseImageWith1Layer",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+		  "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:d4994ff5bda31913c54af389d68d27418b294cde415cb41282b513900bd11f1e\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"container\":\"99664df33257d325a5d3c082e72a5b6bf86adf1d4e75af6c5a5c4cdaab1fac58\",\"container_config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"],\"Image\":\"sha256:d4994ff5bda31913c54af389d68d27418b294cde415cb41282b513900bd11f1e\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2016-02-15T07:30:37.655693399Z\",\"docker_version\":\"1.10.0\",\"id\":\"3303329125f4954da646b116f6e4a7e40d03656d4802340d46aca8a473d9c3e4\",\"os\":\"linux\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// 2 data layers, the first is shared with baseImageWith1Layer, total size of 240 B
+const baseImageWith2LayersDigest = "sha256:77371f61c054608a4bb1a96b99f9be69f0868340f5c924ecd8813172f7cf853d"
+const baseImageWith2Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/baseImageWith2Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:e7900a2e6943680b384950859a0616089757cae4d8c6e98db9cfec6c41fe2834"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+          "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:356b1cbd1af67cfa316c7066895954a69865b972abe680942c123e8bfbbd7458\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"container\":\"686b99d75c4a744420c9a6bf9d3ba2548e72462e4719c8202878315f48083b2c\",\"container_config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:23d2e6ff1c67ff4caee900c71d58df6e37bfb9defe46085018c4ba29c3d2de5a in /data2\"],\"Image\":\"sha256:356b1cbd1af67cfa316c7066895954a69865b972abe680942c123e8bfbbd7458\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2016-02-15T07:31:50.390272025Z\",\"docker_version\":\"1.10.0\",\"id\":\"61c8a7f2be3a9b6fcd46f24da46eedfd37200b0d067d487595942b5b8bacbce7\",\"os\":\"linux\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"size\":112}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// based on baseImageWith1Layer, it adds a new data layer of 126 B
+const childImageWith2LayersDigest = "sha256:a9f073fbf2c9835711acd09081d87f5b7129ac6269e0df834240000f48abecd4"
+const childImageWith2Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/childImageWith2Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:766b6e9134dc2819fae9c5e67d39e14272948bc8967df9a119418cca84cab089"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+          "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:27bc5bf237c48c2b41b0636a3876960a9adb6c2ac9ff95ac879d56b1046ba5a1\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"container\":\"c2d2505e43f4fd479aa21d356270d0791633e838284d7010cba1f61992907c69\",\"container_config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:859e4175fd5743f276905245e351272b425232cfd3b30a3fc6bff351da308996 in /data3\"],\"Image\":\"sha256:27bc5bf237c48c2b41b0636a3876960a9adb6c2ac9ff95ac879d56b1046ba5a1\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"created\":\"2016-02-15T07:33:17.59074814Z\",\"docker_version\":\"1.10.0\",\"id\":\"e6a8e2793d6cad7d503aa5a3b55fd2c19b3b190d480a175b21d5f7b50c86d27b\",\"os\":\"linux\",\"parent\":\"84dc393745ff2631760c4bdbf1168af188fcd4606c1400c6900487fdc75a9ed5\",\"size\":126}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"84dc393745ff2631760c4bdbf1168af188fcd4606c1400c6900487fdc75a9ed5\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"created\":\"2016-02-15T07:33:17.454934648Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// based on baseImageWith2Layers, it adds a new data layer of 70 B
+const childImageWith3LayersDigest = "sha256:2282a6d553353756fa43ba8672807d3fe81f8fdef54b0f6a360d64aaef2f243a"
+const childImageWith3Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/childImageWith3Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:77ef66f4abb43c5e17bcacdfe744f6959365f6244b66a6565470083fbdd15178"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:e7900a2e6943680b384950859a0616089757cae4d8c6e98db9cfec6c41fe2834"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:8b0241d44c66c1bcf48c66d0465ee6bf6ac2117e9936a9ec2337122e08d109ef\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"container\":\"61c9522f27b7052081b61b72d70dd71ce7050566812f050158e03954b493e446\",\"container_config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:7781db9ed3a36b0607009b073a99802a9ad834bbb5e3bcbcf83a7d27146a1a5b in /data4\"],\"Image\":\"sha256:8b0241d44c66c1bcf48c66d0465ee6bf6ac2117e9936a9ec2337122e08d109ef\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"created\":\"2016-02-15T07:36:13.703778299Z\",\"docker_version\":\"1.10.0\",\"id\":\"8e7b1ec73ed1d21747991c2101d1db51e97c4f62931bbaa575aeba11286d6748\",\"os\":\"linux\",\"parent\":\"fbe31426cd0e8c5545ddc5c8318499682d52ff96118e36e49616ac3aee32c47c\",\"size\":70}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"fbe31426cd0e8c5545ddc5c8318499682d52ff96118e36e49616ac3aee32c47c\",\"parent\":\"9b1154060650718a3850e625464addb217c1064f18dd693cf635dfcabdc9de50\",\"created\":\"2016-02-15T07:36:13.585345649Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"9b1154060650718a3850e625464addb217c1064f18dd693cf635dfcabdc9de50\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"created\":\"2016-02-15T07:31:50.390272025Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:23d2e6ff1c67ff4caee900c71d58df6e37bfb9defe46085018c4ba29c3d2de5a in /data2\"]},\"size\":112}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// another base image with unique data layer of 554 B
+const miscImageDigest = "sha256:2643199e5ed5047eeed22da854748ed88b3a63ba0497601ba75852f7b92d4640"
+const miscImage = `{
+   "schemaVersion": 1,
+   "name": "miminar/misc",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:eeee0535bf3cec7a24bff2c6e97481afa3d37e2cdeff277c57cb5cbdb2fa9e92"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"964092b7f3e54185d3f425880be0b022bfc9a706701390e0ceab527c84dea3e3\",\"parent\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"created\":\"2016-01-15T18:06:41.282540103Z\",\"container\":\"4e937d31f242d087cce0ec5b9fdbceaf1a13b40704e9147962cc80947e4ab86b\",\"container_config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.3\",\"config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"created\":\"2016-01-15T18:06:40.707908287Z\",\"container\":\"aded96b43f48d94eb80642c210b89f119ab2a233c1c7c7055104fb052937f12c\",\"container_config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:a62b361be92f978752150570261ddc6fc21b025e3a28418820a1f39b7db7498c in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.3\",\"config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":554}"
+      }
+   ]
+}`

--- a/pkg/quota/image/imagestreammapping_evaluator.go
+++ b/pkg/quota/image/imagestreammapping_evaluator.go
@@ -1,0 +1,146 @@
+package image
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	quotautil "github.com/openshift/origin/pkg/quota/util"
+)
+
+// NewImageStreamMappingEvaluator computes resource usage for ImageStreamMapping objects. This particular kind
+// is a virtual resource. It depends on ImageStream usage evaluator to compute project image size accross all
+// image streams in the namespace.
+func NewImageStreamMappingEvaluator(osClient osclient.Interface) kquota.Evaluator {
+	computeResources := []kapi.ResourceName{
+		imageapi.ResourceProjectImagesSize,
+		imageapi.ResourceImageStreamSize,
+		imageapi.ResourceImageSize,
+	}
+
+	matchesScopeFunc := func(kapi.ResourceQuotaScope, runtime.Object) bool { return true }
+	listFuncByNamespace := func(namespace string, options kapi.ListOptions) (runtime.Object, error) {
+		// we don't want to be called on image stream changes; ImageStreamEvaluator will do the job
+		return &kapi.List{Items: []runtime.Object{}}, nil
+	}
+
+	return quotautil.NewSharedContextEvaluator(
+		"ImageStreamMapping evaluator",
+		kapi.Kind("ImageStreamMapping"),
+		map[admission.Operation][]kapi.ResourceName{admission.Create: computeResources},
+		matchesScopeFunc,
+		nil,
+		listFuncByNamespace,
+		imageStreamMappingConstraintsFunc,
+		makeImageStreamMappingUsageComputerFactory(osClient),
+	)
+}
+
+// imageStreamMappingConstraintsFunc checks that given object is an image stream
+func imageStreamMappingConstraintsFunc(required []kapi.ResourceName, object runtime.Object) error {
+	if _, ok := object.(*imageapi.ImageStreamMapping); !ok {
+		return fmt.Errorf("Unexpected input object %v", object)
+	}
+	return nil
+}
+
+func makeImageStreamMappingUsageComputerFactory(osClient osclient.Interface) quotautil.UsageComputerFactory {
+	return func() quotautil.UsageComputer {
+		return &imageStreamMappingUsageComputer{
+			osClient:         osClient,
+			imageStreamCache: make(map[string]*imageapi.ImageStream),
+			imageCache:       make(map[string]*imageapi.Image),
+		}
+	}
+}
+
+// imageStreamMappingUsageComputer is used to compute usage for ImageStreamMapping.
+type imageStreamMappingUsageComputer struct {
+	osClient osclient.Interface
+	// imageStreamCache maps image stream names to image stream objects. Used in case of evaluation of all
+	// ImageStreamMapping object in a namespace. Which will hardly ever happen unless list function returns
+	// non-empty lists.
+	imageStreamCache map[string]*imageapi.ImageStream
+	// imageCache maps image names to image objects. Used to reduce repeated resource fetches.
+	imageCache map[string]*imageapi.Image
+}
+
+// Usage computes usage of image stream mapping objects. There are two scenarios when this can be called:
+//
+//  1. admission check for CREATE on ImageStreamMapping object
+//  2. evaluation of image stream mapping objects for a namespace triggered by resource quota controller
+//
+// In the former case, we are expected to return size increments for all the resources. For image size and
+// image stream size it means to return their whole size because their quota usage is always 0.
+//
+// In the latter case, we return only project images size which is scoped to namespace and thus its usage
+// should be accumulated. This scenario actually shouldn't happen because it is covered by image stream
+// evaluator.
+func (c *imageStreamMappingUsageComputer) Usage(object runtime.Object) kapi.ResourceList {
+	ism, ok := object.(*imageapi.ImageStreamMapping)
+	if !ok {
+		return kapi.ResourceList{}
+	}
+
+	var isSize *resource.Quantity
+	var err error
+	is, isLoaded := c.imageStreamCache[ism.Name]
+
+	res := map[kapi.ResourceName]resource.Quantity{
+		imageapi.ResourceProjectImagesSize: *resource.NewQuantity(0, resource.BinarySI),
+		imageapi.ResourceImageStreamSize:   *resource.NewQuantity(0, resource.BinarySI),
+		imageapi.ResourceImageSize:         *resource.NewQuantity(0, resource.BinarySI),
+	}
+
+	if !isLoaded {
+		is, err = c.osClient.ImageStreams(ism.Namespace).Get(ism.Name)
+		if err != nil {
+			glog.Errorf("Failed to get image stream %s/%s: %v", ism.Namespace, ism.Name, err)
+			return map[kapi.ResourceName]resource.Quantity{}
+		}
+		isSize = GetImageStreamSize(c.osClient, is, c.imageCache)
+	}
+
+	img, imgLoaded := c.imageCache[ism.Image.Name]
+
+	if isLoaded && imgLoaded {
+		// quota evaluation; image stream has been already processed
+		return res
+	}
+
+	if !imgLoaded {
+		// handling CREATE admission check - image is about to be created
+		img = &ism.Image
+
+		if value, exists := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !exists || value != "true" {
+			return res
+		}
+
+		_, sizeIncrement, err2 := GetImageStreamSizeIncrement(c.osClient, is, img, c.imageCache)
+		if err2 != nil {
+			glog.Errorf("Failed to get repository size increment of %s/%s with an image %q: %v", ism.Namespace, ism.Name, img.Name, err2)
+			return map[kapi.ResourceName]resource.Quantity{}
+		}
+
+		// Values for repository size and image size resources don't accumulate, that's why we return whole usage.
+		isSize.Add(*sizeIncrement)
+		res[imageapi.ResourceImageStreamSize] = *isSize
+		res[imageapi.ResourceImageSize] = *resource.NewQuantity(img.DockerImageMetadata.Size, resource.BinarySI)
+		// Caller expects us to return usage increments for the CREATE operation.
+		res[imageapi.ResourceProjectImagesSize] = *sizeIncrement
+
+	} else {
+		// handling quota evaluation
+		res[imageapi.ResourceProjectImagesSize] = *isSize
+	}
+
+	return res
+}

--- a/pkg/quota/image/imagestreammapping_evaluator_test.go
+++ b/pkg/quota/image/imagestreammapping_evaluator_test.go
@@ -1,0 +1,250 @@
+package image
+
+import (
+	"fmt"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func TestImageStreamMappingEvaluatorUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		iss              []imageapi.ImageStream
+		imageName        string
+		imageManifest    string
+		imageAnnotations map[string]string
+		destISNamespace  string
+		destISName       string
+		expectedUsage    kapi.ResourceList
+	}{
+		{
+			name: "empty image stream",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is",
+					},
+					Status: imageapi.ImageStreamStatus{},
+				},
+			},
+			imageName:        miscImageDigest,
+			imageManifest:    miscImage,
+			imageAnnotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+			destISNamespace:  "test",
+			destISName:       "is",
+			expectedUsage: kapi.ResourceList{
+				// increase usage for the whole misc image size
+				imageapi.ResourceProjectImagesSize: resource.MustParse("554"),
+				imageapi.ResourceImageStreamSize:   resource.MustParse("554"),
+				imageapi.ResourceImageSize:         resource.MustParse("554"),
+			},
+		},
+
+		{
+			name:             "no image stream",
+			imageName:        miscImageDigest,
+			imageManifest:    miscImage,
+			imageAnnotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+			destISNamespace:  "test",
+			destISName:       "is",
+		},
+
+		{
+			name: "missing image annotation",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is",
+					},
+					Status: imageapi.ImageStreamStatus{},
+				},
+			},
+			imageName:       miscImageDigest,
+			imageManifest:   miscImage,
+			destISNamespace: "test",
+			destISName:      "is",
+			expectedUsage: kapi.ResourceList{
+				imageapi.ResourceProjectImagesSize: resource.MustParse("0"),
+				imageapi.ResourceImageStreamSize:   resource.MustParse("0"),
+				imageapi.ResourceImageSize:         resource.MustParse("0"),
+			},
+		},
+
+		{
+			name: "update existing tag",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "havingtag",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/havingtag@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			imageName:        childImageWith2LayersDigest,
+			imageManifest:    childImageWith2Layers,
+			imageAnnotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+			destISNamespace:  "test",
+			destISName:       "havingtag",
+			expectedUsage: kapi.ResourceList{
+				// count only the second data layer (first is already present in the image stream)
+				imageapi.ResourceProjectImagesSize: resource.MustParse("126"),
+				// compute whole registry size - original image is contained in the new one
+				imageapi.ResourceImageStreamSize: resource.MustParse("254"),
+				// compute whole image size
+				imageapi.ResourceImageSize: resource.MustParse("254"),
+			},
+		},
+
+		{
+			name: "add a new tag with with 2 image streams ",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "destis",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/destis@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", miscImageDigest),
+										Image:                miscImageDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "other",
+						Name:      "is2",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", baseImageWith2LayersDigest),
+										Image:                baseImageWith2LayersDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			imageName:        childImageWith3LayersDigest,
+			imageManifest:    childImageWith3Layers,
+			imageAnnotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+			destISNamespace:  "test",
+			destISName:       "destis",
+			expectedUsage: kapi.ResourceList{
+				// count only the last 2 data layers of the image (first layer is already in the is)
+				imageapi.ResourceProjectImagesSize: resource.MustParse("182"),
+				// compute whole registry size
+				imageapi.ResourceImageStreamSize: resource.MustParse("864"),
+				// compute whole image size
+				imageapi.ResourceImageSize: resource.MustParse("310"),
+			},
+		},
+	} {
+
+		fakeClient := &testclient.Fake{}
+		fakeClient.AddReactor("get", "imagestreams", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			switch a := action.(type) {
+			case ktestclient.GetAction:
+				for _, is := range tc.iss {
+					if a.GetNamespace() != is.Namespace {
+						continue
+					}
+					if a.GetName() != is.Name {
+						continue
+					}
+
+					t.Logf("imagestream get handler: returning image stream %s/%s", is.Namespace, is.Name)
+					return true, &is, nil
+				}
+				return true, nil, fmt.Errorf("image stream %s/%s not found", a.GetNamespace(), a.GetName())
+			}
+
+			return false, nil, nil
+		})
+		fakeClient.AddReactor("get", "imagestreamimages", getFakeImageStreamImageGetHandler(t, tc.destISNamespace, tc.iss...))
+
+		evaluator := NewImageStreamMappingEvaluator(fakeClient)
+
+		ism := &imageapi.ImageStreamMapping{
+			ObjectMeta: kapi.ObjectMeta{
+				Namespace: tc.destISNamespace,
+				Name:      tc.destISName,
+			},
+			Image: imageapi.Image{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:        tc.imageName,
+					Annotations: tc.imageAnnotations,
+				},
+				DockerImageReference: fmt.Sprintf("registry.example.org/%s/%s@%s", tc.destISNamespace, tc.destISName, tc.imageName),
+				DockerImageManifest:  tc.imageManifest,
+			},
+		}
+
+		usage := evaluator.Usage(ism)
+
+		if len(usage) != len(tc.expectedUsage) {
+			t.Errorf("[%s]: got unexpected number of computed resources: %d != %d", tc.name, len(usage), len(expectedResources))
+		}
+
+		expectedResourceNames := kquota.ResourceNames(tc.expectedUsage)
+		masked := kquota.Mask(usage, expectedResourceNames)
+
+		if len(masked) != len(tc.expectedUsage) {
+			for k := range usage {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: got unexpected resource %q from Usage() method", tc.name, k)
+				}
+			}
+
+			for k := range tc.expectedUsage {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: expected resource %q not computed", tc.name, k)
+				}
+			}
+		}
+
+		for rname, expectedValue := range tc.expectedUsage {
+			if v, exists := masked[rname]; exists {
+				if v.Cmp(expectedValue) != 0 {
+					t.Errorf("[%s]: got unexpected usage for %q: %s != %s", tc.name, rname, v.String(), expectedValue.String())
+				}
+			}
+		}
+	}
+}

--- a/pkg/quota/image/registry.go
+++ b/pkg/quota/image/registry.go
@@ -1,0 +1,22 @@
+package image
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+// NewImageRegistry returns a registry for quota evaluation of OpenShift resources related to images and image
+// streams.
+func NewImageRegistry(osClient osclient.Interface) quota.Registry {
+	imageStream := NewImageStreamEvaluator(osClient)
+	imageStreamMapping := NewImageStreamMappingEvaluator(osClient)
+	return &generic.GenericRegistry{
+		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
+			imageStream.GroupKind():        imageStream,
+			imageStreamMapping.GroupKind(): imageStreamMapping,
+		},
+	}
+}

--- a/pkg/quota/image/usage.go
+++ b/pkg/quota/image/usage.go
@@ -1,0 +1,148 @@
+package image
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// GetImageStreamSize computes a sum of sizes of image layers occupying given image stream. Each layer
+// is added just once even if it occurs in multiple images.
+func GetImageStreamSize(osClient osclient.Interface, is *imageapi.ImageStream, imageCache map[string]*imageapi.Image) *resource.Quantity {
+	size := resource.NewQuantity(0, resource.BinarySI)
+
+	processedImages := make(map[string]sets.Empty)
+	processedLayers := make(map[string]sets.Empty)
+
+	for _, history := range is.Status.Tags {
+		for i := range history.Items {
+			imgName := history.Items[i].Image
+			if len(history.Items[i].DockerImageReference) == 0 || len(imgName) == 0 {
+				continue
+			}
+
+			if _, exists := processedImages[imgName]; exists {
+				continue
+			}
+			processedImages[imgName] = sets.Empty{}
+
+			img, exists := imageCache[imgName]
+			if !exists {
+				imi, err := osClient.ImageStreamImages(is.Namespace).Get(is.Name, imgName)
+				if err != nil {
+					glog.Errorf("Failed to get image %s of image stream %s/%s: %v", imgName, is.Namespace, is.Name, err)
+					continue
+				}
+				img = &imi.Image
+				imageCache[imgName] = img
+			}
+
+			if value, ok := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !ok || value != "true" {
+				glog.V(5).Infof("Image %q with DockerImageReference %q belongs to an external registry - skipping", img.Name, img.DockerImageReference)
+				continue
+			}
+
+			if len(img.DockerImageLayers) == 0 || img.DockerImageMetadata.Size == 0 {
+				if err := imageapi.ImageWithMetadata(img); err != nil {
+					glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", img.Name, img.DockerImageReference, err)
+					continue
+				}
+			}
+
+			for _, layer := range img.DockerImageLayers {
+				if _, ok := processedLayers[layer.Name]; ok {
+					continue
+				}
+				size.Add(*resource.NewQuantity(layer.Size, resource.BinarySI))
+				processedLayers[layer.Name] = sets.Empty{}
+			}
+		}
+	}
+
+	return size
+}
+
+// GetImageStreamSizeIncrement computes a sum of sizes of image layers occupying given image stream.
+// Additionally it returns an increment which will be added to the size when the given image will be tagged
+// into the image stream. In case the is is nil, returned size will be 0 and returned increment will equal to
+// the image size.
+//
+// Size increment will always be less or equal to the image size. Less means, that some of image's layers are
+// already stored in a registry.
+func GetImageStreamSizeIncrement(osClient osclient.Interface, is *imageapi.ImageStream, image *imageapi.Image, imageCache map[string]*imageapi.Image) (isSize, sizeIncrement *resource.Quantity, err error) {
+	if len(image.DockerImageLayers) == 0 || image.DockerImageMetadata.Size == 0 {
+		if err = imageapi.ImageWithMetadata(image); err != nil {
+			glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", image.Name, image.DockerImageReference, err)
+			return nil, nil, err
+		}
+	}
+	isSize = resource.NewQuantity(0, resource.BinarySI)
+	if value, ok := image.Annotations[imageapi.ManagedByOpenShiftAnnotation]; ok && value == "true" {
+		sizeIncrement = resource.NewQuantity(image.DockerImageMetadata.Size, resource.BinarySI)
+	} else {
+		sizeIncrement = resource.NewQuantity(0, resource.BinarySI)
+	}
+	if is == nil {
+		return
+	}
+
+	processedImages := make(map[string]sets.Empty)
+	processedLayers := make(map[string]sets.Empty)
+
+	for _, history := range is.Status.Tags {
+		for i := range history.Items {
+			imageName := history.Items[i].Image
+			if len(history.Items[i].DockerImageReference) == 0 || len(imageName) == 0 {
+				continue
+			}
+
+			if _, exists := processedImages[imageName]; exists {
+				continue
+			}
+			processedImages[imageName] = sets.Empty{}
+
+			imi, err2 := osClient.ImageStreamImages(is.Namespace).Get(is.Name, imageName)
+			if err2 != nil {
+				glog.Errorf("Failed to get image %s of image stream %s/%s: %v", image.Name, is.Namespace, is.Name, err2)
+				continue
+			}
+			img := &imi.Image
+
+			if value, ok := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !ok || value != "true" {
+				glog.V(5).Infof("Image %q with DockerImageReference %q belongs to an external registry - skipping", img.Name, img.DockerImageReference)
+				continue
+			}
+
+			if len(img.DockerImageLayers) == 0 || img.DockerImageMetadata.Size == 0 {
+				if err2 := imageapi.ImageWithMetadata(img); err2 != nil {
+					glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", img.Name, img.DockerImageReference, err2)
+					continue
+				}
+			}
+
+			for _, layer := range img.DockerImageLayers {
+				if _, exists := processedLayers[layer.Name]; exists {
+					continue
+				}
+				isSize.Add(*resource.NewQuantity(layer.Size, resource.BinarySI))
+				processedLayers[layer.Name] = sets.Empty{}
+			}
+		}
+	}
+
+	for _, layer := range image.DockerImageLayers {
+		if _, exists := processedLayers[layer.Name]; exists {
+			sizeIncrement.Sub(*resource.NewQuantity(layer.Size, resource.BinarySI))
+			if sizeIncrement.Value() <= 0 {
+				sizeIncrement.Set(0)
+				break
+			}
+		}
+	}
+
+	return
+}

--- a/pkg/quota/registry.go
+++ b/pkg/quota/registry.go
@@ -1,0 +1,13 @@
+package quota
+
+import (
+	kquota "k8s.io/kubernetes/pkg/quota"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/quota/image"
+)
+
+// NewRegistry returns a registry object that knows how to evaluate quota usage of OpenShift resources.
+func NewRegistry(osClient osclient.Interface) kquota.Registry {
+	return image.NewImageRegistry(osClient)
+}

--- a/pkg/quota/util/sharedcontextevaluator.go
+++ b/pkg/quota/util/sharedcontextevaluator.go
@@ -1,0 +1,118 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// SharedContextEvaluator provides an implementation for quota.Evaluator
+type SharedContextEvaluator struct {
+	*generic.GenericEvaluator
+	UsageComputerFactory UsageComputerFactory
+}
+
+var _ quota.Evaluator = &SharedContextEvaluator{}
+
+// NewSharedContextEvaluator creates an evaluator object that allows to share context while computing usage of
+// single namespace. Context is represented by an object returned by usageComputerFactory and is destroyed
+// when the namespace is processed.
+func NewSharedContextEvaluator(
+	name string,
+	groupKind unversioned.GroupKind,
+	operationResources map[admission.Operation][]kapi.ResourceName,
+	matchesScopeFunc generic.MatchesScopeFunc,
+	getFuncByNamespace generic.GetFuncByNamespace,
+	listFuncByNamespace generic.ListFuncByNamespace,
+	constraintsFunc generic.ConstraintsFunc,
+	usageComputerFactory UsageComputerFactory,
+) quota.Evaluator {
+
+	rnSet := sets.String{}
+	for _, resourceNames := range operationResources {
+		rnSet.Insert(quota.ToSet(resourceNames).List()...)
+	}
+	matchedResourceNames := make([]kapi.ResourceName, 0, len(rnSet))
+	for resourceName := range rnSet {
+		matchedResourceNames = append(matchedResourceNames, kapi.ResourceName(resourceName))
+	}
+
+	return &SharedContextEvaluator{
+		GenericEvaluator: &generic.GenericEvaluator{
+			InternalGroupKind:          groupKind,
+			InternalOperationResources: operationResources,
+			MatchedResourceNames:       matchedResourceNames,
+			MatchesScopeFunc:           matchesScopeFunc,
+			GetFuncByNamespace:         getFuncByNamespace,
+			ListFuncByNamespace:        listFuncByNamespace,
+			ConstraintsFunc:            constraintsFunc,
+			UsageFunc: func(object runtime.Object) kapi.ResourceList {
+				comp := usageComputerFactory()
+				return comp.Usage(object)
+			},
+		},
+		UsageComputerFactory: usageComputerFactory,
+	}
+}
+
+// UsageComputer knows how to measure usage associated with an object. Its implementation can store arbitrary
+// data during `Usage()` run as a context while namespace is being evaluated.
+type UsageComputer interface {
+	Usage(object runtime.Object) kapi.ResourceList
+}
+
+// UsageComputerFactory returns a usage computer used during namespace evaluation.
+type UsageComputerFactory func() UsageComputer
+
+// Usage evaluates usage of given object.
+func (sce *SharedContextEvaluator) Usage(object runtime.Object) kapi.ResourceList {
+	usageComp := sce.UsageComputerFactory()
+	return usageComp.Usage(object)
+}
+
+// UsageStats calculates latest observed usage stats for all objects. UsageComputerFactory is used to create a
+// UsageComputer object whose Usage is called on every object in a namespace.
+func (sce *SharedContextEvaluator) UsageStats(options quota.UsageStatsOptions) (quota.UsageStats, error) {
+	// default each tracked resource to zero
+	result := quota.UsageStats{Used: kapi.ResourceList{}}
+	for _, resourceName := range sce.MatchedResourceNames {
+		result.Used[resourceName] = resource.MustParse("0")
+	}
+	list, err := sce.ListFuncByNamespace(options.Namespace, kapi.ListOptions{})
+	if err != nil {
+		return result, fmt.Errorf("%s: Failed to list %v: %v", sce.Name, sce.GroupKind, err)
+	}
+	_, err = meta.Accessor(list)
+	if err != nil {
+		return result, fmt.Errorf("%s: Unable to understand list result %#v", sce.Name, list)
+	}
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return result, fmt.Errorf("%s: Unable to understand list result %#v (%v)", sce.Name, list, err)
+	}
+
+	context := sce.UsageComputerFactory()
+
+	for _, item := range items {
+		// need to verify that the item matches the set of scopes
+		matchesScopes := true
+		for _, scope := range options.Scopes {
+			if !sce.MatchesScope(scope, item) {
+				matchesScopes = false
+			}
+		}
+		// only count usage if there was a match
+		if matchesScopes {
+			result.Used = quota.Add(result.Used, context.Usage(item))
+		}
+	}
+	return result, nil
+}

--- a/test/extended/images/quota_admission.go
+++ b/test/extended/images/quota_admission.go
@@ -1,0 +1,263 @@
+package images
+
+import (
+	cryptorand "crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/quota"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+const (
+	// There are coefficients used to multiply layer data size to get a rough size of uploaded blob.
+	layerSizeMultiplierForDocker18     = 2.0
+	layerSizeMultiplierForLatestDocker = 0.8
+
+	imageSizeHardQuota        = "10000"
+	imageStreamSizeHardQuota  = "20000"
+	projectImageSizeHardQuota = "30000"
+
+	bigImageSize    = 14000
+	middleImageSize = 8000
+	tinyImageSize   = 1000
+)
+
+var _ = g.Describe("[images] openshift image resource quota", func() {
+	defer g.GinkgoRecover()
+	var oc = exutil.NewCLI("imagequota-admission", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		g.By("Waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It(fmt.Sprintf("should deny a push of built image exceeding quota"), func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		rq := &kapi.ResourceQuota{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "all-quota-set",
+			},
+			Spec: kapi.ResourceQuotaSpec{
+				Hard: kapi.ResourceList{
+					imageapi.ResourceImageSize:         resource.MustParse(imageSizeHardQuota),
+					imageapi.ResourceImageStreamSize:   resource.MustParse(imageStreamSizeHardQuota),
+					imageapi.ResourceProjectImagesSize: resource.MustParse(projectImageSizeHardQuota),
+				},
+			},
+		}
+
+		g.By("resource quota needs to be created")
+		_, err := oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Create(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("trying to push image exceeding imagesize quota")
+		buildImageOfSize(oc, "sized", "big", bigImageSize, 3, true)
+
+		g.By("trying to push image below imagesize quota")
+		buildImageOfSize(oc, "sized", "middle", middleImageSize, 2, false)
+		expected := kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)}
+		used, err := waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("trying to push image below imagesize quota")
+		buildImageOfSize(oc, "sized", "middle2", middleImageSize, 2, false)
+		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
+		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("trying to push image exceeding imagestreamsize quota")
+		buildImageOfSize(oc, "sized", "middle3", middleImageSize, 2, true)
+
+		g.By("trying to push image below imagestreamsize quota")
+		buildImageOfSize(oc, "sized", "tiny", tinyImageSize, 1, false)
+		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(tinyImageSize/2, resource.BinarySI)})
+		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("trying to push image below projectimagessize quota")
+		buildImageOfSize(oc, "other", "middle", middleImageSize, 2, false)
+		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
+		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("trying to push image exceeding projectimagessize quota")
+		buildImageOfSize(oc, "other", "middle2", middleImageSize, 2, true)
+
+		expected = quota.Subtract(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
+		g.By("removing image sized:middle")
+		err = oc.REST().ImageStreamTags(oc.Namespace()).Delete("sized", "middle")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// expect usage decrement
+		used, err = exutil.WaitForResourceQuotaSync(
+			oc.KubeREST().ResourceQuotas(oc.Namespace()),
+			"all-quota-set",
+			expected,
+			true,
+			time.Second*5,
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("trying to re-push the image")
+		buildImageOfSize(oc, "sized", "reloaded", middleImageSize, 2, false)
+		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
+		_, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})
+
+// buildImageOfSize tries to build an image of wanted size and number of layers. Built image is stored as an
+// image stream tag <name>:<tag>. If shouldBeDenied is true, a build will be expected to fail with a denied
+// error. Note the size is only approximate. Resulting image size will be different depending on used
+// compression algorithm and metadata overhead.
+func buildImageOfSize(oc *exutil.CLI, name, tag string, size uint64, numberOfLayers int, shouldBeDenied bool) {
+	istName := name
+	if tag != "" {
+		istName += ":" + tag
+	}
+	g.By(fmt.Sprintf("building an image %q of size %d", istName, size))
+
+	bc, err := oc.REST().BuildConfigs(oc.Namespace()).Get(name)
+	if err == nil {
+		g.By(fmt.Sprintf("changing build config %s to store result into %s", name, istName))
+		o.Expect(bc.Spec.BuildSpec.Output.To.Kind).To(o.Equal("ImageStreamTag"))
+		bc.Spec.BuildSpec.Output.To.Name = istName
+		_, err := oc.REST().BuildConfigs(oc.Namespace()).Update(bc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	} else {
+		g.By(fmt.Sprintf("creating a new build config %s with output to %s ", name, istName))
+		err = oc.Run("new-build").Args(
+			"--binary",
+			"--name", name,
+			"--to", istName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+
+	tempDir, err := ioutil.TempDir("", "name-build")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	dataSize := calculateRoughDataSize(size, numberOfLayers)
+
+	lines := make([]string, numberOfLayers+1)
+	lines[0] = "FROM scratch"
+	for i := 1; i <= numberOfLayers; i++ {
+		blobName := fmt.Sprintf("data%d", i)
+		err := createRandomBlob(path.Join(tempDir, blobName), dataSize)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		lines[i] = fmt.Sprintf("COPY %s /%s", blobName, blobName)
+	}
+	err = ioutil.WriteFile(path.Join(tempDir, "Dockerfile"), []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = oc.Run("start-build").Args(name, "--from-dir", tempDir, "--wait").Execute()
+	if shouldBeDenied {
+		o.Expect(err).To(o.HaveOccurred())
+		out, err := oc.Run("logs").Args("bc/" + name).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).Should(o.MatchRegexp("(?i)Failed to push image:.*denied"))
+	} else {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+}
+
+// waitForResourceQuotaSync waits until a usage of a quota reaches given limit with a short timeout
+func waitForResourceQuotaSync(oc *exutil.CLI, name string, expectedResources kapi.ResourceList) (kapi.ResourceList, error) {
+	g.By(fmt.Sprintf("waiting for resource quota %s to get updated", name))
+	used, err := exutil.WaitForResourceQuotaSync(
+		oc.KubeREST().ResourceQuotas(oc.Namespace()),
+		"all-quota-set",
+		expectedResources,
+		false,
+		time.Second*5,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return used, nil
+}
+
+// createRandomBlob creates a random data with bytes from `letters` in order to let docker take advantage of
+// compression
+func createRandomBlob(dest string, size uint64) error {
+	var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	data := make([]byte, size)
+	if _, err = cryptorand.Read(data); err != nil {
+		return err
+	}
+
+	for i := range data {
+		data[i] = letters[uint(data[i])%uint(len(letters))]
+	}
+
+	f.Write(data)
+	return nil
+}
+
+// dockerVersion is a cached version string of Docker daemon
+var dockerVersion = ""
+
+// getDockerVersion returns a version of running Docker daemon which is questioned only during the first
+// invocation.
+func getDockerVersion() (major, minor int, version string, err error) {
+	reVersion := regexp.MustCompile(`^(\d+)\.(\d+)`)
+
+	if dockerVersion == "" {
+		client, err2 := testutil.NewDockerClient()
+		if err = err2; err != nil {
+			return
+		}
+		env, err2 := client.Version()
+		if err = err2; err != nil {
+			return
+		}
+		dockerVersion = env.Get("Version")
+		g.By(fmt.Sprintf("using docker version %s", version))
+	}
+	version = dockerVersion
+
+	matches := reVersion.FindStringSubmatch(version)
+	if len(matches) < 3 {
+		return 0, 0, "", fmt.Errorf("failed to parse version string %s", version)
+	}
+	major, _ = strconv.Atoi(matches[1])
+	minor, _ = strconv.Atoi(matches[2])
+	return
+}
+
+// calculateRoughDataSize returns a rough size of data blob to generate in order to build an image of wanted
+// size. Image is comprised of numberOfLayers layers of the same size.
+func calculateRoughDataSize(wantedImageSize uint64, numberOfLayers int) uint64 {
+	major, minor, version, err := getDockerVersion()
+	if err != nil {
+		g.By(fmt.Sprintf("failed to get docker version: %s", version))
+	}
+	if (major >= 1 && minor >= 9) || version == "" {
+		// running Docker version 1.9+
+		return uint64(float64(wantedImageSize) / (float64(numberOfLayers) * layerSizeMultiplierForLatestDocker))
+	}
+
+	// running Docker daemon < 1.9
+	return uint64(float64(wantedImageSize) / (float64(numberOfLayers) * layerSizeMultiplierForDocker18))
+}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -20,6 +20,7 @@ import (
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/runtime"
 	kutil "k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -271,6 +272,80 @@ func WaitForADeployment(client kclient.ReplicationControllerInterface, name stri
 	case <-time.After(timeout):
 		return fmt.Errorf("timed out waiting for deployment %q after %v", name, timeout)
 	}
+}
+
+func isUsageSynced(received, expected kapi.ResourceList, expectedIsUpperLimit bool) bool {
+	resourceNames := quota.ResourceNames(expected)
+	masked := quota.Mask(received, resourceNames)
+	if len(masked) != len(expected) {
+		return false
+	}
+	if expectedIsUpperLimit {
+		if le, _ := quota.LessThanOrEqual(masked, expected); !le {
+			return false
+		}
+	} else {
+		if le, _ := quota.LessThanOrEqual(expected, masked); !le {
+			return false
+		}
+	}
+	return true
+}
+
+// WaitForResourceQuotaSync watches given resource quota until its usage is updated to desired level or a
+// timeout occurs. If successful, used quota values will be returned for expected resources. Otherwise an
+// ErrWaitTimeout will be returned. If expectedIsUpperLimit is true, given expected usage must compare greater
+// or equal to quota's usage, which is useful for expected usage increment. Otherwise expected usage must
+// compare lower or equal to quota's usage, which is useful for expected usage decrement.
+func WaitForResourceQuotaSync(
+	client kclient.ResourceQuotaInterface,
+	name string,
+	expectedUsage kapi.ResourceList,
+	expectedIsUpperLimit bool,
+	timeout time.Duration) (kapi.ResourceList, error) {
+
+	startTime := time.Now()
+	endTime := startTime.Add(timeout)
+
+	expectedResourceNames := quota.ResourceNames(expectedUsage)
+
+	list, err := client.List(kapi.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector()})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range list.Items {
+		used := quota.Mask(list.Items[i].Status.Used, expectedResourceNames)
+		if isUsageSynced(used, expectedUsage, expectedIsUpperLimit) {
+			return used, nil
+		}
+	}
+
+	rv := list.ResourceVersion
+	w, err := client.Watch(kapi.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector(), ResourceVersion: rv})
+	if err != nil {
+		return nil, err
+	}
+	defer w.Stop()
+
+	for time.Now().Before(endTime) {
+		select {
+		case val, ok := <-w.ResultChan():
+			if !ok {
+				// reget and re-watch
+				continue
+			}
+			if rq, ok := val.Object.(*kapi.ResourceQuota); ok {
+				used := quota.Mask(rq.Status.Used, expectedResourceNames)
+				if isUsageSynced(used, expectedUsage, expectedIsUpperLimit) {
+					return used, nil
+				}
+			}
+		case <-time.After(endTime.Sub(time.Now())):
+			return nil, wait.ErrWaitTimeout
+		}
+	}
+	return nil, wait.ErrWaitTimeout
 }
 
 // CheckDeploymentCompletedFn returns true if the deployment completed

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -727,6 +727,12 @@ items:
     - imagestreammappings
     verbs:
     - create
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - resourcequotas
+    verbs:
+    - list
 - apiVersion: v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
New resource quotas:
    
1. openshift.io/projectimagessize
2. openshift.io/imagestreamsize
3. openshift.io/imagesize

The 1st allows to set a limit for a sum of sizes of all image layers
accross all repositories in a namespace.

The 2nd allows to set a limit for a sum of sizes of all image layers
in a single repository. Usage will always be 0 because we cannot store
different values for different repositories.

The 3rd allows to set a limit for a sum of sizes of all layers of
single image. Usage will always be 0.

Layers occuring multiple times in a single repository count just once.

**TODO**:

- [x] write godocs
- [x] avoid patching upstream `GenericEvaluator`, write our own instead
- [x] fix tests
- [x] write tests
