### PR TITLE
Read extended user attributes from auth proxy

### DIFF
--- a/pkg/auth/authenticator/request/headerrequest/requestheader_test.go
+++ b/pkg/auth/authenticator/request/headerrequest/requestheader_test.go
@@ -2,38 +2,47 @@ package headerrequest
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/openshift/origin/pkg/auth/api"
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
-type TestUserIdentityMapper struct{}
+type TestUserIdentityMapper struct {
+	Identity api.UserIdentityInfo
+}
 
 func (m *TestUserIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
-	return &user.DefaultInfo{Name: identityInfo.GetProviderUserName()}, nil
+	m.Identity = identityInfo
+	username := identityInfo.GetProviderUserName()
+	if preferredUsername := identityInfo.GetExtra()[api.IdentityPreferredUsernameKey]; len(preferredUsername) > 0 {
+		username = preferredUsername
+	}
+	return &user.DefaultInfo{Name: username}, nil
 }
 
 func TestRequestHeader(t *testing.T) {
 	testcases := map[string]struct {
-		ConfiguredHeaders []string
-		RequestHeaders    http.Header
-		ExpectedUsername  string
+		Config           Config
+		RequestHeaders   http.Header
+		ExpectedUsername string
+		ExpectedIdentity api.UserIdentityInfo
 	}{
 		"empty": {
 			ExpectedUsername: "",
 		},
 		"no match": {
-			ConfiguredHeaders: []string{"X-Remote-User"},
-			ExpectedUsername:  "",
+			Config:           Config{IDHeaders: []string{"X-Remote-User"}},
+			ExpectedUsername: "",
 		},
 		"match": {
-			ConfiguredHeaders: []string{"X-Remote-User"},
-			RequestHeaders:    http.Header{"X-Remote-User": {"Bob"}},
-			ExpectedUsername:  "Bob",
+			Config:           Config{IDHeaders: []string{"X-Remote-User"}},
+			RequestHeaders:   http.Header{"X-Remote-User": {"Bob"}},
+			ExpectedUsername: "Bob",
 		},
 		"exact match": {
-			ConfiguredHeaders: []string{"X-Remote-User"},
+			Config: Config{IDHeaders: []string{"X-Remote-User"}},
 			RequestHeaders: http.Header{
 				"Prefixed-X-Remote-User-With-Suffix": {"Bob"},
 				"X-Remote-User-With-Suffix":          {"Bob"},
@@ -41,11 +50,11 @@ func TestRequestHeader(t *testing.T) {
 			ExpectedUsername: "",
 		},
 		"first match": {
-			ConfiguredHeaders: []string{
+			Config: Config{IDHeaders: []string{
 				"X-Remote-User",
 				"A-Second-X-Remote-User",
 				"Another-X-Remote-User",
-			},
+			}},
 			RequestHeaders: http.Header{
 				"X-Remote-User":          {"", "First header, second value"},
 				"A-Second-X-Remote-User": {"Second header, first value", "Second header, second value"},
@@ -53,15 +62,39 @@ func TestRequestHeader(t *testing.T) {
 			ExpectedUsername: "Second header, first value",
 		},
 		"case-insensitive": {
-			ConfiguredHeaders: []string{"x-REMOTE-user"},             // configured headers can be case-insensitive
-			RequestHeaders:    http.Header{"X-Remote-User": {"Bob"}}, // the parsed headers are normalized by the http package
-			ExpectedUsername:  "Bob",
+			Config:           Config{IDHeaders: []string{"x-REMOTE-user"}}, // configured headers can be case-insensitive
+			RequestHeaders:   http.Header{"X-Remote-User": {"Bob"}},        // the parsed headers are normalized by the http package
+			ExpectedUsername: "Bob",
+		},
+		"extended attributes": {
+			Config: Config{
+				IDHeaders:                []string{"x-id", "x-id2"},
+				PreferredUsernameHeaders: []string{"x-preferred-username", "x-preferred-username2"},
+				EmailHeaders:             []string{"x-email", "x-email2"},
+				NameHeaders:              []string{"x-name", "x-name2"},
+			},
+			RequestHeaders: http.Header{
+				"X-Id2":                 {"12345"},
+				"X-Preferred-Username2": {"bob"},
+				"X-Email2":              {"bob@example.com"},
+				"X-Name2":               {"Bob"},
+			},
+			ExpectedUsername: "bob",
+			ExpectedIdentity: &api.DefaultUserIdentityInfo{
+				ProviderName:     "testprovider",
+				ProviderUserName: "12345",
+				Extra: map[string]string{
+					api.IdentityDisplayNameKey:       "Bob",
+					api.IdentityEmailKey:             "bob@example.com",
+					api.IdentityPreferredUsernameKey: "bob",
+				},
+			},
 		},
 	}
 
 	for k, testcase := range testcases {
 		mapper := &TestUserIdentityMapper{}
-		auth := NewAuthenticator("testprovider", &Config{testcase.ConfiguredHeaders}, mapper)
+		auth := NewAuthenticator("testprovider", &testcase.Config, mapper)
 		req := &http.Request{Header: testcase.RequestHeaders}
 
 		user, ok, err := auth.AuthenticateRequest(req)
@@ -83,6 +116,14 @@ func TestRequestHeader(t *testing.T) {
 			if testcase.ExpectedUsername != user.GetName() {
 				t.Errorf("%s: Expected username %s, got %s", k, testcase.ExpectedUsername, user.GetName())
 				continue
+			}
+		}
+		if testcase.ExpectedIdentity != nil {
+			if !reflect.DeepEqual(testcase.ExpectedIdentity.GetExtra(), mapper.Identity.GetExtra()) {
+				t.Errorf("%s: Expected %#v, got %#v", k, testcase.ExpectedIdentity.GetExtra(), mapper.Identity.GetExtra())
+			}
+			if !reflect.DeepEqual(testcase.ExpectedIdentity.GetProviderUserName(), mapper.Identity.GetProviderUserName()) {
+				t.Errorf("%s: Expected %#v, got %#v", k, testcase.ExpectedIdentity.GetProviderUserName(), mapper.Identity.GetProviderUserName())
 			}
 		}
 	}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -675,6 +675,12 @@ type RequestHeaderIdentityProvider struct {
 	ClientCA string
 	// Headers is the set of headers to check for identity information
 	Headers []string
+	// PreferredUsernameHeaders is the set of headers to check for the preferred username
+	PreferredUsernameHeaders []string
+	// NameHeaders is the set of headers to check for the display name
+	NameHeaders []string
+	// EmailHeaders is the set of headers to check for the email address
+	EmailHeaders []string
 }
 
 type GitHubIdentityProvider struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -669,6 +669,12 @@ type RequestHeaderIdentityProvider struct {
 	ClientCA string `json:"clientCA"`
 	// Headers is the set of headers to check for identity information
 	Headers []string `json:"headers"`
+	// PreferredUsernameHeaders is the set of headers to check for the preferred username
+	PreferredUsernameHeaders []string `json:"preferredUsernameHeaders"`
+	// NameHeaders is the set of headers to check for the display name
+	NameHeaders []string `json:"nameHeaders"`
+	// EmailHeaders is the set of headers to check for the email address
+	EmailHeaders []string `json:"emailHeaders"`
 }
 
 // GitHubIdentityProvider provides identities for users authenticating using GitHub credentials

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -245,9 +245,12 @@ oauthConfig:
       apiVersion: v1
       challengeURL: ""
       clientCA: ""
+      emailHeaders: null
       headers: null
       kind: RequestHeaderIdentityProvider
       loginURL: ""
+      nameHeaders: null
+      preferredUsernameHeaders: null
   - challenge: false
     login: false
     mappingMethod: ""

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -615,7 +615,10 @@ func (c *AuthConfig) getAuthenticationRequestHandler() (authenticator.Request, e
 				var authRequestHandler authenticator.Request
 
 				authRequestConfig := &headerrequest.Config{
-					UserNameHeaders: provider.Headers,
+					IDHeaders:                provider.Headers,
+					NameHeaders:              provider.NameHeaders,
+					EmailHeaders:             provider.EmailHeaders,
+					PreferredUsernameHeaders: provider.PreferredUsernameHeaders,
 				}
 				authRequestHandler = headerrequest.NewAuthenticator(identityProvider.Name, authRequestConfig, identityMapper)
 


### PR DESCRIPTION
Bring the requestheader IDP to parity with the other providers by allowing setting the display name, email, and preferred username from header values.

Added config for listing headers to read display name, email, and preferred username from. Example config:
```
oauthConfig:
  ...
  identityProviders:
  - name: "..."
    provider:
      apiVersion: v1
      kind: RequestHeaderIdentityProvider
      headers:
      - X-Remote-User
      emailHeaders:
      - X-Remote-User-Email
      nameHeaders:
      - X-Remote-User-Display-Name
      preferredUsernameHeaders:
      - X-Remote-User-Login
```