### PR TITLE
Add full volume control to SCC

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -18952,6 +18952,7 @@
      "requiredDropCapabilities",
      "allowedCapabilities",
      "allowHostDirVolumePlugin",
+     "volumes",
      "allowHostNetwork",
      "allowHostPorts",
      "allowHostPID",
@@ -19004,6 +19005,13 @@
       "type": "boolean",
       "description": "AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin"
      },
+     "volumes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.FSType"
+      },
+      "description": "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'."
+     },
      "allowHostNetwork": {
       "type": "boolean",
       "description": "AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec."
@@ -19055,6 +19063,10 @@
       "description": "The groups that have permission to use this security context constraints"
      }
     }
+   },
+   "v1.FSType": {
+    "id": "v1.FSType",
+    "properties": {}
    },
    "v1.SELinuxContextStrategyOptions": {
     "id": "v1.SELinuxContextStrategyOptions",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2755,7 +2755,15 @@ func DeepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 	} else {
 		out.AllowedCapabilities = nil
 	}
-	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	if in.Volumes != nil {
+		in, out := in.Volumes, &out.Volumes
+		*out = make([]FSType, len(in))
+		for i := range in {
+			(*out)[i] = in[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
 	out.AllowHostNetwork = in.AllowHostNetwork
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
@@ -443,6 +443,29 @@ func FuzzerFor(t *testing.T, version unversioned.GroupVersion, src rand.Source) 
 			scc.SupplementalGroups.Type = supGroupTypes[c.Rand.Intn(len(supGroupTypes))]
 			fsGroupTypes := []api.FSGroupStrategyType{api.FSGroupStrategyMustRunAs, api.FSGroupStrategyRunAsAny}
 			scc.FSGroup.Type = fsGroupTypes[c.Rand.Intn(len(fsGroupTypes))]
+
+			// when fuzzing the volume types ensure it is set to avoid the defaulter's expansion.
+			// Do not use FSTypeAll or host dir setting to steer clear of defaulting mechanics
+			// which are covered in specific unit tests.
+			volumeTypes := []api.FSType{api.FSTypeAWSElasticBlockStore,
+				api.FSTypeAzureFile,
+				api.FSTypeCephFS,
+				api.FSTypeCinder,
+				api.FSTypeDownwardAPI,
+				api.FSTypeEmptyDir,
+				api.FSTypeFC,
+				api.FSTypeFlexVolume,
+				api.FSTypeFlocker,
+				api.FSTypeGCEPersistentDisk,
+				api.FSTypeGitRepo,
+				api.FSTypeGlusterfs,
+				api.FSTypeISCSI,
+				api.FSTypeNFS,
+				api.FSTypePersistentVolumeClaim,
+				api.FSTypeRBD,
+				api.FSTypeSecret}
+			scc.Volumes = []api.FSType{volumeTypes[c.Rand.Intn(len(volumeTypes))]}
+
 		},
 	)
 	return f

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2567,8 +2567,9 @@ type SecurityContextConstraints struct {
 	// Capabilities in this field maybe added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	AllowedCapabilities []Capability
-	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-	AllowHostDirVolumePlugin bool
+	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	Volumes []FSType
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool
 	// AllowHostPorts determines if the policy allows host ports in the containers.
@@ -2597,6 +2598,32 @@ type SecurityContextConstraints struct {
 	// The groups that have permission to use this security context constraints
 	Groups []string
 }
+
+// FS Type gives strong typing to different file systems that are used by volumes.
+type FSType string
+
+var (
+	FSTypeAzureFile             FSType = "azureFile"
+	FSTypeFlocker               FSType = "flocker"
+	FSTypeFlexVolume            FSType = "flexVolume"
+	FSTypeHostPath              FSType = "hostPath"
+	FSTypeEmptyDir              FSType = "emptyDir"
+	FSTypeGCEPersistentDisk     FSType = "gcePersistentDisk"
+	FSTypeAWSElasticBlockStore  FSType = "awsElasticBlockStore"
+	FSTypeGitRepo               FSType = "gitRepo"
+	FSTypeSecret                FSType = "secret"
+	FSTypeNFS                   FSType = "nfs"
+	FSTypeISCSI                 FSType = "iscsi"
+	FSTypeGlusterfs             FSType = "glusterfs"
+	FSTypePersistentVolumeClaim FSType = "persistentVolumeClaim"
+	FSTypeRBD                   FSType = "rbd"
+	FSTypeCinder                FSType = "cinder"
+	FSTypeCephFS                FSType = "cephFS"
+	FSTypeDownwardAPI           FSType = "downwardAPI"
+	FSTypeFC                    FSType = "fc"
+	FSTypeConfigMap             FSType = "configMap"
+	FSTypeAll                   FSType = "*"
+)
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxContextStrategyOptions struct {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -49,6 +49,9 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 
 		Convert_api_VolumeSource_To_v1_VolumeSource,
 		Convert_v1_VolumeSource_To_api_VolumeSource,
+
+		Convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints,
+		Convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
@@ -674,5 +677,26 @@ func Convert_v1_MetadataFile_To_api_DownwardAPIVolumeFile(in *MetadataFile, out 
 		return err
 	}
 
+	return nil
+}
+
+func Convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in *SecurityContextConstraints, out *api.SecurityContextConstraints, s conversion.Scope) error {
+	return autoConvert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in, out, s)
+}
+
+func Convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in *api.SecurityContextConstraints, out *SecurityContextConstraints, s conversion.Scope) error {
+	if err := autoConvert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in, out, s); err != nil {
+		return err
+	}
+
+	if in.Volumes != nil {
+		for _, v := range in.Volumes {
+			// set the Allow* fields based on the existence in the volume slice
+			switch v {
+			case api.FSTypeHostPath, api.FSTypeAll:
+				out.AllowHostDirVolumePlugin = true
+			}
+		}
+	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -3022,7 +3022,14 @@ func autoConvert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints
 	} else {
 		out.AllowedCapabilities = nil
 	}
-	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	if in.Volumes != nil {
+		out.Volumes = make([]FSType, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = FSType(in.Volumes[i])
+		}
+	} else {
+		out.Volumes = nil
+	}
 	out.AllowHostNetwork = in.AllowHostNetwork
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
@@ -3057,10 +3064,6 @@ func autoConvert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints
 		out.Groups = nil
 	}
 	return nil
-}
-
-func Convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in *api.SecurityContextConstraints, out *SecurityContextConstraints, s conversion.Scope) error {
-	return autoConvert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in, out, s)
 }
 
 func autoConvert_api_SecurityContextConstraintsList_To_v1_SecurityContextConstraintsList(in *api.SecurityContextConstraintsList, out *SecurityContextConstraintsList, s conversion.Scope) error {
@@ -6424,7 +6427,15 @@ func autoConvert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints
 	} else {
 		out.AllowedCapabilities = nil
 	}
-	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	// in.AllowHostDirVolumePlugin has no peer in out
+	if in.Volumes != nil {
+		out.Volumes = make([]api.FSType, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = api.FSType(in.Volumes[i])
+		}
+	} else {
+		out.Volumes = nil
+	}
 	out.AllowHostNetwork = in.AllowHostNetwork
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
@@ -6459,10 +6470,6 @@ func autoConvert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints
 		out.Groups = nil
 	}
 	return nil
-}
-
-func Convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in *SecurityContextConstraints, out *api.SecurityContextConstraints, s conversion.Scope) error {
-	return autoConvert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in, out, s)
 }
 
 func autoConvert_v1_SecurityContextConstraintsList_To_api_SecurityContextConstraintsList(in *SecurityContextConstraintsList, out *api.SecurityContextConstraintsList, s conversion.Scope) error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2379,6 +2379,14 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	if in.Volumes != nil {
+		out.Volumes = make([]FSType, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
 	out.AllowHostNetwork = in.AllowHostNetwork
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
@@ -20,9 +20,11 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"strings"
 
+	sccutil "k8s.io/kubernetes/pkg/securitycontextconstraints/util"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/util/parsers"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) {
@@ -317,4 +319,58 @@ func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
 	if len(scc.SupplementalGroups.Type) == 0 {
 		scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
 	}
+
+	// defaults the volume slice of the SCC.
+	// In order to support old clients the boolean fields will always take precedence.
+	defaultAllowedVolumes := fsTypeToStringSet(scc.Volumes)
+
+	// assume a nil volume slice is allowing everything for backwards compatibility
+	if defaultAllowedVolumes == nil {
+		defaultAllowedVolumes = sets.NewString(string(FSTypeAll))
+	}
+
+	if scc.AllowHostDirVolumePlugin {
+		// if already allowing all then there is no reason to add
+		if !defaultAllowedVolumes.Has(string(FSTypeAll)) {
+			defaultAllowedVolumes.Insert(string(FSTypeHostPath))
+		}
+	} else {
+		// we should only default all volumes if the SCC came in with FSTypeAll or we defaulted it
+		// otherwise we should only change the volumes slice to ensure that it does not conflict with
+		// the AllowHostDirVolumePlugin setting
+		shouldDefaultAllVolumes := defaultAllowedVolumes.Has(string(FSTypeAll))
+
+		// remove anything from volumes that conflicts with AllowHostDirVolumePlugin = false
+		defaultAllowedVolumes.Delete(string(FSTypeAll))
+		defaultAllowedVolumes.Delete(string(FSTypeHostPath))
+
+		if shouldDefaultAllVolumes {
+			allVolumes := sccutil.GetAllFSTypesExcept(string(FSTypeHostPath))
+			defaultAllowedVolumes.Insert(allVolumes.List()...)
+		}
+	}
+
+	scc.Volumes = StringSetToFSType(defaultAllowedVolumes)
+}
+
+func StringSetToFSType(set sets.String) []FSType {
+	if set == nil {
+		return nil
+	}
+	volumes := []FSType{}
+	for _, v := range set.List() {
+		volumes = append(volumes, FSType(v))
+	}
+	return volumes
+}
+
+func fsTypeToStringSet(volumes []FSType) sets.String {
+	if volumes == nil {
+		return nil
+	}
+	set := sets.NewString()
+	for _, v := range volumes {
+		set.Insert(string(v))
+	}
+	return set
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -3018,6 +3018,9 @@ type SecurityContextConstraints struct {
 	AllowedCapabilities []Capability `json:"allowedCapabilities" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" description:"allow the use of the host dir volume plugin"`
+	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	Volumes []FSType `json:"volumes"`
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool `json:"allowHostNetwork" description:"allow the use of the hostNetwork in the pod spec"`
 	// AllowHostPorts determines if the policy allows host ports in the containers.
@@ -3046,6 +3049,32 @@ type SecurityContextConstraints struct {
 	// The groups that have permission to use this security context constraints
 	Groups []string `json:"groups,omitempty" description:"groups allowed to use this SecurityContextConstraints"`
 }
+
+// FS Type gives strong typing to different file systems that are used by volumes.
+type FSType string
+
+var (
+	FSTypeAzureFile             FSType = "azureFile"
+	FSTypeFlocker               FSType = "flocker"
+	FSTypeFlexVolume            FSType = "flexVolume"
+	FSTypeHostPath              FSType = "hostPath"
+	FSTypeEmptyDir              FSType = "emptyDir"
+	FSTypeGCEPersistentDisk     FSType = "gcePersistentDisk"
+	FSTypeAWSElasticBlockStore  FSType = "awsElasticBlockStore"
+	FSTypeGitRepo               FSType = "gitRepo"
+	FSTypeSecret                FSType = "secret"
+	FSTypeNFS                   FSType = "nfs"
+	FSTypeISCSI                 FSType = "iscsi"
+	FSTypeGlusterfs             FSType = "glusterfs"
+	FSTypePersistentVolumeClaim FSType = "persistentVolumeClaim"
+	FSTypeRBD                   FSType = "rbd"
+	FSTypeCinder                FSType = "cinder"
+	FSTypeCephFS                FSType = "cephFS"
+	FSTypeDownwardAPI           FSType = "downwardAPI"
+	FSTypeFC                    FSType = "fc"
+	FSTypeConfigMap             FSType = "configMap"
+	FSTypeAll                   FSType = "*"
+)
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxContextStrategyOptions struct {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -2030,82 +2030,6 @@ func convert_api_SecurityContext_To_v1beta3_SecurityContext(in *api.SecurityCont
 	return nil
 }
 
-func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraints(in *api.SecurityContextConstraints, out *SecurityContextConstraints, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*api.SecurityContextConstraints))(in)
-	}
-
-	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Priority != nil {
-		out.Priority = new(int)
-		*out.Priority = *in.Priority
-	} else {
-		out.Priority = nil
-	}
-	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
-	if in.AllowedCapabilities != nil {
-		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))
-		for i := range in.AllowedCapabilities {
-			out.AllowedCapabilities[i] = Capability(in.AllowedCapabilities[i])
-		}
-	} else {
-		out.AllowedCapabilities = nil
-	}
-	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
-	out.AllowHostNetwork = in.AllowHostNetwork
-	out.AllowHostPorts = in.AllowHostPorts
-	out.AllowHostPID = in.AllowHostPID
-	out.AllowHostIPC = in.AllowHostIPC
-	if err := convert_api_SELinuxContextStrategyOptions_To_v1beta3_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
-		return err
-	}
-	if err := convert_api_RunAsUserStrategyOptions_To_v1beta3_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
-		return err
-	}
-	if err := convert_api_FSGroupStrategyOptions_To_v1beta3_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
-		return err
-	}
-	if err := convert_api_SupplementalGroupsStrategyOptions_To_v1beta3_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
-		return err
-	}
-	if in.DefaultAddCapabilities != nil {
-		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
-		for i := range in.DefaultAddCapabilities {
-			out.DefaultAddCapabilities[i] = Capability(in.DefaultAddCapabilities[i])
-		}
-	} else {
-		out.DefaultAddCapabilities = nil
-	}
-	if in.RequiredDropCapabilities != nil {
-		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
-		for i := range in.RequiredDropCapabilities {
-			out.RequiredDropCapabilities[i] = Capability(in.RequiredDropCapabilities[i])
-		}
-	} else {
-		out.RequiredDropCapabilities = nil
-	}
-	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
-	if in.Users != nil {
-		out.Users = make([]string, len(in.Users))
-		for i := range in.Users {
-			out.Users[i] = in.Users[i]
-		}
-	} else {
-		out.Users = nil
-	}
-	if in.Groups != nil {
-		out.Groups = make([]string, len(in.Groups))
-		for i := range in.Groups {
-			out.Groups[i] = in.Groups[i]
-		}
-	} else {
-		out.Groups = nil
-	}
-	return nil
-}
-
 func convert_api_SecurityContextConstraintsList_To_v1beta3_SecurityContextConstraintsList(in *api.SecurityContextConstraintsList, out *SecurityContextConstraintsList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.SecurityContextConstraintsList))(in)
@@ -4295,82 +4219,6 @@ func convert_v1beta3_SecurityContext_To_api_SecurityContext(in *SecurityContext,
 	return nil
 }
 
-func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraints(in *SecurityContextConstraints, out *api.SecurityContextConstraints, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*SecurityContextConstraints))(in)
-	}
-
-	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Priority != nil {
-		out.Priority = new(int)
-		*out.Priority = *in.Priority
-	} else {
-		out.Priority = nil
-	}
-	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
-	if in.AllowedCapabilities != nil {
-		out.AllowedCapabilities = make([]api.Capability, len(in.AllowedCapabilities))
-		for i := range in.AllowedCapabilities {
-			out.AllowedCapabilities[i] = api.Capability(in.AllowedCapabilities[i])
-		}
-	} else {
-		out.AllowedCapabilities = nil
-	}
-	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
-	out.AllowHostNetwork = in.AllowHostNetwork
-	out.AllowHostPorts = in.AllowHostPorts
-	out.AllowHostPID = in.AllowHostPID
-	out.AllowHostIPC = in.AllowHostIPC
-	if err := convert_v1beta3_SELinuxContextStrategyOptions_To_api_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_RunAsUserStrategyOptions_To_api_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
-		return err
-	}
-	if in.DefaultAddCapabilities != nil {
-		out.DefaultAddCapabilities = make([]api.Capability, len(in.DefaultAddCapabilities))
-		for i := range in.DefaultAddCapabilities {
-			out.DefaultAddCapabilities[i] = api.Capability(in.DefaultAddCapabilities[i])
-		}
-	} else {
-		out.DefaultAddCapabilities = nil
-	}
-	if in.RequiredDropCapabilities != nil {
-		out.RequiredDropCapabilities = make([]api.Capability, len(in.RequiredDropCapabilities))
-		for i := range in.RequiredDropCapabilities {
-			out.RequiredDropCapabilities[i] = api.Capability(in.RequiredDropCapabilities[i])
-		}
-	} else {
-		out.RequiredDropCapabilities = nil
-	}
-	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
-	if in.Users != nil {
-		out.Users = make([]string, len(in.Users))
-		for i := range in.Users {
-			out.Users[i] = in.Users[i]
-		}
-	} else {
-		out.Users = nil
-	}
-	if in.Groups != nil {
-		out.Groups = make([]string, len(in.Groups))
-		for i := range in.Groups {
-			out.Groups[i] = in.Groups[i]
-		}
-	} else {
-		out.Groups = nil
-	}
-	return nil
-}
-
 func convert_v1beta3_SecurityContextConstraintsList_To_api_SecurityContextConstraintsList(in *SecurityContextConstraintsList, out *api.SecurityContextConstraintsList, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*SecurityContextConstraintsList))(in)
@@ -4665,7 +4513,6 @@ func init() {
 		convert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource,
 		convert_api_Secret_To_v1beta3_Secret,
 		convert_api_SecurityContextConstraintsList_To_v1beta3_SecurityContextConstraintsList,
-		convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraints,
 		convert_api_SecurityContext_To_v1beta3_SecurityContext,
 		convert_api_SerializedReference_To_v1beta3_SerializedReference,
 		convert_api_ServiceAccountList_To_v1beta3_ServiceAccountList,
@@ -4785,7 +4632,6 @@ func init() {
 		convert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource,
 		convert_v1beta3_Secret_To_api_Secret,
 		convert_v1beta3_SecurityContextConstraintsList_To_api_SecurityContextConstraintsList,
-		convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraints,
 		convert_v1beta3_SecurityContext_To_api_SecurityContext,
 		convert_v1beta3_SerializedReference_To_api_SerializedReference,
 		convert_v1beta3_ServiceAccountList_To_api_ServiceAccountList,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
@@ -489,7 +489,7 @@ func describeSecurityContextConstraints(scc *api.SecurityContextConstraints) (st
 		fmt.Fprintf(out, "  Default Add Capabilities:\t%s\n", capsToString(scc.DefaultAddCapabilities))
 		fmt.Fprintf(out, "  Required Drop Capabilities:\t%s\n", capsToString(scc.RequiredDropCapabilities))
 		fmt.Fprintf(out, "  Allowed Capabilities:\t%s\n", capsToString(scc.AllowedCapabilities))
-		fmt.Fprintf(out, "  Allow Host Dir Volumes:\t%t\n", scc.AllowHostDirVolumePlugin)
+		fmt.Fprintf(out, "  Allowed Volume Types:\t%s\n", fsTypeToString(scc.Volumes))
 		fmt.Fprintf(out, "  Allow Host Network:\t%t\n", scc.AllowHostNetwork)
 		fmt.Fprintf(out, "  Allow Host Ports:\t%t\n", scc.AllowHostPorts)
 		fmt.Fprintf(out, "  Allow Host PID:\t%t\n", scc.AllowHostPID)
@@ -543,6 +543,14 @@ func stringOrNone(s string) string {
 		return s
 	}
 	return "<none>"
+}
+
+func fsTypeToString(volumes []api.FSType) string {
+	strVolumes := []string{}
+	for _, v := range volumes {
+		strVolumes = append(strVolumes, string(v))
+	}
+	return stringOrNone(strings.Join(strVolumes, ","))
 }
 
 func idRangeToString(ranges []api.IDRange) string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
@@ -420,7 +420,7 @@ var withNamespacePrefixColumns = []string{"NAMESPACE"} // TODO(erictune): print 
 var deploymentColumns = []string{"NAME", "DESIRED", "CURRENT", "UP-TO-DATE", "AVAILABLE", "AGE"}
 var configMapColumns = []string{"NAME", "DATA", "AGE"}
 var podSecurityPolicyColumns = []string{"NAME", "PRIV", "CAPS", "VOLUMEPLUGINS", "SELINUX", "RUNASUSER"}
-var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "HOSTDIR", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP", "PRIORITY", "READONLYROOTFS"}
+var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP", "PRIORITY", "READONLYROOTFS", "VOLUMES"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -1950,9 +1950,9 @@ func printSecurityContextConstraints(item *api.SecurityContextConstraints, w io.
 		priority = strconv.Itoa(*item.Priority)
 	}
 
-	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%t\t%s\t%s\t%s\t%s\t%s\t%t\n", item.Name, item.AllowPrivilegedContainer,
-		item.AllowedCapabilities, item.AllowHostDirVolumePlugin, item.SELinuxContext.Type,
-		item.RunAsUser.Type, item.FSGroup.Type, item.SupplementalGroups.Type, priority, item.ReadOnlyRootFilesystem)
+	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%s\t%s\t%s\t%s\t%s\t%t\t%v\n", item.Name, item.AllowPrivilegedContainer,
+		item.AllowedCapabilities, item.SELinuxContext.Type,
+		item.RunAsUser.Type, item.FSGroup.Type, item.SupplementalGroups.Type, priority, item.ReadOnlyRootFilesystem, item.Volumes)
 	return err
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/util/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/util/util.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func GetAllFSTypesExcept(exceptions ...string) sets.String {
+	fstypes := GetAllFSTypesAsSet()
+	for _, e := range exceptions {
+		fstypes.Delete(e)
+	}
+	return fstypes
+}
+
+func GetAllFSTypesAsSet() sets.String {
+	fstypes := sets.NewString()
+	fstypes.Insert(
+		string(api.FSTypeHostPath),
+		string(api.FSTypeAzureFile),
+		string(api.FSTypeFlocker),
+		string(api.FSTypeFlexVolume),
+		string(api.FSTypeEmptyDir),
+		string(api.FSTypeGCEPersistentDisk),
+		string(api.FSTypeAWSElasticBlockStore),
+		string(api.FSTypeGitRepo),
+		string(api.FSTypeSecret),
+		string(api.FSTypeNFS),
+		string(api.FSTypeISCSI),
+		string(api.FSTypeGlusterfs),
+		string(api.FSTypePersistentVolumeClaim),
+		string(api.FSTypeRBD),
+		string(api.FSTypeCinder),
+		string(api.FSTypeCephFS),
+		string(api.FSTypeDownwardAPI),
+		string(api.FSTypeFC),
+		string(api.FSTypeConfigMap))
+	return fstypes
+}
+
+// getVolumeFSType gets the FSType for a volume.
+func GetVolumeFSType(v api.Volume) (api.FSType, error) {
+	switch {
+	case v.HostPath != nil:
+		return api.FSTypeHostPath, nil
+	case v.EmptyDir != nil:
+		return api.FSTypeEmptyDir, nil
+	case v.GCEPersistentDisk != nil:
+		return api.FSTypeGCEPersistentDisk, nil
+	case v.AWSElasticBlockStore != nil:
+		return api.FSTypeAWSElasticBlockStore, nil
+	case v.GitRepo != nil:
+		return api.FSTypeGitRepo, nil
+	case v.Secret != nil:
+		return api.FSTypeSecret, nil
+	case v.NFS != nil:
+		return api.FSTypeNFS, nil
+	case v.ISCSI != nil:
+		return api.FSTypeISCSI, nil
+	case v.Glusterfs != nil:
+		return api.FSTypeGlusterfs, nil
+	case v.PersistentVolumeClaim != nil:
+		return api.FSTypePersistentVolumeClaim, nil
+	case v.RBD != nil:
+		return api.FSTypeRBD, nil
+	case v.FlexVolume != nil:
+		return api.FSTypeFlexVolume, nil
+	case v.Cinder != nil:
+		return api.FSTypeCinder, nil
+	case v.CephFS != nil:
+		return api.FSTypeCephFS, nil
+	case v.Flocker != nil:
+		return api.FSTypeFlocker, nil
+	case v.DownwardAPI != nil:
+		return api.FSTypeDownwardAPI, nil
+	case v.FC != nil:
+		return api.FSTypeFC, nil
+	case v.AzureFile != nil:
+		return api.FSTypeAzureFile, nil
+	case v.ConfigMap != nil:
+		return api.FSTypeConfigMap, nil
+	}
+
+	return "", fmt.Errorf("unknown volume type for volume: %#v", v)
+}
+
+// fsTypeToStringSet converts an FSType slice to a string set.
+func FSTypeToStringSet(fsTypes []api.FSType) sets.String {
+	set := sets.NewString()
+	for _, v := range fsTypes {
+		set.Insert(string(v))
+	}
+	return set
+}
+
+// SCCAllowsAllVolumes checks for FSTypeAll in the scc's allowed volumes.
+func SCCAllowsAllVolumes(scc *api.SecurityContextConstraints) bool {
+	return SCCAllowsFSType(scc, api.FSTypeAll)
+}
+
+// SCCAllowsFSType is a utility for checking if an SCC allows a particular FSType.
+// If all volumes are allowed then this will return true for any FSType passed.
+func SCCAllowsFSType(scc *api.SecurityContextConstraints, fsType api.FSType) bool {
+	if scc == nil {
+		return false
+	}
+
+	for _, v := range scc.Volumes {
+		if v == fsType || v == api.FSTypeAll {
+			return true
+		}
+	}
+	return false
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/util/util_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/util/util_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// TestVolumeSourceFSTypeDrift ensures that for every known type of volume source (by the fields on
+// a VolumeSource object that GetVolumeFSType is returning a good value.  This ensures both that we're
+// returning an FSType for the VolumeSource field (protect the GetVolumeFSType method) and that we
+// haven't drifted (ensure new fields in VolumeSource are covered).
+func TestVolumeSourceFSTypeDrift(t *testing.T) {
+	allFSTypes := GetAllFSTypesAsSet()
+	val := reflect.ValueOf(api.VolumeSource{})
+
+	for i := 0; i < val.NumField(); i++ {
+		fieldVal := val.Type().Field(i)
+
+		volumeSource := api.VolumeSource{}
+		volumeSourceVolume := reflect.New(fieldVal.Type.Elem())
+
+		reflect.ValueOf(&volumeSource).Elem().FieldByName(fieldVal.Name).Set(volumeSourceVolume)
+
+		fsType, err := GetVolumeFSType(api.Volume{VolumeSource: volumeSource})
+		if err != nil {
+			t.Errorf("error getting fstype for field %s.  This likely means that drift has occured between FSType and VolumeSource.  Please update the api and getVolumeFSType", fieldVal.Name)
+		}
+
+		if !allFSTypes.Has(string(fsType)) {
+			t.Errorf("%s was missing from GetFSTypesAsSet", fsType)
+		}
+	}
+}
+
+func TestSCCAllowsVolumeType(t *testing.T) {
+	tests := map[string]struct {
+		scc    *api.SecurityContextConstraints
+		fsType api.FSType
+		allows bool
+	}{
+		"nil scc": {
+			scc:    nil,
+			fsType: api.FSTypeHostPath,
+			allows: false,
+		},
+		"empty volumes": {
+			scc:    &api.SecurityContextConstraints{},
+			fsType: api.FSTypeHostPath,
+			allows: false,
+		},
+		"non-matching": {
+			scc: &api.SecurityContextConstraints{
+				Volumes: []api.FSType{api.FSTypeAWSElasticBlockStore},
+			},
+			fsType: api.FSTypeHostPath,
+			allows: false,
+		},
+		"match on FSTypeAll": {
+			scc: &api.SecurityContextConstraints{
+				Volumes: []api.FSType{api.FSTypeAll},
+			},
+			fsType: api.FSTypeHostPath,
+			allows: true,
+		},
+		"match on direct match": {
+			scc: &api.SecurityContextConstraints{
+				Volumes: []api.FSType{api.FSTypeHostPath},
+			},
+			fsType: api.FSTypeHostPath,
+			allows: true,
+		},
+	}
+
+	for k, v := range tests {
+		allows := SCCAllowsFSType(v.scc, v.fsType)
+		if v.allows != allows {
+			t.Errorf("%s expected SCCAllowsFSType to return %t but got %t", k, v.allows, allows)
+		}
+	}
+}

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -18956,6 +18956,7 @@
      "requiredDropCapabilities",
      "allowedCapabilities",
      "allowHostDirVolumePlugin",
+     "volumes",
      "allowHostNetwork",
      "allowHostPorts",
      "allowHostPID",
@@ -19008,6 +19009,12 @@
       "type": "boolean",
       "description": "AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin"
      },
+     "volumes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.FSType"
+      }
+     },
      "allowHostNetwork": {
       "type": "boolean",
       "description": "AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec."
@@ -19059,6 +19066,10 @@
       "description": "The groups that have permission to use this security context constraints"
      }
     }
+   },
+   "v1.FSType": {
+    "id": "v1.FSType",
+    "properties": {}
    },
    "v1.SELinuxContextStrategyOptions": {
     "id": "v1.SELinuxContextStrategyOptions",

--- a/pkg/cmd/admin/policy/reconcile_sccs_test.go
+++ b/pkg/cmd/admin/policy/reconcile_sccs_test.go
@@ -15,7 +15,7 @@ func TestComputeDefinitions(t *testing.T) {
 	diffCaps.AllowedCapabilities = []kapi.Capability{"foo"}
 
 	diffHostDir := goodSCC()
-	diffHostDir.AllowHostDirVolumePlugin = true
+	diffHostDir.Volumes = []kapi.FSType{kapi.FSTypeHostPath}
 
 	diffHostNetwork := goodSCC()
 	diffHostNetwork.AllowHostNetwork = true

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -64,7 +64,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				},
 			},
 			AllowPrivilegedContainer: true,
-			AllowHostDirVolumePlugin: true,
+			Volumes:                  []kapi.FSType{kapi.FSTypeAll},
 			AllowHostNetwork:         true,
 			AllowHostPorts:           true,
 			AllowHostPID:             true,
@@ -91,6 +91,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintNonRootDesc,
 				},
 			},
+			Volumes: []kapi.FSType{kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -118,7 +119,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintHostMountAndAnyUIDDesc,
 				},
 			},
-			AllowHostDirVolumePlugin: true,
+			Volumes: []kapi.FSType{kapi.FSTypeHostPath, kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -147,11 +148,11 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintHostNSDesc,
 				},
 			},
-			AllowHostDirVolumePlugin: true,
-			AllowHostNetwork:         true,
-			AllowHostPorts:           true,
-			AllowHostPID:             true,
-			AllowHostIPC:             true,
+			Volumes:          []kapi.FSType{kapi.FSTypeHostPath, kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
+			AllowHostNetwork: true,
+			AllowHostPorts:   true,
+			AllowHostPID:     true,
+			AllowHostIPC:     true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -179,6 +180,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintRestrictedDesc,
 				},
 			},
+			Volumes: []kapi.FSType{kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -208,6 +210,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintsAnyUIDDesc,
 				},
 			},
+			Volumes: []kapi.FSType{kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -238,6 +241,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			},
 			AllowHostNetwork: true,
 			AllowHostPorts:   true,
+			Volumes:          []kapi.FSType{kapi.FSTypeEmptyDir, kapi.FSTypeSecret, kapi.FSTypeDownwardAPI, kapi.FSTypeConfigMap},
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy

--- a/pkg/security/admission/bypriority_test.go
+++ b/pkg/security/admission/bypriority_test.go
@@ -27,7 +27,7 @@ func TestByPrioritiesScore(t *testing.T) {
 	nonPriviledSCC := testSCC("nonprivileged", 1)
 
 	hostDirSCC := testSCC("hostdir", 1)
-	hostDirSCC.AllowHostDirVolumePlugin = true
+	hostDirSCC.Volumes = []kapi.FSType{kapi.FSTypeHostPath}
 
 	sccs := []*kapi.SecurityContextConstraints{nonPriviledSCC, privilegedSCC, hostDirSCC}
 	// with equal priorities expect that the SCCs will be sorted with hold behavior based on their score,

--- a/pkg/security/admission/byrestrictions_test.go
+++ b/pkg/security/admission/byrestrictions_test.go
@@ -1,0 +1,162 @@
+package admission
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestPointValue(t *testing.T) {
+	newSCC := func(priv bool, seLinuxStrategy kapi.SELinuxContextStrategyType, userStrategy kapi.RunAsUserStrategyType) *kapi.SecurityContextConstraints {
+		scc := &kapi.SecurityContextConstraints{
+			SELinuxContext: kapi.SELinuxContextStrategyOptions{
+				Type: seLinuxStrategy,
+			},
+			RunAsUser: kapi.RunAsUserStrategyOptions{
+				Type: userStrategy,
+			},
+		}
+		if priv {
+			scc.AllowPrivilegedContainer = true
+		}
+
+		return scc
+	}
+
+	seLinuxStrategies := map[kapi.SELinuxContextStrategyType]int{
+		kapi.SELinuxStrategyRunAsAny:  4,
+		kapi.SELinuxStrategyMustRunAs: 1,
+	}
+	userStrategies := map[kapi.RunAsUserStrategyType]int{
+		kapi.RunAsUserStrategyRunAsAny:         4,
+		kapi.RunAsUserStrategyMustRunAsNonRoot: 3,
+		kapi.RunAsUserStrategyMustRunAsRange:   2,
+		kapi.RunAsUserStrategyMustRunAs:        1,
+	}
+
+	privilegedPoints := 20
+
+	// run through all combos of user strategy + seLinux strategy + priv
+	for userStrategy, userStrategyPoints := range userStrategies {
+		for seLinuxStrategy, seLinuxStrategyPoints := range seLinuxStrategies {
+			expectedPoints := privilegedPoints + userStrategyPoints + seLinuxStrategyPoints
+			scc := newSCC(true, seLinuxStrategy, userStrategy)
+			actualPoints := pointValue(scc)
+
+			if actualPoints != expectedPoints {
+				t.Errorf("privileged, user: %v, seLinux %v expected %d score but got %d", userStrategy, seLinuxStrategy, expectedPoints, actualPoints)
+			}
+
+			expectedPoints = userStrategyPoints + seLinuxStrategyPoints
+			scc = newSCC(false, seLinuxStrategy, userStrategy)
+			actualPoints = pointValue(scc)
+
+			if actualPoints != expectedPoints {
+				t.Errorf("non privileged, user: %v, seLinux %v expected %d score but got %d", userStrategy, seLinuxStrategy, expectedPoints, actualPoints)
+			}
+		}
+	}
+
+	// sanity check to ensure volume score is added (specific volumes scores are tested below
+	scc := newSCC(false, kapi.SELinuxStrategyMustRunAs, kapi.RunAsUserStrategyMustRunAs)
+	scc.Volumes = []kapi.FSType{kapi.FSTypeHostPath}
+	actualPoints := pointValue(scc)
+	if actualPoints != 12 { //1 (SELinux) + 1 (User) + 10 (host path volume)
+		t.Errorf("volume score was not added to the scc point value correctly!")
+	}
+}
+
+func TestVolumePointValue(t *testing.T) {
+	newSCC := func(host, nonTrivial, trivial bool) *kapi.SecurityContextConstraints {
+		volumes := []kapi.FSType{}
+		if host {
+			volumes = append(volumes, kapi.FSTypeHostPath)
+		}
+		if nonTrivial {
+			volumes = append(volumes, kapi.FSTypeAWSElasticBlockStore)
+		}
+		if trivial {
+			volumes = append(volumes, kapi.FSTypeSecret)
+		}
+		return &kapi.SecurityContextConstraints{
+			Volumes: volumes,
+		}
+	}
+
+	allowAllSCC := &kapi.SecurityContextConstraints{
+		Volumes: []kapi.FSType{kapi.FSTypeAll},
+	}
+	nilVolumeSCC := &kapi.SecurityContextConstraints{}
+
+	tests := map[string]struct {
+		scc            *kapi.SecurityContextConstraints
+		expectedPoints int
+	}{
+		"all volumes": {
+			scc:            allowAllSCC,
+			expectedPoints: 10,
+		},
+		"host volume": {
+			scc:            newSCC(true, false, false),
+			expectedPoints: 10,
+		},
+		"host volume and non trivial volumes": {
+			scc:            newSCC(true, true, false),
+			expectedPoints: 10,
+		},
+		"host volume, non trivial, and trivial": {
+			scc:            newSCC(true, true, true),
+			expectedPoints: 10,
+		},
+		"non trivial": {
+			scc:            newSCC(false, true, false),
+			expectedPoints: 5,
+		},
+		"non trivial and trivial": {
+			scc:            newSCC(false, true, true),
+			expectedPoints: 5,
+		},
+		"trivial": {
+			scc:            newSCC(false, false, true),
+			expectedPoints: 0,
+		},
+		"trivial - secret": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSTypeSecret},
+			},
+			expectedPoints: 0,
+		},
+		"trivial - configMap": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSTypeConfigMap},
+			},
+			expectedPoints: 0,
+		},
+		"trivial - emptyDir": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSTypeEmptyDir},
+			},
+			expectedPoints: 0,
+		},
+		"trivial - downwardAPI": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSTypeDownwardAPI},
+			},
+			expectedPoints: 0,
+		},
+		"no volumes allowed": {
+			scc:            newSCC(false, false, false),
+			expectedPoints: 0,
+		},
+		"nil volumes": {
+			scc:            nilVolumeSCC,
+			expectedPoints: 0,
+		},
+	}
+	for k, v := range tests {
+		actualPoints := volumePointValue(v.scc)
+		if actualPoints != v.expectedPoints {
+			t.Errorf("%s expected %d volume score but got %d", k, v.expectedPoints, actualPoints)
+		}
+	}
+}


### PR DESCRIPTION
Add full volume control to SCC.  In upstream PSP we have proposed using a Volumes slice on the SCC to control volumes.  This introduces that attribute to the SCC

Fixes https://github.com/openshift/origin/issues/7630

Important: 

1.  ~~the comment on PSP was that if the slice was empty you are allowing all volumes.  This is not the case in this PR.  I think we can argue against it upstream if need be.  Nothing has been implemented yet to enforce it in kube.~~ updated defaulting to consider `nil` as allowing all volumes, empty allows none based on feedback
1.  please take note of how the interaction with `Allow*` fields works in conversions and defaulters

Open Questions

1.  ~~Can we retcon the addition of `AllowEmptyDir` in the SCC?  It was added and tagged in 1.1.3 but nothing was noted in the release for it.  I'd like to just rip it out if possible.  For now I've included the conversion code for it.~~ removed

- [x] types
- [x] conversions, generation, and defaulting
- [x] enforcement in the provider
- [x] bootstrap settings

@smarterclayton @liggitt @pmorie @childsb @eparis 