### PR TITLE
Replace kebab with actions button on pages with no primary actions

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -729,7 +729,11 @@ a.disabled-link {
   }
 }
 
-.resource-actions-dropdown {
+.actions-dropdown-btn {
+  margin-left: 5px;
+}
+
+.actions-dropdown-kebab {
   .action-button;
   // Bigger click target for the dropdown icon, which is a narrow ellipsis
   padding: 0 10px;
@@ -831,6 +835,8 @@ pre.clipped {
 
 .k8s-label {
   margin-right: 5px;
+  // A bit more space below the actions button.
+  margin-top: 3px;
   &:before {
     content: ' ';
     white-space: normal;

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -20,18 +20,23 @@
                 </button>
 
                 <!-- Secondary Actions -->
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle actions-dropdown-btn btn btn-default hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret" aria-hidden="true"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li class="visible-xs-inline" ng-class="{ disabled: !canBuild() }">
                     <a href=""
                       role="button"
                       ng-attr-aria-disabled="{{canBuild() ? undefined : 'true'}}"
                       ng-class="{ 'disabled-link': !canBuild() }"
-                      ng-click="startBuild()"
-                    ><i class="fa fa-play fa-fw" aria-hidden="true"></i> Start Build</a>
+                      ng-click="startBuild()">Start Build</a>
                   </li>
                   <li>
-                    <a ng-href="{{buildConfig | editResourceURL}}" role="button"><i class="fa fa-pencil fa-fw" aria-hidden="true"></i> Edit</a>
+                    <a ng-href="{{buildConfig | editResourceURL}}" role="button">Edit</a>
                   </li>
                   <li>
                     <edit-link

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -25,14 +25,19 @@
                           ng-disabled="!canBuild">Rebuild</button>
 
                   <!-- Secondary Actions -->
-                  <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                  <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                    Actions
+                    <span class="caret" aria-hidden="true"></span>
+                  </button>
+                  <a href=""
+                     class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                     data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
                     <li ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)"
                         class="visible-xs-inline">
                       <a href=""
                          role="button"
-                         ng-click="cancelBuild()"
-                      ><i class="fa fa-ban fa-fw" aria-hidden="true"></i> Cancel</a>
+                         ng-click="cancelBuild()">Cancel</a>
                     </li>
                     <li class="visible-xs-inline"
                         ng-class="{ disabled: !canBuild }"
@@ -41,8 +46,7 @@
                          role="button"
                          ng-click="cloneBuild()"
                          ng-attr-aria-disabled="{{canBuild ? undefined : 'true'}}"
-                         ng-class="{ 'disabled-link': !canBuild }"
-                      ><i class="fa fa-refresh fa-fw"></i> Rebuild</a>
+                         ng-class="{ 'disabled-link': !canBuild }">Rebuild</a>
                     </li>
                     <li>
                       <edit-link

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -23,20 +23,24 @@
                   </button>
 
                   <!-- Secondary Actions -->
-                  <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                  <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                    Actions
+                    <span class="caret" aria-hidden="true"></span>
+                  </button>
+                  <a href=""
+                     class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                     data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
                     <li class="visible-xs-inline" ng-class="{ disabled: !canDeploy() }">
                       <a href=""
                         role="button"
                         ng-attr-aria-disabled="{{canDeploy() ? undefined : 'true'}}"
                         ng-class="{ 'disabled-link': !canDeploy() }"
-                        ng-click="startLatestDeployment()"
-                        ><i class="fa fa-play fa-fw" aria-hidden="true"></i> Deploy</a>
+                        ng-click="startLatestDeployment()">Deploy</a>
                     </li>
                     <li>
                       <a href="project/{{projectName}}/set-limits?dcName={{deploymentConfig.metadata.name}}"
-                        role="button"
-                        ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
+                        role="button">Set Resource Limits</a>
                     </li>
                     <li>
                       <edit-link

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -25,7 +25,13 @@
                 <span ng-if="deploymentConfigMissing" class="sr-only">Warning: The deployment's deployment config is missing.</span>
                 <small class="meta">created <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></small>
                 <div class="pull-right dropdown">
-                  <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                  <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                    Actions
+                    <span class="caret"></span>
+                  </button>
+                  <a href=""
+                     class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                     data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
                     <li>
                       <edit-link

--- a/assets/app/views/browse/image.html
+++ b/assets/app/views/browse/image.html
@@ -13,7 +13,13 @@
             <h1>
               {{imageStream.metadata.name}}
               <div class="pull-right dropdown">
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret" aria-hidden="true"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li>
                     <edit-link

--- a/assets/app/views/browse/persistent-volume-claim.html
+++ b/assets/app/views/browse/persistent-volume-claim.html
@@ -20,7 +20,13 @@
               </small>
               <small class="meta">created <relative-timestamp timestamp="pvc.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret" aria-hidden="true"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li>
                     <edit-link

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -14,7 +14,13 @@
                 {{pod.metadata.name}}
 
                 <div class="pull-right dropdown">
-                  <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                  <button type="button" class="dropdown-toggle actions-dropdown-btn btn btn-default hidden-xs" data-toggle="dropdown">
+                    Actions
+                    <span class="caret"></span>
+                  </button>
+                  <a href=""
+                     class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                     data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                   <ul class="dropdown-menu actions action-button">
                     <li>
                       <edit-link

--- a/assets/app/views/browse/replication-controller.html
+++ b/assets/app/views/browse/replication-controller.html
@@ -14,12 +14,17 @@
               {{deployment.metadata.name}}
               <small class="meta">created <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle actions-dropdown-btn btn btn-default hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li>
                     <a href="project/{{projectName}}/set-limits?rcName={{deployment.metadata.name}}"
-                      role="button"
-                      ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
+                       role="button">Set Resource Limits</a>
                   </li>
                   <li>
                     <edit-link

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -18,7 +18,13 @@
               </route-warnings>
               <small class="meta">created <relative-timestamp timestamp="route.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret" aria-hidden="true"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li>
                     <edit-link
@@ -39,10 +45,10 @@
               </div>
             </h1>
             <labels labels="route.metadata.labels" clickable="true" kind="routes" project-name="{{route.metadata.namespace}}" limit="3"></labels> 
-          </div>         
+          </div>
         </div>
       </div><!-- /middle-header-->
-      <div class="middle-content">
+      <div class="middle-content gutter-top">
         <div class="container-fluid">
           <div class="row" ng-if="route">
             <div class="col-md-12">

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -13,7 +13,13 @@
             <h1>
               {{service.metadata.name}}
               <div class="pull-right dropdown">
-                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret"></span>
+                </button>
+                <a href=""
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-link">
                   <li>
                     <edit-link

--- a/assets/app/views/directives/delete-link.html
+++ b/assets/app/views/directives/delete-link.html
@@ -3,4 +3,4 @@
    role="button"
    ng-attr-aria-disabled="{{disableDelete ? 'true' : undefined}}"
    ng-class="{ 'disabled-link': disableDelete }"
- ><i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> Delete</a>
+ >Delete</a>

--- a/assets/app/views/directives/edit-link.html
+++ b/assets/app/views/directives/edit-link.html
@@ -1,1 +1,1 @@
-<a href="" ng-click="openEditModal()" role="button"><i class="fa fa-pencil fa-fw" aria-hidden="true"></i> Edit YAML</a>
+<a href="" ng-click="openEditModal()" role="button">Edit YAML</a>

--- a/assets/app/views/settings.html
+++ b/assets/app/views/settings.html
@@ -11,12 +11,13 @@
             <h1>
               Project Settings
               <div class="pull-right dropdown">
+                <button type="button" class="dropdown-toggle btn btn-default actions-dropdown-btn hidden-xs" data-toggle="dropdown">
+                  Actions
+                  <span class="caret" aria-hidden="true"></span>
+                </button>
                 <a href=""
-                  class="dropdown-toggle resource-actions-dropdown"
-                  data-toggle="dropdown">
-                  <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
-                  <span class="sr-only">Actions</span>
-                </a>
+                   class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
+                   data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
                   <li>
                     <a
@@ -24,9 +25,7 @@
                       role="button"
                       class="button-edit"
                       ng-click="setEditing(true)"
-                      ng-class="{ 'disabled-link': show.editing }">
-                      <i class="fa fa-pencil fa-fw" aria-hidden="true"></i> Edit
-                    </a>
+                      ng-class="{ 'disabled-link': show.editing }">Edit</a>
                   </li>
                   <li>
                     <delete-link

--- a/assets/test/integration/rest_api/project.js
+++ b/assets/test/integration/rest_api/project.js
@@ -191,7 +191,7 @@ describe('', function() {
 
         it('should delete a project', function() {
           h.goToPage('/project/' + project['name'] + '/settings');
-          element(by.css('.resource-actions-dropdown')).click();
+          element(by.css('.actions-dropdown-btn')).click();
           element(by.css('.button-delete')).click();
           element(by.cssContainingText(".modal-dialog .btn", "Delete")).click();
           h.waitForPresence(".alert-success", "marked for deletion");


### PR DESCRIPTION
Add an actions button dropdown in place of the kebab. Keeps the kebab at mobile sizes (for now). Remove icons from the actions menu.

Fixes #6973
Fixes #7387

<img width="797" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13063941/8b251bda-d41b-11e5-8d02-be46fba40f1f.png">

@jwforres @ajacobs21e 
