### PR TITLE
Add pathseg polyfill to fix c3 bar chart runtime error

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -98,6 +98,7 @@
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/yamljs/bin/yaml.js"></script>
     <script src="bower_components/clipboard/dist/clipboard.js"></script>
+    <script src="bower_components/pathseg/pathseg.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -34,7 +34,8 @@
     "angular-ui-ace": "0.2.3",
     "ace-builds": "1.2.2",
     "yamljs": "0.1.5",
-    "clipboard": "1.5.8"
+    "clipboard": "1.5.8",
+    "pathseg": "1.0.2"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",


### PR DESCRIPTION
Fixes errors hovering and clicking on the builds bar chart in Chrome. See https://github.com/masayuki0812/c3/issues/1566. We might be able to remove in the future when the c3 issue is fixed.

@jwforres PTAL