### PR TITLE
Disable externalIP by default

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -347,6 +347,11 @@ type MasterNetworkConfig struct {
 	ClusterNetworkCIDR string
 	HostSubnetLength   uint
 	ServiceNetworkCIDR string
+	// ExternalIPNetworkCIDRs controls what values are acceptable for the service external IP field. If empty, no externalIP
+	// may be set. It may contain a list of CIDRs which are checked for access. If a CIDR is prefixed with !, IPs in that
+	// CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You
+	// should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.
+	ExternalIPNetworkCIDRs []string `json:"externalIPNetworkCIDRs"`
 }
 
 type ImageConfig struct {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -416,11 +416,12 @@ func (MasterConfig) SwaggerDoc() map[string]string {
 }
 
 var map_MasterNetworkConfig = map[string]string{
-	"":                   "MasterNetworkConfig to be passed to the compiled in network plugin",
-	"networkPluginName":  "NetworkPluginName is the name of the network plugin to use",
-	"clusterNetworkCIDR": "ClusterNetworkCIDR is the CIDR string to specify the global overlay network's L3 space",
-	"hostSubnetLength":   "HostSubnetLength is the number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host",
-	"serviceNetworkCIDR": "ServiceNetwork is the CIDR string to specify the service networks",
+	"":                       "MasterNetworkConfig to be passed to the compiled in network plugin",
+	"networkPluginName":      "NetworkPluginName is the name of the network plugin to use",
+	"clusterNetworkCIDR":     "ClusterNetworkCIDR is the CIDR string to specify the global overlay network's L3 space",
+	"hostSubnetLength":       "HostSubnetLength is the number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host",
+	"serviceNetworkCIDR":     "ServiceNetwork is the CIDR string to specify the service networks",
+	"externalIPNetworkCIDRs": "ExternalIPNetworkCIDRs controls what values are acceptable for the service external IP field. If empty, no externalIP may be set. It may contain a list of CIDRs which are checked for access. If a CIDR is prefixed with !, IPs in that CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.",
 }
 
 func (MasterNetworkConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -312,6 +312,11 @@ type MasterNetworkConfig struct {
 	HostSubnetLength uint `json:"hostSubnetLength"`
 	// ServiceNetwork is the CIDR string to specify the service networks
 	ServiceNetworkCIDR string `json:"serviceNetworkCIDR"`
+	// ExternalIPNetworkCIDRs controls what values are acceptable for the service external IP field. If empty, no externalIP
+	// may be set. It may contain a list of CIDRs which are checked for access. If a CIDR is prefixed with !, IPs in that
+	// CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You
+	// should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.
+	ExternalIPNetworkCIDRs []string `json:"externalIPNetworkCIDRs"`
 }
 
 // ImageConfig holds the necessary configuration options for building image names for system components

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -178,6 +178,7 @@ masterClients:
 masterPublicURL: ""
 networkConfig:
   clusterNetworkCIDR: ""
+  externalIPNetworkCIDRs: null
   hostSubnetLength: 0
   networkPluginName: ""
   serviceNetworkCIDR: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -147,6 +147,16 @@ func ValidateMasterConfig(config *api.MasterConfig, fldPath *field.Path) Validat
 			validationResults.AddErrors(field.Invalid(fldPath.Child("networkConfig", "serviceNetworkCIDR"), config.NetworkConfig.ServiceNetworkCIDR, fmt.Sprintf("must match kubernetesMasterConfig.servicesSubnet value of %q", config.KubernetesMasterConfig.ServicesSubnet)))
 		}
 	}
+	if len(config.NetworkConfig.ExternalIPNetworkCIDRs) > 0 {
+		for i, s := range config.NetworkConfig.ExternalIPNetworkCIDRs {
+			if strings.HasPrefix(s, "!") {
+				s = s[1:]
+			}
+			if _, _, err := net.ParseCIDR(s); err != nil {
+				validationResults.AddErrors(field.Invalid(fldPath.Child("networkConfig", "externalIPNetworkCIDRs").Index(i), config.NetworkConfig.ExternalIPNetworkCIDRs[i], "must be a valid CIDR notation IP range (e.g. 172.30.0.0/16) with an optional leading !"))
+			}
+		}
+	}
 
 	validationResults.AddErrors(ValidateKubeConfig(config.MasterClients.OpenShiftLoopbackKubeConfig, fldPath.Child("masterClients", "openShiftLoopbackKubeConfig"))...)
 

--- a/pkg/service/admission/externalip_admission.go
+++ b/pkg/service/admission/externalip_admission.go
@@ -1,0 +1,110 @@
+package admission
+
+import (
+	"io"
+	"net"
+	"strings"
+
+	kadmission "k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	apierrs "k8s.io/kubernetes/pkg/api/errors"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+)
+
+const ExternalIPPluginName = "ExternalIPRanger"
+
+func init() {
+	kadmission.RegisterPlugin("ExternalIPRanger", func(client clientset.Interface, config io.Reader) (kadmission.Interface, error) {
+		return NewExternalIPRanger(nil, nil), nil
+	})
+}
+
+type externalIPRanger struct {
+	*kadmission.Handler
+	reject []*net.IPNet
+	admit  []*net.IPNet
+}
+
+var _ kadmission.Interface = &externalIPRanger{}
+
+// ParseCIDRRules calculates a blacklist and whitelist from a list of string CIDR rules (treating
+// a leading ! as a negation). Returns an error if any rule is invalid.
+func ParseCIDRRules(rules []string) (reject, admit []*net.IPNet, err error) {
+	for _, s := range rules {
+		negate := false
+		if strings.HasPrefix(s, "!") {
+			negate = true
+			s = s[1:]
+		}
+		_, cidr, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		if negate {
+			reject = append(reject, cidr)
+		} else {
+			admit = append(admit, cidr)
+		}
+	}
+	return reject, admit, nil
+}
+
+// NewConstraint creates a new SCC constraint admission plugin.
+func NewExternalIPRanger(reject, admit []*net.IPNet) *externalIPRanger {
+	return &externalIPRanger{
+		Handler: kadmission.NewHandler(kadmission.Create, kadmission.Update),
+		reject:  reject,
+		admit:   admit,
+	}
+}
+
+// networkSlice is a helper for checking whether an IP is contained in a range
+// of networks.
+type networkSlice []*net.IPNet
+
+func (s networkSlice) Contains(ip net.IP) bool {
+	for _, cidr := range s {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Admit determines if the service should be admitted based on the configured network CIDR.
+func (r *externalIPRanger) Admit(a kadmission.Attributes) error {
+	if a.GetResource() != kapi.Resource("services") {
+		return nil
+	}
+
+	svc, ok := a.GetObject().(*kapi.Service)
+	// if we can't convert then we don't handle this object so just return
+	if !ok {
+		return nil
+	}
+
+	var errs field.ErrorList
+	switch {
+	// administrator disabled externalIPs
+	case len(svc.Spec.ExternalIPs) > 0 && len(r.admit) == 0:
+		errs = append(errs, field.Forbidden(field.NewPath("spec", "externalIPs"), "externalIPs have been disabled"))
+	// administrator has limited the range
+	case len(svc.Spec.ExternalIPs) > 0 && len(r.admit) > 0:
+		for i, s := range svc.Spec.ExternalIPs {
+			ip := net.ParseIP(s)
+			if ip == nil {
+				errs = append(errs, field.Forbidden(field.NewPath("spec", "externalIPs").Index(i), "externalIPs must be a valid address"))
+				continue
+			}
+			if networkSlice(r.reject).Contains(ip) || !networkSlice(r.admit).Contains(ip) {
+				errs = append(errs, field.Forbidden(field.NewPath("spec", "externalIPs").Index(i), "externalIP is not allowed"))
+				continue
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return apierrs.NewInvalid(a.GetKind(), a.GetName(), errs)
+	}
+	return nil
+}

--- a/pkg/service/admission/externalip_admission_test.go
+++ b/pkg/service/admission/externalip_admission_test.go
@@ -1,0 +1,188 @@
+package admission
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+// TestAdmission verifies various scenarios involving pod/project/global node label selectors
+func TestAdmission(t *testing.T) {
+	svc := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{Name: "test"},
+	}
+
+	_, ipv4, err := net.ParseCIDR("172.0.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ipv4subset, err := net.ParseCIDR("172.0.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ipv4offset, err := net.ParseCIDR("172.200.0.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, none, err := net.ParseCIDR("0.0.0.0/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, all, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		testName        string
+		rejects, admits []*net.IPNet
+		op              admission.Operation
+		externalIPs     []string
+		admit           bool
+		errFn           func(err error) bool
+	}{
+		{
+			admit:    true,
+			op:       admission.Create,
+			testName: "No external IPs on create",
+		},
+		{
+			admit:    true,
+			op:       admission.Update,
+			testName: "No external IPs on update",
+		},
+		{
+			admit:       false,
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "No external IPs allowed on create",
+			errFn:       func(err error) bool { return strings.Contains(err.Error(), "externalIPs have been disabled") },
+		},
+		{
+			admit:       false,
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Update,
+			testName:    "No external IPs allowed on update",
+			errFn:       func(err error) bool { return strings.Contains(err.Error(), "externalIPs have been disabled") },
+		},
+		{
+			admit:       false,
+			admits:      []*net.IPNet{ipv4},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "IP out of range on create",
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "externalIP is not allowed") &&
+					strings.Contains(err.Error(), "spec.externalIPs[0]")
+			},
+		},
+		{
+			admit:       false,
+			admits:      []*net.IPNet{ipv4},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Update,
+			testName:    "IP out of range on update",
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "externalIP is not allowed") &&
+					strings.Contains(err.Error(), "spec.externalIPs[0]")
+			},
+		},
+		{
+			admit:       false,
+			admits:      []*net.IPNet{ipv4},
+			rejects:     []*net.IPNet{ipv4subset},
+			externalIPs: []string{"172.0.1.1"},
+			op:          admission.Update,
+			testName:    "IP out of range due to blacklist",
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "externalIP is not allowed") &&
+					strings.Contains(err.Error(), "spec.externalIPs[0]")
+			},
+		},
+		{
+			admit:       false,
+			admits:      []*net.IPNet{ipv4},
+			rejects:     []*net.IPNet{ipv4offset},
+			externalIPs: []string{"172.199.1.1"},
+			op:          admission.Update,
+			testName:    "IP not in reject or admit",
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "externalIP is not allowed") &&
+					strings.Contains(err.Error(), "spec.externalIPs[0]")
+			},
+		},
+		{
+			admit:       true,
+			admits:      []*net.IPNet{ipv4},
+			externalIPs: []string{"172.0.0.1"},
+			op:          admission.Create,
+			testName:    "IP in range on create",
+		},
+		{
+			admit:       true,
+			admits:      []*net.IPNet{ipv4},
+			externalIPs: []string{"172.0.0.1"},
+			op:          admission.Update,
+			testName:    "IP in range on update",
+		},
+
+		// other checks
+		{
+			admit:       false,
+			admits:      []*net.IPNet{ipv4},
+			externalIPs: []string{"abcd"},
+			op:          admission.Create,
+			testName:    "IP unparseable on create",
+			errFn: func(err error) bool {
+				return strings.Contains(err.Error(), "externalIPs must be a valid address") &&
+					strings.Contains(err.Error(), "spec.externalIPs[0]")
+			},
+		},
+		{
+			admit:       false,
+			admits:      []*net.IPNet{none},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "IP range is empty",
+		},
+		{
+			admit:       false,
+			rejects:     []*net.IPNet{all},
+			admits:      []*net.IPNet{all},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "rejections can cover the entire range",
+		},
+	}
+	for _, test := range tests {
+		svc.Spec.ExternalIPs = test.externalIPs
+		handler := NewExternalIPRanger(test.rejects, test.admits)
+
+		err := handler.Admit(admission.NewAttributesRecord(svc, kapi.Kind("Service"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services"), "", test.op, nil))
+		if test.admit && err != nil {
+			t.Errorf("%s: expected no error but got: %s", test.testName, err)
+		} else if !test.admit && err == nil {
+			t.Errorf("%s: expected an error", test.testName)
+		}
+		if test.errFn != nil && !test.errFn(err) {
+			t.Errorf("%s: unexpected error: %v", test.testName, err)
+		}
+	}
+}
+
+func TestHandles(t *testing.T) {
+	for op, shouldHandle := range map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  true,
+		admission.Connect: false,
+		admission.Delete:  false,
+	} {
+		ranger := NewExternalIPRanger(nil, nil)
+		if e, a := shouldHandle, ranger.Handles(op); e != a {
+			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Allow IP to be set if the admin sets a CIDR.  No controls yet on who can
set out of the range. Could be on a limitranger.

Fixes #7808

@derekwaynecarr @deads2k @knobunc this closes the potential security hole for online