### PR TITLE
Use git shallow clone when not using ref

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -209,7 +209,7 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 
 	// Only use the quiet flag if Verbosity is not 5 or greater
 	quiet := !bool(glog.V(5))
-	if err := gitClient.CloneWithOptions(dir, gitSource.URI, git.CloneOptions{Recursive: !usingRef, Quiet: quiet}); err != nil {
+	if err := gitClient.CloneWithOptions(dir, gitSource.URI, git.CloneOptions{Recursive: !usingRef, Quiet: quiet, Shallow: !usingRef}); err != nil {
 		return true, err
 	}
 
@@ -230,6 +230,7 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 			return true, err
 		}
 	}
+
 	return true, nil
 }
 

--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -2,12 +2,18 @@ package builder
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/generate/git"
 )
 
@@ -39,5 +45,255 @@ func TestCheckRemoteGit(t *testing.T) {
 	err = checkRemoteGit(gitRepo, "https://github.com/openshift/origin", 10*time.Second)
 	if err != nil {
 		t.Errorf("unexpected error %q", err)
+	}
+}
+
+type testGitRepo struct {
+	Name      string
+	Path      string
+	Files     []string
+	Submodule *testGitRepo
+}
+
+func initializeTestGitRepo(name string) (*testGitRepo, error) {
+	repo := &testGitRepo{Name: name}
+	dir, err := ioutil.TempDir("", "test-"+repo.Name)
+	if err != nil {
+		return repo, err
+	}
+	repo.Path = dir
+	tmpfn := filepath.Join(dir, "initial-file")
+	if err := ioutil.WriteFile(tmpfn, []byte("test"), 0666); err != nil {
+		return repo, fmt.Errorf("unable to create temporary file")
+	}
+	repo.Files = append(repo.Files, tmpfn)
+	initCmd := exec.Command("git", "init")
+	initCmd.Dir = dir
+	if out, err := initCmd.Output(); err != nil {
+		return repo, fmt.Errorf("unable to initialize repository: %q", out)
+	}
+	return repo, nil
+}
+
+func (r *testGitRepo) addSubmodule() error {
+	subRepo, err := initializeTestGitRepo("submodule")
+	if err != nil {
+		return err
+	}
+	if err := subRepo.addCommit(); err != nil {
+		return err
+	}
+	subCmd := exec.Command("git", "submodule", "add", "file://"+subRepo.Path, "sub")
+	subCmd.Dir = r.Path
+	if out, err := subCmd.Output(); err != nil {
+		return fmt.Errorf("unable to add submodule: %q", out)
+	}
+	r.Submodule = subRepo
+	return nil
+}
+
+// getRef returns the sha256 of the commit specified by the negative offset.
+// The '0' is the current HEAD.
+func (r *testGitRepo) getRef(offset int) (string, error) {
+	q := ""
+	for i := offset; i != 0; i++ {
+		q += "^"
+	}
+	refCmd := exec.Command("git", "rev-parse", "HEAD"+q)
+	refCmd.Dir = r.Path
+	if out, err := refCmd.Output(); err != nil {
+		return "", fmt.Errorf("unable to checkout %d offset: %q", offset, out)
+	} else {
+		return strings.TrimSpace(string(out)), nil
+	}
+}
+
+func (r *testGitRepo) createBranch(name string) error {
+	refCmd := exec.Command("git", "checkout", "-b", name)
+	refCmd.Dir = r.Path
+	if out, err := refCmd.Output(); err != nil {
+		return fmt.Errorf("unable to checkout new branch: %q", out)
+	}
+	return nil
+}
+
+func (r *testGitRepo) switchBranch(name string) error {
+	refCmd := exec.Command("git", "checkout", name)
+	refCmd.Dir = r.Path
+	if out, err := refCmd.Output(); err != nil {
+		return fmt.Errorf("unable to checkout branch: %q", out)
+	}
+	return nil
+}
+
+func (r *testGitRepo) cleanup() {
+	os.RemoveAll(r.Path)
+	if r.Submodule != nil {
+		os.RemoveAll(r.Submodule.Path)
+	}
+}
+
+func (r *testGitRepo) addCommit() error {
+	f, err := ioutil.TempFile(r.Path, "")
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte("test"), 0666); err != nil {
+		return fmt.Errorf("unable to create temporary file %q", f.Name())
+	}
+	addCmd := exec.Command("git", "add", ".")
+	addCmd.Dir = r.Path
+	if out, err := addCmd.Output(); err != nil {
+		return fmt.Errorf("unable to add files to repo: %q", out)
+	}
+	commitCmd := exec.Command("git", "commit", "-a", "-m", "test commit")
+	commitCmd.Dir = r.Path
+	out, err := commitCmd.Output()
+	if err != nil {
+		return fmt.Errorf("unable to commit: %q", out)
+	}
+	r.Files = append(r.Files, f.Name())
+	return nil
+}
+
+func TestUnqualifiedClone(t *testing.T) {
+	repo, err := initializeTestGitRepo("unqualified")
+	defer repo.cleanup()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if err := repo.addSubmodule(); err != nil {
+		t.Errorf("%v", err)
+	}
+	// add two commits to check that shallow clone take account
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	destDir, err := ioutil.TempDir("", "clone-dest-")
+	defer os.RemoveAll(destDir)
+	client := git.NewRepositoryWithEnv([]string{})
+	source := &api.GitBuildSource{URI: "file://" + repo.Path}
+	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	if _, err = extractGitSource(client, source, &revision, destDir, 10*time.Second); err != nil {
+		t.Errorf("%v", err)
+	}
+	for _, f := range repo.Files {
+		if _, err := os.Stat(filepath.Join(destDir, path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("unable to find repository file %q", path.Base(f))
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "sub")); os.IsNotExist(err) {
+		t.Errorf("unable to find submodule dir")
+	}
+	for _, f := range repo.Submodule.Files {
+		if _, err := os.Stat(filepath.Join(destDir, "sub/"+path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("unable to find submodule repository file %q", path.Base(f))
+		}
+	}
+}
+
+func TestCloneFromRef(t *testing.T) {
+	repo, err := initializeTestGitRepo("commit")
+	defer repo.cleanup()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if err := repo.addSubmodule(); err != nil {
+		t.Errorf("%v", err)
+	}
+	// add two commits to check that shallow clone take account
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	destDir, err := ioutil.TempDir("", "commit-dest-")
+	defer os.RemoveAll(destDir)
+	client := git.NewRepositoryWithEnv([]string{})
+	firstCommitRef, err := repo.getRef(-1)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	source := &api.GitBuildSource{
+		URI: "file://" + repo.Path,
+		Ref: firstCommitRef,
+	}
+	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	if _, err = extractGitSource(client, source, &revision, destDir, 10*time.Second); err != nil {
+		t.Errorf("%v", err)
+	}
+	for _, f := range repo.Files[:len(repo.Files)-1] {
+		if _, err := os.Stat(filepath.Join(destDir, path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("unable to find repository file %q", path.Base(f))
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, path.Base(repo.Files[len(repo.Files)-1]))); !os.IsNotExist(err) {
+		t.Errorf("last file should not exists in this checkout")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "sub")); os.IsNotExist(err) {
+		t.Errorf("unable to find submodule dir")
+	}
+	for _, f := range repo.Submodule.Files {
+		if _, err := os.Stat(filepath.Join(destDir, "sub/"+path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("unable to find submodule repository file %q", path.Base(f))
+		}
+	}
+}
+
+func TestCloneFromBranch(t *testing.T) {
+	repo, err := initializeTestGitRepo("branch")
+	defer repo.cleanup()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if err := repo.addSubmodule(); err != nil {
+		t.Errorf("%v", err)
+	}
+	// add two commits to check that shallow clone take account
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	if err := repo.createBranch("test"); err != nil {
+		t.Errorf("%v", err)
+	}
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	if err := repo.switchBranch("master"); err != nil {
+		t.Errorf("%v", err)
+	}
+	if err := repo.addCommit(); err != nil {
+		t.Errorf("unable to add commit: %v", err)
+	}
+	destDir, err := ioutil.TempDir("", "branch-dest-")
+	defer os.RemoveAll(destDir)
+	client := git.NewRepositoryWithEnv([]string{})
+	source := &api.GitBuildSource{
+		URI: "file://" + repo.Path,
+		Ref: "test",
+	}
+	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	if _, err = extractGitSource(client, source, &revision, destDir, 10*time.Second); err != nil {
+		t.Errorf("%v", err)
+	}
+	for _, f := range repo.Files[:len(repo.Files)-1] {
+		if _, err := os.Stat(filepath.Join(destDir, path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("file %q should not exists in the test branch", f)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, path.Base(repo.Files[len(repo.Files)-1]))); !os.IsNotExist(err) {
+		t.Errorf("last file should not exists in the test branch")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "sub")); os.IsNotExist(err) {
+		t.Errorf("unable to find submodule dir")
+	}
+	for _, f := range repo.Submodule.Files {
+		if _, err := os.Stat(filepath.Join(destDir, "sub/"+path.Base(f))); os.IsNotExist(err) {
+			t.Errorf("unable to find submodule repository file %q", path.Base(f))
+		}
 	}
 }

--- a/pkg/generate/app/strategyref.go
+++ b/pkg/generate/app/strategyref.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -71,13 +70,6 @@ func (g *BuildStrategyRefGenerator) getSource(srcRef *SourceRef) error {
 	if srcRef.Dir, err = ioutil.TempDir("", "gen"); err != nil {
 		return err
 	}
-	if err = g.gitRepository.Clone(srcRef.Dir, srcRef.URL.String()); err != nil {
-		return fmt.Errorf("unable to clone repository at %s", srcRef.URL.String())
-	}
-	if len(srcRef.Ref) != 0 {
-		if err = g.gitRepository.Checkout(srcRef.Dir, srcRef.Ref); err != nil {
-			return fmt.Errorf("unable to checkout reference %s from repository at %s", srcRef.Ref, srcRef.URL.String())
-		}
-	}
-	return nil
+	_, err = CloneAndCheckoutSources(g.gitRepository, srcRef.URL.String(), srcRef.Ref, srcRef.Dir, "")
+	return err
 }


### PR DESCRIPTION
According to `git clone` man page:

```
--depth
Create a shallow clone with a history truncated to the specified number of commits.
```

This **significantly** improves the times of downloading the source code repository, when there is no "ref" specified (basically just get the latest master). In case of origin, it is ~20seconds.

The downside of doing shallow clone is inability to checkout/fetch the ref if specified, so when you do specify "ref", we need to fallback to "slow" full git clone. 