### PR TITLE
Add support for build config into oc set env

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -957,14 +957,14 @@ DEPRECATED: set env
   # Update deployment 'registry' with a new environment variable
   $ oc env dc/registry STORAGE_DIR=/local
 
-  # List the environment variables defined on a deployment config 'registry'
-  $ oc env dc/registry --list
+  # List the environment variables defined on a build config 'sample-build'
+  $ oc env bc/sample-build --list
 
   # List the environment variables defined on all pods
   $ oc env pods --all --list
 
-  # Output modified deployment config in YAML, and does not alter the object on the server
-  $ oc env dc/registry STORAGE_DIR=/data -o yaml
+  # Output modified build config in YAML, and does not alter the object on the server
+  $ oc env bc/sample-build STORAGE_DIR=/data -o yaml
 
   # Update all containers in all replication controllers in the project to have ENV=prod
   $ oc env rc --all ENV=prod
@@ -1635,14 +1635,14 @@ Update environment variables on a pod template
   # Update deployment 'registry' with a new environment variable
   $ oc set env dc/registry STORAGE_DIR=/local
 
-  # List the environment variables defined on a deployment config 'registry'
-  $ oc set env dc/registry --list
+  # List the environment variables defined on a build config 'sample-build'
+  $ oc set env bc/sample-build --list
 
   # List the environment variables defined on all pods
   $ oc set env pods --all --list
 
-  # Output modified deployment config in YAML, and does not alter the object on the server
-  $ oc set env dc/registry STORAGE_DIR=/data -o yaml
+  # Output modified build config in YAML, and does not alter the object on the server
+  $ oc set env bc/sample-build STORAGE_DIR=/data -o yaml
 
   # Update all containers in all replication controllers in the project to have ENV=prod
   $ oc set env rc --all ENV=prod

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -460,6 +460,23 @@ func getPorts(spec api.PodSpec) []string {
 	return result
 }
 
+// UpdateObjectEnvironment update the environment variables in object specification.
+func (f *Factory) UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error) {
+	switch t := obj.(type) {
+	case *buildapi.BuildConfig:
+		if t.Spec.Strategy.CustomStrategy != nil {
+			return true, fn(&t.Spec.Strategy.CustomStrategy.Env)
+		}
+		if t.Spec.Strategy.SourceStrategy != nil {
+			return true, fn(&t.Spec.Strategy.SourceStrategy.Env)
+		}
+		if t.Spec.Strategy.DockerStrategy != nil {
+			return true, fn(&t.Spec.Strategy.DockerStrategy.Env)
+		}
+	}
+	return false, fmt.Errorf("object does not contain any environment variables")
+}
+
 // UpdatePodSpecForObject update the pod specification for the provided object
 // TODO: move to upstream
 func (f *Factory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -140,6 +140,17 @@ os::cmd::expect_success_and_not_text "oc get dc/test-deployment-config -o yaml" 
 os::cmd::expect_success "oc delete dc/test-deployment-config"
 echo "set probe: ok"
 
+os::cmd::expect_success "oc create -f test/integration/fixtures/test-deployment-config.yaml"
+os::cmd::expect_success "oc create -f test/integration/fixtures/test-buildcli.json"
+os::cmd::expect_success_and_text "oc set env dc/test-deployment-config FOO=bar" "updated"
+os::cmd::expect_success_and_text "oc set env dc/test-deployment-config --list" "FOO=bar"
+os::cmd::expect_success_and_text "oc set env bc --all FOO=bar" "updated"
+os::cmd::expect_success_and_text "oc set env bc --all --list" "FOO=bar"
+os::cmd::expect_success_and_text "oc set env bc --all FOO-" "updated"
+os::cmd::expect_success "oc delete dc/test-deployment-config"
+os::cmd::expect_success "oc delete bc/ruby-sample-build-validtag"
+echo "set env: ok"
+
 # Expose service as a route
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-service.json'
 os::cmd::expect_failure 'oc expose service frontend --create-external-load-balancer'


### PR DESCRIPTION
Allow to run:

```console
[root@localhost origin]# oc set env bc/ruby-hello-world FOO=bar
buildconfig "ruby-hello-world" updated
[root@localhost origin]# oc set env bc/ruby-hello-world --list
# buildconfigs ruby-hello-world
FOO=bar
[root@localhost origin]# oc set env dc/ruby-hello-world bc/ruby-hello-world FOO=foo
deploymentconfig "ruby-hello-world" updated
buildconfig "ruby-hello-world" updated
```