### PR TITLE
Restoring fix for route names overflowing .componet in Safari for iOS

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -88,6 +88,8 @@
         .flex-direction(@direction: row);
       }
       .component {
+        // so that Safari for iOS properly truncates
+        width: 100%;
         @media (min-width: @screen-md-min) {
           // assign flex properties when >=992 for proper layout so that .component no longer stack; % on flex-basis value necessary for IE
           .flex(@columns: 2 0 0%);


### PR DESCRIPTION
Fixes #7473 
@spadgett, review and merge, please?

<img width="1395" alt="screen shot 2016-02-19 at 5 30 25 pm" src="https://cloud.githubusercontent.com/assets/895728/13190974/85c5fbb2-d72e-11e5-8ad9-7f6b73d2d23b.PNG">
