### PR TITLE
fix variable shadowing complained about by govet for 1.4

### DIFF
--- a/pkg/serviceaccounts/client.go
+++ b/pkg/serviceaccounts/client.go
@@ -37,8 +37,8 @@ func (s *ClientLookupTokenRetriever) GetToken(namespace, name string) (string, e
 		// Get the secrets
 		// TODO: JTL: create one directly once we have that ability
 		for _, secretRef := range serviceAccount.Secrets {
-			secret, err := s.Client.Secrets(namespace).Get(secretRef.Name)
-			if err != nil {
+			secret, err2 := s.Client.Secrets(namespace).Get(secretRef.Name)
+			if err2 != nil {
 				// Tolerate fetch errors on a particular secret
 				continue
 			}

--- a/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
@@ -244,9 +244,9 @@ func (e *DockercfgController) createTokenSecret(serviceAccount *api.ServiceAccou
 	// now we have to wait for the service account token controller to make this valid
 	// TODO remove this once we have a create-token endpoint
 	for i := 0; i <= tokenSecretWaitTimes; i++ {
-		liveTokenSecret, err := e.client.Secrets(tokenSecret.Namespace).Get(tokenSecret.Name)
-		if err != nil {
-			return nil, err
+		liveTokenSecret, err2 := e.client.Secrets(tokenSecret.Namespace).Get(tokenSecret.Name)
+		if err2 != nil {
+			return nil, err2
 		}
 
 		if len(liveTokenSecret.Data[api.ServiceAccountTokenKey]) > 0 {
@@ -259,8 +259,8 @@ func (e *DockercfgController) createTokenSecret(serviceAccount *api.ServiceAccou
 
 	// the token wasn't ever created, attempt deletion
 	glog.Warningf("Deleting unfilled token secret %s/%s", tokenSecret.Namespace, tokenSecret.Name)
-	if err := e.client.Secrets(tokenSecret.Namespace).Delete(tokenSecret.Name); (err != nil) && !kapierrors.IsNotFound(err) {
-		util.HandleError(err)
+	if deleteErr := e.client.Secrets(tokenSecret.Namespace).Delete(tokenSecret.Name); (deleteErr != nil) && !kapierrors.IsNotFound(deleteErr) {
+		util.HandleError(deleteErr)
 	}
 	return nil, fmt.Errorf("token never generated for %s", tokenSecret.Name)
 }

--- a/pkg/serviceaccounts/controllers/docker_registry_service.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service.go
@@ -182,15 +182,15 @@ func (e *DockerRegistryServiceController) handleLocationChange(serviceLocation s
 		t := credentialprovider.DockerConfig(dockercfgMap)
 		dockercfg = &t
 
-		dockercfgContent, err := json.Marshal(dockercfg)
-		if err != nil {
-			util.HandleError(err)
+		dockercfgContent, err2 := json.Marshal(dockercfg)
+		if err2 != nil {
+			util.HandleError(err2)
 			continue
 		}
 		dockercfgSecret.Data[api.DockerConfigKey] = dockercfgContent
 
-		if _, err := e.client.Secrets(dockercfgSecret.Namespace).Update(dockercfgSecret); err != nil {
-			util.HandleError(err)
+		if _, updateErr := e.client.Secrets(dockercfgSecret.Namespace).Update(dockercfgSecret); updateErr != nil {
+			util.HandleError(updateErr)
 			continue
 		}
 	}


### PR DESCRIPTION
fixes these complaints from travis govet:
```
pkg/serviceaccounts/client.go:40: declaration of err shadows declaration at pkg/serviceaccounts/client.go:32: 

pkg/serviceaccounts/controllers/create_dockercfg_secrets.go:247: declaration of err shadows declaration at pkg/serviceaccounts/controllers/create_dockercfg_secrets.go:239: 

pkg/serviceaccounts/controllers/docker_registry_service.go:185: declaration of err shadows declaration at pkg/serviceaccounts/controllers/docker_registry_service.go:155: 

pkg/serviceaccounts/controllers/docker_registry_service.go:192: declaration of err shadows declaration at pkg/serviceaccounts/controllers/docker_registry_service.go:185: 
```