### PR TITLE
Allow restricting GitHub authentication to an organization

### DIFF
--- a/pkg/auth/oauth/external/github/github.go
+++ b/pkg/auth/oauth/external/github/github.go
@@ -4,27 +4,40 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/RangelReale/osincli"
 	"github.com/golang/glog"
 
 	authapi "github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/auth/oauth/external"
+	"github.com/openshift/origin/pkg/util/http/links"
 )
 
 const (
 	githubAuthorizeURL = "https://github.com/login/oauth/authorize"
 	githubTokenURL     = "https://github.com/login/oauth/access_token"
 	githubUserApiURL   = "https://api.github.com/user"
+	githubUserOrgURL   = "https://api.github.com/user/orgs"
 	githubOAuthScope   = "user:email"
+	githubOrgScope     = "read:org"
+
+	// https://developer.github.com/v3/#current-version
+	// https://developer.github.com/v3/media/#request-specific-version
+	githubAccept = "application/vnd.github.v3+json"
 )
 
 type provider struct {
-	providerName, clientID, clientSecret string
+	providerName         string
+	clientID             string
+	clientSecret         string
+	allowedOrganizations sets.String
 }
 
+// https://developer.github.com/v3/users/#response
 type githubUser struct {
 	ID    uint64
 	Login string
@@ -32,16 +45,40 @@ type githubUser struct {
 	Name  string
 }
 
-func NewProvider(providerName, clientID, clientSecret string) external.Provider {
-	return provider{providerName, clientID, clientSecret}
+// https://developer.github.com/v3/orgs/#response
+type githubOrg struct {
+	ID    uint64
+	Login string
 }
 
-func (p provider) GetTransport() (http.RoundTripper, error) {
+func NewProvider(providerName, clientID, clientSecret string, organizations []string) external.Provider {
+	allowedOrganizations := sets.NewString()
+	for _, org := range organizations {
+		if len(org) > 0 {
+			allowedOrganizations.Insert(strings.ToLower(org))
+		}
+	}
+
+	return &provider{
+		providerName:         providerName,
+		clientID:             clientID,
+		clientSecret:         clientSecret,
+		allowedOrganizations: allowedOrganizations,
+	}
+}
+
+func (p *provider) GetTransport() (http.RoundTripper, error) {
 	return nil, nil
 }
 
 // NewConfig implements external/interfaces/Provider.NewConfig
-func (p provider) NewConfig() (*osincli.ClientConfig, error) {
+func (p *provider) NewConfig() (*osincli.ClientConfig, error) {
+	scopes := []string{githubOAuthScope}
+	// if we're limiting to specific organizations, we also need to read their org membership
+	if len(p.allowedOrganizations) > 0 {
+		scopes = append(scopes, githubOrgScope)
+	}
+
 	config := &osincli.ClientConfig{
 		ClientId:                 p.clientID,
 		ClientSecret:             p.clientSecret,
@@ -49,7 +86,7 @@ func (p provider) NewConfig() (*osincli.ClientConfig, error) {
 		SendClientSecretInParams: true,
 		AuthorizeUrl:             githubAuthorizeURL,
 		TokenUrl:                 githubTokenURL,
-		Scope:                    githubOAuthScope,
+		Scope:                    strings.Join(scopes, " "),
 	}
 	return config, nil
 }
@@ -59,29 +96,24 @@ func (p provider) AddCustomParameters(req *osincli.AuthorizeRequest) {
 }
 
 // GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
-func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
-	req, _ := http.NewRequest("GET", githubUserApiURL, nil)
-	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", data.AccessToken))
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, false, err
-	}
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, false, err
-	}
-
+func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
 	userdata := githubUser{}
-	err = json.Unmarshal(body, &userdata)
-	if err != nil {
+	if _, err := getJSON(githubUserApiURL, data.AccessToken, &userdata); err != nil {
 		return nil, false, err
 	}
-
 	if userdata.ID == 0 {
 		return nil, false, errors.New("Could not retrieve GitHub id")
+	}
+
+	if len(p.allowedOrganizations) > 0 {
+		userOrgs, err := getUserOrgs(data.AccessToken)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !userOrgs.HasAny(p.allowedOrganizations.List()...) {
+			return nil, false, fmt.Errorf("User %s is not a member of any allowed organizations %v (user is a member of %v)", userdata.Login, p.allowedOrganizations.List(), userOrgs.List())
+		}
 	}
 
 	identity := authapi.NewDefaultUserIdentityInfo(p.providerName, fmt.Sprintf("%d", userdata.ID))
@@ -97,4 +129,68 @@ func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentit
 	glog.V(4).Infof("Got identity=%#v", identity)
 
 	return identity, true, nil
+}
+
+// getUserOrgs retrieves the organization membership for the user with the given access token.
+func getUserOrgs(token string) (sets.String, error) {
+	// start with the empty set, and the initial org url
+	userOrgs := sets.NewString()
+	orgURL := githubUserOrgURL
+	// track urls we've fetched to avoid cycles
+	fetchedURLs := sets.NewString(orgURL)
+	for {
+		// fetch organizations
+		organizations := []githubOrg{}
+		links, err := getJSON(orgURL, token, &organizations)
+		if err != nil {
+			return nil, err
+		}
+		for _, org := range organizations {
+			if len(org.Login) > 0 {
+				userOrgs.Insert(strings.ToLower(org.Login))
+			}
+		}
+
+		// see if we need to page
+		// https://developer.github.com/v3/#link-header
+		nextURL := links["next"]
+		if len(nextURL) == 0 {
+			// no next URL, we're done paging
+			break
+		}
+		if fetchedURLs.Has(nextURL) {
+			// break to avoid a loop
+			break
+		}
+		// remember to avoid a loop
+		fetchedURLs.Insert(nextURL)
+		orgURL = nextURL
+	}
+
+	return userOrgs, nil
+}
+
+// getJSON fetches and deserializes JSON into the given object.
+// returns a (possibly empty) map of link relations to url strings, or an error.
+func getJSON(url string, token string, data interface{}) (map[string]string, error) {
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
+	req.Header.Set("Accept", githubAccept)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-200 response from GitHub API call %s: %d", url, res.StatusCode)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	links := links.ParseLinks(res.Header.Get("Link"))
+	return links, nil
 }

--- a/pkg/auth/oauth/external/github/github_test.go
+++ b/pkg/auth/oauth/external/github/github_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestGitHub(t *testing.T) {
-	_ = external.Provider(NewProvider("github", "clientid", "clientsecret"))
+	_ = external.Provider(NewProvider("github", "clientid", "clientsecret", nil))
 }

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -675,6 +675,8 @@ type GitHubIdentityProvider struct {
 	ClientID string
 	// ClientSecret is the oauth client secret
 	ClientSecret string
+	// Organizations optionally restricts which organizations are allowed to log in
+	Organizations []string
 }
 
 type GitLabIdentityProvider struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -628,6 +628,8 @@ type GitHubIdentityProvider struct {
 	ClientID string `json:"clientID"`
 	// ClientSecret is the oauth client secret
 	ClientSecret string `json:"clientSecret"`
+	// Organizations optionally restricts which organizations are allowed to log in
+	Organizations []string `json:"organizations"`
 }
 
 type GitLabIdentityProvider struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -268,6 +268,7 @@ oauthConfig:
       clientID: ""
       clientSecret: ""
       kind: GitHubIdentityProvider
+      organizations: null
   - challenge: false
     login: false
     mappingMethod: ""

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -465,7 +465,7 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 func (c *AuthConfig) getOAuthProvider(identityProvider configapi.IdentityProvider) (external.Provider, error) {
 	switch provider := identityProvider.Provider.(type) {
 	case (*configapi.GitHubIdentityProvider):
-		return github.NewProvider(identityProvider.Name, provider.ClientID, provider.ClientSecret), nil
+		return github.NewProvider(identityProvider.Name, provider.ClientID, provider.ClientSecret, provider.Organizations), nil
 
 	case (*configapi.GitLabIdentityProvider):
 		transport, err := cmdutil.TransportFor(provider.CA, "", "")

--- a/pkg/util/http/links/links.go
+++ b/pkg/util/http/links/links.go
@@ -1,0 +1,25 @@
+package links
+
+import "regexp"
+
+// Matches URL+rel links defined by https://tools.ietf.org/html/rfc5988
+// Examples header values:
+//   <http://www.example.com/foo?page=3>; rel="next"
+//   <http://www.example.com/foo?page=3>; rel="next", <http://www.example.com/foo?page=1>; rel="prev"
+var linkRegex = regexp.MustCompile(`\<(.+?)\>\s*;\s*rel="(.+?)"(?:\s*,\s*)?`)
+
+// ParseLinks extracts link relations from the given header value.
+func ParseLinks(header string) map[string]string {
+	links := map[string]string{}
+	if len(header) == 0 {
+		return links
+	}
+
+	matches := linkRegex.FindAllStringSubmatch(header, -1)
+	for _, match := range matches {
+		url := match[1]
+		rel := match[2]
+		links[rel] = url
+	}
+	return links
+}

--- a/pkg/util/http/links/links_test.go
+++ b/pkg/util/http/links/links_test.go
@@ -1,0 +1,61 @@
+package links
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLinks(t *testing.T) {
+	testcases := map[string]struct {
+		header string
+		links  map[string]string
+	}{
+		"empty": {
+			header: "",
+			links:  map[string]string{},
+		},
+		"unparseable": {
+			header: "foo bar baz",
+			links:  map[string]string{},
+		},
+		"single link": {
+			header: `<https://example.com/user/orgs?per_page=1&page=2>; rel="next"`,
+			links: map[string]string{
+				"next": "https://example.com/user/orgs?per_page=1&page=2",
+			},
+		},
+		"single link with unknown suffix": {
+			header: `<https://example.com/user/orgs?per_page=1&page=2>; rel="next", foo bar baz`,
+			links: map[string]string{
+				"next": "https://example.com/user/orgs?per_page=1&page=2",
+			},
+		},
+		"duplicate link": {
+			header: `<https://example.com/user/orgs?per_page=1&page=2>; rel="next", <https://example.com/user/orgs?per_page=1&page=3>; rel="next"`,
+			links: map[string]string{
+				"next": "https://example.com/user/orgs?per_page=1&page=3",
+			},
+		},
+		"no whitespace": {
+			header: `<https://example.com/user/orgs?per_page=1&page=2>;rel="next",<https://example.com/user/orgs?per_page=1&page=8>;rel="last"`,
+			links: map[string]string{
+				"next": "https://example.com/user/orgs?per_page=1&page=2",
+				"last": "https://example.com/user/orgs?per_page=1&page=8",
+			},
+		},
+		"extra whitespace": {
+			header: `  <https://example.com/user/orgs?per_page=1&page=2>;  rel="next"  ,		<https://example.com/user/orgs?per_page=1&page=8>		;		rel="last"		`,
+			links: map[string]string{
+				"next": "https://example.com/user/orgs?per_page=1&page=2",
+				"last": "https://example.com/user/orgs?per_page=1&page=8",
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		links := ParseLinks(tc.header)
+		if !reflect.DeepEqual(links, tc.links) {
+			t.Errorf("%s: Expected\n%#v\ngot\n%#v", k, tc.links, links)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #7157
Adds the ability to limit github logins to members of particular GitHub organizations. By default, all github users are allowed to log in using the github IDP.

Example config to allow members of `myorgname` or `anotherorgname` to log in:
```
oauthConfig:
  ...
  identityProviders:
  - name: github 
    challenge: false 
    login: true 
    mappingMethod: claim
    provider:
      apiVersion: v1
      kind: GitHubIdentityProvider
      clientID: ...
      clientSecret: ...
      organizations:
      - myorgname
      - anotherorgname
```