### PR TITLE
Make sure extended networking isolation test doesn't run for subnet plugin

### DIFF
--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -148,7 +148,7 @@ function run-extended-tests() {
       # Only the multitenant plugin can pass the isolation test
       if ! grep -q 'redhat/openshift-ovs-multitenant' \
            $(find "${conf_path}" -name 'node-config.yaml' | head -n 1); then
-        skip_regex="${skip_regex}|networking: isolation"
+        skip_regex="${skip_regex}|\[networking\] network isolation plugin"
       fi
   fi
 

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -8,6 +8,7 @@ import (
 )
 
 // This test requires a network plugin that supports namespace isolation.
+// NOTE: if you change the test description, update networking.sh too!
 var _ = Describe("[networking] network isolation plugin", func() {
 	f1 := e2e.NewFramework("net-isolation1")
 	f2 := e2e.NewFramework("net-isolation2")


### PR DESCRIPTION
Only multitenant supports isolation.

Fixes: 2cb2a753beb0de6830d93d4c179a82125288e5a9