### PR TITLE
Updated copy-kube-artifacts to current k8s

### DIFF
--- a/hack/copy-kube-artifacts.sh
+++ b/hack/copy-kube-artifacts.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+# this will allow matching files also in subdirs with **/*.json pattern
+shopt -s globstar
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
@@ -24,20 +26,26 @@ rsync -av \
   --include-from=- \
   --exclude='*' \
   $KUBE_ROOT/ $KUBE_GODEP_ROOT <<EOF
+test/e2e/**/*.yaml
+test/e2e/**/*.json
 api/swagger-spec/v1.json
 cmd/integration/**.json
 cmd/integration/**.yaml
 docs/admin/**.json
 docs/admin/**.yaml
-docs/user-guide/**.json
-docs/user-guide/**.yaml
+docs/user-guide/**/*.json
+docs/user-guide/**/*.yaml
 docs/user-guide/simple-yaml.md
 docs/user-guide/walkthrough/README.md
 examples/***
+pkg/api/**/*.json
+pkg/api/**/*.yaml
 pkg/client/testdata/myCA.cer
 pkg/client/testdata/myCA.key
 pkg/client/testdata/mycertvalid.cer
 pkg/client/testdata/mycertvalid.key
 pkg/client/testdata/mycertvalid.req
+cmd/libs/***
+third_party/golang/***
 README.md
 EOF


### PR DESCRIPTION
Fixes #7356.

Mostly I've added setting `globstar` option which allows for more general globbing syntax, eg. `**/*.json` will match all json files in current and nested directories. I've updated missing dirs based on previous rebase.
@pweil- @deads2k @liggitt ptal