### PR TITLE
Improve Dockerfile keyword highlighting in web console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -94,6 +94,7 @@
     <script src="bower_components/ace-builds/src-min-noconflict/ace.js"></script>
     <script src="bower_components/ace-builds/src-min-noconflict/mode-yaml.js"></script>
     <script src="bower_components/ace-builds/src-min-noconflict/mode-dockerfile.js"></script>
+    <script src="bower_components/ace-builds/src-min-noconflict/theme-dreamweaver.js"></script>
     <script src="bower_components/ace-builds/src-min-noconflict/theme-eclipse.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/yamljs/bin/yaml.js"></script>

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -773,8 +773,8 @@ a.disabled-link {
   }
 }
 
-// Disable numeric highlighting in YAML because of bugs
-.editor.yaml-mode .ace_constant.ace_numeric {
+// Disable numeric highlighting in YAML and Dockerfile modes because of bugs
+.editor.yaml-mode .ace_constant.ace_numeric, .ace_editor.dockerfile-mode .ace_constant.ace_numeric {
   color: inherit;
 }
 

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -215,7 +215,7 @@
                                     <dt>Dockerfile:</dt><dd></dd>
                                     <div ui-ace="{
                                       mode: 'dockerfile',
-                                      theme: 'eclipse',
+                                      theme: 'dreamweaver',
                                       onLoad: aceLoaded,
                                       rendererOptions: {
                                         fadeFoldWidgets: true,

--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -79,7 +79,7 @@
                             <label for="buildFrom">Dockerfile</label>
                               <div ui-ace="{
                                 mode: 'dockerfile',
-                                theme: 'eclipse',
+                                theme: 'dreamweaver',
                                 onLoad: aceLoaded,
                                 rendererOptions: {
                                   fadeFoldWidgets: true,

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -88,6 +88,7 @@
         "src-min-noconflict/ace.js",
         "src-min-noconflict/mode-yaml.js",
         "src-min-noconflict/mode-dockerfile.js",
+        "src-min-noconflict/theme-dreamweaver.js",
         "src-min-noconflict/theme-eclipse.js"
       ]
     },


### PR DESCRIPTION
Switch Ace editor themes for Dockerfiles so more keywords are highlighted.

![openshift_web_console_and_openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/13360134/aaeff166-dc85-11e5-92c2-ecfc00995c69.png)

/cc @jhadvig @jwforres 