### PR TITLE
Contextualize errors from GetCGroupLimits

### DIFF
--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
@@ -70,7 +71,7 @@ func getDockerNetworkMode() s2iapi.DockerNetworkMode {
 func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 	byteLimit, err := readInt64("/sys/fs/cgroup/memory/memory.limit_in_bytes")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot determine cgroup limits: %v", err)
 	}
 
 	// different docker versions seem to use different cgroup directories,
@@ -95,17 +96,17 @@ func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 
 	cpuQuota, err := readInt64(filepath.Join(cpuDir, "cpu.cfs_quota_us"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot determine cgroup limits: %v", err)
 	}
 
 	cpuPeriod, err := readInt64(filepath.Join(cpuDir, "cpu.cfs_period_us"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot determine cgroup limits: %v", err)
 	}
 
 	cpuShares, err := readInt64(filepath.Join(cpuDir, "cpu.shares"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot determine cgroup limits: %v", err)
 	}
 
 	return &s2iapi.CGroupLimits{


### PR DESCRIPTION
Sometimes (seemingly at random) I hit one of those errors coming out of `GetCGroupLimits`:

```
I0223 13:31:43.527505       1 common.go:134] Running post commit hook with image demo/rails-postgresql-example-1:a6c30562 ...
F0223 13:31:45.419145       1 builder.go:204] Error: build error: start container "openshift_s2i-build_rails-postgresql-example
-1_demo_post-commit": API error (500): Cannot start container bfe2cd0409699208608dacfc279d2d4c25db9693b350912c49110881b7c0235b: [8] System error: open /sys/fs/cgroup/cpu,cpuacct/system.slice/docker-bfe2cd0409699208608dacfc279d2d4c25db9693b350912c49110881
b7c0235b.scope/cpu.cfs_quota_us: no such file or directory
```

:fearful: The message looks pretty scary to me, there are some long hex strings, and if I didn't know what the message is about, I think I'd feel lost trying to understand a "no such file or directory" error referring to a file I (as a user) don't know about.


The proposed changes here don't make things much better, but at least would give some more context and perhaps keywords to seek for help (cgroup, limits).
