### PR TITLE
Prevent client skew

### DIFF
--- a/pkg/cmd/server/api/serialization_test.go
+++ b/pkg/cmd/server/api/serialization_test.go
@@ -80,6 +80,15 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 				obj.PodEvictionTimeout = "5m"
 			}
 		},
+		func(obj *configapi.LegacyClientPolicyConfig, c fuzz.Continue) {
+			c.FuzzNoCustom(obj)
+			if len(obj.LegacyClientPolicy) == 0 {
+				obj.LegacyClientPolicy = configapi.AllowAll
+			}
+			if len(obj.RestrictedHTTPVerbs) == 0 {
+				obj.RestrictedHTTPVerbs = []string{"PUT", "POST"}
+			}
+		},
 		func(obj *configapi.NodeConfig, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
 			// Defaults/migrations for NetworkConfig

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -317,7 +317,29 @@ type PolicyConfig struct {
 
 	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
 	OpenShiftInfrastructureNamespace string
+
+	// LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	LegacyClientPolicyConfig LegacyClientPolicyConfig
 }
+
+type LegacyClientPolicyConfig struct {
+	// LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	// The default is AllowAll
+	LegacyClientPolicy LegacyClientPolicy
+	// RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST
+	RestrictedHTTPVerbs []string
+}
+
+type LegacyClientPolicy string
+
+var (
+	// AllowAll does not prevent any kinds of client version skew
+	AllowAll LegacyClientPolicy = "allow-all"
+	// DenyOldClients prevents older clients (but not newer ones) from issuing stomping requests
+	DenyOldClients LegacyClientPolicy = "deny-old-clients"
+	// DenySkewedClients prevents any non-matching client from issuing stomping requests
+	DenySkewedClients LegacyClientPolicy = "deny-skewed-clients"
+)
 
 // MasterNetworkConfig to be passed to the compiled in network plugin
 type MasterNetworkConfig struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -65,6 +65,14 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				obj.PodEvictionTimeout = "5m"
 			}
 		},
+		func(obj *LegacyClientPolicyConfig) {
+			if len(obj.LegacyClientPolicy) == 0 {
+				obj.LegacyClientPolicy = AllowAll
+			}
+			if obj.LegacyClientPolicy != AllowAll && len(obj.RestrictedHTTPVerbs) == 0 {
+				obj.RestrictedHTTPVerbs = []string{"PUT", "POST"}
+			}
+		},
 		func(obj *NodeConfig) {
 			// Defaults/migrations for NetworkConfig
 			if len(obj.NetworkConfig.NetworkPluginName) == 0 {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -362,6 +362,16 @@ func (LDAPSyncConfig) SwaggerDoc() map[string]string {
 	return map_LDAPSyncConfig
 }
 
+var map_LegacyClientPolicyConfig = map[string]string{
+	"":                    "LegacyClientPolicyConfig holds configuration options for preventing *opt-in* clients using some HTTP verbs when talking to the API",
+	"legacyClientPolicy":  "LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS! The default is AllowAll",
+	"restrictedHTTPVerbs": "RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST",
+}
+
+func (LegacyClientPolicyConfig) SwaggerDoc() map[string]string {
+	return map_LegacyClientPolicyConfig
+}
+
 var map_MasterClients = map[string]string{
 	"": "MasterClients holds references to `.kubeconfig` files that qualify master clients for OpenShift and Kubernetes",
 	"openshiftLoopbackKubeConfig":  "OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master",
@@ -555,6 +565,7 @@ var map_PolicyConfig = map[string]string{
 	"bootstrapPolicyFile":               "BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace",
 	"openshiftSharedResourcesNamespace": "OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)",
 	"openshiftInfrastructureNamespace":  "OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)",
+	"legacyClientPolicyConfig":          "LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!",
 }
 
 func (PolicyConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -269,7 +269,30 @@ type PolicyConfig struct {
 
 	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
 	OpenShiftInfrastructureNamespace string `json:"openshiftInfrastructureNamespace"`
+
+	// LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	LegacyClientPolicyConfig LegacyClientPolicyConfig `json:"legacyClientPolicyConfig"`
 }
+
+// LegacyClientPolicyConfig holds configuration options for preventing *opt-in* clients using some HTTP verbs when talking to the API
+type LegacyClientPolicyConfig struct {
+	// LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	// The default is AllowAll
+	LegacyClientPolicy LegacyClientPolicy `json:"legacyClientPolicy"`
+	// RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST
+	RestrictedHTTPVerbs []string `json:"restrictedHTTPVerbs"`
+}
+
+type LegacyClientPolicy string
+
+var (
+	// AllowAll does not prevent any kinds of client version skew
+	AllowAll LegacyClientPolicy = "allow-all"
+	// DenyOldClients prevents older clients (but not newer ones) from issuing stomping requests
+	DenyOldClients LegacyClientPolicy = "deny-old-clients"
+	// DenySkewedClients prevents any non-matching client from issuing stomping requests
+	DenySkewedClients LegacyClientPolicy = "deny-skewed-clients"
+)
 
 // RoutingConfig holds the necessary configuration options for routing to subdomains
 type RoutingConfig struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -421,6 +421,9 @@ oauthConfig:
 pauseControllers: false
 policyConfig:
   bootstrapPolicyFile: ""
+  legacyClientPolicyConfig:
+    legacyClientPolicy: ""
+    restrictedHTTPVerbs: null
   openshiftInfrastructureNamespace: ""
   openshiftSharedResourcesNamespace: ""
 projectConfig:

--- a/pkg/cmd/server/origin/handlers_test.go
+++ b/pkg/cmd/server/origin/handlers_test.go
@@ -1,0 +1,248 @@
+package origin
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	kversion "k8s.io/kubernetes/pkg/version"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/version"
+)
+
+var (
+	currentOCKubeResources                 = "oc/v1.2.0 (linux/amd64) kubernetes/bc4550d"
+	currentOCOriginResources               = "oc/v1.1.3 (linux/amd64) openshift/b348c2f"
+	currentOpenshiftKubectlKubeResources   = "openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d"
+	currentOpenshiftKubectlOriginResources = "openshift/v1.1.3 (linux/amd64) openshift/b348c2f"
+	currentOADMKubeResources               = "oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d"
+	currentOADMOriginResources             = "oadm/v1.1.3 (linux/amd64) openshift/b348c2f"
+	currentVersionUserAgents               = []string{
+		currentOCKubeResources, currentOCOriginResources, currentOpenshiftKubectlKubeResources, currentOpenshiftKubectlOriginResources, currentOADMKubeResources, currentOADMOriginResources}
+
+	olderOCKubeResources                 = "oc/v1.1.10 (linux/amd64) kubernetes/bc4550d"
+	olderOCOriginResources               = "oc/v1.1.1 (linux/amd64) openshift/b348c2f"
+	olderOpenshiftKubectlKubeResources   = "openshift/v1.1.10 (linux/amd64) kubernetes/bc4550d"
+	olderOpenshiftKubectlOriginResources = "openshift/v1.1.1 (linux/amd64) openshift/b348c2f"
+	olderOADMKubeResources               = "oadm/v1.1.10 (linux/amd64) kubernetes/bc4550d"
+	olderOADMOriginResources             = "oadm/v1.1.1 (linux/amd64) openshift/b348c2f"
+	olderVersionUserAgents               = []string{
+		olderOCKubeResources, olderOCOriginResources, olderOpenshiftKubectlKubeResources, olderOpenshiftKubectlOriginResources, olderOADMKubeResources, olderOADMOriginResources}
+
+	newerOCKubeResources                 = "oc/v1.2.1 (linux/amd64) kubernetes/bc4550d"
+	newerOCOriginResources               = "oc/v1.1.4 (linux/amd64) openshift/b348c2f"
+	newerOpenshiftKubectlKubeResources   = "openshift/v1.2.1 (linux/amd64) kubernetes/bc4550d"
+	newerOpenshiftKubectlOriginResources = "openshift/v1.1.4 (linux/amd64) openshift/b348c2f"
+	newerOADMKubeResources               = "oadm/v1.2.1 (linux/amd64) kubernetes/bc4550d"
+	newerOADMOriginResources             = "oadm/v1.1.4 (linux/amd64) openshift/b348c2f"
+	newerVersionUserAgents               = []string{
+		newerOCKubeResources, newerOCOriginResources, newerOpenshiftKubectlKubeResources, newerOpenshiftKubectlOriginResources, newerOADMKubeResources, newerOADMOriginResources}
+
+	notOCVersion = "something else"
+
+	openshiftServerVersion = version.Info{GitVersion: "v1.1.3"}
+	kubeServerVersion      = kversion.Info{GitVersion: "v1.2.0"}
+)
+
+type versionSkewTestCase struct {
+	name           string
+	userAgents     []string
+	failureMessage string
+	methods        []string
+}
+
+func (tc versionSkewTestCase) Run(url string, t *testing.T) {
+	// gets always succeed
+	for _, userAgent := range tc.userAgents {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			return
+		}
+		req.Header.Add("User-Agent", userAgent)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("%s: unexpected status: %v", tc.name, resp.StatusCode)
+			return
+		}
+	}
+
+	for _, method := range tc.methods {
+		for _, userAgent := range tc.userAgents {
+			req, err := http.NewRequest(method, url, nil)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+				return
+			}
+			req.Header.Add("User-Agent", userAgent)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+				return
+			}
+			if len(tc.failureMessage) == 0 {
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("%s: unexpected status: %v", tc.name, resp.StatusCode)
+					return
+				}
+
+			} else {
+				if resp.StatusCode != http.StatusForbidden {
+					t.Errorf("%s: unexpected status: %v", tc.name, resp.StatusCode)
+					return
+				}
+
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, err)
+					return
+				}
+
+				if !strings.Contains(string(body), tc.failureMessage) {
+					t.Errorf("%s: expected %v, got %v", tc.name, tc.failureMessage, string(body))
+					return
+				}
+			}
+		}
+	}
+
+}
+
+func TestVersionSkewFilterAllowAll(t *testing.T) {
+	verbs := []string{"PUT", "POST"}
+	doNothingHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	})
+	config := MasterConfig{}
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.LegacyClientPolicy = configapi.AllowAll
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.RestrictedHTTPVerbs = verbs
+	server := httptest.NewServer(config.versionSkewFilter(openshiftServerVersion, kubeServerVersion, doNothingHandler))
+	defer server.Close()
+
+	testCases := []versionSkewTestCase{
+		{
+			name:       "missing",
+			userAgents: []string{""},
+			methods:    verbs,
+		},
+		{
+			name:       "not oc",
+			userAgents: []string{notOCVersion},
+			methods:    verbs,
+		},
+		{
+			name:       "older",
+			userAgents: olderVersionUserAgents,
+			methods:    verbs,
+		},
+		{
+			name:       "newer",
+			userAgents: newerVersionUserAgents,
+			methods:    verbs,
+		},
+		{
+			name:       "exact",
+			userAgents: currentVersionUserAgents,
+			methods:    verbs,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(server.URL, t)
+	}
+}
+
+func TestVersionSkewFilterDenyOld(t *testing.T) {
+	verbs := []string{"PATCH", "POST"}
+	doNothingHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	})
+	config := MasterConfig{}
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.LegacyClientPolicy = configapi.DenyOldClients
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.RestrictedHTTPVerbs = verbs
+	server := httptest.NewServer(config.versionSkewFilter(openshiftServerVersion, kubeServerVersion, doNothingHandler))
+	defer server.Close()
+
+	testCases := []versionSkewTestCase{
+		{
+			name:       "missing",
+			userAgents: []string{""},
+			methods:    verbs,
+		},
+		{
+			name:       "not oc",
+			userAgents: []string{notOCVersion},
+			methods:    verbs,
+		},
+		{
+			name:           "older",
+			userAgents:     olderVersionUserAgents,
+			failureMessage: " is older than the server version",
+			methods:        verbs,
+		},
+		{
+			name:       "newer",
+			userAgents: newerVersionUserAgents,
+			methods:    verbs,
+		},
+		{
+			name:       "exact",
+			userAgents: currentVersionUserAgents,
+			methods:    verbs,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(server.URL, t)
+	}
+}
+
+func TestVersionSkewFilterDenySkewed(t *testing.T) {
+	verbs := []string{"PUT", "DELETE"}
+	doNothingHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	})
+	config := MasterConfig{}
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.LegacyClientPolicy = configapi.DenySkewedClients
+	config.Options.PolicyConfig.LegacyClientPolicyConfig.RestrictedHTTPVerbs = verbs
+	server := httptest.NewServer(config.versionSkewFilter(openshiftServerVersion, kubeServerVersion, doNothingHandler))
+	defer server.Close()
+
+	testCases := []versionSkewTestCase{
+		{
+			name:       "missing",
+			userAgents: []string{""},
+			methods:    verbs,
+		},
+		{
+			name:       "not oc",
+			userAgents: []string{notOCVersion},
+			methods:    verbs,
+		},
+		{
+			name:           "older",
+			userAgents:     olderVersionUserAgents,
+			failureMessage: "is different than the server version",
+			methods:        verbs,
+		},
+		{
+			name:           "newer",
+			userAgents:     newerVersionUserAgents,
+			failureMessage: "is different than the server version",
+			methods:        verbs,
+		},
+		{
+			name:       "current",
+			userAgents: currentVersionUserAgents,
+			methods:    verbs,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.Run(server.URL, t)
+	}
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utilwait "k8s.io/kubernetes/pkg/util/wait"
+	kversion "k8s.io/kubernetes/pkg/version"
 
 	"github.com/openshift/origin/pkg/api/v1"
 	"github.com/openshift/origin/pkg/api/v1beta3"
@@ -104,6 +105,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	routeplugin "github.com/openshift/origin/pkg/route/allocation/simple"
+	"github.com/openshift/origin/pkg/version"
 )
 
 const (
@@ -159,7 +161,8 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 		}
 		extra = append(extra, msgs...)
 	}
-	handler := c.authorizationFilter(safe)
+	handler := c.versionSkewFilter(version.Get(), kversion.Get(), safe)
+	handler = c.authorizationFilter(handler)
 	handler = authenticationHandlerFilter(handler, c.Authenticator, c.getRequestContextMapper())
 	handler = namespacingFilter(handler, c.getRequestContextMapper())
 	handler = cacheControlFilter(handler, "no-store") // protected endpoints should not be cached


### PR DESCRIPTION
Adds an option to prevent skewed oc clients from performing PUT or POST (update or create) actions on the API server.  This can prevent weirdness where fields are dropped by old oc clients.  The default is to avoid restricting any client.  Any client not strictly conforming to `DefaultOpenShiftUserAgent` is allowed.

Also fixed here: update the server and client to always identify as openshift, not as kubernetes.  Our client is not the same as kube and the commits didn't really line up due to patches anyway.

@fabianofranz @jwforres since you asked.
@liggitt hold your nose, I don't think its ever going to smell nice.

Buzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1306590