### PR TITLE
Add pods donut to deployment page

### DIFF
--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DeploymentController', function ($scope, $routeParams, AlertMessageService, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter) {
+  .controller('DeploymentController', function ($scope, $routeParams, AlertMessageService, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, Navigate, $filter) {
     $scope.projectName = $routeParams.project;
     $scope.deployment = null;
     $scope.deploymentConfig = null;
@@ -87,6 +87,17 @@ angular.module('openshiftConsole')
           }));
         };
 
+        var pods, selector;
+        var updatePodsForDeployment = function() {
+          if (!pods || !selector) {
+            return;
+          }
+
+          $scope.podsForDeployment = _.filter(pods, function(pod) {
+            return selector.matches(pod);
+          });
+        };
+
         DataService.get("replicationcontrollers", $routeParams.deployment || $routeParams.replicationcontroller, context).then(
           // success
           function(deployment) {
@@ -115,6 +126,16 @@ angular.module('openshiftConsole')
               // Check if we're the active deployment to enable or disable scaling.
               watchActiveDeployment();
             }
+
+            $scope.$watch('deployment.spec.selector', function() {
+              selector = new LabelSelector($scope.deployment.spec.selector);
+              updatePodsForDeployment();
+            }, true);
+
+            watches.push(DataService.watch("pods", context, function(podData) {
+              pods = podData.by('metadata.name');
+              updatePodsForDeployment();
+            }));
           },
           // failure
           function(e) {
@@ -150,6 +171,7 @@ angular.module('openshiftConsole')
             }
           );
         }
+
 
         function extractPodTemplates() {
           angular.forEach($scope.deployments, function(deployment, deploymentId){
@@ -242,6 +264,14 @@ angular.module('openshiftConsole')
           } else {
             DeploymentsService.scaleRC($scope.deployment, replicas).then(_.noop, showScalingError);
           }
+        };
+
+        $scope.viewPodsForDeployment = function() {
+          if ($filter('hashSize')($scope.podsForDeployment) === 0) {
+            return;
+          }
+
+          Navigate.toPodsForDeployment($scope.deployment);
         };
 
         $scope.$on('$destroy', function(){

--- a/assets/app/scripts/directives/overviewDeployment.js
+++ b/assets/app/scripts/directives/overviewDeployment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .directive('overviewDeployment', function($location, $uibModal, $timeout, $filter, LabelFilter, DeploymentsService, hashSizeFilter, isDeploymentFilter) {
+  .directive('overviewDeployment', function($location, $uibModal, $timeout, $filter, LabelFilter, DeploymentsService, Navigate, hashSizeFilter, isDeploymentFilter) {
     return {
       restrict: 'E',
       scope: {
@@ -58,10 +58,7 @@ angular.module('openshiftConsole')
             return;
           }
 
-          $location.url("/project/" + deployment.metadata.namespace + "/browse/pods");
-          $timeout(function() {
-            LabelFilter.setLabelSelector(new LabelSelector(deployment.spec.selector, true));
-          }, 1);
+          Navigate.toPodsForDeployment(deployment);
         };
 
         $scope.scaleUp = function() {

--- a/assets/app/scripts/services/navigate.js
+++ b/assets/app/scripts/services/navigate.js
@@ -1,7 +1,7 @@
 "use strict";
 
 angular.module("openshiftConsole")
-  .service("Navigate", function($location, annotationFilter){
+  .service("Navigate", function($location, $timeout, annotationFilter, LabelFilter){
     return {
       /**
        * Navigate and display the error page.
@@ -46,6 +46,13 @@ angular.module("openshiftConsole")
        */
       toNextSteps: function(name, projectName){
         $location.path("project/" + encodeURIComponent(projectName) + "/create/next").search("name", name);
+      },
+
+      toPodsForDeployment: function(deployment) {
+        $location.url("/project/" + deployment.metadata.namespace + "/browse/pods");
+        $timeout(function() {
+          LabelFilter.setLabelSelector(new LabelSelector(deployment.spec.selector, true));
+        }, 1);
       },
 
       // Resource is either a resource object, or a name.  If resource is a name, kind and namespace must be specified

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -235,22 +235,24 @@
   }
 }
 
+.clickable {
+  cursor: pointer;
+}
+
+.pod-status-chart {
+  // Give an empty pod donut chart a light gray outline.
+  path.c3-arc-Empty {
+    stroke: #d1d1d1;
+    // Override the style set in JavaScript since you can't click or hover
+    // on the empty chart.
+    cursor: inherit !important;
+  }
+}
+
 .pod-block {
   .overview-pods {
     margin-right: 10px;
     min-width: 190px;
-    .clickable {
-      cursor: pointer;
-    }
-    .pod-status-chart {
-      // Give an empty pod donut chart a light gray outline.
-      path.c3-arc-Empty {
-        stroke: #d1d1d1;
-        // Override the style set in JavaScript since you can't click or hover
-        // on the empty chart.
-        cursor: inherit !important;
-      }
-    }
     .scaling-controls {
       font-size: 24px;
       a {

--- a/assets/app/views/browse/_deployment-details.html
+++ b/assets/app/views/browse/_deployment-details.html
@@ -1,75 +1,97 @@
-<dl class="dl-horizontal left">
-  <dt ng-if-start="deployment | isDeployment">Status:</dt>
-  <dd ng-if-end>
-    <status-icon status="deployment | deploymentStatus"></status-icon>
-    {{deployment | deploymentStatus}}
-    <span style="margin-left: 7px;">
-      <button ng-show="!rollBackCollapsed && (deployment | deploymentStatus) == 'Complete' && !(deployment | deploymentIsLatest : deploymentConfig) && !deployment.metadata.deletionTimestamp" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" type="button" class="btn btn-default btn-xs" ng-click="rollBackCollapsed = !rollBackCollapsed">Roll Back</button>
-      <div ng-show="rollBackCollapsed" class="well well-sm">
-        Use the following settings from {{deployment.metadata.name}} when rolling back:
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" ng-model="changeScaleSettings" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> replica count and selector
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" ng-model="changeStrategy" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment strategy
-          </label>
-        </div>
-        <div class="checkbox">
-          <label>
-            <input type="checkbox" ng-model="changeTriggers" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment trigger
-          </label>
-        </div>
-        <button type="button" ng-click="rollbackToDeployment(deployment, changeScaleSettings, changeStrategy, changeTriggers)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-default btn-xs">Roll Back</button>
-      </div>
-      <!-- disabled until we have an api endpoint for retry
-      <button ng-show="(deployment | deploymentStatus) == 'Failed'" type="button" ng-click="retryFailedDeployment(deployment)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-default btn-xs" ng-if="(deployment | deploymentIsLatest : deploymentConfig) && !deployment.metadata.deletionTimestamp">Retry</button>
-      -->
-      <button ng-show="(deployment | deploymentIsInProgress) && !deployment.metadata.deletionTimestamp" type="button" ng-click="cancelRunningDeployment(deployment)" class="btn btn-default btn-xs">Cancel</button>
-    </span>
-  </dd>
-  <dt ng-if-start="deployment | isDeployment">Deployment config:</dt>
-  <dd ng-if-end>
-    <a href="{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : deployment.metadata.namespace}}">{{deploymentConfigName}}</a>
-  </dd>
-  <dt ng-if-start="deployment | annotation:'deploymentStatusReason'">Status reason:</dt>
-  <dd ng-if-end>
-    {{deployment | annotation:'deploymentStatusReason'}}
-  </dd>
-  <dt ng-if-start="deployment | deploymentIsInProgress">Duration:</dt>
-  <dd ng-if-end>
-    <span ng-switch="deployment | deploymentStatus" class="hide-ng-leave">
-      <span ng-switch-when="Running">running for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
-      <span ng-switch-default>waiting for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
-    </span>
-  </dd>
-  <dt>Selectors:</dt>
-  <dd>
-    <span ng-if="!deployment.spec.selector">none</span>
-    <span ng-repeat="(labelKey, labelValue) in deployment.spec.selector">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
-  </dd>
-  <dt>Replicas:</dt>
-  <dd>
-    <!-- Enable scaling if this is a plain replication controller or it's the active deployment. -->
-    <replicas status="deployment.status.replicas"
-              spec="deployment.spec.replicas"
-              disable-scaling="(deployment | isDeployment) && !deploymentConfigMissing && (!isActive || !deploymentConfig)"
-              scale-fn="scale(replicas)">
-    </replicas>
-  </dd>
-  <annotations annotations="deployment.metadata.annotations"></annotations>
-</dl>
-<div class="deployment-detail">
+<div class="row" style="max-width: 650px;">
+  <div class="col-sm-4 col-sm-push-8 text-center">
+    <pod-status-chart
+        pods="podsForDeployment"
+        ng-if="podsForDeployment"
+        desired="deployment.spec.replicas"
+        ng-click="viewPodsForDeployment()"
+        ng-class="{ clickable: (podsForDeployment | hashSize) > 0 }"
+        style="display: inline-block;">
+    </pod-status-chart>
+    <!-- Add a link for screen readers. -->
+    <a href=""
+       class="sr-only"
+       ng-click="viewPodsForDeployment()"
+       ng-if="(podsForDeployment | hashSize) > 0"
+       role="button">
+       View pods for deployment.metadata.name
+    </a>
+  </div>
+  <div class="col-sm-8 col-sm-pull-4">
+    <dl class="dl-horizontal left">
+      <dt ng-if-start="deployment | isDeployment">Status:</dt>
+      <dd ng-if-end>
+        <status-icon status="deployment | deploymentStatus"></status-icon>
+        {{deployment | deploymentStatus}}
+        <span style="margin-left: 7px;">
+          <button ng-show="!rollBackCollapsed && (deployment | deploymentStatus) == 'Complete' && !(deployment | deploymentIsLatest : deploymentConfig) && !deployment.metadata.deletionTimestamp" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" type="button" class="btn btn-default btn-xs" ng-click="rollBackCollapsed = !rollBackCollapsed">Roll Back</button>
+          <div ng-show="rollBackCollapsed" class="well well-sm">
+            Use the following settings from {{deployment.metadata.name}} when rolling back:
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="changeScaleSettings" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> replica count and selector
+              </label>
+            </div>
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="changeStrategy" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment strategy
+              </label>
+            </div>
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" ng-model="changeTriggers" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment trigger
+              </label>
+            </div>
+            <button type="button" ng-click="rollbackToDeployment(deployment, changeScaleSettings, changeStrategy, changeTriggers)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-default btn-xs">Roll Back</button>
+          </div>
+          <!-- disabled until we have an api endpoint for retry
+          <button ng-show="(deployment | deploymentStatus) == 'Failed'" type="button" ng-click="retryFailedDeployment(deployment)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-default btn-xs" ng-if="(deployment | deploymentIsLatest : deploymentConfig) && !deployment.metadata.deletionTimestamp">Retry</button>
+          -->
+          <button ng-show="(deployment | deploymentIsInProgress) && !deployment.metadata.deletionTimestamp" type="button" ng-click="cancelRunningDeployment(deployment)" class="btn btn-default btn-xs">Cancel</button>
+        </span>
+      </dd>
+      <dt ng-if-start="deployment | isDeployment">Deployment config:</dt>
+      <dd ng-if-end>
+        <a href="{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : deployment.metadata.namespace}}">{{deploymentConfigName}}</a>
+      </dd>
+      <dt ng-if-start="deployment | annotation:'deploymentStatusReason'">Status reason:</dt>
+      <dd ng-if-end>
+        {{deployment | annotation:'deploymentStatusReason'}}
+      </dd>
+      <dt ng-if-start="deployment | deploymentIsInProgress">Duration:</dt>
+      <dd ng-if-end>
+        <span ng-switch="deployment | deploymentStatus" class="hide-ng-leave">
+          <span ng-switch-when="Running">running for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
+          <span ng-switch-default>waiting for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
+        </span>
+      </dd>
+      <dt>Selectors:</dt>
+      <dd>
+        <span ng-if="!deployment.spec.selector">none</span>
+        <span ng-repeat="(labelKey, labelValue) in deployment.spec.selector">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
+      </dd>
+      <dt>Replicas:</dt>
+      <dd>
+        <!-- Enable scaling if this is a plain replication controller or it's the active deployment. -->
+        <replicas status="deployment.status.replicas"
+                  spec="deployment.spec.replicas"
+                  disable-scaling="(deployment | isDeployment) && !deploymentConfigMissing && (!isActive || !deploymentConfig)"
+                  scale-fn="scale(replicas)">
+        </replicas>
+      </dd>
+      <annotations annotations="deployment.metadata.annotations"></annotations>
+    </dl>
+  </div>
+</div>
+<div class="deployment-detail gutter-bottom">
   <span>Pod template:</span>
   <pod-template
     pod-template="deployment.spec.template"
     images-by-docker-reference="imagesByDockerReference"
     builds="builds"
     detailed="true"></pod-template>
-    <h4 style="margin-top: 20px;">Volumes</h4>
-    <a ng-if="!deployment.spec.template.spec.volumes.length"
-       ng-href="project/{{project.metadata.name}}/attach-pvc?deployment={{deployment.metadata.name}}">Attach storage</a>
-    <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
+  <h4 style="margin-top: 20px;">Volumes</h4>
+  <a ng-if="!deployment.spec.template.spec.volumes.length"
+     ng-href="project/{{project.metadata.name}}/attach-pvc?deployment={{deployment.metadata.name}}">Attach storage</a>
+  <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
 </div>


### PR DESCRIPTION
Also adds a link to the pods for the deployment by clicking the donut. I haven't added the scaling arrows.

/cc @jwforres 

Desktop:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/12897271/71398230-ce74-11e5-87ae-cccaf311e0c5.png)

Mobile:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/12897294/8e03a29c-ce74-11e5-8c7e-fee01fd7b2bd.png)
