### PR TITLE
Add .gitignore check for /pkg/**/*.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /examples/sample-app/openshift.local.*
 /examples/sample-app/logs/openshift.log
 /dind-*.rc
+/pkg/**/*.test
 *.swp
 .vimrc
 .vagrant-openshift.json*


### PR DESCRIPTION
This prevents accidentally adding the test droppings, without also
targeting valid source file
`/images/ipfailover/keepalived/makefile.test`