### PR TITLE
Make conversions public for performance

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20257,6 +20257,9 @@
    "v1.DeploymentDetails": {
     "id": "v1.DeploymentDetails",
     "description": "DeploymentDetails captures information about the causes of a deployment.",
+    "required": [
+     "causes"
+    ],
     "properties": {
      "message": {
       "type": "string",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1558,14 +1558,10 @@ func deepCopy_api_DeploymentConfigStatus(in deployapi.DeploymentConfigStatus, ou
 func deepCopy_api_DeploymentDetails(in deployapi.DeploymentDetails, out *deployapi.DeploymentDetails, c *conversion.Cloner) error {
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapi.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapi.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if newVal, err := c.DeepCopy(in.Causes[i]); err != nil {
+			if err := deepCopy_api_DeploymentCause(in.Causes[i], &out.Causes[i], c); err != nil {
 				return err
-			} else if newVal == nil {
-				out.Causes[i] = nil
-			} else {
-				out.Causes[i] = newVal.(*deployapi.DeploymentCause)
 			}
 		}
 	} else {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -42,7 +42,7 @@ func autoConvert_api_ClusterPolicy_To_v1_ClusterPolicy(in *authorizationapi.Clus
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastModified, &out.LastModified, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+	if err := authorizationapiv1.Convert_api_ClusterRoleArray_to_v1_NamedClusterRoleArray(&in.Roles, &out.Roles, s); err != nil {
 		return err
 	}
 	return nil
@@ -61,7 +61,7 @@ func autoConvert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding(in *authori
 	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.PolicyRef, &out.PolicyRef, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.RoleBindings, &out.RoleBindings, 0); err != nil {
+	if err := authorizationapiv1.Convert_api_ClusterRoleBindingArray_to_v1_NamedClusterRoleBindingArray(&in.RoleBindings, &out.RoleBindings, s); err != nil {
 		return err
 	}
 	return nil
@@ -77,7 +77,7 @@ func autoConvert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList(in 
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.ClusterPolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -101,7 +101,7 @@ func autoConvert_api_ClusterPolicyList_To_v1_ClusterPolicyList(in *authorization
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.ClusterPolicy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_ClusterPolicy_To_v1_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -125,7 +125,7 @@ func autoConvert_api_ClusterRole_To_v1_ClusterRole(in *authorizationapi.ClusterR
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapiv1.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_PolicyRule_To_v1_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -172,7 +172,7 @@ func autoConvert_api_ClusterRoleBindingList_To_v1_ClusterRoleBindingList(in *aut
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.ClusterRoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -249,7 +249,7 @@ func autoConvert_api_Policy_To_v1_Policy(in *authorizationapi.Policy, out *autho
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastModified, &out.LastModified, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+	if err := authorizationapiv1.Convert_api_NamedRoleArray_to_v1_RoleArray(&in.Roles, &out.Roles, s); err != nil {
 		return err
 	}
 	return nil
@@ -268,7 +268,7 @@ func autoConvert_api_PolicyBinding_To_v1_PolicyBinding(in *authorizationapi.Poli
 	if err := Convert_api_ObjectReference_To_v1_ObjectReference(&in.PolicyRef, &out.PolicyRef, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.RoleBindings, &out.RoleBindings, 0); err != nil {
+	if err := authorizationapiv1.Convert_api_RoleBindingArray_to_v1_NamedRoleBindingArray(&in.RoleBindings, &out.RoleBindings, s); err != nil {
 		return err
 	}
 	return nil
@@ -284,7 +284,7 @@ func autoConvert_api_PolicyBindingList_To_v1_PolicyBindingList(in *authorization
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.PolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_PolicyBinding_To_v1_PolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -308,7 +308,7 @@ func autoConvert_api_PolicyList_To_v1_PolicyList(in *authorizationapi.PolicyList
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.Policy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_Policy_To_v1_Policy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -372,7 +372,7 @@ func autoConvert_api_Role_To_v1_Role(in *authorizationapi.Role, out *authorizati
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapiv1.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_PolicyRule_To_v1_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -419,7 +419,7 @@ func autoConvert_api_RoleBindingList_To_v1_RoleBindingList(in *authorizationapi.
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1.RoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_api_RoleBinding_To_v1_RoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -491,7 +491,7 @@ func autoConvert_v1_ClusterPolicy_To_api_ClusterPolicy(in *authorizationapiv1.Cl
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastModified, &out.LastModified, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+	if err := authorizationapiv1.Convert_v1_NamedClusterRoleArray_to_api_ClusterRoleArray(&in.Roles, &out.Roles, s); err != nil {
 		return err
 	}
 	return nil
@@ -510,7 +510,7 @@ func autoConvert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *authori
 	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.PolicyRef, &out.PolicyRef, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.RoleBindings, &out.RoleBindings, 0); err != nil {
+	if err := authorizationapiv1.Convert_v1_NamedClusterRoleBindingArray_to_ClusterRoleBindingArray(&in.RoleBindings, &out.RoleBindings, s); err != nil {
 		return err
 	}
 	return nil
@@ -526,7 +526,7 @@ func autoConvert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList(in 
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -550,7 +550,7 @@ func autoConvert_v1_ClusterPolicyList_To_api_ClusterPolicyList(in *authorization
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.ClusterPolicy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_ClusterPolicy_To_api_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -574,7 +574,7 @@ func autoConvert_v1_ClusterRole_To_api_ClusterRole(in *authorizationapiv1.Cluste
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -623,7 +623,7 @@ func autoConvert_v1_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in *aut
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -700,7 +700,7 @@ func autoConvert_v1_Policy_To_api_Policy(in *authorizationapiv1.Policy, out *aut
 	if err := api.Convert_unversioned_Time_To_unversioned_Time(&in.LastModified, &out.LastModified, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+	if err := authorizationapiv1.Convert_v1_NamedRoleArray_to_api_RoleArray(&in.Roles, &out.Roles, s); err != nil {
 		return err
 	}
 	return nil
@@ -719,7 +719,7 @@ func autoConvert_v1_PolicyBinding_To_api_PolicyBinding(in *authorizationapiv1.Po
 	if err := Convert_v1_ObjectReference_To_api_ObjectReference(&in.PolicyRef, &out.PolicyRef, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.RoleBindings, &out.RoleBindings, 0); err != nil {
+	if err := authorizationapiv1.Convert_v1_NamedRoleBindingArray_to_api_RoleBindingArray(&in.RoleBindings, &out.RoleBindings, s); err != nil {
 		return err
 	}
 	return nil
@@ -735,7 +735,7 @@ func autoConvert_v1_PolicyBindingList_To_api_PolicyBindingList(in *authorization
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_PolicyBinding_To_api_PolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -759,7 +759,7 @@ func autoConvert_v1_PolicyList_To_api_PolicyList(in *authorizationapiv1.PolicyLi
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.Policy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_Policy_To_api_Policy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -823,7 +823,7 @@ func autoConvert_v1_Role_To_api_Role(in *authorizationapiv1.Role, out *authoriza
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -872,7 +872,7 @@ func autoConvert_v1_RoleBindingList_To_api_RoleBindingList(in *authorizationapiv
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1.Convert_v1_RoleBinding_To_api_RoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1013,7 +1013,7 @@ func autoConvert_api_BuildConfigList_To_v1_BuildConfigList(in *buildapi.BuildCon
 	if in.Items != nil {
 		out.Items = make([]v1.BuildConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := v1.Convert_api_BuildConfig_To_v1_BuildConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1034,7 +1034,7 @@ func autoConvert_api_BuildConfigSpec_To_v1_BuildConfigSpec(in *buildapi.BuildCon
 	if in.Triggers != nil {
 		out.Triggers = make([]v1.BuildTriggerPolicy, len(in.Triggers))
 		for i := range in.Triggers {
-			if err := s.Convert(&in.Triggers[i], &out.Triggers[i], 0); err != nil {
+			if err := v1.Convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
 				return err
 			}
 		}
@@ -1209,7 +1209,8 @@ func autoConvert_api_BuildRequest_To_v1_BuildRequest(in *buildapi.BuildRequest, 
 	}
 	// unable to generate simple pointer conversion for api.SourceRevision -> v1.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(v1.SourceRevision)
+		if err := v1.Convert_api_SourceRevision_To_v1_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
@@ -1331,21 +1332,22 @@ func autoConvert_api_BuildSpec_To_v1_BuildSpec(in *buildapi.BuildSpec, out *v1.B
 		defaulting.(func(*buildapi.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
+	if err := v1.Convert_api_BuildSource_To_v1_BuildSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
 	// unable to generate simple pointer conversion for api.SourceRevision -> v1.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(v1.SourceRevision)
+		if err := v1.Convert_api_SourceRevision_To_v1_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
+	if err := v1.Convert_api_BuildStrategy_To_v1_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
+	if err := v1.Convert_api_BuildOutput_To_v1_BuildOutput(&in.Output, &out.Output, s); err != nil {
 		return err
 	}
 	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
@@ -1417,7 +1419,8 @@ func autoConvert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrateg
 	}
 	// unable to generate simple pointer conversion for api.DockerBuildStrategy -> v1.DockerBuildStrategy
 	if in.DockerStrategy != nil {
-		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
+		out.DockerStrategy = new(v1.DockerBuildStrategy)
+		if err := v1.Convert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy(in.DockerStrategy, out.DockerStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1425,7 +1428,8 @@ func autoConvert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrateg
 	}
 	// unable to generate simple pointer conversion for api.SourceBuildStrategy -> v1.SourceBuildStrategy
 	if in.SourceStrategy != nil {
-		if err := s.Convert(&in.SourceStrategy, &out.SourceStrategy, 0); err != nil {
+		out.SourceStrategy = new(v1.SourceBuildStrategy)
+		if err := v1.Convert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in.SourceStrategy, out.SourceStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1433,7 +1437,8 @@ func autoConvert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrateg
 	}
 	// unable to generate simple pointer conversion for api.CustomBuildStrategy -> v1.CustomBuildStrategy
 	if in.CustomStrategy != nil {
-		if err := s.Convert(&in.CustomStrategy, &out.CustomStrategy, 0); err != nil {
+		out.CustomStrategy = new(v1.CustomBuildStrategy)
+		if err := v1.Convert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy(in.CustomStrategy, out.CustomStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1850,7 +1855,7 @@ func autoConvert_v1_BuildConfigList_To_api_BuildConfigList(in *v1.BuildConfigLis
 	if in.Items != nil {
 		out.Items = make([]buildapi.BuildConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := v1.Convert_v1_BuildConfig_To_api_BuildConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1871,7 +1876,7 @@ func autoConvert_v1_BuildConfigSpec_To_api_BuildConfigSpec(in *v1.BuildConfigSpe
 	if in.Triggers != nil {
 		out.Triggers = make([]buildapi.BuildTriggerPolicy, len(in.Triggers))
 		for i := range in.Triggers {
-			if err := s.Convert(&in.Triggers[i], &out.Triggers[i], 0); err != nil {
+			if err := v1.Convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
 				return err
 			}
 		}
@@ -2046,7 +2051,8 @@ func autoConvert_v1_BuildRequest_To_api_BuildRequest(in *v1.BuildRequest, out *b
 	}
 	// unable to generate simple pointer conversion for v1.SourceRevision -> api.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(buildapi.SourceRevision)
+		if err := v1.Convert_v1_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
@@ -2169,21 +2175,22 @@ func autoConvert_v1_BuildSpec_To_api_BuildSpec(in *v1.BuildSpec, out *buildapi.B
 		defaulting.(func(*v1.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
+	if err := v1.Convert_v1_BuildSource_To_api_BuildSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
 	// unable to generate simple pointer conversion for v1.SourceRevision -> api.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(buildapi.SourceRevision)
+		if err := v1.Convert_v1_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
+	if err := v1.Convert_v1_BuildStrategy_To_api_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
+	if err := v1.Convert_v1_BuildOutput_To_api_BuildOutput(&in.Output, &out.Output, s); err != nil {
 		return err
 	}
 	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
@@ -2256,7 +2263,8 @@ func autoConvert_v1_BuildStrategy_To_api_BuildStrategy(in *v1.BuildStrategy, out
 	// in.Type has no peer in out
 	// unable to generate simple pointer conversion for v1.DockerBuildStrategy -> api.DockerBuildStrategy
 	if in.DockerStrategy != nil {
-		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
+		out.DockerStrategy = new(buildapi.DockerBuildStrategy)
+		if err := v1.Convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in.DockerStrategy, out.DockerStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2264,7 +2272,8 @@ func autoConvert_v1_BuildStrategy_To_api_BuildStrategy(in *v1.BuildStrategy, out
 	}
 	// unable to generate simple pointer conversion for v1.SourceBuildStrategy -> api.SourceBuildStrategy
 	if in.SourceStrategy != nil {
-		if err := s.Convert(&in.SourceStrategy, &out.SourceStrategy, 0); err != nil {
+		out.SourceStrategy = new(buildapi.SourceBuildStrategy)
+		if err := v1.Convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in.SourceStrategy, out.SourceStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2272,7 +2281,8 @@ func autoConvert_v1_BuildStrategy_To_api_BuildStrategy(in *v1.BuildStrategy, out
 	}
 	// unable to generate simple pointer conversion for v1.CustomBuildStrategy -> api.CustomBuildStrategy
 	if in.CustomStrategy != nil {
-		if err := s.Convert(&in.CustomStrategy, &out.CustomStrategy, 0); err != nil {
+		out.CustomStrategy = new(buildapi.CustomBuildStrategy)
+		if err := v1.Convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy(in.CustomStrategy, out.CustomStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2822,9 +2832,9 @@ func autoConvert_api_DeploymentDetails_To_v1_DeploymentDetails(in *deployapi.Dep
 	}
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapiv1.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapiv1.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+			if err := Convert_api_DeploymentCause_To_v1_DeploymentCause(&in.Causes[i], &out.Causes[i], s); err != nil {
 				return err
 			}
 		}
@@ -2923,7 +2933,8 @@ func autoConvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *deployapi.D
 	}
 	// unable to generate simple pointer conversion for api.RollingDeploymentStrategyParams -> v1.RollingDeploymentStrategyParams
 	if in.RollingParams != nil {
-		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+		out.RollingParams = new(deployapiv1.RollingDeploymentStrategyParams)
+		if err := deployapiv1.Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams(in.RollingParams, out.RollingParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -2982,7 +2993,8 @@ func autoConvert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy(in *d
 	out.Type = deployapiv1.DeploymentTriggerType(in.Type)
 	// unable to generate simple pointer conversion for api.DeploymentTriggerImageChangeParams -> v1.DeploymentTriggerImageChangeParams
 	if in.ImageChangeParams != nil {
-		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+		out.ImageChangeParams = new(deployapiv1.DeploymentTriggerImageChangeParams)
+		if err := deployapiv1.Convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams(in.ImageChangeParams, out.ImageChangeParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -3389,9 +3401,9 @@ func autoConvert_v1_DeploymentDetails_To_api_DeploymentDetails(in *deployapiv1.D
 	}
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapi.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapi.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+			if err := Convert_v1_DeploymentCause_To_api_DeploymentCause(&in.Causes[i], &out.Causes[i], s); err != nil {
 				return err
 			}
 		}
@@ -3490,7 +3502,8 @@ func autoConvert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *deployapiv1
 	}
 	// unable to generate simple pointer conversion for v1.RollingDeploymentStrategyParams -> api.RollingDeploymentStrategyParams
 	if in.RollingParams != nil {
-		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+		out.RollingParams = new(deployapi.RollingDeploymentStrategyParams)
+		if err := deployapiv1.Convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in.RollingParams, out.RollingParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -3549,7 +3562,8 @@ func autoConvert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in *d
 	out.Type = deployapi.DeploymentTriggerType(in.Type)
 	// unable to generate simple pointer conversion for v1.DeploymentTriggerImageChangeParams -> api.DeploymentTriggerImageChangeParams
 	if in.ImageChangeParams != nil {
-		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+		out.ImageChangeParams = new(deployapi.DeploymentTriggerImageChangeParams)
+		if err := deployapiv1.Convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in.ImageChangeParams, out.ImageChangeParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -3804,7 +3818,8 @@ func autoConvert_api_ImageImportStatus_To_v1_ImageImportStatus(in *imageapi.Imag
 	}
 	// unable to generate simple pointer conversion for api.Image -> v1.Image
 	if in.Image != nil {
-		if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+		out.Image = new(imageapiv1.Image)
+		if err := imageapiv1.Convert_api_Image_To_v1_Image(in.Image, out.Image, s); err != nil {
 			return err
 		}
 	} else {
@@ -3827,7 +3842,7 @@ func autoConvert_api_ImageList_To_v1_ImageList(in *imageapi.ImageList, out *imag
 	if in.Items != nil {
 		out.Items = make([]imageapiv1.Image, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1.Convert_api_Image_To_v1_Image(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3848,10 +3863,10 @@ func autoConvert_api_ImageStream_To_v1_ImageStream(in *imageapi.ImageStream, out
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+	if err := imageapiv1.Convert_api_ImageStreamSpec_To_v1_ImageStreamSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+	if err := imageapiv1.Convert_api_ImageStreamStatus_To_v1_ImageStreamStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
@@ -3868,7 +3883,7 @@ func autoConvert_api_ImageStreamImage_To_v1_ImageStreamImage(in *imageapi.ImageS
 	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_api_Image_To_v1_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -4000,7 +4015,7 @@ func autoConvert_api_ImageStreamMapping_To_v1_ImageStreamMapping(in *imageapi.Im
 		return err
 	}
 	// in.DockerImageRepository has no peer in out
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_api_Image_To_v1_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	out.Tag = in.Tag
@@ -4012,7 +4027,7 @@ func autoConvert_api_ImageStreamSpec_To_v1_ImageStreamSpec(in *imageapi.ImageStr
 		defaulting.(func(*imageapi.ImageStreamSpec))(in)
 	}
 	out.DockerImageRepository = in.DockerImageRepository
-	if err := s.Convert(&in.Tags, &out.Tags, 0); err != nil {
+	if err := imageapiv1.Convert_api_TagReferenceMap_to_v1_TagReferenceArray(&in.Tags, &out.Tags, s); err != nil {
 		return err
 	}
 	return nil
@@ -4023,7 +4038,7 @@ func autoConvert_api_ImageStreamStatus_To_v1_ImageStreamStatus(in *imageapi.Imag
 		defaulting.(func(*imageapi.ImageStreamStatus))(in)
 	}
 	out.DockerImageRepository = in.DockerImageRepository
-	if err := s.Convert(&in.Tags, &out.Tags, 0); err != nil {
+	if err := imageapiv1.Convert_api_TagEventListArray_to_v1_NamedTagEventListArray(&in.Tags, &out.Tags, s); err != nil {
 		return err
 	}
 	return nil
@@ -4056,7 +4071,7 @@ func autoConvert_api_ImageStreamTag_To_v1_ImageStreamTag(in *imageapi.ImageStrea
 	} else {
 		out.Conditions = nil
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_api_Image_To_v1_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -4273,7 +4288,8 @@ func autoConvert_v1_ImageImportStatus_To_api_ImageImportStatus(in *imageapiv1.Im
 	}
 	// unable to generate simple pointer conversion for v1.Image -> api.Image
 	if in.Image != nil {
-		if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+		out.Image = new(imageapi.Image)
+		if err := imageapiv1.Convert_v1_Image_To_api_Image(in.Image, out.Image, s); err != nil {
 			return err
 		}
 	} else {
@@ -4297,7 +4313,7 @@ func autoConvert_v1_ImageList_To_api_ImageList(in *imageapiv1.ImageList, out *im
 	if in.Items != nil {
 		out.Items = make([]imageapi.Image, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1.Convert_v1_Image_To_api_Image(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4318,10 +4334,10 @@ func autoConvert_v1_ImageStream_To_api_ImageStream(in *imageapiv1.ImageStream, o
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+	if err := imageapiv1.Convert_v1_ImageStreamSpec_To_api_ImageStreamSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+	if err := imageapiv1.Convert_v1_ImageStreamStatus_To_api_ImageStreamStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
@@ -4338,7 +4354,7 @@ func autoConvert_v1_ImageStreamImage_To_api_ImageStreamImage(in *imageapiv1.Imag
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_v1_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -4469,7 +4485,7 @@ func autoConvert_v1_ImageStreamMapping_To_api_ImageStreamMapping(in *imageapiv1.
 	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_v1_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	out.Tag = in.Tag
@@ -4481,7 +4497,7 @@ func autoConvert_v1_ImageStreamSpec_To_api_ImageStreamSpec(in *imageapiv1.ImageS
 		defaulting.(func(*imageapiv1.ImageStreamSpec))(in)
 	}
 	out.DockerImageRepository = in.DockerImageRepository
-	if err := s.Convert(&in.Tags, &out.Tags, 0); err != nil {
+	if err := imageapiv1.Convert_v1_TagReferenceArray_to_api_TagReferenceMap(&in.Tags, &out.Tags, s); err != nil {
 		return err
 	}
 	return nil
@@ -4492,7 +4508,7 @@ func autoConvert_v1_ImageStreamStatus_To_api_ImageStreamStatus(in *imageapiv1.Im
 		defaulting.(func(*imageapiv1.ImageStreamStatus))(in)
 	}
 	out.DockerImageRepository = in.DockerImageRepository
-	if err := s.Convert(&in.Tags, &out.Tags, 0); err != nil {
+	if err := imageapiv1.Convert_v1_NamedTagEventListArray_to_api_TagEventListArray(&in.Tags, &out.Tags, s); err != nil {
 		return err
 	}
 	return nil
@@ -4525,7 +4541,7 @@ func autoConvert_v1_ImageStreamTag_To_api_ImageStreamTag(in *imageapiv1.ImageStr
 	} else {
 		out.Conditions = nil
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1.Convert_v1_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -5923,7 +5939,7 @@ func autoConvert_api_TemplateList_To_v1_TemplateList(in *templateapi.TemplateLis
 	if in.Items != nil {
 		out.Items = make([]templateapiv1.Template, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := templateapiv1.Convert_api_Template_To_v1_Template(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -6003,7 +6019,7 @@ func autoConvert_v1_TemplateList_To_api_TemplateList(in *templateapiv1.TemplateL
 	if in.Items != nil {
 		out.Items = make([]templateapi.Template, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := templateapiv1.Convert_v1_Template_To_api_Template(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1581,14 +1581,10 @@ func deepCopy_v1_DeploymentConfigStatus(in deployapiv1.DeploymentConfigStatus, o
 func deepCopy_v1_DeploymentDetails(in deployapiv1.DeploymentDetails, out *deployapiv1.DeploymentDetails, c *conversion.Cloner) error {
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapiv1.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapiv1.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if newVal, err := c.DeepCopy(in.Causes[i]); err != nil {
+			if err := deepCopy_v1_DeploymentCause(in.Causes[i], &out.Causes[i], c); err != nil {
 				return err
-			} else if newVal == nil {
-				out.Causes[i] = nil
-			} else {
-				out.Causes[i] = newVal.(*deployapiv1.DeploymentCause)
 			}
 		}
 	} else {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -80,7 +80,7 @@ func autoConvert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingLis
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.ClusterPolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -104,7 +104,7 @@ func autoConvert_api_ClusterPolicyList_To_v1beta3_ClusterPolicyList(in *authoriz
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.ClusterPolicy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -128,7 +128,7 @@ func autoConvert_api_ClusterRole_To_v1beta3_ClusterRole(in *authorizationapi.Clu
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapiv1beta3.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_PolicyRule_To_v1beta3_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -175,7 +175,7 @@ func autoConvert_api_ClusterRoleBindingList_To_v1beta3_ClusterRoleBindingList(in
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.ClusterRoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -287,7 +287,7 @@ func autoConvert_api_PolicyBindingList_To_v1beta3_PolicyBindingList(in *authoriz
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.PolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_PolicyBinding_To_v1beta3_PolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -311,7 +311,7 @@ func autoConvert_api_PolicyList_To_v1beta3_PolicyList(in *authorizationapi.Polic
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.Policy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_Policy_To_v1beta3_Policy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -375,7 +375,7 @@ func autoConvert_api_Role_To_v1beta3_Role(in *authorizationapi.Role, out *author
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapiv1beta3.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_PolicyRule_To_v1beta3_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -422,7 +422,7 @@ func autoConvert_api_RoleBindingList_To_v1beta3_RoleBindingList(in *authorizatio
 	if in.Items != nil {
 		out.Items = make([]authorizationapiv1beta3.RoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_api_RoleBinding_To_v1beta3_RoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -533,7 +533,7 @@ func autoConvert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingLis
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -581,7 +581,7 @@ func autoConvert_v1beta3_ClusterRole_To_api_ClusterRole(in *authorizationapiv1be
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -630,7 +630,7 @@ func autoConvert_v1beta3_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -742,7 +742,7 @@ func autoConvert_v1beta3_PolicyBindingList_To_api_PolicyBindingList(in *authoriz
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_PolicyBinding_To_api_PolicyBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -766,7 +766,7 @@ func autoConvert_v1beta3_PolicyList_To_api_PolicyList(in *authorizationapiv1beta
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.Policy, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_Policy_To_api_Policy(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -831,7 +831,7 @@ func autoConvert_v1beta3_Role_To_api_Role(in *authorizationapiv1beta3.Role, out 
 	if in.Rules != nil {
 		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
 		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
 				return err
 			}
 		}
@@ -880,7 +880,7 @@ func autoConvert_v1beta3_RoleBindingList_To_api_RoleBindingList(in *authorizatio
 	if in.Items != nil {
 		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := authorizationapiv1beta3.Convert_v1beta3_RoleBinding_To_api_RoleBinding(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1021,7 +1021,7 @@ func autoConvert_api_BuildConfigList_To_v1beta3_BuildConfigList(in *buildapi.Bui
 	if in.Items != nil {
 		out.Items = make([]v1beta3.BuildConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := v1beta3.Convert_api_BuildConfig_To_v1beta3_BuildConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1042,7 +1042,7 @@ func autoConvert_api_BuildConfigSpec_To_v1beta3_BuildConfigSpec(in *buildapi.Bui
 	if in.Triggers != nil {
 		out.Triggers = make([]v1beta3.BuildTriggerPolicy, len(in.Triggers))
 		for i := range in.Triggers {
-			if err := s.Convert(&in.Triggers[i], &out.Triggers[i], 0); err != nil {
+			if err := v1beta3.Convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
 				return err
 			}
 		}
@@ -1274,21 +1274,22 @@ func autoConvert_api_BuildSpec_To_v1beta3_BuildSpec(in *buildapi.BuildSpec, out 
 		defaulting.(func(*buildapi.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
+	if err := v1beta3.Convert_api_BuildSource_To_v1beta3_BuildSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
 	// unable to generate simple pointer conversion for api.SourceRevision -> v1beta3.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(v1beta3.SourceRevision)
+		if err := v1beta3.Convert_api_SourceRevision_To_v1beta3_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
+	if err := v1beta3.Convert_api_BuildStrategy_To_v1beta3_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
+	if err := v1beta3.Convert_api_BuildOutput_To_v1beta3_BuildOutput(&in.Output, &out.Output, s); err != nil {
 		return err
 	}
 	if err := Convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
@@ -1360,7 +1361,8 @@ func autoConvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildSt
 	}
 	// unable to generate simple pointer conversion for api.DockerBuildStrategy -> v1beta3.DockerBuildStrategy
 	if in.DockerStrategy != nil {
-		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
+		out.DockerStrategy = new(v1beta3.DockerBuildStrategy)
+		if err := v1beta3.Convert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy(in.DockerStrategy, out.DockerStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1368,7 +1370,8 @@ func autoConvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildSt
 	}
 	// unable to generate simple pointer conversion for api.SourceBuildStrategy -> v1beta3.SourceBuildStrategy
 	if in.SourceStrategy != nil {
-		if err := s.Convert(&in.SourceStrategy, &out.SourceStrategy, 0); err != nil {
+		out.SourceStrategy = new(v1beta3.SourceBuildStrategy)
+		if err := v1beta3.Convert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy(in.SourceStrategy, out.SourceStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1376,7 +1379,8 @@ func autoConvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildSt
 	}
 	// unable to generate simple pointer conversion for api.CustomBuildStrategy -> v1beta3.CustomBuildStrategy
 	if in.CustomStrategy != nil {
-		if err := s.Convert(&in.CustomStrategy, &out.CustomStrategy, 0); err != nil {
+		out.CustomStrategy = new(v1beta3.CustomBuildStrategy)
+		if err := v1beta3.Convert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy(in.CustomStrategy, out.CustomStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -1793,7 +1797,7 @@ func autoConvert_v1beta3_BuildConfigList_To_api_BuildConfigList(in *v1beta3.Buil
 	if in.Items != nil {
 		out.Items = make([]buildapi.BuildConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := v1beta3.Convert_v1beta3_BuildConfig_To_api_BuildConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -1814,7 +1818,7 @@ func autoConvert_v1beta3_BuildConfigSpec_To_api_BuildConfigSpec(in *v1beta3.Buil
 	if in.Triggers != nil {
 		out.Triggers = make([]buildapi.BuildTriggerPolicy, len(in.Triggers))
 		for i := range in.Triggers {
-			if err := s.Convert(&in.Triggers[i], &out.Triggers[i], 0); err != nil {
+			if err := v1beta3.Convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
 				return err
 			}
 		}
@@ -2047,21 +2051,22 @@ func autoConvert_v1beta3_BuildSpec_To_api_BuildSpec(in *v1beta3.BuildSpec, out *
 		defaulting.(func(*v1beta3.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
+	if err := v1beta3.Convert_v1beta3_BuildSource_To_api_BuildSource(&in.Source, &out.Source, s); err != nil {
 		return err
 	}
 	// unable to generate simple pointer conversion for v1beta3.SourceRevision -> api.SourceRevision
 	if in.Revision != nil {
-		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+		out.Revision = new(buildapi.SourceRevision)
+		if err := v1beta3.Convert_v1beta3_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
+	if err := v1beta3.Convert_v1beta3_BuildStrategy_To_api_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
+	if err := v1beta3.Convert_v1beta3_BuildOutput_To_api_BuildOutput(&in.Output, &out.Output, s); err != nil {
 		return err
 	}
 	if err := Convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
@@ -2134,7 +2139,8 @@ func autoConvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *v1beta3.BuildStr
 	// in.Type has no peer in out
 	// unable to generate simple pointer conversion for v1beta3.DockerBuildStrategy -> api.DockerBuildStrategy
 	if in.DockerStrategy != nil {
-		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
+		out.DockerStrategy = new(buildapi.DockerBuildStrategy)
+		if err := v1beta3.Convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in.DockerStrategy, out.DockerStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2142,7 +2148,8 @@ func autoConvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *v1beta3.BuildStr
 	}
 	// unable to generate simple pointer conversion for v1beta3.SourceBuildStrategy -> api.SourceBuildStrategy
 	if in.SourceStrategy != nil {
-		if err := s.Convert(&in.SourceStrategy, &out.SourceStrategy, 0); err != nil {
+		out.SourceStrategy = new(buildapi.SourceBuildStrategy)
+		if err := v1beta3.Convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy(in.SourceStrategy, out.SourceStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2150,7 +2157,8 @@ func autoConvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *v1beta3.BuildStr
 	}
 	// unable to generate simple pointer conversion for v1beta3.CustomBuildStrategy -> api.CustomBuildStrategy
 	if in.CustomStrategy != nil {
-		if err := s.Convert(&in.CustomStrategy, &out.CustomStrategy, 0); err != nil {
+		out.CustomStrategy = new(buildapi.CustomBuildStrategy)
+		if err := v1beta3.Convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy(in.CustomStrategy, out.CustomStrategy, s); err != nil {
 			return err
 		}
 	} else {
@@ -2562,9 +2570,9 @@ func autoConvert_api_DeploymentDetails_To_v1beta3_DeploymentDetails(in *deployap
 	}
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapiv1beta3.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapiv1beta3.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+			if err := Convert_api_DeploymentCause_To_v1beta3_DeploymentCause(&in.Causes[i], &out.Causes[i], s); err != nil {
 				return err
 			}
 		}
@@ -2665,7 +2673,8 @@ func autoConvert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy(
 	out.Type = deployapiv1beta3.DeploymentTriggerType(in.Type)
 	// unable to generate simple pointer conversion for api.DeploymentTriggerImageChangeParams -> v1beta3.DeploymentTriggerImageChangeParams
 	if in.ImageChangeParams != nil {
-		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+		out.ImageChangeParams = new(deployapiv1beta3.DeploymentTriggerImageChangeParams)
+		if err := deployapiv1beta3.Convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams(in.ImageChangeParams, out.ImageChangeParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -2840,9 +2849,9 @@ func autoConvert_v1beta3_DeploymentDetails_To_api_DeploymentDetails(in *deployap
 	}
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapi.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapi.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+			if err := Convert_v1beta3_DeploymentCause_To_api_DeploymentCause(&in.Causes[i], &out.Causes[i], s); err != nil {
 				return err
 			}
 		}
@@ -2943,7 +2952,8 @@ func autoConvert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(
 	out.Type = deployapi.DeploymentTriggerType(in.Type)
 	// unable to generate simple pointer conversion for v1beta3.DeploymentTriggerImageChangeParams -> api.DeploymentTriggerImageChangeParams
 	if in.ImageChangeParams != nil {
-		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+		out.ImageChangeParams = new(deployapi.DeploymentTriggerImageChangeParams)
+		if err := deployapiv1beta3.Convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in.ImageChangeParams, out.ImageChangeParams, s); err != nil {
 			return err
 		}
 	} else {
@@ -3056,7 +3066,7 @@ func autoConvert_api_ImageList_To_v1beta3_ImageList(in *imageapi.ImageList, out 
 	if in.Items != nil {
 		out.Items = make([]imageapiv1beta3.Image, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_api_Image_To_v1beta3_Image(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3077,10 +3087,10 @@ func autoConvert_api_ImageStream_To_v1beta3_ImageStream(in *imageapi.ImageStream
 	if err := Convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+	if err := imageapiv1beta3.Convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+	if err := imageapiv1beta3.Convert_api_ImageStreamStatus_To_v1beta3_ImageStreamStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
@@ -3093,7 +3103,7 @@ func autoConvert_api_ImageStreamImage_To_v1beta3_ImageStreamImage(in *imageapi.I
 	if err := Convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_api_Image_To_v1beta3_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -3109,7 +3119,7 @@ func autoConvert_api_ImageStreamList_To_v1beta3_ImageStreamList(in *imageapi.Ima
 	if in.Items != nil {
 		out.Items = make([]imageapiv1beta3.ImageStream, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_api_ImageStream_To_v1beta3_ImageStream(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3131,7 +3141,7 @@ func autoConvert_api_ImageStreamMapping_To_v1beta3_ImageStreamMapping(in *imagea
 		return err
 	}
 	// in.DockerImageRepository has no peer in out
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_api_Image_To_v1beta3_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	out.Tag = in.Tag
@@ -3170,7 +3180,7 @@ func autoConvert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(in *imageapi.Image
 	// in.Tag has no peer in out
 	out.Generation = in.Generation
 	// in.Conditions has no peer in out
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_api_Image_To_v1beta3_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	return nil
@@ -3186,7 +3196,7 @@ func autoConvert_api_ImageStreamTagList_To_v1beta3_ImageStreamTagList(in *imagea
 	if in.Items != nil {
 		out.Items = make([]imageapiv1beta3.ImageStreamTag, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3236,7 +3246,7 @@ func autoConvert_v1beta3_ImageList_To_api_ImageList(in *imageapiv1beta3.ImageLis
 	if in.Items != nil {
 		out.Items = make([]imageapi.Image, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_v1beta3_Image_To_api_Image(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3257,10 +3267,10 @@ func autoConvert_v1beta3_ImageStream_To_api_ImageStream(in *imageapiv1beta3.Imag
 	if err := Convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+	if err := imageapiv1beta3.Convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Status, &out.Status, 0); err != nil {
+	if err := imageapiv1beta3.Convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
 	return nil
@@ -3270,7 +3280,7 @@ func autoConvert_v1beta3_ImageStreamImage_To_api_ImageStreamImage(in *imageapiv1
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*imageapiv1beta3.ImageStreamImage))(in)
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_v1beta3_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	// in.ImageName has no peer in out
@@ -3287,7 +3297,7 @@ func autoConvert_v1beta3_ImageStreamList_To_api_ImageStreamList(in *imageapiv1be
 	if in.Items != nil {
 		out.Items = make([]imageapi.ImageStream, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_v1beta3_ImageStream_To_api_ImageStream(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -3308,7 +3318,7 @@ func autoConvert_v1beta3_ImageStreamMapping_To_api_ImageStreamMapping(in *imagea
 	if err := Convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_v1beta3_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	out.Tag = in.Tag
@@ -3341,7 +3351,7 @@ func autoConvert_v1beta3_ImageStreamTag_To_api_ImageStreamTag(in *imageapiv1beta
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*imageapiv1beta3.ImageStreamTag))(in)
 	}
-	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
+	if err := imageapiv1beta3.Convert_v1beta3_Image_To_api_Image(&in.Image, &out.Image, s); err != nil {
 		return err
 	}
 	// in.ImageName has no peer in out
@@ -3358,7 +3368,7 @@ func autoConvert_v1beta3_ImageStreamTagList_To_api_ImageStreamTagList(in *imagea
 	if in.Items != nil {
 		out.Items = make([]imageapi.ImageStreamTag, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := imageapiv1beta3.Convert_v1beta3_ImageStreamTag_To_api_ImageStreamTag(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4615,7 +4625,7 @@ func autoConvert_api_TemplateList_To_v1beta3_TemplateList(in *templateapi.Templa
 	if in.Items != nil {
 		out.Items = make([]templateapiv1beta3.Template, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := templateapiv1beta3.Convert_api_Template_To_v1beta3_Template(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -4695,7 +4705,7 @@ func autoConvert_v1beta3_TemplateList_To_api_TemplateList(in *templateapiv1beta3
 	if in.Items != nil {
 		out.Items = make([]templateapi.Template, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := templateapiv1beta3.Convert_v1beta3_Template_To_api_Template(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1589,14 +1589,10 @@ func deepCopy_v1beta3_DeploymentConfigStatus(in deployapiv1beta3.DeploymentConfi
 func deepCopy_v1beta3_DeploymentDetails(in deployapiv1beta3.DeploymentDetails, out *deployapiv1beta3.DeploymentDetails, c *conversion.Cloner) error {
 	out.Message = in.Message
 	if in.Causes != nil {
-		out.Causes = make([]*deployapiv1beta3.DeploymentCause, len(in.Causes))
+		out.Causes = make([]deployapiv1beta3.DeploymentCause, len(in.Causes))
 		for i := range in.Causes {
-			if newVal, err := c.DeepCopy(in.Causes[i]); err != nil {
+			if err := deepCopy_v1beta3_DeploymentCause(in.Causes[i], &out.Causes[i], c); err != nil {
 				return err
-			} else if newVal == nil {
-				out.Causes[i] = nil
-			} else {
-				out.Causes[i] = newVal.(*deployapiv1beta3.DeploymentCause)
 			}
 		}
 	} else {

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"reflect"
 	"sort"
 
 	"k8s.io/kubernetes/pkg/conversion"
@@ -12,7 +13,7 @@ import (
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
-func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
+func Convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -23,7 +24,7 @@ func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAcc
 	return nil
 }
 
-func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
+func Convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -34,7 +35,7 @@ func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *newer.Resou
 	return nil
 }
 
-func convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
+func Convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -45,7 +46,7 @@ func convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *L
 	return nil
 }
 
-func convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
+func Convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -56,33 +57,7 @@ func convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview(in *n
 	return nil
 }
 
-func convert_v1_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-
-	out.Groups = sets.NewString(in.GroupsSlice...)
-
-	return nil
-}
-
-func convert_api_SubjectAccessReview_To_v1_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-
-	out.GroupsSlice = in.Groups.List()
-
-	return nil
-}
-
-func convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+func Convert_v1_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -95,7 +70,7 @@ func convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *Loc
 	return nil
 }
 
-func convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+func Convert_api_SubjectAccessReview_To_v1_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -108,7 +83,33 @@ func convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview(in *new
 	return nil
 }
 
-func convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse(in *ResourceAccessReviewResponse, out *newer.ResourceAccessReviewResponse, s conversion.Scope) error {
+func Convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.Groups = sets.NewString(in.GroupsSlice...)
+
+	return nil
+}
+
+func Convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.GroupsSlice = in.Groups.List()
+
+	return nil
+}
+
+func Convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse(in *ResourceAccessReviewResponse, out *newer.ResourceAccessReviewResponse, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -119,7 +120,7 @@ func convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse
 	return nil
 }
 
-func convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse(in *newer.ResourceAccessReviewResponse, out *ResourceAccessReviewResponse, s conversion.Scope) error {
+func Convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse(in *newer.ResourceAccessReviewResponse, out *ResourceAccessReviewResponse, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -130,7 +131,10 @@ func convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse
 	return nil
 }
 
-func convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRule, s conversion.Scope) error {
+func Convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRule, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*PolicyRule))(in)
+	}
 	if err := oapi.Convert_runtime_RawExtension_To_runtime_Object(&in.AttributeRestrictions, out.AttributeRestrictions, s); err != nil {
 		return err
 	}
@@ -153,7 +157,7 @@ func convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRu
 	return nil
 }
 
-func convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRule, s conversion.Scope) error {
+func Convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRule, s conversion.Scope) error {
 	if err := oapi.Convert_runtime_Object_To_runtime_RawExtension(in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
@@ -173,19 +177,19 @@ func convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRu
 	return nil
 }
 
-func convert_v1_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
+func Convert_v1_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make(map[string]*newer.Role)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_Policy_To_v1_Policy(in *newer.Policy, out *Policy, s conversion.Scope) error {
+func Convert_api_Policy_To_v1_Policy(in *newer.Policy, out *Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make([]NamedRole, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_v1_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleBinding, s conversion.Scope) error {
+func Convert_v1_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -200,7 +204,7 @@ func convert_v1_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleB
 	return nil
 }
 
-func convert_api_RoleBinding_To_v1_RoleBinding(in *newer.RoleBinding, out *RoleBinding, s conversion.Scope) error {
+func Convert_api_RoleBinding_To_v1_RoleBinding(in *newer.RoleBinding, out *RoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -210,32 +214,32 @@ func convert_api_RoleBinding_To_v1_RoleBinding(in *newer.RoleBinding, out *RoleB
 	return nil
 }
 
-func convert_v1_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
+func Convert_v1_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make(map[string]*newer.RoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_PolicyBinding_To_v1_PolicyBinding(in *newer.PolicyBinding, out *PolicyBinding, s conversion.Scope) error {
+func Convert_api_PolicyBinding_To_v1_PolicyBinding(in *newer.PolicyBinding, out *PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make([]NamedRoleBinding, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
 // and now the globals
-func convert_v1_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
+func Convert_v1_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make(map[string]*newer.ClusterRole)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_ClusterPolicy_To_v1_ClusterPolicy(in *newer.ClusterPolicy, out *ClusterPolicy, s conversion.Scope) error {
+func Convert_api_ClusterPolicy_To_v1_ClusterPolicy(in *newer.ClusterPolicy, out *ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make([]NamedClusterRole, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBinding, out *newer.ClusterRoleBinding, s conversion.Scope) error {
+func Convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBinding, out *newer.ClusterRoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -250,7 +254,7 @@ func convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBind
 	return nil
 }
 
-func convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
+func Convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -260,171 +264,180 @@ func convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer.ClusterRo
 	return nil
 }
 
-func convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
+func Convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make(map[string]*newer.ClusterRoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding(in *newer.ClusterPolicyBinding, out *ClusterPolicyBinding, s conversion.Scope) error {
+func Convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding(in *newer.ClusterPolicyBinding, out *ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make([]NamedClusterRoleBinding, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
+func Convert_v1_NamedRoleArray_to_api_RoleArray(in *[]NamedRole, out *map[string]*newer.Role, s conversion.Scope) error {
+	for _, curr := range *in {
+		newRole := &newer.Role{}
+		if err := s.Convert(&curr.Role, newRole, 0); err != nil {
+			return err
+		}
+		(*out)[curr.Name] = newRole
+	}
+
+	return nil
+}
+func Convert_api_NamedRoleArray_to_v1_RoleArray(in *map[string]*newer.Role, out *[]NamedRole, s conversion.Scope) error {
+	allKeys := make([]string, 0, len(*in))
+	for key := range *in {
+		allKeys = append(allKeys, key)
+	}
+	sort.Strings(allKeys)
+
+	for _, key := range allKeys {
+		newRole := (*in)[key]
+		oldRole := &Role{}
+		if err := s.Convert(newRole, oldRole, 0); err != nil {
+			return err
+		}
+
+		namedRole := NamedRole{key, *oldRole}
+		*out = append(*out, namedRole)
+	}
+
+	return nil
+}
+
+func Convert_v1_NamedRoleBindingArray_to_api_RoleBindingArray(in *[]NamedRoleBinding, out *map[string]*newer.RoleBinding, s conversion.Scope) error {
+	for _, curr := range *in {
+		newRoleBinding := &newer.RoleBinding{}
+		if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
+			return err
+		}
+		(*out)[curr.Name] = newRoleBinding
+	}
+
+	return nil
+}
+func Convert_api_RoleBindingArray_to_v1_NamedRoleBindingArray(in *map[string]*newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
+	allKeys := make([]string, 0, len(*in))
+	for key := range *in {
+		allKeys = append(allKeys, key)
+	}
+	sort.Strings(allKeys)
+
+	for _, key := range allKeys {
+		newRoleBinding := (*in)[key]
+		oldRoleBinding := &RoleBinding{}
+		if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
+			return err
+		}
+
+		namedRoleBinding := NamedRoleBinding{key, *oldRoleBinding}
+		*out = append(*out, namedRoleBinding)
+	}
+
+	return nil
+}
+
+func Convert_v1_NamedClusterRoleArray_to_api_ClusterRoleArray(in *[]NamedClusterRole, out *map[string]*newer.ClusterRole, s conversion.Scope) error {
+	for _, curr := range *in {
+		newRole := &newer.ClusterRole{}
+		if err := s.Convert(&curr.Role, newRole, 0); err != nil {
+			return err
+		}
+		(*out)[curr.Name] = newRole
+	}
+
+	return nil
+}
+func Convert_api_ClusterRoleArray_to_v1_NamedClusterRoleArray(in *map[string]*newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
+	allKeys := make([]string, 0, len(*in))
+	for key := range *in {
+		allKeys = append(allKeys, key)
+	}
+	sort.Strings(allKeys)
+
+	for _, key := range allKeys {
+		newRole := (*in)[key]
+		oldRole := &ClusterRole{}
+		if err := s.Convert(newRole, oldRole, 0); err != nil {
+			return err
+		}
+
+		namedRole := NamedClusterRole{key, *oldRole}
+		*out = append(*out, namedRole)
+	}
+
+	return nil
+}
+func Convert_v1_NamedClusterRoleBindingArray_to_ClusterRoleBindingArray(in *[]NamedClusterRoleBinding, out *map[string]*newer.ClusterRoleBinding, s conversion.Scope) error {
+	for _, curr := range *in {
+		newRoleBinding := &newer.ClusterRoleBinding{}
+		if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
+			return err
+		}
+		(*out)[curr.Name] = newRoleBinding
+	}
+
+	return nil
+}
+func Convert_api_ClusterRoleBindingArray_to_v1_NamedClusterRoleBindingArray(in *map[string]*newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
+	allKeys := make([]string, 0, len(*in))
+	for key := range *in {
+		allKeys = append(allKeys, key)
+	}
+	sort.Strings(allKeys)
+
+	for _, key := range allKeys {
+		newRoleBinding := (*in)[key]
+		oldRoleBinding := &ClusterRoleBinding{}
+		if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
+			return err
+		}
+
+		namedRoleBinding := NamedClusterRoleBinding{key, *oldRoleBinding}
+		*out = append(*out, namedRoleBinding)
+	}
+
+	return nil
+}
+
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		func(in *[]NamedRole, out *map[string]*newer.Role, s conversion.Scope) error {
-			for _, curr := range *in {
-				newRole := &newer.Role{}
-				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
-					return err
-				}
-				(*out)[curr.Name] = newRole
-			}
+		Convert_v1_NamedRoleArray_to_api_RoleArray,
+		Convert_api_NamedRoleArray_to_v1_RoleArray,
+		Convert_v1_NamedRoleBindingArray_to_api_RoleBindingArray,
+		Convert_api_RoleBindingArray_to_v1_NamedRoleBindingArray,
+		Convert_v1_NamedClusterRoleArray_to_api_ClusterRoleArray,
+		Convert_api_ClusterRoleArray_to_v1_NamedClusterRoleArray,
+		Convert_v1_NamedClusterRoleBindingArray_to_ClusterRoleBindingArray,
+		Convert_api_ClusterRoleBindingArray_to_v1_NamedClusterRoleBindingArray,
 
-			return nil
-		},
-		func(in *map[string]*newer.Role, out *[]NamedRole, s conversion.Scope) error {
-			allKeys := make([]string, 0, len(*in))
-			for key := range *in {
-				allKeys = append(allKeys, key)
-			}
-			sort.Strings(allKeys)
-
-			for _, key := range allKeys {
-				newRole := (*in)[key]
-				oldRole := &Role{}
-				if err := s.Convert(newRole, oldRole, 0); err != nil {
-					return err
-				}
-
-				namedRole := NamedRole{key, *oldRole}
-				*out = append(*out, namedRole)
-			}
-
-			return nil
-		},
-
-		func(in *[]NamedRoleBinding, out *map[string]*newer.RoleBinding, s conversion.Scope) error {
-			for _, curr := range *in {
-				newRoleBinding := &newer.RoleBinding{}
-				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
-					return err
-				}
-				(*out)[curr.Name] = newRoleBinding
-			}
-
-			return nil
-		},
-		func(in *map[string]*newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
-			allKeys := make([]string, 0, len(*in))
-			for key := range *in {
-				allKeys = append(allKeys, key)
-			}
-			sort.Strings(allKeys)
-
-			for _, key := range allKeys {
-				newRoleBinding := (*in)[key]
-				oldRoleBinding := &RoleBinding{}
-				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
-					return err
-				}
-
-				namedRoleBinding := NamedRoleBinding{key, *oldRoleBinding}
-				*out = append(*out, namedRoleBinding)
-			}
-
-			return nil
-		},
-
-		func(in *[]NamedClusterRole, out *map[string]*newer.ClusterRole, s conversion.Scope) error {
-			for _, curr := range *in {
-				newRole := &newer.ClusterRole{}
-				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
-					return err
-				}
-				(*out)[curr.Name] = newRole
-			}
-
-			return nil
-		},
-		func(in *map[string]*newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
-			allKeys := make([]string, 0, len(*in))
-			for key := range *in {
-				allKeys = append(allKeys, key)
-			}
-			sort.Strings(allKeys)
-
-			for _, key := range allKeys {
-				newRole := (*in)[key]
-				oldRole := &ClusterRole{}
-				if err := s.Convert(newRole, oldRole, 0); err != nil {
-					return err
-				}
-
-				namedRole := NamedClusterRole{key, *oldRole}
-				*out = append(*out, namedRole)
-			}
-
-			return nil
-		},
-		func(in *[]NamedClusterRoleBinding, out *map[string]*newer.ClusterRoleBinding, s conversion.Scope) error {
-			for _, curr := range *in {
-				newRoleBinding := &newer.ClusterRoleBinding{}
-				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
-					return err
-				}
-				(*out)[curr.Name] = newRoleBinding
-			}
-
-			return nil
-		},
-		func(in *map[string]*newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
-			allKeys := make([]string, 0, len(*in))
-			for key := range *in {
-				allKeys = append(allKeys, key)
-			}
-			sort.Strings(allKeys)
-
-			for _, key := range allKeys {
-				newRoleBinding := (*in)[key]
-				oldRoleBinding := &ClusterRoleBinding{}
-				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
-					return err
-				}
-
-				namedRoleBinding := NamedClusterRoleBinding{key, *oldRoleBinding}
-				*out = append(*out, namedRoleBinding)
-			}
-
-			return nil
-		},
-
-		convert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
-		convert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
-		convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
-		convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview,
-		convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
-		convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
-		convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
-		convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview,
-		convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
-		convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse,
-		convert_v1_PolicyRule_To_api_PolicyRule,
-		convert_api_PolicyRule_To_v1_PolicyRule,
-		convert_v1_Policy_To_api_Policy,
-		convert_api_Policy_To_v1_Policy,
-		convert_v1_RoleBinding_To_api_RoleBinding,
-		convert_api_RoleBinding_To_v1_RoleBinding,
-		convert_v1_PolicyBinding_To_api_PolicyBinding,
-		convert_api_PolicyBinding_To_v1_PolicyBinding,
-		convert_v1_ClusterPolicy_To_api_ClusterPolicy,
-		convert_api_ClusterPolicy_To_v1_ClusterPolicy,
-		convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding,
-		convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding,
-		convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding,
-		convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding,
+		Convert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
+		Convert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
+		Convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		Convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview,
+		Convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
+		Convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
+		Convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
+		Convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview,
+		Convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
+		Convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse,
+		Convert_v1_PolicyRule_To_api_PolicyRule,
+		Convert_api_PolicyRule_To_v1_PolicyRule,
+		Convert_v1_Policy_To_api_Policy,
+		Convert_api_Policy_To_v1_Policy,
+		Convert_v1_RoleBinding_To_api_RoleBinding,
+		Convert_api_RoleBinding_To_v1_RoleBinding,
+		Convert_v1_PolicyBinding_To_api_PolicyBinding,
+		Convert_api_PolicyBinding_To_v1_PolicyBinding,
+		Convert_v1_ClusterPolicy_To_api_ClusterPolicy,
+		Convert_api_ClusterPolicy_To_v1_ClusterPolicy,
+		Convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding,
+		Convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding,
+		Convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding,
+		Convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/authorization/api/v1/defaults_test.go
+++ b/pkg/authorization/api/v1/defaults_test.go
@@ -1,0 +1,29 @@
+package v1_test
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/api/v1"
+
+	// install all APIs
+	_ "github.com/openshift/origin/pkg/api/install"
+)
+
+func TestDefaults(t *testing.T) {
+	obj := &v1.PolicyRule{
+		APIGroups: nil,
+		Verbs:     []string{api.VerbAll},
+		Resources: []string{api.ResourceAll},
+	}
+	out := &api.PolicyRule{}
+	if err := kapi.Scheme.Convert(obj, out); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(out.APIGroups, []string{api.APIGroupAll}) {
+		t.Errorf("did not default api groups: %#v", out)
+	}
+}

--- a/pkg/authorization/api/v1beta3/conversion.go
+++ b/pkg/authorization/api/v1beta3/conversion.go
@@ -12,7 +12,7 @@ import (
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
-func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
+func Convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *Resour
 	return nil
 }
 
-func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
+func Convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *newer.
 	return nil
 }
 
-func convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
+func Convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview(
 	return nil
 }
 
-func convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
+func Convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -56,33 +56,7 @@ func convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview(
 	return nil
 }
 
-func convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-
-	out.Groups = sets.NewString(in.GroupsSlice...)
-
-	return nil
-}
-
-func convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-
-	out.GroupsSlice = in.Groups.List()
-
-	return nil
-}
-
-func convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+func Convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -95,7 +69,7 @@ func convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in
 	return nil
 }
 
-func convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+func Convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -108,7 +82,33 @@ func convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview(in
 	return nil
 }
 
-func convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse(in *ResourceAccessReviewResponse, out *newer.ResourceAccessReviewResponse, s conversion.Scope) error {
+func Convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.Groups = sets.NewString(in.GroupsSlice...)
+
+	return nil
+}
+
+func Convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.GroupsSlice = in.Groups.List()
+
+	return nil
+}
+
+func Convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse(in *ResourceAccessReviewResponse, out *newer.ResourceAccessReviewResponse, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewRes
 	return nil
 }
 
-func convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse(in *newer.ResourceAccessReviewResponse, out *ResourceAccessReviewResponse, s conversion.Scope) error {
+func Convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse(in *newer.ResourceAccessReviewResponse, out *ResourceAccessReviewResponse, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewRes
 	return nil
 }
 
-func convert_v1beta3_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRule, s conversion.Scope) error {
+func Convert_v1beta3_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRule, s conversion.Scope) error {
 	if err := oapi.Convert_runtime_RawExtension_To_runtime_Object(&in.AttributeRestrictions, out.AttributeRestrictions, s); err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func convert_v1beta3_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.Pol
 	return nil
 }
 
-func convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *PolicyRule, s conversion.Scope) error {
+func Convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *PolicyRule, s conversion.Scope) error {
 	if err := oapi.Convert_runtime_Object_To_runtime_RawExtension(in.AttributeRestrictions, &out.AttributeRestrictions, s); err != nil {
 		return err
 	}
@@ -174,19 +174,19 @@ func convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *Pol
 	return nil
 }
 
-func convert_v1beta3_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
+func Convert_v1beta3_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make(map[string]*newer.Role)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_Policy_To_v1beta3_Policy(in *newer.Policy, out *Policy, s conversion.Scope) error {
+func Convert_api_Policy_To_v1beta3_Policy(in *newer.Policy, out *Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make([]NamedRole, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_v1beta3_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleBinding, s conversion.Scope) error {
+func Convert_v1beta3_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func convert_v1beta3_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.
 	return nil
 }
 
-func convert_api_RoleBinding_To_v1beta3_RoleBinding(in *newer.RoleBinding, out *RoleBinding, s conversion.Scope) error {
+func Convert_api_RoleBinding_To_v1beta3_RoleBinding(in *newer.RoleBinding, out *RoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -211,32 +211,32 @@ func convert_api_RoleBinding_To_v1beta3_RoleBinding(in *newer.RoleBinding, out *
 	return nil
 }
 
-func convert_v1beta3_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
+func Convert_v1beta3_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make(map[string]*newer.RoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_PolicyBinding_To_v1beta3_PolicyBinding(in *newer.PolicyBinding, out *PolicyBinding, s conversion.Scope) error {
+func Convert_api_PolicyBinding_To_v1beta3_PolicyBinding(in *newer.PolicyBinding, out *PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make([]NamedRoleBinding, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
 // and now the globals
-func convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
+func Convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make(map[string]*newer.ClusterRole)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(in *newer.ClusterPolicy, out *ClusterPolicy, s conversion.Scope) error {
+func Convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(in *newer.ClusterPolicy, out *ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.Roles = make([]NamedClusterRole, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBinding, out *newer.ClusterRoleBinding, s conversion.Scope) error {
+func Convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBinding, out *newer.ClusterRoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRol
 	return nil
 }
 
-func convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding(in *newer.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
+func Convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding(in *newer.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
 		return err
 	}
@@ -261,13 +261,13 @@ func convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding(in *newer.Clus
 	return nil
 }
 
-func convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
+func Convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make(map[string]*newer.ClusterRoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
-func convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding(in *newer.ClusterPolicyBinding, out *ClusterPolicyBinding, s conversion.Scope) error {
+func Convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding(in *newer.ClusterPolicyBinding, out *ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
 	out.RoleBindings = make([]NamedClusterRoleBinding, 0, 0)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
@@ -275,29 +275,29 @@ func convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding(in *newer.
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
-		convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
-		convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
-		convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview,
-		convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
-		convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
-		convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
-		convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview,
-		convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
-		convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse,
-		convert_v1beta3_PolicyRule_To_api_PolicyRule,
-		convert_api_PolicyRule_To_v1beta3_PolicyRule,
-		convert_v1beta3_Policy_To_api_Policy,
-		convert_api_Policy_To_v1beta3_Policy,
-		convert_v1beta3_RoleBinding_To_api_RoleBinding,
-		convert_api_RoleBinding_To_v1beta3_RoleBinding,
-		convert_v1beta3_PolicyBinding_To_api_PolicyBinding,
-		convert_api_PolicyBinding_To_v1beta3_PolicyBinding,
-		convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy,
-		convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding,
-		convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding,
-		convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding,
-		convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding,
+		Convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
+		Convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
+		Convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		Convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview,
+		Convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
+		Convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
+		Convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
+		Convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview,
+		Convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
+		Convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse,
+		Convert_v1beta3_PolicyRule_To_api_PolicyRule,
+		Convert_api_PolicyRule_To_v1beta3_PolicyRule,
+		Convert_v1beta3_Policy_To_api_Policy,
+		Convert_api_Policy_To_v1beta3_Policy,
+		Convert_v1beta3_RoleBinding_To_api_RoleBinding,
+		Convert_api_RoleBinding_To_v1beta3_RoleBinding,
+		Convert_v1beta3_PolicyBinding_To_api_PolicyBinding,
+		Convert_api_PolicyBinding_To_v1beta3_PolicyBinding,
+		Convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy,
+		Convert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding,
+		Convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding,
+		Convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding,
+		Convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding,
 
 		func(in *[]NamedRoleBinding, out *map[string]*newer.RoleBinding, s conversion.Scope) error {
 			for _, curr := range *in {

--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -10,7 +10,7 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.BuildConfig, s conversion.Scope) error {
+func Convert_v1_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.BuildConfig, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -36,14 +36,14 @@ func convert_v1_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.Build
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_BuildConfig_To_v1_BuildConfig(in *newer.BuildConfig, out *BuildConfig, s conversion.Scope) error {
+func Convert_api_BuildConfig_To_v1_BuildConfig(in *newer.BuildConfig, out *BuildConfig, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBuildStrategy, out *newer.SourceBuildStrategy, s conversion.Scope) error {
+func Convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBuildStrategy, out *newer.SourceBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -56,14 +56,14 @@ func convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBuildSt
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *newer.SourceBuildStrategy, out *SourceBuildStrategy, s conversion.Scope) error {
+func Convert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *newer.SourceBuildStrategy, out *SourceBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildStrategy, out *newer.DockerBuildStrategy, s conversion.Scope) error {
+func Convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildStrategy, out *newer.DockerBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -78,14 +78,14 @@ func convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildSt
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy(in *newer.DockerBuildStrategy, out *DockerBuildStrategy, s conversion.Scope) error {
+func Convert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy(in *newer.DockerBuildStrategy, out *DockerBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildStrategy, out *newer.CustomBuildStrategy, s conversion.Scope) error {
+func Convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildStrategy, out *newer.CustomBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -98,14 +98,14 @@ func convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildSt
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy(in *newer.CustomBuildStrategy, out *CustomBuildStrategy, s conversion.Scope) error {
+func Convert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy(in *newer.CustomBuildStrategy, out *CustomBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.BuildOutput, s conversion.Scope) error {
+func Convert_v1_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.BuildOutput, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func convert_v1_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.Build
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_BuildOutput_To_v1_BuildOutput(in *newer.BuildOutput, out *BuildOutput, s conversion.Scope) error {
+func Convert_api_BuildOutput_To_v1_BuildOutput(in *newer.BuildOutput, out *BuildOutput, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -125,14 +125,14 @@ func convert_api_BuildOutput_To_v1_BuildOutput(in *newer.BuildOutput, out *Build
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy(in *newer.BuildTriggerPolicy, out *BuildTriggerPolicy, s conversion.Scope) error {
+func Convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy(in *newer.BuildTriggerPolicy, out *BuildTriggerPolicy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.DestFromSource); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPolicy, out *newer.BuildTriggerPolicy, s conversion.Scope) error {
+func Convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPolicy, out *newer.BuildTriggerPolicy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.DestFromSource); err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPol
 	return nil
 }
 
-func convert_api_SourceRevision_To_v1_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
+func Convert_api_SourceRevision_To_v1_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -155,14 +155,14 @@ func convert_api_SourceRevision_To_v1_SourceRevision(in *newer.SourceRevision, o
 	return nil
 }
 
-func convert_v1_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
+func Convert_v1_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_BuildSource_To_v1_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
+func Convert_api_BuildSource_To_v1_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -181,14 +181,14 @@ func convert_api_BuildSource_To_v1_BuildSource(in *newer.BuildSource, out *Build
 	return nil
 }
 
-func convert_v1_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
+func Convert_v1_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_BuildStrategy_To_v1_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
+func Convert_api_BuildStrategy_To_v1_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func convert_api_BuildStrategy_To_v1_BuildStrategy(in *newer.BuildStrategy, out 
 	return nil
 }
 
-func convert_v1_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
+func Convert_v1_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -237,6 +237,8 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 				obj.From.Kind = "ImageStreamTag"
 			}
 		},
+		// TODO: this defaulter is never called, because triggers with ImageChange type but imagechange nil
+		// are dropped.
 		func(obj *BuildTriggerPolicy) {
 			if obj.Type == ImageChangeBuildTriggerType && obj.ImageChange == nil {
 				obj.ImageChange = &ImageChangeTrigger{}
@@ -248,24 +250,24 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 
 	scheme.AddConversionFuncs(
-		convert_v1_BuildConfig_To_api_BuildConfig,
-		convert_api_BuildConfig_To_v1_BuildConfig,
-		convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy,
-		convert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy,
-		convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy,
-		convert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy,
-		convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy,
-		convert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy,
-		convert_v1_BuildOutput_To_api_BuildOutput,
-		convert_api_BuildOutput_To_v1_BuildOutput,
-		convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
-		convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy,
-		convert_v1_SourceRevision_To_api_SourceRevision,
-		convert_api_SourceRevision_To_v1_SourceRevision,
-		convert_v1_BuildSource_To_api_BuildSource,
-		convert_api_BuildSource_To_v1_BuildSource,
-		convert_v1_BuildStrategy_To_api_BuildStrategy,
-		convert_api_BuildStrategy_To_v1_BuildStrategy,
+		Convert_v1_BuildConfig_To_api_BuildConfig,
+		Convert_api_BuildConfig_To_v1_BuildConfig,
+		Convert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy,
+		Convert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy,
+		Convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy,
+		Convert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy,
+		Convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy,
+		Convert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy,
+		Convert_v1_BuildOutput_To_api_BuildOutput,
+		Convert_api_BuildOutput_To_v1_BuildOutput,
+		Convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
+		Convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy,
+		Convert_v1_SourceRevision_To_api_SourceRevision,
+		Convert_api_SourceRevision_To_v1_SourceRevision,
+		Convert_v1_BuildSource_To_api_BuildSource,
+		Convert_api_BuildSource_To_v1_BuildSource,
+		Convert_v1_BuildStrategy_To_api_BuildStrategy,
+		Convert_api_BuildStrategy_To_v1_BuildStrategy,
 	)
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Build",

--- a/pkg/build/api/v1/defaults_test.go
+++ b/pkg/build/api/v1/defaults_test.go
@@ -1,0 +1,84 @@
+package v1_test
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/api/v1"
+
+	// install all APIs
+	_ "github.com/openshift/origin/pkg/api/install"
+)
+
+func TestDefaults(t *testing.T) {
+	testCases := []struct {
+		External runtime.Object
+		Internal runtime.Object
+		Ok       func(runtime.Object) bool
+	}{
+		{
+			External: &v1.Build{
+				Spec: v1.BuildSpec{Strategy: v1.BuildStrategy{Type: v1.DockerBuildStrategyType}},
+			},
+			Internal: &api.Build{},
+			Ok: func(out runtime.Object) bool {
+				obj := out.(*api.Build)
+				return obj.Spec.Strategy.DockerStrategy != nil
+			},
+		},
+		{
+			External: &v1.Build{
+				Spec: v1.BuildSpec{Strategy: v1.BuildStrategy{SourceStrategy: &v1.SourceBuildStrategy{}}},
+			},
+			Internal: &api.Build{},
+			Ok: func(out runtime.Object) bool {
+				obj := out.(*api.Build)
+				return obj.Spec.Strategy.SourceStrategy.From.Kind == "ImageStreamTag"
+			},
+		},
+		{
+			External: &v1.Build{
+				Spec: v1.BuildSpec{Strategy: v1.BuildStrategy{DockerStrategy: &v1.DockerBuildStrategy{From: &kapiv1.ObjectReference{}}}},
+			},
+			Internal: &api.Build{},
+			Ok: func(out runtime.Object) bool {
+				obj := out.(*api.Build)
+				return obj.Spec.Strategy.DockerStrategy.From.Kind == "ImageStreamTag"
+			},
+		},
+		{
+			External: &v1.Build{
+				Spec: v1.BuildSpec{Strategy: v1.BuildStrategy{CustomStrategy: &v1.CustomBuildStrategy{}}},
+			},
+			Internal: &api.Build{},
+			Ok: func(out runtime.Object) bool {
+				obj := out.(*api.Build)
+				return obj.Spec.Strategy.CustomStrategy.From.Kind == "ImageStreamTag"
+			},
+		},
+		{
+			External: &v1.BuildConfig{
+				Spec: v1.BuildConfigSpec{Triggers: []v1.BuildTriggerPolicy{{Type: v1.ImageChangeBuildTriggerType}}},
+			},
+			Internal: &api.BuildConfig{},
+			Ok: func(out runtime.Object) bool {
+				obj := out.(*api.BuildConfig)
+				// conversion drops this trigger because it has no type
+				return len(obj.Spec.Triggers) == 0
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		if err := kapi.Scheme.Convert(test.External, test.Internal); err != nil {
+			t.Fatal(err)
+		}
+		if !test.Ok(test.Internal) {
+			t.Errorf("%d: did not match: %#v", i, test.Internal)
+		}
+	}
+}

--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -11,7 +11,7 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1beta3_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.BuildConfig, s conversion.Scope) error {
+func Convert_v1beta3_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.BuildConfig, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -37,14 +37,14 @@ func convert_v1beta3_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_BuildConfig_To_v1beta3_BuildConfig(in *newer.BuildConfig, out *BuildConfig, s conversion.Scope) error {
+func Convert_api_BuildConfig_To_v1beta3_BuildConfig(in *newer.BuildConfig, out *BuildConfig, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBuildStrategy, out *newer.SourceBuildStrategy, s conversion.Scope) error {
+func Convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBuildStrategy, out *newer.SourceBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -57,14 +57,14 @@ func convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBu
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy(in *newer.SourceBuildStrategy, out *SourceBuildStrategy, s conversion.Scope) error {
+func Convert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy(in *newer.SourceBuildStrategy, out *SourceBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildStrategy, out *newer.DockerBuildStrategy, s conversion.Scope) error {
+func Convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildStrategy, out *newer.DockerBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -79,14 +79,14 @@ func convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBu
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy(in *newer.DockerBuildStrategy, out *DockerBuildStrategy, s conversion.Scope) error {
+func Convert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy(in *newer.DockerBuildStrategy, out *DockerBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildStrategy, out *newer.CustomBuildStrategy, s conversion.Scope) error {
+func Convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildStrategy, out *newer.CustomBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -99,14 +99,14 @@ func convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBu
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy(in *newer.CustomBuildStrategy, out *CustomBuildStrategy, s conversion.Scope) error {
+func Convert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy(in *newer.CustomBuildStrategy, out *CustomBuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta3_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.BuildOutput, s conversion.Scope) error {
+func Convert_v1beta3_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.BuildOutput, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -118,14 +118,14 @@ func convert_v1beta3_BuildOutput_To_api_BuildOutput(in *BuildOutput, out *newer.
 }
 
 // empty conversion needed because the conversion generator can't handle unidirectional custom conversions
-func convert_api_BuildOutput_To_v1beta3_BuildOutput(in *newer.BuildOutput, out *BuildOutput, s conversion.Scope) error {
+func Convert_api_BuildOutput_To_v1beta3_BuildOutput(in *newer.BuildOutput, out *BuildOutput, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPolicy, out *newer.BuildTriggerPolicy, s conversion.Scope) error {
+func Convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPolicy, out *newer.BuildTriggerPolicy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.DestFromSource); err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTrigg
 	return nil
 }
 
-func convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(in *newer.BuildTriggerPolicy, out *BuildTriggerPolicy, s conversion.Scope) error {
+func Convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(in *newer.BuildTriggerPolicy, out *BuildTriggerPolicy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.DestFromSource); err != nil {
 		return err
 	}
@@ -155,14 +155,14 @@ func convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(in *newer.Buil
 	return nil
 }
 
-func convert_v1beta3_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
+func Convert_v1beta3_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_SourceRevision_To_v1beta3_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
+func Convert_api_SourceRevision_To_v1beta3_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -170,14 +170,14 @@ func convert_api_SourceRevision_To_v1beta3_SourceRevision(in *newer.SourceRevisi
 	return nil
 }
 
-func convert_v1beta3_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
+func Convert_v1beta3_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_BuildSource_To_v1beta3_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
+func Convert_api_BuildSource_To_v1beta3_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -196,14 +196,14 @@ func convert_api_BuildSource_To_v1beta3_BuildSource(in *newer.BuildSource, out *
 	return nil
 }
 
-func convert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
+func Convert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	return nil
 }
 
-func convert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
+func Convert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -254,24 +254,24 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 
 	scheme.AddConversionFuncs(
-		convert_v1beta3_BuildConfig_To_api_BuildConfig,
-		convert_api_BuildConfig_To_v1beta3_BuildConfig,
-		convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy,
-		convert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy,
-		convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy,
-		convert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy,
-		convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy,
-		convert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy,
-		convert_v1beta3_BuildOutput_To_api_BuildOutput,
-		convert_api_BuildOutput_To_v1beta3_BuildOutput,
-		convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
-		convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy,
-		convert_v1beta3_SourceRevision_To_api_SourceRevision,
-		convert_api_SourceRevision_To_v1beta3_SourceRevision,
-		convert_v1beta3_BuildSource_To_api_BuildSource,
-		convert_api_BuildSource_To_v1beta3_BuildSource,
-		convert_v1beta3_BuildStrategy_To_api_BuildStrategy,
-		convert_api_BuildStrategy_To_v1beta3_BuildStrategy,
+		Convert_v1beta3_BuildConfig_To_api_BuildConfig,
+		Convert_api_BuildConfig_To_v1beta3_BuildConfig,
+		Convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy,
+		Convert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy,
+		Convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy,
+		Convert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy,
+		Convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy,
+		Convert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy,
+		Convert_v1beta3_BuildOutput_To_api_BuildOutput,
+		Convert_api_BuildOutput_To_v1beta3_BuildOutput,
+		Convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
+		Convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy,
+		Convert_v1beta3_SourceRevision_To_api_SourceRevision,
+		Convert_api_SourceRevision_To_v1beta3_SourceRevision,
+		Convert_v1beta3_BuildSource_To_api_BuildSource,
+		Convert_api_BuildSource_To_v1beta3_BuildSource,
+		Convert_v1beta3_BuildStrategy_To_api_BuildStrategy,
+		Convert_api_BuildStrategy_To_v1beta3_BuildStrategy,
 	)
 
 	// Add field conversion funcs.

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -28,7 +28,7 @@ func OkDeploymentConfigStatus(version int) deployapi.DeploymentConfigStatus {
 
 func OkImageChangeDetails() *deployapi.DeploymentDetails {
 	return &deployapi.DeploymentDetails{
-		Causes: []*deployapi.DeploymentCause{{
+		Causes: []deployapi.DeploymentCause{{
 			Type: deployapi.DeploymentTriggerOnImageChange,
 			ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
 				From: kapi.ObjectReference{
@@ -39,7 +39,7 @@ func OkImageChangeDetails() *deployapi.DeploymentDetails {
 
 func OkConfigChangeDetails() *deployapi.DeploymentDetails {
 	return &deployapi.DeploymentDetails{
-		Causes: []*deployapi.DeploymentCause{{
+		Causes: []deployapi.DeploymentCause{{
 			Type: deployapi.DeploymentTriggerOnConfigChange,
 		}}}
 }

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -354,7 +354,7 @@ type DeploymentDetails struct {
 	// Message is the user specified change message, if this deployment was triggered manually by the user
 	Message string
 	// Causes are extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause
+	Causes []DeploymentCause
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/conversion"
@@ -14,7 +15,11 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+func Convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DeploymentTriggerImageChangeParams))(in)
+	}
+
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -31,7 +36,7 @@ func convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImage
 	return nil
 }
 
-func convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+func Convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -48,7 +53,10 @@ func convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImage
 	return nil
 }
 
-func convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *RollingDeploymentStrategyParams, out *newer.RollingDeploymentStrategyParams, s conversion.Scope) error {
+func Convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *RollingDeploymentStrategyParams, out *newer.RollingDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*RollingDeploymentStrategyParams))(in)
+	}
 	out.UpdatePeriodSeconds = in.UpdatePeriodSeconds
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
@@ -83,7 +91,7 @@ func convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategy
 	return nil
 }
 
-func convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams(in *newer.RollingDeploymentStrategyParams, out *RollingDeploymentStrategyParams, s conversion.Scope) error {
+func Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams(in *newer.RollingDeploymentStrategyParams, out *RollingDeploymentStrategyParams, s conversion.Scope) error {
 	out.UpdatePeriodSeconds = in.UpdatePeriodSeconds
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
@@ -126,11 +134,11 @@ func convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategy
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
-		convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams,
+		Convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
+		Convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams,
 
-		convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
-		convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,
+		Convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
+		Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -320,7 +320,7 @@ type DeploymentDetails struct {
 	// Message is the user specified change message, if this deployment was triggered manually by the user
 	Message string `json:"message,omitempty"`
 	// Causes are extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause `json:"causes,omitempty"`
+	Causes []DeploymentCause `json:"causes"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/api/v1beta3/conversion.go
+++ b/pkg/deploy/api/v1beta3/conversion.go
@@ -13,7 +13,7 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+func Convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTrigger
 	return nil
 }
 
-func convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+func Convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTrigger
 	return nil
 }
 
-func convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *RollingDeploymentStrategyParams, out *newer.RollingDeploymentStrategyParams, s conversion.Scope) error {
+func Convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *RollingDeploymentStrategyParams, out *newer.RollingDeploymentStrategyParams, s conversion.Scope) error {
 	out.UpdatePeriodSeconds = in.UpdatePeriodSeconds
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
@@ -82,7 +82,7 @@ func convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStr
 	return nil
 }
 
-func convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams(in *newer.RollingDeploymentStrategyParams, out *RollingDeploymentStrategyParams, s conversion.Scope) error {
+func Convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams(in *newer.RollingDeploymentStrategyParams, out *RollingDeploymentStrategyParams, s conversion.Scope) error {
 	out.UpdatePeriodSeconds = in.UpdatePeriodSeconds
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
@@ -125,11 +125,11 @@ func convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStr
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
-		convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams,
+		Convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
+		Convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams,
 
-		convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
-		convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams,
+		Convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
+		Convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -334,7 +334,7 @@ type DeploymentDetails struct {
 	// The user specified change message, if this deployment was triggered manually by the user
 	Message string `json:"message,omitempty"`
 	// Extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause `json:"causes,omitempty"`
+	Causes []DeploymentCause `json:"causes"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -110,11 +110,11 @@ func (c *DeploymentConfigChangeController) generateDeployment(config *deployapi.
 	}
 
 	// set the trigger details for the new deployment config
-	causes := []*deployapi.DeploymentCause{}
-	causes = append(causes,
-		&deployapi.DeploymentCause{
+	causes := []deployapi.DeploymentCause{
+		{
 			Type: deployapi.DeploymentTriggerOnConfigChange,
-		})
+		},
+	}
 	newConfig.Status.Details = &deployapi.DeploymentDetails{
 		Causes: causes,
 	}

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -31,7 +31,7 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 	// Update the containers with new images based on defined triggers
 	configChanged := false
 	errs := field.ErrorList{}
-	causes := []*deployapi.DeploymentCause{}
+	causes := []deployapi.DeploymentCause{}
 	for i, trigger := range config.Spec.Triggers {
 		params := trigger.ImageChangeParams
 
@@ -85,16 +85,15 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 		// If any container was updated, create a cause for the change
 		if containerChanged {
 			configChanged = true
-			causes = append(causes,
-				&deployapi.DeploymentCause{
-					Type: deployapi.DeploymentTriggerOnImageChange,
-					ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
-						From: kapi.ObjectReference{
-							Name: imageapi.JoinImageStreamTag(imageStream.Name, tag),
-							Kind: "ImageStreamTag",
-						},
+			causes = append(causes, deployapi.DeploymentCause{
+				Type: deployapi.DeploymentTriggerOnImageChange,
+				ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
+					From: kapi.ObjectReference{
+						Name: imageapi.JoinImageStreamTag(imageStream.Name, tag),
+						Kind: "ImageStreamTag",
 					},
-				})
+				},
+			})
 		}
 	}
 

--- a/pkg/image/api/dockerpre012/conversion.go
+++ b/pkg/image/api/dockerpre012/conversion.go
@@ -10,45 +10,48 @@ import (
 	newer "github.com/openshift/origin/pkg/image/api"
 )
 
+// Convert docker client object to internal object, but only when this package is included
+func Convert_dockerpre012_ImagePre_012_to_api_DockerImage(in *docker.ImagePre012, out *newer.DockerImage, s conversion.Scope) error {
+	if err := s.Convert(in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ContainerConfig, &out.ContainerConfig, conversion.AllowDifferentFieldTypeNames); err != nil {
+		return err
+	}
+	out.ID = in.ID
+	out.Parent = in.Parent
+	out.Comment = in.Comment
+	out.Created = unversioned.NewTime(in.Created)
+	out.Container = in.Container
+	out.DockerVersion = in.DockerVersion
+	out.Author = in.Author
+	out.Architecture = in.Architecture
+	out.Size = in.Size
+	return nil
+}
+func Convert_api_DockerImage_to_dockerpre012_ImagePre_012(in *newer.DockerImage, out *docker.ImagePre012, s conversion.Scope) error {
+	if err := s.Convert(&in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.ContainerConfig, &out.ContainerConfig, conversion.AllowDifferentFieldTypeNames); err != nil {
+		return err
+	}
+	out.ID = in.ID
+	out.Parent = in.Parent
+	out.Comment = in.Comment
+	out.Created = in.Created.Time
+	out.Container = in.Container
+	out.DockerVersion = in.DockerVersion
+	out.Author = in.Author
+	out.Architecture = in.Architecture
+	out.Size = in.Size
+	return nil
+}
+
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		// Convert docker client object to internal object, but only when this package is included
-		func(in *docker.ImagePre012, out *newer.DockerImage, s conversion.Scope) error {
-			if err := s.Convert(in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ContainerConfig, &out.ContainerConfig, conversion.AllowDifferentFieldTypeNames); err != nil {
-				return err
-			}
-			out.ID = in.ID
-			out.Parent = in.Parent
-			out.Comment = in.Comment
-			out.Created = unversioned.NewTime(in.Created)
-			out.Container = in.Container
-			out.DockerVersion = in.DockerVersion
-			out.Author = in.Author
-			out.Architecture = in.Architecture
-			out.Size = in.Size
-			return nil
-		},
-		func(in *newer.DockerImage, out *docker.ImagePre012, s conversion.Scope) error {
-			if err := s.Convert(&in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
-				return err
-			}
-			if err := s.Convert(&in.ContainerConfig, &out.ContainerConfig, conversion.AllowDifferentFieldTypeNames); err != nil {
-				return err
-			}
-			out.ID = in.ID
-			out.Parent = in.Parent
-			out.Comment = in.Comment
-			out.Created = in.Created.Time
-			out.Container = in.Container
-			out.DockerVersion = in.DockerVersion
-			out.Author = in.Author
-			out.Architecture = in.Architecture
-			out.Size = in.Size
-			return nil
-		},
+		Convert_dockerpre012_ImagePre_012_to_api_DockerImage,
+		Convert_api_DockerImage_to_dockerpre012_ImagePre_012,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/image/api/v1/conversion_test.go
+++ b/pkg/image/api/v1/conversion_test.go
@@ -60,3 +60,25 @@ func TestFieldSelectors(t *testing.T) {
 		"name", "spec.dockerImageRepository", "status.dockerImageRepository",
 	)
 }
+
+func TestImageImportSpecDefaulting(t *testing.T) {
+	i := &newer.ImageStreamImport{
+		Spec: newer.ImageStreamImportSpec{
+			Images: []newer.ImageImportSpec{
+				{From: kapi.ObjectReference{Name: "something:other"}},
+			},
+		},
+	}
+	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := runtime.Decode(kapi.Codecs.UniversalDecoder(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isi := obj.(*newer.ImageStreamImport)
+	if isi.Spec.Images[0].To == nil || isi.Spec.Images[0].To.Name != "other" {
+		t.Errorf("unexpected round trip: %#v", isi)
+	}
+}

--- a/pkg/image/api/v1beta3/conversion.go
+++ b/pkg/image/api/v1beta3/conversion.go
@@ -14,7 +14,7 @@ import (
 )
 
 // The docker metadata must be cast to a version
-func convert_api_Image_To_v1beta3_Image(in *newer.Image, out *Image, s conversion.Scope) error {
+func Convert_api_Image_To_v1beta3_Image(in *newer.Image, out *Image, s conversion.Scope) error {
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func convert_api_Image_To_v1beta3_Image(in *newer.Image, out *Image, s conversio
 	return nil
 }
 
-func convert_v1beta3_Image_To_api_Image(in *Image, out *newer.Image, s conversion.Scope) error {
+func Convert_v1beta3_Image_To_api_Image(in *Image, out *newer.Image, s conversion.Scope) error {
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func convert_v1beta3_Image_To_api_Image(in *Image, out *newer.Image, s conversio
 	return nil
 }
 
-func convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec, out *newer.ImageStreamSpec, s conversion.Scope) error {
+func Convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec, out *newer.ImageStreamSpec, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	if len(in.DockerImageRepository) > 0 {
 		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
@@ -89,13 +89,13 @@ func convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec,
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
-func convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec(in *newer.ImageStreamSpec, out *ImageStreamSpec, s conversion.Scope) error {
+func Convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec(in *newer.ImageStreamSpec, out *ImageStreamSpec, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	out.Tags = make([]TagReference, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
-func convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus(in *ImageStreamStatus, out *newer.ImageStreamStatus, s conversion.Scope) error {
+func Convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus(in *ImageStreamStatus, out *newer.ImageStreamStatus, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	if len(in.DockerImageRepository) > 0 {
 		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
@@ -110,21 +110,21 @@ func convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus(in *ImageStreamS
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
-func convert_api_ImageStreamStatus_To_v1beta3_ImageStreamStatus(in *newer.ImageStreamStatus, out *ImageStreamStatus, s conversion.Scope) error {
+func Convert_api_ImageStreamStatus_To_v1beta3_ImageStreamStatus(in *newer.ImageStreamStatus, out *ImageStreamStatus, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
 	out.Tags = make([]NamedTagEventList, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
 
-func convert_api_ImageStreamMapping_To_v1beta3_ImageStreamMapping(in *newer.ImageStreamMapping, out *ImageStreamMapping, s conversion.Scope) error {
+func Convert_api_ImageStreamMapping_To_v1beta3_ImageStreamMapping(in *newer.ImageStreamMapping, out *ImageStreamMapping, s conversion.Scope) error {
 	return s.DefaultConvert(in, out, conversion.DestFromSource)
 }
 
-func convert_v1beta3_ImageStreamMapping_To_api_ImageStreamMapping(in *ImageStreamMapping, out *newer.ImageStreamMapping, s conversion.Scope) error {
+func Convert_v1beta3_ImageStreamMapping_To_api_ImageStreamMapping(in *ImageStreamMapping, out *newer.ImageStreamMapping, s conversion.Scope) error {
 	return s.DefaultConvert(in, out, conversion.SourceToDest)
 }
 
-func convert_api_ImageStream_To_v1beta3_ImageStream(in *newer.ImageStream, out *ImageStream, s conversion.Scope) error {
+func Convert_api_ImageStream_To_v1beta3_ImageStream(in *newer.ImageStream, out *ImageStream, s conversion.Scope) error {
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func convert_api_ImageStream_To_v1beta3_ImageStream(in *newer.ImageStream, out *
 	return s.Convert(&in.Status, &out.Status, 0)
 }
 
-func convert_v1beta3_ImageStream_To_api_ImageStream(in *ImageStream, out *newer.ImageStream, s conversion.Scope) error {
+func Convert_v1beta3_ImageStream_To_api_ImageStream(in *ImageStream, out *newer.ImageStream, s conversion.Scope) error {
 	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func convert_v1beta3_ImageStream_To_api_ImageStream(in *ImageStream, out *newer.
 	return s.Convert(&in.Status, &out.Status, 0)
 }
 
-func convert_api_ImageStreamImage_To_v1beta3_ImageStreamImage(in *newer.ImageStreamImage, out *ImageStreamImage, s conversion.Scope) error {
+func Convert_api_ImageStreamImage_To_v1beta3_ImageStreamImage(in *newer.ImageStreamImage, out *ImageStreamImage, s conversion.Scope) error {
 	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func convert_api_ImageStreamImage_To_v1beta3_ImageStreamImage(in *newer.ImageStr
 	return nil
 }
 
-func convert_v1beta3_ImageStreamImage_To_api_ImageStreamImage(in *ImageStreamImage, out *newer.ImageStreamImage, s conversion.Scope) error {
+func Convert_v1beta3_ImageStreamImage_To_api_ImageStreamImage(in *ImageStreamImage, out *newer.ImageStreamImage, s conversion.Scope) error {
 	imageName := in.ImageName
 	isiName := in.Name
 
@@ -177,7 +177,7 @@ func convert_v1beta3_ImageStreamImage_To_api_ImageStreamImage(in *ImageStreamIma
 	return nil
 }
 
-func convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(in *newer.ImageStreamTag, out *ImageStreamTag, s conversion.Scope) error {
+func Convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(in *newer.ImageStreamTag, out *ImageStreamTag, s conversion.Scope) error {
 	if err := s.Convert(&in.Image, &out.Image, 0); err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag(in *newer.ImageStreamT
 	return nil
 }
 
-func convert_v1beta3_ImageStreamTag_To_api_ImageStreamTag(in *ImageStreamTag, out *newer.ImageStreamTag, s conversion.Scope) error {
+func Convert_v1beta3_ImageStreamTag_To_api_ImageStreamTag(in *ImageStreamTag, out *newer.ImageStreamTag, s conversion.Scope) error {
 	imageName := in.ImageName
 	istName := in.Name
 
@@ -276,20 +276,20 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 			return nil
 		},
 
-		convert_api_Image_To_v1beta3_Image,
-		convert_v1beta3_Image_To_api_Image,
-		convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec,
-		convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec,
-		convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus,
-		convert_api_ImageStreamStatus_To_v1beta3_ImageStreamStatus,
-		convert_api_ImageStreamMapping_To_v1beta3_ImageStreamMapping,
-		convert_v1beta3_ImageStreamMapping_To_api_ImageStreamMapping,
-		convert_api_ImageStream_To_v1beta3_ImageStream,
-		convert_v1beta3_ImageStream_To_api_ImageStream,
-		convert_api_ImageStreamImage_To_v1beta3_ImageStreamImage,
-		convert_v1beta3_ImageStreamImage_To_api_ImageStreamImage,
-		convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag,
-		convert_v1beta3_ImageStreamTag_To_api_ImageStreamTag,
+		Convert_api_Image_To_v1beta3_Image,
+		Convert_v1beta3_Image_To_api_Image,
+		Convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec,
+		Convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec,
+		Convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus,
+		Convert_api_ImageStreamStatus_To_v1beta3_ImageStreamStatus,
+		Convert_api_ImageStreamMapping_To_v1beta3_ImageStreamMapping,
+		Convert_v1beta3_ImageStreamMapping_To_api_ImageStreamMapping,
+		Convert_api_ImageStream_To_v1beta3_ImageStream,
+		Convert_v1beta3_ImageStream_To_api_ImageStream,
+		Convert_api_ImageStreamImage_To_v1beta3_ImageStreamImage,
+		Convert_v1beta3_ImageStreamImage_To_api_ImageStreamImage,
+		Convert_api_ImageStreamTag_To_v1beta3_ImageStreamTag,
+		Convert_v1beta3_ImageStreamTag_To_api_ImageStreamTag,
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/route/api/v1/conversion_test.go
+++ b/pkg/route/api/v1/conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/route/api"
 	"github.com/openshift/origin/pkg/route/api/v1"
@@ -37,5 +38,24 @@ func TestSupportingCamelConstants(t *testing.T) {
 		if out.Termination != v {
 			t.Errorf("%s: did not default termination: %#v", k, out)
 		}
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	obj := &v1.Route{
+		Spec: v1.RouteSpec{
+			To:  kapiv1.ObjectReference{Name: "other"},
+			TLS: &v1.TLSConfig{},
+		},
+	}
+	out := &api.Route{}
+	if err := kapi.Scheme.Convert(obj, out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Spec.TLS.Termination != api.TLSTerminationEdge {
+		t.Errorf("did not default termination: %#v", out)
+	}
+	if out.Spec.To.Kind != "Service" {
+		t.Errorf("did not default object reference kind: %#v", out)
 	}
 }

--- a/pkg/template/api/v1/conversion.go
+++ b/pkg/template/api/v1/conversion.go
@@ -8,7 +8,7 @@ import (
 	newer "github.com/openshift/origin/pkg/template/api"
 )
 
-func convert_api_Template_To_v1_Template(in *newer.Template, out *Template, s conversion.Scope) error {
+func Convert_api_Template_To_v1_Template(in *newer.Template, out *Template, s conversion.Scope) error {
 	//FIXME: DefaultConvert should not overwrite the Labels field on the
 	//       the base object. This is likely a bug in the DefaultConvert
 	//       code. For now, it is called before converting the labels.
@@ -34,7 +34,7 @@ func convert_api_Template_To_v1_Template(in *newer.Template, out *Template, s co
 	return nil
 }
 
-func convert_v1_Template_To_api_Template(in *Template, out *newer.Template, s conversion.Scope) error {
+func Convert_v1_Template_To_api_Template(in *Template, out *newer.Template, s conversion.Scope) error {
 	if err := s.Convert(&in.Labels, &out.ObjectLabels, 0); err != nil {
 		return err
 	}
@@ -43,8 +43,8 @@ func convert_v1_Template_To_api_Template(in *Template, out *newer.Template, s co
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		convert_api_Template_To_v1_Template,
-		convert_v1_Template_To_api_Template,
+		Convert_api_Template_To_v1_Template,
+		Convert_v1_Template_To_api_Template,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/template/api/v1beta3/conversion.go
+++ b/pkg/template/api/v1beta3/conversion.go
@@ -7,7 +7,7 @@ import (
 	newer "github.com/openshift/origin/pkg/template/api"
 )
 
-func convert_api_Template_To_v1beta3_Template(in *newer.Template, out *Template, s conversion.Scope) error {
+func Convert_api_Template_To_v1beta3_Template(in *newer.Template, out *Template, s conversion.Scope) error {
 	//FIXME: DefaultConvert should not overwrite the Labels field on the
 	//       the base object. This is likely a bug in the DefaultConvert
 	//       code. For now, it is called before converting the labels.
@@ -33,7 +33,7 @@ func convert_api_Template_To_v1beta3_Template(in *newer.Template, out *Template,
 	return nil
 }
 
-func convert_v1beta3_Template_To_api_Template(in *Template, out *newer.Template, s conversion.Scope) error {
+func Convert_v1beta3_Template_To_api_Template(in *Template, out *newer.Template, s conversion.Scope) error {
 	if err := s.Convert(&in.Labels, &out.ObjectLabels, 0); err != nil {
 		return err
 	}
@@ -42,8 +42,8 @@ func convert_v1beta3_Template_To_api_Template(in *Template, out *newer.Template,
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
-		convert_api_Template_To_v1beta3_Template,
-		convert_v1beta3_Template_To_api_Template,
+		Convert_api_Template_To_v1beta3_Template,
+		Convert_v1beta3_Template_To_api_Template,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Generates faster conversion code, removes allocations and reflection, and gets rid of warnings in tooling.

Fixes #7084

[test]