### PR TITLE
UPSTREAM: 22634: kubectl: print errors that wont be reloaded in the editor

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -176,7 +176,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdReplace(f, out))
 	cmds.AddCommand(NewCmdPatch(f, out))
 	cmds.AddCommand(NewCmdDelete(f, out))
-	cmds.AddCommand(NewCmdEdit(f, out))
+	cmds.AddCommand(NewCmdEdit(f, out, err))
 	cmds.AddCommand(NewCmdApply(f, out))
 
 	cmds.AddCommand(NewCmdNamespace(out))

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -114,7 +114,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 			Commands: []*cobra.Command{
 				cmd.NewCmdGet(fullName, f, out),
 				cmd.NewCmdDescribe(fullName, f, out),
-				cmd.NewCmdEdit(fullName, f, out),
+				cmd.NewCmdEdit(fullName, f, out, errout),
 				set.NewCmdSet(fullName, f, in, out, errout),
 				cmd.NewCmdLabel(fullName, f, out),
 				cmd.NewCmdAnnotate(fullName, f, out),

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -554,8 +554,8 @@ saved copy to include the latest resource version.`
   $ %[1]s edit svc/docker-registry --output-version=v1beta3 -o json`
 )
 
-func NewCmdEdit(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdEdit(f.Factory, out)
+func NewCmdEdit(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+	cmd := kcmd.NewCmdEdit(f.Factory, out, errout)
 	cmd.Long = editLong
 	cmd.Example = fmt.Sprintf(editExample, fullName)
 	return cmd


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7811

@smarterclayton 