### PR TITLE
Filter and sort web console events table

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -21,6 +21,7 @@ angular
     'kubernetesUI',
     'ui.bootstrap',
     'patternfly.charts',
+    'patternfly.sort',
     'openshiftConsoleTemplates',
     'ui.ace'
   ])

--- a/assets/app/scripts/controllers/events.js
+++ b/assets/app/scripts/controllers/events.js
@@ -8,28 +8,16 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('EventsController', function ($routeParams, $scope, DataService, ProjectsService, Logger) {
+  .controller('EventsController', function ($routeParams, $scope, ProjectsService) {
     $scope.projectName = $routeParams.project;
-    $scope.emptyMessage = "Loading...";
-    $scope.events = {};
     $scope.renderOptions = {
       hideFilterWidget: true
     };
-    var watches = [];
 
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
-        watches.push(DataService.watch("events", context, function(events) {
-          $scope.events = events.by("metadata.name");
-          $scope.emptyMessage = "No events to show";
-          Logger.log("events (subscribe)", $scope.events);
-        }));
-
-        $scope.$on('$destroy', function(){
-          DataService.unwatchAll(watches);
-        });
+        $scope.projectContext = context;
       }));
   });
-

--- a/assets/app/scripts/directives/events.js
+++ b/assets/app/scripts/directives/events.js
@@ -5,22 +5,126 @@ angular.module('openshiftConsole')
     return {
       restrict: 'E',
       scope: {
-        resourceKind: "@",
-        resourceName: "@",
+        resourceKind: "@?",
+        resourceName: "@?",
         projectContext: "="
       },
       templateUrl: 'views/directives/events.html',
       controller: function($scope){
-
-        var filterEvent = function(event) {
-          return (event.involvedObject.kind === $scope.resourceKind) && (event.involvedObject.name === $scope.resourceName);
+        $scope.filter = {
+          text: ''
         };
+
+        var filterForResource = function(events) {
+          if (!$scope.resourceKind || !$scope.resourceName) {
+            return events;
+          }
+
+          return _.filter(events, function(event) {
+            return event.involvedObject.kind === $scope.resourceKind &&
+                   event.involvedObject.name === $scope.resourceName;
+          });
+        };
+
+        var sortedEvents = [];
+        var sortEvents = function() {
+          // TODO: currentField is renamed in angular-patternfly 3.0
+          var sortID = _.get($scope, 'sortConfig.currentField.id', 'lastTimestamp'),
+              order = $scope.sortConfig.isAscending ? 'asc' : 'desc';
+          sortedEvents = _.sortByOrder($scope.events, [sortID], [order]);
+        };
+
+        var keywords = [];
+        var updateKeywords = function() {
+          if (!$scope.filter.text) {
+            keywords = [];
+            return;
+          }
+
+          keywords = _.uniq($scope.filter.text.split(/\s+/));
+          // Sort the longest keyword first.
+          keywords.sort(function(a, b){
+            return b.length - a.length;
+          });
+        };
+
+        var applyFilter = $filter('filter');
+        var filterForKeyword = function() {
+          $scope.filteredEvents = sortedEvents;
+          if (!keywords.length) {
+            return;
+          }
+
+          // Find events that match all keywords, removing duplicates.
+          angular.forEach(keywords, function(keyword) {
+            $scope.filteredEvents = applyFilter($scope.filteredEvents, keyword);
+          });
+        };
+
+        $scope.$watch('filter.text', _.debounce(function() {
+          updateKeywords();
+          $scope.$apply(filterForKeyword);
+        }, 50, { maxWait: 250 }));
+
+        var update = function() {
+          // Sort first so we can update the filter as the user types without resorting.
+          sortEvents();
+          filterForKeyword();
+        };
+
+        // Invoke update when first called, debouncing subsequent calls.
+        var debounceUpdate = _.debounce(function() {
+          $scope.$evalAsync(update);
+        }, 250, {
+          leading: true,
+          trailing: false,
+          maxWait: 1000
+        });
+
+        // Set up the sort configuration for `pf-simple-sort`.
+        $scope.sortConfig = {
+          fields: [{
+            id: 'lastTimestamp',
+            title: 'Time',
+            sortType: 'alpha'
+          }, {
+            id: 'type',
+            title: 'Severity',
+            sortType: 'alpha'
+          }, {
+            id: 'reason',
+            title: 'Reason',
+            sortType: 'alpha'
+          }, {
+            id: 'message',
+            title: 'Message',
+            sortType: 'alpha'
+          }, {
+            id: 'count',
+            title: 'Count',
+            sortType: 'numeric'
+          }],
+          isAscending: false,
+          onSortChange: update
+        };
+
+        // Conditionally add kind and name to sort fields if not passed to the directive.
+        if (!$scope.resourceKind || !$scope.resourceName) {
+          $scope.sortConfig.fields.splice(1, 0, {
+            id: 'involvedObject.name',
+            title: 'Name',
+            sortType: 'alpha'
+          }, {
+            id: 'involvedObject.kind',
+            title: 'Kind',
+            sortType: 'alpha'
+          });
+        }
 
         var watches = [];
         watches.push(DataService.watch("events", $scope.projectContext, function(events) {
-          $scope.emptyMessage = "No events to show";
-          // $scope.eventsArray = $filter('toArray')(events.by("metadata.name"));
-          $scope.filteredEvents = _.filter(events.by("metadata.name"), filterEvent);
+          $scope.events = filterForResource(events.by('metadata.name'));
+          debounceUpdate();
           Logger.log("events (subscribe)", $scope.filteredEvents);
         }));
 

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -779,8 +779,23 @@ angular.module('openshiftConsole')
       }
     };
   })
+  .filter('humanizeKind', function () {
+    return function(kind) {
+      if (!kind) {
+        return kind;
+      }
+
+      // ReplicationController -> Replication Controller
+      // https://lodash.com/docs#startCase
+      return _.startCase(kind);
+    };
+  })
   .filter('humanizeResourceType', function() {
     return function(resourceType) {
+      if (!resourceType) {
+        return resourceType;
+      }
+
       var nameFormatMap = {
         'build': 'Build',
         'buildconfig': 'Build Config',

--- a/assets/app/styles/_tables.less
+++ b/assets/app/styles/_tables.less
@@ -61,6 +61,38 @@
   }
 }
 
+.table-toolbar {
+  .filter-controls input {
+    width: 100%;
+  }
+  .vertical-divider {
+    // Controls are stacked at mobile, so hide the divider.
+    display: none;
+  }
+  @media (min-width: @screen-sm-min) {
+    // Only needed at larger sizes since form-group has a bottom margin at mobile.
+    .gutter-bottom;
+    .filter-controls, .sort-controls {
+      // Inline controls at wider widths.
+      display: inline-block;
+    }
+    .filter-controls input {
+      width: 300px;
+    }
+    .vertical-divider {
+      // @gray-light is too dark, and @gray-lighter is too light.
+      // Choose another gray from the Patternfly palette.
+      //   https://www.patternfly.org/styles/color-palette/
+      border-left: 1px solid #bbbbbb;
+      display: inline-block;
+      height: 25px;
+      margin: 0 7px;
+      vertical-align: middle;
+      width: 1px;
+    }
+  }
+}
+
 @media (max-width: @screen-xs-max) {
   .table-mobile {
     border-top: 2px solid @table-border-color;

--- a/assets/app/views/directives/events.html
+++ b/assets/app/views/directives/events.html
@@ -1,37 +1,80 @@
-<table class="table table-bordered table-condensed table-mobile table-hover events-table">
-  <thead>
-    <tr>
-      <th>Time</th>
-      <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
-      <th>Reason</th>
-      <th>Message</th>
-    </tr>
-  </thead>
-  <tbody ng-if="(filteredEvents | hashSize) === 0">
-    <tr>
-      <td><em>{{emptyMessage}}</em></td>
-      <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-      <td class="hidden-xs">&nbsp;</td>
-      <td class="hidden-xs">&nbsp;</td>
-    </tr>
-  </tbody>
-  <tbody ng-repeat="event in filteredEvents | orderBy:'-lastTimestamp'">
-    <tr>
-      <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
-      <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">
-        <span class="sr-only">{{event.type}}</span>
-        <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span></td>
-      <td data-title="Reason" class="event-time">
-        {{event.reason}}&nbsp;
-        <span class="hidden-lg pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
-      </td>
-      <td data-title="Message" class="word-break">
-        {{event.message}}
-        <div ng-if="event.count > 1" class="text-muted small">
-          {{event.count}} times in the last
-          <duration-until-now timestamp="event.firstTimestamp" omit-single="true" precision="1"></duration-until-now>
-        </div>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div ng-if="!events">
+  Loading...
+</div>
+<div ng-if="events">
+  <div class="table-toolbar form-inline">
+    <div class="form-group filter-controls">
+      <label for="events-filter" class="sr-only">Filter</label>
+      <input type="search"
+             placeholder="Filter by keyword"
+             class="form-control"
+             id="events-filter"
+             ng-model="filter.text">
+    </div>
+    <div class="vertical-divider"></div>
+    <!-- TODO: Change to pf-sort in angular-patternfly 3.0 -->
+    <div pf-simple-sort config="sortConfig" class="sort-controls"></div>
+  </div>
+  <table class="table table-bordered table-condensed table-mobile table-hover events-table">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <!-- Only show Name and Kind columns if not passed to the directive. -->
+        <th ng-if="!resourceKind || !resourceName">
+          <span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and Name</span>
+          <span class="visible-lg-inline">Name</span>
+        </th>
+        <th ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md">
+          <span class="visible-lg-inline">Kind</span>
+        </th>
+        <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
+        <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
+        <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
+      </tr>
+    </thead>
+    <tbody ng-if="(filteredEvents | hashSize) === 0">
+      <tr>
+        <td>
+          <span ng-if="(unfilteredEvents | hashSize) === 0"><em>No events to show.</em></span>
+          <span ng-if="(unfilteredEvents | hashSize) > 0">
+            All events hidden by filter.
+            <a href="" ng-click="filter.text = ''" role="button">Clear filter</a>
+          </span>
+        </td>
+        <td ng-if="!resourceKind || !resourceName" class="hidden-xs">&nbsp;</td>
+        <td ng-if="!resourceKind || !resourceName" class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+        <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+        <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
+        <td class="hidden-xs">&nbsp;</td>
+      </tr>
+    </tbody>
+    <tbody ng-repeat="event in filteredEvents">
+      <tr>
+        <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
+        <td ng-if="!resourceKind || !resourceName" data-title="Name" class="event-time">
+          <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">{{event.involvedObject.kind | humanizeKind}}</div>
+          {{event.involvedObject.name}}
+        </td>
+        <td ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md" data-title="Kind">
+          {{event.involvedObject.kind | humanizeKind}}</td>
+        <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">
+          <span class="sr-only">{{event.type}}</span>
+          <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span></td>
+        <td class="hidden-sm hidden-md" data-title="Reason">
+          {{event.reason | sentenceCase}}&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
+        </td>
+        <td data-title="Message" class="word-break">
+          <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
+            {{event.reason | sentenceCase}}&nbsp;
+            <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
+          </div>
+          {{event.message}}
+          <div ng-if="event.count > 1" class="text-muted small">
+            {{event.count}} times in the last
+            <duration-until-now timestamp="event.firstTimestamp" omit-single="true" precision="1"></duration-until-now>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/assets/app/views/events.html
+++ b/assets/app/views/events.html
@@ -1,6 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
-
+<project-page>
   <!-- Middle section -->
   <div class="middle-section">
     <div id="scrollable-content" class="middle-container has-scroll">
@@ -15,61 +14,12 @@
       <div class="middle-content">
         <div class="container-fluid">
           <div class="row">
-            <div class="col-md-12 gutter-top">
-              <table class="table table-bordered table-condensed table-mobile table-hover events-table">
-                <thead>
-                  <tr>
-                    <th>Time</th>
-                    <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and </span>Name</th>
-                    <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Kind</span></th>
-                    <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
-                    <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
-                    <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
-                  </tr>
-                </thead>
-                <tbody ng-if="(events | hashSize) === 0">
-                  <tr>
-                    <td><em>{{emptyMessage}}</em></td>
-                    <td class="hidden-xs">&nbsp;</td>
-                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-                    <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-                    <td class="hidden-xs">&nbsp;</td>
-                  </tr>
-                </tbody>
-                <tbody ng-repeat="event in events | toArray | orderBy:'-lastTimestamp'">
-                  <tr>
-                    <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
-                    <td data-title="Name" class="event-time">
-                      <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
-                      {{event.involvedObject.kind}}</div>
-                      {{event.involvedObject.name}}</td>
-                    <td class="hidden-sm hidden-md" data-title="Kind">
-                      {{event.involvedObject.kind}}</td>
-                    <td data-title="Severity" class="hidden-xs hidden-sm hidden-md text-center severity-icon-td">
-                      <span class="sr-only">{{event.type}}</span>
-                      <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span></td>
-                    <td class="hidden-sm hidden-md" data-title="Reason">
-                      {{event.reason}}&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
-                    </td>
-                    <td data-title="Message" class="word-break">
-                      <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
-                        {{event.reason}}&nbsp;
-                        <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-placement="right" data-original-title="Warning"></span>
-                      </div>
-                      {{event.message}}
-                      <div ng-if="event.count > 1" class="text-muted small">
-                        {{event.count}} times in the last
-                        <duration-until-now timestamp="event.firstTimestamp" omit-single="true" precision="1"></duration-until-now>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div><!-- /col-* -->
+            <div class="col-md-12 gutter-top" ng-if="projectContext">
+              <events project-context="projectContext" ng-if="projectContext"></events>
+            </div>
           </div>
         </div>
       </div><!-- /middle-content -->
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
-  </project-page>
+</project-page>


### PR DESCRIPTION
As-you-type filter and sorting controls for events table. The sort works even when fields are combined into the same column at smaller widths. Uses the `pf-simple-sort` directive for sorting as in @ajacobs21e mockups.

TODO:

- [x] Styling
- [x] Update events directive for individual browse pages
- [x] Show message when all events are hidden
- [x] Filter / sort in controller rather than view

<img width="1006" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13164682/2eb793ac-d685-11e5-9ffe-4ed8f26be000.png">

Fixes #7445

/cc @smarterclayton @jwforres 