### PR TITLE
Improve performance of overview page with many deployments

### DIFF
--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -297,12 +297,13 @@ angular.module('openshiftConsole')
           });
         }
 
+        var deploymentsByDepConfig = {};
         function deploymentRelationships() {
           var bySvc = $scope.deploymentsByService = {"": {}};
           var bySvcByDepCfg = $scope.deploymentsByServiceByDeploymentConfig = {"": {}};
 
           // Also keep a map of deployments by deployment config to determine which are scalable.
-          var byDepConfig = {};
+          deploymentsByDepConfig = {};
 
           angular.forEach($scope.deployments, function(deployment, depName){
             var foundMatch = false;
@@ -311,8 +312,8 @@ angular.module('openshiftConsole')
             var depConfigName = annotationFilter(deployment, 'deploymentConfig') || "";
 
             if (depConfigName) {
-              byDepConfig[depConfigName] = byDepConfig[depConfigName] || [];
-              byDepConfig[depConfigName].push(deployment);
+              deploymentsByDepConfig[depConfigName] = deploymentsByDepConfig[depConfigName] || [];
+              deploymentsByDepConfig[depConfigName].push(deployment);
             }
 
             angular.forEach($scope.unfilteredServices, function(service, name){
@@ -334,8 +335,6 @@ angular.module('openshiftConsole')
               bySvcByDepCfg[""][depConfigName] = bySvcByDepCfg[""][depConfigName] || {};
               bySvcByDepCfg[""][depConfigName][depName] = deployment;
             }
-
-            updateScalableDeployments(byDepConfig);
           });
         }
 
@@ -356,6 +355,7 @@ angular.module('openshiftConsole')
           // Order is important here since podRelationships expects deploymentsByServiceByDeploymentConfig to be up to date
           deploymentRelationships();
           podRelationships();
+          updateScalableDeployments(deploymentsByDepConfig);
 
           // Must be called after podRelationships()
           updateShowGetStarted();

--- a/assets/app/scripts/filters/date.js
+++ b/assets/app/scripts/filters/date.js
@@ -66,13 +66,31 @@ angular.module('openshiftConsole')
   .filter('orderObjectsByDate', function(toArrayFilter) {
     return function(items, reverse) {
       items = toArrayFilter(items);
+
+      /*
+       * Note: This is a hotspot in our code. We sort frequently by date on
+       *       the overview and browse pages.
+       */
+
       items.sort(function (a, b) {
         if (!a.metadata || !a.metadata.creationTimestamp || !b.metadata || !b.metadata.creationTimestamp) {
           throw "orderObjectsByDate expects all objects to have the field metadata.creationTimestamp";
         }
-        var diff = moment(a.metadata.creationTimestamp).diff(moment(b.metadata.creationTimestamp));
-        return reverse ? diff * -1 : diff;
+
+        // The date format can be sorted using straight string comparison.
+        // Compare as strings for performance.
+        // Example Date: 2016-02-02T21:53:07Z
+        if (a.metadata.creationTimestamp < b.metadata.creationTimestamp) {
+          return reverse ? 1 : -1;
+        }
+
+        if (a.metadata.creationTimestamp > b.metadata.creationTimestamp) {
+          return reverse ? -1 : 1;
+        }
+
+        return 0;
       });
+
       return items;
     };
   });


### PR DESCRIPTION
This change improves the performance rendering the overview when there are many deployments.

* Only recalculate scalable deployments from the replication controller watch.
* Find active deployment in linear time without sorting the entire list.

Fixes #7255