### PR TITLE
Refactoring .component to prevent weird wrapping issues

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -75,59 +75,53 @@
     }
     .component-block {
       .flex-display(@display: flex);
-      .flex-direction(@direction: row);
+      .flex-direction(@direction: column);
       .flex-wrap(@wrap: wrap);
-      @media (max-width: @screen-sm-min) {
-        /* Switch to vertical layout at small sizes */
-        .flex-direction(@direction: column);
-      }
-      &.pod-container {
+      @media (min-width: @screen-md-min) {
+        // switch to horizontal layout when >=992
         .flex-direction(@direction: row);
       }
       &.component-meta {
         margin: 4px 0 6px;
       }
+      &.pod-container {
+        .flex-direction(@direction: row);
+      }
       .component {
-        // prevent content from overflowing the parent in Safari
-        width: 100%;
-        @media (min-width: @screen-sm-min) {
-          // assign flex properties when >768 for proper layout then .component divs will stack at mobile by default
-          .flex(@columns: 2 1 0%);
-        }
-        h2,h3 {
-          margin: 0 0 5px;
-          .truncate();
+        @media (min-width: @screen-md-min) {
+          // assign flex properties when >=992 for proper layout so that .component no longer stack; % on flex-basis value necessary for IE
+          .flex(@columns: 2 0 0%);
+          // so that long strings with nowrap truncate
+          min-width: 0;
         }
         &.meta-data {
-          @media (min-width: @screen-sm-min) {
-            // assign flex properties when >768 for proper layout then .component divs will stack at mobile by default
-            .flex(@columns: 1 1 0%);
-          }
-          font-size: @component-label + 1;
-          text-align: right;
-          line-height: @line-height-base;
-          .align-self(@align: left);
           color: @gray-light;
-          @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
-            // block display multiple port mappings at specific widths to prevent breaking of layout, but also prevent wrapping when not needed
+          font-size: @component-label;
+          line-height: @line-height-base;
+          @media (min-width: @screen-md-min) {
+            // assign flex properties when >=992 for proper layout so that .component no longer stack; % on flex-basis value necessary for IE
+            .flex(@columns: 1 0 0%);
+            text-align: right;
+            .more-ports,
             .port-mappings {
-              display: block;
+              white-space: nowrap;
             }
+          }
+        }
+        @media (max-width: @screen-sm-max) {
+          .ports {
+            margin-right: 5px;
           }
         }
         .add-route-link {
           text-transform: none;
-        }
-        @media (max-width: @screen-sm-min) {
-          // display side-by-side at mobile resolutions
-          .port-mappings, .add-route-link {
+          @media (max-width: @screen-sm-max) {
             display: inline-block;
-            margin-right: 5px;
           }
-          &.meta-data {
-            /* Left align for vertical layout at small sizes */
-            text-align: left;
-          }
+        }
+        h2,h3 {
+          margin: 0 0 5px;
+          .truncate();
         }
       }
     }

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -123,7 +123,7 @@
                       </div>
 
                       <div class="component meta-data">
-                        <span ng-if="numPorts">
+                        <span ng-if="numPorts" class="ports">
                           <!--
                           Show only the first two ports if there are many since we don't have much space here.
                           The full list is visible elsewhere.
@@ -135,7 +135,7 @@
                                          There's just not enough room now, and we already have problems with wrapping. -->
                               <span ng-attr-title="{{portMapping.name}}">{{portMapping.port}}/{{portMapping.protocol}}</span>&#8201;&#8594;&#8201;{{portMapping.targetPort}}<span ng-if="$index < (numPorts - 1)">, </span></span>
                           </span>
-                          <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
+                          <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2" class="more-ports">
                             and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}
                           </span>
                         </span>


### PR DESCRIPTION
@sg00dwin, @spadgett, @benjaminapetersen, @jwforres, @ajacobs21e, please review.

i made quite a few tweaks.  a few highlights:

* optimized existing responsive rules to be mobile first
* changed the .meta-data font size to 11px so it's the same size as .component-label so that they both sit on the same baseline
* changed the breakpoint where columns switch to rows from 768px to 992px so that the .meta-data only displays in the upper right of the box at medium and up sized screens
* fixed bug where .component h2 didn't truncate consistently (in most cases, the h2 would render full width)
* made each individual .port-mappings and .more-ports not wrap so all portions of each stay on the same line

Fixes #6189