### PR TITLE
Web Console: improve error messages when logs cannot be displayed

### DIFF
--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -95,8 +95,8 @@
                         context="projectContext"
                         options="logOptions"
                         status="build.status.phase"
-                        start="build.status.startTimestamp | date : 'short'"
-                        end="build.status.completionTimestamp | date : 'short'"
+                        time-start="build.status.startTimestamp | date : 'short'"
+                        time-end="build.status.completionTimestamp | date : 'short'"
                         run="logCanRun">
                       </log-viewer>
                     </uib-tab>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -82,7 +82,7 @@
                       context="projectContext"
                       options="logOptions"
                       status="deployment | deploymentStatus"
-                      start="deployment.metadata.creationTimestamp | date : 'short'"
+                      time-start="deployment.metadata.creationTimestamp | date : 'short'"
                       run="logCanRun">
                     </log-viewer>
                   </uib-tab>

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -94,8 +94,7 @@
                         name="pod.metadata.name"
                         context="projectContext"
                         options="logOptions"
-                        status="pod.status.phase"
-                        start="pod.status.startTime | date : 'short'"
+                        time-start="pod.status.startTime | date : 'short'"
                         run="logCanRun">
                     </log-viewer>
                   </uib-tab>

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,7 +1,9 @@
-<div row class="log-timestamp" ng-if="!chromeless && start">
+<div
+  row class="log-timestamp"
+  ng-if="(!chromeless) && state=='logs' && timeStart">
   <div>
-    <span>Current log from {{start}}&nbsp;</span>
-    <span ng-if="end">to {{end}}</span>
+    <span>Current log from {{timeStart}}&nbsp;</span>
+    <span ng-if="end">to {{timeEnd}}</span>
   </div>
   <div flex></div>
   <div ng-if="kibanaAuthUrl">
@@ -24,14 +26,16 @@
 
 
 <div class="row" ng-if="!chromeless">
-  <div class="col-md-6 col-sm-12 status">
+  <div class="col-md-6 col-sm-12">
     <span ng-if="status">
       <span>Status:&nbsp;&nbsp;</span>
       <status-icon status="status"></status-icon>
-      <span>&nbsp;&nbsp;{{status}}</span>
+      <span>{{status}}</span>
     </span>
   </div>
-  <div class="log-link-external col-md-6 col-sm-12 text-right">
+  <div
+    class="log-link-external col-md-6 col-sm-12 text-right"
+    ng-if="state=='logs'">
     <a href=""  ng-click="goChromeless(options)">
       Open full view of log<i class="fa fa-external-link"></i>
     </a>
@@ -39,8 +43,29 @@
 </div>
 
 
+<div class="empty-state-message text-center" ng-if="state=='empty'">
+  <h2>Logs are not available.</h2>
 
-<div flex height-max>
+  <p>
+    {{emptyStateMessage}}
+  </p>
+
+  <div ng-if="kibanaAuthUrl">
+    <form
+      action="{{kibanaAuthUrl}}"
+      method="POST">
+      <input type="hidden" name="redirect" value="{{archiveLocation}}">
+      <input type="hidden" name="access_token" value="{{access_token}}">
+      <button class="btn btn-primary btn-lg">
+        View Archive
+      </button>
+    </form>
+  </div>
+</div>
+
+
+<!-- must be ng-show rather than ng-if, else DOM is not rendered in time to cache nodes -->
+<div flex height-max ng-show="state=='logs'">
   <a
     name="logTop"
     id="logTop"></a>
@@ -83,10 +108,13 @@
   The maximum web console log size has been reached. Use the command-line interface or
   <a href="" ng-click="restartLogs()">reload</a> the log to see new messages.
 </div>
-<div ng-if="!loading && !limitReached && !error" class="text-muted">
+
+<div ng-if="(!loading) && (!limitReached) && (!errorWhileRunning) && state=='logs'" class="text-muted">
   End of log
 </div>
-<div ng-if="error" class="text-muted">
+
+
+<div ng-if="errorWhileRunning" class="text-muted">
   An error occurred loading the log.
   <a href="" ng-click="restartLogs()">Reload</a>
 </div>

--- a/assets/app/views/logs/chromeless-build-log.html
+++ b/assets/app/views/logs/chromeless-build-log.html
@@ -17,8 +17,8 @@
             name="build.metadata.name"
             context="projectContext"
             status="build.status.phase"
-            start="build.status.startTimestamp | date : 'short'"
-            end="build.status.completionTimestamp | date : 'short'"
+            time-start="build.status.startTimestamp | date : 'short'"
+            time-end="build.status.completionTimestamp | date : 'short'"
             chromeless="true"
             run="logCanRun"
             flex>

--- a/assets/app/views/logs/chromeless-pod-log.html
+++ b/assets/app/views/logs/chromeless-pod-log.html
@@ -18,7 +18,7 @@
             context="projectContext"
             options="logOptions"
             status="pod.status.phase"
-            start="pod.status.startTime | date : 'short'"
+            time-start="pod.status.startTime | date : 'short'"
             chromeless="true"
             run="logCanRun"
             flex>


### PR DESCRIPTION
Fixes issue #5913
- Adds an empty state message to view when logs are not viewable.

Work in progress, I may want to tweak a couple things but I think it gets us where we want to be going.
@spadgett @jwforres 