### PR TITLE
[WIP] Adding oadm quota to show the quota usage for images.

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/admin/project"
 	"github.com/openshift/origin/pkg/cmd/admin/prune"
+	"github.com/openshift/origin/pkg/cmd/admin/quota"
 	"github.com/openshift/origin/pkg/cmd/admin/registry"
 	"github.com/openshift/origin/pkg/cmd/admin/router"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
@@ -67,6 +68,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer, errout io.Writer) *co
 				diagnostics.NewCmdDiagnostics(diagnostics.DiagnosticsRecommendedName, fullName+" "+diagnostics.DiagnosticsRecommendedName, out),
 				node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out),
 				prune.NewCommandPrune(prune.PruneRecommendedName, fullName+" "+prune.PruneRecommendedName, f, out),
+				quota.NewCommandQuota(quota.QuotaRecommendedName, fullName+" "+quota.QuotaRecommendedName, f, out),
 			},
 		},
 		{

--- a/pkg/cmd/admin/quota/quota.go
+++ b/pkg/cmd/admin/quota/quota.go
@@ -1,0 +1,126 @@
+package quota
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	imagequota "github.com/openshift/origin/pkg/quota/image"
+)
+
+const QuotaRecommendedName = "quota"
+
+const quotaLong = `todo`
+
+func NewCommandQuota(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	opts := &QuotaOptions{}
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "todo",
+		Long:  quotaLong,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(opts.Complete(f, cmd, args, out))
+			kcmdutil.CheckErr(opts.Validate(cmd))
+			kcmdutil.CheckErr(opts.Run())
+		},
+	}
+
+	return cmd
+}
+
+type QuotaOptions struct {
+	// internal values
+	Namespace string
+
+	// helpers
+	out      io.Writer
+	osClient client.Interface
+	kClient  kclient.Interface
+}
+
+// Complete turns a partially defined QuotaOptions into a solvent structure
+// which can be validated and used for showing quota usage.
+func (o *QuotaOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+	osClient, kClient, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.Namespace = cmd.Flag("namespace").Value.String()
+
+	o.osClient = osClient
+	o.kClient = kClient
+	o.out = out
+
+	return nil
+}
+
+// Validate ensures that a QuotaOptions is valid and can be used to execute command.
+func (o *QuotaOptions) Validate(cmd *cobra.Command) error {
+	return nil
+}
+
+// Run contains all the necessary functionality to show current quota usage.
+func (o *QuotaOptions) Run() error {
+	opts := kapi.ListOptions{}
+	if len(o.Namespace) != 0 {
+		opts.FieldSelector = fields.SelectorFromSet(fields.Set(map[string]string{"metadata.name": o.Namespace}))
+	}
+	nss, err := o.kClient.Namespaces().List(opts)
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range nss.Items {
+		total := int64(0)
+		fmt.Fprintf(o.out, "Namespace: %s\n", ns.Name)
+		quotas, err := o.kClient.ResourceQuotas(ns.Name).List(kapi.ListOptions{})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(o.out, "Quotas:\n")
+		for _, quota := range quotas.Items {
+			fmt.Fprintf(o.out, "%s:\n", quota.Name)
+			fmt.Fprintf(o.out, formatQuota(quota, imageapi.ResourceProjectImagesSize))
+			fmt.Fprintf(o.out, formatQuota(quota, imageapi.ResourceImageStreamSize))
+			fmt.Fprintf(o.out, formatQuota(quota, imageapi.ResourceImageSize))
+		}
+		if len(quotas.Items) == 0 {
+			fmt.Fprintf(o.out, "- <none>\n")
+		}
+
+		fmt.Fprintf(o.out, "Image Streams:\n")
+		iss, err := o.osClient.ImageStreams(ns.Name).List(kapi.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, is := range iss.Items {
+			quantity := imagequota.GetImageStreamSize(o.osClient, &is, make(map[string]*imageapi.Image))
+			fmt.Fprintf(o.out, "- %s\t\t%s\n", is.Name, describe.FormatQuantity(quantity, describe.Giga))
+			total += quantity.Value()
+		}
+		if len(iss.Items) == 0 {
+			fmt.Fprintf(o.out, "- <none>\n")
+		}
+		fmt.Fprintf(o.out, "Total: %s\n\n", describe.FormatQuantity(
+			resource.NewQuantity(total, resource.BinarySI), describe.Giga))
+	}
+	return nil
+}
+
+func formatQuota(quota kapi.ResourceQuota, resource kapi.ResourceName) string {
+	if value, ok := quota.Spec.Hard[resource]; ok {
+		return fmt.Sprintf("- %v\t\t%s\n", resource, describe.FormatQuantity(&value, describe.Giga))
+	}
+	return fmt.Sprintf("- %v\t\t<unset>\n", resource)
+}

--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -322,12 +322,12 @@ func formatImageStreamQuota(out *tabwriter.Writer, c client.Interface, kc kclien
 	}
 	if limit != nil {
 		quantity := imagequota.GetImageStreamSize(c, stream, make(map[string]*imageapi.Image))
-		scale := mega
-		if quantity.Value() >= (1<<giga.scale) || limit.Value() >= (1<<giga.scale) {
-			scale = giga
+		scale := Mega
+		if quantity.Value() >= (1<<Giga.scale) || limit.Value() >= (1<<Giga.scale) {
+			scale = Giga
 		}
 		formatString(out, "Quota Usage", fmt.Sprintf("%s / %s",
-			formatQuantity(quantity, scale), formatQuantity(limit, scale)))
+			FormatQuantity(quantity, scale), FormatQuantity(limit, scale)))
 	}
 }
 
@@ -337,13 +337,13 @@ type scale struct {
 }
 
 var (
-	mega = scale{20, "MiB"}
-	giga = scale{30, "GiB"}
+	Mega = scale{20, "MiB"}
+	Giga = scale{30, "GiB"}
 )
 
 // formatQuantity prints quantity according to passed scale. Manual scaling was
 // done here to make sure we print correct binary values for quantity.
-func formatQuantity(quantity *resource.Quantity, scale scale) string {
+func FormatQuantity(quantity *resource.Quantity, scale scale) string {
 	integer := quantity.Value() >> scale.scale
 	// fraction is the reminder of a division shifted by one order of magnitude
 	fraction := (quantity.Value() % (1 << scale.scale)) >> (scale.scale - 10)


### PR DESCRIPTION
Second part of my [card](https://trello.com/c/L9Coo2Zi/425-5-admin-can-understand-manage-image-use), covering presenting image quota usage to an administrator. 
@openshift/api-review for the new command review
@miminar for image quota related stuff

Example output from the command is:
```
[root@openshiftdev ~]# oadm quota -n openshift
Namespace: openshift
Quotas:
- <none>
Image Streams:
- jenkins		0GiB
- mongodb		0GiB
- mysql		0GiB
- nodejs		0GiB
- perl		0GiB
- php		0GiB
- postgresql		0GiB
- python		0GiB
- ruby		0GiB
- wildfly		0GiB
Total: 0GiB
```

The formatting is