### PR TITLE
tweak registry roles

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -59,9 +59,9 @@ const (
 	BasicUserRoleName       = "basic-user"
 	StatusCheckerRoleName   = "cluster-status"
 
-	RegistryAdminRoleName  = "system:registry-admin"
-	RegistryViewerRoleName = "system:registry-viewer"
-	RegistryEditorRoleName = "system:registry-editor"
+	RegistryAdminRoleName  = "registry-admin"
+	RegistryViewerRoleName = "registry-viewer"
+	RegistryEditorRoleName = "registry-editor"
 
 	ImagePullerRoleName       = "system:image-puller"
 	ImagePusherRoleName       = "system:image-pusher"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -101,7 +101,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource, "deploymentconfigs/scale"),
+					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource, "deploymentconfigs/scale", "imagestreams/secrets"),
 				},
 				{
 					APIGroups: []string{authorizationapi.APIGroupExtensions},
@@ -131,7 +131,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource, "deploymentconfigs/scale"),
+					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource, "deploymentconfigs/scale", "imagestreams/secrets"),
 				},
 				{
 					APIGroups: []string{authorizationapi.APIGroupExtensions},

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -170,6 +170,7 @@ items:
     - imagestreamimports
     - imagestreammappings
     - imagestreams
+    - imagestreams/secrets
     - imagestreamtags
     - localresourceaccessreviews
     - localsubjectaccessreviews
@@ -295,6 +296,7 @@ items:
     - imagestreamimports
     - imagestreammappings
     - imagestreams
+    - imagestreams/secrets
     - imagestreamtags
     - persistentvolumeclaims
     - pods
@@ -989,7 +991,7 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
-    name: system:registry-admin
+    name: registry-admin
   rules:
   - apiGroups: null
     attributeRestrictions: null
@@ -1054,7 +1056,7 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
-    name: system:registry-viewer
+    name: registry-viewer
   rules:
   - apiGroups: null
     attributeRestrictions: null
@@ -1080,7 +1082,7 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
-    name: system:registry-editor
+    name: registry-editor
   rules:
   - apiGroups: null
     attributeRestrictions: null


### PR DESCRIPTION
Removes the `system:` prefix, since the infrastructure won't fall over if this doesn't work.  Adds the `imagestreams/secrets` to a project-admin so that you won't get an escalation when granting rights.

This makes the flow work:
```bash
[deads@deads-dev-01 origin]$ oc login -u deads -p asdf
Login successful.

You don't have any projects. You can try to create a new project, by running

    $ oc new-project <projectname>

[deads@deads-dev-01 origin]$ oc new-project foo
Now using project "foo" on server "https://localhost:8443".

You can add applications to this project with the 'new-app' command. For example, try:

    $ oc new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-hello-world.git

to build a new hello-world application in Ruby.
[deads@deads-dev-01 origin]$ oc policy add-role-to-user registry-admin bob
[deads@deads-dev-01 origin]$ oc policy who-can get imagestreams
Namespace: foo
Verb:      get
Resource:  imagestreams

Users:  bob
        deads
        system:serviceaccount:openshift-infra:build-controller

Groups: system:cluster-admins
        system:cluster-readers
        system:masters
        system:registries
```

@legionus ptal
@sub-mod @aweiteka fyi