### PR TITLE
Set maximum deadline in seconds for lifecycle pod

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -18964,12 +18964,17 @@
     "id": "v1.LifecycleHook",
     "description": "LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.",
     "required": [
-     "failurePolicy"
+     "failurePolicy",
+     "progressDeadlineSeconds"
     ],
     "properties": {
      "failurePolicy": {
       "type": "string",
       "description": "FailurePolicy specifies what action to take if the hook fails."
+     },
+     "progressDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64"
      },
      "execNewPod": {
       "$ref": "v1.ExecNewPodHook",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1747,6 +1747,12 @@ func deepCopy_api_ExecNewPodHook(in deployapi.ExecNewPodHook, out *deployapi.Exe
 
 func deepCopy_api_LifecycleHook(in deployapi.LifecycleHook, out *deployapi.LifecycleHook, c *conversion.Cloner) error {
 	out.FailurePolicy = in.FailurePolicy
+	if in.ProgressDeadlineSeconds != nil {
+		out.ProgressDeadlineSeconds = new(int64)
+		*out.ProgressDeadlineSeconds = *in.ProgressDeadlineSeconds
+	} else {
+		out.ProgressDeadlineSeconds = nil
+	}
 	if in.ExecNewPod != nil {
 		out.ExecNewPod = new(deployapi.ExecNewPodHook)
 		if err := deepCopy_api_ExecNewPodHook(*in.ExecNewPod, out.ExecNewPod, c); err != nil {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -3038,6 +3038,12 @@ func autoConvert_api_LifecycleHook_To_v1_LifecycleHook(in *deployapi.LifecycleHo
 		defaulting.(func(*deployapi.LifecycleHook))(in)
 	}
 	out.FailurePolicy = deployapiv1.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ProgressDeadlineSeconds != nil {
+		out.ProgressDeadlineSeconds = new(int64)
+		*out.ProgressDeadlineSeconds = *in.ProgressDeadlineSeconds
+	} else {
+		out.ProgressDeadlineSeconds = nil
+	}
 	// unable to generate simple pointer conversion for api.ExecNewPodHook -> v1.ExecNewPodHook
 	if in.ExecNewPod != nil {
 		out.ExecNewPod = new(deployapiv1.ExecNewPodHook)
@@ -3605,6 +3611,12 @@ func autoConvert_v1_LifecycleHook_To_api_LifecycleHook(in *deployapiv1.Lifecycle
 		defaulting.(func(*deployapiv1.LifecycleHook))(in)
 	}
 	out.FailurePolicy = deployapi.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ProgressDeadlineSeconds != nil {
+		out.ProgressDeadlineSeconds = new(int64)
+		*out.ProgressDeadlineSeconds = *in.ProgressDeadlineSeconds
+	} else {
+		out.ProgressDeadlineSeconds = nil
+	}
 	// unable to generate simple pointer conversion for v1.ExecNewPodHook -> api.ExecNewPodHook
 	if in.ExecNewPod != nil {
 		out.ExecNewPod = new(deployapi.ExecNewPodHook)

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1770,6 +1770,12 @@ func deepCopy_v1_ExecNewPodHook(in deployapiv1.ExecNewPodHook, out *deployapiv1.
 
 func deepCopy_v1_LifecycleHook(in deployapiv1.LifecycleHook, out *deployapiv1.LifecycleHook, c *conversion.Cloner) error {
 	out.FailurePolicy = in.FailurePolicy
+	if in.ProgressDeadlineSeconds != nil {
+		out.ProgressDeadlineSeconds = new(int64)
+		*out.ProgressDeadlineSeconds = *in.ProgressDeadlineSeconds
+	} else {
+		out.ProgressDeadlineSeconds = nil
+	}
 	if in.ExecNewPod != nil {
 		out.ExecNewPod = new(deployapiv1.ExecNewPodHook)
 		if err := deepCopy_v1_ExecNewPodHook(*in.ExecNewPod, out.ExecNewPod, c); err != nil {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1778,6 +1778,12 @@ func deepCopy_v1beta3_ExecNewPodHook(in deployapiv1beta3.ExecNewPodHook, out *de
 
 func deepCopy_v1beta3_LifecycleHook(in deployapiv1beta3.LifecycleHook, out *deployapiv1beta3.LifecycleHook, c *conversion.Cloner) error {
 	out.FailurePolicy = in.FailurePolicy
+	if in.ProgressDeadlineSeconds != nil {
+		out.ProgressDeadlineSeconds = new(int64)
+		*out.ProgressDeadlineSeconds = *in.ProgressDeadlineSeconds
+	} else {
+		out.ProgressDeadlineSeconds = nil
+	}
 	if in.ExecNewPod != nil {
 		out.ExecNewPod = new(deployapiv1beta3.ExecNewPodHook)
 		if err := deepCopy_v1beta3_ExecNewPodHook(*in.ExecNewPod, out.ExecNewPod, c); err != nil {

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -374,7 +374,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					// RecreateDeploymentStrategy.hookExecutor
 					// RollingDeploymentStrategy.hookExecutor
-					Verbs:     sets.NewString("get", "list", "watch", "create"),
+					Verbs:     sets.NewString("get", "list", "watch", "create", "delete"),
 					Resources: sets.NewString("pods"),
 				},
 				{

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -88,6 +88,11 @@ type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
 	FailurePolicy LifecycleHookFailurePolicy
 
+	// ProgressDeadlineSeconds specifies the time to wait for the lifecycle hook
+	// to finish. If this deadline is exceeded, the pod created by the lifecycle
+	// hook is deleted and deployment is considered as failed.
+	ProgressDeadlineSeconds *int64
+
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
 	ExecNewPod *ExecNewPodHook
 

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -188,10 +188,11 @@ func (ExecNewPodHook) SwaggerDoc() map[string]string {
 }
 
 var map_LifecycleHook = map[string]string{
-	"":              "LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.",
-	"failurePolicy": "FailurePolicy specifies what action to take if the hook fails.",
-	"execNewPod":    "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
-	"tagImages":     "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+	"":                        "LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.",
+	"failurePolicy":           "FailurePolicy specifies what action to take if the hook fails.",
+	"progressDeadlineSeconds": "ProgressDeadlineSeconds specifies the time to wait for the lifecycle hook to finish. If this deadline is exceeded, the pod created by the lifecycle hook is deleted and deployment is considered as failed.",
+	"execNewPod":              "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+	"tagImages":               "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
 }
 
 func (LifecycleHook) SwaggerDoc() map[string]string {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -88,6 +88,11 @@ type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
 	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy"`
 
+	// ProgressDeadlineSeconds specifies the time to wait for the lifecycle hook
+	// to finish. If this deadline is exceeded, the pod created by the lifecycle
+	// hook is deleted and deployment is considered as failed.
+	ProgressDeadlineSeconds *int64 `json:"progressDeadlineSeconds"`
+
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
 	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty"`
 

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -89,6 +89,11 @@ type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
 	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy"`
 
+	// ProgressDeadlineSeconds specifies the time to wait for the lifecycle hook
+	// to finish. If this deadline is exceeded, the pod created by the lifecycle
+	// hook is deleted and deployment is considered as failed.
+	ProgressDeadlineSeconds *int64 `json:"progressDeadlineSeconds"`
+
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
 	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty"`
 

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -154,6 +154,18 @@ func validateLifecycleHook(hook *deployapi.LifecycleHook, pod *kapi.PodSpec, fld
 		errs = append(errs, field.Required(fldPath.Child("failurePolicy"), ""))
 	}
 
+	if *hook.ProgressDeadlineSeconds > 0 && hook.FailurePolicy != deployapi.LifecycleHookFailurePolicyRetry {
+		errs = append(errs, field.Invalid(fldPath, "<hook>", "progressDeadlineSeconds can be used only with the 'Retry' failurePolicy"))
+	}
+
+	if *hook.ProgressDeadlineSeconds < 0 {
+		errs = append(errs, field.Invalid(fldPath, "<hook>", "progressDeadlineSeconds cannot be negative number"))
+	}
+
+	if *hook.ProgressDeadlineSeconds >= deployapi.MaxDeploymentDurationSeconds {
+		errs = append(errs, field.Invalid(fldPath, "<hook>", "progressDeadlineSeconds must be lower than %ds", deployapi.MaxDeploymentDurationSeconds))
+	}
+
 	switch {
 	case hook.ExecNewPod != nil && len(hook.TagImages) > 0:
 		errs = append(errs, field.Invalid(fldPath, "<hook>", "only one of 'execNewPod' of 'tagImages' may be specified"))

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -261,6 +261,12 @@ func makeHookPod(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationCont
 	// Assigning to a variable since its address is required
 	maxDeploymentDurationSeconds := deployapi.MaxDeploymentDurationSeconds
 
+	// When user specify the progressDeadlineSeconds for hook, use that value
+	// instead of default MaxDeploymentDurationSeconds
+	if *hook.ProgressDeadlineSeconds > 0 {
+		maxDeploymentDurationSeconds = *hook.ProgressDeadlineSeconds
+	}
+
 	// Let the kubelet manage retries if requested
 	restartPolicy := kapi.RestartPolicyNever
 	if hook.FailurePolicy == deployapi.LifecycleHookFailurePolicyRetry {


### PR DESCRIPTION
Fixes: #7754 

Example:

```yaml
      pre:
        failurePolicy: Retry
        progressDeadlineSeconds: 5
        execNewPod:
          command:
            - ./migrate-database.sh
          containerName: cakephp-mysql-example
```

In this case, we attempt to migrate database in the pre-deployment hook. If the database is not available, we fail and the container in lifecycle pod will restart. After 5 restarts, the deployment fails.