### PR TITLE
remove volumes when removing containers

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -552,7 +552,7 @@ function cleanup_openshift {
 		if docker version >/dev/null 2>&1; then
 			echo "[INFO] Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop -t 1 >/dev/null
 			if [[ -z "${SKIP_IMAGE_CLEANUP-}" ]]; then
-				echo "[INFO] Removing k8s docker containers"; docker ps -a | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker rm >/dev/null
+				echo "[INFO] Removing k8s docker containers"; docker ps -a | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker rm -v >/dev/null
 			fi
 		fi
 		


### PR DESCRIPTION
If we don't remove the volumes when we clean up, dev environments like my local machine slowly get to the point where there's no hard disk space free. We should remove them by default, and if we use them anywhere after the container is dead we can add a flag to stop it from happening. AFAIK we don't, however - we stopped downloading them from Jenkins runs, anyway.

/cc @derekwaynecarr @deads2k @smarterclayton 