### PR TITLE
Run DNS on the node

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kubelet/app/options/options.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kubelet/app/options/options.go
@@ -127,6 +127,7 @@ func NewKubeletServer() *KubeletServer {
 			RegistryBurst:                  10,
 			RegistryPullQPS:                5.0,
 			KubeletCgroups:                 "",
+			ResolverConfig:                 kubetypes.ResolvConfDefault,
 			RktPath:                        "",
 			RktAPIEndpoint:                 rkt.DefaultRktAPIServiceEndpoint,
 			RktStage1Image:                 "",
@@ -233,7 +234,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
 	fs.StringVar(&s.NonMasqueradeCIDR, "non-masquerade-cidr", s.NonMasqueradeCIDR, "Traffic to IPs outside this range will use IP masquerade.")
 	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
-	fs.StringVar(&s.ResolverConfig, "resolv-conf", kubetypes.ResolvConfDefault, "Resolver configuration file used as the basis for the container DNS resolution configuration.")
+	fs.StringVar(&s.ResolverConfig, "resolv-conf", s.ResolverConfig, "Resolver configuration file used as the basis for the container DNS resolution configuration.")
 	fs.BoolVar(&s.CPUCFSQuota, "cpu-cfs-quota", s.CPUCFSQuota, "Enable CPU CFS quota enforcement for containers that specify CPU limits")
 	// Flags intended for testing, not recommended used in production environments.
 	fs.BoolVar(&s.ReallyCrashForTesting, "really-crash-for-testing", s.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/config/api.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/config/api.go
@@ -21,41 +21,54 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 )
 
 // NewSourceAPI creates config source that watches for changes to the services and endpoints.
-func NewSourceAPI(c *client.Client, period time.Duration, servicesChan chan<- ServiceUpdate, endpointsChan chan<- EndpointsUpdate) {
+func NewSourceAPI(c cache.Getter, period time.Duration, servicesChan chan<- ServiceUpdate, endpointsChan chan<- EndpointsUpdate) {
 	servicesLW := cache.NewListWatchFromClient(c, "services", api.NamespaceAll, fields.Everything())
-	endpointsLW := cache.NewListWatchFromClient(c, "endpoints", api.NamespaceAll, fields.Everything())
+	cache.NewReflector(servicesLW, &api.Service{}, NewServiceStore(nil, servicesChan), period).Run()
 
-	newServicesSourceApiFromLW(servicesLW, period, servicesChan)
-	newEndpointsSourceApiFromLW(endpointsLW, period, endpointsChan)
+	endpointsLW := cache.NewListWatchFromClient(c, "endpoints", api.NamespaceAll, fields.Everything())
+	cache.NewReflector(endpointsLW, &api.Endpoints{}, NewEndpointsStore(nil, endpointsChan), period).Run()
 }
 
-func newServicesSourceApiFromLW(servicesLW cache.ListerWatcher, period time.Duration, servicesChan chan<- ServiceUpdate) {
-	servicesPush := func(objs []interface{}) {
+// NewServiceStore creates an undelta store that expands updates to the store into
+// ServiceUpdate events on the channel. If no store is passed, a default store will
+// be initialized. Allows reuse of a cache store across multiple components.
+func NewServiceStore(store cache.Store, ch chan<- ServiceUpdate) cache.Store {
+	fn := func(objs []interface{}) {
 		var services []api.Service
 		for _, o := range objs {
 			services = append(services, *(o.(*api.Service)))
 		}
-		servicesChan <- ServiceUpdate{Op: SET, Services: services}
+		ch <- ServiceUpdate{Op: SET, Services: services}
 	}
-
-	serviceQueue := cache.NewUndeltaStore(servicesPush, cache.MetaNamespaceKeyFunc)
-	cache.NewReflector(servicesLW, &api.Service{}, serviceQueue, period).Run()
+	if store == nil {
+		store = cache.NewStore(cache.MetaNamespaceKeyFunc)
+	}
+	return &cache.UndeltaStore{
+		Store:    store,
+		PushFunc: fn,
+	}
 }
 
-func newEndpointsSourceApiFromLW(endpointsLW cache.ListerWatcher, period time.Duration, endpointsChan chan<- EndpointsUpdate) {
-	endpointsPush := func(objs []interface{}) {
+// NewEndpointsStore creates an undelta store that expands updates to the store into
+// EndpointsUpdate events on the channel. If no store is passed, a default store will
+// be initialized. Allows reuse of a cache store across multiple components.
+func NewEndpointsStore(store cache.Store, ch chan<- EndpointsUpdate) cache.Store {
+	fn := func(objs []interface{}) {
 		var endpoints []api.Endpoints
 		for _, o := range objs {
 			endpoints = append(endpoints, *(o.(*api.Endpoints)))
 		}
-		endpointsChan <- EndpointsUpdate{Op: SET, Endpoints: endpoints}
+		ch <- EndpointsUpdate{Op: SET, Endpoints: endpoints}
 	}
-
-	endpointQueue := cache.NewUndeltaStore(endpointsPush, cache.MetaNamespaceKeyFunc)
-	cache.NewReflector(endpointsLW, &api.Endpoints{}, endpointQueue, period).Run()
+	if store == nil {
+		store = cache.NewStore(cache.MetaNamespaceKeyFunc)
+	}
+	return &cache.UndeltaStore{
+		Store:    store,
+		PushFunc: fn,
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/config/api_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/config/api_test.go
@@ -61,7 +61,7 @@ func TestNewServicesSourceApi_UpdatesAndMultipleServices(t *testing.T) {
 
 	ch := make(chan ServiceUpdate)
 
-	newServicesSourceApiFromLW(lw, 30*time.Second, ch)
+	cache.NewReflector(lw, &api.Service{}, NewServiceStore(nil, ch), 30*time.Second).Run()
 
 	got, ok := <-ch
 	if !ok {
@@ -172,7 +172,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 
 	ch := make(chan EndpointsUpdate)
 
-	newEndpointsSourceApiFromLW(lw, 30*time.Second, ch)
+	cache.NewReflector(lw, &api.Endpoints{}, NewEndpointsStore(nil, ch), 30*time.Second).Run()
 
 	got, ok := <-ch
 	if !ok {

--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/golang/glog"
+
 	"github.com/openshift/origin/pkg/cmd/openshift"
 	"github.com/openshift/origin/pkg/cmd/util/serviceability"
 
@@ -17,6 +19,8 @@ import (
 func main() {
 	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
 	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	glog.CopyStandardLogTo("INFO")
 
 	if len(os.Getenv("GOMAXPROCS")) == 0 {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/pkg/cmd/server/kubernetes/node_config_test.go
+++ b/pkg/cmd/server/kubernetes/node_config_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	"k8s.io/kubernetes/pkg/kubelet/rkt"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util"
 	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	"k8s.io/kubernetes/pkg/util/diff"
@@ -78,6 +79,7 @@ func TestKubeletDefaults(t *testing.T) {
 			RegisterSchedulable:            true,
 			RegistryBurst:                  10,
 			RegistryPullQPS:                5.0,
+			ResolverConfig:                 kubetypes.ResolvConfDefault,
 			KubeletCgroups:                 "",
 			RktAPIEndpoint:                 rkt.DefaultRktAPIServiceEndpoint,
 			RktPath:                        "",

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -30,7 +30,6 @@ import (
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
-	"github.com/openshift/origin/pkg/cmd/server/etcd"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	configchangecontroller "github.com/openshift/origin/pkg/deploy/controller/configchange"
@@ -209,12 +208,9 @@ func (c *MasterConfig) RunDNSServer() {
 	}
 
 	go func() {
-		etcdClient, err := etcd.GetAndTestEtcdClient(c.Options.EtcdClientInfo)
-		if err != nil {
-			glog.Fatalf("Could not get etcd client: %v", err)
-			return
-		}
-		err = dns.ListenAndServe(config, c.DNSServerClient(), etcdClient)
+		s := dns.NewServer(config, c.DNSServerClient())
+		s.MetricsName = "apiserver"
+		err := s.ListenAndServe()
 		glog.Fatalf("Could not start DNS: %v", err)
 	}()
 

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -280,7 +280,7 @@ func (o NodeOptions) IsRunFromConfig() bool {
 }
 
 func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentFlag) error {
-	config, err := kubernetes.BuildKubernetesNodeConfig(nodeConfig)
+	config, err := kubernetes.BuildKubernetesNodeConfig(nodeConfig, components.Enabled(ComponentProxy), components.Enabled(ComponentDNS))
 	if err != nil {
 		return err
 	}
@@ -316,6 +316,11 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 	if components.Enabled(ComponentProxy) {
 		config.RunProxy()
 	}
+	if components.Enabled(ComponentDNS) {
+		config.RunDNS()
+	}
+
+	config.RunServiceStores(components.Enabled(ComponentProxy), components.Enabled(ComponentDNS))
 
 	return nil
 }

--- a/pkg/cmd/util/flags/flags.go
+++ b/pkg/cmd/util/flags/flags.go
@@ -59,6 +59,19 @@ func NewComponentFlag(mappings map[string][]string, allowed ...string) *Componen
 	}
 }
 
+// DefaultEnable resets the enabled components to only those provided that are also in the allowed
+// list.
+func (f *ComponentFlag) DefaultEnable(components ...string) *ComponentFlag {
+	f.enabled = strings.Join(f.allowed.Union(sets.NewString(components...)).List(), ",")
+	return f
+}
+
+// DefaultDisable resets the default enabled set to all allowed components except the provided.
+func (f *ComponentFlag) DefaultDisable(components ...string) *ComponentFlag {
+	f.enabled = strings.Join(f.allowed.Difference(sets.NewString(components...)).List(), ",")
+	return f
+}
+
 // Disable marks the provided components as disabled.
 func (f *ComponentFlag) Disable(components ...string) {
 	f.Calculated().Delete(components...)

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -1,14 +1,11 @@
 package dns
 
 import (
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-
 	"github.com/golang/glog"
 
-	"github.com/coreos/go-etcd/etcd"
-	"github.com/prometheus/client_golang/prometheus"
-	backendetcd "github.com/skynetservices/skydns/backends/etcd"
 	"github.com/skynetservices/skydns/server"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 // NewServerDefaults returns the default SkyDNS server configuration for a DNS server.
@@ -21,25 +18,39 @@ func NewServerDefaults() (*server.Config, error) {
 	return config, server.SetDefaults(config)
 }
 
+type Server struct {
+	Config      *server.Config
+	Services    ServiceAccessor
+	Endpoints   client.EndpointsNamespacer
+	MetricsName string
+
+	Stop chan struct{}
+}
+
+// NewServer creates a server from the provided config and client.
+func NewServer(config *server.Config, client *client.Client) *Server {
+	stop := make(chan struct{})
+	return &Server{
+		Config:    config,
+		Services:  NewCachedServiceAccessor(client, stop),
+		Endpoints: client,
+		Stop:      stop,
+	}
+}
+
 // ListenAndServe starts a DNS server that exposes services and values stored in etcd (if etcdclient
 // is not nil). It will block until the server exits.
-// TODO: hoist the service accessor out of this package so it can be reused.
-func ListenAndServe(config *server.Config, client *client.Client, etcdclient *etcd.Client) error {
-	stop := make(chan struct{})
-	accessor := NewCachedServiceAccessor(client, stop)
-	resolver := NewServiceResolver(config, accessor, client, openshiftFallback)
+func (s *Server) ListenAndServe() error {
+	resolver := NewServiceResolver(s.Config, s.Services, s.Endpoints, openshiftFallback)
 	resolvers := server.FirstBackend{resolver}
-	if etcdclient != nil {
-		resolvers = append(resolvers, backendetcd.NewBackend(etcdclient, &backendetcd.Config{
-			Ttl:      config.Ttl,
-			Priority: config.Priority,
-		}))
+	if len(s.MetricsName) > 0 {
+		server.RegisterMetrics(s.MetricsName, "")
 	}
-
-	server.RegisterMetrics("", "")
-	s := server.New(resolvers, config)
-	defer close(stop)
-	return s.Run()
+	dns := server.New(resolvers, s.Config)
+	if s.Stop != nil {
+		defer close(s.Stop)
+	}
+	return dns.Run()
 }
 
 func openshiftFallback(name string, exact bool) (string, bool) {
@@ -50,20 +61,4 @@ func openshiftFallback(name string, exact bool) (string, bool) {
 		return "_endpoints.kubernetes.default.", true
 	}
 	return "", false
-}
-
-// counter is a SkyDNS compatible Counter
-type counter struct {
-	prometheus.Counter
-}
-
-// newCounter registers a prometheus counter and wraps it to match SkyDNS
-func newCounter(c prometheus.Counter) server.Counter {
-	prometheus.MustRegister(c)
-	return counter{c}
-}
-
-// Inc increases the counter with the given value
-func (c counter) Inc(val int64) {
-	c.Counter.Add(float64(val))
 }

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -41,10 +41,10 @@ os::cmd::expect_failure_and_text 'openshift start network' 'kubeconfig must be s
 os::cmd::expect_failure_and_text 'openshift start network --config=${NODECONFIG} --enable=kubelet' 'the following components are not recognized: kubelet'
 os::cmd::expect_failure_and_text 'openshift start network --config=${NODECONFIG} --enable=kubelet,other' 'the following components are not recognized: kubelet, other'
 os::cmd::expect_failure_and_text 'openshift start network --config=${NODECONFIG} --disable=other' 'the following components are not recognized: other'
-os::cmd::expect_failure_and_text 'openshift start network --config=${NODECONFIG} --disable=proxy,plugins' 'at least one node component must be enabled \(plugins, proxy\)'
+os::cmd::expect_failure_and_text 'openshift start network --config=${NODECONFIG} --disable=dns,proxy,plugins' 'at least one node component must be enabled \(dns, plugins, proxy\)'
 os::cmd::expect_failure_and_text 'openshift start node' 'kubeconfig must be set'
 os::cmd::expect_failure_and_text 'openshift start node --config=${NODECONFIG} --disable=other' 'the following components are not recognized: other'
-os::cmd::expect_failure_and_text 'openshift start node --config=${NODECONFIG} --disable=kubelet,proxy,plugins' 'at least one node component must be enabled \(kubelet, plugins, proxy\)'
+os::cmd::expect_failure_and_text 'openshift start node --config=${NODECONFIG} --disable=dns,kubelet,proxy,plugins' 'at least one node component must be enabled \(dns, kubelet, plugins, proxy\)'
 os::cmd::expect_failure_and_text 'openshift start --write-config=/tmp/test --hostname=""' 'error: --hostname must have a value'
 os::test::junit::declare_suite_end
 

--- a/test/util/etcd.go
+++ b/test/util/etcd.go
@@ -24,8 +24,11 @@ func init() {
 		AllowPrivileged: true,
 	})
 	flag.Set("v", "5")
-	if len(os.Getenv("OSTEST_VERBOSE_ETCD")) > 0 {
+	if len(os.Getenv("OS_TEST_VERBOSE_ETCD")) > 0 {
 		capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+		capnslog.SetFormatter(capnslog.NewGlogFormatter(os.Stderr))
+	} else {
+		capnslog.SetGlobalLogLevel(capnslog.INFO)
 		capnslog.SetFormatter(capnslog.NewGlogFormatter(os.Stderr))
 	}
 }


### PR DESCRIPTION
This adds a node-side, optional DNS component that reuses the service proxy cache.  The all-in-one enables node dns and master dns at the same time, starting master DNS on 8053.  If the user specifies --dns-addr on the CLI for the all in one, any port other than 53 will result in node dns being enabled (since Node DNS can't proxy ports).

A future change would allow master DNS to be disabled, but because we expose DNS over the kubernetes service we can't change that now.