### PR TITLE
[WIP] Web console: debug terminal for crashing pods

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -133,6 +133,7 @@
         <script src="scripts/services/constants.js"></script>
         <script src="scripts/services/limits.js"></script>
         <script src="scripts/services/routes.js"></script>
+        <script src="scripts/services/pods.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
@@ -170,6 +171,7 @@
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/controllers/modals/editModal.js"></script>
+        <script src="scripts/controllers/modals/debugTerminal.js"></script>
         <script src="scripts/controllers/about.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>

--- a/assets/app/scripts/controllers/modals/debugTerminal.js
+++ b/assets/app/scripts/controllers/modals/debugTerminal.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:DebugTerminalModalController
+ * @description
+ * # DebugTerminalModalController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('DebugTerminalModalController', function ($scope, $filter, $uibModalInstance, containerName) {
+    $scope.containerName = containerName;
+    $scope.close = function() {
+      $uibModalInstance.close('close');
+    };
+  });

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('PodController', function ($scope, $routeParams, $timeout, DataService, ProjectsService, $filter, ImageStreamResolver, MetricsService) {
+  .controller('PodController', function ($scope, $routeParams, $timeout, $uibModal, DataService, PodsService, ProjectsService, $filter, ImageStreamResolver, MetricsService) {
     $scope.projectName = $routeParams.project;
     $scope.pod = null;
     $scope.imageStreams = {};
@@ -96,6 +96,73 @@ angular.module('openshiftConsole')
           Logger.log("builds (subscribe)", $scope.builds);
         }));
 
+        var debugPodWatch;
+        $scope.debugTerminal = function(containerName) {
+          var debugPod = PodsService.generateDebugPod($scope.pod, containerName);
+          if (!debugPod) {
+            $scope.alerts['debug-container-error'] = {
+              type: "error",
+              message: "Could not debug container " + containerName
+            }
+            return;
+          }
+
+          // Create the debug pod.
+          DataService.create("pods", null, debugPod, context).then(
+            // success
+            function(pod) {
+              // Watch the pod so we know when it's running to connect.
+              // Keep the watch handle in a var outside the watches array so we
+              // can unwatch immediately when the terminal is closed.
+              debugPodWatch = DataService.watchObject("pods", debugPod.metadata.name, context, function(pod, action) {
+                $scope.debugPod = pod;
+              });
+
+              // Show the terminal in a modal window.
+              var modalInstance = $uibModal.open({
+                animation: true,
+                templateUrl: 'views/modals/debug-terminal.html',
+                controller: 'DebugTerminalModalController',
+                scope: $scope,
+                resolve: {
+                  containerName: function() {
+                    return containerName
+                  }
+                },
+                backdrop: 'static' // don't close modal when clicking backdrop
+              });
+
+              // On modal close, delete the pod.
+              // TODO: Try to delete pod when user navigates away without closing modal.
+              modalInstance.result.then(function() {
+                DataService.unwatch(debugPodWatch);
+                debugPodWatch = null;
+                // Delete the pod when done.
+                DataService.delete("pods", pod.metadata.name, context).then(
+                  // success
+                  function() {
+                    $scope.debugPod = null;
+                  },
+                  // failure
+                  function(result) {
+                    $scope.alerts['debug-container-error'] = {
+                      type: "error",
+                      message: "Could not delete pod " + pod.metadata.name,
+                      details: "Reason: " + $filter('getErrorDetails')(result)
+                    };
+                  });
+              });
+            },
+            //failure
+            function(result) {
+              $scope.alerts['debug-container-error'] = {
+                type: "error",
+                message: "Could not debug container " + containerName,
+                details: "Reason: " + $filter('getErrorDetails')(result)
+              };
+            });
+        };
+
         $scope.containersRunning = function(containerStatuses) {
           var running = 0;
           if (containerStatuses) {
@@ -110,7 +177,10 @@ angular.module('openshiftConsole')
 
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);
+          if (debugPodWatch) {
+            DataService.unwatch(debugPodWatch);
+            debugPodWatch = null;
+          }
         });
-
     }));
   });

--- a/assets/app/scripts/services/pods.js
+++ b/assets/app/scripts/services/pods.js
@@ -1,0 +1,37 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("PodsService", function() {
+    return {
+      // Generates a copy of pod for debugging crash loops.
+      generateDebugPod: function(pod, containerName) {
+        var container = _.find(pod.spec.containers, { name: containerName });
+        if (!container) {
+          return null;
+        }
+
+        // Copy the pod and make some changes for debugging.
+        var debugPod = angular.copy(pod);
+        debugPod.metadata = {
+          // Use same naming convention as `oc debug`
+          name: "debug-" + pod.metadata.name + "-" + containerName,
+          annotations: {
+            "debug.openshift.io/source-container": containerName,
+            "debug.openshift.io/source-resource": "pod/" + pod.metadata.name
+          }
+        };
+        debugPod.labels = {
+          'debug.openshift.io/name': pod.metadata.name
+        }
+        debugPod.spec.restartPolicy = "Never";
+
+        // Prevent container from stopping immediately.
+        container.command = ['tail'];
+        container.args = ['-f', '/dev/null'];
+        debugPod.spec.containers = [container];
+
+        return debugPod;
+      }
+    };
+  });
+

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -775,6 +775,19 @@ a.disabled-link {
   }
 }
 
+.modal-debug-terminal {
+  .modal-body {
+    border-top: 1px solid #bbbbbb;
+    padding: 0;
+    .alert {
+      margin-bottom: 0;
+    }
+  }
+  .modal-footer {
+    margin-top: 0;
+  }
+}
+
 .dockerfile-editor {
   height: 200px;
 }

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -27,6 +27,9 @@
           <dt>State:</dt>
           <dd>
             <kubernetes-object-describe-container-state container-state="containerStatus.state"></kubernetes-object-describe-container-state>
+            <span ng-if="!containerStatus.state.running">
+              &mdash; <a href="" ng-click="debugTerminal(containerStatus.name)">Debug in Terminal</a>
+            </span>
           </dd>
           <dt ng-if="!(containerStatus.lastState | isEmptyObj)">Last State</dt>
           <dd ng-if="!(containerStatus.lastState | isEmptyObj)">

--- a/assets/app/views/modals/debug-terminal.html
+++ b/assets/app/views/modals/debug-terminal.html
@@ -1,0 +1,20 @@
+<div class="modal-debug-terminal">
+  <div class="modal-header">
+    <h2><i class="fa fa-terminal" aria-hidden="true"></i> Debugging Container {{containerName}}</h2>
+  </div>
+  <div class="modal-body">
+    <div ng-if="!debugPod.status.containerStatuses[0].state.running" class="h2 text-muted text-center gutter-top gutter-bottom">
+      <p>Waiting for container {{containerName}} to start...</p>
+    </div>
+    <kubernetes-container-terminal
+        pod="debugPod"
+        container="containerName"
+        ng-if="debugPod.status.containerStatuses[0].state.running"
+        class="text-center"
+        style="overflow: hidden;">
+    </kubernetes-container-terminal>
+  </div>
+  <div class="modal-footer">
+      <button class="btn btn-lg btn-primary" type="button" ng-click="close()">Close</button>
+  </div>
+</div>


### PR DESCRIPTION
WIP, not ready for code review. See also #7294.

Starts a debug pod that runs a different command to prevent the container crashing and opens a terminal window.

TODO:

- [ ] Align behavior with `oc debug`
  - [ ] Use same debug pod name
  - [ ] Disable readiness and liveness probes by default
  - [ ] Remove annotations by default
- [ ] Show help text
- [ ] Try to delete pod if user navigates away without closing modal

Debug in Terminal link for crash-looping containers on browse pod page:

<img width="640" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13055150/b0be97f8-d3db-11e5-852e-e5ba12180e1d.png">

Debug terminal modal:

![debug-terminal](https://cloud.githubusercontent.com/assets/1167259/13055157/b8343fec-d3db-11e5-83a3-7ac8d29a7284.png)

/cc @jwforres @smarterclayton 