### PR TITLE
Hide copy to clipboard button on iOS

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -290,6 +290,8 @@ angular
     screenXlgMin: 1600   // screen-xlg
   })
   .constant('SOURCE_URL_PATTERN', /^((ftp|http|https|git):\/\/(\w+:{0,1}[^\s@]*@)|git@)?([^\s@]+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/ )
+  // http://stackoverflow.com/questions/9038625/detect-if-device-is-ios
+  .constant('IS_IOS', /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream)
   .config(function($httpProvider, AuthServiceProvider, RedirectLoginServiceProvider, AUTH_CFG, API_CFG, kubernetesContainerSocketProvider) {
     $httpProvider.interceptors.push('AuthInterceptor');
 

--- a/assets/app/scripts/directives/util.js
+++ b/assets/app/scripts/directives/util.js
@@ -71,7 +71,7 @@ angular.module('openshiftConsole')
       }
     };
   })
-  .directive('copyToClipboardButton', function() {
+  .directive('copyToClipboardButton', function(IS_IOS) {
     return {
       restrict: 'E',
       scope: {
@@ -82,6 +82,11 @@ angular.module('openshiftConsole')
         $scope.id = _.uniqueId('clipboardJs');
       },
       link: function($scope, element) {
+        if (IS_IOS) {
+          $scope.hidden = true;
+          return;
+        }
+
         var node = $('button', element);
         var clipboard = new Clipboard( node.get(0) );
         clipboard.on('success', function (e) {

--- a/assets/app/views/directives/_copy-to-clipboard.html
+++ b/assets/app/views/directives/_copy-to-clipboard.html
@@ -1,2 +1,7 @@
-<button data-clipboard-target="#{{id}}" data-toggle="tooltip" data-placement="top" title="Copy to clipboard" class="btn btn-default"><i class="fa fa-clipboard"/></button>
+<button data-clipboard-target="#{{id}}"
+        data-toggle="tooltip"
+        data-placement="top"
+        title="Copy to clipboard"
+        class="btn btn-default"
+        ng-hide="hidden"><i class="fa fa-clipboard"/></button>
 <textarea id="{{id}}" class="sr-only">{{clipboardText}}</textarea>


### PR DESCRIPTION
Hide the copy to clipboard button on iOS since it doesn't work. clipboard.js does not support iOS.

We could at some point have the button just select text on the page on iOS. It's still a problem for things like webhooks and API tokens that we don't want visible anywhere.

Fixes #7467

/cc @jwforres @rhamilto 