### PR TITLE
add hostnetwork scc

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 
 	authapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
@@ -767,5 +768,6 @@ func validateServiceAccount(client *kclient.Client, ns string, serviceAccount st
 		}
 	}
 
-	return fmt.Errorf("service account %q is not allowed to access the host network on nodes, needs access via a security context constraint", serviceAccount)
+	errMsg := "service account %q is not allowed to access the host network on nodes, grant access with oadm policy add-scc-to-user %s -z %s"
+	return fmt.Errorf(errMsg, serviceAccount, bootstrappolicy.SecurityContextConstraintsHostNetwork, serviceAccount)
 }

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -14,6 +14,7 @@ func TestBootstrappedConstraints(t *testing.T) {
 		SecurityContextConstraintHostMountAndAnyUID,
 		SecurityContextConstraintHostNS,
 		SecurityContextConstraintsAnyUID,
+		SecurityContextConstraintsHostNetwork,
 	}
 	expectedGroups, expectedUsers := getExpectedAccess()
 


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/7249

Add SCC for host network/host ports that still uses namespace allocation strategies for strategy based fields.

Updates the oadm router command to give an error message that show the exact command to use to grant access to the service account

```
[vagrant@localhost origin]$ oadm router --credentials="$KUBECONFIG" --service-account=default
error: router could not be created; service account "default" is not allowed to access the host network on nodes, grant access with oadm policy add-scc-to-user hostnetwork system:serviceaccount:default:default
[vagrant@localhost origin]$ oadm policy add-scc-to-user hostnetwork system:serviceaccount:default:default
[vagrant@localhost origin]$ oadm router --credentials="$KUBECONFIG" --service-account=default
info: password for stats user admin has been set to xTKqHh3s9Q
deploymentconfig "router" created
service "router" created
```

HAProxy router running as not root uid (because we grant it cap_net_bind_service in the dockerfile)

```
[vagrant@localhost origin]$ docker logs 3655
I0219 21:51:54.605337       1 router.go:161] Router is including routes in all namespaces
[vagrant@localhost origin]$ curl 0.0.0.0
<html>
  <body>
    <h1>503 Service Unavailable</h1>
    No server available to handle the request.
  </body>
</html>
[vagrant@localhost origin]$ ps -ef | grep haproxy
1000010+ 17061 16942  0 21:52 ?        00:00:00 /usr/sbin/haproxy -f /var/lib/haproxy/conf/haproxy.config -p /var/lib/haproxy/run/haproxy.pid -sf 42
```

@smarterclayton @ramr @deads2k 