### PR TITLE
UPSTREAM: <carry>: Increase test etcd request timeout to 30s

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/testing/utils.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/testing/utils.go
@@ -118,7 +118,7 @@ func (m *EtcdTestServer) launch(t *testing.T) error {
 	for _, ln := range m.ClientListeners {
 		hs := &httptest.Server{
 			Listener: ln,
-			Config:   &http.Server{Handler: etcdhttp.NewClientHandler(m.s, m.ServerConfig.ReqTimeout())},
+			Config:   &http.Server{Handler: etcdhttp.NewClientHandler(m.s, 30*time.Second)},
 		}
 		hs.Start()
 		m.hss = append(m.hss, hs)


### PR DESCRIPTION
EBS on AWS can pause for 5-25s unless every block on disk has been
written to. The IO latency causes fsync to take > default etcd http
timeout, which causes operations on startup to fail. Since tests cannot
tolerate real world conditions, increase the testing timeout.

Fixes #7243