### PR TITLE
Fixed races in ratelimiter tests on go1.5

### DIFF
--- a/pkg/util/ratelimiter/ratelimiter_test.go
+++ b/pkg/util/ratelimiter/ratelimiter_test.go
@@ -1,9 +1,28 @@
 package ratelimiter
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
+
+type handler struct {
+	_counter int
+	sync.Mutex
+}
+
+func (h *handler) handle() error {
+	h.Lock()
+	defer h.Unlock()
+	h._counter += 1
+	return nil
+}
+
+func (h *handler) counter() int {
+	h.Lock()
+	defer h.Unlock()
+	return h._counter
+}
 
 func TestRateLimitedFunction(t *testing.T) {
 	tests := []struct {
@@ -33,28 +52,25 @@ func TestRateLimitedFunction(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		counter := 0
-		handler := func() error {
-			counter += 1
-			return nil
-		}
-
+		h := &handler{}
 		quit := make(chan struct{})
-		rlf := NewRateLimitedFunction(keyFunc, tc.Interval, handler)
+		rlf := NewRateLimitedFunction(keyFunc, tc.Interval, h.handle)
 		rlf.RunUntil(quit)
 
 		for i := 0; i < tc.Times; i++ {
-			go func() {
-				if tc.Interval > 0 {
+			go func(rlf *RateLimitedFunction, idx, interval int) {
+				if interval > 0 {
 					rlf.Invoke(rlf)
 				} else {
-					rlf.Invoke(i)
+					rlf.Invoke(idx)
 				}
-			}()
+			}(rlf, i, tc.Interval)
 		}
 
 		select {
 		case <-time.After(time.Duration(tc.Interval+2) * time.Second):
+			close(quit)
+			counter := h.counter()
 			if tc.Interval > 0 && counter >= tc.Times/2 {
 				t.Errorf("For coalesced calls, expected number of invocations to be atleast half. Expected: < %v  Got: %v",
 					tc.Times/2, counter)


### PR DESCRIPTION
Fixes #7785. This bites me heavily, so I've decided to fix it.
@ramr ptal