### PR TITLE
fix oc logs --since-time

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/unversioned/time.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/unversioned/time.go
@@ -88,6 +88,11 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	var str string
 	json.Unmarshal(b, &str)
 
+	// we were probably called with *only* the time part (no tag) from query deserialization
+	if len(b) > 0 && len(str) == 0 {
+		str = string(b)
+	}
+
 	pt, err := time.Parse(time.RFC3339, str)
 	if err != nil {
 		return err

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/conversion/converter.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/conversion/converter.go
@@ -659,6 +659,32 @@ func (c *Converter) defaultConvert(sv, dv reflect.Value, scope *scope) error {
 		switch st.Kind() {
 		case reflect.Ptr, reflect.Interface:
 			return c.convert(sv.Elem(), dv.Elem(), scope)
+
+		case reflect.Slice:
+			// url values enter here as string slices.
+			// if the destinationvalue can unmarshal json and the source value is a string slice with exactly one value, unmarshal the string
+			// if this doesn't work for some reason, call the default convert instead of failing
+			if sv.Len() != 1 {
+				return c.convert(sv, dv.Elem(), scope)
+			}
+			sliceElement := sv.Index(0)
+			if sliceElement.Kind() != reflect.String {
+				return c.convert(sv, dv.Elem(), scope)
+			}
+
+			unmarshalFunction := dv.MethodByName("UnmarshalJSON")
+			if unmarshalFunction.Kind() == reflect.Invalid {
+				return c.convert(sv, dv.Elem(), scope)
+			}
+			unmarshalValue := unmarshalFunction.Call([]reflect.Value{reflect.ValueOf([]byte(sliceElement.String()))})
+			if unmarshalValue[0].IsNil() {
+				return nil
+			}
+
+			// reset the destination value and call normal conversion
+			dv.Set(reflect.New(dt.Elem()))
+			return c.convert(sv, dv.Elem(), scope)
+
 		default:
 			return c.convert(sv, dv.Elem(), scope)
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/conversion/queryparams/convert.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/conversion/queryparams/convert.go
@@ -56,6 +56,15 @@ func isStructKind(kind reflect.Kind) bool {
 	return kind == reflect.Struct
 }
 
+func marshalFunction(value reflect.Value) *reflect.Value {
+	marshalFunction := value.MethodByName("MarshalJSON")
+	if marshalFunction.Kind() == reflect.Invalid {
+		return nil
+	}
+
+	return &marshalFunction
+}
+
 func isValueKind(kind reflect.Kind) bool {
 	switch kind {
 	case reflect.String, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16,
@@ -128,7 +137,8 @@ func convertStruct(result url.Values, st reflect.Type, sv reflect.Value) {
 
 		kind := ft.Kind()
 		if isPointerKind(kind) {
-			kind = ft.Elem().Kind()
+			ft = ft.Elem()
+			kind = ft.Kind()
 			if !field.IsNil() {
 				field = reflect.Indirect(field)
 			}
@@ -142,7 +152,19 @@ func convertStruct(result url.Values, st reflect.Type, sv reflect.Value) {
 				addListOfParams(result, tag, omitempty, field)
 			}
 		case isStructKind(kind) && !(zeroValue(field) && omitempty):
-			convertStruct(result, ft, field)
+			if marshalFunction := marshalFunction(field); marshalFunction != nil {
+				marshalReturn := marshalFunction.Call([]reflect.Value{})
+				errorValue := marshalReturn[1]
+				if errorValue.IsNil() {
+					bytes := marshalReturn[0].Interface().([]byte)
+					asString := string(bytes)
+					addParam(result, tag, omitempty, reflect.ValueOf(asString))
+				}
+
+			} else {
+				convertStruct(result, ft, field)
+			}
 		}
 	}
+
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -195,6 +195,7 @@ oc logs dc/failing-dc-mid | grep 'test mid hook executed'
 oc deploy failing-dc-mid --latest
 oc logs --version=1 dc/failing-dc-mid | grep 'test mid hook executed'
 oc logs --previous dc/failing-dc-mid | grep 'test mid hook executed'
+oc logs --previous --since-time=2100-02-15T15:21:26-05:00 --loglevel=6 dc/failing-dc-mid 2>&1 | grep 'sinceTime'
 
 echo "[INFO] Run pod diagnostics"
 # Requires a node to run the pod; uses origin-deployer pod, expects registry deployed


### PR DESCRIPTION
Fixes the serialization of query parameters to allow `unversioned.Time` again.

@Miciah this fixed the `oc logs` problem on master.  The error looked very similar to yours.