### PR TITLE
Run-once pod duration: remove flag from plugin config

### DIFF
--- a/pkg/build/admission/config.go
+++ b/pkg/build/admission/config.go
@@ -20,7 +20,7 @@ func ReadPluginConfig(reader io.Reader, config runtime.Object) error {
 	if err != nil {
 		return err
 	}
-	err = configlatest.ReadYAML(configBytes, config)
+	err = configlatest.ReadYAMLInto(configBytes, config)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/pluginconfig/config_test.go
+++ b/pkg/cmd/util/pluginconfig/config_test.go
@@ -47,7 +47,7 @@ func TestGetPluginConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	resultConfig := &TestConfig{}
-	if err = latest.ReadYAMLFile(fileName, resultConfig); err != nil {
+	if err = latest.ReadYAMLFileInto(fileName, resultConfig); err != nil {
 		t.Fatalf("error reading config file: %v", err)
 	}
 	if !reflect.DeepEqual(testConfig, resultConfig) {

--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -3,8 +3,6 @@ package requestlimit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
-	"reflect"
 
 	"k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -31,18 +29,16 @@ func init() {
 }
 
 func readConfig(reader io.Reader) (*requestlimitapi.ProjectRequestLimitConfig, error) {
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return &requestlimitapi.ProjectRequestLimitConfig{}, nil
-	}
-
-	configBytes, err := ioutil.ReadAll(reader)
+	obj, err := configlatest.ReadYAML(reader)
 	if err != nil {
 		return nil, err
 	}
-	config := &requestlimitapi.ProjectRequestLimitConfig{}
-	err = configlatest.ReadYAML(configBytes, config)
-	if err != nil {
-		return nil, err
+	if obj == nil {
+		return nil, nil
+	}
+	config, ok := obj.(*requestlimitapi.ProjectRequestLimitConfig)
+	if !ok {
+		return nil, fmt.Errorf("unexpected config object: %#v", obj)
 	}
 	errs := requestlimitapivalidation.ValidateProjectRequestLimitConfig(config)
 	if len(errs) > 0 {

--- a/pkg/quota/admission/runonceduration/admission.go
+++ b/pkg/quota/admission/runonceduration/admission.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"reflect"
 	"strconv"
 
 	"k8s.io/kubernetes/pkg/admission"
@@ -30,17 +28,16 @@ func init() {
 }
 
 func readConfig(reader io.Reader) (*api.RunOnceDurationConfig, error) {
-	config := &api.RunOnceDurationConfig{}
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return config, nil
-	}
-	configBytes, err := ioutil.ReadAll(reader)
+	obj, err := configlatest.ReadYAML(reader)
 	if err != nil {
 		return nil, err
 	}
-	err = configlatest.ReadYAML(configBytes, config)
-	if err != nil {
-		return nil, err
+	if obj == nil {
+		return nil, nil
+	}
+	config, ok := obj.(*api.RunOnceDurationConfig)
+	if !ok {
+		return nil, fmt.Errorf("unexpected config object %#v", obj)
 	}
 	errs := validation.ValidateRunOnceDurationConfig(config)
 	if len(errs) > 0 {
@@ -49,6 +46,7 @@ func readConfig(reader io.Reader) (*api.RunOnceDurationConfig, error) {
 	return config, nil
 }
 
+// NewRunOnceDuration creates a new RunOnceDuration admission plugin
 func NewRunOnceDuration(config *api.RunOnceDurationConfig) admission.Interface {
 	return &runOnceDuration{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
@@ -68,7 +66,6 @@ var _ = oadmission.Validator(&runOnceDuration{})
 func (a *runOnceDuration) Admit(attributes admission.Attributes) error {
 	switch {
 	case a.config == nil,
-		!a.config.Enabled,
 		attributes.GetResource() != kapi.Resource("pods"),
 		len(attributes.GetSubresource()) > 0:
 		return nil

--- a/pkg/quota/admission/runonceduration/admission_test.go
+++ b/pkg/quota/admission/runonceduration/admission_test.go
@@ -29,7 +29,6 @@ func testCache(projectAnnotations map[string]string) *projectcache.ProjectCache 
 func testConfig(n *int64) *api.RunOnceDurationConfig {
 	return &api.RunOnceDurationConfig{
 		ActiveDeadlineSecondsOverride: n,
-		Enabled: true,
 	}
 }
 
@@ -152,7 +151,6 @@ func TestReadConfig(t *testing.T) {
 	configStr := `apiVersion: v1
 kind: RunOnceDurationConfig
 activeDeadlineSecondsOverride: 3600
-enabled: true
 `
 	buf := bytes.NewBufferString(configStr)
 	config, err := readConfig(buf)
@@ -164,8 +162,5 @@ enabled: true
 	}
 	if *config.ActiveDeadlineSecondsOverride != 3600 {
 		t.Errorf("unexpected value for ActiveDeadlineSecondsOverride: %d", config.ActiveDeadlineSecondsOverride)
-	}
-	if !config.Enabled {
-		t.Errorf("unexpected value for Enabled")
 	}
 }

--- a/pkg/quota/admission/runonceduration/api/register.go
+++ b/pkg/quota/admission/runonceduration/api/register.go
@@ -18,6 +18,7 @@ func Resource(resource string) unversioned.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
+// AddToScheme adds known types to the given scheme
 func AddToScheme(scheme *runtime.Scheme) {
 	addKnownTypes(scheme)
 }

--- a/pkg/quota/admission/runonceduration/api/types.go
+++ b/pkg/quota/admission/runonceduration/api/types.go
@@ -11,14 +11,12 @@ import (
 type RunOnceDurationConfig struct {
 	unversioned.TypeMeta
 
-	// Enabled if false disables the effect of this plugin. A global override will
-	// not be applied and projects will not be checked for an override annotation.
-	Enabled bool
-
 	// ActiveDeadlineSecondsOverride is the value to set on containers of run-once pods
 	// Only a positive value is valid. Absence of a value means that the plugin
 	// won't make any changes to the pod
 	ActiveDeadlineSecondsOverride *int64
 }
 
+// ActiveDeadlineSecondsOverrideAnnotation can be set on a project to override the number of
+// seconds that a run-once pod can be active in that project
 const ActiveDeadlineSecondsOverrideAnnotation = "openshift.io/active-deadline-seconds-override"

--- a/pkg/quota/admission/runonceduration/api/v1/types.go
+++ b/pkg/quota/admission/runonceduration/api/v1/types.go
@@ -11,10 +11,6 @@ import (
 type RunOnceDurationConfig struct {
 	unversioned.TypeMeta `json:",inline"`
 
-	// Enabled if false disables the effect of this plugin. A global override will
-	// not be applied and projects will not be checked for an override annotation.
-	Enabled bool `json:"enabled",description:"set to true to enable the plugin"`
-
 	// ActiveDeadlineSecondsOverride is the value to set on containers of run-once pods
 	// Only a positive value is valid. Absence of a value means that the plugin
 	// won't make any changes to the pod

--- a/pkg/quota/admission/runonceduration/doc.go
+++ b/pkg/quota/admission/runonceduration/doc.go
@@ -19,5 +19,4 @@ The plugin is configured via a RunOnceDurationConfig object:
  enabled: true
  activeDeadlineSecondsOverride: 3600
 */
-
 package runonceduration

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -33,7 +33,6 @@ func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsOverride: &secs,
-		Enabled: true,
 	}
 	kclient := setupRunOnceDurationTest(t, config, nil)
 	pod, err := kclient.Pods(testutil.Namespace()).Create(testRunOnceDurationPod())
@@ -49,7 +48,6 @@ func TestRunOnceDurationAdmissionPluginProjectOverride(t *testing.T) {
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsOverride: &secs,
-		Enabled: true,
 	}
 	nsAnnotations := map[string]string{
 		pluginapi.ActiveDeadlineSecondsOverrideAnnotation: "100",


### PR DESCRIPTION
Sets up the config to be similar to ClusterResourceOverride plugin, nil config means disabled.