### PR TITLE
Web console: set terminal cols (width) on initial load to fit screen

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -183,6 +183,7 @@
         <script src="scripts/directives/oscKeyValues.js"></script>
         <script src="scripts/directives/oscRouting.js"></script>
         <script src="scripts/directives/oscUnique.js"></script>
+        <script src="scripts/directives/oscContainerTerminal.js"></script>
         <script src="scripts/directives/replicas.js"></script>
         <script src="scripts/directives/resources.js"></script>
         <script src="scripts/directives/overviewDeployment.js"></script>

--- a/assets/app/scripts/directives/oscContainerTerminal.js
+++ b/assets/app/scripts/directives/oscContainerTerminal.js
@@ -25,25 +25,23 @@ angular
       link: function($scope, $elem) {
         // to test for # of cols
         var proxyDOM = $elem[0].find('.terminal-wrap');
+        // CSS kubernetes-container-terminal .terminal sets font-size to 10px.
+        // At this size, each character takes up roughly 6.5px space.
+        // Therefore, once we get the width of the .terminal-wrap node, we can
+        // calculate the # of cols we can generate to roughly fill the parent
+        // node at render time.
+        var COL_PIX = 6.5;
 
-        $scope.canRender = false;
-
-        if(!$scope.rows) {
-          $scope.rows = 24;
-        }
-        if(!$scope.screenKeys) {
-          $scope.screenKeys = true;
-        }
+        $scope.rows = ('rows' in $scope) ? $scope.rows : 24;
+        $scope.screenKeys = ('screenKeys' in $scope) ? $scope.screenKeys : true;
 
         $scope.$watch('prevent', function(prevent) {
           var maxWidth;
-          if(!prevent) {
+          if(!prevent && !$scope.cols) {
             $timeout(function() {
-              if(!$scope.cols) {
-                maxWidth = Math.floor(proxyDOM.clientWidth/6);
-                $scope.cols = (maxWidth <= 80) ? maxWidth : 80;
-                  $scope.canRender = true;
-                }
+              maxWidth = Math.floor(proxyDOM.clientWidth/COL_PIX);
+              // once cols is set the kubernetes-container-terminal will render.
+              $scope.cols = (maxWidth <= 80) ? maxWidth : 80;
             },1);
           }
         });

--- a/assets/app/scripts/directives/oscContainerTerminal.js
+++ b/assets/app/scripts/directives/oscContainerTerminal.js
@@ -1,0 +1,52 @@
+'use strict';
+// osc-container-terminal is a wrapper around kubernetes-container-terminal
+// - it takes the same configuration options are kubernetes-container-terminal
+// - if rows/cols attribs are not provided it will check browser window and
+//   set these to something that should fit the window on initial page load.
+//   note that we cannot resize the terminal at this time, there is no way to
+//   send a SIGWINCH signal, and we don't want to restart the terminal.
+angular
+  .module('openshiftConsole')
+  // note: could use BREAKPOINTS constant if we
+  // want to standardize on a few terminal sizes
+  .directive('oscContainerTerminal', function($compile, $sce, $timeout) {
+    return {
+      restrict: 'E',
+      scope: {
+        pod: '=',
+        container: '=',
+        prevent: '=',
+        screenKeys: '=?',
+        // optional, will set in link fn to something sensible.
+        rows: '=?',
+        cols: '=?'
+      },
+      templateUrl: 'views/directives/osc-container-terminal.html',
+      link: function($scope, $elem) {
+        // to test for # of cols
+        var proxyDOM = $elem[0].find('.terminal-wrap');
+
+        $scope.canRender = false;
+
+        if(!$scope.rows) {
+          $scope.rows = 24;
+        }
+        if(!$scope.screenKeys) {
+          $scope.screenKeys = true;
+        }
+
+        $scope.$watch('prevent', function(prevent) {
+          var maxWidth;
+          if(!prevent) {
+            $timeout(function() {
+              if(!$scope.cols) {
+                maxWidth = Math.floor(proxyDOM.clientWidth/6);
+                $scope.cols = (maxWidth <= 80) ? maxWidth : 80;
+                  $scope.canRender = true;
+                }
+            },1);
+          }
+        });
+      }
+    };
+  });

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -122,9 +122,10 @@
                       ng-repeat="container in containers | orderBy:'name' track by container.name"
                       ng-if="container.state.running">
                       <h3 ng-if="containers.length > 1">{{container.name}}</h3>
-                      <kubernetes-container-terminal pod="pod" container="container.name"
-                        prevent="!terminalTabWasSelected">
-                      </kubernetes-container-terminal>
+                      <osc-container-terminal
+                        pod="pod"
+                        container="container.name"
+                        prevent="!terminalTabWasSelected"></osc-container-terminal>
                     </div>
     	            </uib-tab>
 

--- a/assets/app/views/directives/osc-container-terminal.html
+++ b/assets/app/views/directives/osc-container-terminal.html
@@ -1,0 +1,11 @@
+<div class="terminal-wrap">
+  <kubernetes-container-terminal
+    ng-if="canRender"
+    pod="pod"
+    container="container"
+    prevent="prevent"
+    rows="rows"
+    cols="cols"
+    screenKeys="screenKeys">
+  </kubernetes-container-terminal>
+</div>

--- a/assets/app/views/directives/osc-container-terminal.html
+++ b/assets/app/views/directives/osc-container-terminal.html
@@ -1,6 +1,6 @@
 <div class="terminal-wrap">
   <kubernetes-container-terminal
-    ng-if="canRender"
+    ng-if="cols"
     pod="pod"
     container="container"
     prevent="prevent"

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -27,7 +27,7 @@
     "messenger": "1.4.1",
     "kubernetes-label-selector": "0.0.18",
     "kubernetes-topology-graph": "0.0.21",
-    "kubernetes-container-terminal": "0.0.7",
+    "kubernetes-container-terminal": "0.0.10",
     "openshift-object-describer": "1.1.1",
     "layout.attrs": "1.1.2",
     "bootstrap-hover-dropdown": "2.1.3",


### PR DESCRIPTION
- Fix #6992 (at least to the degree we can without SIGWINCH)

I created a directive called `osc-container-terminal` that is just a wrapper around `kubernetes-container-terminal` but contains a bit of logic to test for available space then create a terminal with `cols` set to fill the space.  It seem that values above 80 cols will have little effect, so the max is set at 80.

Screenshot of terminal in a mobile view:

![screen shot 2016-02-25 at 4 02 01 pm](https://cloud.githubusercontent.com/assets/280512/13334272/2cb8237e-dbd9-11e5-9a4c-1dfb909f2901.png)


@spadgett @jwforres 