### PR TITLE
UPSTREAM: 20213: Fixed persistent volume claim controllers processing an old volume

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
@@ -111,6 +111,7 @@ func TestClaimRace(t *testing.T) {
 
 	volumeIndex := NewPersistentVolumeOrderedIndex()
 	mockClient := &mockBinderClient{}
+	mockClient.volume = v
 
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(host_path.ProbeRecyclableVolumePlugins(newMockRecycler, volume.VolumeConfig{}), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
@@ -196,7 +197,8 @@ func TestClaimSyncAfterVolumeProvisioning(t *testing.T) {
 
 	volumeIndex := NewPersistentVolumeOrderedIndex()
 	mockClient := &mockBinderClient{
-		claim: claim,
+		claim:  claim,
+		volume: pv,
 	}
 
 	plugMgr := volume.VolumePluginMgr{}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
@@ -211,6 +211,14 @@ func (controller *PersistentVolumeProvisionerController) reconcileClaim(claim *a
 func (controller *PersistentVolumeProvisionerController) reconcileVolume(pv *api.PersistentVolume) error {
 	glog.V(5).Infof("PersistentVolume[%s] reconciling", pv.Name)
 
+	// The PV may have been modified by parallel call to reconcileVolume, load
+	// the current version.
+	newPv, err := controller.client.GetPersistentVolume(pv.Name)
+	if err != nil {
+		return fmt.Errorf("Cannot reload volume %s: %v", pv.Name, err)
+	}
+	pv = newPv
+
 	if pv.Spec.ClaimRef == nil {
 		glog.V(5).Infof("PersistentVolume[%s] is not bound to a claim.  No provisioning required", pv.Name)
 		return nil
@@ -244,7 +252,7 @@ func (controller *PersistentVolumeProvisionerController) reconcileVolume(pv *api
 
 	// provisioning is incomplete.  Attempt to provision the volume.
 	glog.V(5).Infof("PersistentVolume[%s] provisioning in progress", pv.Name)
-	err := provisionVolume(pv, controller)
+	err = provisionVolume(pv, controller)
 	if err != nil {
 		return fmt.Errorf("Error provisioning PersistentVolume[%s]: %v", err)
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller_test.go
@@ -144,6 +144,7 @@ func TestReconcileVolume(t *testing.T) {
 	controller, mockClient, mockVolumePlugin := makeTestController()
 	pv := makeTestVolume()
 	pvc := makeTestClaim()
+	mockClient.volume = pv
 
 	err := controller.reconcileVolume(pv)
 	if err != nil {
@@ -158,6 +159,7 @@ func TestReconcileVolume(t *testing.T) {
 	// pretend the claim and volume are bound, no provisioning required
 	claimRef, _ := api.GetReference(pvc)
 	pv.Spec.ClaimRef = claimRef
+	mockClient.volume = pv
 	err = controller.reconcileVolume(pv)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -165,6 +167,7 @@ func TestReconcileVolume(t *testing.T) {
 
 	pv.Annotations[pvProvisioningRequiredAnnotationKey] = "!pvProvisioningCompleted"
 	pv.Annotations[qosProvisioningKey] = "foo"
+	mockClient.volume = pv
 	err = controller.reconcileVolume(pv)
 
 	if !isAnnotationMatch(pvProvisioningRequiredAnnotationKey, pvProvisioningCompletedAnnotationValue, mockClient.volume.Annotations) {


### PR DESCRIPTION
Partly fixes BZ#1305546: Dynamic provisioner can create several Persistent Volume for one claim