### PR TITLE
Web console: add "Completed" to status-icon directive

### DIFF
--- a/assets/app/views/directives/_status-icon.html
+++ b/assets/app/views/directives/_status-icon.html
@@ -1,6 +1,7 @@
 <span ng-switch="status" class="hide-ng-leave status-icon">
   <span ng-switch-when="Cancelled" class="fa fa-ban text-muted" aria-hidden="true"></span>
   <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
+  <span ng-switch-when="Completed" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Deployed" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Error" class="fa fa-times text-danger" aria-hidden="true"></span>
   <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>


### PR DESCRIPTION
Fix regression from #7434 where "Completed" pods are showing a question mark icon. Add container state reason "Completed" to status-icon directive.

@jwforres PTAL