### PR TITLE
Work around Vagrant libvirt image misformat

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -257,6 +257,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       libvirt.cpus        = vagrant_openshift_config['cpus'].to_i
       # run on libvirt somewhere other than default:
       libvirt.uri         = ENV["VAGRANT_LIBVIRT_URI"] if ENV["VAGRANT_LIBVIRT_URI"]
+      libvirt.storage :file, :type => 'qcow2', :size => '5G'
     end if vagrant_openshift_config['libvirt']
 
     # ###################################

--- a/contrib/vagrant/provision-dind.sh
+++ b/contrib/vagrant/provision-dind.sh
@@ -4,6 +4,10 @@ set -euo
 USERNAME=vagrant
 ORIGIN_ROOT=${1:-/vagrant}
 
+source ${ORIGIN_ROOT}/contrib/vagrant/provision-util.sh
+
+os::provision::libvirt-vg-setup
+
 yum install -y deltarpm
 yum update -y
 yum install -y docker-io go git bash-completion


### PR DESCRIPTION
See https://github.com/openshift/vagrant-openshift/issues/403

For whatever reason, the default Origin vagrant libvirt images
don't include the docker volumes since the switch to using
docker LVM storage.  Work around that.