### PR TITLE
oc: enhance deploymentconfig description

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe_test.go
@@ -268,7 +268,7 @@ func TestDescribeContainers(t *testing.T) {
 				ContainerStatuses: []api.ContainerStatus{testCase.status},
 			},
 		}
-		describeContainers(&pod, out)
+		DescribeContainers(pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(&pod), out)
 		output := out.String()
 		for _, expected := range testCase.expectedElements {
 			if !strings.Contains(output, expected) {


### PR DESCRIPTION
@smarterclayton @ironcladlou how about 
```
$ oc describe dc/router
Name:		router
Created:	8 minutes ago
Labels:		router=router
Annotations:	<none>
Latest Version:	1
Triggers:	Config
Strategy:	Rolling
Template:
  Selector:	router=router
  Replicas:	1
  Containers:
  router:
    Image:	openshift/origin-haproxy-router:v1.1.2
    QoS Tier:
      memory:	BestEffort
      cpu:	BestEffort
    Liveness Probe:
      HTTP request:
      Path: /healthz
      Port: 1936
      Host: localhost
      Scheme: HTTP
    Initial Delay: 10s
    Timeout: 1s
    Period: 10s
    SuccessThreshold: 1
    FailureThreshold: 3
    Readiness Probe:
      HTTP request:
      Path: /healthz
      Port: 1936
      Host: localhost
      Scheme: HTTP
    Initial Delay: 10s
    Timeout: 1s
    Period: 10s
    SuccessThreshold: 1
    FailureThreshold: 3
    Environment Variables:
      DEFAULT_CERTIFICATE:	-----BEGIN CERTIFICATE-----
MIIDEjCCAfqgAwIBAgIBDTANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
c2hpZnQtc2lnbmVyQDE0NTU2NDk1MTcwHhcNMTYwMjE2MTkwNTM0WhcNMTgwMjE1
MTkwNTM1WjAdMRswGQYDVQQDExIqLjEyNy4wLjAuMS54aXAuaW8wggEiMA0GCSqG
...

      OPENSHIFT_CERT_DATA:			
      OPENSHIFT_INSECURE:			false
      OPENSHIFT_KEY_DATA:			
      OPENSHIFT_MASTER:				https://localhost:8443
      ROUTER_EXTERNAL_HOST_HOSTNAME:		
      ROUTER_EXTERNAL_HOST_HTTPS_VSERVER:	
      ROUTER_EXTERNAL_HOST_HTTP_VSERVER:	
      ROUTER_EXTERNAL_HOST_INSECURE:		false
      ROUTER_EXTERNAL_HOST_PARTITION_PATH:	
      ROUTER_EXTERNAL_HOST_PASSWORD:		
      ROUTER_EXTERNAL_HOST_PRIVKEY:		/etc/secret-volume/router.pem
      ROUTER_EXTERNAL_HOST_USERNAME:		
      ROUTER_SERVICE_NAME:			router
      ROUTER_SERVICE_NAMESPACE:			default
      STATS_PASSWORD:				TGxmIeyfxk
      STATS_PORT:				1936
      STATS_USERNAME:				admin
Deployment #1 (latest):
	Name:		router-1
	Created:	8 minutes ago
	Status:		Complete
	Replicas:	1 current / 1 desired
	Selector:	deployment=router-1,deploymentconfig=router,router=router
	Labels:		openshift.io/deployment-config.name=router,router=router
	Pods Status:	1 Running / 0 Waiting / 0 Succeeded / 0 Failed
Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  8m		8m		1	{deploymentconfig-controller }		Normal		DeploymentCreated	Created new deployment "router-1" for version 1

```
cc: @jwforres @fabianofranz 

Fixes https://github.com/openshift/origin/issues/7330