### PR TITLE
Generation and separate status updates for DCs

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20531,6 +20531,11 @@
      "details": {
       "$ref": "v1.DeploymentDetails",
       "description": "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger"
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration is the most recent generation observed by the controller."
      }
     }
    },

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -5530,6 +5530,66 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/deploymentconfigs/{name}/status",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.DeploymentConfig",
+      "method": "PUT",
+      "summary": "replace status of the specified DeploymentConfig",
+      "nickname": "replaceNamespacedDeploymentConfigStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DeploymentConfig",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DeploymentConfig",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DeploymentConfig"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/namespaces/{namespace}/generatedeploymentconfigs/{name}",
     "description": "OpenShift REST API, version v1",
     "operations": [

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1611,6 +1611,7 @@ func deepCopy_v1beta3_DeploymentConfigStatus(in deployapiv1beta3.DeploymentConfi
 	} else {
 		out.Details = nil
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -94,7 +94,7 @@ var (
 		OpenshiftAllGroupName: {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects",
 			"clusterroles", "clusterrolebindings", "clusterpolicies", "clusterpolicybindings", "images" /* cluster scoped*/, "projectrequests", "builds/details", "imagestreams/secrets",
 			"selfsubjectrulesreviews"},
-		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status"},
+		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status", "deploymentconfigs/status"},
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
 		KubeExposedGroupName:   {"pods", "replicationcontrollers", "serviceaccounts", "services", "endpoints", "persistentvolumeclaims", "pods/log", "configmaps"},

--- a/pkg/client/deploymentconfigs.go
+++ b/pkg/client/deploymentconfigs.go
@@ -27,6 +27,7 @@ type DeploymentConfigInterface interface {
 	Rollback(config *deployapi.DeploymentConfigRollback) (*deployapi.DeploymentConfig, error)
 	GetScale(name string) (*extensions.Scale, error)
 	UpdateScale(scale *extensions.Scale) (*extensions.Scale, error)
+	UpdateStatus(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
 }
 
 // deploymentConfigs implements DeploymentConfigsNamespacer interface
@@ -98,6 +99,7 @@ func (c *deploymentConfigs) Generate(name string) (result *deployapi.DeploymentC
 	return
 }
 
+// Rollback rolls a deploymentConfig back to a previous configuration
 func (c *deploymentConfigs) Rollback(config *deployapi.DeploymentConfigRollback) (result *deployapi.DeploymentConfig, err error) {
 	result = &deployapi.DeploymentConfig{}
 	err = c.r.Post().
@@ -109,14 +111,14 @@ func (c *deploymentConfigs) Rollback(config *deployapi.DeploymentConfigRollback)
 	return
 }
 
-// Get returns information about a particular deploymentConfig
+// GetScale returns information about a particular deploymentConfig via its scale subresource
 func (c *deploymentConfigs) GetScale(name string) (result *extensions.Scale, err error) {
 	result = &extensions.Scale{}
 	err = c.r.Get().Namespace(c.ns).Resource("deploymentConfigs").Name(name).SubResource("scale").Do().Into(result)
 	return
 }
 
-// Update updates an existing deploymentConfig
+// UpdateScale scales an existing deploymentConfig via its scale subresource
 func (c *deploymentConfigs) UpdateScale(scale *extensions.Scale) (result *extensions.Scale, err error) {
 	result = &extensions.Scale{}
 
@@ -127,5 +129,12 @@ func (c *deploymentConfigs) UpdateScale(scale *extensions.Scale) (result *extens
 	}
 
 	err = c.r.Put().Namespace(c.ns).Resource("deploymentConfigs").Name(scale.Name).SubResource("scale").Body(encodedBytes).Do().Into(result)
+	return
+}
+
+// UpdateStatus updates the status for an existing deploymentConfig.
+func (c *deploymentConfigs) UpdateStatus(deploymentConfig *deployapi.DeploymentConfig) (result *deployapi.DeploymentConfig, err error) {
+	result = &deployapi.DeploymentConfig{}
+	err = c.r.Put().Namespace(c.ns).Resource("deploymentConfigs").Name(deploymentConfig.Name).SubResource("status").Body(deploymentConfig).Do().Into(result)
 	return
 }

--- a/pkg/client/testclient/fake_deploymentconfigs.go
+++ b/pkg/client/testclient/fake_deploymentconfigs.go
@@ -63,7 +63,6 @@ func (c *FakeDeploymentConfigs) Watch(opts kapi.ListOptions) (watch.Interface, e
 
 func (c *FakeDeploymentConfigs) Generate(name string) (*deployapi.DeploymentConfig, error) {
 	obj, err := c.Fake.Invokes(ktestclient.NewGetAction("generatedeploymentconfigs", c.Namespace, name), &deployapi.DeploymentConfig{})
-
 	if obj == nil {
 		return nil, err
 	}
@@ -96,4 +95,13 @@ func (c *FakeDeploymentConfigs) UpdateScale(inObj *extensions.Scale) (*extension
 	}
 
 	return obj.(*extensions.Scale), err
+}
+
+func (c *FakeDeploymentConfigs) UpdateStatus(inObj *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewUpdateAction("deploymentconfigs/status", c.Namespace, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*deployapi.DeploymentConfig), err
 }

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -65,9 +65,8 @@ func TestCmdDeploy_latestOk(t *testing.T) {
 		if updatedConfig == nil {
 			t.Fatalf("expected updated config")
 		}
-
-		if e, a := 2, updatedConfig.Status.LatestVersion; e != a {
-			t.Fatalf("expected updated config version %d, got %d", e, a)
+		if !deployutil.IsInstantiated(updatedConfig) {
+			t.Fatalf("expected deployment config instantiation")
 		}
 	}
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -374,7 +374,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	buildConfigStorage := buildconfigetcd.NewREST(c.EtcdHelper)
 	buildConfigRegistry := buildconfigregistry.NewRegistry(buildConfigStorage)
 
-	deployConfigStorage, deployConfigScaleStorage := deployconfigetcd.NewREST(c.EtcdHelper, c.DeploymentConfigScaleClient())
+	deployConfigStorage, deployConfigStatusStorage, deployConfigScaleStorage := deployconfigetcd.NewREST(c.EtcdHelper, c.DeploymentConfigScaleClient())
 	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage)
 
 	routeAllocator := c.RouteAllocator()
@@ -500,6 +500,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 		"deploymentConfigs":         deployConfigStorage,
 		"deploymentConfigs/scale":   deployConfigScaleStorage,
+		"deploymentConfigs/status":  deployConfigStatusStorage,
 		"generateDeploymentConfigs": deployconfiggenerator.NewREST(deployConfigGenerator, c.EtcdHelper.Codec()),
 		"deploymentConfigRollbacks": deployrollback.NewREST(deployRollbackClient, c.EtcdHelper.Codec()),
 		"deploymentConfigs/log":     deploylogregistry.NewREST(configClient, kclient, c.DeploymentLogClient(), kubeletClient),

--- a/pkg/deploy/api/deep_copy_generated.go
+++ b/pkg/deploy/api/deep_copy_generated.go
@@ -192,6 +192,7 @@ func DeepCopy_api_DeploymentConfigStatus(in DeploymentConfigStatus, out *Deploym
 	} else {
 		out.Details = nil
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -238,6 +238,9 @@ const (
 	// DeploymentReplicasAnnotation is for internal use only and is for
 	// detecting external modifications to deployment replica counts.
 	DeploymentReplicasAnnotation = "openshift.io/deployment.replicas"
+	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
+	// The annotation value does not matter and its mere presence indicates instantiation.
+	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
 	// PostHookPodSuffix is the suffix added to all pre hook pods
 	PreHookPodSuffix = "hook-pre"
 	// PostHookPodSuffix is the suffix added to all mid hook pods
@@ -263,6 +266,10 @@ const MaxDeploymentDurationSeconds int64 = 21600
 // DeploymentCancelledAnnotationValue represents the value for the DeploymentCancelledAnnotation
 // annotation that signifies that the deployment should be cancelled
 const DeploymentCancelledAnnotationValue = "true"
+
+// DeploymentInstantiatedAnnotationValue represents the value for the DeploymentInstantiatedAnnotation
+// annotation that signifies that the deployment should be instantiated.
+const DeploymentInstantiatedAnnotationValue = "true"
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -313,6 +313,8 @@ type DeploymentConfigStatus struct {
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/api/v1/conversion_generated.go
+++ b/pkg/deploy/api/v1/conversion_generated.go
@@ -477,6 +477,7 @@ func autoConvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *Dep
 	} else {
 		out.Details = nil
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -498,6 +499,7 @@ func autoConvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in *dep
 	} else {
 		out.Details = nil
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/v1/deep_copy_generated.go
+++ b/pkg/deploy/api/v1/deep_copy_generated.go
@@ -191,6 +191,7 @@ func DeepCopy_v1_DeploymentConfigStatus(in DeploymentConfigStatus, out *Deployme
 	} else {
 		out.Details = nil
 	}
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -93,9 +93,10 @@ func (DeploymentConfigSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentConfigStatus = map[string]string{
-	"":              "DeploymentConfigStatus represents the current deployment state.",
-	"latestVersion": "LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig is out of sync.",
-	"details":       "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger",
+	"":                   "DeploymentConfigStatus represents the current deployment state.",
+	"latestVersion":      "LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig is out of sync.",
+	"details":            "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger",
+	"observedGeneration": "ObservedGeneration is the most recent generation observed by the controller.",
 }
 
 func (DeploymentConfigStatus) SwaggerDoc() map[string]string {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -281,6 +281,8 @@ type DeploymentConfigStatus struct {
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty"`
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -229,6 +229,9 @@ const (
 	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
 	// The annotation value does not matter and its mere presence indicates cancellation
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
+	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
+	// The annotation value does not matter and its mere presence indicates instantiation.
+	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
 )
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -229,6 +229,9 @@ const (
 	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
 	// The annotation value does not matter and its mere presence indicates cancellation
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
+	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
+	// The annotation value does not matter and its mere presence indicates instantiation.
+	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
 )
 
 // These constants represent the various reasons for cancelling a deployment

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -296,6 +296,8 @@ type DeploymentConfigStatus struct {
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty"`
+	// ObservedGeneration is the most recent generation observed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -7,7 +7,9 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
+	osclient "github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -18,8 +20,9 @@ import (
 //
 // Use the DeploymentConfigChangeControllerFactory to create this controller.
 type DeploymentConfigChangeController struct {
-	// changeStrategy knows how to generate and update DeploymentConfigs.
-	changeStrategy changeStrategy
+	client  osclient.Interface
+	kClient kclient.Interface
+
 	// decodeConfig knows how to decode the deploymentConfig from a deployment's annotations.
 	decodeConfig func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error)
 }
@@ -34,7 +37,7 @@ func (e fatalError) Error() string {
 // Handle processes change triggers for config.
 func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentConfig) error {
 	if !deployutil.HasChangeTrigger(config) {
-		glog.V(5).Infof("Ignoring DeploymentConfig %s; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
+		glog.V(5).Infof("Ignoring deployment config %q; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -42,38 +45,38 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 		_, _, abort, err := c.generateDeployment(config)
 		if err != nil {
 			if kerrors.IsConflict(err) {
-				return fatalError(fmt.Sprintf("DeploymentConfig %s updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
+				return fatalError(fmt.Sprintf("deployment config %q updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
 			}
-			glog.V(4).Infof("Couldn't create initial deployment for deploymentConfig %q: %v", deployutil.LabelForDeploymentConfig(config), err)
+			glog.V(4).Infof("Couldn't create initial deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
 			return nil
 		}
 		if !abort {
-			glog.V(4).Infof("Created initial deployment for deploymentConfig %q", deployutil.LabelForDeploymentConfig(config))
+			glog.V(4).Infof("Created initial deployment for deployment config %q", deployutil.LabelForDeploymentConfig(config))
 		}
 		return nil
 	}
 
 	latestDeploymentName := deployutil.LatestDeploymentNameForConfig(config)
-	deployment, err := c.changeStrategy.getDeployment(config.Namespace, latestDeploymentName)
+	deployment, err := c.kClient.ReplicationControllers(config.Namespace).Get(latestDeploymentName)
 	if err != nil {
 		// If there's no deployment for the latest config, we have no basis of
 		// comparison. It's the responsibility of the deployment config controller
 		// to make the deployment for the config, so return early.
 		if kerrors.IsNotFound(err) {
-			glog.V(5).Infof("Ignoring change for DeploymentConfig %s; no existing Deployment found", deployutil.LabelForDeploymentConfig(config))
+			glog.V(5).Infof("Ignoring change for deployment config %q; no existing deployment found", deployutil.LabelForDeploymentConfig(config))
 			return nil
 		}
-		return fmt.Errorf("couldn't retrieve Deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't retrieve deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 
 	deployedConfig, err := c.decodeConfig(deployment)
 	if err != nil {
-		return fatalError(fmt.Sprintf("error decoding DeploymentConfig from Deployment %s for DeploymentConfig %s: %v", deployutil.LabelForDeployment(deployment), deployutil.LabelForDeploymentConfig(config), err))
+		return fatalError(fmt.Sprintf("error decoding deployment config from deployment %q for deployment config %s: %v", deployutil.LabelForDeployment(deployment), deployutil.LabelForDeploymentConfig(config), err))
 	}
 
 	// Detect template diffs, and return early if there aren't any changes.
 	if kapi.Semantic.DeepEqual(config.Spec.Template, deployedConfig.Spec.Template) {
-		glog.V(5).Infof("Ignoring DeploymentConfig change for %s (latestVersion=%d); same as Deployment %s", deployutil.LabelForDeploymentConfig(config), config.Status.LatestVersion, deployutil.LabelForDeployment(deployment))
+		glog.V(5).Infof("Ignoring deployment config change for %q (latestVersion=%d); same as deployment %q", deployutil.LabelForDeploymentConfig(config), config.Status.LatestVersion, deployutil.LabelForDeployment(deployment))
 		return nil
 	}
 
@@ -81,18 +84,18 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 	fromVersion, toVersion, abort, err := c.generateDeployment(config)
 	if err != nil {
 		if kerrors.IsConflict(err) {
-			return fatalError(fmt.Sprintf("DeploymentConfig %s updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
+			return fatalError(fmt.Sprintf("deployment config %q updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
 		}
-		return fmt.Errorf("couldn't generate deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't generate deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 	if !abort {
-		glog.V(4).Infof("Updated DeploymentConfig %s from version %d to %d for existing deployment %s", deployutil.LabelForDeploymentConfig(config), fromVersion, toVersion, deployutil.LabelForDeployment(deployment))
+		glog.V(4).Infof("Updated deployment config %q from version %d to %d for existing deployment %s", deployutil.LabelForDeploymentConfig(config), fromVersion, toVersion, deployutil.LabelForDeployment(deployment))
 	}
 	return nil
 }
 
 func (c *DeploymentConfigChangeController) generateDeployment(config *deployapi.DeploymentConfig) (int, int, bool, error) {
-	newConfig, err := c.changeStrategy.generateDeploymentConfig(config.Namespace, config.Name)
+	newConfig, err := c.client.DeploymentConfigs(config.Namespace).Generate(config.Name)
 	if err != nil {
 		return -1, -1, false, err
 	}
@@ -122,36 +125,10 @@ func (c *DeploymentConfigChangeController) generateDeployment(config *deployapi.
 	// This update is atomic. If it fails because a newer resource was already persisted, that's
 	// okay - we can just ignore the update for the old resource and any changes to the more
 	// current config will be captured in future events.
-	updatedConfig, err := c.changeStrategy.updateDeploymentConfig(config.Namespace, newConfig)
+	updatedConfig, err := c.client.DeploymentConfigs(config.Namespace).UpdateStatus(newConfig)
 	if err != nil {
 		return config.Status.LatestVersion, newConfig.Status.LatestVersion, false, err
 	}
 
 	return config.Status.LatestVersion, updatedConfig.Status.LatestVersion, false, nil
-}
-
-// changeStrategy knows how to generate and update DeploymentConfigs.
-type changeStrategy interface {
-	getDeployment(namespace, name string) (*kapi.ReplicationController, error)
-	generateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
-	updateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-}
-
-// changeStrategyImpl is a pluggable changeStrategy.
-type changeStrategyImpl struct {
-	getDeploymentFunc            func(namespace, name string) (*kapi.ReplicationController, error)
-	generateDeploymentConfigFunc func(namespace, name string) (*deployapi.DeploymentConfig, error)
-	updateDeploymentConfigFunc   func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-}
-
-func (i *changeStrategyImpl) getDeployment(namespace, name string) (*kapi.ReplicationController, error) {
-	return i.getDeploymentFunc(namespace, name)
-}
-
-func (i *changeStrategyImpl) generateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error) {
-	return i.generateDeploymentConfigFunc(namespace, name)
-}
-
-func (i *changeStrategyImpl) updateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-	return i.updateDeploymentConfigFunc(namespace, config)
 }

--- a/pkg/deploy/controller/configchange/factory.go
+++ b/pkg/deploy/controller/configchange/factory.go
@@ -46,17 +46,8 @@ func (factory *DeploymentConfigChangeControllerFactory) Create() controller.Runn
 	eventBroadcaster.StartRecordingToSink(factory.KubeClient.Events(""))
 
 	changeController := &DeploymentConfigChangeController{
-		changeStrategy: &changeStrategyImpl{
-			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return factory.KubeClient.ReplicationControllers(namespace).Get(name)
-			},
-			generateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				return factory.Client.DeploymentConfigs(namespace).Generate(name)
-			},
-			updateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-				return factory.Client.DeploymentConfigs(namespace).Update(config)
-			},
-		},
+		client:  factory.Client,
+		kClient: factory.KubeClient,
 		decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
 			return deployutil.DecodeDeploymentConfig(deployment, factory.Codec)
 		},

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -67,7 +67,7 @@ func NewDeploymentConfigController(kubeClient kclient.Interface, osClient osclie
 func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) error {
 	// There's nothing to reconcile until the version is nonzero.
 	if config.Status.LatestVersion == 0 {
-		glog.V(5).Infof("Waiting for first version of %s", deployutil.LabelForDeploymentConfig(config))
+		glog.V(5).Infof("Waiting for first version of %q", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -136,10 +136,8 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		return fmt.Errorf("couldn't create deployment for deployment config %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 	c.recorder.Eventf(config, kapi.EventTypeNormal, "DeploymentCreated", "Created new deployment %q for version %d", created.Name, config.Status.LatestVersion)
-	// Supposedly we have to update the dc status here; will get the separate status call with https://github.com/openshift/origin/pull/6479
-	config.Status.ObservedGeneration = int(config.Generation)
-	_, err = c.osClient.DeploymentConfigs(config.Namespace).Update(config)
-	return err
+
+	return c.updateStatus(config)
 }
 
 // reconcileDeployments reconciles existing deployment replica counts which
@@ -264,8 +262,18 @@ func (c *DeploymentConfigController) reconcileDeployments(existingDeployments *k
 			}
 		}
 	}
-	// Supposedly we have to update the dc status here; will get the separate status call with https://github.com/openshift/origin/pull/6479
-	config.Status.ObservedGeneration = int(config.Generation)
-	_, err := c.osClient.DeploymentConfigs(config.Namespace).Update(config)
-	return err
+
+	return c.updateStatus(config)
+}
+
+func (c *DeploymentConfigController) updateStatus(config *deployapi.DeploymentConfig) error {
+	if config.Generation > config.Status.ObservedGeneration {
+		config.Status.ObservedGeneration = config.Generation
+	}
+	if _, err := c.osClient.DeploymentConfigs(config.Namespace).UpdateStatus(config); err != nil {
+		glog.V(2).Infof("Cannot update the status for %q: %v", deployutil.LabelForDeploymentConfig(config), err)
+		return transientError(fmt.Sprintf("cannot update the status for %q - requeuing", deployutil.LabelForDeploymentConfig(config)))
+	}
+	glog.V(4).Infof("Updated the status for %q (observed generation: %d)", deployutil.LabelForDeploymentConfig(config), config.Status.ObservedGeneration)
+	return nil
 }

--- a/pkg/deploy/registry/deployconfig/etcd/etcd_test.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd_test.go
@@ -17,7 +17,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	storage, _ := NewREST(etcdStorage, testclient.NewSimpleFake())
+	storage, _, _ := NewREST(etcdStorage, testclient.NewSimpleFake())
 	return storage, server
 }
 

--- a/pkg/deploy/registry/deployconfig/strategy_test.go
+++ b/pkg/deploy/registry/deployconfig/strategy_test.go
@@ -1,9 +1,11 @@
 package deployconfig
 
 import (
+	"reflect"
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
@@ -27,7 +29,7 @@ func TestDeploymentConfigStrategy(t *testing.T) {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
 	updatedDeploymentConfig := &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "default"},
+		ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "default", Generation: 1},
 		Spec:       deploytest.OkDeploymentConfigSpec(),
 	}
 	errs = Strategy.ValidateUpdate(ctx, updatedDeploymentConfig, deploymentConfig)
@@ -46,4 +48,93 @@ func TestDeploymentConfigStrategy(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("Expected error validating")
 	}
+}
+
+// TestPrepareForUpdate exercises updates made by both old and new clients.
+func TestPrepareForUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+
+		prev     runtime.Object
+		after    runtime.Object
+		expected runtime.Object
+	}{
+		{
+			name:     "old client update",
+			prev:     prevDeployment(),
+			after:    afterDeploymentByOldClient(),
+			expected: expectedAfterByOldClient(),
+		},
+		{
+			name:     "new client update",
+			prev:     prevDeployment(),
+			after:    afterDeploymentByNewClient(),
+			expected: expectedAfterByNewClient(),
+		},
+		{
+			name:     "spec change",
+			prev:     prevDeployment(),
+			after:    afterDeployment(),
+			expected: expectedAfterDeployment(),
+		},
+	}
+
+	for _, test := range tests {
+		strategy{}.PrepareForUpdate(test.after, test.prev)
+		if !reflect.DeepEqual(test.expected, test.after) {
+			t.Errorf("%s: unexpected object mismatch! Expected:\n%#v\ngot:\n%#v", test.name, test.expected, test.after)
+		}
+	}
+}
+
+// prevDeployment is the old object tested for both old and new client updates.
+func prevDeployment() *deployapi.DeploymentConfig {
+	return &deployapi.DeploymentConfig{
+		ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "default", Generation: 4, Annotations: make(map[string]string)},
+		Spec:       deploytest.OkDeploymentConfigSpec(),
+		Status:     deploytest.OkDeploymentConfigStatus(1),
+	}
+}
+
+// afterDeployment is used for a spec change check.
+func afterDeployment() *deployapi.DeploymentConfig {
+	dc := prevDeployment()
+	dc.Spec.Replicas++
+	return dc
+}
+
+// expectedAfterDeployment is used for a spec change check.
+func expectedAfterDeployment() *deployapi.DeploymentConfig {
+	dc := afterDeployment()
+	dc.Generation++
+	return dc
+}
+
+// afterDeploymentByOldClient is a deployment updated by an old oc client.
+func afterDeploymentByOldClient() *deployapi.DeploymentConfig {
+	dc := prevDeployment()
+	dc.Status.LatestVersion++
+	return dc
+}
+
+// expectedAfterByOldClient is the object we expect from the update hook after an old client update.
+func expectedAfterByOldClient() *deployapi.DeploymentConfig {
+	dc := afterDeploymentByOldClient()
+	dc.Generation++
+	return dc
+}
+
+// afterDeploymentByNewClient is a deployment updated by an new oc client.
+func afterDeploymentByNewClient() *deployapi.DeploymentConfig {
+	dc := prevDeployment()
+	dc.Annotations[deployapi.DeploymentInstantiatedAnnotation] = deployapi.DeploymentInstantiatedAnnotationValue
+	return dc
+}
+
+// expectedAfterByNewClient is the object we expect from the update hook after a new client update.
+func expectedAfterByNewClient() *deployapi.DeploymentConfig {
+	dc := prevDeployment()
+	dc.Status.LatestVersion++
+	dc.Generation++
+	return dc
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -208,7 +208,9 @@ tryuntil oc get rc/failing-dc-mid-1
 oc logs -f dc/failing-dc-mid
 wait_for_command "oc get rc/failing-dc-mid-1 --template={{.metadata.annotations}} | grep openshift.io/deployment.phase:Failed" $((60*TIME_SEC))
 os::cmd::expect_success_and_text 'oc logs dc/failing-dc-mid' 'test mid hook executed'
-oc deploy failing-dc-mid --latest
+# The following command is the equivalent of 'oc deploy --latest' on old clients
+# Ensures we won't break those while removing the dc status update from oc
+os::cmd::expect_success "oc patch dc/failing-dc-mid -p '{\"status\":{\"latestVersion\":2}}'"
 os::cmd::expect_success_and_text 'oc logs --version=1 dc/failing-dc-mid' 'test mid hook executed'
 os::cmd::expect_success_and_text 'oc logs --previous dc/failing-dc-mid'  'test mid hook executed'
 

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/wait"
-
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -426,3 +425,74 @@ func waitForLatestCondition(oc *exutil.CLI, name string, timeout time.Duration, 
 		return fn(dc, rcs)
 	})
 }
+
+var _ = g.Describe("deployments: parallel: deployment generation", func() {
+	defer g.GinkgoRecover()
+	var (
+		generationFixture = exutil.FixturePath("..", "extended", "fixtures", "test-deployment.yaml")
+		oc                = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
+	)
+
+	g.Describe("deployment generation", func() {
+		g.It("should deploy based on a status version bump", func() {
+			resource, err := oc.Run("create").Args("-f", generationFixture, "-o", "name").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			parts := strings.Split(resource, "/")
+			if len(parts) != 2 {
+				o.Expect(fmt.Errorf("expected type/name syntax, got: %s", resource)).NotTo(o.HaveOccurred())
+			}
+			dcName := parts[1]
+
+			g.By("verifying that both latestVersion and generation are updated")
+			version, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.latestVersion}\"").Output()
+			version = strings.Trim(version, "\"")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the latest version for %s: %s", resource, version))
+			o.Expect(version).To(o.ContainSubstring("1"))
+			generation, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.metadata.generation}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the generation for %s: %s", resource, generation))
+			o.Expect(generation).To(o.ContainSubstring("1"))
+
+			g.By("verifying the deployment is marked complete")
+			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get(dcName + "-" + version)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				return deployutil.IsTerminatedDeployment(rc), nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that scaling updates the generation")
+			_, err = oc.Run("scale").Args(resource, "--replicas=2").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			generation, err = oc.Run("get").Args(resource, "--output=jsonpath=\"{.metadata.generation}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the generation for %s: %s", resource, generation))
+			o.Expect(generation).To(o.ContainSubstring("2"))
+
+			g.By("deploying a second time [new client]")
+			_, err = oc.Run("deploy").Args("--latest", dcName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that both latestVersion and generation are updated")
+			version, err = oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.latestVersion}\"").Output()
+			version = strings.Trim(version, "\"")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the latest version for %s: %s", resource, version))
+			o.Expect(version).To(o.ContainSubstring("2"))
+			generation, err = oc.Run("get").Args(resource, "--output=jsonpath=\"{.metadata.generation}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("checking the generation for %s: %s", resource, generation))
+			o.Expect(generation).To(o.ContainSubstring("3"))
+
+			g.By("verifying the second deployment is marked complete")
+			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get(dcName + "-" + version)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				return deployutil.IsTerminatedDeployment(rc), nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+	})
+})

--- a/test/extended/fixtures/test-deployment.yaml
+++ b/test/extended/fixtures/test-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: gentest
+spec:
+  replicas: 1
+  selector:
+    name: gentest
+  strategy:
+    type: Rolling
+    rollingParams:
+      pre:
+        failurePolicy: Abort
+        execNewPod:
+          containerName: myapp
+          command:
+          - /bin/echo
+          - test pre hook executed
+  template:
+    metadata:
+      labels:
+        name: gentest
+    spec:
+      containers:
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        command:
+        - /bin/sleep
+        - "100"
+  triggers:
+  - type: ConfigChange

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -64,6 +64,7 @@ items:
     - deploymentconfigs
     - deploymentconfigs/log
     - deploymentconfigs/scale
+    - deploymentconfigs/status
     - endpoints
     - events
     - generatedeploymentconfigs
@@ -367,6 +368,7 @@ items:
     resources:
     - bindings
     - configmaps
+    - deploymentconfigs/status
     - endpoints
     - events
     - imagestreams/status
@@ -543,6 +545,7 @@ items:
     resources:
     - bindings
     - configmaps
+    - deploymentconfigs/status
     - endpoints
     - events
     - imagestreams/status
@@ -600,6 +603,7 @@ items:
     - deploymentconfigs
     - deploymentconfigs/log
     - deploymentconfigs/scale
+    - deploymentconfigs/status
     - endpoints
     - events
     - generatedeploymentconfigs


### PR DESCRIPTION
This PR adds generation numbers and separate status call for DCs.

@smarterclayton @ironcladlou @deads2k @liggitt @openshift/api-review 

Closes https://github.com/openshift/origin/issues/6337
Closes https://github.com/openshift/origin/issues/6465