### PR TITLE
Update hack/update-external-examples.sh

### DIFF
--- a/examples/quickstarts/README.md
+++ b/examples/quickstarts/README.md
@@ -1,14 +1,23 @@
 QuickStarts
 ===========
 
-QuickStarts provide the basic skeleton of an application.  Generally they reference a repository containing very simple source code that implements a trivial application using a particular framework.  In addition they define any components needed for the application including a Build configuration, supporting services such as Databases, etc.
+QuickStarts provide the basic skeleton of an application. Generally they
+reference a repository containing very simple source code that implements a
+trivial application using a particular framework. In addition they define any
+components needed for the application including a Build configuration,
+supporting services such as Databases, etc.
 
-You can instantiate these templates as is, or fork the source repository they reference and supply your forked repository as the source-repository when instantiating them.
+You can instantiate these templates as is, or fork the source repository they
+reference and supply your forked repository as the source-repository when
+instantiating them.
 
-* [CakePHP](https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp-mysql.json) - Provides a basic CakePHP application with a MySQL database.  For more information see the [source repository](https://github.com/openshift/cakephp-ex).
-* [Dancer](https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer-mysql.json) - Provides a basic Dancer(Perl) application with a MySQL database.  For more information see the [source repository](https://github.com/openshift/dancer-ex).
-* [Django](https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django-postgresql.json) - Provides a basic Django(Python) application with a PostgreSQL database.  For more information see the [source repository](https://github.com/openshift/django-ex).
-* [NodeJS](https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json) - Provides a basic NodeJS application with a MongoDB database.  For more information see the [source repository](https://github.com/openshift/nodejs-ex).
-* [Rails](https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json) - Provides a basic Rails(Ruby) application with a PostgreSQL database.  For more information see the [source repository](https://github.com/openshift/rails-ex).
+* [CakePHP](https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp-mysql.json) - Provides a basic CakePHP application with a MySQL database. For more information see the [source repository](https://github.com/openshift/cakephp-ex).
+* [Dancer](https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer-mysql.json) - Provides a basic Dancer (Perl) application with a MySQL database. For more information see the [source repository](https://github.com/openshift/dancer-ex).
+* [Django](https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django-postgresql.json) - Provides a basic Django (Python) application with a PostgreSQL database. For more information see the [source repository](https://github.com/openshift/django-ex).
+* [NodeJS](https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json) - Provides a basic NodeJS application with a MongoDB database. For more information see the [source repository](https://github.com/openshift/nodejs-ex).
+* [Rails](https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json) - Provides a basic Rails (Ruby) application with a PostgreSQL database. For more information see the [source repository](https://github.com/openshift/rails-ex).
 
-Note: This file is processed by hack/update-external-examples.sh.  New examples must follow the exact syntax of the existing entries.  Files in this directory are automatically pulled down, do not add additional files directly to this directory.
+Note: This file is processed by `hack/update-external-examples.sh`. New examples
+must follow the exact syntax of the existing entries. Files in this directory
+are automatically pulled down, do not add additional files directly to this
+directory.

--- a/hack/update-external-examples.sh
+++ b/hack/update-external-examples.sh
@@ -1,16 +1,26 @@
-#!/bin/sh
+#!/bin/bash
+
 # This script pulls down example files (eg templates) from external repositories
 # so they can be included directly in our repository.
 # Feeds off a README.md file with well defined syntax that informs this
 # script how to pull the file down.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+
 # For now the only external examples are in examples/quickstarts.
-pushd examples/quickstarts
-rm *json
-rm *yaml
-# Assume the README.md file contains lines with URLs for the raw json/yaml file to be downloaded.
-# Specifically look for a line containing https://raw.githubusercontent.com, then
-# look for the first content in ()s on that line, which will be the actual url of the file,
-# then use curl to pull that file down.
-curl `grep https://raw.githubusercontent.com README.md | sed -E "s/.*\((.*)\) -.*/\\1 -O/"`
-popd
+QUICKSTARTS_DIR="${OS_ROOT}/examples/quickstarts"
+(
+  cd "${QUICKSTARTS_DIR}"
+
+  rm -vf *.{json,yaml,yml}
+
+  # Assume the README.md file contains lines with URLs for the raw json/yaml file to be downloaded.
+  # Specifically look for a line containing https://raw.githubusercontent.com, then
+  # look for the first content in ()s on that line, which will be the actual url of the file,
+  # then use curl to pull that file down.
+  curl -# $(grep https://raw.githubusercontent.com README.md | sed -E 's/.*\((.*)\) -.*/\1 -O/')
+)


### PR DESCRIPTION
Make it more similar to the other hack/*.sh scripts by using bash,
setting common shell options, making it work on paths relative to the
project root.