### PR TITLE
Slim down all to be the set of things applications need

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -34,11 +34,11 @@ var originTypesLock sync.Once
 // UserResources are the resource names that apply to the primary, user facing resources used by
 // client tools. They are in deletion-first order - dependent resources should be last.
 var UserResources = []string{
-	"buildConfigs", "builds",
+	"buildConfigs",
 	"imageStreams",
-	"deploymentConfigs", "replicationControllers",
-	"routes", "services",
-	"pods",
+	"deploymentConfigs",
+	"routes",
+	"services",
 }
 
 // OriginKind returns true if OpenShift owns the GroupVersionKind.


### PR DESCRIPTION
Child resources are deleted automatically, it does mean that
builds, rcs, and pods could be left behind... but on the other hand, if
they're not cascading then they may not be necessary to delete.

Speculative, not sure I want to merge this, but it seems like this is
more in line with the original intent.

[test]