### PR TITLE
Web console: show more detailed pod status

### DIFF
--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -5,15 +5,14 @@
       <dl class="dl-horizontal left">
         <dt>Phase:</dt>
         <dd>
-          <span ng-switch="pod.status.phase">
-            <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
-            <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
-            <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
-            <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
-            <span ng-switch-when="Running" class="fa fa-refresh" aria-hidden="true"></span>
-          </span>
+          <status-icon status="pod.status.phase"></status-icon>
           {{pod.status.phase}}
+          <span ng-if="pod.status.reason">
+            ({{pod.status.reason}})
+          </span>
         </dd>
+        <dt ng-if-start="pod.status.message">Message:</dt>
+        <dd ng-if-end>{{pod.status.message}}</dd>
         <dt>IP:</dt>
         <dd>{{pod.status.podIP || 'unknown'}}</dd>
         <dt>Node:</dt>

--- a/assets/app/views/directives/_status-icon.html
+++ b/assets/app/views/directives/_status-icon.html
@@ -9,7 +9,24 @@
   <span ng-switch-when="Running" class="fa fa-refresh" ng-class="{'fa-spin' : spinning }" aria-hidden="true"></span>
   <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Bound" class="fa fa-check text-success" aria-hidden="true"></span>
+  <span ng-switch-when="Terminating" class="fa fa-times text-danger" aria-hidden="true"></span>
   <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
   <span ng-switch-when="Unknown" class="fa fa-question text-danger" aria-hidden="true"></span>
-  <span ng-switch-default class="fa fa-question text-danger" aria-hidden="true"></span>
+
+  <!-- Container Runtime Errors -->
+  <span ng-switch-when="CrashLoopBackOff" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="ImagePullBackOff" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="ImageInspectError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="ErrImagePull" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="ErrImageNeverPull" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="no matching container" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="RegistryUnavailable" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="RunContainerError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="KillContainerError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="VerifyNonRootError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="SetupNetworkError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="TeardownNetworkError" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="DeadlineExceeded" class="fa fa-times text-danger" aria-hidden="true"></span>
+
+  <span ng-switch-default class="fa fa-question text-muted" aria-hidden="true"></span>
 </span>

--- a/assets/app/views/pods.html
+++ b/assets/app/views/pods.html
@@ -44,8 +44,8 @@
                     </td>
                     <td data-title="Status">
                       <div row class="status">
-                        <status-icon status="pod.status.phase" disable-animation></status-icon>
-                        <span flex>{{pod.status.phase}}</span>
+                        <status-icon status="pod | podStatus" disable-animation></status-icon>
+                        <span flex>{{pod | podStatus | sentenceCase}}</span>
                       </div>
                     </td>
                     <td data-title="Ready">{{pod | numContainersReady}}/{{pod.spec.containers.length}}</td>


### PR DESCRIPTION
Display the same output in the browse pods table as `oc get pods` (although we sentence case the reason).

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/13156526/e59c679e-d650-11e5-92da-6d579310ba05.png)

Fixes #6584