### PR TITLE
Use args flavor sample-app build hooks

### DIFF
--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -145,7 +145,7 @@
           }
         },
         "postCommit": {
-          "script": "bundle exec rake test"
+          "args": ["bundle", "exec", "rake", "test"]
         },
         "resources": {}
       },

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -137,7 +137,7 @@
           }
         },
         "postCommit": {
-          "script": "bundle exec rake test"
+          "args": ["bundle", "exec", "rake", "test"]
         },
         "resources": {}
       },

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -147,7 +147,7 @@
           }
         },
         "postCommit": {
-          "script": "bundle exec rake test"
+          "args": ["bundle", "exec", "rake", "test"]
         },
         "resources": {}
       },


### PR DESCRIPTION
This form will work for people running the latest release, v1.1.3,
whereas the script form is broken for SCL-powered images (in that version).

Example of problem users with the 1.1.3 release (latest) could run into if using the sample-app template from master: https://github.com/openshift/origin/pull/7379#commitcomment-16273464 (builds always fail because `bundle` is not found in the PATH)