### PR TITLE
Web console: tighten up spacing above log viewer

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -1,9 +1,6 @@
 .log-title {
   margin-top: 0;
 }
-.log-timestamp, .log-size-warning {
-  margin-bottom: 10px;
-}
 .log-view {
   background-color: @log-bg-color;
   font-family: @font-family-monospace;
@@ -94,9 +91,6 @@
 
 .log-link-external {
   text-align: right;
-  a {
-    margin-left: 20px;
-  }
   i {
     font-size: @font-size-xsmall;
     margin-left: 5px;

--- a/assets/app/styles/_typography.less
+++ b/assets/app/styles/_typography.less
@@ -1,0 +1,42 @@
+/* Device specific text alignment classes.
+   - use with the basic align-left & align-right provided by bootstrap.
+   - example usage:
+     <div class="text-xs-left text-right">
+     would align text to left on mobile, else align right on other devices.
+ ---------------------------------------------------------------------------- */
+// extra small
+@media (max-width: @screen-xs-max) {
+  .text-xs-left {
+    text-align: left;
+  }
+  .text-xs-right {
+    text-align: right;
+  }
+}
+// small
+@media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  .text-sm-left {
+    text-align: left;
+  }
+  .text-sm-right {
+    text-align: right;
+  }
+}
+// medium
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  .text-md-left {
+    text-align: left;
+  }
+  .text-md-right {
+    text-align: right;
+  }
+}
+// large
+@media (min-width: @screen-lg-min) {
+  .text-lg-left {
+    text-align: left;
+  }
+  .text-lg-right {
+    text-align: right;
+  }
+}

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -85,3 +85,4 @@
 @import "_tile.less";
 @import "_topology.less";
 @import "_log.less";
+@import "_typography.less";

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -26,7 +26,7 @@
 
 
 <div class="row" ng-if="(!chromeless)">
-  <div class="col-md-6 col-sm-12">
+  <div class="col-xs-12 col-sm-6">
     <span ng-if="status">
       <span>Status:&nbsp;&nbsp;</span>
       <status-icon status="status"></status-icon>
@@ -34,7 +34,7 @@
     </span>
   </div>
   <div
-    class="log-link-external col-md-6 col-sm-12 text-right"
+    class="log-link-external col-xs-12 col-sm-6 text-xs-left text-right"
     ng-if="state=='logs'">
     <a href=""  ng-click="goChromeless(options)">
       Open full view of log<i class="fa fa-external-link"></i>


### PR DESCRIPTION
Fix #5750 

- [x] Adds a few typographical utility classes to a new `_typography.less` file & eliminate extra padding
- [ ] Q: so should we move status to above the tabs? (per [this comment](https://github.com/openshift/origin/issues/5750#issuecomment-154439165))

@sg00dwin pinging you, I believe you may have done some special case IE stuff in here, want your thoughts for review!

Full view:
![screen shot 2016-02-25 at 4 43 25 pm](https://cloud.githubusercontent.com/assets/280512/13335526/8c5e7976-dbdf-11e5-9ad8-05a6face4939.png)

Mobile view:
![screen shot 2016-02-25 at 4 43 37 pm](https://cloud.githubusercontent.com/assets/280512/13335531/978c6d44-dbdf-11e5-9c8b-249e9b4a890c.png)



@jwforres @spadgett  