### PR TITLE
Revert SDN bridge-nf-call-iptables=0 hack

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -28,7 +28,6 @@ import (
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
-	"k8s.io/kubernetes/pkg/util/sysctl"
 	"k8s.io/kubernetes/pkg/volume"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -308,18 +307,6 @@ func (c *NodeConfig) RunPlugin() {
 	}
 	if err := c.SDNPlugin.StartNode(c.MTU); err != nil {
 		glog.Fatalf("error: SDN node startup failed: %v", err)
-	}
-}
-
-// ResetSysctlFromProxy resets the bridge-nf-call-iptables systctl that the Kube proxy sets, which
-// is required for normal Docker containers to talk to the SDN plugin on the local system.
-// Resolution is https://github.com/kubernetes/kubernetes/pull/20647
-func (c *NodeConfig) ResetSysctlFromProxy() {
-	if c.SDNPlugin == nil {
-		return
-	}
-	if err := sysctl.SetSysctl("net/bridge/bridge-nf-call-iptables", 0); err != nil {
-		glog.Warningf("Could not set net.bridge.bridge-nf-call-iptables sysctl: %s", err)
 	}
 }
 

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -316,10 +316,6 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 	if components.Enabled(ComponentProxy) {
 		config.RunProxy()
 	}
-	// if we are running plugins in this process, reset the bridge ip rule
-	if components.Enabled(ComponentPlugins) {
-		config.ResetSysctlFromProxy()
-	}
 
 	return nil
 }


### PR DESCRIPTION
https://trello.com/c/vnvUCQPG/112-3-remove-the-bridge-nf-call-iptables-hack-sdn-techdebt

Effectively reverts d510a7624da16e5ab821db58e7a1a17e27300e50
"Fix up net.bridge.bridge-nf-call-iptables after kubernetes breaks it"
now that upstream kube PR https://github.com/kubernetes/kubernetes/pull/20647
got merged.  The hack is no longer necessary.