### PR TITLE
Only show builds bar chart when at least 4 builds

### DIFF
--- a/assets/app/scripts/directives/buildTrendsChart.js
+++ b/assets/app/scripts/directives/buildTrendsChart.js
@@ -12,6 +12,9 @@ angular.module('openshiftConsole')
         var buildByNumber;
         var completePhases = ['Complete', 'Failed', 'Cancelled', 'Error'];
 
+        // Minimum number of builds to show.
+        $scope.minBuilds = _.constant(4);
+
         // Simple humanize function that returns an abbreviated duration like "1h 4m" or "2m 4s"
         // suitable for use on the chart y-axis.
         var humanize = function(value) {
@@ -301,4 +304,3 @@ angular.module('openshiftConsole')
       }
     };
   });
-

--- a/assets/app/views/_build-trends-chart.html
+++ b/assets/app/views/_build-trends-chart.html
@@ -1,6 +1,8 @@
 <!-- aria-hidden since we have the build table below with the same details -->
 <!-- Wrap the content in a scrollable div for mobile -->
-<div class="build-trends-responsive" aria-hidden="true">
+<div class="build-trends-responsive"
+     aria-hidden="true"
+     ng-show="completeBuilds.length >= minBuilds()">
   <div class="build-trends-container">
     <!-- Build trends chart -->
     <div ng-attr-id="{{chartID}}" class="build-trends-chart"></div>
@@ -18,6 +20,9 @@
     </div>
   </div>
 </div>
+
+<!-- Add some space when the chart is missing. -->
+<div ng-if="completeBuilds.length < minBuilds()" class="gutter-bottom"></div>
 
 <div ng-if="averageDurationText" class="sr-only">
   Average build duration {{averageDurationText}}


### PR DESCRIPTION
Fixes #6535

![hide-chart](https://cloud.githubusercontent.com/assets/1167259/13321802/3a63e8a8-db9f-11e5-8d3f-16c32796afd8.png)

@jwforres PTAL