### PR TITLE
oc rsync: do not set owner when extracting with the tar strategy

### DIFF
--- a/pkg/cmd/cli/cmd/rsync/copytar.go
+++ b/pkg/cmd/cli/cmd/rsync/copytar.go
@@ -235,7 +235,7 @@ func untarLocal(tar tar.Tar, destinationDir string, r io.Reader, quiet bool, log
 }
 
 func untarRemote(exec executor, destinationDir string, quiet bool, in io.Reader, out, errOut io.Writer) error {
-	cmd := []string{"tar", "-C", destinationDir, "-x"}
+	cmd := []string{"tar", "-C", destinationDir, "-ox"}
 	if !quiet {
 		cmd = append(cmd, "-v")
 	}


### PR DESCRIPTION
Adds the -o option to the tar command when extracting files on the container side. This should prevent tar from attempting to set the original owner of the file and failing.

Fixes #7650