### PR TITLE
Pick correct strategy for binary builds

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -377,7 +377,7 @@ func (c *AppConfig) validate() (app.ComponentReferences, app.SourceRepositories,
 	b.AddGroups(c.Groups)
 	refs, repos, errs := b.Result()
 
-	if len(c.Strategy) != 0 && len(repos) == 0 {
+	if len(c.Strategy) != 0 && len(repos) == 0 && !c.BinaryBuild {
 		errs = append(errs, fmt.Errorf("when --strategy is specified you must provide at least one source code location"))
 	}
 
@@ -595,7 +595,8 @@ func (c *AppConfig) ensureHasSource(components app.ComponentReferences, reposito
 						continue
 					}
 					repo := app.NewBinarySourceRepository()
-					if c.Strategy == "docker" || len(c.Strategy) == 0 {
+					isBuilder := input.ResolvedMatch != nil && input.ResolvedMatch.Builder
+					if c.Strategy == "docker" || (len(c.Strategy) == 0 && !isBuilder) {
 						repo.BuildWithDocker()
 					}
 					input.Use(repo)

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -155,6 +155,12 @@ os::cmd::expect_failure_and_text 'oc new-build https://github.com/openshift/node
 # but succeed with multiple intput repos and no output image specified
 os::cmd::expect_success 'oc new-build https://github.com/openshift/nodejs-ex https://github.com/openshift/ruby-ex -o yaml'
 
+# check that binary build with a builder image results in a source type build
+os::cmd::expect_success_and_text 'oc new-build --binary --image=ruby -o yaml' 'type: Source'
+
+# check that binary build with a specific strategy uses that strategy regardless of the image type
+os::cmd::expect_success_and_text 'oc new-build --binary --image=ruby --strategy=docker -o yaml' 'type: Docker'
+
 os::cmd::expect_success 'oc delete imageStreams --all'
 
 # check that we can create from the template without errors


### PR DESCRIPTION
For binary builds, default to source if passed in a builder image. 
Allow the strategy flag to override the type of binary build to create.

Fixes BZ 1312477