### PR TITLE
Fix build link in alert message

### DIFF
--- a/assets/app/scripts/services/builds.js
+++ b/assets/app/scripts/services/builds.js
@@ -19,8 +19,7 @@ angular.module("openshiftConsole")
             $scope.alerts["create"] =
               {
                 type: "success",
-                message: "Build " + build.metadata.name + " has started.",
-                link: $filter('navigateResourceURL')(build)
+                message: "Build " + build.metadata.name + " has started."
               };
         },
         function(result) { //failure
@@ -75,7 +74,10 @@ angular.module("openshiftConsole")
             {
               type: "success",
               message: "Build " + buildName + " is being rebuilt as " + build.metadata.name + ".",
-              link: $filter('navigateResourceURL')(build)
+              links: [{
+                href: $filter('navigateResourceURL')(build) + "?tab=logs",
+                label: "View Log"
+              }]
             };
         },
         function(result) { //failure

--- a/assets/app/views/_alerts.html
+++ b/assets/app/views/_alerts.html
@@ -17,5 +17,9 @@
     }"></span>
     <span class="sr-only">{{alert.type}}</span>
     <strong ng-if="alert.message" style="margin-right: 5px;">{{alert.message}}</strong><span ng-if="alert.details">{{alert.details}}</span>
+    <span ng-repeat="link in alert.links">
+      <a ng-href="{{link.href}}">{{link.label}}</a>
+      <span ng-if="!$last" class="action-divider">|</span>
+    </span>
   </div>
 </div>


### PR DESCRIPTION
There was code to add links to alerts, but it wasn't working.

I removed the link from the start build alert since there is a large link on the build config page already.

<img width="825" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13482522/d43064e0-e0bb-11e5-88c2-7a1c6036f46d.png">

@jwforres PTAL