### PR TITLE
check covers for role changes

### DIFF
--- a/pkg/authorization/api/v1/defaults.go
+++ b/pkg/authorization/api/v1/defaults.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	internal "github.com/openshift/origin/pkg/authorization/api"
+)
+
+var oldAllowAllPolicyRule = PolicyRule{APIGroups: nil, Verbs: []string{internal.VerbAll}, Resources: []string{internal.ResourceAll}}
+
+func addDefaultingFuncs(scheme *runtime.Scheme) {
+	err := scheme.AddDefaultingFuncs(
+		func(obj *PolicyRule) {
+			if obj == nil {
+				return
+			}
+
+			// this seems really strange, but semantic equality checks most of what we want, but nil == {}
+			// this is ok for the restof the fields, but not APIGroups
+			if kapi.Semantic.Equalities.DeepEqual(oldAllowAllPolicyRule, *obj) && obj.APIGroups == nil {
+				obj.APIGroups = []string{internal.APIGroupAll}
+			}
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/authorization/api/v1/register.go
+++ b/pkg/authorization/api/v1/register.go
@@ -13,6 +13,7 @@ var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1
 func AddToScheme(scheme *runtime.Scheme) {
 	addKnownTypes(scheme)
 	addConversionFuncs(scheme)
+	addDefaultingFuncs(scheme)
 }
 
 // Adds the list of known types to api.Scheme.

--- a/pkg/authorization/api/v1beta3/defaults.go
+++ b/pkg/authorization/api/v1beta3/defaults.go
@@ -1,0 +1,29 @@
+package v1beta3
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	internal "github.com/openshift/origin/pkg/authorization/api"
+)
+
+var oldAllowAllPolicyRule = PolicyRule{APIGroups: nil, Verbs: []string{internal.VerbAll}, Resources: []string{internal.ResourceAll}}
+
+func addDefaultingFuncs(scheme *runtime.Scheme) {
+	err := scheme.AddDefaultingFuncs(
+		func(obj *PolicyRule) {
+			if obj == nil {
+				return
+			}
+
+			// this seems really strange, but semantic equality checks most of what we want, but nil == {}
+			// this is ok for the restof the fields, but not APIGroups
+			if kapi.Semantic.Equalities.DeepEqual(oldAllowAllPolicyRule, *obj) && obj.APIGroups == nil {
+				obj.APIGroups = []string{internal.APIGroupAll}
+			}
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -13,6 +13,7 @@ var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1
 func AddToScheme(scheme *runtime.Scheme) {
 	addKnownTypes(scheme)
 	addConversionFuncs(scheme)
+	addDefaultingFuncs(scheme)
 }
 
 // Adds the list of known types to api.Scheme.

--- a/pkg/authorization/registry/clusterrole/registry.go
+++ b/pkg/authorization/registry/clusterrole/registry.go
@@ -27,6 +27,11 @@ type Storage interface {
 	rest.Lister
 	rest.CreaterUpdater
 	rest.GracefulDeleter
+
+	// CreateRoleWithEscalation creates a new policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
+	CreateRoleWithEscalation(ctx kapi.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, error)
+	// UpdateRoleWithEscalation updates a policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
+	UpdateRoleWithEscalation(ctx kapi.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, bool, error)
 }
 
 // storage puts strong typing around storage calls

--- a/pkg/authorization/registry/role/registry.go
+++ b/pkg/authorization/registry/role/registry.go
@@ -27,6 +27,11 @@ type Storage interface {
 	rest.Lister
 	rest.CreaterUpdater
 	rest.GracefulDeleter
+
+	// CreateRoleWithEscalation creates a new policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
+	CreateRoleWithEscalation(ctx kapi.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, error)
+	// UpdateRoleWithEscalation updates a policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
+	UpdateRoleWithEscalation(ctx kapi.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, bool, error)
 }
 
 // storage puts strong typing around storage calls

--- a/pkg/authorization/rulevalidation/user_covers.go
+++ b/pkg/authorization/rulevalidation/user_covers.go
@@ -1,0 +1,45 @@
+package rulevalidation
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationinterfaces "github.com/openshift/origin/pkg/authorization/interfaces"
+)
+
+func ConfirmNoEscalation(ctx kapi.Context, ruleResolver AuthorizationRuleResolver, role authorizationinterfaces.Role) error {
+	ruleResolutionErrors := []error{}
+
+	ownerLocalRules, err := ruleResolver.GetEffectivePolicyRules(ctx)
+	if err != nil {
+		// do not fail in this case.  Rules are purely additive, so we can continue with a coverage check based on the rules we have
+		user, _ := kapi.UserFrom(ctx)
+		glog.V(1).Infof("non-fatal error getting local rules for %v: %v", user, err)
+		ruleResolutionErrors = append(ruleResolutionErrors, err)
+	}
+	masterContext := kapi.WithNamespace(ctx, "")
+	ownerGlobalRules, err := ruleResolver.GetEffectivePolicyRules(masterContext)
+	if err != nil {
+		// do not fail in this case.  Rules are purely additive, so we can continue with a coverage check based on the rules we have
+		user, _ := kapi.UserFrom(ctx)
+		glog.V(1).Infof("non-fatal error getting global rules for %v: %v", user, err)
+		ruleResolutionErrors = append(ruleResolutionErrors, err)
+	}
+
+	ownerRules := make([]authorizationapi.PolicyRule, 0, len(ownerGlobalRules)+len(ownerLocalRules))
+	ownerRules = append(ownerRules, ownerLocalRules...)
+	ownerRules = append(ownerRules, ownerGlobalRules...)
+
+	ownerRightsCover, missingRights := Covers(ownerRules, role.Rules())
+	if !ownerRightsCover {
+		user, _ := kapi.UserFrom(ctx)
+		return kapierrors.NewUnauthorized(fmt.Sprintf("attempt to grant extra privileges: %v user=%v ownerrules=%v ruleResolutionErrors=%v", missingRights, user, ownerRules, ruleResolutionErrors))
+	}
+
+	return nil
+}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -131,7 +131,7 @@ os::cmd::expect_success 'oc delete clusterrole/cluster-status --cascade=false'
 os::cmd::expect_failure 'oc get clusterrole/cluster-status'
 os::cmd::expect_success 'oadm policy reconcile-cluster-roles'
 os::cmd::expect_failure 'oc get clusterrole/cluster-status'
-os::cmd::expect_success 'oadm policy reconcile-cluster-roles --confirm'
+os::cmd::expect_success 'oadm policy reconcile-cluster-roles --confirm --loglevel=8'
 os::cmd::expect_success 'oc get clusterrole/cluster-status'
 # check the reconcile again with a specific cluster role name
 os::cmd::expect_success 'oc delete clusterrole/cluster-status --cascade=false'

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -34,4 +34,36 @@ os::cmd::expect_success_and_not_text 'oc get rolebinding/cluster-admin --no-head
 
 os::cmd::expect_success 'oc policy remove-group system:unauthenticated'
 os::cmd::expect_success 'oc policy remove-user system:no-user'
+
+# adjust the cluster-admin role to check defaulting and coverage checks
+# this is done here instead of an integration test because we need to make sure the actual yaml serializations work
+workingdir=$(mktemp -d --suffix=policy)
+cp ${OS_ROOT}/test/fixtures/bootstrappolicy/cluster_admin_1.0.yaml ${workingdir}
+os::util::sed "s/RESOURCE_VERSION//g" ${workingdir}/cluster_admin_1.0.yaml
+os::cmd::expect_success "oc create -f ${workingdir}/cluster_admin_1.0.yaml"
+os::cmd::expect_success 'oadm policy add-cluster-role-to-user alternate-cluster-admin alternate-cluster-admin-user'
+
+# switch to test user to be sure that default project admin policy works properly
+new_kubeconfig="${workingdir}/tempconfig"
+os::cmd::expect_success "oc config view --raw > $new_kubeconfig"
+os::cmd::expect_success "oc login -u alternate-cluster-admin-user -p anything --config=${new_kubeconfig}"
+
+# alternate-cluster-admin should default to having star rights, so he should be able to update his role to that
+resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+cp ${OS_ROOT}/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml ${workingdir}
+os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_cluster_admin.yaml
+os::cmd::expect_success "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml"
+
+# alternate-cluster-admin can restrict himself to no groups
+resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+cp ${OS_ROOT}/test/fixtures/bootstrappolicy/cluster_admin_without_apigroups.yaml ${workingdir}
+os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/cluster_admin_without_apigroups.yaml
+os::cmd::expect_success "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/cluster_admin_without_apigroups.yaml"
+
+# alternate-cluster-admin should NOT have the power add back star now
+resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+cp ${OS_ROOT}/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml ${workingdir}
+os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_cluster_admin.yaml
+os::cmd::expect_failure_and_text "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml" "attempt to grant extra privileges"
+
 echo "policy: ok"

--- a/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml
+++ b/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: alternate-cluster-admin
+  resourceVersion: "RESOURCE_VERSION"
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'

--- a/test/fixtures/bootstrappolicy/cluster_admin_1.0.yaml
+++ b/test/fixtures/bootstrappolicy/cluster_admin_1.0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: alternate-cluster-admin
+  resourceVersion: "RESOURCE_VERSION"
+rules:
+- attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'

--- a/test/fixtures/bootstrappolicy/cluster_admin_without_apigroups.yaml
+++ b/test/fixtures/bootstrappolicy/cluster_admin_without_apigroups.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: alternate-cluster-admin
+  resourceVersion: "RESOURCE_VERSION"
+rules:
+- apiGroups: []
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups: null
+  attributeRestrictions: null
+  nonResourceURLs:
+  - '*'
+  resources: []
+  verbs:
+  - '*'


### PR DESCRIPTION
Prevents escalation through role manipulation post binding after being explicitly granted the power to bind local roles by the cluster-admin.

Also updates defaulting so that `* on *.nil` is now `* on *.*`.