### PR TITLE
Check the existence of home dir reported by env vars on Windows

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
@@ -34,6 +34,7 @@ import (
 	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/homedir"
 )
 
 const (
@@ -44,8 +45,8 @@ const (
 	RecommendedSchemaName       = "schema"
 )
 
-var RecommendedHomeFile = path.Join(HomeDir(), RecommendedHomeDir, RecommendedFileName)
-var RecommendedSchemaFile = path.Join(HomeDir(), RecommendedHomeDir, RecommendedSchemaName)
+var RecommendedHomeFile = path.Join(homedir.HomeDir(), RecommendedHomeDir, RecommendedFileName)
+var RecommendedSchemaFile = path.Join(homedir.HomeDir(), RecommendedHomeDir, RecommendedSchemaName)
 
 // currentMigrationRules returns a map that holds the history of recommended home directories used in previous versions.
 // Any future changes to RecommendedHomeFile and related are expected to add a migration rule here, in order to make
@@ -465,17 +466,4 @@ func MakeRelative(path, base string) (string, error) {
 		return rel, nil
 	}
 	return path, nil
-}
-
-// HomeDir return the home directory for the current user
-func HomeDir() string {
-	if goruntime.GOOS == "windows" {
-		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
-			return homeDrive + homePath
-		}
-		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
-			return userProfile
-		}
-	}
-	return os.Getenv("HOME")
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/homedir/homedir.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/homedir/homedir.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package homedir
+
+import (
+	"os"
+	"runtime"
+)
+
+// HomeDir returns the home directory for the current user
+func HomeDir() string {
+	if runtime.GOOS == "windows" {
+		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
+			homeDir := homeDrive + homePath
+			if _, err := os.Stat(homeDir); err == nil {
+				return homeDir
+			}
+		}
+		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
+			if _, err := os.Stat(userProfile); err == nil {
+				return userProfile
+			}
+		}
+	}
+	return os.Getenv("HOME")
+}

--- a/pkg/cmd/cli/config/loader.go
+++ b/pkg/cmd/cli/config/loader.go
@@ -12,6 +12,7 @@ import (
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kubecmdconfig "k8s.io/kubernetes/pkg/kubectl/cmd/config"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/homedir"
 )
 
 const (
@@ -22,13 +23,13 @@ const (
 	OpenShiftConfigHomeDirFileName = OpenShiftConfigHomeDir + "/" + OpenShiftConfigHomeFileName
 )
 
-var RecommendedHomeFile = path.Join(kclientcmd.HomeDir(), OpenShiftConfigHomeDirFileName)
+var RecommendedHomeFile = path.Join(homedir.HomeDir(), OpenShiftConfigHomeDirFileName)
 
 // currentMigrationRules returns a map that holds the history of recommended home directories used in previous versions.
 // Any future changes to RecommendedHomeFile and related are expected to add a migration rule here, in order to make
 // sure existing config files are migrated to their new locations properly.
 func currentMigrationRules() map[string]string {
-	oldRecommendedHomeFile := path.Join(kclientcmd.HomeDir(), ".kube/.config")
+	oldRecommendedHomeFile := path.Join(homedir.HomeDir(), ".kube/.config")
 	oldRecommendedWindowsHomeFile := path.Join(os.Getenv("HOME"), OpenShiftConfigHomeDirFileName)
 
 	migrationRules := map[string]string{}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1305765

Sometimes the home directory env vars on Windows can point to directories that actually don't exist. We need to check the existence of what's reported as home dir when on the Windows platform, and fallback to `$HOME` if nothing else works.  