### PR TITLE
Bug 1309195 - Return ErrNotV2Registry when falling back to http backend

### DIFF
--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -696,7 +696,7 @@ func (r *repositoryRetriever) ping(registry url.URL, insecure bool, transport ht
 			registry.Scheme = "http"
 			_, nErr := r.ping(registry, true, transport)
 			if nErr != nil {
-				return nil, err
+				return nil, nErr
 			}
 			return &registry, nil
 		}

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -352,3 +352,21 @@ func TestDockerV1Fallback(t *testing.T) {
 		t.Errorf("unexpected images: %#v", images)
 	}
 }
+
+func TestPing(t *testing.T) {
+	retriever := NewContext(http.DefaultTransport, http.DefaultTransport).WithCredentials(NoCredentials).(*repositoryRetriever)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	uri, _ := url.Parse(server.URL)
+
+	_, err := retriever.ping(*uri, true, retriever.context.InsecureTransport)
+	if !strings.Contains(err.Error(), "does not support v2 API") {
+		t.Errorf("Expected ErrNotV2Registry, got %v", err)
+	}
+
+	uri.Scheme = "https"
+	_, err = retriever.ping(*uri, true, retriever.context.InsecureTransport)
+	if !strings.Contains(err.Error(), "does not support v2 API") {
+		t.Errorf("Expected ErrNotV2Registry, got %v", err)
+	}
+}


### PR DESCRIPTION
This return proper error from the 2nd ping operation, when we fallback to using http, when https failed. Without this change insecure repos didn't fallback to using v1.
@smarterclayton ptal