### PR TITLE
Resource specific events on browse pages

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -174,6 +174,7 @@
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>
+        <script src="scripts/directives/events.js"></script>
         <script src="scripts/directives/oscFileInput.js"></script>
         <script src="scripts/directives/oscFormSection.js"></script>
         <script src="scripts/directives/oscGitLink.js"></script>

--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -49,7 +49,7 @@ angular.module('openshiftConsole')
         // FIXME: DataService.createStream() requires a scope with a
         // projectPromise rather than just a namespace, so we have to pass the
         // context into the log-viewer directive.
-        $scope.logContext = context;
+        $scope.projectContext = context;
         $scope.logOptions = {};
         DataService.get("builds", $routeParams.build, context).then(
           // success

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -62,7 +62,7 @@ angular.module('openshiftConsole')
         // FIXME: DataService.createStream() requires a scope with a
         // projectPromise rather than just a namespace, so we have to pass the
         // context into the log-viewer directive.
-        $scope.logContext = context;
+        $scope.projectContext = context;
 
         var watchActiveDeployment = function() {
           // Watch all replication controllers so we know if this is the active deployment to enable scaling.

--- a/assets/app/scripts/controllers/deploymentConfig.js
+++ b/assets/app/scripts/controllers/deploymentConfig.js
@@ -53,6 +53,7 @@ angular.module('openshiftConsole')
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
+        $scope.projectContext = context;
         DataService.get("deploymentconfigs", $routeParams.deploymentconfig, context).then(
           // success
           function(deploymentConfig) {

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -49,7 +49,7 @@ angular.module('openshiftConsole')
         // FIXME: DataService.createStream() requires a scope with a
         // projectPromise rather than just a namespace, so we have to pass the
         // context into the log-viewer directive.
-        $scope.logContext = context;
+        $scope.projectContext = context;
         DataService.get("pods", $routeParams.pod, context).then(
           // success
           function(pod) {

--- a/assets/app/scripts/controllers/service.js
+++ b/assets/app/scripts/controllers/service.js
@@ -29,6 +29,7 @@ angular.module('openshiftConsole')
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
+        $scope.projectContext = context;
         DataService.get("services", $routeParams.service, context).then(
           // success
           function(service) {

--- a/assets/app/scripts/directives/events.js
+++ b/assets/app/scripts/directives/events.js
@@ -1,0 +1,33 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('events', function($routeParams, $filter, DataService, ProjectsService, Logger) {
+    return {
+      restrict: 'E',
+      scope: {
+        resourceKind: "@",
+        resourceName: "@",
+        projectContext: "="
+      },
+      templateUrl: 'views/directives/events.html',
+      controller: function($scope){
+
+        var filterEvent = function(event) {
+          return (event.involvedObject.kind === $scope.resourceKind) && (event.involvedObject.name === $scope.resourceName);
+        };
+
+        var watches = [];
+        watches.push(DataService.watch("events", $scope.projectContext, function(events) {
+          $scope.emptyMessage = "No events to show";
+          // $scope.eventsArray = $filter('toArray')(events.by("metadata.name"));
+          $scope.filteredEvents = _.filter(events.by("metadata.name"), filterEvent);
+          Logger.log("events (subscribe)", $scope.filteredEvents);
+        }));
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+      },
+    };
+  });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -177,6 +177,16 @@
   }
 }
 
+.events-table {
+  .pficon {
+    vertical-align: middle;
+  }
+  .severity-icon-td {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 .build-config-summary {
   .latest-build-status {
     margin-right: 5px;

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -92,13 +92,17 @@
                         follow-affix-bottom="90"
                         resource="builds/log"
                         name="build.metadata.name"
-                        context="logContext"
+                        context="projectContext"
                         options="logOptions"
                         status="build.status.phase"
                         start="build.status.startTimestamp | date : 'short'"
                         end="build.status.completionTimestamp | date : 'short'"
                         run="logCanRun">
                       </log-viewer>
+                    </uib-tab>
+                    <uib-tab active="selectedTab.events">
+                      <uib-tab-heading>Events</uib-tab-heading>
+                      <events resource-kind="Pod" resource-name="{{build | annotation : 'buildPod'}}" project-context="projectContext" ng-if="selectedTab.events"></events>
                     </uib-tab>
                   </uib-tabset>
 

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -207,6 +207,10 @@
                       <em ng-if="!container.env.length">The container specification has no environment variables set.</em>
                     </div>
                   </uib-tab>
+                  <uib-tab active="selectedTab.events">
+                    <uib-tab-heading>Events</uib-tab-heading>
+                    <events resource-kind="DeploymentConfig" resource-name="{{deploymentConfig.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                  </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->
             </div>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -79,12 +79,16 @@
                       follow-affix-bottom="90"
                       resource="deploymentconfigs/log"
                       name="deploymentConfigName"
-                      context="logContext"
+                      context="projectContext"
                       options="logOptions"
                       status="deployment | deploymentStatus"
                       start="deployment.metadata.creationTimestamp | date : 'short'"
                       run="logCanRun">
                     </log-viewer>
+                  </uib-tab>
+                  <uib-tab active="selectedTab.events">
+                    <uib-tab-heading>Events</uib-tab-heading>
+                    <events resource-kind="ReplicationController" resource-name="{{deployment.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
                   </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -92,7 +92,7 @@
                         follow-affix-bottom="90"
                         resource="pods/log"
                         name="pod.metadata.name"
-                        context="logContext"
+                        context="projectContext"
                         options="logOptions"
                         status="pod.status.phase"
                         start="pod.status.startTime | date : 'short'"
@@ -120,6 +120,10 @@
                     </div>
     	            </uib-tab>
 
+                  <uib-tab active="selectedTab.events">
+                    <uib-tab-heading>Events</uib-tab-heading>
+                    <events resource-kind="Pod" resource-name="{{pod.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                  </uib-tab>
                 </uib-tabset>
               </div><!-- /col-* -->
             </div>

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -38,76 +38,83 @@
           </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content gutter-top">
+      <div class="middle-content">
         <div class="container-fluid">
           <div class="row" ng-if="service">
             <div class="col-md-12">
-                <div class="resource-details">
-                  <dl class="dl-horizontal left">
-                    <dt>Selectors:</dt>
-                    <dd>
-                      <span ng-if="!service.spec.selector"><em>none</em></span>
-                      <span ng-repeat="(selectorLabel, selectorValue) in service.spec.selector"> {{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></span>
-                    </dd>
-                    <dt>Type:</dt>
-                    <dd>{{service.spec.type}}</dd>
-                    <dt>IP:</dt>
-                    <dd>{{service.spec.clusterIP}}</dd>
-                    <dt>Session affinity:</dt>
-                    <dd>{{service.spec.sessionAffinity}}</dd>
-                    <dt ng-if="resource.status.loadBalancer.ingress.length">Ingress points</dt>
-                    <dd ng-if="resource.status.loadBalancer.ingress.length">
-                      <span ng-repeat="ingress in resource.status.loadBalancer.ingress"
-                        >{{ingress.ip}}<span ng-if="!$last">, </span></span>
-                    </dd>
-                  </dl>
-                  <div class="service-table table-responsive">
-                    <table ng-if="service.spec.ports.length" style="max-width: 650px;">
-                      <thead>
-                        <tr>
-                          <th>Node Port</th>
-                          <th role="presentation"></th>
-                          <th>
-                            Service Port
-                            <!-- Show cluster IP in column header instead of table body at small screen widths to save space. -->
-                            <span class="visible-xs">({{service.spec.clusterIP}})</span>
-                          </th>
-                          <th role="presentation"></th>
-                          <th>Target Port</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
-                          <td>
-                            <span ng-if="portMapping.nodePort">{{portMapping.nodePort}}</span>
-                            <span ng-if="!portMapping.nodePort" class="text-muted">none</span>
-                          </td>
-                          <td role="presentation" class="text-muted">&#8594;</td>
-                          <td>{{portMapping.port}}/{{portMapping.protocol}}
-                              <span ng-if="portMapping.name">({{portMapping.name}})</span></td>
-                          <td role="presentation" class="text-muted">&#8594;</td>
-                          <td>{{portMapping.targetPort}}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                  <!-- No bottom margin so Create Route link is close to content. -->
-                  <dl class="dl-horizontal left" style="margin-bottom: 0;">
-                    <dt>Routes:</dt>
-                    <dd>
-                      <span ng-if="!routesForService.length"><em>none</em></span>
-                      <span ng-repeat="route in routesForService">
-                          <span ng-if="route | isWebRoute"><a ng-href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>
-                          <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
-                          <span ng-show="!$last">, </span>
-                      </span>
-                    </dd>
-                  </dl>
-                  <div class="gutter-bottom">
+              <uib-tabset>
+                <uib-tab active="selectedTab.details">
+                  <uib-tab-heading>Details</uib-tab-heading>
+                  <div class="resource-details">
+                    <dl class="dl-horizontal left">
+                      <dt>Selectors:</dt>
+                      <dd>
+                        <span ng-if="!service.spec.selector"><em>none</em></span>
+                        <span ng-repeat="(selectorLabel, selectorValue) in service.spec.selector"> {{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></span>
+                      </dd>
+                      <dt>Type:</dt>
+                      <dd>{{service.spec.type}}</dd>
+                      <dt>IP:</dt>
+                      <dd>{{service.spec.clusterIP}}</dd>
+                      <dt>Session affinity:</dt>
+                      <dd>{{service.spec.sessionAffinity}}</dd>
+                      <dt ng-if="resource.status.loadBalancer.ingress.length">Ingress points</dt>
+                      <dd ng-if="resource.status.loadBalancer.ingress.length">
+                        <span ng-repeat="ingress in resource.status.loadBalancer.ingress"
+                          >{{ingress.ip}}<span ng-if="!$last">, </span></span>
+                      </dd>
+                    </dl>
+                    <div class="service-table table-responsive">
+                      <table ng-if="service.spec.ports.length" style="max-width: 650px;">
+                        <thead>
+                          <tr>
+                            <th>Node Port</th>
+                            <th role="presentation"></th>
+                            <th>
+                              Service Port
+                              <!-- Show cluster IP in column header instead of table body at small screen widths to save space. -->
+                              <span class="visible-xs">({{service.spec.clusterIP}})</span>
+                            </th>
+                            <th role="presentation"></th>
+                            <th>Target Port</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
+                            <td>
+                              <span ng-if="portMapping.nodePort">{{portMapping.nodePort}}</span>
+                              <span ng-if="!portMapping.nodePort" class="text-muted">none</span>
+                            </td>
+                            <td role="presentation" class="text-muted">&#8594;</td>
+                            <td>{{portMapping.port}}/{{portMapping.protocol}}
+                                <span ng-if="portMapping.name">({{portMapping.name}})</span></td>
+                            <td role="presentation" class="text-muted">&#8594;</td>
+                            <td>{{portMapping.targetPort}}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <!-- No bottom margin so Create Route link is close to content. -->
+                    <dl class="dl-horizontal left" style="margin-bottom: 0;">
+                      <dt>Routes:</dt>
+                      <dd>
+                        <span ng-if="!routesForService.length"><em>none</em></span>
+                        <span ng-repeat="route in routesForService">
+                            <span ng-if="route | isWebRoute"><a ng-href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>
+                            <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
+                            <span ng-show="!$last">, </span>
+                        </span>
+                      </dd>
+                    </dl>
                     <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}">Create route</a>
+                    <annotations annotations="service.metadata.annotations"></annotations>
                   </div>
-                  <annotations annotations="service.metadata.annotations"></annotations>
-                </div>
+                </uib-tab>
+                <uib-tab active="selectedTab.events">
+                  <uib-tab-heading>Events</uib-tab-heading>
+                  <events resource-kind="Service" resource-name="{{service.metadata.name}}" project-context="projectContext" ng-if="selectedTab.events"></events>
+                </uib-tab>
+              </uib-tabset>
             </div><!-- /col-* -->
           </div>
         </div>

--- a/assets/app/views/directives/events.html
+++ b/assets/app/views/directives/events.html
@@ -1,0 +1,37 @@
+<table class="table table-bordered table-condensed table-mobile table-hover events-table">
+  <thead>
+    <tr>
+      <th>Time</th>
+      <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
+      <th>Reason</th>
+      <th>Message</th>
+    </tr>
+  </thead>
+  <tbody ng-if="(filteredEvents | hashSize) === 0">
+    <tr>
+      <td><em>{{emptyMessage}}</em></td>
+      <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+      <td class="hidden-xs">&nbsp;</td>
+      <td class="hidden-xs">&nbsp;</td>
+    </tr>
+  </tbody>
+  <tbody ng-repeat="event in filteredEvents | orderBy:'-lastTimestamp'">
+    <tr>
+      <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
+      <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">
+        <span class="sr-only">{{event.type}}</span>
+        <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span></td>
+      <td data-title="Reason" class="event-time">
+        {{event.reason}}&nbsp;
+        <span class="hidden-lg pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
+      </td>
+      <td data-title="Message" class="word-break">
+        {{event.message}}
+        <span class="text-muted small" ng-if="event.count > 1">
+          ({{event.count}} times in the last
+            {{event.firstTimestamp | duration:event.lastTimestamp:true}})
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/assets/app/views/events.html
+++ b/assets/app/views/events.html
@@ -16,12 +16,13 @@
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-12 gutter-top">
-              <table class="table table-bordered table-condensed table-mobile table-hover">
+              <table class="table table-bordered table-condensed table-mobile table-hover events-table">
                 <thead>
                   <tr>
                     <th>Time</th>
                     <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and </span>Name</th>
                     <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Kind</span></th>
+                    <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
                     <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
                     <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
                   </tr>
@@ -30,6 +31,7 @@
                   <tr>
                     <td><em>{{emptyMessage}}</em></td>
                     <td class="hidden-xs">&nbsp;</td>
+                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
                     <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
                     <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
                     <td class="hidden-xs">&nbsp;</td>
@@ -44,10 +46,17 @@
                       {{event.involvedObject.name}}</td>
                     <td class="hidden-sm hidden-md" data-title="Kind">
                       {{event.involvedObject.kind}}</td>
+                    <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">
+                      <span class="sr-only">{{event.type}}</span>
+                      <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span></td>
                     <td class="hidden-sm hidden-md" data-title="Reason">
-                      {{event.reason}}</td>
+                      {{event.reason}}&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
+                    </td>
                     <td data-title="Message" class="word-break">
-                      <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">{{event.reason}}</div>
+                      <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
+                        {{event.reason}}&nbsp;
+                        <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
+                      </div>
                       {{event.message}}
                       <span class="text-muted small" ng-if="event.count > 1">
                         ({{event.count}} times in the last

--- a/assets/app/views/logs/chromeless-build-log.html
+++ b/assets/app/views/logs/chromeless-build-log.html
@@ -15,7 +15,7 @@
           <log-viewer
             resource="builds/log"
             name="build.metadata.name"
-            context="logContext"
+            context="projectContext"
             status="build.status.phase"
             start="build.status.startTimestamp | date : 'short'"
             end="build.status.completionTimestamp | date : 'short'"

--- a/assets/app/views/logs/chromeless-deployment-log.html
+++ b/assets/app/views/logs/chromeless-deployment-log.html
@@ -16,7 +16,7 @@
             ng-if="deploymentConfigName && logOptions.version"
             resource="deploymentconfigs/log"
             name="deploymentConfigName"
-            context="logContext"
+            context="projectContext"
             options="logOptions"
             chromeless="true"
             run="logCanRun"

--- a/assets/app/views/logs/chromeless-pod-log.html
+++ b/assets/app/views/logs/chromeless-pod-log.html
@@ -15,7 +15,7 @@
           <log-viewer
             resource="pods/log"
             name="pod.metadata.name"
-            context="logContext"
+            context="projectContext"
             options="logOptions"
             status="pod.status.phase"
             start="pod.status.startTime | date : 'short'"


### PR DESCRIPTION
https://trello.com/c/DRFgGKxF

I've added the `Events` tab to following resources:
- pod
- build
- deployment
- deploymentConfig
- service
Rest of the resources that we display - ImageStream, Routes, Storage don't create any events since their controllers doesn't have `EventRecorder`.

Resource events will be displayed like this:
- pod - will display events from Pod kind specified by name
- build - will display events from Pod kind that is named after the build with `-build` suffix (eg. ruby-sample-build-1-build)
- service - will display events from Service kind specified by name
- deploymentConfig - will display events from DeploymentConfig kind specified by name
- deployment - will display events from ReplicationController kind specified by name

Dont really know if `*-posthook`, `*-prehook`, `*-deploy` Pods (eg. `database-2-deploy`) should be displayed as part of a specific Deployment or not, so I've left it out for now.

Also I've updated the Events page and added the `Warning` and `Normal` icons with tooltip in front of the reasoning in the Reason column.

 Attaching screens of how the Events tab  looks like with different resolutions:
![screenshot-20](https://cloud.githubusercontent.com/assets/1668218/12925860/c6b3b202-cf60-11e5-873b-93068640eeea.png)
![screenshot-21](https://cloud.githubusercontent.com/assets/1668218/12925864/ca07844c-cf60-11e5-8485-0e430c44ec46.png)
![screenshot-22](https://cloud.githubusercontent.com/assets/1668218/12925871/cdd06be8-cf60-11e5-9a06-ed535594167f.png)

And updated Events browse page:
![screenshot-23](https://cloud.githubusercontent.com/assets/1668218/12925888/de0437c4-cf60-11e5-994d-2ed6b6a1fb29.png)

@spadgett PTAL


