### PR TITLE
Web console: fix log start on pod state transition

### DIFF
--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -42,6 +42,11 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
+    var setLogVars = function(build) {
+      $scope.logOptions.container = $filter("annotation")(build, "buildPod");
+      $scope.logCanRun = !(_.includes(['New', 'Pending', 'Error'], build.status.phase));
+    };
+
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
@@ -57,7 +62,7 @@ angular.module('openshiftConsole')
 
             $scope.loaded = true;
             $scope.build = build;
-            $scope.logOptions.container = $filter("annotation")(build, "buildPod");
+            setLogVars(build);
             var buildNumber = $filter("annotation")(build, "buildNumber");
             if (buildNumber) {
               $scope.breadcrumbs[2].title = "#" + buildNumber;
@@ -72,9 +77,7 @@ angular.module('openshiftConsole')
                 };
               }
               $scope.build = build;
-              // TODO: if build.status.phase === 'Error' then we should not
-              // fetch the log, BUT ALSO indicate this somehow in UI
-              $scope.logCanRun = !(_.includes(['New', 'Pending', 'Error'], build.status.phase));
+              setLogVars(build);
             }));
           },
           // failure

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -42,6 +42,11 @@ angular.module('openshiftConsole')
       $scope.metricsAvailable = available;
     });
 
+    var setLogVars = function(pod) {
+      $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
+      $scope.logCanRun = !(_.includes(['New', 'Pending', 'Unknown'], pod.status.phase));
+    };
+
     ProjectsService
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
@@ -55,8 +60,7 @@ angular.module('openshiftConsole')
           function(pod) {
             $scope.loaded = true;
             $scope.pod = pod;
-            $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
-            $scope.logCanRun = !(_.includes(['New', 'Pending', 'Unknown'], pod.status.phase));
+            setLogVars(pod);
             var pods = {};
             pods[pod.metadata.name] = pod;
             ImageStreamResolver.fetchReferencedImageStreamImages(pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
@@ -70,6 +74,7 @@ angular.module('openshiftConsole')
                 };
               }
               $scope.pod = pod;
+              setLogVars(pod);
             }));
           },
           // failure


### PR DESCRIPTION
Fix #7533 

- Ensure log run vars are set in GET and WATCH on build, pod & deployment 

@spadgett @jwforres 
