### PR TITLE
router: use explicit maxUnavailable number of pods

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -659,7 +659,6 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			},
 		)
 	}
-	updatePercent := int(-25)
 	objects = append(objects, &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
@@ -667,8 +666,10 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 		},
 		Spec: deployapi.DeploymentConfigSpec{
 			Strategy: deployapi.DeploymentStrategy{
-				Type:          deployapi.DeploymentStrategyTypeRolling,
-				RollingParams: &deployapi.RollingDeploymentStrategyParams{UpdatePercent: &updatePercent},
+				Type: deployapi.DeploymentStrategyTypeRolling,
+				RollingParams: &deployapi.RollingDeploymentStrategyParams{
+					MaxUnavailable: intstr.FromInt(1),
+				},
 			},
 			Replicas: cfg.Replicas,
 			Selector: label,


### PR DESCRIPTION
The way to calculate maximum unavailable pods for a deployment recently
changed to use math.Floor (over math.Ceil it was using before), meaning
for a deployment with size N=1, maxUnavailable=25% previously would
resolve to 1, now it resolves to 0. This commit switches router's
maxUnavailable to use an explicit number instead of a percent. 25%
doesn't make sense for less than 4 pods and takes effect only after 8
instances of a router are up and running.

We even propose 2 pods for HA [in the help](https://github.com/openshift/origin/blob/7ba70f0c87ac91a6fe0c070c229ed02bfe0c4047/pkg/cmd/admin/router/router.go#L240).

@smarterclayton @pweil- @ironcladlou 

Fixes https://github.com/openshift/origin/issues/7700