### PR TITLE
Adjust kube-topology so that it doesn't extend off of iOS viewport.

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -148,6 +148,7 @@
 }
 
 .nav-tabs, .tab-content {
+  margin-bottom: @grid-gutter-width / 2;
   margin-top: @grid-gutter-width / 2;
 }
 

--- a/assets/app/styles/_substructure.less
+++ b/assets/app/styles/_substructure.less
@@ -75,9 +75,6 @@ html,body {
           .flex(@columns: 1 1 auto);
           position: relative;
           width: 100%;
-          .container-fluid {
-            padding-bottom: 20px;
-          }
         }
       }
     }

--- a/assets/app/styles/_topology.less
+++ b/assets/app/styles/_topology.less
@@ -7,6 +7,12 @@
 kubernetes-topology-graph {
   height: 700px;
 }
+@media (max-width: @screen-xs-max) {
+  .kube-topology-block {
+    // adjust kubernetes-topology-graph to the left to prevent nodes from extending off the right side viewport on iOS
+    margin-left: -@grid-gutter-width/2;
+  }
+}
 
 .kube-topology {
   margin-bottom: -5px; // allow extra height to prevent inadvertent scrollbars with topology view

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -58,7 +58,7 @@
                 </div>
               </div>
 
-              <div ng-if="overviewMode == 'topology' && !renderOptions.showGetStarted">
+              <div ng-if="overviewMode == 'topology' && !renderOptions.showGetStarted" class="kube-topology-block">
                 <kubernetes-topology-graph bottom-of-window="1" items="topologyItems"
                   relations="topologyRelations" kinds="topologyKinds" selection="topologySelection">
                 </kubernetes-topology-graph>


### PR DESCRIPTION
Move bottom spacing from container-fluid to tab-content, because it reintroduced unnecessary scrollbars issue. https://github.com/openshift/origin/issues/6975

Fixes https://github.com/openshift/origin/issues/7654
Fixes https://github.com/openshift/origin/issues/7553