### PR TITLE
Tolerate dirty version of master when building

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
@@ -51,7 +52,7 @@ func newBuilderConfigFromEnvironment() (*builderConfig, error) {
 
 	masterVersion := os.Getenv(api.OriginVersion)
 	thisVersion := version.Get().String()
-	if len(masterVersion) != 0 && masterVersion != thisVersion {
+	if len(masterVersion) != 0 && strings.HasPrefix(masterVersion, thisVersion) {
 		glog.Warningf("Master version %q does not match Builder image version %q", masterVersion, thisVersion)
 	} else {
 		glog.V(2).Infof("Master version %q, Builder versions %q", masterVersion, thisVersion)


### PR DESCRIPTION
Get rid of this ugly warning:
```
Master version "v1.1.3-174-g6061189-dirty" does not match Builder image version "v1.1.3-174-g6061189"
```