### PR TITLE
fix test flake

### DIFF
--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -60,6 +60,9 @@ func TestClusterResourceOverridePlugin(t *testing.T) {
 	}
 	_, err = limitHandler.Create(limit)
 	checkErr(t, err)
+	// stall in the hopes the LimitRanger cache will also get the new object before our next pod runs through it
+	_, err = limitHandler.Get(limit.Name)
+	checkErr(t, err)
 	podCreated, err = podHandler.Create(testClusterResourceOverridePod("limit-with-default", "", "1"))
 	checkErr(t, err)
 	if memory := podCreated.Spec.Containers[0].Resources.Limits.Memory(); memory.Cmp(resource.MustParse("512Mi")) != 0 {


### PR DESCRIPTION
https://github.com/openshift/origin/issues/7401

Looks like one LimitRanger cache didn't have the LimitRange object
that was created right before the pod, but the other (that runs
after overrides) did. There's no good way to wait for watches to
propagate but getting the LimitRange object from the API may help.