### PR TITLE
[WIP] Web console support for health checks

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -154,6 +154,7 @@
         <script src="scripts/controllers/persistentVolumeClaim.js"></script>
         <script src="scripts/controllers/setLimits.js"></script>
         <script src="scripts/controllers/edit/buildConfig.js"></script>
+        <script src="scripts/controllers/edit/healthChecks.js"></script>
         <script src="scripts/controllers/create/createFromImage.js"></script>
         <script src="scripts/controllers/create/nextSteps.js"></script>
         <script src="scripts/controllers/newfromtemplate.js"></script>
@@ -202,6 +203,7 @@
         <script src="scripts/directives/quotaUsageChart.js"></script>
         <script src="scripts/directives/buildTrendsChart.js"></script>
         <script src="scripts/directives/editRequestLimit.js"></script>
+        <script src="scripts/directives/editProbe.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -244,6 +244,10 @@ angular
         templateUrl: 'views/set-limits.html',
         controller: 'SetLimitsController'
       })
+      .when('/project/:project/edit-health-checks', {
+        templateUrl: 'views/edit-health-checks.html',
+        controller: 'EditHealthChecksController'
+      })
       .when('/about', {
         templateUrl: 'views/about.html',
         controller: 'AboutController'

--- a/assets/app/scripts/constants.js
+++ b/assets/app/scripts/constants.js
@@ -15,6 +15,7 @@ window.OPENSHIFT_CONSTANTS = {
     "route-types":             "https://docs.openshift.org/latest/architecture/core_concepts/routes.html#route-types",
     "persistent_volumes":      "https://docs.openshift.org/latest/dev_guide/persistent_volumes.html",
     "compute_resources":       "https://docs.openshift.org/latest/dev_guide/compute_resources.html",
+    "application_health":      "https://docs.openshift.org/latest/dev_guide/application_health.html",
     "default":                 "https://docs.openshift.org/latest/welcome/index.html"
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.
@@ -22,4 +23,3 @@ window.OPENSHIFT_CONSTANTS = {
     "Latest Release":          "https://github.com/openshift/origin/releases/latest"
   }
 };
-

--- a/assets/app/scripts/directives/editProbe.js
+++ b/assets/app/scripts/directives/editProbe.js
@@ -1,0 +1,81 @@
+"use strict";
+
+angular.module('openshiftConsole')
+  .directive('editProbe', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        probe: '=',
+        exposedPorts: '='
+      },
+      templateUrl: 'views/_edit-probe.html',
+      link: function(scope) {
+        scope.id = _.uniqueId('edit-probe-');
+        scope.probe = scope.probe || {};
+        scope.command = { arg: '' };
+
+        // Map of previous probes by type so switching to a different type and
+        // back remembers the previous values.
+        scope.previousProbes = {};
+
+        // Only allow selecting TCP ports for HTTP and TCP socket checks.
+        scope.tcpPorts = _.filter(scope.exposedPorts, { protocol: "TCP" });
+
+        var updateSelectedType = function(newType, oldType) {
+          scope.probe = scope.probe || {};
+
+          // Remember the values entered for `oldType`.
+          scope.previousProbes[oldType] = scope.probe[oldType];
+
+          // Use previous values when switching back to `newType` if found.
+          scope.probe[newType] = scope.previousProbes[newType];
+
+          // If no previous values, set the defaults.
+          if (!scope.probe[newType]) {
+            switch (newType) {
+            case 'httpGet':
+            case 'tcpSocket':
+              var firstPort = _.head(scope.tcpPorts);
+              scope.probe[newType] = {
+                port: firstPort ? firstPort.containerPort : ''
+              };
+              break;
+            case 'exec':
+              scope.probe = {
+                exec: {
+                  command: []
+                }
+              };
+              break;
+            }
+          }
+        };
+
+        // Initialize type from existing data.
+        if (scope.probe.httpGet) {
+          scope.type = 'httpGet';
+        } else if (scope.probe.exec) {
+          scope.type = 'exec';
+        } else if (scope.probe.tcpSocket) {
+          scope.type = 'tcpSocket';
+        } else {
+          // Set defaults for new probe.
+          scope.type = 'httpGet';
+          updateSelectedType('httpGet');
+        }
+
+        scope.$watch('type', function(newType, oldType) {
+          if (newType === oldType) {
+            return;
+          }
+
+          updateSelectedType(newType, oldType);
+        });
+
+        scope.addCommandArg = function() {
+          scope.probe.exec.command.push(scope.command.arg);
+          scope.command.arg = '';
+        };
+      }
+    };
+  });

--- a/assets/app/scripts/directives/resources.js
+++ b/assets/app/scripts/directives/resources.js
@@ -147,4 +147,13 @@ angular.module('openshiftConsole')
         $scope.expanded = {};
       }
     };
+  })
+  .directive('probe', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        probe: '='
+      },
+      templateUrl: 'views/directives/_probe.html'
+    };
   });

--- a/assets/app/views/_edit-probe.html
+++ b/assets/app/views/_edit-probe.html
@@ -1,0 +1,137 @@
+<ng-form name="form">
+  <div class="form-group">
+    <label ng-attr-for="{{id}}-type" class="required">Type</label>
+    <select
+        ng-model="type"
+        ng-attr-id="{{id}}-type"
+        required
+        class="form-control">
+      <option value="httpGet">HTTP</option>
+      <option value="exec">Container Command</option>
+      <option value="tcpSocket">TCP Socket</option>
+    </select>
+  </div>
+  <fieldset ng-if="type === 'httpGet'">
+    <div class="form-group">
+      <label ng-attr-for="{{id}}-path">Path</label>
+      <div>
+        <input
+            ng-attr-id="{{id}}-path"
+            ng-model="probe.httpGet.path"
+            type="text"
+            placeholder="/"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            class="form-control">
+      </div>
+    </div>
+    <div class="form-group">
+      <label ng-attr-for="{{id}}-http-port" class="required">Port</label>
+      <select
+          id="{{id}}-http-port"
+          ng-model="probe.httpGet.port"
+          ng-options="port.containerPort as port.containerPort for port in tcpPorts"
+          required
+          class="form-control">
+      </select>
+      <div ng-if="!tcpPorts.length" class="has-error">
+        <span class="help-block">Container has no TCP ports.</span>
+      </div>
+    </div>
+  </fieldset>
+  <fieldset ng-if="type === 'exec'">
+    <label class="required">Command</label>
+    <div class="form-group">
+      <div ng-if="!probe.exec.command.length"><em>No command set.</em></div>
+      <div ng-if="probe.exec.command.length">
+        <span ng-repeat="arg in probe.exec.command" class="label label-default">
+          {{arg}} <a href="">x</a>
+        </span>
+        <button ng-click="probe.exec.command = []" class="btn btn-link">Clear</button>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="sr-only" ng-attr-for="{{id}}-add-arg">Add Argument</label>
+      <span class="input-group">
+        <input
+            type="text"
+            ng-model="command.arg"
+            ng-attr-id="{{id}}-add-arg"
+            ng-required="!probe.exec.command.length"
+            placeholder="Command Argument"
+            class="form-control"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false">
+        <span class="input-group-btn">
+          <button class="btn btn-default" ng-click="addCommandArg()" ng-disabled="!command.arg">Add</button>
+        </span>
+      </span>
+    </div>
+  </fieldset>
+  <fieldset ng-if="type === 'tcpSocket'">
+    <div class="form-group">
+      <label ng-attr-for="{{id}}-tcp-port" class="required">Port</label>
+      <select
+          id="{{id}}-tcp-port"
+          ng-model="tcpSocket.port"
+          ng-options="port.containerPort for port in exposedPorts"
+          required
+          class="form-control">
+      </select>
+    </div>
+  </fieldset>
+  <div class="form-group">
+    <label ng-attr-for="{{id}}-initial-delay">Initial Delay</label>
+    <span class="input-group">
+      <input
+          type="number"
+          name="initialDelaySeconds"
+          ng-model="probe.initialDelaySeconds"
+          min="0"
+          ng-attr-id="{{id}}-initial-delay"
+          class="form-control"
+          ng-attr-aria-describedby="{{id}}-delay-description">
+      <span class="input-group-addon">seconds</span>
+    </span>
+    <div class="help-block" ng-attr-id="{{id}}-delay-description">
+      How long to wait after the container starts to check health.
+    </div>
+    <div ng-if="form.initialDelaySeconds.$invalid && form.initialDelaySeconds.$touched" class="has-error">
+      <div ng-if="form.initialDelaySeconds.$error.number" class="help-block">
+        Must be a number.
+      </div>
+      <div ng-if="form.initialDelaySeconds.$error.min" class="help-block">
+        Delay can't be negative.
+      </div>
+    </div>
+  </div>
+  <div class="form-group">
+    <label ng-attr-for="{{id}}-timeout">Timeout</label>
+    <span class="input-group"
+       ng-class="{ 'has-error': form.timeoutSeconds.$invalid && form.timeoutSeconds.$touched }">
+      <input
+          type="number"
+          name="timeoutSeconds"
+          ng-modeal="probe.timeoutSeconds"
+          min="0"
+          placeholder="1"
+          ng-attr-id="{{id}}-timeout"
+          class="form-control"
+          ng-attr-aria-describedby="{{id}}-timeout-description">
+      <span class="input-group-addon">seconds</span>
+    </span>
+    <div class="help-block" ng-attr-id="{{id}}-timeout-description">
+      How long to wait for the probe to finish. If the time is exceeded, the probe is considered failed.
+    </div>
+    <div ng-if="form.timeoutSeconds.$invalid && form.timeoutSeconds.$touched" class="has-error">
+      <div ng-if="form.timeoutSeconds.$error.number" class="help-block">
+        Must be a number.
+      </div>
+      <div ng-if="form.timeoutSeconds.$error.min" class="help-block">
+        Timeout can't be negative.
+      </div>
+    </div>
+  </div>
+</ng-form>

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -124,6 +124,24 @@
         </div>
       </div>
 
+      <div row ng-if="detailed && container.livenessProbe" class="icon-row">
+        <div>
+          <i class="fa fa-medkit" aria-hidden="true"></i>
+        </div>
+        <div flex>
+          Liveness Probe: <probe probe="container.livenessProbe"></probe>
+        </div>
+      </div>
+
+      <div row ng-if="detailed && container.readinessProbe" class="icon-row">
+        <div>
+          <i class="fa fa-medkit" aria-hidden="true"></i>
+        </div>
+        <div flex>
+          Readiness Probe: <probe probe="container.readinessProbe"></probe>
+        </div>
+      </div>
+
       <div hawtio-extension name="container-links"></div>
 
     </div>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -39,6 +39,11 @@
                         ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
                     </li>
                     <li>
+                      <a href="project/{{projectName}}/edit-health-checks?dcName={{deploymentConfig.metadata.name}}"
+                        role="button"
+                        ><i class="fa fa-medkit fa-fw" aria-hidden="true"></i> Edit Health Checks</a>
+                    </li>
+                    <li>
                       <edit-link
                         resource="deploymentConfig"
                         kind="deploymentconfigs"

--- a/assets/app/views/browse/replication-controller.html
+++ b/assets/app/views/browse/replication-controller.html
@@ -22,6 +22,11 @@
                       ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
                   </li>
                   <li>
+                    <a href="project/{{projectName}}/edit-health-checks?rcName={{deployment.metadata.name}}"
+                      role="button"
+                      ><i class="fa fa-medkit fa-fw" aria-hidden="true"></i> Edit Health Checks</a>
+                  </li>
+                  <li>
                     <edit-link
                       resource="deployment"
                       kind="replicationcontrollers"

--- a/assets/app/views/directives/_probe.html
+++ b/assets/app/views/directives/_probe.html
@@ -1,0 +1,15 @@
+<!-- Make sure there is no whitespace before comma -->
+<span ng-if="probe.httpGet">
+  GET {{probe.httpGET.path || '/'}} on port {{probe.httpGet.port || 'unknown'}}
+</span>
+<span ng-if="probe.exec.command">
+  <code ng-repeat="arg in probe.exec.command">{{arg}}</code>
+</span>
+<span ng-if="probe.tcpSocket">
+  Open socket on port {{probe.tcpSocket.port}}
+</span>
+
+<small class="text-muted">
+  <span ng-if="probe.initialDelaySeconds">{{probe.initialDelaySeconds}}s delay, </span>
+  {{probe.timeoutSeconds || 1}}s timeout
+</small>

--- a/assets/app/views/edit-health-checks.html
+++ b/assets/app/views/edit-health-checks.html
@@ -1,0 +1,85 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle">
+    <!-- Middle section -->
+    <div class="middle-section surface-shaded">
+      <div class="middle-container has-scroll">
+        <div class="middle-content">
+          <div class="container surface-shaded">
+            <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+            <div class="row">
+              <div class="col-md-12">
+                <alerts alerts="alerts"></alerts>
+                <div ng-show="!containers.length">Loading...</div>
+                <form ng-show="containers.length" name="form">
+                  <h1>Health Checks: {{name}}</h1>
+                  <div class="help-block">
+                    Container health is periodically checked using readiness and liveness probes.
+                  </div>
+                  <div class="learn-more-block">
+                    <a href="{{'application_health' | helpLink}}" target="_blank">Learn more <i class="fa fa-external-link" aria-hidden> </i></a>
+                  </div>
+                  <fieldset ng-disabled="disableInputs">
+                    <div ng-repeat="container in containers"
+                         ng-init="formName = container.name + '-form'">
+                      <h2 ng-if="containers.length > 1">Container {{container.name}}</h2>
+                      <h3>Readiness Probe</h3>
+                      <div class="help-block" ng-if="$first">
+                        A readiness probe determines if the container is ready to
+                        service requests. A failed readiness probe signals that a
+                        container should not receive any traffic from a proxy
+                        even if running.
+                      </div>
+                      <div ng-if="!container.readinessProbe">
+                        <a href="" ng-click="addProbe(container, 'readinessProbe')">Add Readiness Probe</a>
+                      </div>
+                      <div ng-if="container.readinessProbe">
+                        <edit-probe
+                            probe="container.readinessProbe"
+                            exposed-ports="container.ports"
+                            ng-if="container.readinessProbe">
+                        </edit-probe>
+                        <p>
+                          <a href="" ng-click="removeProbe(container, 'readinessProbe')">Remove Readiness Probe</a>
+                        </p>
+                      </div>
+                      <h3>Liveness Probe</h3>
+                      <div class="help-block" ng-if="$first">
+                        A liveness probe checks if the container is still
+                        running. If the liveness probe fails, the container is
+                        killed.
+                      </div>
+                      <div ng-if="!container.livenessProbe">
+                        <a href="" ng-click="addProbe(container, 'livenessProbe')">Add Liveness Probe</a>
+                      </div>
+                      <div ng-if="container.livenessProbe">
+                        <edit-probe
+                            probe="container.livenessProbe"
+                            exposed-ports="container.ports">
+                        </edit-probe>
+                        <p>
+                          <a href="" ng-click="removeProbe(container, 'livenessProbe')">Remove Liveness Probe</a>
+                        </p>
+                      </div>
+                    </div>
+                    <div class="button-group gutter-top gutter-bottom">
+                      <button type="submit"
+                        class="btn btn-primary btn-lg"
+                        ng-click="save()"
+                        ng-disabled="form.$invalid || isPristine() || disableInputs"
+                        value="">Save</button>
+                      <a class="btn btn-default btn-lg" ng-href="{{resourceURL}}">Cancel</a>
+                    </div>
+                  </fieldset>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->


### PR DESCRIPTION
Work in progress, not ready for code review.

* Shows liveness and readiness probes in the detailed pod template.
* Adds support for editing liveness and readiness probes for deployment configs and replication controllers with no deployment configs.

TODO:

- [ ] Show warning if no health checks set
- [x] Let users remove health checks
- [x] Move readiness above liveness
- [x] Only show TCP ports in dropdown
- [ ] Improve command input
- [ ] Make command input its own directive
- [x] Remember previous values when switching between types
- [ ] Improve help text
- [x] Fix breadcrumb to match menu label
- [ ] Fix form validation
- [x] Move editHealthChecks.js under controllers/edit dir
- [ ] Update online-extensions.js for new doc link
- [ ] General clean-up

![edit-health-checks](https://cloud.githubusercontent.com/assets/1167259/13058886/445dc3f4-d3f4-11e5-8d66-fdad75a5ef0b.png)

/cc @jwforres @smarterclayton 