### PR TITLE
Remove custom SIGQUIT handler

### DIFF
--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -1,12 +1,6 @@
 package builder
 
 import (
-	"os"
-	"os/signal"
-	"runtime"
-	"syscall"
-
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/build/builder/cmd"
@@ -34,18 +28,6 @@ func NewCommandSTIBuilder(name string) *cobra.Command {
 		Short: "Run a Source-to-Image build",
 		Long:  stiBuilderLong,
 		Run: func(c *cobra.Command, args []string) {
-			go func() {
-				for {
-					sigs := make(chan os.Signal, 1)
-					signal.Notify(sigs, syscall.SIGQUIT)
-					buf := make([]byte, 1<<20)
-					for {
-						<-sigs
-						runtime.Stack(buf, true)
-						glog.Infof("=== received SIGQUIT ===\n*** goroutine dump...\n%s\n*** end\n", buf)
-					}
-				}
-			}()
 			cmd.RunSTIBuild()
 		},
 	}


### PR DESCRIPTION
Go prints a stack trace of all goroutines by default on SIGQUIT, except those related to the runtime.
To include all goroutines, set GOTRACEBACK=2 or GOTRACEBACK=crash.

http://stackoverflow.com/a/35290196/4804690