### PR TITLE
origin-pod rpm does not require the base rpm

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -140,7 +140,6 @@ Requires:       %{name} = %{version}-%{release}
 
 %package pod
 Summary:        %{product_name} Pod
-Requires:       %{name} = %{version}-%{release}
 
 %description pod
 %{summary}


### PR DESCRIPTION
This prevents the pod rpm from pulling in ~176MB of deps (origin, and origin-clients RPMs)