### PR TITLE
Making margin consistent around alerts inside.modal-resource-edit

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -811,7 +811,10 @@ a.disabled-link {
     border-bottom: 1px solid #bbbbbb;
     padding: 0;
     .alert {
-      margin-bottom: 0;
+      margin: 10px;
+      &:not(.ng-hide) + .ace_editor {
+        border-top: 1px solid #bbb;
+      }
     }
   }
   .modal-footer {


### PR DESCRIPTION
to improve appearance.  To my eye, the alert butted up against the left, right, and bottom edges looks like a mistake.

Before:
![screen shot 2016-02-17 at 4 08 34 pm](https://cloud.githubusercontent.com/assets/895728/13124995/5933ba7e-d591-11e5-998b-e73529f29a48.PNG)

After:
![screen shot 2016-02-17 at 4 08 03 pm](https://cloud.githubusercontent.com/assets/895728/13124998/5d0c87e8-d591-11e5-8836-befef91d0e0c.PNG)

Thoughts, @spadgett, @sg00dwin, @benjaminapetersen, @jwforres?
