### PR TITLE
oc: cleanup expose; make --port configurable for routes

### DIFF
--- a/pkg/route/generator/generate.go
+++ b/pkg/route/generator/generate.go
@@ -23,7 +23,7 @@ func (RouteGenerator) ParamNames() []kubectl.GeneratorParam {
 	return []kubectl.GeneratorParam{
 		{"labels", false},
 		{"default-name", true},
-		{"target-port", false},
+		{"port", false},
 		{"name", false},
 		{"hostname", false},
 		{"path", false},
@@ -76,7 +76,7 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 		},
 	}
 
-	portString := params["target-port"]
+	portString := params["port"]
 	if len(portString) > 0 {
 		var targetPort intstr.IntOrString
 		if port, err := strconv.Atoi(portString); err == nil {

--- a/pkg/route/generator/generate_test.go
+++ b/pkg/route/generator/generate_test.go
@@ -41,8 +41,8 @@ func TestGenerateRoute(t *testing.T) {
 					},
 					Port: &routeapi.RoutePort{
 						TargetPort: intstr.IntOrString{
-							Type:   intstr.String,
-							StrVal: "svcportname",
+							Type:   intstr.Int,
+							IntVal: 80,
 						},
 					},
 				},
@@ -53,7 +53,7 @@ func TestGenerateRoute(t *testing.T) {
 				"labels":       "foo=bar",
 				"name":         "test",
 				"default-name": "someservice",
-				"port":         "80",
+				"port":         "web",
 				"ports":        "80,443",
 				"hostname":     "www.example.com",
 			},
@@ -66,6 +66,12 @@ func TestGenerateRoute(t *testing.T) {
 				},
 				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
+					Port: &routeapi.RoutePort{
+						TargetPort: intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: "web",
+						},
+					},
 					To: api.ObjectReference{
 						Name: "someservice",
 					},

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -235,7 +235,7 @@ os::cmd::expect_failure 'oc expose service frontend --port=40 --type=NodePort'
 os::cmd::expect_success 'oc expose service frontend --path=/test'
 os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.path}}'" "/test"
 os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.to.name}}'" "frontend"           # routes to correct service
-os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.port.targetPort}}'" "<no value>" # no target port for services with unnamed ports
+os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.port.targetPort}}'" ""
 os::cmd::expect_success 'oc delete svc,route -l name=frontend'
 # Test that external services are exposable
 os::cmd::expect_success 'oc create -f test/testdata/external-service.yaml'


### PR DESCRIPTION
Cleans up the expose code we add on top (not needed after https://github.com/kubernetes/kubernetes/pull/17516),
and makes route ports configurable via `--port` to be on par with `create route`.

@liggitt @deads2k I know you have been against having a flag
for both generators. Maybe things are better now with `create route`.?

cc: @fabianofranz @smarterclayton 

Fixes https://github.com/openshift/origin/issues/8699