### PR TITLE
Remove invisible browse option from web console catalog

### DIFF
--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -58,7 +58,7 @@
                             <span class="caret" aria-hidden="true"></span>
                           </button>
                           <ul class="uib-dropdown-menu">
-                            <li ng-repeat="tag in categoryTags" role="menuitem">
+                            <li ng-repeat="tag in categoryTags" ng-if="tag" role="menuitem">
                               <a href="" ng-click="filter.tag = tag">{{tag}}</a>
                             </li>
                           </ul>


### PR DESCRIPTION
Removes this empty option:

![screen shot 2016-03-04 at 4 46 36 pm](https://cloud.githubusercontent.com/assets/1167259/13541354/bdcf6222-e229-11e5-95db-ee8300da53cd.png)

@jwforres 