### PR TITLE
Show kind in editor modal

### DIFF
--- a/assets/app/views/modals/edit-resource.html
+++ b/assets/app/views/modals/edit-resource.html
@@ -1,6 +1,6 @@
 <div class="modal-resource-edit">
   <div class="modal-header">
-    <h2><i class="fa fa-pencil" aria-hidden="true"></i> Editing {{resource.metadata.name}}</h2>
+    <h2>Editing <span class="hidden-xs">{{resource.kind | humanizeKind}}</span> {{resource.metadata.name}}</h2>
   </div>
   <div class="modal-body">
     <!-- Error messages -->


### PR DESCRIPTION
Show kind and not just name in the web console editor modal.

<img width="567" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13604556/4d87558e-e511-11e5-92bc-c01fabbaec69.png">

@jwforres 