### PR TITLE
Set source of incremental build artifacts

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -834,47 +834,47 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "41947800efb9fb7f5c3a13e977d26ac0815fa4fb"
+			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/describe/describer.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/describe/describer.go
@@ -40,6 +40,7 @@ func DescribeConfig(config *api.Config) string {
 		}
 		fmt.Fprintf(out, "Remove Old Build:\t%s\n", printBool(config.RemovePreviousImage))
 		fmt.Fprintf(out, "Builder Pull Policy:\t%s\n", config.BuilderPullPolicy)
+		fmt.Fprintf(out, "Previous Image Pull Policy:\t%s\n", config.PreviousImagePullPolicy)
 		fmt.Fprintf(out, "Quiet:\t%s\n", printBool(config.Quiet))
 		fmt.Fprintf(out, "Layered Build:\t%s\n", printBool(config.LayeredBuild))
 		if len(config.Destination) > 0 {

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
@@ -35,7 +35,7 @@ const (
 
 	// DefaultPreviousImagePullPolicy specifies policy for pulling the previously
 	// build Docker image when doing incremental build
-	DefaultPreviousImagePullPolicy = PullAlways
+	DefaultPreviousImagePullPolicy = PullIfNotPresent
 )
 
 // Config contains essential fields for performing build.
@@ -106,6 +106,10 @@ type Config struct {
 
 	// Incremental describes whether to try to perform incremental build.
 	Incremental bool
+
+	// IncrementalFromTag sets an alternative image tag to look for existing
+	// artifacts. Tag is used by default if this is not set.
+	IncrementalFromTag string
 
 	// RemovePreviousImage describes if previous image should be removed after successful build.
 	// This applies only to incremental builds.

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
@@ -147,7 +147,10 @@ func (f *FakeDocker) PullImage(imageName string) (*dockerclient.Image, error) {
 
 // CheckAndPullImage pulls a fake docker image
 func (f *FakeDocker) CheckAndPullImage(name string) (*dockerclient.Image, error) {
-	return nil, nil
+	if f.PullResult {
+		return &dockerclient.Image{}, nil
+	}
+	return nil, f.PullError
 }
 
 // BuildImage builds image

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -167,8 +167,9 @@ func (s *S2IBuilder) Build() error {
 
 		ScriptsURL: s.build.Spec.Strategy.SourceStrategy.Scripts,
 
-		BuilderImage: s.build.Spec.Strategy.SourceStrategy.From.Name,
-		Incremental:  s.build.Spec.Strategy.SourceStrategy.Incremental,
+		BuilderImage:       s.build.Spec.Strategy.SourceStrategy.From.Name,
+		Incremental:        s.build.Spec.Strategy.SourceStrategy.Incremental,
+		IncrementalFromTag: pushTag,
 
 		Environment:       buildEnvVars(s.build),
 		DockerNetworkMode: getDockerNetworkMode(),


### PR DESCRIPTION
Using different image tags for build output and incremental build artifacts allows us to build with a disposable `buildTag` while getting artifacts from the stable `pushTag`.

Fixes #7708 