### PR TITLE
UPSTREAM: coreos/etcd: 4503: expose error details for normal stringify

### DIFF
--- a/Godeps/_workspace/src/github.com/coreos/etcd/client/cluster_error.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/client/cluster_error.go
@@ -21,7 +21,11 @@ type ClusterError struct {
 }
 
 func (ce *ClusterError) Error() string {
-	return ErrClusterUnavailable.Error()
+	s := ce.Detail()
+	if len(s) > 0 {
+		return s
+	}
+	return "ClusterError without any details"
 }
 
 func (ce *ClusterError) Detail() string {


### PR DESCRIPTION
Start debugging flakes by gathering error information.

@liggitt @smarterclayton I'd like this now so we get more details.