### PR TITLE
Show project display name in breadcrumbs

### DIFF
--- a/assets/app/scripts/controllers/attachPVC.js
+++ b/assets/app/scripts/controllers/attachPVC.js
@@ -45,6 +45,9 @@ angular.module('openshiftConsole')
       .then(_.spread(function(project, context) {
         $scope.project = project;
 
+        // Update project breadcrumb with display name.
+        $scope.breadcrumbs[0].title = $filter('displayName')(project);
+
         var orderByDisplayName = $filter('orderByDisplayName');
         var getErrorDetails = $filter('getErrorDetails');
         var navigateResourceURL = $filter('navigateResourceURL');

--- a/assets/app/scripts/controllers/edit/buildConfig.js
+++ b/assets/app/scripts/controllers/edit/buildConfig.js
@@ -107,6 +107,10 @@ angular.module('openshiftConsole')
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
+
+        // Update project breadcrumb with display name.
+        $scope.breadcrumbs[0].title = $filter('displayName')(project);
+
         DataService.get("buildconfigs", $routeParams.buildconfig, context).then(
           // success
           function(buildConfig) {

--- a/assets/app/scripts/controllers/setLimits.js
+++ b/assets/app/scripts/controllers/setLimits.js
@@ -60,6 +60,9 @@ angular.module('openshiftConsole')
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
+        // Update project breadcrumb with display name.
+        $scope.breadcrumbs[0].title = $filter('displayName')(project);
+
         // Check if requests or limits are calculated. Memory limit is never calculated.
         $scope.cpuRequestCalculated = LimitRangesService.isRequestCalculated('cpu', project);
         $scope.cpuLimitCalculated = LimitRangesService.isLimitCalculated('cpu', project);


### PR DESCRIPTION
Display name was not used on the edit build config, attach storage, or set limits pages.

Fixes #7491

@jwforres 