### PR TITLE
Prevent log line number selection in Chrome

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -22,7 +22,11 @@ angular.module('openshiftConsole')
           '</tr>').get(0);
       var buildLogLineNode = function(lineNumber, text) {
         var line = logLineTemplate.cloneNode(true);
-        line.firstChild.appendChild(document.createTextNode(lineNumber));
+        // Set the line number as a data attribute and display it using the
+        // ::before pseudo-element in CSS so it isn't copied. Works around
+        // this webkit bug with user-select: none;
+        //   https://bugs.webkit.org/show_bug.cgi?id=80159
+        line.firstChild.setAttribute('data-line-number', lineNumber);
         line.lastChild.appendChild(document.createTextNode(text));
 
         return line;

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -109,6 +109,9 @@
     color: #ededed;
   }
 }
+.log-line-number:before {
+  content: attr(data-line-number);
+}
 .log-line-number {
   .unselectable();
   border-right: 1px lighten(@log-bg-color, 10%) solid;


### PR DESCRIPTION
Fixes the problem in Chrome and Safari. No change of behavior in Firefox and IE. Unfortunately, the line numbers are still selectable in IE, but they were before.

Fixes #7693

@jwforres PTAL