### PR TITLE
[AEP] 'oc get' must ignore 404 errors in certain cases

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/cmd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/cmd_test.go
@@ -230,7 +230,8 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 
 	f := &cmdutil.Factory{
 		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {
-			return testapi.Default.RESTMapper(), api.Scheme
+			mapper := kubectl.ShortcutExpander{RESTMapper: testapi.Default.RESTMapper()}
+			return mapper, api.Scheme
 		},
 		Client: func() (*client.Client, error) {
 			// Swap out the HTTP client out of the client with the fake's version.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -199,6 +200,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		ExportParam(export).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().
+		ComplacentErrorInGroupingAliases(errors.IsNotFound).
 		Latest()
 	printer, generic, err := cmdutil.PrinterForCommand(cmd)
 	if err != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get_test.go
@@ -441,6 +441,46 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 	}
 }
 
+func TestGetMultipleTypeWithAliasObjects(t *testing.T) {
+	pods, svc, rc := testData()
+
+	f, tf, codec := NewAPIFactory()
+	tf.Printer = &testPrinter{}
+	tf.Client = &fake.RESTClient{
+		Codec: codec,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/namespaces/test/pods":
+				return &http.Response{StatusCode: 200, Body: objBody(codec, pods)}, nil
+			case "/namespaces/test/services":
+				return &http.Response{StatusCode: 200, Body: objBody(codec, svc)}, nil
+			case "/namespaces/test/replicationcontrollers":
+				return &http.Response{StatusCode: 200, Body: objBody(codec, rc)}, nil
+			default:
+				return &http.Response{StatusCode: 404, Body: stringBody("")}, nil
+			}
+		}),
+	}
+	tf.Namespace = "test"
+	buf := bytes.NewBuffer([]byte{})
+
+	cmd := NewCmdGet(f, buf)
+	cmd.SetOutput(buf)
+	cmd.Run(cmd, []string{"all"})
+
+	expected, err := extractResourceList([]runtime.Object{rc, svc, pods})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	actual := tf.Printer.(*testPrinter).Objects
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("unexpected object, expected: %#v, got: %#v", expected, actual)
+	}
+	if len(buf.String()) == 0 {
+		t.Errorf("unexpected empty output")
+	}
+}
+
 func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	pods, svc, _ := testData()
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/visitor.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -200,6 +201,37 @@ func (l EagerVisitorList) Visit(fn VisitorFunc) error {
 		}
 	}
 	return utilerrors.NewAggregate(errs)
+}
+
+// ComplacentVisitorList contains a sub visitor but it's complacent about
+// errors returned by the sub visitor if they match the Matcher condition.
+type ComplacentVisitorList struct {
+	Visitor
+	utilerrors.Matcher
+}
+
+// Visit implements Visitor, and logs errors that occur during processing
+// (never return them in the end) if they attend the given Matcher.
+func (l ComplacentVisitorList) Visit(fn VisitorFunc) error {
+	visitorErr := l.Visitor.Visit(fn)
+	if visitorErr != nil {
+		aggregated := utilerrors.NewAggregate([]error{visitorErr})
+		flattened := utilerrors.Flatten(aggregated)
+
+		unmatchedErrs := []error(nil)
+		for _, err := range flattened.Errors() {
+			if l.Matcher(err) {
+				glog.V(4).Infof("%v", err)
+				continue
+			}
+			unmatchedErrs = append(unmatchedErrs, err)
+		}
+
+		if len(unmatchedErrs) > 0 {
+			return utilerrors.NewAggregate(unmatchedErrs)
+		}
+	}
+	return nil
 }
 
 func ValidateSchema(data []byte, schema validation.Schema) error {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1311049

`oc get` will silently ignore (log as `V(4)`) "not found" errors when there are other good results to display. This specifically fixes `oc get all` against an AEP server (which fails because it does not provide builds and buildconfigs, expected as part of "all" by `oc`).