### PR TITLE
Resolving visual defect on Storage .page-header

### DIFF
--- a/assets/app/views/storage.html
+++ b/assets/app/views/storage.html
@@ -6,7 +6,7 @@
     <div id="scrollable-content" class="middle-container has-scroll">
       <div class="middle-header header-light">
         <div class="container-fluid">
-          <div class="page-header page-header-bleed-right">
+          <div class="page-header page-header-bleed-right page-header-bleed-left">
             <h1>Storage</h1>
           </div>
           <alerts alerts="alerts"></alerts>


### PR DESCRIPTION
Border below "Storage" wasn't bleeding to the edges because of missing .page-header-bleed-left on .page-header.

Before:

![screen shot 2016-03-03 at 4 57 13 pm](https://cloud.githubusercontent.com/assets/895728/13511279/9c35ccea-e162-11e5-85ae-4ace1d25bf49.PNG)

After:

![screen shot 2016-03-03 at 4 59 46 pm](https://cloud.githubusercontent.com/assets/895728/13511286/a4e9b752-e162-11e5-8c2e-02246d1778fd.PNG)