### PR TITLE
updated commitchecker regex to work for ldap package

### DIFF
--- a/tools/rebasehelpers/commitchecker/validate_test.go
+++ b/tools/rebasehelpers/commitchecker/validate_test.go
@@ -217,6 +217,7 @@ func TestValidateUpstreamCommitSummaries(t *testing.T) {
 		{valid: true, summary: "UPSTREAM: revert: abcd123: coreos/etcd: <carry>: a change"},
 		{valid: true, summary: "UPSTREAM: revert: abcd123: coreos/etcd: <drop>: a change"},
 		{valid: false, summary: "UPSTREAM: whoopsie daisy"},
+		{valid: true, summary: "UPSTREAM: gopkg.in/ldap.v2: 51: exposed better API for paged search"},
 	}
 	for _, test := range tests {
 		commit := util.Commit{Summary: test.summary, Sha: "abcd000"}

--- a/tools/rebasehelpers/util/git.go
+++ b/tools/rebasehelpers/util/git.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var UpstreamSummaryPattern = regexp.MustCompile(`UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-]+)?: )?(\d+:|<carry>:|<drop>:)`)
+var UpstreamSummaryPattern = regexp.MustCompile(`UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-\.-]+)?: )?(\d+:|<carry>:|<drop>:)`)
 
 // supportedHosts maps source hosts to the number of path segments that
 // represent the account/repo for that host. This is necessary because we


### PR DESCRIPTION
@ironcladlou updated your regex to work with the naming scheme for the LDAP package