### PR TITLE
Fix EmptyDir mounting for dind

### DIFF
--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -208,6 +208,11 @@ os::provision::base-provision() {
   local origin_root=$1
   local is_master=${2:-false}
 
+  # Ensure that secrets can be correctly mounted for pods.
+  if os::provision::in-container; then
+    mount --make-shared /
+  fi
+
   # Add a convenience symlink to the gopath repo
   ln -sf "${origin_root}" /
 

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -269,17 +269,15 @@ function stop() {
   # The container will have created configuration as root
   sudo rm -rf ${CONFIG_ROOT}/openshift.local.*
 
-  # Volume cleanup is not compatible with SELinux
-  check-selinux
-
   # Cleanup orphaned volumes
   #
   # See: https://github.com/jpetazzo/dind#important-warning-about-disk-usage
   #
   echo "Cleaning up volumes used by docker-in-docker daemons"
-  ${DOCKER_CMD} run -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes
-
+  local volume_ids=$(${DOCKER_CMD} volume ls -qf dangling=true)
+  if [[ "${volume_ids}" ]]; then
+    ${DOCKER_CMD} volume rm ${volume_ids}
+  fi
 }
 
 # Build and deploy openshift binaries to an existing cluster

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -32,9 +32,7 @@ NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services|EmptyDir volume
 NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 
 DEFAULT_SKIP_LIST=(
-  # Skip tests that require secrets.  Secrets are not supported by
-  # dind without docker >= 1.10.
-  "Networking should function for intra-pod"
+  # TODO(marun) This should work with docker >= 1.10
   "openshift router"
 
   # DNS inside container fails in CI but works locally

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -25,7 +25,10 @@ os::log::install_errexit
 NETWORKING_DEBUG=${NETWORKING_DEBUG:-false}
 
 # These strings filter the available tests.
-NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services}"
+#
+# The EmptyDir test is a canary; it will fail if mount propagation is
+# not properly configured on the host.
+NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services|EmptyDir volumes should support \(root,0644,tmpfs\)}"
 NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 
 DEFAULT_SKIP_LIST=(


### PR DESCRIPTION
Support for mount propagation is included in docker 1.10.  This fixes EmptyDir support for dind which allows secrets and the downward api to work correctly (#6589).

This patch was tested against upstream docker 1.10 on fedora 23.  It was necessary to remove MountFlags=private from the upstream provided /usr/lib/systemd/system/docker.service to allow the nested docker to use shared propogation on /.  

This PR should not be merged until the official docker 1.10 packages land in fedora 23.

[skuznets edit:]
fixes https://github.com/openshift/origin/issues/9279