### PR TITLE
added test to deserialize and validate LDAP sync config fixtures

### DIFF
--- a/pkg/cmd/admin/groups/examples/examples_test.go
+++ b/pkg/cmd/admin/groups/examples/examples_test.go
@@ -1,0 +1,55 @@
+package examples
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/yaml"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	_ "github.com/openshift/origin/pkg/cmd/server/api/install"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"github.com/openshift/origin/pkg/cmd/server/api/validation"
+)
+
+func TestLDAPSyncConfigFixtures(t *testing.T) {
+	fixtures := []string{}
+
+	// build a list of common configurations for all schemas
+	schemas := []string{"rfc2307", "ad", "augmented-ad"}
+	for _, schema := range schemas {
+		fixtures = append(fixtures, schema+"/sync-config.yaml")
+		fixtures = append(fixtures, schema+"/sync-config-dn-everywhere.yaml")
+		fixtures = append(fixtures, schema+"/sync-config-partially-user-defined.yaml")
+		fixtures = append(fixtures, schema+"/sync-config-user-defined.yaml")
+	}
+
+	for _, fixture := range fixtures {
+		var config api.LDAPSyncConfig
+
+		yamlConfig, err := ioutil.ReadFile("./../../../../../test/extended/authentication/ldap/" + fixture)
+		if err != nil {
+			t.Errorf("could not read fixture at %q: %v", fixture, err)
+			continue
+		}
+
+		jsonConfig, err := yaml.ToJSON(yamlConfig)
+		if err != nil {
+			t.Errorf("could not convert YAML fixture at %q to JSON: %v", fixture, err)
+			continue
+		}
+
+		if err := runtime.DecodeInto(configapilatest.Codec, jsonConfig, &config); err != nil {
+			t.Errorf("could not deocde fixture at %q into internal type: %v", fixture, err)
+			continue
+		}
+
+		if results := validation.ValidateLDAPSyncConfig(&config); len(results.Errors) > 0 {
+			t.Errorf("validation of fixture at %q failed with %d errors:", fixture, len(results.Errors))
+			for _, err := range results.Errors {
+				t.Error(err)
+			}
+		}
+	}
+}

--- a/pkg/cmd/server/api/validation/ldap.go
+++ b/pkg/cmd/server/api/validation/ldap.go
@@ -40,10 +40,10 @@ func ValidateLDAPSyncConfig(config *api.LDAPSyncConfig) ValidationResults {
 	}
 
 	if len(schemaConfigsFound) > 1 {
-		validationResults.AddErrors(field.Invalid(nil, config, fmt.Sprintf("only one schema-specific config is allowed; found %v", schemaConfigsFound)))
+		validationResults.AddErrors(field.Invalid(field.NewPath("schema"), config, fmt.Sprintf("only one schema-specific config is allowed; found %v", schemaConfigsFound)))
 	}
 	if len(schemaConfigsFound) == 0 {
-		validationResults.AddErrors(field.Invalid(nil, config, fmt.Sprintf("exactly one schema-specific config is required;  one of %v", []string{"rfc2307", "activeDirectory", "augmentedActiveDirectory"})))
+		validationResults.AddErrors(field.Required(field.NewPath("schema"), fmt.Sprintf("exactly one schema-specific config is required;  one of %v", []string{"rfc2307", "activeDirectory", "augmentedActiveDirectory"})))
 	}
 
 	return validationResults


### PR DESCRIPTION
This changes the `examples_test` to only test things explicitly asked of it, then explicitly adds tests for LDAP sync configuration files in the extended tests fixtures.

Currently broken:
```
$ hack/test-go.sh examples/...
--- FAIL: TestExampleObjectSchemas (0.02s)
	examples_test.go:227: validating "../test/extended/authentication/ldap/ad/sync-config-dn-everywhere.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/ad/sync-config-partially-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/ad/sync-config-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/ad/sync-config.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:162: "../test/templates/fixtures/crunchydata-pod.json" is skipped
	examples_test.go:227: validating "../test/extended/authentication/ldap/rfc2307/sync-config-dn-everywhere.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/rfc2307/sync-config-partially-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/rfc2307/sync-config-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/rfc2307/sync-config.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/augmented-ad/sync-config-dn-everywhere.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/augmented-ad/sync-config-partially-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/augmented-ad/sync-config-user-defined.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:227: validating "../test/extended/authentication/ldap/augmented-ad/sync-config.yaml" returned errors: [url: Required value : Invalid value: {"kind":"LDAPSyncConfig","apiVersion":"v1","URL":"","BindDN":"","BindPassword":"","Insecure":false,"CA":"","LDAPGroupUIDToOpenShiftGroupNameMapping":null,"RFC2307Config":null,"ActiveDirectoryConfig":null,"AugmentedActiveDirectoryConfig":null}: exactly one schema-specific config is required;  one of [rfc2307 activeDirectory augmentedActiveDirectory]]
	examples_test.go:162: "../test/integration/fixtures/project-request-template-with-quota.yaml" is skipped
	examples_test.go:162: "../test/integration/fixtures/test-image-stream-mapping.json" is skipped
FAIL
FAIL	github.com/openshift/origin/examples	0.046s
```

/cc @liggitt @deads2k 