### PR TITLE
Add an image that can setup the base image to build all images from l…

### DIFF
--- a/images/base/Dockerfile.rpm
+++ b/images/base/Dockerfile.rpm
@@ -1,0 +1,27 @@
+#
+# This is the base image from which all OpenShift Origin images inherit. Only packages
+# common to all downstream images should be here.
+#
+# The standard name for this image is openshift/origin-base
+#
+# This version is built from local generated origin rpms and a local repo
+# It is intended use is with the vagrant-openshift plugin
+FROM centos:centos7
+
+# Add in local RPMs and repo for all images
+ENV REPO_BASE /data/src/github.com/openshift
+RUN mkdir -p ${REPO_BASE}
+ADD x86_64 ${REPO_BASE}
+ADD origin_local.repo .
+RUN yum clean all
+
+
+# components from EPEL must be installed in a separate yum install step
+
+# TODO: systemd update from centos 7.1 -> 7.2 is broken, remove this once 7.2
+# base images land
+RUN yum swap -y -- remove systemd-container\* -- install systemd systemd-libs
+
+RUN yum install -y which git tar wget hostname sysvinit-tools util-linux bsdtar epel-release \
+    socat ethtool device-mapper iptables && \
+    yum clean all


### PR DESCRIPTION
…ocal rpm repos.

This is meant to be used in conjuction with the vagrant-openshift plugin