### PR TITLE
Bump vagrant ram

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -240,8 +240,6 @@ use cases.
 To run a dind cluster in a VM, follow steps 1-3 of the Vagrant
 instructions and then execute the following:
 
-        # Extra memory is required to build the extended tests
-        $ export OPENSHIFT_MEMORY=3072
         $ export OPENSHIFT_DIND_DEV_CLUSTER=true
         $ vagrant up
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "num_minions"       => ENV['OPENSHIFT_NUM_MINIONS'] || 2,
     "rebuild_yum_cache" => false,
     "cpus"              => ENV['OPENSHIFT_NUM_CPUS'] || 2,
-    "memory"            => ENV['OPENSHIFT_MEMORY'] || 2560,
+    "memory"            => ENV['OPENSHIFT_MEMORY'] || 3072,
     "fixup_net_udev"    => ENV['OPENSHIFT_FIXUP_NET_UDEV'] || true,
     "skip_build"        => ENV['OPENSHIFT_SKIP_BUILD'] || false,
     "sync_folders_type" => nil,


### PR DESCRIPTION
We're now running out of memory building OpenShift in the latest F23 vagrant image.  3072 was chosen because it matches the DIND requirement mentioned in CONTRIBUTING.

@eparis @marun @danwinship 