### PR TITLE
Bug fix where table border on right side of thead was disappearing at…

### DIFF
--- a/assets/app/views/events.html
+++ b/assets/app/views/events.html
@@ -27,7 +27,13 @@
                   </tr>
                 </thead>
                 <tbody ng-if="(events | hashSize) === 0">
-                  <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
+                  <tr>
+                    <td><em>{{emptyMessage}}</em></td>
+                    <td class="hidden-xs">&nbsp;</td>
+                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+                    <td class="hidden-xs">&nbsp;</td>
+                  </tr>
                 </tbody>
                 <tbody ng-repeat="event in events | toArray | orderBy:'-lastTimestamp'">
                   <tr>


### PR DESCRIPTION
… sm and md sizes.  Note:  this introduces a cosmetic defect at xs size where the bottom border is doubled.  I think this new defect is the lesser of the two, hence the PR.

before:

![screen shot 2016-02-09 at 12 23 53 pm](https://cloud.githubusercontent.com/assets/895728/12924539/af5b44fe-cf28-11e5-8a73-0971d307bd3c.PNG)

after:

![screen shot 2016-02-09 at 12 24 48 pm](https://cloud.githubusercontent.com/assets/895728/12924541/b78a56f6-cf28-11e5-9def-85814db67d2c.PNG)

new defect:

![screen shot 2016-02-09 at 12 24 41 pm](https://cloud.githubusercontent.com/assets/895728/12924562/c3e8c0e0-cf28-11e5-9ad6-d677d63f74df.PNG)

@spadgett, review and merge, please assuming @sg00dwin is good with it.


