### PR TITLE
Adjust empty state margin for pages with tabs

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -153,12 +153,15 @@
 }
 
 .empty-state-message {
-  margin: @grid-gutter-width auto;
+  margin: 60px auto @grid-gutter-width;
   max-width: 600px;
   padding: 0 (@grid-gutter-width / 2);
   .btn {
     margin: 10px 0 20px;
   }
+}
+
+.empty-state-message.empty-state-full-page {
   @media (min-height: 500px) {
     margin-top: 150px;
   }

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -129,7 +129,7 @@
 
                       <build-trends-chart builds="builds"></build-trends-chart>
                     </div>
-                    <div ng-if="loaded">
+                    <div ng-if="loaded && (unfilteredBuilds | hashSize) > 0">
                       <table class="table table-bordered table-hover table-mobile">
                         <thead>
                           <tr>


### PR DESCRIPTION
Adjust the top margin using the existing `empty-state-full-page` style. Pages with tabs (build config, logs) will use the style without the large top margin.

Fixes #7435 

@jwforres PTAL