### PR TITLE
Change build button label from just "Cancel" to "Cancel Build"

### DIFF
--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -25,7 +25,7 @@
                   <!-- Primary Actions -->
                   <button class="btn btn-default hidden-xs"
                           ng-click="cancelBuild()"
-                          ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel</button>
+                          ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel Build</button>
                   <button class="btn btn-default hidden-xs"
                           ng-click="cloneBuild()"
                           ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)"
@@ -44,7 +44,7 @@
                         class="visible-xs-inline">
                       <a href=""
                          role="button"
-                         ng-click="cancelBuild()">Cancel</a>
+                         ng-click="cancelBuild()">Cancel Build</a>
                     </li>
                     <li class="visible-xs-inline"
                         ng-class="{ disabled: !canBuild }"


### PR DESCRIPTION
Change the button text is it's more obvious what it does. "Cancel" is usually safe to click, but on this page, it stops the build. "Cancel Build" also mirrors "Start Build" on the build config page.

<img width="260" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13340894/f074e662-dc01-11e5-965e-cec3c299f459.png">

@jwforres 