### PR TITLE
refactored test-end-to-end/core to use os::cmd functions

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -9,6 +9,7 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
 source "${OS_ROOT}/hack/lib/util/environment.sh"
@@ -16,23 +17,24 @@ os::util::environment::setup_time_vars
 
 TEST_ASSETS="${TEST_ASSETS:-false}"
 
+export VERBOSE=true
 
 function wait_for_app() {
   echo "[INFO] Waiting for app in namespace $1"
   echo "[INFO] Waiting for database pod to start"
-  wait_for_command "oc get -n $1 pods -l name=database | grep -i Running" $((60*TIME_SEC))
-  oc logs dc/database -n $1
+  os::cmd::try_until_text "oc get -n $1 pods -l name=database" 'Running'
+  os::cmd::expect_success "oc logs dc/database -n $1"
 
   echo "[INFO] Waiting for database service to start"
-  wait_for_command "oc get -n $1 services | grep database" $((20*TIME_SEC))
+  os::cmd::try_until_text "oc get -n $1 services" 'database' "$(( 2 * TIME_MIN ))"
   DB_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.portalIP }}" service database)
 
   echo "[INFO] Waiting for frontend pod to start"
-  wait_for_command "oc get -n $1 pods | grep frontend | grep -i Running" $((120*TIME_SEC))
-  oc logs dc/frontend -n $1
+  os::cmd::try_until_text "oc get -n $1 pods" 'frontend.+Running' "$(( 2 * TIME_MIN ))"
+  os::cmd::expect_success "oc logs dc/frontend -n $1"
 
   echo "[INFO] Waiting for frontend service to start"
-  wait_for_command "oc get -n $1 services | grep frontend" $((20*TIME_SEC))
+  os::cmd::try_until_text "oc get -n $1 services" 'frontend' "$(( 2 * TIME_MIN ))"
   FRONTEND_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.portalIP }}" service frontend)
 
   echo "[INFO] Waiting for database to start..."
@@ -50,25 +52,25 @@ function wait_for_app() {
 # find the IP of the master service by asking the API_HOST to verify DNS is running there
 MASTER_SERVICE_IP="$(dig @${API_HOST} "kubernetes.default.svc.cluster.local." +short A | head -n 1)"
 # find the IP of the master service again by asking the IP of the master service, to verify port 53 tcp/udp is routed by the service
-[ "$(dig +tcp @${MASTER_SERVICE_IP} "kubernetes.default.svc.cluster.local." +short A | head -n 1)" == "${MASTER_SERVICE_IP}" ]
-[ "$(dig +notcp @${MASTER_SERVICE_IP} "kubernetes.default.svc.cluster.local." +short A | head -n 1)" == "${MASTER_SERVICE_IP}" ]
+os::cmd::expect_success_and_text "dig +tcp @${MASTER_SERVICE_IP} kubernetes.default.svc.cluster.local. +short A | head -n 1" "${MASTER_SERVICE_IP}"
+os::cmd::expect_success_and_text "dig +notcp @${MASTER_SERVICE_IP} kubernetes.default.svc.cluster.local. +short A | head -n 1" "${MASTER_SERVICE_IP}"
 
 # add e2e-user as a viewer for the default namespace so we can see infrastructure pieces appear
-openshift admin policy add-role-to-user view e2e-user --namespace=default
+os::cmd::expect_success 'openshift admin policy add-role-to-user view e2e-user --namespace=default'
 
 # pre-load some image streams and templates
-oc create -f examples/image-streams/image-streams-centos7.json --namespace=openshift
-oc create -f examples/sample-app/application-template-stibuild.json --namespace=openshift
-oc create -f examples/jenkins/application-template.json --namespace=openshift
-oc create -f examples/db-templates/mongodb-ephemeral-template.json --namespace=openshift
-oc create -f examples/db-templates/mysql-ephemeral-template.json --namespace=openshift
-oc create -f examples/db-templates/postgresql-ephemeral-template.json --namespace=openshift
+os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json --namespace=openshift'
+os::cmd::expect_success 'oc create -f examples/sample-app/application-template-stibuild.json --namespace=openshift'
+os::cmd::expect_success 'oc create -f examples/jenkins/application-template.json --namespace=openshift'
+os::cmd::expect_success 'oc create -f examples/db-templates/mongodb-ephemeral-template.json --namespace=openshift'
+os::cmd::expect_success 'oc create -f examples/db-templates/mysql-ephemeral-template.json --namespace=openshift'
+os::cmd::expect_success 'oc create -f examples/db-templates/postgresql-ephemeral-template.json --namespace=openshift'
 
 # create test project so that this shows up in the console
-openshift admin new-project test --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
-openshift admin new-project docker --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
-openshift admin new-project custom --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
-openshift admin new-project cache --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
+os::cmd::expect_success "openshift admin new-project test --description='This is an example project to demonstrate OpenShift v3' --admin='e2e-user'"
+os::cmd::expect_success "openshift admin new-project docker --description='This is an example project to demonstrate OpenShift v3' --admin='e2e-user'"
+os::cmd::expect_success "openshift admin new-project custom --description='This is an example project to demonstrate OpenShift v3' --admin='e2e-user'"
+os::cmd::expect_success "openshift admin new-project cache --description='This is an example project to demonstrate OpenShift v3' --admin='e2e-user'"
 
 echo "The console should be available at ${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}/console."
 echo "Log in as 'e2e-user' to see the 'test' project."
@@ -77,7 +79,7 @@ install_router
 install_registry
 
 echo "[INFO] Pre-pulling and pushing ruby-22-centos7"
-docker pull centos/ruby-22-centos7:latest
+os::cmd::expect_success 'docker pull centos/ruby-22-centos7:latest'
 echo "[INFO] Pulled ruby-22-centos7"
 
 echo "[INFO] Waiting for Docker registry pod to start"
@@ -95,31 +97,31 @@ registry="$(dig @${API_HOST} "docker-registry.default.svc.cluster.local." +short
 echo "[INFO] Verifying the docker-registry is up at ${DOCKER_REGISTRY}"
 wait_for_url_timed "http://${DOCKER_REGISTRY}/" "[INFO] Docker registry says: " $((2*TIME_MIN))
 # ensure original healthz route works as well
-curl -f "http://${DOCKER_REGISTRY}/healthz"
+os::cmd::expect_success "curl -f http://${DOCKER_REGISTRY}/healthz"
 
-[ "$(dig @${API_HOST} "docker-registry.default.local." A)" ]
+os::cmd::expect_success "dig @${API_HOST} docker-registry.default.local. A"
 
 # Client setup (log in as e2e-user and set 'test' as the default project)
 # This is required to be able to push to the registry!
 echo "[INFO] Logging in as a regular user (e2e-user:pass) with project 'test'..."
-oc login -u e2e-user -p pass
-[ "$(oc whoami | grep 'e2e-user')" ]
+os::cmd::expect_success 'oc login -u e2e-user -p pass'
+os::cmd::expect_success_and_text 'oc whoami' 'e2e-user'
  
 # make sure viewers can see oc status
-oc status -n default
+os::cmd::expect_success 'oc status -n default'
 
 # check to make sure a project admin can push an image to an image stream that doesn't exist
-oc project cache
+os::cmd::expect_success 'oc project cache'
 e2e_user_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
-[[ -n ${e2e_user_token} ]]
+os::cmd::expect_success_and_text "echo ${e2e_user_token}" '.+'
 
 echo "[INFO] Docker login as e2e-user to ${DOCKER_REGISTRY}"
-docker login -u e2e-user -p ${e2e_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}
+os::cmd::expect_success "docker login -u e2e-user -p ${e2e_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}"
 echo "[INFO] Docker login successful"
 
 echo "[INFO] Tagging and pushing ruby-22-centos7 to ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest"
-docker tag -f centos/ruby-22-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
-docker push ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
+os::cmd::expect_success "docker tag -f centos/ruby-22-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest"
+os::cmd::expect_success "docker push ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest"
 echo "[INFO] Pushed ruby-22-centos7"
 
 # verify remote images can be pulled directly from the local registry
@@ -127,56 +129,54 @@ oc import-image --confirm --from=mysql:latest mysql:pullthrough
 docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough
 
 # check to make sure an image-pusher can push an image
-oc policy add-role-to-user system:image-pusher pusher
-oc login -u pusher -p pass
+os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher pusher'
+os::cmd::expect_success 'oc login -u pusher -p pass'
 pusher_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
-[[ -n ${pusher_token} ]]
+os::cmd::expect_success_and_text "echo ${pusher_token}" '.+'
 
 echo "[INFO] Docker login as pusher to ${DOCKER_REGISTRY}"
-docker login -u e2e-user -p ${pusher_token} -e pusher@openshift.com ${DOCKER_REGISTRY}
+os::cmd::expect_success "docker login -u e2e-user -p ${pusher_token} -e pusher@openshift.com ${DOCKER_REGISTRY}"
 echo "[INFO] Docker login successful"
 
 # log back into docker as e2e-user again
-docker login -u e2e-user -p ${e2e_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}
+os::cmd::expect_success "docker login -u e2e-user -p ${e2e_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}"
 
 echo "[INFO] Back to 'default' project with 'admin' user..."
-oc project ${CLUSTER_ADMIN_CONTEXT}
-[ "$(oc whoami | grep 'system:admin')" ]
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
+os::cmd::expect_success_and_text 'oc whoami' 'system:admin'
 
 # The build requires a dockercfg secret in the builder service account in order
 # to be able to push to the registry.  Make sure it exists first.
 echo "[INFO] Waiting for dockercfg secrets to be generated in project 'test' before building"
-wait_for_command "oc get -n test serviceaccount/builder -o yaml | grep dockercfg > /dev/null" $((60*TIME_SEC))
+os::cmd::try_until_text 'oc get -n test serviceaccount/builder -o yaml' 'dockercfg'
 
 # Process template and create
 echo "[INFO] Submitting application template json for processing..."
 STI_CONFIG_FILE="${ARTIFACT_DIR}/stiAppConfig.json"
 DOCKER_CONFIG_FILE="${ARTIFACT_DIR}/dockerAppConfig.json"
 CUSTOM_CONFIG_FILE="${ARTIFACT_DIR}/customAppConfig.json"
-oc process -n test -f examples/sample-app/application-template-stibuild.json > "${STI_CONFIG_FILE}"
-oc process -n docker -f examples/sample-app/application-template-dockerbuild.json > "${DOCKER_CONFIG_FILE}"
-oc process -n custom -f examples/sample-app/application-template-custombuild.json > "${CUSTOM_CONFIG_FILE}"
+os::cmd::expect_success "oc process -n test -f examples/sample-app/application-template-stibuild.json > '${STI_CONFIG_FILE}'"
+os::cmd::expect_success "oc process -n docker -f examples/sample-app/application-template-dockerbuild.json > '${DOCKER_CONFIG_FILE}'"
+os::cmd::expect_success "oc process -n custom -f examples/sample-app/application-template-custombuild.json > '${CUSTOM_CONFIG_FILE}'"
 
 echo "[INFO] Back to 'test' context with 'e2e-user' user"
-oc login -u e2e-user
-oc project test
-oc whoami
+os::cmd::expect_success 'oc login -u e2e-user'
+os::cmd::expect_success 'oc project test'
+os::cmd::expect_success 'oc whoami'
 
 echo "[INFO] Running a CLI command in a container using the service account"
-oc policy add-role-to-user view -z default
+os::cmd::expect_success 'oc policy add-role-to-user view -z default'
 oc run cli-with-token --attach --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 > ${LOG_DIR}/cli-with-token.log 2>&1
-cat ${LOG_DIR}/cli-with-token.log
-[ "$(cat ${LOG_DIR}/cli-with-token.log | grep 'Using in-cluster configuration')" ]
-[ "$(cat ${LOG_DIR}/cli-with-token.log | grep 'In project test')" ]
-oc delete pod cli-with-token
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+os::cmd::expect_success 'oc delete pod cli-with-token'
 oc run cli-with-token-2 --attach --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=4 > ${LOG_DIR}/cli-with-token2.log 2>&1
-cat ${LOG_DIR}/cli-with-token2.log
-[ "$(cat ${LOG_DIR}/cli-with-token2.log | grep 'system:serviceaccount:test:default')" ]
-oc delete pod cli-with-token-2
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+os::cmd::expect_success 'oc delete pod cli-with-token-2'
 oc run kubectl-with-token --attach --image=openshift/origin:${TAG} --restart=Never --command -- kubectl get pods --loglevel=4 > ${LOG_DIR}/kubectl-with-token.log 2>&1
 cat ${LOG_DIR}/kubectl-with-token.log
-[ "$(cat ${LOG_DIR}/kubectl-with-token.log | grep 'Using in-cluster configuration')" ]
-[ "$(cat ${LOG_DIR}/kubectl-with-token.log | grep 'kubectl-with-token')" ]
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
 
 echo "[INFO] Testing deployment logs and failing pre and mid hooks ..."
 # test the pre hook on a rolling deployment
@@ -204,7 +204,7 @@ echo "[INFO] Run pod diagnostics"
 openshift ex diagnostics DiagnosticPod --images="${USE_IMAGES}"
 
 echo "[INFO] Applying STI application config"
-oc create -f "${STI_CONFIG_FILE}"
+os::cmd::expect_success "oc create -f ${STI_CONFIG_FILE}"
 
 # Wait for build which should have triggered automatically
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} and streaming its logs..."
@@ -217,53 +217,52 @@ wait_for_app "test"
 
 # logs can't be tested without a node, so has to be in e2e
 POD_NAME=$(oc get pods -n test --template='{{(index .items 0).metadata.name}}')
-oc logs pod/${POD_NAME} --loglevel=6
-oc logs ${POD_NAME} --loglevel=6
+os::cmd::expect_success "oc logs pod/${POD_NAME} --loglevel=6"
+os::cmd::expect_success "oc logs ${POD_NAME} --loglevel=6"
+
 BUILD_NAME=$(oc get builds -n test --template='{{(index .items 0).metadata.name}}')
-oc logs build/${BUILD_NAME} --loglevel=6
-oc logs build/${BUILD_NAME} --loglevel=6
-oc logs bc/ruby-sample-build --loglevel=6
-oc logs buildconfigs/ruby-sample-build --loglevel=6
-oc logs buildconfig/ruby-sample-build --loglevel=6
+os::cmd::expect_success "oc logs build/${BUILD_NAME} --loglevel=6"
+os::cmd::expect_success "oc logs build/${BUILD_NAME} --loglevel=6"
+os::cmd::expect_success 'oc logs bc/ruby-sample-build --loglevel=6'
+os::cmd::expect_success 'oc logs buildconfigs/ruby-sample-build --loglevel=6'
+os::cmd::expect_success 'oc logs buildconfig/ruby-sample-build --loglevel=6'
 echo "logs: ok"
 
 echo "[INFO] Starting a deployment to test scaling and image tag..."
-oc create -f test/integration/fixtures/test-deployment-config.yaml
+os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.yaml'
 # scaling which might conflict with the deployment should work
-oc scale dc/test-deployment-config --replicas=2
-tryuntil '[ "$(oc get rc/test-deployment-config-1 -o yaml | grep Complete)" ]'
+os::cmd::expect_success 'oc scale dc/test-deployment-config --replicas=2'
+os::cmd::try_until_text 'oc get rc/test-deployment-config-1 -o yaml' 'Complete'
 # scale rc via deployment configuration
-oc scale dc/test-deployment-config --replicas=3 --timeout=1m
-oc delete dc/test-deployment-config
+os::cmd::expect_success 'oc scale dc/test-deployment-config --replicas=3 --timeout=1m'
+os::cmd::expect_success 'oc delete dc/test-deployment-config'
 # expect the post deployment action to set a tag
 oc get istag/origin-ruby-sample:deployed
 echo "scale: ok"
 
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} with non-existing commit..."
-set +e
-oc start-build test --commit=fffffff --wait && echo "The build was supposed to fail, but it succeeded." && exit 1
-set -e
+os::cmd::expect_failure 'oc start-build test --commit=fffffff --wait'
 
 # Remote command execution
 echo "[INFO] Validating exec"
 frontend_pod=$(oc get pod -l deploymentconfig=frontend --template='{{(index .items 0).metadata.name}}')
 # when running as a restricted pod the registry will run with a pre-allocated
 # user in the neighborhood of 1000000+.  Look for a substring of the pre-allocated uid range
-[ "$(oc exec -p ${frontend_pod} id | grep 1000)" ]
-[ "$(oc rsh ${frontend_pod} id -u | grep 1000)" ]
-[ "$(oc rsh -T ${frontend_pod} id -u | grep 1000)" ]
+os::cmd::expect_success_and_text "oc exec -p ${frontend_pod} id" '1000'
+os::cmd::expect_success_and_text "oc rsh ${frontend_pod} id -u" '1000'
+os::cmd::expect_success_and_text "oc rsh -T ${frontend_pod} id -u" '1000'
 # Test retrieving application logs from dc
 oc logs dc/frontend | grep "Connecting to production database"
 
 # Port forwarding
 echo "[INFO] Validating port-forward"
-oc port-forward -p ${frontend_pod} 10080:8080  &> "${LOG_DIR}/port-forward.log" &
+os::cmd::expect_success "oc port-forward -p ${frontend_pod} 10080:8080  &> '${LOG_DIR}/port-forward.log' &"
 wait_for_url_timed "http://localhost:10080" "[INFO] Frontend says: " $((10*TIME_SEC))
 
 # Rsync
 echo "[INFO] Validating rsync"
-oc rsync examples/sample-app ${frontend_pod}:/tmp
-[ "$(oc rsh ${frontend_pod} ls /tmp/sample-app | grep "application-template-stibuild")" ]
+os::cmd::expect_success "oc rsync examples/sample-app ${frontend_pod}:/tmp"
+os::cmd::expect_success_and_text "oc rsh ${frontend_pod} ls /tmp/sample-app" 'application-template-stibuild'
 
 #echo "[INFO] Applying Docker application config"
 #oc create -n docker -f "${DOCKER_CONFIG_FILE}"
@@ -280,26 +279,22 @@ oc rsync examples/sample-app ${frontend_pod}:/tmp
 #wait_for_app "custom"
 
 echo "[INFO] Back to 'default' project with 'admin' user..."
-oc project ${CLUSTER_ADMIN_CONTEXT}
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
 
 # ensure the router is started
 # TODO: simplify when #4702 is fixed upstream
-wait_for_command '[[ "$(oc get endpoints router --output-version=v1beta3 --template="{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
+os::cmd::try_until_text "oc get endpoints router --output-version=v1beta3 --template='{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}'" '[1-9]+' $((5*TIME_MIN))
 
 # Check for privileged exec limitations.
 echo "[INFO] Validating privileged pod exec"
 router_pod=$(oc get pod -n default -l deploymentconfig=router --template='{{(index .items 0).metadata.name}}')
-oc policy add-role-to-user admin e2e-default-admin
+os::cmd::expect_success 'oc policy add-role-to-user admin e2e-default-admin'
 # login as a user that can't run privileged pods
-oc login -u e2e-default-admin -p pass
-# this next call should fail, but we want the output from it
-set +e
-output=$(oc exec -n default -tip ${router_pod} ls 2>&1)
-set -e
-echo "${output}" | grep -q "unable to validate against any security context constraint"
+os::cmd::expect_success 'oc login -u e2e-default-admin -p pass'
+os::cmd::expect_failure_and_text "oc exec -n default -tip ${router_pod} ls" 'unable to validate against any security context constraint'
 # system:admin should be able to exec into it
-oc project ${CLUSTER_ADMIN_CONTEXT}
-oc exec -n default -tip ${router_pod} ls
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
+os::cmd::expect_success "oc exec -n default -tip ${router_pod} ls"
 
 
 echo "[INFO] Validating routed app response..."
@@ -319,51 +314,53 @@ validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_AP
 # Pod node selection
 echo "[INFO] Validating pod.spec.nodeSelector rejections"
 # Create a project that enforces an impossible to satisfy nodeSelector, and two pods, one of which has an explicit node name
-openshift admin new-project node-selector --description="This is an example project to test node selection prevents deployment" --admin="e2e-user" --node-selector="impossible-label=true"
+os::cmd::expect_success "openshift admin new-project node-selector --description='This is an example project to test node selection prevents deployment' --admin='e2e-user' --node-selector='impossible-label=true'"
 NODE_NAME=`oc get node --no-headers | awk '{print $1}'`
-oc process -n node-selector -v NODE_NAME="${NODE_NAME}" -f test/fixtures/node-selector/pods.json | oc create -n node-selector -f -
+os::cmd::expect_success "oc process -n node-selector -v NODE_NAME='${NODE_NAME}' -f test/fixtures/node-selector/pods.json | oc create -n node-selector -f -"
 # The pod without a node name should fail to schedule
-wait_for_command "oc get events -n node-selector | grep pod-without-node-name | grep FailedScheduling"        $((20*TIME_SEC))
+os::cmd::try_until_text 'oc get events -n node-selector' 'pod-without-node-name.+FailedScheduling' $((20*TIME_SEC))
 # The pod with a node name should be rejected by the kubelet
-wait_for_command "oc get events -n node-selector | grep pod-with-node-name    | grep NodeSelectorMismatching" $((20*TIME_SEC))
+os::cmd::try_until_text 'oc get events -n node-selector' 'pod-with-node-name.+NodeSelectorMismatching' $((20*TIME_SEC))
 
 
 # Image pruning
 echo "[INFO] Validating image pruning"
-docker pull busybox
-docker pull gcr.io/google_containers/pause
-docker pull openshift/hello-openshift
+os::cmd::expect_success 'docker pull busybox'
+os::cmd::expect_success 'docker pull gcr.io/google_containers/pause'
+os::cmd::expect_success 'docker pull openshift/hello-openshift'
 
 # tag and push 1st image - layers unique to this image will be pruned
-docker tag -f busybox ${DOCKER_REGISTRY}/cache/prune
-docker push ${DOCKER_REGISTRY}/cache/prune
+os::cmd::expect_success "docker tag -f busybox ${DOCKER_REGISTRY}/cache/prune"
+os::cmd::expect_success "docker push ${DOCKER_REGISTRY}/cache/prune"
 
 # tag and push 2nd image - layers unique to this image will be pruned
-docker tag -f openshift/hello-openshift ${DOCKER_REGISTRY}/cache/prune
-docker push ${DOCKER_REGISTRY}/cache/prune
+os::cmd::expect_success "docker tag -f openshift/hello-openshift ${DOCKER_REGISTRY}/cache/prune"
+os::cmd::expect_success "docker push ${DOCKER_REGISTRY}/cache/prune"
 
 # tag and push 3rd image - it won't be pruned
-docker tag -f gcr.io/google_containers/pause ${DOCKER_REGISTRY}/cache/prune
-docker push ${DOCKER_REGISTRY}/cache/prune
+os::cmd::expect_success "docker tag -f gcr.io/google_containers/pause ${DOCKER_REGISTRY}/cache/prune"
+os::cmd::expect_success "docker push ${DOCKER_REGISTRY}/cache/prune"
 
 # record the storage before pruning
 registry_pod=$(oc get pod -l deploymentconfig=docker-registry --template='{{(index .items 0).metadata.name}}')
-oc exec -p ${registry_pod} du /registry > ${LOG_DIR}/prune-images.before.txt
+os::cmd::expect_success "oc exec -p ${registry_pod} du /registry > '${LOG_DIR}/prune-images.before.txt'"
 
 # set up pruner user
-oadm policy add-cluster-role-to-user system:image-pruner e2e-pruner
-oc login -u e2e-pruner -p pass
+os::cmd::expect_success 'oadm policy add-cluster-role-to-user system:image-pruner e2e-pruner'
+os::cmd::expect_success 'oc login -u e2e-pruner -p pass'
 
 # run image pruning
-oadm prune images --keep-younger-than=0 --keep-tag-revisions=1 --confirm &> ${LOG_DIR}/prune-images.log
-! grep error ${LOG_DIR}/prune-images.log
+os::cmd::expect_success "oadm prune images --keep-younger-than=0 --keep-tag-revisions=1 --confirm &> '${LOG_DIR}/prune-images.log'"
+os::cmd::expect_success_and_not_text "cat ${LOG_DIR}/prune-images.log" 'error'
 
-oc project ${CLUSTER_ADMIN_CONTEXT}
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
 # record the storage after pruning
-oc exec -p ${registry_pod} du /registry > ${LOG_DIR}/prune-images.after.txt
+os::cmd::expect_success "oc exec -p ${registry_pod} du /registry > '${LOG_DIR}/prune-images.after.txt'"
 
 # make sure there were changes to the registry's storage
-[ -n "$(diff ${LOG_DIR}/prune-images.before.txt ${LOG_DIR}/prune-images.after.txt)" ]
+os::cmd::expect_code "diff ${LOG_DIR}/prune-images.before.txt ${LOG_DIR}/prune-images.after.txt" 1
+
+unset VERBOSE
 
 # UI e2e tests can be found in assets/test/e2e
 if [[ "$TEST_ASSETS" == "true" ]]; then


### PR DESCRIPTION
https://github.com/openshift/origin/pull/6481 without throwing the baby out with the bathwater.

@liggitt I reviewed his pull before and this is most of it without stripping out useful function.  Double check my rebase?