### PR TITLE
Use route ingress status in console

### DIFF
--- a/assets/app/scripts/directives/popups.js
+++ b/assets/app/scripts/directives/popups.js
@@ -86,15 +86,17 @@ angular.module('openshiftConsole')
       restrict: 'E',
       scope: {
         route: '=',
-        service: '='
+        service: '=',
+        warnings: '=' // instead of route and service, can provide an existing set of warnings
       },
       link: function($scope) {
         var updateWarnings = function() {
-          var warnings = RoutesService.getRouteWarnings($scope.route, $scope.service);
+          var warnings = $scope.warnings || RoutesService.getRouteWarnings($scope.route, $scope.service);
           $scope.content = warnings.join('<br>');
         };
         $scope.$watch('route', updateWarnings, true);
         $scope.$watch('service', updateWarnings, true);
+        $scope.$watch('warnings', updateWarnings, true);
       },
       templateUrl: 'views/directives/_warnings-popover.html'
     };

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -54,14 +54,33 @@
             <div class="col-md-12">
               <div class="resource-details">
                 <dl class="dl-horizontal left">
-                  <dt>Hostname:</dt>
+                  <dt>Hostname<span ng-if="route.status.ingress.length > 1">s</span>:</dt>
                   <dd>
-                    <span ng-if="(route | isWebRoute)">
-                      <a href="{{route | routeWebURL}}" target="_blank">{{route | routeLabel}}</a>
-                    </span>
-                    <span ng-if="!(route | isWebRoute)">
+                    <span ng-if="!route.status.ingress">
                       {{route | routeLabel}}
-                    </span>
+                      <span data-toggle="popover" data-placement="right" data-trigger="hover" data-content="The route is not accepting traffic yet because it has not been admitted by a router." style="cursor: help; padding-left: 5px;">
+                        <status-icon status="'Pending'" disable-animation></status-icon>
+                        <span class="sr-only">Pending</span>                        
+                      </span>
+                    </span>  
+                    <div ng-repeat="ingress in route.status.ingress">
+                      <span ng-if="(route | isWebRoute)">
+                        <a href="{{route | routeWebURL : ingress.host}}" target="_blank">{{route | routeLabel : ingress.host}}</a>
+                      </span>
+                      <span ng-if="!(route | isWebRoute)">
+                        {{route | routeLabel : ingress.host}}
+                      </span>                    
+                      &ndash;
+                      <span ng-init="admittedCondition = (ingress | routeIngressCondition : 'Admitted')">
+                        <span ng-if="!admittedCondition">admission status unknown for router '{{ingress.routerName}}'</span>
+                        <span ng-if="admittedCondition.status === 'True'">
+                          exposed on router '{{ingress.routerName}}' <relative-timestamp timestamp="admittedCondition.lastTransitionTime"></relative-timestamp>
+                        </span>
+                        <span ng-if="admittedCondition.status === 'False'">
+                          rejected by router '{{ingress.routerName}}' <relative-timestamp timestamp="admittedCondition.lastTransitionTime"></relative-timestamp>
+                        </span>                        
+                      </span>
+                    </div>
                   </dd>
                   <dt>Path:</dt>
                   <dd>

--- a/assets/app/views/browse/routes.html
+++ b/assets/app/views/browse/routes.html
@@ -47,12 +47,16 @@
                       </route-warnings>
                     </td>
                     <td data-title="Hostname">
-                      <div ng-if="(route | isWebRoute)" class="word-break">
+                      <span ng-if="(route | isWebRoute)" class="word-break">
                         <a href="{{route | routeWebURL}}" target="_blank">{{route | routeLabel}}</a>
-                      </div>
-                      <div ng-if="!(route | isWebRoute)" class="word-break">
+                      </span>
+                      <span ng-if="!(route | isWebRoute)" class="word-break">
                         {{route | routeLabel}}
-                      </div>
+                      </span>
+                      <span ng-if="!route.status.ingress" data-toggle="popover" data-placement="right" data-trigger="hover" data-content="The route is not accepting traffic yet because it has not been admitted by a router." style="cursor: help; padding-left: 5px;">
+                        <status-icon status="'Pending'" disable-animation></status-icon>
+                        <span class="sr-only">Pending</span>                        
+                      </span>                      
                     </td>
                     <td data-title="Routes To">
                       <span ng-if="route.spec.to.kind !== 'Service'">{{route.spec.to.kind}}: {{route.spec.to.name}}</span>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -113,6 +113,15 @@
                             (and
                             <a href="{{service | navigateResourceURL}}">{{otherRoutes}} other {{(otherRoutes == 1) ? 'route' : 'routes'}}</a>)
                           </span>
+                          <span ng-if="!otherRoutes">
+                            <route-warnings warnings="routeWarningsByService[serviceId][displayRouteByService[serviceId].metadata.name]"></route-warnings>
+                          </span>
+                          <div ng-if="(routeWarningsByService[serviceId] | hashSize) > 0 && otherRoutes">
+                            <small>
+                              <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+                              This service has <a href="project/{{projectName}}/browse/routes">routes</a> with warnings.
+                            </small>
+                          </div>                          
                         </h2>
 
                         <!-- If no route is present, show the service name large -->

--- a/assets/test/spec/services/routesSpec.js
+++ b/assets/test/spec/services/routesSpec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-describe("ApplicationGenerator", function(){
+describe("RoutesService", function(){
   var RoutesService;
 
   beforeEach(function(){
@@ -28,6 +28,9 @@ describe("ApplicationGenerator", function(){
           name: "frontend"
         },
         host: "www.example.com"
+      },
+      status: {
+        ingress: null
       }
     };
 
@@ -112,6 +115,24 @@ describe("ApplicationGenerator", function(){
       var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
       expect(warnings).toEqual(['Route path "/test" will be ignored since the route uses passthrough termination.']);
     });
+
+    it("should warn if route has an ingress that has not been admitted", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.path = '/test';
+      route.status.ingress = [{
+        host: 'www.example.com',
+        routerName: 'foo',
+        conditions: [{
+          type: "Admitted",
+          status: "False",
+          lastTransitionTime: "2016-02-17T17:18:51Z",
+          reason: "HostAlreadyClaimed",
+          message: "route bar already exposes www.example.com and is older"
+        }]
+      }];
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings).toEqual(["Requested host www.example.com was rejected by the router. Reason: route bar already exposes www.example.com and is older."]);
+    });    
 
     it("should not warn if there are no problems", function() {
       var route = angular.copy(routeTemplate);


### PR DESCRIPTION
![route_ingress_status](https://cloud.githubusercontent.com/assets/1467629/13064379/3240bc86-d420-11e5-957e-741b7c407aa2.png)


Fixes: https://github.com/openshift/origin/issues/6621

TODO:
- [x] Add full ingress details on route page
- [ ] Move some of this stuff out of filters if possible
- [x] Overview, pick which route to show when there are multiple? we dont show route warnings
- [ ] Once https://github.com/openshift/origin/pull/7388 merges remove the extra `|| route.spec.host` in several places