### PR TITLE
Bump docker minimum version to 1.9.1 in preparation for v1.2

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -10,7 +10,7 @@
 %global kube_plugin_path /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet
 
 # docker_version is the version of docker requires by packages
-%global docker_version 1.8.2
+%global docker_version 1.9.1
 # tuned_version is the version of tuned requires by packages
 %global tuned_version  2.3
 # openvswitch_version is the version of openvswitch requires by packages


### PR DESCRIPTION
@danmcp I think I picked up from the call that we're requiring docker-1.9 for v1.2? Is that correct for both Origin and OSE?

cc: @brenton 