### PR TITLE
MongoDB replication tests

### DIFF
--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -65,8 +65,7 @@ var _ = g.Describe("[builds][Slow] can use private repositories as build input",
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("expecting the deployment of the gitserver to be in the Complete phase")
-		err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName,
-			exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		sourceSecretName := secretFunc()

--- a/test/extended/images/mongodb_replica.go
+++ b/test/extended/images/mongodb_replica.go
@@ -1,0 +1,116 @@
+package images
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/db"
+)
+
+var _ = g.Describe("[images][mongodb] openshift mongodb replication", func() {
+	defer g.GinkgoRecover()
+
+	const (
+		templatePath         = "https://raw.githubusercontent.com/openshift/mongodb/master/2.4/examples/replica/mongodb-clustered.json"
+		deploymentConfigName = "mongodb"
+		expectedValue        = `{ "status" : "passed" }`
+		insertCmd            = "db.bar.save(" + expectedValue + ")"
+	)
+
+	const (
+		expectedReplicasAfterDeployment = 3
+		expectedReplicasAfterScalingUp  = expectedReplicasAfterDeployment + 2
+	)
+
+	oc := exutil.NewCLI("mongodb-replica", exutil.KubeConfigPath()).Verbose()
+
+	g.Describe("creating from a template", func() {
+		g.It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
+
+			g.By("creating a new app")
+			o.Expect(oc.Run("new-app").Args("-f", templatePath).Execute()).Should(o.Succeed())
+
+			g.By("waiting for the deployment to complete")
+			o.Expect(exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), deploymentConfigName)).Should(o.Succeed())
+
+			podNames := waitForNumberOfPodsWithLabel(oc, expectedReplicasAfterDeployment, "mongodb-replica")
+			mongo := db.NewMongoDB(podNames[0])
+
+			g.By(fmt.Sprintf("expecting that replica set have %d members", expectedReplicasAfterDeployment))
+			assertMembersInReplica(oc, mongo, expectedReplicasAfterDeployment)
+
+			g.By("expecting that we can insert a new record on primary node")
+			replicaSet := mongo.(exutil.ReplicaSet)
+			_, err := replicaSet.QueryPrimary(oc, insertCmd)
+			o.Expect(err).ShouldNot(o.HaveOccurred())
+
+			g.By("expecting that we can read a record from all members")
+			for _, podName := range podNames {
+				tryToReadFromPod(oc, podName, expectedValue)
+			}
+
+			g.By(fmt.Sprintf("scaling deployment config %s to %d replicas", deploymentConfigName, expectedReplicasAfterScalingUp))
+
+			err = oc.Run("scale").Args("dc", deploymentConfigName, "--replicas="+fmt.Sprint(expectedReplicasAfterScalingUp), "--timeout=30s").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			podNames = waitForNumberOfPodsWithLabel(oc, expectedReplicasAfterScalingUp, "mongodb-replica")
+			mongo = db.NewMongoDB(podNames[0])
+
+			g.By("expecting that scaling replica set up should have more members")
+			assertMembersInReplica(oc, mongo, expectedReplicasAfterScalingUp)
+		})
+	})
+
+})
+
+func tryToReadFromPod(oc *exutil.CLI, podName, expectedValue string) {
+	// don't include _id field to output because it changes every time
+	findCmd := "rs.slaveOk(); printjson(db.bar.find({}, {_id: 0}).toArray())"
+
+	fmt.Fprintf(g.GinkgoWriter, "DEBUG: reading record from pod %v\n", podName)
+
+	mongoPod := db.NewMongoDB(podName)
+	result, err := mongoPod.Query(oc, findCmd)
+	o.Expect(err).ShouldNot(o.HaveOccurred())
+	o.Expect(result).Should(o.ContainSubstring(expectedValue))
+}
+
+func waitForNumberOfPodsWithLabel(oc *exutil.CLI, number int, label string) []string {
+	g.By(fmt.Sprintf("expecting that there are %d running pods with label name=%s", number, label))
+
+	podNames, err := exutil.WaitForPods(
+		oc.KubeREST().Pods(oc.Namespace()),
+		exutil.ParseLabelsOrDie("name="+label),
+		exutil.CheckPodIsRunningFn,
+		number,
+		1*time.Minute,
+	)
+	o.Expect(err).ShouldNot(o.HaveOccurred())
+	o.Expect(podNames).Should(o.HaveLen(number))
+
+	return podNames
+}
+
+func assertMembersInReplica(oc *exutil.CLI, db exutil.Database, expectedReplicas int) {
+	isMasterCmd := "printjson(db.isMaster())"
+	getReplicaHostsCmd := "print(db.isMaster().hosts.length)"
+
+	// pod is running but we need to wait when it will be really ready (became member of the replica)
+	err := exutil.WaitForQueryOutputSatisfies(oc, db, 1*time.Minute, false, isMasterCmd, func(commandOutput string) bool {
+		return commandOutput != ""
+	})
+	o.Expect(err).ShouldNot(o.HaveOccurred())
+
+	isMasterOutput, _ := db.Query(oc, isMasterCmd)
+	fmt.Fprintf(g.GinkgoWriter, "DEBUG: Output of the db.isMaster() command: %v\n", isMasterOutput)
+
+	members, err := db.Query(oc, getReplicaHostsCmd)
+	o.Expect(err).ShouldNot(o.HaveOccurred())
+	o.Expect(members).Should(o.Equal(strconv.Itoa(expectedReplicas)))
+}

--- a/test/extended/images/mysql_replica.go
+++ b/test/extended/images/mysql_replica.go
@@ -115,12 +115,12 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Make sure data is present on master
-			err = exutil.WaitForQueryOutput(oc, master, 10*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
+			err = exutil.WaitForQueryOutputContains(oc, master, 10*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Make sure data was replicated to all slaves
 			for _, slave := range slaves {
-				err = exutil.WaitForQueryOutput(oc, slave, 90*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
+				err = exutil.WaitForQueryOutputContains(oc, slave, 90*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 

--- a/test/extended/images/postgresql_replica.go
+++ b/test/extended/images/postgresql_replica.go
@@ -107,14 +107,14 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Make sure data is present on master
-			err = exutil.WaitForQueryOutput(oc, master, 10*time.Second, false,
+			err = exutil.WaitForQueryOutputContains(oc, master, 10*time.Second, false,
 				fmt.Sprintf("SELECT * FROM %s;", table),
 				"col1 | val1\ncol2 | val2")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Make sure data was replicated to all slaves
 			for _, slave := range slaves {
-				err = exutil.WaitForQueryOutput(oc, slave, 90*time.Second, false,
+				err = exutil.WaitForQueryOutputContains(oc, slave, 90*time.Second, false,
 					fmt.Sprintf("SELECT * FROM %s;", table),
 					"col1 | val1\ncol2 | val2")
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/sample_repos.go
+++ b/test/extended/images/sample_repos.go
@@ -55,7 +55,7 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 				}
 
 				g.By("expecting the deployment to be complete")
-				err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), c.deploymentConfigName, exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+				err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), c.deploymentConfigName)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("expecting the service is available")

--- a/test/extended/jenkins/kubernetes_plugin.go
+++ b/test/extended/jenkins/kubernetes_plugin.go
@@ -70,8 +70,7 @@ var _ = g.Describe("[jenkins] schedule jobs on pod slaves", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("wait for jenkins deployment")
-			err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins",
-				exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("get ip and port for jenkins service")

--- a/test/extended/jenkins/plugin.go
+++ b/test/extended/jenkins/plugin.go
@@ -111,7 +111,7 @@ var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for jenkins deployment")
-		err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins", exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins")
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("get ip and port for jenkins service")
@@ -144,9 +144,9 @@ var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 			// we leverage some of the openshift utilities for waiting for the deployment before we poll
 			// jenkins for the sucessful job completion
 			g.By("waiting for frontend, frontend-prod deployments as signs that the build has finished")
-			err := exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend", exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend")
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend-prod", exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend-prod")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("get build console logs and see if succeeded")

--- a/test/extended/util/db/mongodb.go
+++ b/test/extended/util/db/mongodb.go
@@ -9,18 +9,13 @@ import (
 
 // MongoDB is a MongoDB helper for executing commands.
 type MongoDB struct {
-	podName       string
-	masterPodName string
+	podName string
 }
 
 // NewMongoDB creates a new util.Database instance.
-func NewMongoDB(podName, masterPodName string) util.Database {
-	if masterPodName == "" {
-		masterPodName = podName
-	}
+func NewMongoDB(podName string) util.Database {
 	return &MongoDB{
-		podName:       podName,
-		masterPodName: masterPodName,
+		podName: podName,
 	}
 }
 
@@ -53,7 +48,19 @@ func (m MongoDB) QueryPrivileged(oc *util.CLI, query string) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-// TestRemoteLogin tests wheather it is possible to remote login to hostAddress.
+// TestRemoteLogin tests whether it is possible to remote login to hostAddress.
 func (m MongoDB) TestRemoteLogin(oc *util.CLI, hostAddress string) error {
 	return errors.New("not implemented")
+}
+
+// // QueryPrimary queries the database on primary node as a regular user.
+func (m MongoDB) QueryPrimary(oc *util.CLI, query string) (string, error) {
+	return executeShellCommand(
+		oc,
+		m.podName,
+		fmt.Sprintf(
+			`mongo --quiet "$MONGODB_DATABASE" --username "$MONGODB_USER" --password "$MONGODB_PASSWORD" --host "$MONGODB_REPLICA_NAME/localhost" --eval '%s'`,
+			query,
+		),
+	)
 }

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -274,6 +274,11 @@ func WaitForADeployment(client kclient.ReplicationControllerInterface, name stri
 	}
 }
 
+// WaitForADeploymentToComplete waits for a deployment to complete.
+func WaitForADeploymentToComplete(client kclient.ReplicationControllerInterface, name string) error {
+	return WaitForADeployment(client, name, CheckDeploymentCompletedFn, CheckDeploymentFailedFn)
+}
+
 func isUsageSynced(received, expected kapi.ResourceList, expectedIsUpperLimit bool) bool {
 	resourceNames := quota.ResourceNames(expected)
 	masked := quota.Mask(received, resourceNames)


### PR DESCRIPTION
Summary:
- Add replication test for MongoDB
- `mongodb_ephemeral` and other tests: use `WaitForADeploymentToComplete()`
- `Database.TestRemoteLogin`: fix typo in godoc

Replication test doesn't contain scenario for scaling down because it works when I run it manually and it always fails when it's running as part of the test, so I believe that this should be fixed independently.

PTAL @bparees @rhcarvalho @mnagy

Trello card: https://trello.com/c/KFl01HTE/775-5-extended-tests-for-mongo-replication
