### PR TITLE
fix jenkins testjob xml; fix jenkins ext test deployment error handling

### DIFF
--- a/test/extended/fixtures/testjob-plugin.xml
+++ b/test/extended/fixtures/testjob-plugin.xml
@@ -20,27 +20,20 @@
       <authToken></authToken>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
     
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
-      <depCfg>frontend</depCfg>
-      <namespace>PROJECT_NAME</namespace>
-      <replicaCount>0</replicaCount>
-      <authToken></authToken>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-
     <com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <bldCfg>frontend</bldCfg>
       <namespace>PROJECT_NAME</namespace>
       <authToken></authToken>
       <followLog>true</followLog>
+      <checkForTriggeredDeployments>true</checkForTriggeredDeployments>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
     
     <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
       <namespace>PROJECT_NAME</namespace>
-      <replicaCount>1</replicaCount>
+      <replicaCount>0</replicaCount>
       <authToken></authToken>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
@@ -50,15 +43,9 @@
       <namespace>PROJECT_NAME</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
+      <verifyReplicaCount>true</verifyReplicaCount>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
-      <depCfg>frontend</depCfg>
-      <namespace>PROJECT_NAME</namespace>
-      <replicaCount>1</replicaCount>
-      <authToken></authToken>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-
+    
      <com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <svcName>frontend</svcName>
@@ -69,8 +56,10 @@
     <com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <namespace>PROJECT_NAME</namespace>
-      <testTag>origin-nodejs-sample:latest</testTag>
-      <prodTag>origin-nodejs-sample:prod</prodTag>
+      <testTag>latest</testTag>
+      <prodTag>prod</prodTag>
+      <testStream>origin-nodejs-sample</testStream>
+      <prodStream>origin-nodejs-sample</prodStream>
       <authToken></authToken>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
     
@@ -78,7 +67,7 @@
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend-prod</depCfg>
       <namespace>PROJECT_NAME</namespace>
-      <replicaCount>1</replicaCount>
+      <replicaCount>0</replicaCount>
       <authToken></authToken>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 


### PR DESCRIPTION
@bparees PTAL

fyi - i debated creating a "poll only" version of wait for deployment, but in the end, just applied the tweak to the watch you suggested;  i also left the 15 min timeout alone, not hearing any explicit calls to back off of that 

Fixes https://github.com/openshift/origin/issues/7277