### PR TITLE
Use "install" to install SDN scripts to make sure they get exec permission

### DIFF
--- a/contrib/node/install-sdn.sh
+++ b/contrib/node/install-sdn.sh
@@ -14,8 +14,8 @@ os::provision::install-sdn() {
   local osdn_plugin_path="${osdn_base_path}/plugins/osdn"
   mkdir -p "${target}/bin/"
   pushd "${osdn_plugin_path}" > /dev/null
-    cp -f ovs/bin/openshift-sdn-ovs "${target}/bin/"
-    cp -f ovs/bin/openshift-sdn-docker-setup.sh "${target}/bin/"
+    install ovs/bin/openshift-sdn-ovs "${target}/bin/"
+    install ovs/bin/openshift-sdn-docker-setup.sh "${target}/bin/"
   popd > /dev/null
 
   # osdn plugin setup writes docker network options to


### PR DESCRIPTION
In https://github.com/openshift/origin/commit/cc8749a, @pweil- removed exec permission from openshift-sdn-ovs and openshift-sdn-docker-setup.sh in the source tree. I'm not sure if this was intentional or accidental, but either way we should probably force them to have the right permissions when installing them anyway. (origin.spec already does this, so it's only vagrant installs that got broken.)

(@marun)
