### PR TITLE
resync openshift-sdn: ARP/OVS rule fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -804,32 +804,32 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/cmd/admin/network",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/exec",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ipcmd",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/netutils",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ovs",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins/osdn",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "08a79d5adc8af21b14adcc0b9650df2d5fccf2f0"
+			"Rev": "58baf17e027bc1fd913cddd55c5eed4782400c60"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -25,6 +25,12 @@ get_veth_host() {
     ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
 }
 
+get_container_mac() {
+    local pid=$1
+
+    nsenter -n -t $pid -- ip link show dev eth0 | sed -n -e 's/.*link.ether \([^ ]*\).*/\1/p'
+}
+
 get_ipaddr_pid_veth() {
     network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
     if [ "${network_mode}" == "host" ]; then
@@ -37,6 +43,7 @@ get_ipaddr_pid_veth() {
     ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
     pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
     veth_host=$(get_veth_host $pid)
+    macaddr=$(get_container_mac $pid)
 }
 
 add_ovs_port() {
@@ -53,29 +60,29 @@ del_ovs_port() {
 }
 
 add_ovs_flows() {
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+    ovs_port=$(ovs-vsctl get Interface ${veth_host} ofport)
 
-    case $tenant_id in
-	-1) # single-tenant plugin
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=goto_table:6"
-	    ;;
+    # from container
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, arp_sha=${macaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:3"
 
-	0)  # multi-tenant plugin, admin namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
-	    ;;
+    # arp request/response to container (not isolated)
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=100, arp, nw_dst=${ipaddr}, actions=output:${ovs_port}"
 
-	*)  # multi-tenant plugin, normal namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
-	    ;;
-    esac
+    # IP to container
+    if [ $tenant_id = "0" ]; then
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+    else
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+    fi
 }
 
 del_ovs_flows() {
     ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_dst=${ipaddr}"
     ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_src=${ipaddr}"
     ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
+    ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
 }
 
 add_subnet_route() {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/controller.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/controller.go
@@ -187,62 +187,66 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	otx.AddPort(TUN, 2, "type=internal")
 	otx.AddPort(VOVSBR, 3)
 
-	// Table 0; VXLAN filtering; the first rule sends un-tunnelled packets
-	// to table 1. Additional per-node rules are filled in by controller.go
-	otx.AddFlow("table=0, tun_src=0.0.0.0, actions=goto_table:1")
-	// eg, "table=0, tun_src=${remote_node}, actions=goto_table:1"
+	// Table 0: initial dispatch based on in_port
+	// vxlan0
+	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:1", clusterNetworkCIDR, localSubnetCIDR)
+	otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:1", clusterNetworkCIDR, localSubnetCIDR)
+	otx.AddFlow("table=0, priority=150, in_port=1, actions=drop")
+	// tun0
+	otx.AddFlow("table=0, priority=200, in_port=2, arp, nw_src=%s, nw_dst=%s, actions=goto_table:5", localSubnetGateway, clusterNetworkCIDR)
+	otx.AddFlow("table=0, priority=200, in_port=2, ip, actions=goto_table:5")
+	otx.AddFlow("table=0, priority=150, in_port=2, actions=drop")
+	// vovsbr
+	otx.AddFlow("table=0, priority=200, in_port=3, arp, nw_src=%s, actions=goto_table:5", localSubnetCIDR)
+	otx.AddFlow("table=0, priority=200, in_port=3, ip, nw_src=%s, actions=goto_table:5", localSubnetCIDR)
+	otx.AddFlow("table=0, priority=150, in_port=3, actions=drop")
+	// else, from a container
+	otx.AddFlow("table=0, priority=100, arp, actions=goto_table:2")
+	otx.AddFlow("table=0, priority=100, ip, actions=goto_table:2")
+	otx.AddFlow("table=0, priority=0, actions=drop")
 
-	// Table 1; learn MAC addresses and continue with table 2
-	otx.AddFlow("table=1, actions=learn(table=9, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:2")
+	// Table 1: VXLAN ingress filtering; filled in by AddOFRules()
+	// eg, "table=1, priority=100, tun_src=${remote_node_ip}, actions=goto_table:5"
+	otx.AddFlow("table=1, priority=0, actions=drop")
 
-	// Table 2; initial dispatch
-	otx.AddFlow("table=2, priority=200, arp, actions=goto_table:9")
-	otx.AddFlow("table=2, priority=100, in_port=1, actions=goto_table:3") // vxlan0
-	otx.AddFlow("table=2, priority=100, in_port=2, actions=goto_table:6") // tun0
-	otx.AddFlow("table=2, priority=100, in_port=3, actions=goto_table:6") // vovsbr
-	otx.AddFlow("table=2, priority=0, actions=goto_table:4")              // container
+	// Table 2: from OpenShift container; validate IP/MAC, assign tenant-id; filled in by openshift-sdn-ovs
+	// eg, "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, arp_sha=${macaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+	//     "table=2, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:3"
+	// (${tenant_id} is always 0 for single-tenant)
+	otx.AddFlow("table=2, priority=0, actions=drop")
 
-	// Table 3; incoming from vxlan
-	otx.AddFlow("table=3, priority=200, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
-	if c.multitenant {
-		otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:6", localSubnetCIDR)
-	} else {
-		otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=goto_table:9", localSubnetCIDR)
-	}
+	// Table 3: from OpenShift container; service vs non-service
+	otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=goto_table:4", servicesNetworkCIDR)
+	otx.AddFlow("table=3, priority=0, actions=goto_table:5")
 
-	// Table 4; incoming from container; filled in by openshift-sdn-ovs
-	// eg, single-tenant: "table=4, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, goto_table:6"
-	//     multitenant:   "table=4, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+	// Table 4: from OpenShift container; service dispatch; filled in by AddServiceOFRules()
+	otx.AddFlow("table=4, priority=200, reg0=0, actions=output:2")
+	// eg, "table=4, priority=100, reg0=${tenant_id}, ${service_proto}, nw_dst=${service_ip}, tp_dst=${service_port}, actions=output:2"
+	otx.AddFlow("table=4, priority=0, actions=drop")
 
-	// Table 5; service isolation; mostly filled in by AddServiceOFRules()
-	if c.multitenant {
-		otx.AddFlow("table=5, priority=200, reg0=0, ip, nw_dst=%s, actions=output:2", servicesNetworkCIDR)
-		// eg, "table=5, priority=200, ${service_proto}, nw_dst=${service_ip}, tp_dst=${service_port}, actions=output:2"
-		otx.AddFlow("table=5, priority=100, ip, nw_dst=%s, actions=drop", servicesNetworkCIDR)
-		otx.AddFlow("table=5, priority=0, actions=goto_table:6")
-	}
+	// Table 5: general routing
+	otx.AddFlow("table=5, priority=300, arp, nw_dst=%s, actions=output:2", localSubnetGateway)
+	otx.AddFlow("table=5, priority=300, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
+	otx.AddFlow("table=5, priority=200, arp, nw_dst=%s, actions=goto_table:6", localSubnetCIDR)
+	otx.AddFlow("table=5, priority=200, ip, nw_dst=%s, actions=goto_table:7", localSubnetCIDR)
+	otx.AddFlow("table=5, priority=100, arp, nw_dst=%s, actions=goto_table:8", clusterNetworkCIDR)
+	otx.AddFlow("table=5, priority=100, ip, nw_dst=%s, actions=goto_table:8", clusterNetworkCIDR)
+	otx.AddFlow("table=5, priority=0, ip, actions=output:2")
+	otx.AddFlow("table=5, priority=0, arp, actions=drop")
 
-	// Table 6; general routing
-	otx.AddFlow("table=6, priority=200, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
-	if c.multitenant {
-		otx.AddFlow("table=6, priority=175, ip, reg0=0, nw_dst=%s, actions=goto_table:9", localSubnetCIDR)
-		otx.AddFlow("table=6, priority=150, ip, nw_dst=%s, actions=goto_table:7", localSubnetCIDR)
-	} else {
-		otx.AddFlow("table=6, priority=150, ip, nw_dst=%s, actions=goto_table:9", localSubnetCIDR)
-	}
-	otx.AddFlow("table=6, priority=100, ip, nw_dst=%s, actions=goto_table:8", clusterNetworkCIDR)
-	otx.AddFlow("table=6, priority=0, ip, actions=output:2")
+	// Table 6: ARP to container, filled in by openshift-sdn-ovs
+	// eg, "table=6, priority=100, arp, nw_dst=${container_ip}, actions=output:${ovs_port}"
+	otx.AddFlow("table=6, priority=0, actions=output:3")
 
-	// Table 7; to local container with isolation; filled in by openshift-sdn-ovs
-	// eg, "table=7, priority=100, ip, nw_dst=${ipaddr}, reg0=${tenant_id}, actions=output:${ovs_port}"
+	// Table 7: IP to container; filled in by openshift-sdn-ovs
+	// eg, "table=7, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	// eg, "table=7, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	otx.AddFlow("table=7, priority=0, actions=output:3")
 
-	// Table 8; to remote container; filled in by AddOFRules()
+	// Table 8: to remote container; filled in by AddOFRules()
+	// eg, "table=8, priority=100, arp, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
 	// eg, "table=8, priority=100, ip, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
-
-	// Table 9; MAC dispatch / ARP, filled in by Table 1's learn() rule
-	// and with per-node vxlan ARP rules by AddOFRules()
-	otx.AddFlow("table=9, priority=0, arp, actions=flood")
-	// eg, "table=9, priority=100, arp, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
+	otx.AddFlow("table=8, priority=0, actions=drop")
 
 	err = otx.EndTransaction()
 	if err != nil {
@@ -310,9 +314,9 @@ func (c *FlowController) AddOFRules(nodeIP, nodeSubnetCIDR, localIP string) erro
 	cookie := generateCookie(nodeIP)
 	otx := ovs.NewTransaction(BR)
 
-	otx.AddFlow("table=0,cookie=0x%s,tun_src=%s,actions=goto_table:1", cookie, nodeIP)
-	otx.AddFlow("table=8,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
-	otx.AddFlow("table=9,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
+	otx.AddFlow("table=1, cookie=0x%s, priority=100, tun_src=%s, actions=goto_table:5", cookie, nodeIP)
+	otx.AddFlow("table=8, cookie=0x%s, priority=100, arp, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
+	otx.AddFlow("table=8, cookie=0x%s, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
 
 	err := otx.EndTransaction()
 	if err != nil {
@@ -374,15 +378,15 @@ func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.S
 }
 
 func generateBaseServiceRule(IP string, protocol api.ServiceProtocol, port uint) string {
-	return fmt.Sprintf("table=5,%s,nw_dst=%s,tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
+	return fmt.Sprintf("table=4, %s, nw_dst=%s, tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
 }
 
 func generateAddServiceRule(netID uint, IP string, protocol api.ServiceProtocol, port uint) string {
 	baseRule := generateBaseServiceRule(IP, protocol, port)
 	if netID == 0 {
-		return fmt.Sprintf("%s,priority=200,actions=output:2", baseRule)
+		return fmt.Sprintf("%s, priority=100, actions=output:2", baseRule)
 	} else {
-		return fmt.Sprintf("%s,priority=200,reg0=%d,actions=output:2", baseRule, netID)
+		return fmt.Sprintf("%s, priority=100, reg0=%d, actions=output:2", baseRule, netID)
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
@@ -120,7 +120,7 @@ func (plugin *ovsPlugin) getVNID(namespace string) (string, error) {
 		return strconv.FormatUint(uint64(vnid), 10), nil
 	}
 
-	return "-1", nil
+	return "0", nil
 }
 
 func (plugin *ovsPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) error {


### PR DESCRIPTION
Main changes/fixes:
- Fixes ARP caching problems that can cause sporadic connectivity failures if you have certain traffic patterns (https://github.com/openshift/openshift-sdn/issues/231)
- Adds more anti-spoofing checks to the OVS rules, in particular to prevent (cross-tenant) DoS attacks by messing up other pods' ARP caches

Includes https://github.com/openshift/openshift-sdn/pull/254 and https://github.com/openshift/openshift-sdn/pull/265. OSE packages with this patch have already passed QA (https://bugzilla.redhat.com/show_bug.cgi?id=1311702) so I believe this is safe to go in for 3.2.

@openshift/networking 