### PR TITLE
Fix for haproxy reload stops pulling config

### DIFF
--- a/images/router/haproxy-base/Dockerfile
+++ b/images/router/haproxy-base/Dockerfile
@@ -11,7 +11,7 @@ FROM openshift/origin-base
 #       this is temporary and should be removed when the container is switch to an empty-dir
 #       with gid support.
 #
-RUN yum -y install haproxy iptables && \
+RUN yum -y install haproxy iptables lsof && \
     mkdir -p /var/lib/containers/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_edge_http_expose,os_edge_http_redirect}.map,haproxy.config} && \

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -4,6 +4,26 @@ config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
 old_pid=""
 haproxy_conf_dir=/var/lib/haproxy/conf
+readonly max_retries=30
+
+function waitForHAProxyToStartListening() {
+  local port=${STATS_PORT:-"1936"}
+  local retries=0
+
+  echo " - Checking if HAProxy is listening on port $port ..."
+  while ! lsof -n -P -p $(< $pid_file) | grep ":${port} (LISTEN)" &> /dev/null ; do
+    sleep 0.2
+    retries=$((retries + 1))
+    if [ $retries -ge $max_retries ]; then
+      echo " - Exceeded $max_retries retries waiting for HAProxy to start listening on port $port"
+      return
+    fi
+  done
+
+  echo " - HAProxy listening on port $port : $retries retry attempt(s)."
+  return 0
+}
+
 
 # How many times to retry removal of the iptables rules (if requested at all)
 # It will sleep for 1/2 a second between attempts, so the time is retries / 2 secs
@@ -15,13 +35,11 @@ for mapfile in "$haproxy_conf_dir"/*.map; do
   sort -r "$mapfile" -o "$mapfile"
 done
 
-if [ -f $pid_file ]; then
-  old_pid=$(<$pid_file)
-fi
+old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' | awk '{print $1}' | tr '\n' ' ')
 
 DROP_SYN_DURING_RESTART=1
 installed_iptables=0
-if [ -n "$old_pid" ]; then
+if [ -n "$old_pids" ]; then
   if $(set | grep DROP_SYN_DURING_RESTART= > /dev/null) && [[ "$DROP_SYN_DURING_RESTART" == 1 ]]; then
     # We install the syn eater so that connections that come in during the restart don't
     # go onto the wrong socket, which is then closed.
@@ -45,7 +63,7 @@ if [ -n "$old_pid" ]; then
     fi
   fi
 
-  /usr/sbin/haproxy -f $config_file -p $pid_file -sf $old_pid
+  /usr/sbin/haproxy -f $config_file -p $pid_file -sf $old_pids
 
   if [[ "$installed_iptables" == 1 ]]; then
     # We NEVER want to leave the syn eater in place after the reload or haproxy
@@ -73,3 +91,5 @@ if [ -n "$old_pid" ]; then
 else
   /usr/sbin/haproxy -f $config_file -p $pid_file
 fi
+
+waitForHAProxyToStartListening

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -34,6 +34,8 @@ You may restrict the set of routes exposed to a single project (with --namespace
 access to with a set of labels (--project-labels), namespaces matching a label (--namespace-labels), or all
 namespaces (no argument). You can limit the routes to those matching a --labels or --fields selector. Note
 that you must have a cluster-wide administrative role to view all namespaces.`
+	// defaultReloadInterval is how often to do reloads in seconds.
+	defaultReloadInterval = 5
 )
 
 type TemplateRouterOptions struct {
@@ -55,6 +57,18 @@ type TemplateRouter struct {
 	RouterService          *ktypes.NamespacedName
 }
 
+// reloadInterval returns how often to run the router reloads. The interval
+// value is based on an environment variable or the default.
+func reloadInterval() time.Duration {
+	interval := util.Env("RELOAD_INTERVAL", fmt.Sprintf("%vs", defaultReloadInterval))
+	value, err := time.ParseDuration(interval)
+	if err != nil {
+		glog.Warningf("Invalid RELOAD_INTERVAL %q, using default value %v ...", interval, defaultReloadInterval)
+		value = time.Duration(defaultReloadInterval * time.Second)
+	}
+	return value
+}
+
 func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.RouterName, "name", util.Env("ROUTER_SERVICE_NAME", "public"), "The name the router will identify itself with in the route status")
 	flag.StringVar(&o.WorkingDir, "working-dir", "/var/lib/containers/router", "The working directory for the router plugin")
@@ -62,16 +76,7 @@ func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.DefaultCertificatePath, "default-certificate-path", util.Env("DEFAULT_CERTIFICATE_PATH", ""), "A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format")
 	flag.StringVar(&o.TemplateFile, "template", util.Env("TEMPLATE_FILE", ""), "The path to the template file to use")
 	flag.StringVar(&o.ReloadScript, "reload", util.Env("RELOAD_SCRIPT", ""), "The path to the reload script to use")
-
-	interval := util.Env("RELOAD_INTERVAL", "0s")
-
-	var err error
-	o.ReloadInterval, err = time.ParseDuration(interval)
-	if err != nil {
-		glog.Warningf("Invalid RELOAD_INTERVAL %q, ignoring ...", interval)
-		o.ReloadInterval = time.Duration(0 * time.Second)
-	}
-	flag.DurationVar(&o.ReloadInterval, "interval", o.ReloadInterval, "Controls how often router reloads are invoked. Mutiple router reload requests are coalesced for the duration of this interval since the last reload time.")
+	flag.DurationVar(&o.ReloadInterval, "interval", reloadInterval(), "Controls how often router reloads are invoked. Mutiple router reload requests are coalesced for the duration of this interval since the last reload time.")
 }
 
 type RouterStats struct {
@@ -139,7 +144,7 @@ func (o *TemplateRouterOptions) Complete() error {
 		o.StatsPort = statsPort
 	}
 
-	if nsecs := int(o.ReloadInterval.Seconds()); nsecs < 0 {
+	if nsecs := int(o.ReloadInterval.Seconds()); nsecs < 1 {
 		return fmt.Errorf("invalid reload interval: %v - must be a positive duration", nsecs)
 	}
 

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -74,7 +74,7 @@ func TestRouter(t *testing.T) {
 		t.Fatalf("Unable to get docker client: %v", err)
 	}
 
-	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 0)
+	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 1)
 
 	if err != nil {
 		t.Fatalf("Error starting container %s : %v", getRouterImage(), err)
@@ -406,7 +406,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 		t.Fatalf("Unable to get docker client: %v", err)
 	}
 
-	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 0)
+	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 1)
 	if err != nil {
 		t.Fatalf("Error starting container %s : %v", getRouterImage(), err)
 	}
@@ -661,7 +661,7 @@ func TestRouterDuplications(t *testing.T) {
 		t.Fatalf("Unable to get docker client: %v", err)
 	}
 
-	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 0)
+	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 1)
 	if err != nil {
 		t.Fatalf("Error starting container %s : %v", getRouterImage(), err)
 	}
@@ -805,7 +805,7 @@ func TestRouterStatsPort(t *testing.T) {
 		t.Fatalf("Unable to get docker client: %v", err)
 	}
 
-	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 0)
+	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 1)
 	if err != nil {
 		t.Fatalf("Error starting container %s : %v", getRouterImage(), err)
 	}
@@ -865,7 +865,7 @@ func TestRouterHealthzEndpoint(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, tc.port, 0)
+		routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, tc.port, 1)
 		if err != nil {
 			t.Fatalf("Test with %q error starting container %s : %v", tc.name, getRouterImage(), err)
 		}
@@ -910,7 +910,7 @@ func TestRouterServiceUnavailable(t *testing.T) {
 		t.Fatalf("Unable to get docker client: %v", err)
 	}
 
-	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 0)
+	routerId, err := createAndStartRouterContainer(dockerCli, fakeMasterAndPod.MasterHttpAddr, statsPort, 1)
 	if err != nil {
 		t.Fatalf("Error starting container %s : %v", getRouterImage(), err)
 	}


### PR DESCRIPTION
fixes #7657   and replaces PR #7781 

  o  Set default template router reload interval to 5 seconds.
  o  Send graceful shutdown signal to all haproxy processes + wait for process to start listening.
      Along with the liveness probe this takes care of the unhealthy cases.

@smarterclayton  PTAL Thx