### PR TITLE
focus includes file name

### DIFF
--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/spec/specs.go
@@ -72,7 +72,7 @@ func (e *Specs) applyRegExpFocus(description string, focusString string, skipStr
 		matchesFocus := true
 		matchesSkip := false
 
-		toMatch := []byte(description + " " + spec.ConcatenatedString())
+		toMatch := []byte(description + " " + spec.ConcatenatedString() + " " +spec.subject.CodeLocation().FileName)
 
 		if focusString != "" {
 			focusFilter := regexp.MustCompile(focusString)


### PR DESCRIPTION
Here's a one liner patch that we can carry that should make focus / dryrun filtering of upstream tests very easy to do, just `ginkgo.focus=k8s.io` .  Tested lightly looks to work properly

extended tests:
```
➜  origin git:(focus_file_name) ✗  KUBECONFIG=/opt/kubecfg /home/jayunit100/Development/gopath/src/github.com/openshift/origin/_output/local/bin/linux/amd64/extended.test --ginkgo.focus='extended' --ginkgo.dryRun=true ; 
Running Suite: Extended Core
============================
Random Seed: 1456687821
Will run 103 of 326 specs

SSSS••••••••••••••••••••••••••••••••••••SSSSSSSS•SS••••SS•••••••••SS•SSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSS•SSSSSSS••S•••SSSSSSSSSSSSSSSSSSSSSSSS••••••SSSSSSSS•SSSSSSSSSSSSS•••SS•S•••SSSSSS•S••SSS•••••••••SSSSSSSSSSS••S•••SS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••SSSSSSSS•••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•
Ran 103 of 326 Specs in 0.001 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 223 Skipped PASS
```

upstream tests
```
➜  origin git:(focus_file_name) ✗  KUBECONFIG=/opt/kubecfg /home/jayunit100/Development/gopath/src/github.com/openshift/origin/_output/local/bin/linux/amd64/extended.test --ginkgo.focus='e2e' --ginkgo.dryRun=true ;     
Running Suite: Extended Core
============================
Random Seed: 1456687828
Will run 223 of 326 specs

•S•••••••••SS••••••SSSSSSSSSSS••••••••SS•••S••••S••••••••••••••••••••••••••••SS••SSSSS••••••••SSSSSSSSS•••••••••••SSSS•••SS•••S•••••••••••••SSS••••S••••SS••••••••••••••••••••S•••••••••••••••••••••••••••••••S••••SSSS•••••••••••SS•••••••••••••••••••••••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••S•••••••SS•••••••••••••SSSSSSS
Ran 223 of 326 Specs in 0.002 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 103 Skipped PASS
```

Adding the `-v` arg gives you the whole list of everything.   

This would obviate the need for any synthetic skipping.

cc @smarterclayton  @timothysc 