### PR TITLE
Including css declarations of flex specific prefixes for IE10 to postion correctly

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -487,6 +487,9 @@ label.checkbox {
     .flex-direction(@direction: row);
     .flex-wrap(@wrap: wrap);
     .justify-content(@justify: flex-start);
+    // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+    -ms-flex-pack: start;
+
     .tile-template, .tile-image {
       .flex(@columns: 1 0 auto);
       width: 100%;

--- a/assets/app/styles/_flexbox.less
+++ b/assets/app/styles/_flexbox.less
@@ -75,7 +75,7 @@
 
 // Flex shr
 // - applies to: flex itemsink factor
-// <number> 
+// <number>
 .flex-shrink(@shrink: 1) {
   -webkit-flex-shrink: @shrink;
      -moz-flex-shrink: @shrink;
@@ -86,7 +86,7 @@
 // Flex basis
 // - the initial main size of the flex item
 // - applies to: flex itemsnitial main size of the flex item
-// <width> 
+// <width>
 .flex-basis(@width: auto) {
   -webkit-flex-basis: @width;
      -moz-flex-basis: @width;
@@ -96,40 +96,36 @@
 
 // Axis Alignment
 // - applies to: flex containers
-// flex-start | flex-end | center | space-between | space-around 
+// flex-start | flex-end | center | space-between | space-around
 .justify-content(@justify: flex-start) {
   -webkit-justify-content: @justify;
      -moz-justify-content: @justify;
-      -ms-justify-content: @justify;
           justify-content: @justify;
 }
 
 // Packing Flex Lines
 // - applies to: multi-line flex containers
-// flex-start | flex-end | center | space-between | space-around | stretch 
+// flex-start | flex-end | center | space-between | space-around | stretch
 .align-content(@align: stretch) {
   -webkit-align-content: @align;
      -moz-align-content: @align;
-      -ms-align-content: @align;
           align-content: @align;
 }
 
 // Cross-axis Alignment
 // - applies to: flex containers
-// flex-start | flex-end | center | baseline | stretch 
+// flex-start | flex-end | center | baseline | stretch
 .align-items(@align: stretch) {
   -webkit-align-items: @align;
      -moz-align-items: @align;
-      -ms-align-items: @align;
           align-items: @align;
 }
 
 // Cross-axis Alignment
 // - applies to: flex items
-// auto | flex-start | flex-end | center | baseline | stretch 
+// auto | flex-start | flex-end | center | baseline | stretch
 .align-self(@align: auto) {
   -webkit-align-self: @align;
      -moz-align-self: @align;
-      -ms-align-self: @align;
           align-self: @align;
 }

--- a/assets/app/styles/_navbar-alt.less
+++ b/assets/app/styles/_navbar-alt.less
@@ -42,6 +42,10 @@
       .flex(@columns: 1 0 0%);
       .flex-display(@display: flex);
       .justify-content(@justify: center);
+      // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+      -ms-flex-align: center;
+      -ms-flex-pack: center;
+
       color: @sidebar-os-color;
       font-weight: 300;
       text-decoration: none;
@@ -203,6 +207,10 @@
     .align-items(@align: center);
     .flex(@columns: 1 0 0%);
     .justify-content(@justify: center);
+    // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+    -ms-flex-align: center;
+    -ms-flex-pack: center;
+
     width: 100%; // fix ie10 issue
     &:hover {
       background-color: @navbar-os-project-menu-active-bg;
@@ -334,6 +342,9 @@
       width: 208px;
       .navbar-home {
         .justify-content(@justify: flex-start);
+        // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+        -ms-flex-pack: start;
+
         font-size: @font-size-base + 1;
         margin-top: 0;
         padding-left: 20px;

--- a/assets/app/styles/_substructure.less
+++ b/assets/app/styles/_substructure.less
@@ -156,6 +156,10 @@ html,body {
       .flex-wrap(@wrap: nowrap);
       .align-items(@align: flex-start);
       .justify-content(@justify: flex-start);
+      // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+      -ms-flex-align: start;
+      -ms-flex-pack: start;
+
       height: 100%;
       position: absolute;
       overflow: hidden; //make scrollable
@@ -195,6 +199,10 @@ html,body {
       .flex-wrap(@wrap: nowrap);
       .align-items(@align: flex-start);
       .justify-content(@justify: flex-start);
+      // remove ie prefixes when PostCSS Autoprefixer is included for github issue #7559
+      -ms-flex-align: start;
+      -ms-flex-pack: start;
+      
       height: 100%;
       position: absolute;
       overflow: hidden;


### PR DESCRIPTION
	- This is a temporary fix until PostCSS Autoprefixer is included to address
	  https://github.com/openshift/origin/issues/7559