### PR TITLE
Route ordering is unstable, and writes must be ignored

### DIFF
--- a/pkg/router/controller/controller.go
+++ b/pkg/router/controller/controller.go
@@ -77,7 +77,7 @@ func (c *RouterController) HandleRoute() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	glog.V(4).Infof("Processing Route: %s", route.Spec.To.Name)
+	glog.V(4).Infof("Processing Route: %s -> %s", route.Name, route.Spec.To.Name)
 	glog.V(4).Infof("           Alias: %s", route.Spec.Host)
 	glog.V(4).Infof("           Event: %s", eventType)
 

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -166,6 +167,21 @@ func (r *routesByHost) Endpoints(namespace, name string) *kapi.Endpoints {
 	return obj.(*kapi.Endpoints)
 }
 
+// routeAge sorts routes from oldest to newest and is stable for all routes.
+type routeAge []routeapi.Route
+
+func (r routeAge) Len() int      { return len(r) }
+func (r routeAge) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r routeAge) Less(i, j int) bool {
+	if r[i].CreationTimestamp.Before(r[j].CreationTimestamp) {
+		return true
+	}
+	if r[i].Namespace < r[j].Namespace {
+		return true
+	}
+	return r[i].Name < r[j].Name
+}
+
 func oldestRoute(routes []interface{}) *routeapi.Route {
 	var oldest *routeapi.Route
 	for i := range routes {
@@ -202,7 +218,13 @@ func (lw *routeLW) List(options kapi.ListOptions) (runtime.Object, error) {
 		LabelSelector: lw.label,
 		FieldSelector: lw.field,
 	}
-	return lw.client.Routes(lw.namespace).List(opts)
+	routes, err := lw.client.Routes(lw.namespace).List(opts)
+	if err != nil {
+		return nil, err
+	}
+	// return routes in order of age to avoid rejections during resync
+	sort.Sort(routeAge(routes.Items))
+	return routes, nil
 }
 
 func (lw *routeLW) Watch(options kapi.ListOptions) (watch.Interface, error) {

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -92,7 +92,8 @@ func findOrCreateIngress(route *routeapi.Route, name string) (_ *routeapi.RouteI
 // false if no modification was made.
 func setIngressCondition(ingress *routeapi.RouteIngress, condition routeapi.RouteIngressCondition) bool {
 	for _, existing := range ingress.Conditions {
-		//existing.LastTransitionTime = nil
+		// ensures that the comparison is based on the actual value, not the time
+		existing.LastTransitionTime = condition.LastTransitionTime
 		if existing == condition {
 			return false
 		}


### PR DESCRIPTION
The resync function of the controller results in results being sent in
different orders, which results in the router sometimes processing new
routes first, then replacing them with older ones. We now sort the
resync list to be oldest -> newest, which results in stable outcomes.

We also we generating extra writes when comparing the old rejection
notice to the new one - the time field was different, causing every
rejection notice (even those for the same reason) to be written to etcd.
Fixed by restoring the clear of the time and adding a comment.

Fixes #7386

@ramr @pweil- @jwforres