### PR TITLE
refactor docker image searching

### DIFF
--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -247,7 +247,7 @@ func transformBuildError(err error, c *cobra.Command, fullName string, groups er
 				  2. Images in the Docker Hub, on remote registries, or on the local Docker engine
 				  3. Git repository URLs or local paths that point to Git repositories
 
-				--allow-missing-images can be used to point to an image that is only on your system
+				--allow-missing-images can be used to force the use of an image that was not matched
 
 				See '%[1]s -h' for examples.`, c.CommandPath(),
 			),

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -145,7 +145,7 @@ func TestBuildTemplates(t *testing.T) {
 		appCfg := AppConfig{}
 		appCfg.Out = &bytes.Buffer{}
 		appCfg.RefBuilder = &app.ReferenceBuilder{}
-		appCfg.SetOpenShiftClient(&client.Fake{}, c.namespace)
+		appCfg.SetOpenShiftClient(&client.Fake{}, c.namespace, nil)
 		appCfg.KubeClient = ktestclient.NewSimpleFake()
 		appCfg.TemplateSearcher = fakeTemplateSearcher()
 		appCfg.AddArguments([]string{c.templateName})

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -64,7 +64,7 @@ func (pb *pipelineBuilder) NewBuildPipeline(from string, resolvedMatch *Componen
 			return nil, fmt.Errorf("can't build %q: %v", from, err)
 		}
 		input = inputImage
-		if !input.AsImageStream {
+		if !input.AsImageStream && resolvedMatch.Value != "scratch" {
 			msg := "Could not find an image stream match for %q. Make sure that a Docker image with that tag is available on the node for the build to succeed."
 			glog.Warningf(msg, resolvedMatch.Value)
 		}


### PR DESCRIPTION
0) always match "scratch"
1) try to search the registry via openshift
2) try to search the registry via the docker daemon
3) search the local registry
4) if --allow-missing-images is set, create a fake exact match