### PR TITLE
Web Console: fix pod status, start & end times on pod page

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -6,6 +6,7 @@
   "camelcase": false,
   "curly": true,
   "eqeqeq": true,
+  "expr" : true,
   "immed": true,
   "indent": 2,
   "latedef": true,

--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -208,6 +208,7 @@
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/strings.js"></script>
         <script src="scripts/extensions/javaLink.js"></script>
         <script src="scripts/directives/affix.js"></script>
         <script src="scripts/services/logLinks.js"></script>

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -44,9 +44,6 @@ angular.module('openshiftConsole')
           name: '=',
           context: '=',
           options: '=?',
-          status: '=?',
-          timeStart: '=?',
-          timeEnd: '=?',
           chromeless: '=?',
           run: '=?'         // boolean, logs will not run until this is truthy
         },

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -861,18 +861,6 @@ angular.module('openshiftConsole')
       return portDisplayValue(servicePort.port, servicePort.targetPort, servicePort.protocol);
     };
   })
-  .filter('sentenceCase', function() {
-    // Converts a camel case string to sentence case
-    return function(str) {
-      if (!str) {
-        return str;
-      }
-
-      // Unfortunately, _.lowerCase() and _.upperFirst() aren't in our lodash version.
-      var lower = _.startCase(str).toLowerCase();
-      return lower.charAt(0).toUpperCase() + lower.slice(1);
-    };
-  })
   .filter('podStatus', function() {
     // Return results that match kubernetes/pkg/kubectl/resource_printer.go
     return function(pod) {
@@ -911,14 +899,14 @@ angular.module('openshiftConsole')
       });
 
       return reason;
-    };      
+    };
   })
   .filter('routeIngressCondition', function() {
     return function(ingress, type) {
       if (!ingress) {
         return null;
       }
-      return _.find(ingress.conditions, {type: type}); 
+      return _.find(ingress.conditions, {type: type});
     };
   })
   .filter('routeHost', function() {

--- a/assets/app/scripts/filters/strings.js
+++ b/assets/app/scripts/filters/strings.js
@@ -1,0 +1,19 @@
+'use strict';
+angular.module('openshiftConsole')
+  .filter('sentenceCase', function() {
+    // Converts a camel case string to sentence case
+    return function(str) {
+      if (!str) {
+        return str;
+      }
+
+      // Unfortunately, _.lowerCase() and _.upperFirst() aren't in our lodash version.
+      var lower = _.startCase(str).toLowerCase();
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    };
+  })
+  .filter('capitalize', function() {
+    return function(input) {
+      return _.capitalize(input);
+    };
+  });

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -96,6 +96,8 @@
   text-align: right;
   a {
     margin-left: 20px;
+    margin-right: 10px;
+    white-space: nowrap;
   }
   i {
     font-size: @font-size-xsmall;

--- a/assets/app/styles/_typography.less
+++ b/assets/app/styles/_typography.less
@@ -1,0 +1,50 @@
+/* force a space where it may collapse */
+.space-after:after {
+  content: "\00a0";
+}
+.space-before:before {
+  content: "\00a0";
+}
+
+/* Device specific text alignment classes.
+   - use with the basic align-left & align-right provided by bootstrap.
+   - example usage:
+     <div class="text-xs-left text-right">
+     would align text to left on mobile, else align right on other devices.
+ ---------------------------------------------------------------------------- */
+// extra small
+@media (max-width: @screen-xs-max) {
+  .text-xs-left {
+    text-align: left;
+  }
+  .text-xs-right {
+    text-align: right;
+  }
+}
+// small
+@media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  .text-sm-left {
+    text-align: left;
+  }
+  .text-sm-right {
+    text-align: right;
+  }
+}
+// medium
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  .text-md-left {
+    text-align: left;
+  }
+  .text-md-right {
+    text-align: right;
+  }
+}
+// large
+@media (min-width: @screen-lg-min) {
+  .text-lg-left {
+    text-align: left;
+  }
+  .text-lg-right {
+    text-align: right;
+  }
+}

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -84,4 +84,5 @@
 @import "_tables.less";
 @import "_tile.less";
 @import "_topology.less";
+@import "_typography.less";
 @import "_log.less";

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -105,10 +105,23 @@
                         name="build.metadata.name"
                         context="projectContext"
                         options="logOptions"
-                        status="build.status.phase"
-                        time-start="build.status.startTimestamp | date : 'short'"
-                        time-end="build.status.completionTimestamp | date : 'short'"
                         run="logCanRun">
+
+                        <div row cross-axis="center">
+                          <div>
+                            Build status:
+                            <status-icon status="build.status.phase"></status-icon>
+                            <span class="space-after">{{build.status.phase}}</span>
+
+                            <span ng-if="build.status.startTimestamp">
+                              &mdash; Log from {{build.status.startTimestamp  | date : 'short'}}
+                              <span ng-if="build.status.completionTimestamp">
+                                to {{build.status.completionTimestamp  | date : 'short'}}
+                              </span>
+                            </span>
+                          </div>
+                        </div>
+
                       </log-viewer>
                     </uib-tab>
                     <uib-tab active="selectedTab.events">

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -91,9 +91,23 @@
                       name="deploymentConfigName"
                       context="projectContext"
                       options="logOptions"
-                      status="deployment | deploymentStatus"
-                      time-start="deployment.metadata.creationTimestamp | date : 'short'"
                       run="logCanRun">
+
+                      <div row cross-axis="center">
+                        <div row>
+                          <div ng-if="deployment | deploymentStatus">
+                            Deployment status:
+                            <status-icon status="deployment | deploymentStatus"></status-icon>
+                            {{deployment | deploymentStatus}}
+                          </div>
+                          <div ng-if="deployment.metadata.creationTimestamp">
+                            <div ng-if="(deployment | deploymentStatus) !== 'Deployed'">
+                              &mdash; Log from {{deployment.metadata.creationTimestamp  | date : 'short'}}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
                     </log-viewer>
                   </uib-tab>
                   <uib-tab active="selectedTab.events">

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -96,15 +96,32 @@
                     </select>
 
                     <log-viewer
-                        ng-if="selectedTab.logs"
-                        follow-affix-top="390"
-                        follow-affix-bottom="90"
-                        resource="pods/log"
-                        name="pod.metadata.name"
-                        context="projectContext"
-                        options="logOptions"
-                        time-start="pod.status.startTime | date : 'short'"
-                        run="logCanRun">
+                      ng-if="selectedTab.logs"
+                      follow-affix-top="390"
+                      follow-affix-bottom="90"
+                      resource="pods/log"
+                      name="pod.metadata.name"
+                      context="projectContext"
+                      options="logOptions"
+                      run="logCanRun">
+
+                      <div row mobile="column" tablet="column">
+                        <div class="nowrap">
+                          Container status:
+                          <status-icon status="containerStateReason || containerStatusKey"></status-icon>
+                          <span class="space-after">{{containerStateReason || containerStatusKey | sentenceCase}}</span>
+                        </div>
+                        <div ng-if="containerStartTime">
+                          &mdash;
+                          <span ng-if="lasStatusKey">
+                            Last {{lasStatusKey}} log
+                          </span>
+                          <span ng-if="(!lasStatusKey)">Log</span>
+                            from {{containerStartTime  | date : 'short'}}
+                          <span ng-if="containerEndTime">to {{containerEndTime  | date : 'short'}}</span>
+                        </div>
+                      </div>
+
                     </log-viewer>
                   </uib-tab>
 

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,19 +1,23 @@
 <div
-  row class="log-timestamp"
-  ng-if="(!chromeless) && state=='logs' && timeStart">
-  <div>
-    <span>Current log from {{timeStart}}&nbsp;</span>
-    <span ng-if="end">to {{timeEnd}}</span>
-  </div>
-  <div flex></div>
-  <div ng-if="kibanaAuthUrl">
-    <form
-      action="{{kibanaAuthUrl}}"
-      method="POST">
-      <input type="hidden" name="redirect" value="{{kibanaArchiveUrl}}">
-      <input type="hidden" name="access_token" value="{{access_token}}">
-      <button class="btn btn-sm btn-primary">View Archive</button>
-    </form>
+  row
+  mobile="column"
+  tablet="column"
+  ng-if="(!chromeless)"
+  style="margin-bottom: 10px;">
+  <div ng-transclude flex><!-- expect start time, end time, status details --></div>
+  <div row class="text-right text-xs-left">
+    <a href="" ng-click="goChromeless(options)" style="margin-right: 10px;">
+      Open full view of log <i class="fa fa-external-link"></i>
+    </a>
+    <div ng-if="kibanaAuthUrl">
+      <form
+        action="{{kibanaAuthUrl}}"
+        method="POST">
+        <input type="hidden" name="redirect" value="{{kibanaArchiveUrl}}">
+        <input type="hidden" name="access_token" value="{{access_token}}">
+        <button class="btn btn-sm btn-primary">View Archive</button>
+      </form>
+    </div>
   </div>
 </div>
 
@@ -24,23 +28,6 @@
   messages will be displayed because of the large log size.
 </div>
 
-
-<div class="row" ng-if="(!chromeless)">
-  <div class="col-md-6 col-sm-12">
-    <span ng-if="status">
-      <span>Status:&nbsp;&nbsp;</span>
-      <status-icon status="status"></status-icon>
-      <span>{{status}}</span>
-    </span>
-  </div>
-  <div
-    class="log-link-external col-md-6 col-sm-12 text-right"
-    ng-if="state=='logs'">
-    <a href=""  ng-click="goChromeless(options)">
-      Open full view of log<i class="fa fa-external-link"></i>
-    </a>
-  </div>
-</div>
 
 <!-- show this spinner until the log viewer starts. important for pending state, etc -->
 <div row main-axis="center" ng-if="(!state)">


### PR DESCRIPTION
- fixes bug 1312218 (bugzilla)
- fixes #7646 
- fixes #7726 

- [x] Get the status for the container from the pod.status.containerStatuses, as well as startedAt and finishedAt, if available.  Status will only display if `running, waiting, terminated`.
- [x] Use containerStatus.state, fallback to containerStatus.lastState
- [x] Move the ` | date : 'short'` filter into the `_log_viewer.html` template (rather than in attribs)

@jwforres @spadgett 