### PR TITLE
Fix networking service e2e tests

### DIFF
--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -215,6 +215,12 @@ os::provision::base-provision() {
       # network plugins need to be able to work with one enabled.
       systemctl enable iptables.service
       systemctl start iptables.service
+
+      # Ensure that the master can access the kubelet for capabilities
+      # like 'oc exec'.  Explicitly specifying the insertion location
+      # is brittle but the tests should catch conflicts with the
+      # package rules.
+      iptables -I INPUT 4 -p tcp -m state --state NEW --dport 10250 -j ACCEPT
     fi
   fi
 }

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -25,7 +25,7 @@ os::log::install_errexit
 NETWORKING_DEBUG=${NETWORKING_DEBUG:-false}
 
 # These strings filter the available tests.
-NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking}"
+NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services}"
 NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 
 DEFAULT_SKIP_LIST=(


### PR DESCRIPTION
The last rebase from kube resulted in broken NodePort service e2e tests.  The tests switched from using ssh to a HostExec pod to verify that a port allocated for a NodePort service is allocated on the host, and this is broken on multinode openshift.  

The tests were disabled by #7244 and are intended to be re-enabled by this PR when a fix is found.