### PR TITLE
Misc provisioning improvements

### DIFF
--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -37,5 +37,11 @@ if [ "${SDN_NODE}" = "true" ]; then
 
   # Disable scheduling for the sdn node - it's purpose is only to ensure
   # pod network connectivity on the master.
-  os::provision::disable-sdn-node "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
+  #
+  # This will be performed separately for dind to allow as much time
+  # as possible for the node to register itself.  Vagrant can deploy
+  # in parallel but dind deploys serially for simplicity.
+  if ! os::provision::in-container; then
+    os::provision::disable-sdn-node "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
+  fi
 fi

--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -7,9 +7,7 @@ os::provision::base-provision "${ORIGIN_ROOT}" true
 os::provision::build-origin "${ORIGIN_ROOT}" "${SKIP_BUILD}"
 os::provision::build-etcd "${ORIGIN_ROOT}" "${SKIP_BUILD}"
 
-echo "Installing openshift"
-os::provision::install-cmds "${ORIGIN_ROOT}"
-os::provision::install-sdn "${ORIGIN_ROOT}"
+os::provision::base-install "${ORIGIN_ROOT}" "${CONFIG_ROOT}"
 
 if [ "${SDN_NODE}" = "true" ]; then
   # Running an sdn node on the master when using an openshift sdn
@@ -41,5 +39,3 @@ if [ "${SDN_NODE}" = "true" ]; then
   # pod network connectivity on the master.
   os::provision::disable-sdn-node "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
 fi
-
-os::provision::set-os-env "${ORIGIN_ROOT}" "${CONFIG_ROOT}"

--- a/contrib/vagrant/provision-node.sh
+++ b/contrib/vagrant/provision-node.sh
@@ -13,12 +13,9 @@ if ! os::provision::in-container; then
   os::provision::wait-for-node-config "${CONFIG_ROOT}" "${NODE_NAME}"
 fi
 
-# openshift is assumed to have been built before node deployment
-os::provision::install-cmds "${ORIGIN_ROOT}"
-
-os::provision::install-sdn "${ORIGIN_ROOT}"
+# Binaries are expected to have been built by the time node
+# configuration is available.
+os::provision::base-install "${ORIGIN_ROOT}" "${CONFIG_ROOT}"
 
 echo "Launching openshift daemon"
 os::provision::start-node-service "${CONFIG_ROOT}" "${NODE_NAME}"
-
-os::provision::set-os-env "${ORIGIN_ROOT}" "${CONFIG_ROOT}"

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -35,7 +35,9 @@ os::provision::build-etcd() {
   if [ -f "${origin_root}/_tools/etcd/bin/etcd" ] &&
      [ "${skip_build}" = "true" ]; then
     echo "WARNING: Skipping etcd build due to OPENSHIFT_SKIP_BUILD=true"
-  else
+  # Etcd is required for integration testing which isn't a use case
+  # for dind.
+  elif ! os::provision::in-container; then
     echo "Building etcd"
     ${origin_root}/hack/install-etcd.sh
   fi

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -277,7 +277,7 @@ os::provision::start-os-service() {
     dind_env_var="OPENSHIFT_DIND=true"
   fi
 
-  cat <<EOF > "/usr/lib/systemd/system/${unit_name}.service"
+  cat <<EOF > "/etc/systemd/system/${unit_name}.service"
 [Unit]
 Description=${description}
 Requires=network.target

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -41,6 +41,16 @@ os::provision::build-etcd() {
   fi
 }
 
+os::provision::base-install() {
+  local origin_root=$1
+  local config_root=$2
+
+  echo "Installing openshift"
+  os::provision::install-cmds "${origin_root}"
+  os::provision::install-sdn "${origin_root}"
+  os::provision::set-os-env "${origin_root}" "${config_root}"
+}
+
 os::provision::install-cmds() {
   local deployed_root=$1
 

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -233,8 +233,16 @@ ${DEPLOYED_CONFIG_ROOT}"
 
   local rc_file="dind-${INSTANCE_PREFIX}.rc"
   local admin_config=$(os::provision::get-admin-config ${CONFIG_ROOT})
+  local origin_bin_path="${ORIGIN_ROOT}/_output/local/bin/linux/amd64"
   echo "export KUBECONFIG=${admin_config}
-export PATH=\$PATH:${ORIGIN_ROOT}/_output/local/bin/linux/amd64" > "${rc_file}"
+export PATH=\$PATH:${origin_bin_path}" > "${rc_file}"
+
+  # Disable the sdn node as late as possible to allow time for the
+  # node to register itself.
+  if [ "${SDN_NODE}" = "true" ]; then
+    export PATH="${PATH}:${origin_bin_path}"
+    os::provision::disable-sdn-node "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
+  fi
 
   if [ "${KUBECONFIG:-}" != "${admin_config}" ]; then
     echo ""


### PR DESCRIPTION
- simplify vagrant/dind host provisioning
- dind: disable sdn node at the end of provisioning
- dind: skip building etcd
- put dev cluster unit files in /etc/systemd/system
