### PR TITLE
Add Patternfly button styles to catalog browse button

### DIFF
--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -53,7 +53,7 @@
                         <!-- Pull the filter right so the input and dropdown button
                              can use 100% width on the same line. -->
                         <div uib-dropdown uib-keyboard-nav class="btn-group pull-right">
-                          <button class="dropdown-toggle" data-toggle="dropdown" role="menu">
+                          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" role="menu">
                             Browse
                             <span class="caret" aria-hidden="true"></span>
                           </button>


### PR DESCRIPTION
The browse button was missing the `btn btn-default` classes, which made it look different on some platforms.

Before:

<img width="356" alt="screen shot 2016-02-25 at 1 45 19 pm" src="https://cloud.githubusercontent.com/assets/1167259/13330328/6b51763e-dbc6-11e5-8dfe-13f31f5c1358.png">

After:

<img width="355" alt="screen shot 2016-02-25 at 1 45 39 pm" src="https://cloud.githubusercontent.com/assets/1167259/13330352/84108e26-dbc6-11e5-8b5b-48e39e3d8aba.png">

@jwforres 