### PR TITLE
always pull the previous image for s2i builds

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -178,13 +178,12 @@ func (s *S2IBuilder) Build() error {
 
 	if s.build.Spec.Strategy.SourceStrategy.ForcePull {
 		glog.V(4).Infof("With force pull true, setting policies to %s", s2iapi.PullAlways)
-		config.PreviousImagePullPolicy = s2iapi.PullAlways
 		config.BuilderPullPolicy = s2iapi.PullAlways
 	} else {
 		glog.V(4).Infof("With force pull false, setting policies to %s", s2iapi.PullIfNotPresent)
-		config.PreviousImagePullPolicy = s2iapi.PullIfNotPresent
 		config.BuilderPullPolicy = s2iapi.PullIfNotPresent
 	}
+	config.PreviousImagePullPolicy = s2iapi.PullAlways
 
 	allowedUIDs := os.Getenv("ALLOWED_UIDS")
 	glog.V(2).Infof("The value of ALLOWED_UIDS is [%s]", allowedUIDs)


### PR DESCRIPTION
when doing an incremental build, we always want to ensure we
are using the latest previous image.