### PR TITLE
Add "quickstart" to web console browse menu

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -212,8 +212,7 @@ module.exports = function (grunt) {
           'bower_components/messenger/build/css/messenger-theme-block.css',
           'bower_components/messenger/build/css/messenger-theme-air.css',
           'bower_components/messenger/build/css/messenger-theme-ice.css',
-          'bower_components/messenger/build/js/messenger-theme-future.js',
-          'bower_components/fontawesome/css/font-awesome.css'
+          'bower_components/messenger/build/js/messenger-theme-future.js'
         ]
       }
     },
@@ -446,7 +445,7 @@ module.exports = function (grunt) {
           dest: '<%= yeoman.dist %>/styles'
         }, {
           expand: true,
-          cwd: 'bower_components/patternfly/components/font-awesome',
+          cwd: 'bower_components/font-awesome',
           src: 'fonts/*',
           dest: '<%= yeoman.dist %>/styles'
         },
@@ -473,7 +472,7 @@ module.exports = function (grunt) {
           dest: '.tmp/styles'
         }, {
           expand: true,
-          cwd: 'bower_components/patternfly/components/font-awesome',
+          cwd: 'bower_components/font-awesome',
           src: 'fonts/*',
           dest: '.tmp/styles'
         }]

--- a/assets/app/scripts/controllers/create.js
+++ b/assets/app/scripts/controllers/create.js
@@ -33,6 +33,12 @@ angular.module('openshiftConsole')
       "" // "Other" category
     ];
 
+    // General tags shown at the top of the browse menu.
+    $scope.browseGeneral = ['instant-app', 'quickstart'];
+
+    // Specific technologies shown after the divider. Drop any tags included in general tags.
+    $scope.browseTechnologies = _.difference($scope.categoryTags, $scope.browseGeneral);
+
     // Map of tags to labels to show in the view.
     $scope.categoryLabels = {
       "instant-app": "Instant Apps",

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -174,7 +174,7 @@ angular.module('openshiftConsole')
       var icon = annotationFilter(resource, "iconClass");
       if (!icon) {
         if (kind === "template") {
-          return "fa fa-bolt";
+          return "fa fa-clone";
         }
 
         return "";

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -318,13 +318,16 @@ label.checkbox {
 // Make sure icons are the same size so headings align.
 .add-to-project {
   .catalog-legend {
-    dd {
-      margin-bottom: 5px;
+    dt, dd {
+      display: inline;
     }
-    .fa, .pficon {
-      width: 12px;
-      margin-right: 5px;
-      text-align: center;
+    dt:before {
+      content: "";
+      display: block;
+    }
+    dd:before {
+      // dash and space
+      content: '\2014\00a0';
     }
   }
 

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -1,5 +1,6 @@
 @pf-path: "../../bower_components/patternfly/less";
 @pf-components-path: "../../bower_components/patternfly";
+@bower-path: "../../bower_components";
 
 /* PatternFly */
 
@@ -7,7 +8,7 @@
 @import "@{pf-components-path}/components/bootstrap/less/bootstrap.less";
 
 // /* Font Awesome */
-@import "@{pf-components-path}/components/font-awesome/less/font-awesome.less";
+@import "@{bower-path}/font-awesome/less/font-awesome.less";
 
 // /* Bootstrap-Combobox */
 @import "@{pf-components-path}/components/bootstrap-combobox/less/combobox.less";

--- a/assets/app/views/catalog/_template.html
+++ b/assets/app/views/catalog/_template.html
@@ -28,8 +28,19 @@
     </div>
     <!-- Unset title attribute to prevent two tooltips. -->
     <div title="">
+      <span ng-if="(template | tags).indexOf('quickstart') !== -1">
+        <i
+          class="fa fa-bolt tile-badge-icon"
+          style="margin-right: 5px;"
+          aria-hidden="true"
+          data-toggle="tooltip"
+          data-placement="bottom"
+          data-container="body"
+          data-original-title="Quickstart"></i>
+        <span class="sr-only">Quickstart</span>
+      </span>
       <i
-        class="fa fa-bolt tile-badge-icon"
+        class="fa fa-clone tile-badge-icon"
         aria-hidden="true"
         data-toggle="tooltip"
         data-placement="bottom"

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -58,7 +58,11 @@
                             <span class="caret" aria-hidden="true"></span>
                           </button>
                           <ul class="uib-dropdown-menu">
-                            <li ng-repeat="tag in categoryTags" ng-if="tag" role="menuitem">
+                            <li ng-repeat="tag in browseGeneral" role="menuitem">
+                              <a href="" ng-click="filter.tag = tag">{{tag}}</a>
+                            </li>
+                            <li class="divider"></li>
+                            <li ng-repeat="tag in browseTechnologies" ng-if="tag" role="menuitem">
                               <a href="" ng-click="filter.tag = tag">{{tag}}</a>
                             </li>
                           </ul>
@@ -90,13 +94,17 @@
                     <div class="col-sm-6 catalog-legend">
                       <dl aria-hidden="true" class="text-muted">
                         <dt>
-                          <i class="pficon pficon-image"></i> Builder Image
+                          <i class="pficon pficon-image fa-fw"></i> Builder Image
                         </dt>
                         <dd>Builds images from source code in a Git repository.</dd>
                         <dt>
-                          <i class="fa fa-bolt"></i> Template
+                          <i class="fa fa-clone fa-fw"></i> Template
                         </dt>
                         <dd>Creates a predefined set of resources.</dd>
+                        <dt>
+                          <i class="fa fa-bolt fa-fw"></i> Quickstart
+                        </dt>
+                        <dd>Provides a skeleton for developing an application.</dd>
                       </dl>
                     </div>
                   </div>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -35,7 +35,8 @@
     "ace-builds": "1.2.2",
     "yamljs": "0.1.5",
     "clipboard": "1.5.8",
-    "pathseg": "1.0.2"
+    "pathseg": "1.0.2",
+    "fontawesome": "4.5.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",
@@ -43,7 +44,8 @@
   },
   "appPath": "app",
   "resolutions": {
-    "lodash": "3.10.1"
+    "lodash": "3.10.1",
+    "fontawesome": "4.5.0"
   },
   "overrides": {
     "angular-patternfly": {


### PR DESCRIPTION
Does not add a top-level catagory, but adds the quickstart tag to the browse dropdown.

See #7602

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/13331566/0d84172c-dbcc-11e5-9830-38a5fad5623e.png)

@jwforres @bparees @sspeiche 