### PR TITLE
UPSTREAM: <drop>: patch for 16146: Fix validate event for non-namespa…

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/events.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/events.go
@@ -38,9 +38,9 @@ func ValidateEvent(event *api.Event) field.ErrorList {
 	// Suppose them are namespaced. Do check if we can get the piece of information.
 	// This should apply to all groups served by this apiserver.
 	namespacedKindFlag, err := isNamespacedKind(event.InvolvedObject.Kind, event.InvolvedObject.APIVersion)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("involvedObject", "kind"), event.InvolvedObject.Kind, fmt.Sprintf("couldn't check whether namespace is allowed: %s", err)))
-	} else {
+
+	// if we don't know whether this type is namespace or not, don't fail the event.  We shouldn't assume that we know about every type in the universe
+	if err == nil {
 		if !namespacedKindFlag &&
 			event.Namespace != api.NamespaceDefault &&
 			event.Namespace != "" {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/events_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/events_test.go
@@ -87,7 +87,7 @@ func TestValidateEvent(t *testing.T) {
 					Namespace:  api.NamespaceDefault,
 				},
 			},
-			false,
+			true,
 		}, {
 			&api.Event{
 				ObjectMeta: api.ObjectMeta{
@@ -126,7 +126,7 @@ func TestValidateEvent(t *testing.T) {
 					Namespace:  "foo",
 				},
 			},
-			false,
+			true,
 		}, {
 			&api.Event{
 				ObjectMeta: api.ObjectMeta{
@@ -139,8 +139,7 @@ func TestValidateEvent(t *testing.T) {
 					Namespace:  "foo",
 				},
 			},
-			// this will be invalid based on there not being an "other" group registered
-			false,
+			true,
 		}, {
 			&api.Event{
 				ObjectMeta: api.ObjectMeta{
@@ -153,7 +152,7 @@ func TestValidateEvent(t *testing.T) {
 					Namespace:  "foo",
 				},
 			},
-			false,
+			true,
 		}, {
 			&api.Event{
 				ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
…ced kinds

Fixes https://github.com/openshift/origin/issues/7437

Relaxes the restriction on knowing every type.  Comment made on upstream pull which is still open.

@pweil- @ncdc 