### PR TITLE
Handle multiple imageChange triggers in BC edit page

### DIFF
--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -470,7 +470,7 @@
                           <div>
                             <div class="checkbox" ng-if="sources.git" >
                               <label>
-                                <input type="checkbox" ng-model="pickedTriggers['webhook']"/>
+                                <input type="checkbox" ng-model="triggers.present.webhook"/>
                                 Enable the webhook build trigger
                                 <span class="help action-inline">
                                   <a href>
@@ -480,23 +480,25 @@
                                 </span>
                               </label>
                             </div>
+
                             <div class="checkbox">
                               <label>
-                                <input type="checkbox" ng-model="pickedTriggers['imageChange']" ng-disabled="builderOptions.pickedType === 'None'"/>
-                                Automatically build a new image when the builder image changes
-                                <span class="help action-inline">
-                                  <a href>
-                                    <i class="pficon pficon-help" data-placement="left" aria-hidden="true"
-                                    data-toggle="tooltip" data-original-title="Automatically building a new image when the builder image changes allows your code to always run on the latest updates.">
-                                  </i>
-                                  </a>
-                                </span>
+                                <input type="checkbox" ng-model="triggers.present.configChange"/>
+                                Automatically build a new image when the build configuration changes
                               </label>
                             </div>
+
                             <div class="checkbox">
                               <label>
-                                <input type="checkbox" ng-model="pickedTriggers['configChange']"/>
-                                Automatically build a new image when the build configuration changes
+                                <input type="checkbox" ng-model="triggers.present.imageChange" ng-disabled="builderOptions.pickedType === 'None'"/>
+                                  Automatically build a new image when the builder image changes
+                                  <span class="help action-inline">
+                                    <a href>
+                                      <i class="pficon pficon-help" data-placement="left" aria-hidden="true"
+                                      data-toggle="tooltip" data-original-title="Automatically building a new image when the builder image changes allows your code to always run on the latest updates.">
+                                    </i>
+                                    </a>
+                                  </span>
                               </label>
                             </div>
                           </div>


### PR DESCRIPTION
BuildConfig can specify multiple imageChange triggers pointing on multiple images. Adding option to disable those triggers and also prevent loss of data.
If only one imageChange trigger is set(for the builder), the trigger will be displayed inline:
![screenshot-6](https://cloud.githubusercontent.com/assets/1668218/13110567/2aed46a4-d581-11e5-9967-82450a029da1.png)

In case of multiple imageChange triggers, they will be displayed in a list:
![screenshot-4](https://cloud.githubusercontent.com/assets/1668218/13110584/46df2f12-d581-11e5-88b3-51bfd1db030a.png)

If the builder imageChange trigger is disabled, user will be able to enable it in next edit form:
![screenshot-7](https://cloud.githubusercontent.com/assets/1668218/13110691/d3df261a-d581-11e5-9f27-0b4bea3ab0c3.png)


@spadgett PTAL