### PR TITLE
Add quota information to oc describe image stream

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -29,6 +29,7 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
+
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
@@ -41,7 +42,7 @@ func describerMap(c *client.Client, kclient kclient.Interface, host string) map[
 		deployapi.Kind("DeploymentConfig"):            NewDeploymentConfigDescriber(c, kclient),
 		authorizationapi.Kind("Identity"):             &IdentityDescriber{c},
 		imageapi.Kind("Image"):                        &ImageDescriber{c},
-		imageapi.Kind("ImageStream"):                  &ImageStreamDescriber{c},
+		imageapi.Kind("ImageStream"):                  &ImageStreamDescriber{c, kclient},
 		imageapi.Kind("ImageStreamTag"):               &ImageStreamTagDescriber{c},
 		imageapi.Kind("ImageStreamImage"):             &ImageStreamImageDescriber{c},
 		routeapi.Kind("Route"):                        &RouteDescriber{c, kclient},
@@ -586,12 +587,13 @@ func (d *ImageStreamImageDescriber) Describe(namespace, name string) (string, er
 
 // ImageStreamDescriber generates information about a ImageStream
 type ImageStreamDescriber struct {
-	client.Interface
+	OSClient   client.Interface
+	KubeClient kclient.Interface
 }
 
 // Describe returns the description of an imageStream
 func (d *ImageStreamDescriber) Describe(namespace, name string) (string, error) {
-	c := d.ImageStreams(namespace)
+	c := d.OSClient.ImageStreams(namespace)
 	imageStream, err := c.Get(name)
 	if err != nil {
 		return "", err
@@ -600,6 +602,7 @@ func (d *ImageStreamDescriber) Describe(namespace, name string) (string, error) 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
 		formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
+		formatImageStreamQuota(out, d.OSClient, d.KubeClient, imageStream)
 		formatImageStreamTags(out, imageStream)
 		return nil
 	})

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -121,7 +121,7 @@ func TestDescribers(t *testing.T) {
 		&BuildDescriber{c, fakeKube},
 		&BuildConfigDescriber{c, ""},
 		&ImageDescriber{c},
-		&ImageStreamDescriber{c},
+		&ImageStreamDescriber{c, fakeKube},
 		&ImageStreamTagDescriber{c},
 		&ImageStreamImageDescriber{c},
 		&RouteDescriber{c, fakeKube},

--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -11,12 +11,15 @@ import (
 	"github.com/docker/docker/pkg/units"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	imagequota "github.com/openshift/origin/pkg/quota/image"
 )
 
 const emptyString = "<none>"
@@ -300,4 +303,54 @@ func formatImageStreamTags(out *tabwriter.Writer, stream *imageapi.ImageStream) 
 			fmt.Fprintf(out, "  ! tag is insecure and can be imported over HTTP or self-signed HTTPS\n")
 		}
 	}
+}
+
+func formatImageStreamQuota(out *tabwriter.Writer, c client.Interface, kc kclient.Interface, stream *imageapi.ImageStream) {
+	quotas, err := kc.ResourceQuotas(stream.Namespace).List(api.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	var limit *resource.Quantity
+	for _, item := range quotas.Items {
+		// search for smallest ImageStream quota
+		if value, ok := item.Spec.Hard[imageapi.ResourceImageStreamSize]; ok {
+			if limit == nil || limit.Cmp(value) > 0 {
+				limit = &value
+			}
+		}
+	}
+	if limit != nil {
+		quantity := imagequota.GetImageStreamSize(c, stream, make(map[string]*imageapi.Image))
+		scale := mega
+		if quantity.Value() >= (1<<giga.scale) || limit.Value() >= (1<<giga.scale) {
+			scale = giga
+		}
+		formatString(out, "Quota Usage", fmt.Sprintf("%s / %s",
+			formatQuantity(quantity, scale), formatQuantity(limit, scale)))
+	}
+}
+
+type scale struct {
+	scale uint64
+	unit  string
+}
+
+var (
+	mega = scale{20, "MiB"}
+	giga = scale{30, "GiB"}
+)
+
+// formatQuantity prints quantity according to passed scale. Manual scaling was
+// done here to make sure we print correct binary values for quantity.
+func formatQuantity(quantity *resource.Quantity, scale scale) string {
+	integer := quantity.Value() >> scale.scale
+	// fraction is the reminder of a division shifted by one order of magnitude
+	fraction := (quantity.Value() % (1 << scale.scale)) >> (scale.scale - 10)
+	// additionally we present only 2 digits after dot, so divide by 10
+	fraction = fraction / 10
+	if fraction > 0 {
+		return fmt.Sprintf("%d.%02d%s", integer, fraction, scale.unit)
+	}
+	return fmt.Sprintf("%d%s", integer, scale.unit)
 }

--- a/pkg/cmd/cli/describe/helpers_test.go
+++ b/pkg/cmd/cli/describe/helpers_test.go
@@ -6,9 +6,11 @@ import (
 	"text/tabwriter"
 	"time"
 
-	imageapi "github.com/openshift/origin/pkg/image/api"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 func TestFormatImageStreamTags(t *testing.T) {
@@ -78,4 +80,46 @@ func TestFormatImageStreamTags(t *testing.T) {
 	out.Flush()
 	actual := string(buf.String())
 	t.Logf("\n%s", actual)
+}
+
+func TestFormatQuantity(t *testing.T) {
+	testCases := []struct {
+		value    int64
+		scale    scale
+		expected string
+	}{
+		{
+			value:    1 << 30,
+			scale:    giga,
+			expected: "1GiB",
+		},
+		{
+			value:    1 << 20,
+			scale:    mega,
+			expected: "1MiB",
+		},
+		{
+			value:    10 * (1 << 20),
+			scale:    giga,
+			expected: "0.01GiB",
+		},
+		{
+			value:    (1 << 30) + (1 << 20),
+			scale:    giga,
+			expected: "1GiB",
+		},
+		{
+			value:    (1 << 30) + 10*(1<<20),
+			scale:    giga,
+			expected: "1.01GiB",
+		},
+	}
+
+	for idx, test := range testCases {
+		quantity := resource.NewQuantity(test.value, resource.BinarySI)
+		actual := formatQuantity(quantity, test.scale)
+		if actual != test.expected {
+			t.Errorf("(%d) expected '%s', got '%s'", idx, test.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
This is the client side of my [card](https://trello.com/c/L9Coo2Zi/425-5-admin-can-understand-manage-image-use). It adds information about current usage of image stream quota (iff one is defined), sample output:
```
$ oc describe is/redis -n test
...
Quota usage:		152Mi / 525Mi
```

Depends on #7128.



@miminar @pweil- @openshift/ui-review ptal (just the last commit)