### PR TITLE
Use normal GOPATH for build

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -20,8 +20,7 @@ os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 # linux-only, and are compiled with flags to make them static for use in Docker
 # images "FROM scratch".
 OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
-CGO_ENABLED=0 OS_GOFLAGS="-a" os::build::build_binaries "${OS_IMAGE_COMPILE_TARGETS[@]-}"
-CGO_ENABLED=0 OS_GOFLAGS="-a -installsuffix cgo" os::build::build_binaries "${OS_SCRATCH_IMAGE_COMPILE_TARGETS[@]-}"
+os::build::build_static_binaries "${OS_IMAGE_COMPILE_TARGETS[@]-}" "${OS_SCRATCH_IMAGE_COMPILE_TARGETS[@]-}"
 
 # Make the primary client/server release.
 OS_RELEASE_ARCHIVE="openshift-origin"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -147,7 +147,7 @@ function start_os_server {
 	date
 
 	wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
-	wait_for_url "${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz" "[INFO] kubelet: " 0.5 60
+	wait_for_url "${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz" "[INFO] kubelet: " 0.5 120
 	wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz/ready" "apiserver(ready): " 0.25 80
 	wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/nodes/${KUBELET_HOST}" "apiserver(nodes): " 0.25 80
 


### PR DESCRIPTION
Remove the old _output/local/go abstraction from the builds and improve
how we build static binaries and images. Pass OS_RELEASE=n to
build-images.sh to build from local binaries rather than a release.

[test]