### PR TITLE
Many anyuid programs fail due to SETGID/SETUID caps

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -226,7 +226,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			// prefer the anyuid SCC over ones that force a uid
 			Priority: &securityContextConstraintsAnyUIDPriority,
 			// drops unsafe caps
-			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SYS_CHROOT", "SETUID", "SETGID"},
+			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SYS_CHROOT"},
 		},
 	}
 


### PR DESCRIPTION
It looks like a majority of programs running as root that do drop caps
are being blocked by SETGID/SETUID being dropped for anyuid, including
most Kube e2e programs.

@pweil-