### PR TITLE
launch integration tests using only the API server when possible

### DIFF
--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +93,7 @@ func waitForProject(t *testing.T, client client.Interface, projectName string, d
 }
 
 func TestAuthorizationResolution(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -276,7 +276,7 @@ func (test localResourceAccessReviewTest) run(t *testing.T) {
 }
 
 func TestAuthorizationResourceAccessReview(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -466,7 +466,7 @@ func (test subjectAccessReviewTest) run(t *testing.T) {
 }
 
 func TestAuthorizationSubjectAccessReview(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -750,7 +750,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 // TestOldLocalSubjectAccessReviewEndpoint checks to make sure that the old subject access review endpoint still functions properly
 // this is needed to support old docker registry images
 func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -876,7 +876,7 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 // TestOldLocalResourceAccessReviewEndpoint checks to make sure that the old resource access review endpoint still functions properly
 // this is needed to support old who-can client
 func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
 }
 
 func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 }
 
 func TestSelfSubjectAccessReviewsNonExistingNamespace(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
-	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t)
+	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, false)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
 	builds := map[string]*buildapi.Build{}
@@ -74,7 +74,7 @@ func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
 }
 
 func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *testing.T) {
-	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t)
+	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, true)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
 	buildConfigs := map[string]*buildapi.BuildConfig{}
@@ -132,9 +132,16 @@ func buildStrategyTypes() []string {
 	return []string{"source", "docker", "custom"}
 }
 
-func setupBuildStrategyTest(t *testing.T) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client) {
+func setupBuildStrategyTest(t *testing.T, includeControllers bool) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client) {
 	namespace := testutil.Namespace()
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	var clusterAdminKubeConfig string
+	var err error
+
+	if includeControllers {
+		_, clusterAdminKubeConfig, err = testserver.StartTestMaster()
+	} else {
+		_, clusterAdminKubeConfig, err = testserver.StartTestMasterAPI()
+	}
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/external_kube_test.go
+++ b/test/integration/external_kube_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestExternalKube(t *testing.T) {
 	// Start one OpenShift master as "cluster1" to play the external kube server
-	cluster1MasterConfig, cluster1AdminConfigFile, err := testserver.StartTestMaster()
+	cluster1MasterConfig, cluster1AdminConfigFile, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBasicUserBasedGroupManipulation(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 }
 
 func TestBasicGroupManipulation(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 }
 
 func TestGroupCommands(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -48,7 +48,7 @@ func mockImageStream() *imageapi.ImageStream {
 }
 
 func TestImageStreamCreate(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestImageStreamCreate(t *testing.T) {
 }
 
 func TestImageStreamMappingCreate(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -244,33 +244,4 @@ func TestImageStreamMappingCreate(t *testing.T) {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
-}
-
-func TestImageStreamDelete(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	stream := mockImageStream()
-
-	if err := clusterAdminClient.ImageStreams(testutil.Namespace()).Delete(stream.Name); err == nil || !errors.IsNotFound(err) {
-		t.Fatalf("Unxpected non-error or type: %v", err)
-	}
-	actual, err := clusterAdminClient.ImageStreams(testutil.Namespace()).Create(stream)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if err := clusterAdminClient.ImageStreams(testutil.Namespace()).Delete(actual.Name); err != nil {
-		t.Fatalf("Unxpected error: %v", err)
-	}
 }

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -29,7 +29,7 @@ func init() {
 func TestLogin(t *testing.T) {
 	clientcmd.DefaultCluster = clientcmdapi.Cluster{Server: ""}
 
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestPolicyCommands(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -19,7 +19,7 @@ func init() {
 
 // TestProjectIsNamespace verifies that a project is a namespace, and a namespace is a project
 func TestProjectIsNamespace(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestProjectIsNamespace(t *testing.T) {
 
 // TestProjectMustExist verifies that content cannot be added in a project that does not exist
 func TestProjectMustExist(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/root_redirect_test.go
+++ b/test/integration/root_redirect_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRootRedirect(t *testing.T) {
-	masterConfig, _, err := testserver.StartTestMaster()
+	masterConfig, _, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/template_test.go
+++ b/test/integration/template_test.go
@@ -23,7 +23,7 @@ func init() {
 	testutil.RequireEtcd()
 }
 func TestTemplate(t *testing.T) {
-	_, path, err := testserver.StartTestMaster()
+	_, path, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestUnprivilegedNewProject(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 }
 
 func TestUnprivilegedNewProjectDenied(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -72,7 +72,7 @@ func makeMapping(user, identity string) *api.UserIdentityMapping {
 
 func TestUserInitialization(t *testing.T) {
 
-	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -78,7 +78,7 @@ func signedManifest(name string) ([]byte, digest.Digest, error) {
 }
 
 func TestV2RegistryGetTags(t *testing.T) {
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}


### PR DESCRIPTION
Many integration tests don't require controllers.   There's no reason to wait for them to start.

@stevekuznetsov ptal