### PR TITLE
Web console fix log follow after window.resize event

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -71,8 +71,8 @@ angular.module('openshiftConsole')
 
 
 
-
-            var updateScrollLinks = function() {
+            // is just toggling show/hide, nothing else.
+            var updateScrollLinksVisibility = function() {
               $scope.$apply(function() {
                 // Show scroll links if the top or bottom of the log is off screen.
                 var r = cachedLogNode.getBoundingClientRect();
@@ -93,19 +93,21 @@ angular.module('openshiftConsole')
               } else {
                 // If the user scrolled the window manually, stop auto-scrolling.
                 $scope.$evalAsync(function() {
-                  $scope.autoScroll = false;
+                  $scope.autoScrollActive = false;
                 });
               }
             };
 
 
-
             var attachScrollEvents = function() {
-              if(window.innerWidth < BREAKPOINTS.screenSmMin) {
+              // always clear all scroll listeners before reattaching
+              $cachedScrollableNode.off('scroll', onScroll);
+              $win.off('scroll', onScroll);
+
+              // only add the appropriate event
+              if(window.innerWidth <= BREAKPOINTS.screenSmMin) {
                 $win.on('scroll', onScroll);
-                $cachedScrollableNode.off('scroll', onScroll);
               } else {
-                $win.off('scroll', onScroll);
                 $cachedScrollableNode.on('scroll', onScroll);
               }
             };
@@ -142,13 +144,13 @@ angular.module('openshiftConsole')
 
             // roll up & debounce the various fns to call on resize
             var onResize = _.debounce(function() {
-              // toggle off the follow behavior if the user resizes the window
-              onScroll();
-              // and udpate scroll handlers
+              // update scroll handlers
               detectScrollableNode();
               attachScrollEvents();
-              updateScrollLinks();
+              updateScrollLinksVisibility();  // toggles show/hide
               affix();
+              // toggle off the follow behavior if the user resizes the window
+              onScroll();
             }, 100);
 
 
@@ -168,8 +170,8 @@ angular.module('openshiftConsole')
 
 
             var toggleAutoScroll = function() {
-              $scope.autoScroll = !$scope.autoScroll;
-              if ($scope.autoScroll) {
+              $scope.autoScrollActive = !$scope.autoScrollActive;
+              if ($scope.autoScrollActive) {
                 // Scroll immediately. Don't wait the next message.
                 autoScrollBottom();
               }
@@ -182,12 +184,12 @@ angular.module('openshiftConsole')
               buffer = document.createDocumentFragment();
 
               // Follow the bottom of the log if auto-scroll is on.
-              if ($scope.autoScroll) {
+              if ($scope.autoScrollActive) {
                 autoScrollBottom();
               }
 
               if (!$scope.showScrollLinks) {
-                updateScrollLinks();
+                updateScrollLinksVisibility(); // toggles show/hide
               }
             }, 100, { maxWait: 300 });
 
@@ -266,7 +268,7 @@ angular.module('openshiftConsole')
               streamer.onClose(function() {
                 streamer = null;
                 $scope.$evalAsync(function() {
-                  $scope.autoScroll = false;
+                  $scope.autoScrollActive = false;
                 });
 
                 // Wrap in a timeout so that content displays before we remove the loading ellipses.
@@ -303,7 +305,7 @@ angular.module('openshiftConsole')
                 logLinks.scrollBottom(scrollableDOMNode);
               },
               onScrollTop: function() {
-                $scope.autoScroll = false;
+                $scope.autoScrollActive = false;
                 logLinks.scrollTop(scrollableDOMNode);
               },
               toggleAutoScroll: toggleAutoScroll,

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -51,8 +51,8 @@
       id="affixedFollow"
       class="log-scroll log-scroll-top">
       <a ng-if="loading" href="" ng-click="toggleAutoScroll()">
-        <span ng-if="!autoScroll">Follow</span>
-        <span ng-if="autoScroll">Stop following</span>
+        <span ng-if="!autoScrollActive">Follow</span>
+        <span ng-if="autoScrollActive">Stop following</span>
       </a>
       <a ng-if="!loading" href="" ng-click="onScrollBottom()">
         Go to end


### PR DESCRIPTION
Fix attachScrollEvents on window.resize causing affixed follow links in logViewer to behave inconsistently

Fixes #7146

- attachScrollEvents now removes all resize events before attaching new
	- ensures only one event attached at any single moment
  - follow/stop following links now continue to function appropriately after resize

- lingering issues:
	- TL;DR
		- affix is set about 50px off to accomodate certain DOM nodes with ng-show & differences w/mobile
	- LONG:
  	- affix position is set once in markup, but ng-show may add or remove log dates from DOM, which affects position
    	- current position is set with additional space in mind, but this means affix does not take effect immediately
    - possible fix:
			- use a hack to detect DOM nodes added to document
      - MutationObserver is one way to detect added nodes
			- detect logViewer distance from top of document
      - update affix accordingly

@spadgett @jwforres @sg00dwin 