### PR TITLE
Web console: only show "no services" message if overview empty

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -38,7 +38,7 @@
             <div class="col-md-12 gutter-top">
 
               <!-- Empty states -->
-              <div ng-if="(services | hashSize) == 0">
+              <div ng-if="(services | hashSize) === 0 && (monopodsByService[''] | hashSize) === 0 && (deploymentsByServiceByDeploymentConfig[''] | hashSize) === 0">
                 <!-- Getting started -->
                 <div ng-if="renderOptions.showGetStarted" class="empty-project text-center">
                   <h2>Get started with your project.</h2>


### PR DESCRIPTION
Don't display the "No services to show" message if we're showing other content in the overview like an unserviced deployment of an unserviced pod. The message still appears if a filter is hiding all services.

Before:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/12918885/997737f6-cf0f-11e5-923a-288d97264628.png)

After:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/12918956/eb39d6b6-cf0f-11e5-8653-8ac00db313d5.png)
