### PR TITLE
Fix broken dev cluster go builds

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,6 +110,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }
   }
 
+  sync_from = vagrant_openshift_config['sync_from'] || ENV["VAGRANT_SYNC_FROM"] || '.'
+  sync_to = vagrant_openshift_config['sync_to'] || ENV["VAGRANT_SYNC_TO"] || "/data/src/github.com/openshift/origin"
+
   dind_dev_cluster = vagrant_openshift_config['dind_dev_cluster']
   dev_cluster = vagrant_openshift_config['dev_cluster'] || ENV['OPENSHIFT_DEV_CLUSTER']
   single_vm_cluster = ! (dind_dev_cluster or dev_cluster)
@@ -117,11 +120,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "#{VM_NAME_PREFIX}dind-host" do |config|
       config.vm.box = kube_box[kube_os]["name"]
       config.vm.box_url = kube_box[kube_os]["box_url"]
-      config.vm.provision "shell", inline: "/vagrant/contrib/vagrant/provision-dind.sh"
-      config.vm.provision "shell", inline: "/vagrant/hack/dind-cluster.sh config-host"
-      config.vm.provision "shell", privileged: false, inline: "/vagrant/hack/dind-cluster.sh restart"
+      config.vm.provision "shell", inline: "#{sync_to}/contrib/vagrant/provision-dind.sh"
+      config.vm.provision "shell", inline: "#{sync_to}/hack/dind-cluster.sh config-host"
+      config.vm.provision "shell", privileged: false, inline: "#{sync_to}/hack/dind-cluster.sh restart"
       config.vm.hostname = "openshift-dind-host"
-      config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']
+      config.vm.synced_folder ".", "/vagrant", disabled: true
+      config.vm.synced_folder sync_from, sync_to, type: vagrant_openshift_config['sync_folders_type']
     end
   elsif dev_cluster
     # Start an OpenShift cluster
@@ -161,10 +165,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "#{VM_NAME_PREFIX}master" do |config|
       config.vm.box = kube_box[kube_os]["name"]
       config.vm.box_url = kube_box[kube_os]["box_url"]
-      config.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{network_plugin} #{fixup_net_udev} #{skip_build}"
+      config.vm.provision "shell", inline: "/bin/bash -x #{sync_to}/contrib/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{network_plugin} #{fixup_net_udev} #{skip_build}"
       config.vm.network "private_network", ip: "#{master_ip}"
       config.vm.hostname = "openshift-master"
-      config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']
+      config.vm.synced_folder ".", "/vagrant", disabled: true
+      config.vm.synced_folder sync_from, sync_to, type: vagrant_openshift_config['sync_folders_type']
     end
 
     # OpenShift minion
@@ -174,16 +179,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         minion_ip = minion_ips[n]
         minion.vm.box = kube_box[kube_os]["name"]
         minion.vm.box_url = kube_box[kube_os]["box_url"]
-        minion.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-node.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} -i #{minion_index} #{network_plugin} #{fixup_net_udev} #{skip_build}"
+        minion.vm.provision "shell", inline: "/bin/bash -x #{sync_to}/contrib/vagrant/provision-node.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} -i #{minion_index} #{network_plugin} #{fixup_net_udev} #{skip_build}"
         minion.vm.network "private_network", ip: "#{minion_ip}"
         minion.vm.hostname = "openshift-minion-#{minion_index}"
-        config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']
+        config.vm.synced_folder ".", "/vagrant", disabled: true
+        config.vm.synced_folder sync_from, sync_to, type: vagrant_openshift_config['sync_folders_type']
       end
     end
   else # Single VM dev environment
-    sync_from = vagrant_openshift_config['sync_from'] || ENV["VAGRANT_SYNC_FROM"] || '.'
-    sync_to = vagrant_openshift_config['sync_to'] || ENV["VAGRANT_SYNC_TO"] || "/data/src/github.com/openshift/origin"
-
     ##########################
     # define settings for the single VM being created.
     config.vm.define "#{VM_NAME_PREFIX}openshiftdev", primary: true do |config|
@@ -250,7 +253,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       override.ssh.insert_key = vagrant_openshift_config['insert_key']
       if ! single_vm_cluster
         # Work around https://github.com/pradels/vagrant-libvirt/issues/419
-        override.vm.synced_folder ".", "/vagrant", type: 'nfs'
+        override.vm.synced_folder sync_from, sync_to, type: 'nfs'
       end
       libvirt.driver      = 'kvm'
       libvirt.memory      = vagrant_openshift_config['memory'].to_i

--- a/contrib/vagrant/provision-dind.sh
+++ b/contrib/vagrant/provision-dind.sh
@@ -27,6 +27,9 @@ systemctl start docker
 # Docker-in-docker is not compatible with SELinux enforcement
 setenforce 0 || true
 
+# Add a convenience symlink to the gopath repo
+ln -sf "${ORIGIN_ROOT}" /
+
 function set_env {
   USER_DIR="${1}"
   # Prefer bashrc to bash_profile since bash_profile is only loaded on

--- a/contrib/vagrant/provision-dind.sh
+++ b/contrib/vagrant/provision-dind.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -euo
 
+ORIGIN_ROOT=$(
+  unset CDPATH
+  origin_root=$(dirname "${BASH_SOURCE}")/../..
+  cd "${origin_root}"
+  pwd
+)
 USERNAME=vagrant
-ORIGIN_ROOT=${1:-/vagrant}
 
 yum install -y deltarpm
 yum update -y

--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/provision-config.sh
 
-os::provision::base-provision true
+os::provision::base-provision "${ORIGIN_ROOT}" true
 
 os::provision::build-origin "${ORIGIN_ROOT}" "${SKIP_BUILD}"
 os::provision::build-etcd "${ORIGIN_ROOT}" "${SKIP_BUILD}"

--- a/contrib/vagrant/provision-node.sh
+++ b/contrib/vagrant/provision-node.sh
@@ -5,7 +5,7 @@ source $(dirname $0)/provision-config.sh
 # Provided index is 1-based, array is 0 based
 NODE_NAME=${NODE_NAMES[${NODE_INDEX}-1]}
 
-os::provision::base-provision
+os::provision::base-provision "${ORIGIN_ROOT}"
 
 # Waiting for node config to exist before deploying allows vm
 # provisioning to safely execute in parallel.

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -187,7 +187,11 @@ os::provision::get-network-plugin() {
 }
 
 os::provision::base-provision() {
-  local is_master=${1:-false}
+  local origin_root=$1
+  local is_master=${2:-false}
+
+  # Add a convenience symlink to the gopath repo
+  ln -sf "${origin_root}" /
 
   os::provision::fixup-net-udev
 

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -19,6 +19,11 @@ os::provision::build-origin() {
     echo "WARNING: Skipping openshift build due to OPENSHIFT_SKIP_BUILD=true"
   else
     echo "Building openshift"
+    if os::provision::in-container; then
+      # Default to disabling use of a release build for dind to allow
+      # ci to validate a developer's dev cluster workflow.
+      export OS_RELEASE=${OS_RELEASE:-n}
+    fi
     ${origin_root}/hack/build-go.sh
   fi
 }

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -14,7 +14,8 @@ os::log::install_errexit
 
 # only works on Linux for now, all other platforms must build binaries themselves
 if [[ -z "$@" ]]; then
-  if os::build::detect_local_release_tars $(os::build::host_platform_friendly) >/dev/null; then
+  if [[ "${OS_RELEASE:-}" != "n" ]] && \
+     os::build::detect_local_release_tars $(os::build::host_platform_friendly) >/dev/null; then
     platform=$(os::build::host_platform)
     echo "++ Using release artifacts from ${OS_RELEASE_COMMIT} for ${platform} instead of building"
     mkdir -p "${OS_OUTPUT_BINPATH}/${platform}"

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -93,7 +93,7 @@ DEPLOY_SSH=${OPENSHIFT_DEPLOY_SSH:-true}
 
 DEPLOYED_CONFIG_ROOT="/config"
 
-DEPLOYED_ROOT="/data"
+DEPLOYED_ROOT="/data/src/github.com/openshift/origin"
 
 SCRIPT_ROOT="${DEPLOYED_ROOT}/contrib/vagrant"
 


### PR DESCRIPTION
hack/build-go.sh was changed to require the origin repo to be in a
standard GOPATH tree.  This PR will update dind and vm dev cluster
deployment to meet this expectation.