### PR TITLE
Fix metadata issue for deployment and build configs

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -446,7 +446,7 @@ const (
 // BuildConfig is a template which can be used to create new builds.
 type BuildConfig struct {
 	unversioned.TypeMeta
-	kapi.ObjectMeta
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec holds all the input necessary to produce a new build, and the conditions when
 	// to trigger them.

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -268,7 +268,7 @@ const DeploymentCancelledAnnotationValue = "true"
 // a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
 	unversioned.TypeMeta
-	kapi.ObjectMeta
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec represents a desired deployment state and how to deploy to it.
 	Spec DeploymentConfigSpec


### PR DESCRIPTION
Fix metadata issue for deployment and build configs when these are
retrieved using kubectl get --sort-by=.metadata.name.