### PR TITLE
Fix restmapper

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/errors.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/errors.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// AmbiguousResourceError is returned if the RESTMapper finds multiple matches for a resource
+type AmbiguousResourceError struct {
+	PartialResource unversioned.GroupVersionResource
+
+	MatchingResources []unversioned.GroupVersionResource
+	MatchingKinds     []unversioned.GroupVersionKind
+}
+
+func (e *AmbiguousResourceError) Error() string {
+	switch {
+	case len(e.MatchingKinds) > 0 && len(e.MatchingResources) > 0:
+		return fmt.Sprintf("%v matches multiple resources %v and kinds %v", e.PartialResource, e.MatchingResources, e.MatchingKinds)
+	case len(e.MatchingKinds) > 0:
+		return fmt.Sprintf("%v matches multiple kinds %v", e.PartialResource, e.MatchingKinds)
+	case len(e.MatchingResources) > 0:
+		return fmt.Sprintf("%v matches multiple resources %v", e.PartialResource, e.MatchingResources)
+
+	}
+
+	return fmt.Sprintf("%v matches multiple resources or kinds", e.PartialResource)
+}
+
+func IsAmbiguousResourceError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*AmbiguousResourceError)
+	return ok
+}
+
+// NoResourceMatchError is returned if the RESTMapper can't find any match for a resource
+type NoResourceMatchError struct {
+	PartialResource unversioned.GroupVersionResource
+}
+
+func (e *NoResourceMatchError) Error() string {
+	return fmt.Sprintf("no matches for %v", e.PartialResource)
+}
+
+func IsNoResourceMatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*NoResourceMatchError)
+	return ok
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/multirestmapper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/multirestmapper.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+)
+
+// MultiRESTMapper is a wrapper for multiple RESTMappers.
+type MultiRESTMapper []RESTMapper
+
+func (m MultiRESTMapper) String() string {
+	nested := []string{}
+	for _, t := range m {
+		currString := fmt.Sprintf("%v", t)
+		splitStrings := strings.Split(currString, "\n")
+		nested = append(nested, strings.Join(splitStrings, "\n\t"))
+	}
+
+	return fmt.Sprintf("MultiRESTMapper{\n\t%s\n}", strings.Join(nested, "\n\t"))
+}
+
+// ResourceSingularizer converts a REST resource name from plural to singular (e.g., from pods to pod)
+// This implementation supports multiple REST schemas and return the first match.
+func (m MultiRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	for _, t := range m {
+		singular, err = t.ResourceSingularizer(resource)
+		if err == nil {
+			return
+		}
+	}
+	return
+}
+
+func (m MultiRESTMapper) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	allGVRs := []unversioned.GroupVersionResource{}
+	for _, t := range m {
+		gvrs, err := t.ResourcesFor(resource)
+		// ignore "no match" errors, but any other error percolates back up
+		if err != nil && !IsNoResourceMatchError(err) {
+			return nil, err
+		}
+
+		// walk the existing values to de-dup
+		for _, curr := range gvrs {
+			found := false
+			for _, existing := range allGVRs {
+				if curr == existing {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				allGVRs = append(allGVRs, curr)
+			}
+		}
+	}
+
+	if len(allGVRs) == 0 {
+		return nil, &NoResourceMatchError{PartialResource: resource}
+	}
+
+	return allGVRs, nil
+}
+
+func (m MultiRESTMapper) KindsFor(resource unversioned.GroupVersionResource) (gvk []unversioned.GroupVersionKind, err error) {
+	allGVKs := []unversioned.GroupVersionKind{}
+	for _, t := range m {
+		gvks, err := t.KindsFor(resource)
+		// ignore "no match" errors, but any other error percolates back up
+		if err != nil && !IsNoResourceMatchError(err) {
+			return nil, err
+		}
+
+		// walk the existing values to de-dup
+		for _, curr := range gvks {
+			found := false
+			for _, existing := range allGVKs {
+				if curr == existing {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				allGVKs = append(allGVKs, curr)
+			}
+		}
+	}
+
+	if len(allGVKs) == 0 {
+		return nil, &NoResourceMatchError{PartialResource: resource}
+	}
+
+	return allGVKs, nil
+}
+
+func (m MultiRESTMapper) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	resources, err := m.ResourcesFor(resource)
+	if err != nil {
+		return unversioned.GroupVersionResource{}, err
+	}
+	if len(resources) == 1 {
+		return resources[0], nil
+	}
+
+	preferredResources := getMostPreferredVersionForResource(resources)
+	if len(preferredResources) == 1 {
+		return preferredResources[0], nil
+	}
+
+	return unversioned.GroupVersionResource{}, &AmbiguousResourceError{PartialResource: resource, MatchingResources: resources}
+}
+
+func (m MultiRESTMapper) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
+	kinds, err := m.KindsFor(resource)
+	if err != nil {
+		return unversioned.GroupVersionKind{}, err
+	}
+	if len(kinds) == 1 {
+		return kinds[0], nil
+	}
+
+	// TODO for each group, choose the most preferred (first) version.  This keeps us consistent with code today.
+	// eventually, we'll need a RESTMapper that is aware of what's available server-side and deconflicts that with
+	// user preferences
+	preferredKinds := getMostPreferredVersionForKind(kinds)
+	if len(preferredKinds) == 1 {
+		return preferredKinds[0], nil
+	}
+
+	return unversioned.GroupVersionKind{}, &AmbiguousResourceError{PartialResource: resource, MatchingKinds: kinds}
+}
+
+// RESTMapping provides the REST mapping for the resource based on the
+// kind and version. This implementation supports multiple REST schemas and
+// return the first match.
+func (m MultiRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...string) (*RESTMapping, error) {
+	allMappings := []*RESTMapping{}
+	errors := []error{}
+
+	for _, t := range m {
+		currMapping, err := t.RESTMapping(gk, versions...)
+		// ignore "no match" errors, but any other error percolates back up
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+
+		allMappings = append(allMappings, currMapping)
+	}
+
+	// if we got exactly one mapping, then use it even if other requested failed
+	if len(allMappings) == 1 {
+		return allMappings[0], nil
+	}
+	if len(errors) > 0 {
+		return nil, utilerrors.NewAggregate(errors)
+	}
+	if len(allMappings) == 0 {
+		return nil, fmt.Errorf("no match found for %v in %v", gk, versions)
+	}
+
+	return nil, fmt.Errorf("multiple matches found for %v in %v", gk, versions)
+}
+
+// AliasesForResource finds the first alias response for the provided mappers.
+func (m MultiRESTMapper) AliasesForResource(alias string) ([]string, bool) {
+	allAliases := []string{}
+	handled := false
+
+	for _, t := range m {
+		if currAliases, currOk := t.AliasesForResource(alias); currOk {
+			allAliases = append(allAliases, currAliases...)
+			handled = true
+		}
+	}
+	return allAliases, handled
+}
+
+// ResourceIsValid takes a string (either group/kind or kind) and checks if it's a valid resource
+func (m MultiRESTMapper) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
+	for _, t := range m {
+		if t.ResourceIsValid(resource) {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/multirestmapper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/multirestmapper_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+func TestMultiRESTMapperResourceFor(t *testing.T) {
+	tcs := []struct {
+		name string
+
+		mapper MultiRESTMapper
+		input  unversioned.GroupVersionResource
+		result unversioned.GroupVersionResource
+		err    error
+	}{
+		{
+			name:   "empty",
+			mapper: MultiRESTMapper{},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionResource{},
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "ignore not found",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionResource{},
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "accept first failure",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: errors.New("fail on this")}, fixedRESTMapper{resourcesFor: []unversioned.GroupVersionResource{{Resource: "unused"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionResource{},
+			err:    errors.New("fail on this"),
+		},
+	}
+
+	for _, tc := range tcs {
+		actualResult, actualErr := tc.mapper.ResourceFor(tc.input)
+		if e, a := tc.result, actualResult; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+		switch {
+		case tc.err == nil && actualErr == nil:
+		case tc.err == nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case actualErr == nil:
+			t.Errorf("%s: expected error: %v got nil", tc.name, tc.err)
+		case tc.err.Error() != actualErr.Error():
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+		}
+	}
+}
+
+func TestMultiRESTMapperResourcesFor(t *testing.T) {
+	tcs := []struct {
+		name string
+
+		mapper MultiRESTMapper
+		input  unversioned.GroupVersionResource
+		result []unversioned.GroupVersionResource
+		err    error
+	}{
+		{
+			name:   "empty",
+			mapper: MultiRESTMapper{},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "ignore not found",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "accept first failure",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: errors.New("fail on this")}, fixedRESTMapper{resourcesFor: []unversioned.GroupVersionResource{{Resource: "unused"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    errors.New("fail on this"),
+		},
+		{
+			name: "union and dedup",
+			mapper: MultiRESTMapper{
+				fixedRESTMapper{resourcesFor: []unversioned.GroupVersionResource{{Resource: "dupe"}, {Resource: "first"}}},
+				fixedRESTMapper{resourcesFor: []unversioned.GroupVersionResource{{Resource: "dupe"}, {Resource: "second"}}},
+			},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: []unversioned.GroupVersionResource{{Resource: "dupe"}, {Resource: "first"}, {Resource: "second"}},
+		},
+		{
+			name: "skip not and continue",
+			mapper: MultiRESTMapper{
+				fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}},
+				fixedRESTMapper{resourcesFor: []unversioned.GroupVersionResource{{Resource: "first"}, {Resource: "second"}}},
+			},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: []unversioned.GroupVersionResource{{Resource: "first"}, {Resource: "second"}},
+		},
+	}
+
+	for _, tc := range tcs {
+		actualResult, actualErr := tc.mapper.ResourcesFor(tc.input)
+		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+		switch {
+		case tc.err == nil && actualErr == nil:
+		case tc.err == nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case actualErr == nil:
+			t.Errorf("%s: expected error: %v got nil", tc.name, tc.err)
+		case tc.err.Error() != actualErr.Error():
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+		}
+	}
+}
+
+func TestMultiRESTMapperKindsFor(t *testing.T) {
+	tcs := []struct {
+		name string
+
+		mapper MultiRESTMapper
+		input  unversioned.GroupVersionResource
+		result []unversioned.GroupVersionKind
+		err    error
+	}{
+		{
+			name:   "empty",
+			mapper: MultiRESTMapper{},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "ignore not found",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "accept first failure",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: errors.New("fail on this")}, fixedRESTMapper{kindsFor: []unversioned.GroupVersionKind{{Kind: "unused"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: nil,
+			err:    errors.New("fail on this"),
+		},
+		{
+			name: "union and dedup",
+			mapper: MultiRESTMapper{
+				fixedRESTMapper{kindsFor: []unversioned.GroupVersionKind{{Kind: "dupe"}, {Kind: "first"}}},
+				fixedRESTMapper{kindsFor: []unversioned.GroupVersionKind{{Kind: "dupe"}, {Kind: "second"}}},
+			},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: []unversioned.GroupVersionKind{{Kind: "dupe"}, {Kind: "first"}, {Kind: "second"}},
+		},
+		{
+			name: "skip not and continue",
+			mapper: MultiRESTMapper{
+				fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}},
+				fixedRESTMapper{kindsFor: []unversioned.GroupVersionKind{{Kind: "first"}, {Kind: "second"}}},
+			},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: []unversioned.GroupVersionKind{{Kind: "first"}, {Kind: "second"}},
+		},
+	}
+
+	for _, tc := range tcs {
+		actualResult, actualErr := tc.mapper.KindsFor(tc.input)
+		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+		switch {
+		case tc.err == nil && actualErr == nil:
+		case tc.err == nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case actualErr == nil:
+			t.Errorf("%s: expected error: %v got nil", tc.name, tc.err)
+		case tc.err.Error() != actualErr.Error():
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+		}
+	}
+}
+
+func TestMultiRESTMapperKindFor(t *testing.T) {
+	tcs := []struct {
+		name string
+
+		mapper MultiRESTMapper
+		input  unversioned.GroupVersionResource
+		result unversioned.GroupVersionKind
+		err    error
+	}{
+		{
+			name:   "empty",
+			mapper: MultiRESTMapper{},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionKind{},
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "ignore not found",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "IGNORE_THIS"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionKind{},
+			err:    &NoResourceMatchError{PartialResource: unversioned.GroupVersionResource{Resource: "foo"}},
+		},
+		{
+			name:   "accept first failure",
+			mapper: MultiRESTMapper{fixedRESTMapper{err: errors.New("fail on this")}, fixedRESTMapper{kindsFor: []unversioned.GroupVersionKind{{Kind: "unused"}}}},
+			input:  unversioned.GroupVersionResource{Resource: "foo"},
+			result: unversioned.GroupVersionKind{},
+			err:    errors.New("fail on this"),
+		},
+	}
+
+	for _, tc := range tcs {
+		actualResult, actualErr := tc.mapper.KindFor(tc.input)
+		if e, a := tc.result, actualResult; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+		switch {
+		case tc.err == nil && actualErr == nil:
+		case tc.err == nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case actualErr == nil:
+			t.Errorf("%s: expected error: %v got nil", tc.name, tc.err)
+		case tc.err.Error() != actualErr.Error():
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+		}
+	}
+}
+
+type fixedRESTMapper struct {
+	resourcesFor []unversioned.GroupVersionResource
+	kindsFor     []unversioned.GroupVersionKind
+	resourceFor  unversioned.GroupVersionResource
+	kindFor      unversioned.GroupVersionKind
+
+	err error
+}
+
+func (m fixedRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return "", m.err
+}
+
+func (m fixedRESTMapper) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	return m.resourcesFor, m.err
+}
+
+func (m fixedRESTMapper) KindsFor(resource unversioned.GroupVersionResource) (gvk []unversioned.GroupVersionKind, err error) {
+	return m.kindsFor, m.err
+}
+
+func (m fixedRESTMapper) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	return m.resourceFor, m.err
+}
+
+func (m fixedRESTMapper) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
+	return m.kindFor, m.err
+}
+
+func (m fixedRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...string) (mapping *RESTMapping, err error) {
+	return nil, m.err
+}
+
+func (m fixedRESTMapper) AliasesForResource(alias string) (aliases []string, ok bool) {
+	return nil, false
+}
+
+func (m fixedRESTMapper) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
+	return false
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
@@ -228,23 +228,32 @@ func (m *DefaultRESTMapper) ResourcesFor(resource unversioned.GroupVersionResour
 
 	case hasGroup:
 		requestedGroupResource := resource.GroupResource()
-		for currResource := range m.pluralToSingular {
-			if currResource.GroupResource() == requestedGroupResource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.GroupResource() == requestedGroupResource {
+				ret = append(ret, plural)
+			}
+			if plural.GroupResource() == requestedGroupResource {
+				ret = append(ret, plural)
 			}
 		}
 
 	case hasVersion:
-		for currResource := range m.pluralToSingular {
-			if currResource.Version == resource.Version && currResource.Resource == resource.Resource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.Version == resource.Version && singular.Resource == resource.Resource {
+				ret = append(ret, plural)
+			}
+			if plural.Version == resource.Version && plural.Resource == resource.Resource {
+				ret = append(ret, plural)
 			}
 		}
 
 	default:
-		for currResource := range m.pluralToSingular {
-			if currResource.Resource == resource.Resource {
-				ret = append(ret, currResource)
+		for plural, singular := range m.pluralToSingular {
+			if singular.Resource == resource.Resource {
+				ret = append(ret, plural)
+			}
+			if plural.Resource == resource.Resource {
+				ret = append(ret, plural)
 			}
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Implements RESTScope interface
@@ -199,6 +198,11 @@ func (m *DefaultRESTMapper) ResourceSingularizer(resourceType string) (string, e
 }
 
 func (m *DefaultRESTMapper) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	resource.Resource = strings.ToLower(resource.Resource)
+	if resource.Version == runtime.APIVersionInternal {
+		resource.Version = ""
+	}
+
 	hasResource := len(resource.Resource) > 0
 	hasGroup := len(resource.Group) > 0
 	hasVersion := len(resource.Version) > 0
@@ -260,6 +264,11 @@ func (m *DefaultRESTMapper) ResourceFor(resource unversioned.GroupVersionResourc
 	}
 	if len(resources) == 1 {
 		return resources[0], nil
+	}
+
+	preferredResources := getMostPreferredVersionForResource(resources)
+	if len(preferredResources) == 1 {
+		return preferredResources[0], nil
 	}
 
 	return unversioned.GroupVersionResource{}, &AmbiguousResourceError{PartialResource: resource, MatchingResources: resources}
@@ -328,22 +337,60 @@ func (m *DefaultRESTMapper) KindFor(resource unversioned.GroupVersionResource) (
 	// TODO for each group, choose the most preferred (first) version.  This keeps us consistent with code today.
 	// eventually, we'll need a RESTMapper that is aware of what's available server-side and deconflicts that with
 	// user preferences
-	oneKindPerGroup := []unversioned.GroupVersionKind{}
-	groupsAdded := sets.String{}
-	for _, kind := range kinds {
-		if groupsAdded.Has(kind.Group) {
-			continue
-		}
-
-		oneKindPerGroup = append(oneKindPerGroup, kind)
-		groupsAdded.Insert(kind.Group)
-	}
-
-	if len(oneKindPerGroup) == 1 {
-		return oneKindPerGroup[0], nil
+	preferredKinds := getMostPreferredVersionForKind(kinds)
+	if len(preferredKinds) == 1 {
+		return preferredKinds[0], nil
 	}
 
 	return unversioned.GroupVersionKind{}, &AmbiguousResourceError{PartialResource: resource, MatchingKinds: kinds}
+}
+
+// getMostPreferredVersionForKind chooses the first group,version,kind for a given group,kind and skips the rest
+// this has the effect of choose the most preferred
+func getMostPreferredVersionForKind(kinds []unversioned.GroupVersionKind) []unversioned.GroupVersionKind {
+	observedGroupKinds := []unversioned.GroupKind{}
+	oneVersionPerGroupKind := []unversioned.GroupVersionKind{}
+	for _, kind := range kinds {
+		alreadyObserved := false
+		for _, currObserved := range observedGroupKinds {
+			if kind.GroupKind() == currObserved {
+				alreadyObserved = true
+				break
+			}
+		}
+		if alreadyObserved {
+			continue
+		}
+
+		observedGroupKinds = append(observedGroupKinds, kind.GroupKind())
+		oneVersionPerGroupKind = append(oneVersionPerGroupKind, kind)
+	}
+
+	return oneVersionPerGroupKind
+}
+
+// getMostPreferredVersionForResource chooses the first group,version,resource for a given group,resource and skips the rest
+// this has the effect of choose the most preferred
+func getMostPreferredVersionForResource(resources []unversioned.GroupVersionResource) []unversioned.GroupVersionResource {
+	observedGroupResources := []unversioned.GroupResource{}
+	oneVersionPerGroupResource := []unversioned.GroupVersionResource{}
+	for _, resource := range resources {
+		alreadyObserved := false
+		for _, currObserved := range observedGroupResources {
+			if resource.GroupResource() == currObserved {
+				alreadyObserved = true
+				break
+			}
+		}
+		if alreadyObserved {
+			continue
+		}
+
+		observedGroupResources = append(observedGroupResources, resource.GroupResource())
+		oneVersionPerGroupResource = append(oneVersionPerGroupResource, resource)
+	}
+
+	return oneVersionPerGroupResource
 }
 
 type kindByPreferredGroupVersion struct {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper.go
@@ -246,7 +246,7 @@ func (m *DefaultRESTMapper) ResourcesFor(resource unversioned.GroupVersionResour
 	}
 
 	if len(ret) == 0 {
-		return nil, fmt.Errorf("no resource %v has been defined; known resources: %v", resource, m.pluralToSingular)
+		return nil, &NoResourceMatchError{PartialResource: resource}
 	}
 
 	sort.Sort(resourceByPreferredGroupVersion{ret, m.defaultGroupVersions})
@@ -262,7 +262,7 @@ func (m *DefaultRESTMapper) ResourceFor(resource unversioned.GroupVersionResourc
 		return resources[0], nil
 	}
 
-	return unversioned.GroupVersionResource{}, fmt.Errorf("%v is ambiguous, got: %v", resource, resources)
+	return unversioned.GroupVersionResource{}, &AmbiguousResourceError{PartialResource: resource, MatchingResources: resources}
 }
 
 func (m *DefaultRESTMapper) KindsFor(input unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
@@ -312,7 +312,7 @@ func (m *DefaultRESTMapper) KindsFor(input unversioned.GroupVersionResource) ([]
 	}
 
 	if len(ret) == 0 {
-		return nil, fmt.Errorf("no kind %v has been defined; known resources: %v", resource, m.pluralToSingular)
+		return nil, &NoResourceMatchError{PartialResource: input}
 	}
 
 	sort.Sort(kindByPreferredGroupVersion{ret, m.defaultGroupVersions})
@@ -343,7 +343,7 @@ func (m *DefaultRESTMapper) KindFor(resource unversioned.GroupVersionResource) (
 		return oneKindPerGroup[0], nil
 	}
 
-	return unversioned.GroupVersionKind{}, fmt.Errorf("%v is ambiguous, got: %v", resource, kinds)
+	return unversioned.GroupVersionKind{}, &AmbiguousResourceError{PartialResource: resource, MatchingKinds: kinds}
 }
 
 type kindByPreferredGroupVersion struct {
@@ -521,107 +521,4 @@ func (m *DefaultRESTMapper) AliasesForResource(alias string) ([]string, bool) {
 func (m *DefaultRESTMapper) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
 	_, err := m.KindFor(resource)
 	return err == nil
-}
-
-// MultiRESTMapper is a wrapper for multiple RESTMappers.
-type MultiRESTMapper []RESTMapper
-
-func (m MultiRESTMapper) String() string {
-	nested := []string{}
-	for _, t := range m {
-		currString := fmt.Sprintf("%v", t)
-		splitStrings := strings.Split(currString, "\n")
-		nested = append(nested, strings.Join(splitStrings, "\n\t"))
-	}
-
-	return fmt.Sprintf("MultiRESTMapper{\n\t%s\n}", strings.Join(nested, "\n\t"))
-}
-
-// ResourceSingularizer converts a REST resource name from plural to singular (e.g., from pods to pod)
-// This implementation supports multiple REST schemas and return the first match.
-func (m MultiRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
-	for _, t := range m {
-		singular, err = t.ResourceSingularizer(resource)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func (m MultiRESTMapper) ResourcesFor(resource unversioned.GroupVersionResource) (gvk []unversioned.GroupVersionResource, err error) {
-	for _, t := range m {
-		gvk, err = t.ResourcesFor(resource)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-// KindsFor provides the Kind mappings for the REST resources. This implementation supports multiple REST schemas and returns
-// the first match.
-func (m MultiRESTMapper) KindsFor(resource unversioned.GroupVersionResource) (gvk []unversioned.GroupVersionKind, err error) {
-	for _, t := range m {
-		gvk, err = t.KindsFor(resource)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-func (m MultiRESTMapper) ResourceFor(resource unversioned.GroupVersionResource) (gvk unversioned.GroupVersionResource, err error) {
-	for _, t := range m {
-		gvk, err = t.ResourceFor(resource)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-// KindsFor provides the Kind mapping for the REST resources. This implementation supports multiple REST schemas and returns
-// the first match.
-func (m MultiRESTMapper) KindFor(resource unversioned.GroupVersionResource) (gvk unversioned.GroupVersionKind, err error) {
-	for _, t := range m {
-		gvk, err = t.KindFor(resource)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-// RESTMapping provides the REST mapping for the resource based on the
-// kind and version. This implementation supports multiple REST schemas and
-// return the first match.
-func (m MultiRESTMapper) RESTMapping(gk unversioned.GroupKind, versions ...string) (mapping *RESTMapping, err error) {
-	for _, t := range m {
-		mapping, err = t.RESTMapping(gk, versions...)
-		if err == nil {
-			return
-		}
-	}
-	return
-}
-
-// AliasesForResource finds the first alias response for the provided mappers.
-func (m MultiRESTMapper) AliasesForResource(alias string) (aliases []string, ok bool) {
-	for _, t := range m {
-		if aliases, ok = t.AliasesForResource(alias); ok {
-			return
-		}
-	}
-	return nil, false
-}
-
-// ResourceIsValid takes a string (either group/kind or kind) and checks if it's a valid resource
-func (m MultiRESTMapper) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
-	for _, t := range m {
-		if t.ResourceIsValid(resource) {
-			return true
-		}
-	}
-	return false
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper_test.go
@@ -155,7 +155,7 @@ func TestRESTMapperKindsFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "first-group", Version: "first-version", Kind: "my-kind"},
 			},
-			ExpectedKindErr: "is ambiguous",
+			ExpectedKindErr: " matches multiple kinds ",
 		},
 
 		{
@@ -195,7 +195,7 @@ func TestRESTMapperKindsFor(t *testing.T) {
 				{Group: "first-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 			},
-			ExpectedKindErr: "is ambiguous",
+			ExpectedKindErr: " matches multiple kinds ",
 		},
 	}
 	for _, testCase := range testCases {
@@ -267,7 +267,7 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Resource: "my-kinds"},
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
 			},
-			ExpectedResourceErr: "is ambiguous",
+			ExpectedResourceErr: " matches multiple resources ",
 		},
 
 		{
@@ -307,7 +307,7 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
 				{Group: "second-group", Version: "first-version", Resource: "my-kinds"},
 			},
-			ExpectedResourceErr: "is ambiguous",
+			ExpectedResourceErr: " matches multiple resources ",
 		},
 	}
 	for _, testCase := range testCases {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/restmapper_test.go
@@ -241,10 +241,11 @@ func TestRESTMapperKindsFor(t *testing.T) {
 
 func TestRESTMapperResourcesFor(t *testing.T) {
 	testCases := []struct {
-		Name                     string
-		PreferredOrder           []unversioned.GroupVersion
-		KindsToRegister          []unversioned.GroupVersionKind
-		PartialResourceToRequest unversioned.GroupVersionResource
+		Name                             string
+		PreferredOrder                   []unversioned.GroupVersion
+		KindsToRegister                  []unversioned.GroupVersionKind
+		PluralPartialResourceToRequest   unversioned.GroupVersionResource
+		SingularPartialResourceToRequest unversioned.GroupVersionResource
 
 		ExpectedResources   []unversioned.GroupVersionResource
 		ExpectedResourceErr string
@@ -261,7 +262,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "second-group", Version: "first-version", Resource: "my-kinds"},
@@ -282,7 +284,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Group: "first-group", Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
@@ -301,7 +304,8 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 				{Group: "second-group", Version: "first-version", Kind: "my-kind"},
 				{Group: "second-group", Version: "first-version", Kind: "your-kind"},
 			},
-			PartialResourceToRequest: unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kinds"},
+			PluralPartialResourceToRequest:   unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kinds"},
+			SingularPartialResourceToRequest: unversioned.GroupVersionResource{Version: "first-version", Resource: "my-kind"},
 
 			ExpectedResources: []unversioned.GroupVersionResource{
 				{Group: "first-group", Version: "first-version", Resource: "my-kinds"},
@@ -312,41 +316,44 @@ func TestRESTMapperResourcesFor(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		tcName := testCase.Name
-		mapper := NewDefaultRESTMapper(testCase.PreferredOrder, fakeInterfaces)
-		for _, kind := range testCase.KindsToRegister {
-			mapper.Add(kind, RESTScopeNamespace, false)
-		}
 
-		actualResources, err := mapper.ResourcesFor(testCase.PartialResourceToRequest)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", tcName, err)
-			continue
-		}
-		if !reflect.DeepEqual(testCase.ExpectedResources, actualResources) {
-			t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources, actualResources)
-		}
+		for _, partialResource := range []unversioned.GroupVersionResource{testCase.PluralPartialResourceToRequest, testCase.SingularPartialResourceToRequest} {
+			mapper := NewDefaultRESTMapper(testCase.PreferredOrder, fakeInterfaces)
+			for _, kind := range testCase.KindsToRegister {
+				mapper.Add(kind, RESTScopeNamespace, false)
+			}
 
-		singleResource, err := mapper.ResourceFor(testCase.PartialResourceToRequest)
-		if err == nil && len(testCase.ExpectedResourceErr) != 0 {
-			t.Errorf("%s: expected error: %v", tcName, testCase.ExpectedResourceErr)
-			continue
-		}
-		if err != nil {
-			if len(testCase.ExpectedResourceErr) == 0 {
+			actualResources, err := mapper.ResourcesFor(partialResource)
+			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tcName, err)
 				continue
-			} else {
-				if !strings.Contains(err.Error(), testCase.ExpectedResourceErr) {
-					t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResourceErr, err)
+			}
+			if !reflect.DeepEqual(testCase.ExpectedResources, actualResources) {
+				t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources, actualResources)
+			}
+
+			singleResource, err := mapper.ResourceFor(partialResource)
+			if err == nil && len(testCase.ExpectedResourceErr) != 0 {
+				t.Errorf("%s: expected error: %v", tcName, testCase.ExpectedResourceErr)
+				continue
+			}
+			if err != nil {
+				if len(testCase.ExpectedResourceErr) == 0 {
+					t.Errorf("%s: unexpected error: %v", tcName, err)
 					continue
+				} else {
+					if !strings.Contains(err.Error(), testCase.ExpectedResourceErr) {
+						t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResourceErr, err)
+						continue
+					}
 				}
-			}
 
-		} else {
-			if testCase.ExpectedResources[0] != singleResource {
-				t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources[0], singleResource)
-			}
+			} else {
+				if testCase.ExpectedResources[0] != singleResource {
+					t.Errorf("%s: expected %v, got %v", tcName, testCase.ExpectedResources[0], singleResource)
+				}
 
+			}
 		}
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -113,6 +114,22 @@ func checkErr(err error, handleErr func(string)) {
 		prefix := fmt.Sprintf("The %s %q is invalid.\n", details.Kind, details.Name)
 		errs := statusCausesToAggrError(details.Causes)
 		handleErr(MultilineError(prefix, errs))
+	}
+
+	if meta.IsNoResourceMatchError(err) {
+		noMatch := err.(*meta.NoResourceMatchError)
+
+		switch {
+		case len(noMatch.PartialResource.Group) > 0 && len(noMatch.PartialResource.Version) > 0:
+			handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q and version %q", noMatch.PartialResource.Resource, noMatch.PartialResource.Group, noMatch.PartialResource.Version))
+		case len(noMatch.PartialResource.Group) > 0:
+			handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q", noMatch.PartialResource.Resource, noMatch.PartialResource.Group))
+		case len(noMatch.PartialResource.Version) > 0:
+			handleErr(fmt.Sprintf("the server doesn't have a resource type %q in version %q", noMatch.PartialResource.Resource, noMatch.PartialResource.Version))
+		default:
+			handleErr(fmt.Sprintf("the server doesn't have a resource type %q", noMatch.PartialResource.Resource))
+		}
+		return
 	}
 
 	// handle multiline errors

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/kubectl.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/kubectl.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 const kubectlAnnotationPrefix = "kubectl.kubernetes.io/"
@@ -72,57 +71,77 @@ func (m OutputVersionMapper) RESTMapping(gk unversioned.GroupKind, versions ...s
 }
 
 // ShortcutExpander is a RESTMapper that can be used for Kubernetes
-// resources.
+// resources.  It expands the resource first, then invokes the wrapped
 type ShortcutExpander struct {
-	meta.RESTMapper
+	RESTMapper meta.RESTMapper
 }
 
 var _ meta.RESTMapper = &ShortcutExpander{}
 
-// KindFor implements meta.RESTMapper. It expands the resource first, then invokes the wrapped
-// mapper.
 func (e ShortcutExpander) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
-	resource = expandResourceShortcut(resource)
-	return e.RESTMapper.KindFor(resource)
+	return e.RESTMapper.KindFor(expandResourceShortcut(resource))
 }
 
-// ResourceIsValid takes a string (kind) and checks if it's a valid resource.
-// It expands the resource first, then invokes the wrapped mapper.
+func (e ShortcutExpander) KindsFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
+	return e.RESTMapper.KindsFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourcesFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourceFor(expandResourceShortcut(resource))
+}
+
 func (e ShortcutExpander) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
 	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
 }
 
-// ResourceSingularizer expands the named resource and then singularizes it.
 func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) {
 	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+}
+
+func (e ShortcutExpander) RESTMapping(gk unversioned.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return e.RESTMapper.RESTMapping(gk, versions...)
+}
+
+func (e ShortcutExpander) AliasesForResource(resource string) ([]string, bool) {
+	return e.RESTMapper.AliasesForResource(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+}
+
+// shortForms is the list of short names to their expanded names
+var shortForms = map[string]string{
+	// Please keep this alphabetized
+	"cs":     "componentstatuses",
+	"ds":     "daemonsets",
+	"ep":     "endpoints",
+	"ev":     "events",
+	"hpa":    "horizontalpodautoscalers",
+	"ing":    "ingresses",
+	"limits": "limitranges",
+	"no":     "nodes",
+	"ns":     "namespaces",
+	"po":     "pods",
+	"psp":    "podSecurityPolicies",
+	"pvc":    "persistentvolumeclaims",
+	"pv":     "persistentvolumes",
+	"quota":  "resourcequotas",
+	"rc":     "replicationcontrollers",
+	"rs":     "replicasets",
+	"svc":    "services",
+
+	"scc": "securityContextConstraints",
 }
 
 // expandResourceShortcut will return the expanded version of resource
 // (something that a pkg/api/meta.RESTMapper can understand), if it is
 // indeed a shortcut. Otherwise, will return resource unmodified.
 func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
-	shortForms := map[string]unversioned.GroupVersionResource{
-		// Please keep this alphabetized
-		"cs":     api.SchemeGroupVersion.WithResource("componentstatuses"),
-		"ds":     extensions.SchemeGroupVersion.WithResource("daemonsets"),
-		"ep":     api.SchemeGroupVersion.WithResource("endpoints"),
-		"ev":     api.SchemeGroupVersion.WithResource("events"),
-		"hpa":    extensions.SchemeGroupVersion.WithResource("horizontalpodautoscalers"),
-		"ing":    extensions.SchemeGroupVersion.WithResource("ingresses"),
-		"limits": api.SchemeGroupVersion.WithResource("limitranges"),
-		"no":     api.SchemeGroupVersion.WithResource("nodes"),
-		"ns":     api.SchemeGroupVersion.WithResource("namespaces"),
-		"po":     api.SchemeGroupVersion.WithResource("pods"),
-		"pvc":    api.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
-		"pv":     api.SchemeGroupVersion.WithResource("persistentvolumes"),
-		"quota":  api.SchemeGroupVersion.WithResource("resourcequotas"),
-		"rc":     api.SchemeGroupVersion.WithResource("replicationcontrollers"),
-		"svc":    api.SchemeGroupVersion.WithResource("services"),
-
-		"scc": api.SchemeGroupVersion.WithResource("securityContextConstraints"),
-	}
 	if expanded, ok := shortForms[resource.Resource]; ok {
-		return expanded
+		// don't change the group or version that's already been specified
+		resource.Resource = expanded
+		return resource
 	}
 	return resource
 }

--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
@@ -93,7 +94,7 @@ func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
 		return err
 	}
 
-	printerWithHeaders, printerNoHeaders, err := e.Options.GetPrintersByResource(kapi.SchemeGroupVersion.WithResource("pod"))
+	printerWithHeaders, printerNoHeaders, err := e.Options.GetPrintersByResource(unversioned.GroupVersionResource{Resource: "pod"})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubectl"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -31,7 +32,7 @@ func (l *ListPodsOptions) Run() error {
 	if l.Options.CmdPrinterOutput {
 		printer = l.Options.CmdPrinter
 	} else {
-		printer, _, err = l.Options.GetPrintersByResource(kapi.SchemeGroupVersion.WithResource("pod"))
+		printer, _, err = l.Options.GetPrintersByResource(unversioned.GroupVersionResource{Resource: "pod"})
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -164,11 +164,11 @@ func (n *NodeOptions) GetPrintersByObject(obj runtime.Object) (kubectl.ResourceP
 }
 
 func (n *NodeOptions) GetPrintersByResource(resource unversioned.GroupVersionResource) (kubectl.ResourcePrinter, kubectl.ResourcePrinter, error) {
-	gvk, err := n.Mapper.KindFor(resource)
+	gvks, err := n.Mapper.KindsFor(resource)
 	if err != nil {
 		return nil, nil, err
 	}
-	return n.GetPrinters(gvk)
+	return n.GetPrinters(gvks[0])
 }
 
 func (n *NodeOptions) GetPrinters(gvk unversioned.GroupVersionKind) (kubectl.ResourcePrinter, kubectl.ResourcePrinter, error) {

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/template"
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 const (
@@ -125,11 +125,10 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 	var (
 		objects []runtime.Object
 		infos   []*resource.Info
-		mapping *meta.RESTMapping
 	)
 
-	gvk, err := mapper.KindFor(api.SchemeGroupVersion.WithResource("template"))
-	if mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+	mapping, err := mapper.RESTMapping(templateapi.Kind("Template"))
+	if err != nil {
 		return err
 	}
 
@@ -174,7 +173,7 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 	outputFormat := kcmdutil.GetFlagString(cmd, "output")
 
 	for i := range infos {
-		obj, ok := infos[i].Object.(*api.Template)
+		obj, ok := infos[i].Object.(*templateapi.Template)
 		if !ok {
 			sourceName := filename
 			if len(templateName) > 0 {
@@ -273,7 +272,7 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 }
 
 // injectUserVars injects user specified variables into the Template
-func injectUserVars(values []string, out io.Writer, t *api.Template) {
+func injectUserVars(values []string, out io.Writer, t *templateapi.Template) {
 	for _, keypair := range values {
 		p := strings.SplitN(keypair, "=", 2)
 		if len(p) != 2 {

--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -115,9 +117,9 @@ func parseStreamName(defaultNamespace, name string) (string, string, error) {
 
 func determineSourceKind(f *clientcmd.Factory, input string) string {
 	mapper, _ := f.Object()
-	gvk, err := mapper.KindFor(imageapi.SchemeGroupVersion.WithResource(input))
+	gvks, err := mapper.KindsFor(unversioned.GroupVersionResource{Group: imageapi.GroupName, Resource: input})
 	if err == nil {
-		return gvk.Kind
+		return gvks[0].Kind
 	}
 
 	// DockerImage isn't in RESTMapper

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -41,7 +41,6 @@ import (
 	deployreaper "github.com/openshift/origin/pkg/deploy/reaper"
 	deployscaler "github.com/openshift/origin/pkg/deploy/scaler"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
-	imageapi "github.com/openshift/origin/pkg/image/api"
 	routegen "github.com/openshift/origin/pkg/route/generator"
 	userapi "github.com/openshift/origin/pkg/user/api"
 	authenticationreaper "github.com/openshift/origin/pkg/user/reaper"
@@ -485,16 +484,39 @@ func (f *Factory) OriginSwaggerSchema(client *kclient.RESTClient, version unvers
 	return &schema, nil
 }
 
-// ShortcutExpander is a RESTMapper that can be used for OpenShift resources.
+// ShortcutExpander is a RESTMapper that can be used for OpenShift resources.   It expands the resource first, then invokes the wrapped
 type ShortcutExpander struct {
-	meta.RESTMapper
+	RESTMapper meta.RESTMapper
 }
 
-// KindFor implements meta.RESTMapper. It expands the resource first, then invokes the wrapped
-// mapper.
+var _ meta.RESTMapper = &ShortcutExpander{}
+
 func (e ShortcutExpander) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
-	resource = expandResourceShortcut(resource)
-	return e.RESTMapper.KindFor(resource)
+	return e.RESTMapper.KindFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) KindsFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
+	return e.RESTMapper.KindsFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourcesFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourceFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
+	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) {
+	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+}
+
+func (e ShortcutExpander) RESTMapping(gk unversioned.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return e.RESTMapper.RESTMapping(gk, versions...)
 }
 
 // AliasesForResource returns whether a resource has an alias or not
@@ -506,35 +528,28 @@ func (e ShortcutExpander) AliasesForResource(resource string) ([]string, bool) {
 	if res, ok := aliases[resource]; ok {
 		return res, true
 	}
-	return nil, false
+	return e.RESTMapper.AliasesForResource(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
 }
 
-// ResourceIsValid takes a string (kind) and checks if it's a valid resource.
-// It expands the resource first, then invokes the wrapped mapper.
-func (e ShortcutExpander) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
-	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) {
-	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+// shortForms is the list of short names to their expanded names
+var shortForms = map[string]string{
+	"dc":      "deploymentconfigs",
+	"bc":      "buildconfigs",
+	"is":      "imagestreams",
+	"istag":   "imagestreamtags",
+	"isimage": "imagestreamimages",
+	"sa":      "serviceaccounts",
+	"pv":      "persistentvolumes",
+	"pvc":     "persistentvolumeclaims",
 }
 
 // expandResourceShortcut will return the expanded version of resource
 // (something that a pkg/api/meta.RESTMapper can understand), if it is
 // indeed a shortcut. Otherwise, will return resource unmodified.
 func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
-	shortForms := map[string]unversioned.GroupVersionResource{
-		"dc":      deployapi.SchemeGroupVersion.WithResource("deploymentconfigs"),
-		"bc":      buildapi.SchemeGroupVersion.WithResource("buildconfigs"),
-		"is":      imageapi.SchemeGroupVersion.WithResource("imagestreams"),
-		"istag":   imageapi.SchemeGroupVersion.WithResource("imagestreamtags"),
-		"isimage": imageapi.SchemeGroupVersion.WithResource("imagestreamimages"),
-		"sa":      api.SchemeGroupVersion.WithResource("serviceaccounts"),
-		"pv":      api.SchemeGroupVersion.WithResource("persistentvolumes"),
-		"pvc":     api.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
-	}
 	if expanded, ok := shortForms[resource.Resource]; ok {
-		return expanded
+		resource.Resource = expanded
+		return resource
 	}
 	return resource
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7090

The `MultiRESTMapper` didn't correctly combine errors and the shortcut expanding RESTMapper failed to override the required functions because it was anonymously including another RESTMapper.

New message for missing resource:
```
[deads@deads-dev-01 origin]$ oc get foo
the server doesn't have a resource type "foo"
```