### PR TITLE
Support HTTP pprof server in registry

### DIFF
--- a/cmd/dockerregistry/main.go
+++ b/cmd/dockerregistry/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 
@@ -16,6 +18,18 @@ import (
 )
 
 func main() {
+	// Start the profiling server, if requested.
+	profilingAddr := os.Getenv("OPENSHIFT_PROFILE")
+	if len(profilingAddr) > 0 {
+		go func() {
+			log.Infof("Starting profiling server at %s", profilingAddr)
+			err := http.ListenAndServe(profilingAddr, nil)
+			if err != nil {
+				log.Errorf("Couldn't start profiling server: %v", err)
+			}
+		}()
+	}
+
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
 

--- a/cmd/dockerregistry/main.go
+++ b/cmd/dockerregistry/main.go
@@ -10,6 +10,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/openshift/origin/pkg/cmd/dockerregistry"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -18,17 +20,9 @@ import (
 )
 
 func main() {
-	// Start the profiling server, if requested.
-	profilingAddr := os.Getenv("OPENSHIFT_PROFILE")
-	if len(profilingAddr) > 0 {
-		go func() {
-			log.Infof("Starting profiling server at %s", profilingAddr)
-			err := http.ListenAndServe(profilingAddr, nil)
-			if err != nil {
-				log.Errorf("Couldn't start profiling server: %v", err)
-			}
-		}()
-	}
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+	startProfiler()
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
@@ -55,4 +49,15 @@ func main() {
 	}
 
 	dockerregistry.Execute(configFile)
+}
+
+func startProfiler() {
+	if cmdutil.Env("OPENSHIFT_PROFILE", "") == "web" {
+		go func() {
+			runtime.SetBlockProfileRate(1)
+			profile_port := cmdutil.Env("OPENSHIFT_PROFILE_PORT", "6060")
+			log.Infof(fmt.Sprintf("Starting profiling endpoint at http://127.0.0.1:%s/debug/pprof/", profile_port))
+			log.Fatal(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%s", profile_port), nil))
+		}()
+	}
 }


### PR DESCRIPTION
Support enabling an HTTP pprof server in the registry command. When
the OPENSHIFT_PROFILE environment variable is present, a pprof
server will be started bound to the specified address. The server can
be exposed through a service.

Closes #7740