### PR TITLE
Adds a path for Pure end to end tests

### DIFF
--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -11,15 +11,19 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/router"
 	_ "github.com/openshift/origin/test/extended/security"
+	e2e "k8s.io/kubernetes/test/e2e"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 // init initialize the extended testing suite.
 func init() {
+	// Kubernetes: Pure end to end tests ~ These flags pass through.
+	e2e.RegisterFlags()
 	exutil.InitTest()
 }
 
 func TestExtended(t *testing.T) {
-	exutil.ExecuteTest(t, "Extended Core")
+	// TODO Send a second arg once a name is supported upstream.
+	e2e.RunE2ETests(t)
 }

--- a/test/extended/networking/extended_test.go
+++ b/test/extended/networking/extended_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	e2e "k8s.io/kubernetes/test/e2e"
 )
 
 // init initialize the extended testing suite.
 func init() {
+	// Don't initialize the flags for upstream E2Es, we only care about
+	// running the extended networking tests.
 	exutil.InitTest()
 }
 
 func TestExtended(t *testing.T) {
-	// Avoid using 'networking' in the suite name since that would
-	// make it difficult to avoid running non-network kube e2e tests
-	// via -ginkgo.focus="etworking".
-	exutil.ExecuteTest(t, "Extended Network")
+	e2e.RunE2ETests(t)
 }

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -4,16 +4,11 @@ import (
 	rflag "flag"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
-	"testing"
 
-	"github.com/golang/glog"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/reporters"
-	"github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -76,34 +71,6 @@ func InitTest() {
 
 	// Override the default Kubernetes E2E configuration
 	e2e.SetTestContext(TestContext)
-}
-
-func ExecuteTest(t *testing.T, suite string) {
-	var r []ginkgo.Reporter
-
-	if reportDir != "" {
-		if err := os.MkdirAll(reportDir, 0755); err != nil {
-			glog.Errorf("Failed creating report directory: %v", err)
-		}
-		defer e2e.CoreDump(reportDir)
-	}
-
-	// Disable density test unless it's explicitly requested.
-	if config.GinkgoConfig.FocusString == "" && config.GinkgoConfig.SkipString == "" {
-		config.GinkgoConfig.SkipString = "Skipped"
-	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	if reportDir != "" {
-		r = append(r, reporters.NewJUnitReporter(path.Join(reportDir, fmt.Sprintf("%s_%02d.xml", reportFileName, config.GinkgoConfig.ParallelNode))))
-	}
-
-	if quiet {
-		r = append(r, NewSimpleReporter())
-		ginkgo.RunSpecsWithCustomReporters(t, suite, r)
-	} else {
-		ginkgo.RunSpecsWithDefaultAndCustomReporters(t, suite, r)
-	}
 }
 
 // verifyTestSuitePreconditions ensures that all namespaces prefixed with 'e2e-' have their


### PR DESCRIPTION
This is a first pass at implementing a code path that
- runs upstream E2Es in such a way that all the flags and so on are properly consumed,
- no OS requirements are coupled into the test run.
- invokes the upstream test/e2e/e2e.go in the same way as upstream.
