### PR TITLE
make all alias correctly

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -31,16 +31,6 @@ var originTypes map[unversioned.GroupVersionKind]bool
 // but that is not onerous
 var originTypesLock sync.Once
 
-// UserResources are the resource names that apply to the primary, user facing resources used by
-// client tools. They are in deletion-first order - dependent resources should be last.
-var UserResources = []string{
-	"buildConfigs", "builds",
-	"imageStreams",
-	"deploymentConfigs", "replicationControllers",
-	"routes", "services",
-	"pods",
-}
-
 // OriginKind returns true if OpenShift owns the GroupVersionKind.
 func OriginKind(gvk unversioned.GroupVersionKind) bool {
 	return getOrCreateOriginKinds()[gvk]

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"net/url"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// DiscoveryClient implements the functions that dicovery server-supported API groups,
+// versions and resources.
+type DiscoveryClient struct {
+	*kclient.DiscoveryClient
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (d *DiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (resources *unversioned.APIResourceList, err error) {
+	// we don't expose this version
+	if groupVersion == "v1beta3" {
+		return &unversioned.APIResourceList{}, nil
+	}
+
+	parentList, err := d.DiscoveryClient.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return parentList, err
+	}
+
+	if groupVersion != "v1" {
+		return parentList, nil
+	}
+
+	// we request v1, we must combine the parent list with the list from /oapi
+
+	url := url.URL{}
+	url.Path = "/oapi/" + groupVersion
+	originResources := &unversioned.APIResourceList{}
+	err = d.Get().AbsPath(url.String()).Do().Into(originResources)
+	if err != nil {
+		// ignore 403 or 404 error to be compatible with an v1.0 server.
+		if groupVersion == "v1" && (errors.IsNotFound(err) || errors.IsForbidden(err)) {
+			return parentList, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	parentList.APIResources = append(parentList.APIResources, originResources.APIResources...)
+	return parentList, nil
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+func (d *DiscoveryClient) ServerResources() (map[string]*unversioned.APIResourceList, error) {
+	apiGroups, err := d.ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+	groupVersions := kclient.ExtractGroupVersions(apiGroups)
+	result := map[string]*unversioned.APIResourceList{}
+	for _, groupVersion := range groupVersions {
+		resources, err := d.ServerResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			return nil, err
+		}
+		result[groupVersion] = resources
+	}
+	return result, nil
+}
+
+// New creates a new DiscoveryClient for the given RESTClient.
+func NewDiscoveryClient(c *kclient.RESTClient) *DiscoveryClient {
+	return &DiscoveryClient{kclient.NewDiscoveryClient(c)}
+}

--- a/pkg/cmd/util/clientcmd/cached_discovery.go
+++ b/pkg/cmd/util/clientcmd/cached_discovery.go
@@ -1,0 +1,136 @@
+package clientcmd
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// CachedDiscoveryClient implements the functions that dicovery server-supported API groups,
+// versions and resources.
+type CachedDiscoveryClient struct {
+	kclient.DiscoveryInterface
+
+	// cacheDirectory is the directory where discovery docs are held.  It must be unique per host:port combination to work well.
+	cacheDirectory string
+
+	// ttl is how long the cache should be considered valid
+	ttl time.Duration
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*unversioned.APIResourceList, error) {
+	filename := filepath.Join(d.cacheDirectory, groupVersion, "serverresources.json")
+	cachedBytes, err := d.getCachedFile(filename)
+	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
+	if err == nil {
+		cachedResources := &unversioned.APIResourceList{}
+		if err := runtime.DecodeInto(kapi.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
+			glog.V(6).Infof("returning cached discovery info from %v", filename)
+			return cachedResources, nil
+		}
+	}
+
+	liveResources, err := d.DiscoveryInterface.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return liveResources, err
+	}
+
+	if err := d.writeCachedFile(filename, liveResources); err != nil {
+		glog.V(3).Infof("failed to write cache to %v due to %v", filename, err)
+	}
+
+	return liveResources, nil
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+func (d *CachedDiscoveryClient) ServerResources() (map[string]*unversioned.APIResourceList, error) {
+	apiGroups, err := d.ServerGroups()
+	if err != nil {
+		return nil, err
+	}
+	groupVersions := kclient.ExtractGroupVersions(apiGroups)
+	result := map[string]*unversioned.APIResourceList{}
+	for _, groupVersion := range groupVersions {
+		resources, err := d.ServerResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			return nil, err
+		}
+		result[groupVersion] = resources
+	}
+	return result, nil
+}
+
+func (d *CachedDiscoveryClient) ServerGroups() (*unversioned.APIGroupList, error) {
+	filename := filepath.Join(d.cacheDirectory, "servergroups.json")
+	cachedBytes, err := d.getCachedFile(filename)
+	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
+	if err == nil {
+		cachedGroups := &unversioned.APIGroupList{}
+		if err := runtime.DecodeInto(kapi.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
+			glog.V(6).Infof("returning cached discovery info from %v", filename)
+			return cachedGroups, nil
+		}
+	}
+
+	liveGroups, err := d.DiscoveryInterface.ServerGroups()
+	if err != nil {
+		return liveGroups, err
+	}
+
+	if err := d.writeCachedFile(filename, liveGroups); err != nil {
+		glog.V(3).Infof("failed to write cache to %v due to %v", filename, err)
+	}
+
+	return liveGroups, nil
+}
+
+func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if time.Now().After(fileInfo.ModTime().Add(d.ttl)) {
+		return nil, errors.New("cache expired")
+	}
+
+	// the cache is present and its valid.  Try to read and use it.
+	cachedBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return cachedBytes, nil
+}
+
+func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Object) error {
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return err
+	}
+
+	bytes, err := runtime.Encode(kapi.Codecs.LegacyCodec(), obj)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, bytes, 0755)
+}
+
+// NewCachedDiscoveryClient creates a new DiscoveryClient.  cacheDirectory is the directory where discovery docs are held.  It must be unique per host:port combination to work well.
+func NewCachedDiscoveryClient(delegate kclient.DiscoveryInterface, cacheDirectory string, ttl time.Duration) *CachedDiscoveryClient {
+	return &CachedDiscoveryClient{DiscoveryInterface: delegate, cacheDirectory: cacheDirectory, ttl: ttl}
+}

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -167,7 +167,6 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		}
 		restMapper = meta.MultiRESTMapper(append(restMapper, groupMeta.RESTMapper))
 	}
-	mapper := ShortcutExpander{RESTMapper: kubectl.ShortcutExpander{RESTMapper: restMapper}}
 
 	clients := &clientCache{
 		clients: make(map[string]*client.Client),
@@ -182,16 +181,30 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 	}
 
 	w.Object = func() (meta.RESTMapper, runtime.ObjectTyper) {
+
+		defaultMapper := ShortcutExpander{RESTMapper: kubectl.ShortcutExpander{RESTMapper: restMapper}}
+		defaultTyper := api.Scheme
+
 		// Output using whatever version was negotiated in the client cache. The
 		// version we decode with may not be the same as what the server requires.
-		if cfg, err := clients.ClientConfigForVersion(nil); err == nil {
-			cmdApiVersion := unversioned.GroupVersion{}
-			if cfg.GroupVersion != nil {
-				cmdApiVersion = *cfg.GroupVersion
-			}
-			return kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []unversioned.GroupVersion{cmdApiVersion}}, api.Scheme
+		cfg, err := clients.ClientConfigForVersion(nil)
+		if err != nil {
+			return defaultMapper, defaultTyper
 		}
-		return mapper, api.Scheme
+
+		cmdApiVersion := unversioned.GroupVersion{}
+		if cfg.GroupVersion != nil {
+			cmdApiVersion = *cfg.GroupVersion
+		}
+
+		// at this point we've negotiated and can get the client
+		oclient, err := clients.ClientForVersion(nil)
+		if err != nil {
+			return defaultMapper, defaultTyper
+		}
+
+		mapper := NewShortcutExpander(client.NewDiscoveryClient(oclient.RESTClient), kubectl.ShortcutExpander{RESTMapper: restMapper})
+		return kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []unversioned.GroupVersion{cmdApiVersion}}, api.Scheme
 	}
 
 	kClientForMapping := w.Factory.ClientForMapping
@@ -579,76 +592,6 @@ func (f *Factory) OriginSwaggerSchema(client *kclient.RESTClient, version unvers
 		return nil, fmt.Errorf("got '%s': %v", string(body), err)
 	}
 	return &schema, nil
-}
-
-// ShortcutExpander is a RESTMapper that can be used for OpenShift resources.   It expands the resource first, then invokes the wrapped
-type ShortcutExpander struct {
-	RESTMapper meta.RESTMapper
-}
-
-var _ meta.RESTMapper = &ShortcutExpander{}
-
-func (e ShortcutExpander) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
-	return e.RESTMapper.KindFor(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) KindsFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
-	return e.RESTMapper.KindsFor(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
-	return e.RESTMapper.ResourcesFor(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
-	return e.RESTMapper.ResourceFor(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
-	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
-}
-
-func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) {
-	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
-}
-
-func (e ShortcutExpander) RESTMapping(gk unversioned.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	return e.RESTMapper.RESTMapping(gk, versions...)
-}
-
-// AliasesForResource returns whether a resource has an alias or not
-func (e ShortcutExpander) AliasesForResource(resource string) ([]string, bool) {
-	aliases := map[string][]string{
-		"all": latest.UserResources,
-	}
-
-	if res, ok := aliases[resource]; ok {
-		return res, true
-	}
-	return e.RESTMapper.AliasesForResource(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
-}
-
-// shortForms is the list of short names to their expanded names
-var shortForms = map[string]string{
-	"dc":      "deploymentconfigs",
-	"bc":      "buildconfigs",
-	"is":      "imagestreams",
-	"istag":   "imagestreamtags",
-	"isimage": "imagestreamimages",
-	"sa":      "serviceaccounts",
-	"pv":      "persistentvolumes",
-	"pvc":     "persistentvolumeclaims",
-}
-
-// expandResourceShortcut will return the expanded version of resource
-// (something that a pkg/api/meta.RESTMapper can understand), if it is
-// indeed a shortcut. Otherwise, will return resource unmodified.
-func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
-	if expanded, ok := shortForms[resource.Resource]; ok {
-		resource.Resource = expanded
-		return resource
-	}
-	return resource
 }
 
 // clientCache caches previously loaded clients for reuse. This is largely

--- a/pkg/cmd/util/clientcmd/factory_test.go
+++ b/pkg/cmd/util/clientcmd/factory_test.go
@@ -85,3 +85,53 @@ func TestClientConfigForVersion(t *testing.T) {
 		t.Fatalf("Expected to be called once getting a config for a new version, was called %d times", called)
 	}
 }
+
+func TestComputeDiscoverCacheDir(t *testing.T) {
+	testCases := []struct {
+		name      string
+		parentDir string
+		host      string
+
+		expected string
+	}{
+		{
+			name:      "simple append",
+			parentDir: "~/",
+			host:      "localhost:8443",
+			expected:  "~/localhost_8443",
+		},
+		{
+			name:      "with path",
+			parentDir: "~/",
+			host:      "localhost:8443/prefix",
+			expected:  "~/localhost_8443/prefix",
+		},
+		{
+			name:      "dotted name",
+			parentDir: "~/",
+			host:      "mine.example.org:8443",
+			expected:  "~/mine.example.org_8443",
+		},
+		{
+			name:      "IP",
+			parentDir: "~/",
+			host:      "127.0.0.1:8443",
+			expected:  "~/127.0.0.1_8443",
+		},
+		{
+			// restricted characters from: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions
+			// it's not a complete list because they have a very helpful: "Any other character that the target file system does not allow."
+			name:      "windows safe",
+			parentDir: "~/",
+			host:      `<>:"\|?*`,
+			expected:  "~/________",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := computeDiscoverCacheDir(tc.parentDir, tc.host)
+		if actual != tc.expected {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/cmd/util/clientcmd/shortcut_restmapper.go
+++ b/pkg/cmd/util/clientcmd/shortcut_restmapper.go
@@ -1,0 +1,126 @@
+package clientcmd
+
+import (
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// ShortcutExpander is a RESTMapper that can be used for OpenShift resources.   It expands the resource first, then invokes the wrapped
+type ShortcutExpander struct {
+	RESTMapper meta.RESTMapper
+
+	All []string
+}
+
+var _ meta.RESTMapper = &ShortcutExpander{}
+
+func NewShortcutExpander(discoveryClient kclient.DiscoveryInterface, delegate meta.RESTMapper) ShortcutExpander {
+	defaultMapper := ShortcutExpander{RESTMapper: delegate}
+
+	// this assumes that legacy kube versions and legacy origin versions are the same, probably fair
+	apiResources, err := discoveryClient.ServerResources()
+	if err != nil {
+		return defaultMapper
+	}
+
+	availableResources := []unversioned.GroupVersionResource{}
+	for groupVersionString, resourceList := range apiResources {
+		currVersion, err := unversioned.ParseGroupVersion(groupVersionString)
+		if err != nil {
+			return defaultMapper
+		}
+
+		for _, resource := range resourceList.APIResources {
+			availableResources = append(availableResources, currVersion.WithResource(resource.Name))
+		}
+	}
+
+	availableAll := []string{}
+	for _, requestedResource := range userResources {
+		for _, availableResource := range availableResources {
+			if requestedResource == availableResource.Resource {
+				availableAll = append(availableAll, requestedResource)
+				break
+			}
+		}
+	}
+
+	return ShortcutExpander{All: availableAll, RESTMapper: delegate}
+}
+
+func (e ShortcutExpander) KindFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionKind, error) {
+	return e.RESTMapper.KindFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) KindsFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionKind, error) {
+	return e.RESTMapper.KindsFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourcesFor(resource unversioned.GroupVersionResource) ([]unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourcesFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceFor(resource unversioned.GroupVersionResource) (unversioned.GroupVersionResource, error) {
+	return e.RESTMapper.ResourceFor(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceIsValid(resource unversioned.GroupVersionResource) bool {
+	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
+}
+
+func (e ShortcutExpander) ResourceSingularizer(resource string) (string, error) {
+	return e.RESTMapper.ResourceSingularizer(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+}
+
+func (e ShortcutExpander) RESTMapping(gk unversioned.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return e.RESTMapper.RESTMapping(gk, versions...)
+}
+
+// userResources are the resource names that apply to the primary, user facing resources used by
+// client tools. They are in deletion-first order - dependent resources should be last.
+var userResources = []string{
+	"buildconfigs", "builds",
+	"imagestreams",
+	"deploymentconfigs", "replicationcontrollers",
+	"routes", "services",
+	"pods",
+}
+
+// AliasesForResource returns whether a resource has an alias or not
+func (e ShortcutExpander) AliasesForResource(resource string) ([]string, bool) {
+	aliases := map[string][]string{
+		"all": userResources,
+	}
+	if len(e.All) != 0 {
+		aliases["all"] = e.All
+	}
+
+	if res, ok := aliases[resource]; ok {
+		return res, true
+	}
+	return e.RESTMapper.AliasesForResource(expandResourceShortcut(unversioned.GroupVersionResource{Resource: resource}).Resource)
+}
+
+// shortForms is the list of short names to their expanded names
+var shortForms = map[string]string{
+	"dc":      "deploymentconfigs",
+	"bc":      "buildconfigs",
+	"is":      "imagestreams",
+	"istag":   "imagestreamtags",
+	"isimage": "imagestreamimages",
+	"sa":      "serviceaccounts",
+	"pv":      "persistentvolumes",
+	"pvc":     "persistentvolumeclaims",
+}
+
+// expandResourceShortcut will return the expanded version of resource
+// (something that a pkg/api/meta.RESTMapper can understand), if it is
+// indeed a shortcut. Otherwise, will return resource unmodified.
+func expandResourceShortcut(resource unversioned.GroupVersionResource) unversioned.GroupVersionResource {
+	if expanded, ok := shortForms[resource.Resource]; ok {
+		resource.Resource = expanded
+		return resource
+	}
+	return resource
+}

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -22,6 +22,7 @@ os::log::install_errexit
 
 os::cmd::expect_success_and_text 'oc types' 'Deployment Configuration'
 os::cmd::expect_failure_and_text 'oc get' 'deploymentconfig'
+os::cmd::expect_success_and_text 'oc get all --loglevel=6' 'buildconfigs'
 os::cmd::expect_success_and_text 'oc explain pods' 'Pod is a collection of containers that can run on a host'
 os::cmd::expect_success_and_text 'oc explain pods.spec' 'SecurityContext holds pod-level security attributes'
 os::cmd::expect_success_and_text 'oc explain deploymentconfig' 'a desired deployment state'

--- a/test/integration/shortcut_expansion_test.go
+++ b/test/integration/shortcut_expansion_test.go
@@ -1,0 +1,60 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestFullExpansion(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mapper := clientcmd.NewShortcutExpander(client.NewDiscoveryClient(clusterAdminClient.RESTClient), nil)
+
+	if !sets.NewString(mapper.All...).Has("buildconfigs") {
+		t.Errorf("expected buildconfigs, got: %v", mapper.All)
+	}
+}
+
+func TestExpansionWithoutBuilds(t *testing.T) {
+	testutil.RequireEtcd(t)
+
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	masterConfig.DisabledFeatures = configapi.AtomicDisabledFeatures
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mapper := clientcmd.NewShortcutExpander(client.NewDiscoveryClient(clusterAdminClient.RESTClient), nil)
+
+	if sets.NewString(mapper.All...).Has("buildconfigs") {
+		t.Errorf("expected no buildconfigs, got: %v", mapper.All)
+	}
+}


### PR DESCRIPTION
This updates the `all` alias to actually mean what we want with respect to available resources.  There is refactoring needed upstream for purity, but we can delay that .  This doesn't change behavior of clients against old servers, so our client looks just as ugly if you're hitting an old atomic server.  This doesn't use a cache, but you can see where to plug it.

@smarterclayton @fabianofranz @liggitt 

Alternative to https://github.com/openshift/origin/pull/7634