### PR TITLE
Show better error when S2I builder is used with non-S2I strategy

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -91,6 +91,10 @@ func newS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient 
 
 // Build executes STI build based on configured builder, S2I builder factory and S2I config validator
 func (s *S2IBuilder) Build() error {
+	if s.build.Spec.Strategy.SourceStrategy == nil {
+		return fmt.Errorf("the source to image builder must be used with the source strategy")
+	}
+
 	var push bool
 
 	contextDir := filepath.Clean(s.build.Spec.Source.ContextDir)


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/7674

@smarterclayton @bparees this is my attempt to fix the panic when you use S2I builder image that include S2I builder binary with "custom" strategy. I haven't tried this yet (need to craft some build config).