### PR TITLE
[WIP] Submit forms on enter

### DIFF
--- a/assets/app/scripts/directives/util.js
+++ b/assets/app/scripts/directives/util.js
@@ -166,4 +166,15 @@ angular.module('openshiftConsole')
         });
       }
     };
+  }).directive('onEnter', function(){
+    return function (scope, element, attrs) {
+      element.bind("keydown keypress", function (event) {
+        if(event.which === 13 && !scope.form.$invalid) {
+          scope.$apply(function (){
+            scope.$eval(attrs.onEnter);
+          });
+          event.preventDefault();
+        }
+      });
+    };
   });

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -25,7 +25,7 @@
                       <fieldset ng-disabled="disableInputs">
                         <osc-image-summary resource="image" name="imageName"></osc-image-summary>
                         <div class="clearfix visible-xs-block"></div>
-                        <form class="" ng-show="imageStream" novalidate name="form">
+                        <form class="" ng-show="imageStream" novalidate name="form" ng-submit="createApp()">
                           <div style="margin-bottom: 15px;">
                             <div class="form-group">
                              <label for="appname" class="required">Name</label>
@@ -309,8 +309,8 @@
                           </div>
                           <div class="buttons gutter-top-bottom gutter-top-bottom-2x">
                             <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
-                            <button class="btn btn-primary btn-lg"
-                                ng-click="createApp()"
+                            <button type="submit"
+                                class="btn btn-primary btn-lg"
                                 ng-disabled="form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs"
                                 >Create</button>
                             <a class="btn btn-default btn-lg" href="{{projectName | projectOverviewURL}}">Cancel</a>

--- a/assets/app/views/directives/osc-key-values.html
+++ b/assets/app/views/directives/osc-key-values.html
@@ -20,7 +20,8 @@
               autocapitalize="off"
               spellcheck="false"
               osc-input-validator="key"
-              osc-unique="entries">
+              osc-unique="entries"
+              on-enter="addEntry()">
           </div>
 
           <div
@@ -37,14 +38,19 @@
               autocorrect="off"
               autocapitalize="off"
               spellcheck="false"
-              osc-input-validator="value">
+              osc-input-validator="value"
+              on-enter="addEntry()">
           </div>
-          <button
-            class="btn btn-default"
-            ng-click="addEntry()"
-            ng-disabled="form.$invalid || !key || !value">Add</button>
+          <!-- We need to replace button tag with a link tag cause we are embedding this directive into different forms (BC edit
+          form, from image form) and in order to be able to submit the top level form with hitting Enter key we needed to replace buttons with links.
+          Based on: https://docs.angularjs.org/api/ng/directive/form#submitting-a-form-and-preventing-the-default-action -->
+          <a class="btn btn-default"
+            href=""
+            role="button"
+            ng-disabled="form.$invalid || !key || !value">
+            Add
+          </a>
         </div>
-
 
         <div row class="has-error" ng-show="form.key.$error.oscUnique">
           <span class="help-block">

--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -16,7 +16,7 @@
               Edit Build Config {{buildConfig.metadata.name}} - <small>{{strategyType}} Build Strategy</small>
             </h1>
             <fieldset ng-disabled="disableInputs">
-              <form class="edit-form" name="form" novalidate>
+              <form class="edit-form" name="form" novalidate ng-submit="save()">
                 <div class="resource-details">
                   <div class="row">
                     <div class="col-lg-6">
@@ -506,18 +506,19 @@
                       </div>
                     </div>
                   </div>
-                    <div class="buttons gutter-top-bottom">
-                      <button class="btn btn-primary btn-lg"
-                          ng-click="save()"
-                          ng-disabled="form.$invalid || form.$pristine || disableInputs">
-                          Save
-                      </button>
-                      <a class="btn btn-default btn-lg"
-                        href="{{buildConfig.metadata.name | navigateResourceURL : 'BuildConfig' : projectName}}">
-                        Cancel
-                      </a>
-                    </div>
+                  <div class="buttons gutter-top-bottom">
+                    <button
+                      type="submit"
+                      class="btn btn-primary btn-lg"
+                        ng-disabled="form.$invalid || form.$pristine || disableInputs">
+                        Save
+                    </button>
+                    <a class="btn btn-default btn-lg"
+                      href="{{buildConfig.metadata.name | navigateResourceURL : 'BuildConfig' : projectName}}">
+                      Cancel
+                    </a>
                   </div>
+                </div>
               </form>
             </fieldset>
           </div>


### PR DESCRIPTION
Adding possibility to submit forms by hitting Enter. For this I had to create a standalone `on-enter` directive which will check if the form is valid and then calls the action that will submit the form. 
Had to update the osc-key-values.html with it since when running multiple instances of oscKeyValues form the data are added to the first one, not the one the data are submitted to (eg. imageSource directories && envVars in bc editor).
Unfortunately the new directive has to be added to every `input` field on which we want the form submission to occur when hitting Enter.
I will also update the `fromImage` page form once we decide we wanna go this direction, or some other one(thats why WIP ...)
Was trying to us the `ng-submit` directive but that work well only in case of single `input` field

@spadgett PTAL