### PR TITLE
Drop capabilities in s2i build container by default

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -833,48 +833,48 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
-			"Comment": "v1.0.4-50-g78f4e4f",
-			"Rev": "2e889d092f8f3fd0266610fa6b4d92db999ef68f"
+			"Comment": "v1.0.5-6-g0278ed9",
+			"Rev": "0278ed91e641158fbbf1de08808a12d5719322d8"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
@@ -175,6 +175,9 @@ type Config struct {
 	// CGroupLimits describes the cgroups limits that will be applied to any containers
 	// run by s2i.
 	CGroupLimits *CGroupLimits
+
+	// DropCapabilities contains a list of capabilities to drop when executing containers
+	DropCapabilities []string
 }
 
 type CGroupLimits struct {
@@ -343,7 +346,7 @@ func (p *PullPolicy) Set(v string) error {
 	case "if-not-present":
 		*p = PullIfNotPresent
 	default:
-		return fmt.Errorf("invalid value %q, valid values are: always, never or if-not-present")
+		return fmt.Errorf("invalid value %q, valid values are: always, never or if-not-present", v)
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types_test.go
@@ -1,0 +1,45 @@
+package api
+
+import "testing"
+
+func TestInjectionListSet(t *testing.T) {
+	table := map[string][]InjectPath{
+		"/test:":             {{SourcePath: "/test", DestinationDir: "."}},
+		"/test:/test":        {{SourcePath: "/test", DestinationDir: "/test"}},
+		"/test/foo:/etc/ssl": {{SourcePath: "/test/foo", DestinationDir: "/etc/ssl"}},
+		":/foo":              {{SourcePath: ".", DestinationDir: "/foo"}},
+		"/foo":               {{SourcePath: "/foo", DestinationDir: "."}},
+		":":                  {{SourcePath: ".", DestinationDir: "."}},
+		"/t est/foo:":        {{SourcePath: "/t est/foo", DestinationDir: "."}},
+		`"/test":"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
+		`'/test':"/foo"`:     {{SourcePath: "/test", DestinationDir: "/foo"}},
+		`"/te"st":"/foo"`:    {},
+		"/test/foo:/ss;ss":   {},
+		"/test;foo:/ssss":    {},
+	}
+	for v, expected := range table {
+		got := InjectionList{}
+		err := got.Set(v)
+		if len(expected) == 0 {
+			if err == nil {
+				t.Errorf("Expected error for %q, got %#v", v, got)
+			} else {
+				continue
+			}
+		}
+		if len(got) != len(expected) {
+			t.Errorf("Expected %d injection in the list for %q, got %d", len(expected), v, len(got))
+		}
+		for _, exp := range expected {
+			found := false
+			for _, g := range got {
+				if g.SourcePath == exp.SourcePath && g.DestinationDir == exp.DestinationDir {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Expected %+v injection found in %#v list", exp, got)
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
@@ -1,0 +1,51 @@
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestValidation(t *testing.T) {
+	testCases := []struct {
+		value    *api.Config
+		expected []ValidationError
+	}{
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]ValidationError{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: "foobar",
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]ValidationError{{ValidationErrorInvalidValue, "dockerNetworkMode"}},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]ValidationError{},
+		},
+	}
+	for _, test := range testCases {
+		result := ValidateConfig(test.value)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("got %+v, expected %+v", result, test.expected)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered_test.go
@@ -1,0 +1,184 @@
+package layered
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+type FakeExecutor struct{}
+
+func (f *FakeExecutor) Execute(string, string, *api.Config) error {
+	return nil
+}
+
+func newFakeLayered() *Layered {
+	return &Layered{
+		docker:  &docker.FakeDocker{},
+		config:  &api.Config{},
+		fs:      &test.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		scripts: &FakeExecutor{},
+	}
+}
+
+func newFakeLayeredWithScripts(assemble, workDir string) *Layered {
+	return &Layered{
+		docker:  &docker.FakeDocker{},
+		config:  &api.Config{WorkingDir: workDir},
+		fs:      &test.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		scripts: &FakeExecutor{},
+	}
+}
+
+func TestBuildOK(t *testing.T) {
+	workDir, _ := ioutil.TempDir("", "sti")
+	scriptDir := filepath.Join(workDir, api.UploadScripts)
+	err := os.MkdirAll(scriptDir, 0700)
+	assemble := filepath.Join(scriptDir, api.Assemble)
+	file, err := os.Create(assemble)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	defer file.Close()
+	defer os.RemoveAll(workDir)
+	l := newFakeLayeredWithScripts(assemble, workDir)
+	l.config.BuilderImage = "test/image"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if m, _ := regexp.MatchString(`test/image-\d+`, l.config.BuilderImage); !m {
+		t.Errorf("Expected BuilderImage test/image-withnumbers, but got %s ", l.config.BuilderImage)
+	}
+	// without config.Destination explicitly set, we should get /tmp/scripts for the scripts url
+	// assuming the assemble script we created above is off the working dir
+	if l.config.ScriptsURL != "image:///tmp/scripts" {
+		t.Errorf("Expected ScriptsURL image:///tmp/scripts, but got %s", l.config.ScriptsURL)
+	}
+	if len(l.config.Destination) != 0 {
+		t.Errorf("Unexpected Destination %s", l.config.Destination)
+	}
+}
+
+func TestBuildOKWithImageRef(t *testing.T) {
+	workDir, _ := ioutil.TempDir("", "sti")
+	scriptDir := filepath.Join(workDir, api.UploadScripts)
+	err := os.MkdirAll(scriptDir, 0700)
+	assemble := filepath.Join(scriptDir, api.Assemble)
+	file, err := os.Create(assemble)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	defer file.Close()
+	defer os.RemoveAll(workDir)
+	l := newFakeLayeredWithScripts(assemble, workDir)
+	l.config.BuilderImage = "docker.io/uptoknow/ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "docker.io/uptoknow/ruby-20-centos7:s2i-layered-") {
+		t.Errorf("Expected BuilderImage to start with docker.io/uptoknow/ruby-20-centos7:s2i-layered-, but got %s", l.config.BuilderImage)
+	}
+	l.config.BuilderImage = "uptoknow/ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "uptoknow/ruby-20-centos7:s2i-layered-") {
+		t.Errorf("Expected BuilderImage to start with uptoknow/ruby-20-centos7:s2i-layered-, but got %s", l.config.BuilderImage)
+	}
+	l.config.BuilderImage = "ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "ruby-20-centos7:s2i-layered-") {
+		t.Errorf("Expected BuilderImage to start with /ruby-20-centos7:s2i-layered-, but got %s", l.config.BuilderImage)
+	}
+}
+
+func TestBuildNoScriptsProvided(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	_, err := l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if m, _ := regexp.MatchString(`test/image-\d+`, l.config.BuilderImage); !m {
+		t.Errorf("Expected BuilderImage test/image-withnumbers, but got %s", l.config.BuilderImage)
+	}
+	if len(l.config.Destination) != 0 {
+		t.Errorf("Unexpected Destination %s", l.config.Destination)
+	}
+}
+
+func TestBuildErrorWriteDockerfile(t *testing.T) {
+	l := newFakeLayered()
+	l.fs.(*test.FakeFileSystem).WriteFileError = errors.New("WriteDockerfileError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "WriteDockerfileError" {
+		t.Errorf("An error was expected for WriteDockerfile, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorCreateTarFile(t *testing.T) {
+	l := newFakeLayered()
+	l.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "CreateTarError" {
+		t.Error("An error was expected for CreateTar, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorOpenTarFile(t *testing.T) {
+	l := newFakeLayered()
+	l.fs.(*test.FakeFileSystem).OpenError = errors.New("OpenTarError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "OpenTarError" {
+		t.Errorf("An error was expected for OpenTarFile, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorBuildImage(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	l.docker.(*docker.FakeDocker).BuildImageError = errors.New("BuildImageError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "BuildImageError" {
+		t.Errorf("An error was expected for BuildImage, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorBadImageName(t *testing.T) {
+	l := newFakeLayered()
+	_, err := l.Build(l.config)
+	if err == nil || !strings.Contains(err.Error(), "must be two or three segments separated by slashes") {
+		t.Errorf("An docker spec parse error was expected, but got different: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint_test.go
@@ -1,0 +1,63 @@
+package onbuild
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+func TestGuessEntrypoint(t *testing.T) {
+
+	testMatrix := map[string][]os.FileInfo{
+		"run": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", false, 0777},
+		},
+		"start.sh": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"start.sh", false, 0777},
+		},
+		"execute": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"execute", false, 0777},
+		},
+		"ERR:run_not_executable": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", false, 0600},
+		},
+		"ERR:run_is_dir": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", true, 0777},
+		},
+		"ERR:none": {
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+		},
+	}
+
+	for expectedEntrypoint, files := range testMatrix {
+		f := &test.FakeFileSystem{Files: files}
+		result, err := GuessEntrypoint(f, "/test")
+
+		if strings.HasPrefix(expectedEntrypoint, "ERR:") {
+			if len(result) > 0 {
+				t.Errorf("Expected error for %s, got %s", expectedEntrypoint, result)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("[%s] %s", expectedEntrypoint, err)
+		}
+		if result != expectedEntrypoint {
+			t.Errorf("Expected '%s' entrypoint, got '%v'", expectedEntrypoint, result)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild_test.go
@@ -1,0 +1,132 @@
+package onbuild
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/builder/parser"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+type fakeSourceHandler struct{}
+
+func (*fakeSourceHandler) Prepare(r *api.Config) error {
+	return nil
+}
+
+func (*fakeSourceHandler) Ignore(r *api.Config) error {
+	return nil
+}
+
+func (*fakeSourceHandler) Download(r *api.Config) (*api.SourceInfo, error) {
+	return &api.SourceInfo{}, nil
+}
+
+type fakeCleaner struct{}
+
+func (*fakeCleaner) Cleanup(*api.Config) {}
+
+func newFakeOnBuild() *OnBuild {
+	return &OnBuild{
+		docker:  &docker.FakeDocker{},
+		git:     &test.FakeGit{},
+		fs:      &test.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		source:  &fakeSourceHandler{},
+		garbage: &fakeCleaner{},
+	}
+}
+
+func checkDockerfile(fs *test.FakeFileSystem, t *testing.T) {
+	if fs.WriteFileError != nil {
+		t.Errorf("%v", fs.WriteFileError)
+	}
+	if fs.WriteFileName != "upload/src/Dockerfile" {
+		t.Errorf("Expected Dockerfile in 'upload/src/Dockerfile', got %v", fs.WriteFileName)
+	}
+	if !strings.Contains(fs.WriteFileContent, `ENTRYPOINT ["./run"]`) {
+		t.Errorf("The Dockerfile does not set correct entrypoint:\n %s\n", fs.WriteFileContent)
+	}
+
+	buf := bytes.NewBuffer([]byte(fs.WriteFileContent))
+	if _, err := parser.Parse(buf); err != nil {
+		t.Errorf("cannot parse new Dockerfile: " + err.Error())
+	}
+
+}
+
+func TestCreateDockerfile(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+		Environment:  map[string]string{"FOO": "BAR", "TEST": "A VALUE"},
+	}
+	b := newFakeOnBuild()
+	fakeFs := &test.FakeFileSystem{
+		Files: []os.FileInfo{
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", false, 0777},
+		},
+	}
+	b.fs = fakeFs
+	err := b.CreateDockerfile(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	checkDockerfile(fakeFs, t)
+}
+
+func TestCreateDockerfileWithAssemble(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+	}
+	b := newFakeOnBuild()
+	fakeFs := &test.FakeFileSystem{
+		Files: []os.FileInfo{
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", false, 0777},
+			&test.FakeFile{"assemble", false, 0777},
+		},
+	}
+	b.fs = fakeFs
+	err := b.CreateDockerfile(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	checkDockerfile(fakeFs, t)
+	if !strings.Contains(fakeFs.WriteFileContent, `RUN sh assemble`) {
+		t.Errorf("The Dockerfile does not run assemble:\n%s\n", fakeFs.WriteFileContent)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+		Tag:          "fakeapp",
+	}
+	b := newFakeOnBuild()
+	fakeFs := &test.FakeFileSystem{
+		Files: []os.FileInfo{
+			&test.FakeFile{"config.ru", false, 0600},
+			&test.FakeFile{"app.rb", false, 0600},
+			&test.FakeFile{"run", false, 0777},
+		},
+	}
+	b.fs = fakeFs
+	result, err := b.Build(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected successfull build, got: %v", result)
+	}
+	checkDockerfile(fakeFs, t)
+	fmt.Printf("result: %v\n", result)
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
@@ -403,6 +403,7 @@ func (b *STI) Save(config *api.Config) (err error) {
 		OnStart:         extractFunc,
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
+		CapDrop:         config.DropCapabilities,
 	}
 
 	go dockerpkg.StreamContainerIO(errReader, nil, glog.Error)
@@ -454,6 +455,7 @@ func (b *STI) Execute(command string, user string, config *api.Config) error {
 		PostExec:        b.postExecutor,
 		NetworkMode:     string(config.DockerNetworkMode),
 		CGroupLimits:    config.CGroupLimits,
+		CapDrop:         config.DropCapabilities,
 	}
 
 	// If there are injections specified, override the original assemble script

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti_test.go
@@ -1,0 +1,829 @@
+package sti
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/build"
+	"github.com/openshift/source-to-image/pkg/docker"
+	stierr "github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/ignore"
+	"github.com/openshift/source-to-image/pkg/scm/file"
+	"github.com/openshift/source-to-image/pkg/scm/git"
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+type FakeSTI struct {
+	CleanupCalled          bool
+	PrepareCalled          bool
+	SetupRequired          []string
+	SetupOptional          []string
+	SetupError             error
+	ExistsCalled           bool
+	ExistsError            error
+	BuildRequest           *api.Config
+	BuildResult            *api.Result
+	DownloadError          error
+	SaveArtifactsCalled    bool
+	SaveArtifactsError     error
+	FetchSourceCalled      bool
+	FetchSourceError       error
+	ExecuteCommand         string
+	ExecuteUser            string
+	ExecuteError           error
+	ExpectedError          bool
+	LayeredBuildCalled     bool
+	LayeredBuildError      error
+	PostExecuteDestination string
+	PostExecuteContainerID string
+	PostExecuteError       error
+}
+
+func newFakeBaseSTI() *STI {
+	return &STI{
+		config:    &api.Config{},
+		result:    &api.Result{},
+		docker:    &docker.FakeDocker{},
+		installer: &test.FakeInstaller{},
+		git:       &test.FakeGit{},
+		fs:        &test.FakeFileSystem{},
+		tar:       &test.FakeTar{},
+	}
+}
+
+func newFakeSTI(f *FakeSTI) *STI {
+	s := &STI{
+		config:    &api.Config{},
+		result:    &api.Result{},
+		docker:    &docker.FakeDocker{},
+		installer: &test.FakeInstaller{},
+		git:       &test.FakeGit{},
+		fs:        &test.FakeFileSystem{},
+		tar:       &test.FakeTar{},
+		preparer:  f,
+		ignorer:   &ignore.DockerIgnorer{},
+		artifacts: f,
+		scripts:   f,
+		garbage:   f,
+		layered:   &FakeDockerBuild{f},
+	}
+	s.source = &git.Clone{s.git, s.fs}
+	return s
+}
+
+func (f *FakeSTI) Cleanup(*api.Config) {
+	f.CleanupCalled = true
+}
+
+func (f *FakeSTI) Prepare(*api.Config) error {
+	f.PrepareCalled = true
+	f.SetupRequired = []string{api.Assemble, api.Run}
+	f.SetupOptional = []string{api.SaveArtifacts}
+	return nil
+}
+
+func (f *FakeSTI) Exists(*api.Config) bool {
+	f.ExistsCalled = true
+	return true
+}
+
+func (f *FakeSTI) Request() *api.Config {
+	return f.BuildRequest
+}
+
+func (f *FakeSTI) Result() *api.Result {
+	return f.BuildResult
+}
+
+func (f *FakeSTI) Save(*api.Config) error {
+	f.SaveArtifactsCalled = true
+	return f.SaveArtifactsError
+}
+
+func (f *FakeSTI) fetchSource() error {
+	return f.FetchSourceError
+}
+
+func (f *FakeSTI) Download(*api.Config) (*api.SourceInfo, error) {
+	return nil, f.DownloadError
+}
+
+func (f *FakeSTI) Execute(command string, user string, r *api.Config) error {
+	f.ExecuteCommand = command
+	f.ExecuteUser = user
+	return f.ExecuteError
+}
+
+func (f *FakeSTI) wasExpectedError(text string) bool {
+	return f.ExpectedError
+}
+
+func (f *FakeSTI) PostExecute(id, destination string) error {
+	f.PostExecuteContainerID = id
+	f.PostExecuteDestination = destination
+	return f.PostExecuteError
+}
+
+type FakeDockerBuild struct {
+	*FakeSTI
+}
+
+func (f *FakeDockerBuild) Build(*api.Config) (*api.Result, error) {
+	f.LayeredBuildCalled = true
+	return nil, f.LayeredBuildError
+}
+
+func TestDefaultSource(t *testing.T) {
+	config := &api.Config{
+		Source:       "file://.",
+		DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+	}
+	sti, err := New(config, build.Overrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Source == "" {
+		t.Errorf("Config.Source not set: %v", config.Source)
+	}
+	if _, ok := sti.source.(*file.File); !ok || sti.source == nil {
+		t.Errorf("Source interface not set: %#v", sti.source)
+	}
+}
+
+func TestOverrides(t *testing.T) {
+	fd := &FakeSTI{}
+	sti, err := New(
+		&api.Config{
+			DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+		},
+		build.Overrides{
+			Downloader: fd,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sti.source != fd {
+		t.Errorf("Override of downloader not set: %#v", sti)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	incrementalTest := []bool{false, true}
+	for _, incremental := range incrementalTest {
+		fh := &FakeSTI{
+			BuildRequest: &api.Config{Incremental: incremental},
+			BuildResult:  &api.Result{},
+		}
+
+		builder := newFakeSTI(fh)
+		builder.Build(&api.Config{Incremental: incremental})
+
+		// Verify the right scripts were configed
+		if !reflect.DeepEqual(fh.SetupRequired, []string{api.Assemble, api.Run}) {
+			t.Errorf("Unexpected required scripts configed: %#v", fh.SetupRequired)
+		}
+		if !reflect.DeepEqual(fh.SetupOptional, []string{api.SaveArtifacts}) {
+			t.Errorf("Unexpected optional scripts configed: %#v", fh.SetupOptional)
+		}
+
+		// Verify that Exists was called
+		if !fh.ExistsCalled {
+			t.Errorf("Exists was not called.")
+		}
+
+		// Verify that Save was called for an incremental build
+		if incremental && !fh.SaveArtifactsCalled {
+			t.Errorf("Save artifacts was not called for an incremental build")
+		}
+
+		// Verify that Execute was called with the right script
+		if fh.ExecuteCommand != api.Assemble {
+			t.Errorf("Unexpected execute command: %s", fh.ExecuteCommand)
+		}
+	}
+}
+
+func TestLayeredBuild(t *testing.T) {
+	fh := &FakeSTI{
+		BuildRequest: &api.Config{
+			BuilderImage: "testimage",
+		},
+		BuildResult:   &api.Result{},
+		ExecuteError:  stierr.NewContainerError("", 1, `/bin/sh: tar: not found`),
+		ExpectedError: true,
+	}
+	builder := newFakeSTI(fh)
+	builder.Build(&api.Config{BuilderImage: "testimage"})
+	// Verify layered build
+	if !fh.LayeredBuildCalled {
+		t.Errorf("Layered build was not called.")
+	}
+}
+
+func TestBuildErrorExecute(t *testing.T) {
+	fh := &FakeSTI{
+		BuildRequest: &api.Config{
+			BuilderImage: "testimage",
+		},
+		BuildResult:   &api.Result{},
+		ExecuteError:  errors.New("ExecuteError"),
+		ExpectedError: false,
+	}
+	builder := newFakeSTI(fh)
+	_, err := builder.Build(&api.Config{BuilderImage: "testimage"})
+	if err == nil || err.Error() != "ExecuteError" {
+		t.Errorf("An error was expected, but got different %v", err)
+	}
+}
+
+func TestWasExpectedError(t *testing.T) {
+	type expErr struct {
+		text     string
+		expected bool
+	}
+
+	tests := []expErr{
+		{ // 0 - tar error
+			text:     `/bin/sh: tar: not found`,
+			expected: true,
+		},
+		{ // 1 - tar error
+			text:     `/bin/sh: tar: command not found`,
+			expected: true,
+		},
+		{ // 2 - /bin/sh error
+			text:     `exec: "/bin/sh": stat /bin/sh: no such file or directory`,
+			expected: true,
+		},
+		{ // 3 - non container error
+			text:     "other error",
+			expected: false,
+		},
+	}
+
+	for i, ti := range tests {
+		result := isMissingRequirements(ti.text)
+		if result != ti.expected {
+			t.Errorf("(%d) Unexpected result: %v. Expected: %v", i, result, ti.expected)
+		}
+	}
+}
+
+func testBuildHandler() *STI {
+	s := &STI{
+		docker:            &docker.FakeDocker{},
+		incrementalDocker: &docker.FakeDocker{},
+		installer:         &test.FakeInstaller{},
+		git:               &test.FakeGit{},
+		fs:                &test.FakeFileSystem{ExistsResult: map[string]bool{"a-repo-source/.": true}},
+		tar:               &test.FakeTar{},
+		config:            &api.Config{},
+		result:            &api.Result{},
+		callbackInvoker:   &test.FakeCallbackInvoker{},
+	}
+	s.source = &git.Clone{s.git, s.fs}
+	return s
+}
+
+func TestPostExecute(t *testing.T) {
+	type postExecuteTest struct {
+		tag              string
+		incremental      bool
+		previousImageID  string
+		scriptsFromImage bool
+	}
+	testCases := []postExecuteTest{
+		// 0: tagged, incremental, without previous image
+		{"test/tag", true, "", true},
+		// 1: tagged, incremental, with previous image
+		{"test/tag", true, "test-image", true},
+		// 2: tagged, no incremental, without previous image
+		{"test/tag", false, "", true},
+		// 3: tagged, no incremental, with previous image
+		{"test/tag", false, "test-image", true},
+
+		// 4: no tag, incremental, without previous image
+		{"", true, "", false},
+		// 5: no tag, incremental, with previous image
+		{"", true, "test-image", false},
+		// 6: no tag, no incremental, without previous image
+		{"", false, "", false},
+		// 7: no tag, no incremental, with previous image
+		{"", false, "test-image", false},
+	}
+
+	for i, tc := range testCases {
+		bh := testBuildHandler()
+		containerID := "test-container-id"
+		bh.result.Messages = []string{"one", "two"}
+		bh.config.CallbackURL = "https://my.callback.org/test"
+		bh.config.Tag = tc.tag
+		bh.config.Incremental = tc.incremental
+		dh := bh.docker.(*docker.FakeDocker)
+		if tc.previousImageID != "" {
+			bh.config.RemovePreviousImage = true
+			bh.incremental = tc.incremental
+			bh.docker.(*docker.FakeDocker).GetImageIDResult = tc.previousImageID
+		}
+		ci := bh.callbackInvoker.(*test.FakeCallbackInvoker)
+		if tc.scriptsFromImage {
+			bh.scriptsURL = map[string]string{api.Run: "image:///usr/libexec/s2i/run"}
+		}
+		err := bh.PostExecute(containerID, "cmd1")
+		if err != nil {
+			t.Errorf("(%d) Unexpected error from postExecute: %v", i, err)
+		}
+		// Ensure CommitContainer was called with the right parameters
+		expectedCmd := []string{"cmd1/scripts/" + api.Run}
+		if tc.scriptsFromImage {
+			expectedCmd = []string{"/usr/libexec/s2i/" + api.Run}
+		}
+		if !reflect.DeepEqual(dh.CommitContainerOpts.Command, expectedCmd) {
+			t.Errorf("(%d) Unexpected commit container command: %#v, expected %q", i, dh.CommitContainerOpts.Command, expectedCmd)
+		}
+		if dh.CommitContainerOpts.Repository != tc.tag {
+			t.Errorf("(%d) Unexpected tag commited, expected %s, got %s", i, tc.tag, dh.CommitContainerOpts.Repository)
+		}
+		// Ensure image removal when incremental and previousImageID present
+		if tc.incremental && tc.previousImageID != "" {
+			if dh.RemoveImageName != "test-image" {
+				t.Errorf("(%d) Previous image was not removed: %s", i, dh.RemoveImageName)
+			}
+		} else {
+			if dh.RemoveImageName != "" {
+				t.Errorf("(%d) Unexpected image removed: %s", i, dh.RemoveImageName)
+			}
+		}
+		// Ensure Callback was called
+		if ci.CallbackURL != bh.config.CallbackURL {
+			t.Errorf("(%d) Unexpected callbackURL, expected %s, got %s", i, bh.config.CallbackURL, ci.CallbackURL)
+		}
+	}
+}
+
+func TestExists(t *testing.T) {
+	type incrementalTest struct {
+		// incremental flag was passed
+		incremental bool
+		// previous image existence
+		previousImage bool
+		// script installed
+		scriptInstalled bool
+		// expected result
+		expected bool
+	}
+
+	tests := []incrementalTest{
+		// 0-1: incremental, no image, no matter what with scripts
+		{true, false, false, false},
+		{true, false, true, false},
+
+		// 2: incremental, previous image, no scripts
+		{true, true, false, false},
+		// 3: incremental, previous image, scripts installed
+		{true, true, true, true},
+
+		// 4-7: no incremental build - should always return false no matter what other flags are
+		{false, false, false, false},
+		{false, false, true, false},
+		{false, true, false, false},
+		{false, true, true, false},
+	}
+
+	for i, ti := range tests {
+		bh := testBuildHandler()
+		bh.config.WorkingDir = "/working-dir"
+		bh.config.Incremental = ti.incremental
+		bh.config.BuilderPullPolicy = api.PullAlways
+		bh.installedScripts = map[string]bool{api.SaveArtifacts: ti.scriptInstalled}
+		bh.incrementalDocker.(*docker.FakeDocker).PullResult = ti.previousImage
+		bh.config.DockerConfig = &api.DockerConfig{Endpoint: "http://localhost:4243"}
+		incremental := bh.Exists(bh.config)
+		if incremental != ti.expected {
+			t.Errorf("(%d) Unexpected incremental result: %v. Expected: %v",
+				i, incremental, ti.expected)
+		}
+		if ti.incremental && ti.previousImage && ti.scriptInstalled {
+			if len(bh.fs.(*test.FakeFileSystem).ExistsFile) == 0 {
+				continue
+			}
+			scriptChecked := bh.fs.(*test.FakeFileSystem).ExistsFile[0]
+			expectedScript := "/working-dir/upload/scripts/save-artifacts"
+			if scriptChecked != expectedScript {
+				t.Errorf("(%d) Unexpected script checked. Actual: %s. Expected: %s",
+					i, scriptChecked, expectedScript)
+			}
+		}
+	}
+}
+
+func TestSaveArtifacts(t *testing.T) {
+	bh := testBuildHandler()
+	bh.config.WorkingDir = "/working-dir"
+	bh.config.Tag = "image/tag"
+	fs := bh.fs.(*test.FakeFileSystem)
+	fd := bh.docker.(*docker.FakeDocker)
+	th := bh.tar.(*test.FakeTar)
+	err := bh.Save(bh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when saving artifacts: %v", err)
+	}
+	expectedArtifactDir := "/working-dir/upload/artifacts"
+	if fs.MkdirDir != expectedArtifactDir {
+		t.Errorf("Mkdir was not called with the expected directory: %s",
+			fs.MkdirDir)
+	}
+	if fd.RunContainerOpts.Image != bh.config.Tag {
+		t.Errorf("Unexpected image sent to RunContainer: %s",
+			fd.RunContainerOpts.Image)
+	}
+	if th.ExtractTarDir != expectedArtifactDir || th.ExtractTarReader == nil {
+		t.Errorf("ExtractTar was not called with the expected parameters.")
+	}
+}
+
+func TestSaveArtifactsCustomTag(t *testing.T) {
+	bh := testBuildHandler()
+	bh.config.WorkingDir = "/working-dir"
+	bh.config.IncrementalFromTag = "custom/tag"
+	bh.config.Tag = "image/tag"
+	fs := bh.fs.(*test.FakeFileSystem)
+	fd := bh.docker.(*docker.FakeDocker)
+	th := bh.tar.(*test.FakeTar)
+	err := bh.Save(bh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when saving artifacts: %v", err)
+	}
+	expectedArtifactDir := "/working-dir/upload/artifacts"
+	if fs.MkdirDir != expectedArtifactDir {
+		t.Errorf("Mkdir was not called with the expected directory: %s",
+			fs.MkdirDir)
+	}
+	if fd.RunContainerOpts.Image != bh.config.IncrementalFromTag {
+		t.Errorf("Unexpected image sent to RunContainer: %s",
+			fd.RunContainerOpts.Image)
+	}
+	if th.ExtractTarDir != expectedArtifactDir || th.ExtractTarReader == nil {
+		t.Errorf("ExtractTar was not called with the expected parameters.")
+	}
+}
+
+func TestSaveArtifactsRunError(t *testing.T) {
+	tests := []error{
+		fmt.Errorf("Run error"),
+		stierr.NewContainerError("", -1, ""),
+	}
+	expected := []error{
+		tests[0],
+		stierr.NewSaveArtifactsError("", "", tests[1]),
+	}
+	// test with tar extract error or not
+	tarError := []bool{true, false}
+	for i := range tests {
+		for _, te := range tarError {
+			bh := testBuildHandler()
+			fd := bh.docker.(*docker.FakeDocker)
+			th := bh.tar.(*test.FakeTar)
+			fd.RunContainerError = tests[i]
+			if te {
+				th.ExtractTarError = fmt.Errorf("tar error")
+			}
+			err := bh.Save(bh.config)
+			if !te && err != expected[i] {
+				t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+			} else if te && err != th.ExtractTarError {
+				t.Errorf("Expected tar error. Got %v", err)
+			}
+		}
+	}
+}
+
+func TestSaveArtifactsErrorBeforeStart(t *testing.T) {
+	bh := testBuildHandler()
+	fd := bh.docker.(*docker.FakeDocker)
+	expected := fmt.Errorf("run error")
+	fd.RunContainerError = expected
+	fd.RunContainerErrorBeforeStart = true
+	err := bh.Save(bh.config)
+	if err != expected {
+		t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+	}
+}
+
+func TestSaveArtifactsExtractError(t *testing.T) {
+	bh := testBuildHandler()
+	th := bh.tar.(*test.FakeTar)
+	expected := fmt.Errorf("extract error")
+	th.ExtractTarError = expected
+	err := bh.Save(bh.config)
+	if err != expected {
+		t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+	}
+}
+
+func TestFetchSource(t *testing.T) {
+	type fetchTest struct {
+		validCloneSpec   bool
+		refSpecified     bool
+		cloneExpected    bool
+		checkoutExpected bool
+		copyExpected     bool
+		source_path      string
+		expectedError    *error
+	}
+
+	err := stierr.NewSourcePathError("error")
+	tests := []fetchTest{
+		// 0
+		{
+			validCloneSpec:   false,
+			refSpecified:     false,
+			cloneExpected:    false,
+			checkoutExpected: false,
+			copyExpected:     false,
+			source_path:      "invalid/path",
+			expectedError:    &err,
+		},
+		// 1
+		{
+			validCloneSpec:   false,
+			refSpecified:     false,
+			cloneExpected:    false,
+			checkoutExpected: false,
+			copyExpected:     true,
+		},
+		// 2
+		{
+			validCloneSpec:   true,
+			refSpecified:     false,
+			cloneExpected:    true,
+			checkoutExpected: false,
+			copyExpected:     false,
+		},
+		// 3
+		{
+			validCloneSpec:   true,
+			refSpecified:     true,
+			cloneExpected:    true,
+			checkoutExpected: true,
+			copyExpected:     false,
+		},
+	}
+
+	for testNum, ft := range tests {
+		bh := testBuildHandler()
+		gh := bh.git.(*test.FakeGit)
+		fh := bh.fs.(*test.FakeFileSystem)
+
+		bh.config.WorkingDir = "/working-dir"
+		gh.ValidCloneSpecResult = ft.validCloneSpec
+		if ft.refSpecified {
+			bh.config.Ref = "a-branch"
+		}
+		if len(ft.source_path) == 0 {
+			bh.config.Source = "a-repo-source"
+		} else {
+			bh.config.Source = ft.source_path
+		}
+
+		expectedTargetDir := "/working-dir/upload/src"
+		_, e := bh.source.Download(bh.config)
+		if ft.expectedError == nil && e != nil {
+			t.Errorf("Unexpected error %v [%d]", e, testNum)
+		}
+		if ft.expectedError != nil {
+			if e == nil {
+				t.Errorf("Did not get expected error [%d]", testNum)
+				continue
+			}
+			if (*ft.expectedError).(stierr.Error).ErrorCode != e.(stierr.Error).ErrorCode {
+				t.Errorf("Expected error code %s, got %s [%d]", (*ft.expectedError).(stierr.Error).ErrorCode, e.(stierr.Error).ErrorCode, testNum)
+			}
+		}
+		if ft.cloneExpected {
+			if gh.CloneSource != "a-repo-source" {
+				t.Errorf("Clone was not called with the expected source. Got %s, expected %s [%d]", gh.CloneSource, "a-source-repo-source", testNum)
+			}
+			if gh.CloneTarget != expectedTargetDir {
+				t.Errorf("Unexpected target directory for clone operation. Got %s, expected %s [%d]", gh.CloneTarget, expectedTargetDir, testNum)
+			}
+		}
+		if ft.checkoutExpected {
+			if gh.CheckoutRef != "a-branch" {
+				t.Errorf("Checkout was not called with the expected branch. Got %s, expected %s [%d]", gh.CheckoutRef, "a-branch", testNum)
+			}
+			if gh.CheckoutRepo != expectedTargetDir {
+				t.Errorf("Unexpected target repository for checkout operation. Got %s, expected %s [%d]", gh.CheckoutRepo, expectedTargetDir, testNum)
+			}
+		}
+		if ft.copyExpected {
+			if fh.CopySource != "a-repo-source/." {
+				t.Errorf("Copy was not called with the expected source. Got %s, expected %s [%d]", fh.CopySource, "a-repo-source/.", testNum)
+			}
+			if fh.CopyDest != expectedTargetDir {
+				t.Errorf("Unexpected target director for copy operation. Got %s, expected %s [%d]", fh.CopyDest, expectedTargetDir, testNum)
+			}
+		}
+	}
+}
+
+func TestPrepareOK(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	rh.fs.(*test.FakeFileSystem).WorkingDirResult = "/working-dir"
+	err := rh.Prepare(rh.config)
+	if err != nil {
+		t.Errorf("An error occurred setting up the config handler: %v", err)
+	}
+	if !rh.fs.(*test.FakeFileSystem).WorkingDirCalled {
+		t.Errorf("Working directory was not created.")
+	}
+	var expected []string
+	for _, dir := range workingDirs {
+		expected = append(expected, "/working-dir/"+dir)
+	}
+	mkdirs := rh.fs.(*test.FakeFileSystem).MkdirAllDir
+	if !reflect.DeepEqual(mkdirs, expected) {
+		t.Errorf("Unexpected set of MkdirAll calls: %#v", mkdirs)
+	}
+	scripts := rh.installer.(*test.FakeInstaller).Scripts
+	if !reflect.DeepEqual(scripts[0], []string{api.Assemble, api.Run}) {
+		t.Errorf("Unexpected set of required scripts: %#v", scripts[0])
+	}
+	if !reflect.DeepEqual(scripts[1], []string{api.SaveArtifacts}) {
+		t.Errorf("Unexpected set of optional scripts: %#v", scripts[1])
+	}
+}
+
+func TestPrepareErrorCreatingWorkingDir(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.fs.(*test.FakeFileSystem).WorkingDirError = errors.New("WorkingDirError")
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != "WorkingDirError" {
+		t.Errorf("An error was expected for WorkingDir, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorMkdirAll(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.fs.(*test.FakeFileSystem).MkdirAllError = errors.New("MkdirAllError")
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != "MkdirAllError" {
+		t.Errorf("An error was expected for MkdirAll, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorRequiredDownloadAndInstall(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	rh.installer.(*test.FakeInstaller).Error = fmt.Errorf("%v", api.Assemble)
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != api.Assemble {
+		t.Errorf("An error was expected for required DownloadAndInstall, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorOptionalDownloadAndInstall(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	err := rh.Prepare(rh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when downloading optional scripts: %v", err)
+	}
+}
+
+func equalArrayContents(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, e := range a {
+		found := false
+		for _, f := range b {
+			if f == e {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGenerateConfigEnv(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	testEnv := map[string]string{
+		"Key1": "Value1",
+		"Key2": "Value2",
+		"Key3": "Value3",
+	}
+	rh.config.Environment = testEnv
+	result := rh.generateConfigEnv()
+	expected := []string{"Key1=Value1", "Key2=Value2", "Key3=Value3"}
+	if !equalArrayContents(result, expected) {
+		t.Errorf("Unexpected result. Expected: %#v. Actual: %#v",
+			expected, result)
+	}
+}
+
+func TestExecuteOK(t *testing.T) {
+	rh := newFakeBaseSTI()
+	pe := &FakeSTI{}
+	rh.postExecutor = pe
+	rh.config.WorkingDir = "/working-dir"
+	rh.config.BuilderImage = "test/image"
+	rh.config.BuilderPullPolicy = api.PullAlways
+	th := rh.tar.(*test.FakeTar)
+	th.CreateTarResult = "/working-dir/test.tar"
+	fd := rh.docker.(*docker.FakeDocker)
+	fd.RunContainerContainerID = "1234"
+	fd.RunContainerCmd = []string{"one", "two"}
+
+	err := rh.Execute("test-command", "foo", rh.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	th = rh.tar.(*test.FakeTar).Copy()
+	if th.CreateTarBase != "" {
+		t.Errorf("Unexpected tar base directory: %s", th.CreateTarBase)
+	}
+	if th.CreateTarDir != "/working-dir/upload" {
+		t.Errorf("Unexpected tar directory: %s", th.CreateTarDir)
+	}
+	fh, ok := rh.fs.(*test.FakeFileSystem)
+	if !ok {
+		t.Fatalf("Unable to convert %v to FakeFilesystem", rh.fs)
+	}
+	if fh.OpenFile != "" {
+		t.Fatalf("Unexpected file opened: %s", fh.OpenFile)
+	}
+	if fh.OpenFileResult != nil {
+		t.Errorf("Tar file was opened.")
+	}
+	ro := fd.RunContainerOpts
+
+	if ro.User != "foo" {
+		t.Errorf("Expected user to be foo, got %q", ro.User)
+	}
+
+	if ro.Image != rh.config.BuilderImage {
+		t.Errorf("Unexpected Image passed to RunContainer")
+	}
+	if _, ok := ro.Stdin.(*io.PipeReader); !ok {
+		t.Errorf("Unexpected input stream: %#v", ro.Stdin)
+	}
+	if ro.PullImage {
+		t.Errorf("PullImage is true for RunContainer, should be false")
+	}
+	if ro.Command != "test-command" {
+		t.Errorf("Unexpected command passed to RunContainer: %s",
+			ro.Command)
+	}
+	if pe.PostExecuteContainerID != "1234" {
+		t.Errorf("PostExecutor not called with expected ID: %s",
+			pe.PostExecuteContainerID)
+	}
+	if !reflect.DeepEqual(pe.PostExecuteDestination, "test-command") {
+		t.Errorf("PostExecutor not called with expected command: %s", pe.PostExecuteDestination)
+	}
+}
+
+func TestExecuteErrorCreateTarFile(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")
+	err := rh.Execute("test-command", "", rh.config)
+	if err != nil {
+		t.Errorf("An error was expected for CreateTarFile, but got different: %v", err)
+	}
+	ro := rh.docker.(*docker.FakeDocker).RunContainerOpts
+	if ro.Stdin == nil {
+		t.Fatalf("Stream not passed to Docker interface")
+	}
+	if _, err := ro.Stdin.Read(make([]byte, 5)); err == nil || err.Error() != "CreateTarError" {
+		t.Errorf("An error was expected for CreateTarFile, but got different: %#v", ro)
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	rh := newFakeBaseSTI()
+
+	rh.config.WorkingDir = "/working-dir"
+	preserve := []bool{false, true}
+	for _, p := range preserve {
+		rh.config.PreserveWorkingDir = p
+		rh.fs = &test.FakeFileSystem{}
+		rh.garbage = &build.DefaultCleaner{rh.fs, rh.docker}
+		rh.garbage.Cleanup(rh.config)
+		removedDir := rh.fs.(*test.FakeFileSystem).RemoveDirName
+		if p && removedDir != "" {
+			t.Errorf("Expected working directory to be preserved, but it was removed.")
+		} else if !p && removedDir == "" {
+			t.Errorf("Expected working directory to be removed, but it was preserved.")
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage_test.go
@@ -1,0 +1,100 @@
+package sti
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+type FakeUsageHandler struct {
+	cleanupCalled  bool
+	setupRequired  []string
+	setupOptional  []string
+	setupError     error
+	executeCommand string
+	executeUser    string
+	executeError   error
+}
+
+type FakeCleaner struct {
+	cleanupCalled bool
+}
+
+func (f *FakeCleaner) Cleanup(*api.Config) {
+	f.cleanupCalled = true
+}
+
+func (f *FakeUsageHandler) Prepare(*api.Config) error {
+	return f.setupError
+}
+
+func (f *FakeUsageHandler) SetScripts(r, o []string) {
+	f.setupRequired = r
+	f.setupOptional = o
+}
+
+func (f *FakeUsageHandler) Execute(command string, user string, r *api.Config) error {
+	f.executeCommand = command
+	f.executeUser = user
+	return f.executeError
+}
+
+func (f *FakeUsageHandler) Download(*api.Config) error {
+	return nil
+}
+
+func newTestUsage() *Usage {
+	return &Usage{
+		handler: &FakeUsageHandler{},
+	}
+}
+
+func TestUsage(t *testing.T) {
+	u := newTestUsage()
+	g := &FakeCleaner{}
+	u.garbage = g
+	fh := u.handler.(*FakeUsageHandler)
+	err := u.Show()
+	if err != nil {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+	if !reflect.DeepEqual(fh.setupOptional, []string{}) {
+		t.Errorf("setup called with unexpected optional scripts: %#v", fh.setupOptional)
+	}
+	if !reflect.DeepEqual(fh.setupRequired, []string{api.Usage}) {
+		t.Errorf("setup called with unexpected required scripts: %#v", fh.setupRequired)
+	}
+	if fh.executeCommand != "usage" {
+		t.Errorf("execute called with unexpected command: %#v", fh.executeCommand)
+	}
+	if !g.cleanupCalled {
+		t.Errorf("cleanup was not called from usage.")
+	}
+}
+
+func TestUsageSetupError(t *testing.T) {
+	u := newTestUsage()
+	u.garbage = &FakeCleaner{}
+	fh := u.handler.(*FakeUsageHandler)
+	fh.setupError = fmt.Errorf("setup error")
+	err := u.Show()
+	if err != fh.setupError {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+	if fh.executeCommand != "" {
+		t.Errorf("Execute called when there was a setup error.")
+	}
+}
+
+func TestUsageExecuteError(t *testing.T) {
+	u := newTestUsage()
+	u.garbage = &FakeCleaner{}
+	fh := u.handler.(*FakeUsageHandler)
+	fh.executeError = fmt.Errorf("execute error")
+	err := u.Show()
+	if err != fh.executeError {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
@@ -123,6 +123,7 @@ type RunContainerOptions struct {
 	NetworkMode      string
 	User             string
 	CGroupLimits     *api.CGroupLimits
+	CapDrop          []string
 }
 
 // CommitContainerOptions are options passed in to the CommitContainer method
@@ -611,6 +612,7 @@ func (d *stiDocker) RunContainer(opts RunContainerOptions) (err error) {
 		ccopts.HostConfig.CPUQuota = opts.CGroupLimits.CPUQuota
 		ccopts.HostConfig.CPUPeriod = opts.CGroupLimits.CPUPeriod
 	}
+	ccopts.HostConfig.CapDrop = opts.CapDrop
 	glog.V(2).Infof("Creating container %s using config: %+v, hostconfig: %+v", ccopts.Name, ccopts.Config, ccopts.HostConfig)
 	container, err := d.client.CreateContainer(ccopts)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker_test.go
@@ -1,0 +1,540 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker/test"
+	"github.com/openshift/source-to-image/pkg/errors"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func getDocker(client Client) *stiDocker {
+	return &stiDocker{
+		client:   client,
+		pullAuth: docker.AuthConfiguration{},
+	}
+}
+
+func TestIsImageInLocalRegistry(t *testing.T) {
+	type testDef struct {
+		imageName         string
+		docker            test.FakeDockerClient
+		expectedImageName string
+		expectedResult    bool
+		expectedError     error
+	}
+	otherError := fmt.Errorf("Other")
+	tests := map[string]testDef{
+		"ImageFound":    {"a_test_image", test.FakeDockerClient{Image: &docker.Image{}}, "a_test_image:latest", true, nil},
+		"ImageNotFound": {"a_test_image:sometag", test.FakeDockerClient{InspectImageErr: []error{docker.ErrNoSuchImage}}, "a_test_image:sometag", false, nil},
+		"ErrorOccurred": {"a_test_image", test.FakeDockerClient{InspectImageErr: []error{otherError}}, "a_test_image:latest", false, otherError},
+	}
+
+	for test, def := range tests {
+		dh := getDocker(&def.docker)
+		result, err := dh.IsImageInLocalRegistry(def.imageName)
+		if result != def.expectedResult {
+			t.Errorf("Test - %s: Expected result: %v. Got: %v", test, def.expectedResult, result)
+		}
+		if err != def.expectedError {
+			t.Errorf("Test - %s: Expected error: %v. Got: %v", test, def.expectedError, err)
+		}
+		if def.docker.InspectImageName[0] != def.expectedImageName {
+			t.Errorf("Docker inspect called with unexpected image name: %s\n",
+				def.docker.InspectImageName)
+		}
+	}
+}
+
+func TestCheckAndPullImage(t *testing.T) {
+	type testDef struct {
+		imageName           string
+		docker              test.FakeDockerClient
+		expectedImage       *docker.Image
+		expectedError       int
+		expectedPullOptions docker.PullImageOptions
+	}
+	image := &docker.Image{}
+	imageExistsTest := testDef{
+		imageName: "test_image",
+		docker: test.FakeDockerClient{
+			InspectImageErr:    []error{nil},
+			InspectImageResult: []*docker.Image{image},
+		},
+		expectedImage: image,
+	}
+	imagePulledTest := testDef{
+		imageName: "test_image",
+		docker: test.FakeDockerClient{
+			InspectImageErr:    []error{docker.ErrNoSuchImage, nil},
+			InspectImageResult: []*docker.Image{nil, image},
+		},
+		expectedImage:       image,
+		expectedPullOptions: docker.PullImageOptions{Repository: "test_image:" + DefaultTag},
+	}
+	inspectErrorTest := testDef{
+		imageName: "test_image",
+		docker: test.FakeDockerClient{
+			InspectImageErr:    []error{docker.ErrConnectionRefused},
+			InspectImageResult: []*docker.Image{nil},
+		},
+		expectedImage: nil,
+		expectedError: errors.InspectImageError,
+	}
+	pullErrorTest := testDef{
+		imageName: "test_image",
+		docker: test.FakeDockerClient{
+			PullImageErr:       docker.ErrConnectionRefused,
+			InspectImageErr:    []error{nil},
+			InspectImageResult: []*docker.Image{nil},
+		},
+		expectedImage:       nil,
+		expectedError:       errors.PullImageError,
+		expectedPullOptions: docker.PullImageOptions{Repository: "test_image:" + DefaultTag},
+	}
+	errorAfterPullTest := testDef{
+		imageName: "test_image:testtag",
+		docker: test.FakeDockerClient{
+			InspectImageErr:    []error{docker.ErrNoSuchImage, docker.ErrNoSuchImage},
+			InspectImageResult: []*docker.Image{nil, image},
+		},
+		expectedImage:       nil,
+		expectedError:       errors.InspectImageError,
+		expectedPullOptions: docker.PullImageOptions{Repository: "test_image:testtag"},
+	}
+	tests := map[string]testDef{
+		"ImageExists":    imageExistsTest,
+		"ImagePulled":    imagePulledTest,
+		"InspectError":   inspectErrorTest,
+		"PullError":      pullErrorTest,
+		"ErrorAfterPull": errorAfterPullTest,
+	}
+
+	for test, def := range tests {
+		dh := getDocker(&def.docker)
+		resultImage, resultErr := dh.CheckAndPullImage(def.imageName)
+		if resultImage != def.expectedImage {
+			t.Errorf("%s: Unexpected image result -- %v", test, resultImage)
+		}
+		if e, ok := resultErr.(errors.Error); def.expectedError != 0 && (!ok || e.ErrorCode != def.expectedError) {
+			t.Errorf("%s: Unexpected error result -- %v", test, resultErr)
+		}
+		pullOpts := def.docker.PullImageOpts
+		if !reflect.DeepEqual(pullOpts, def.expectedPullOptions) {
+			t.Errorf("%s: Unexpected pull image opts -- %v", test, pullOpts)
+		}
+	}
+}
+
+func TestRemoveContainer(t *testing.T) {
+	fakeDocker := &test.FakeDockerClient{}
+	dh := getDocker(fakeDocker)
+	containerID := "testContainerId"
+	expectedOpts := docker.RemoveContainerOptions{
+		ID:            containerID,
+		RemoveVolumes: true,
+		Force:         true,
+	}
+	dh.RemoveContainer(containerID)
+	if !reflect.DeepEqual(expectedOpts, fakeDocker.RemoveContainerOpts) {
+		t.Errorf("Unexpected removeContainerOpts. Expected: %#v, Got: %#v",
+			expectedOpts, fakeDocker.RemoveContainerOpts)
+	}
+}
+
+func TestCommitContainer(t *testing.T) {
+	expectedImageID := "test-1234"
+	fakeDocker := &test.FakeDockerClient{Image: &docker.Image{ID: expectedImageID}}
+	dh := getDocker(fakeDocker)
+	containerID := "test-container-id"
+	containerTag := "test-container-tag"
+
+	opt := CommitContainerOptions{
+		ContainerID: containerID,
+		Repository:  containerTag,
+	}
+
+	imageID, err := dh.CommitContainer(opt)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if imageID != expectedImageID {
+		t.Errorf("Did not return the correct image id: %s", imageID)
+	}
+}
+
+func TestCommitContainerError(t *testing.T) {
+	expectedErr := fmt.Errorf("Test error")
+	fakeDocker := &test.FakeDockerClient{CommitContainerErr: expectedErr}
+	dh := getDocker(fakeDocker)
+	containerID := "test-container-id"
+	containerTag := "test-container-tag"
+
+	opt := CommitContainerOptions{
+		ContainerID: containerID,
+		Repository:  containerTag,
+	}
+
+	_, err := dh.CommitContainer(opt)
+
+	expectedOpts := docker.CommitContainerOptions{
+		Container:  containerID,
+		Repository: containerTag,
+	}
+	if !reflect.DeepEqual(expectedOpts, fakeDocker.CommitContainerOpts) {
+		t.Errorf("Commit container called with unexpected parameters: %#v", fakeDocker.CommitContainerOpts)
+	}
+	if err != expectedErr {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+}
+
+func TestGetScriptsURL(t *testing.T) {
+	type urltest struct {
+		image       docker.Image
+		result      string
+		inspectErr  error
+		errExpected bool
+	}
+	tests := map[string]urltest{
+		"not present": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Env:    []string{"Env1=value1"},
+					Labels: map[string]string{},
+				},
+				Config: &docker.Config{
+					Env:    []string{"Env2=value2"},
+					Labels: map[string]string{},
+				},
+			},
+			result: "",
+		},
+
+		"env in containerConfig": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Env: []string{"Env1=value1", ScriptsURLEnvironment + "=test_url_value"},
+				},
+				Config: &docker.Config{},
+			},
+			result: "test_url_value",
+		},
+
+		"env in image config": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config: &docker.Config{
+					Env: []string{
+						"Env1=value1",
+						ScriptsURLEnvironment + "=test_url_value_2",
+						"Env2=value2",
+					},
+				},
+			},
+			result: "test_url_value_2",
+		},
+
+		"label in containerConfig": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Labels: map[string]string{ScriptsURLLabel: "test_url_value"},
+				},
+				Config: &docker.Config{},
+			},
+			result: "test_url_value",
+		},
+
+		"label in image config": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config: &docker.Config{
+					Labels: map[string]string{ScriptsURLLabel: "test_url_value_2"},
+				},
+			},
+			result: "test_url_value_2",
+		},
+
+		"inspect error": {
+			image:       docker.Image{},
+			inspectErr:  fmt.Errorf("Inspect error"),
+			errExpected: true,
+		},
+	}
+	for desc, tst := range tests {
+		fakeDocker := &test.FakeDockerClient{
+			InspectImageResult: []*docker.Image{&tst.image},
+		}
+		if tst.inspectErr != nil {
+			fakeDocker.InspectImageErr = []error{tst.inspectErr}
+		}
+		dh := getDocker(fakeDocker)
+		url, err := dh.GetScriptsURL("test/image")
+		if err != nil && !tst.errExpected {
+			t.Errorf("%s: Unexpected error returned: %v", desc, err)
+		} else if err == nil && tst.errExpected {
+			t.Errorf("%s: Expected error. Did not get one.", desc)
+		}
+		if !tst.errExpected && url != tst.result {
+			t.Errorf("%s: Unexpected result. Expected: %s Actual: %s",
+				desc, tst.result, url)
+		}
+	}
+}
+
+func TestRunContainer(t *testing.T) {
+	type runtest struct {
+		image            docker.Image
+		cmd              string
+		externalScripts  bool
+		paramScriptsURL  string
+		paramDestination string
+		cmdExpected      []string
+	}
+
+	tests := map[string]runtest{
+		"default": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config:          &docker.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /tmp/scripts/%s", api.Assemble)},
+		},
+		"paramDestination": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config:          &docker.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  true,
+			paramDestination: "/opt/test",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/test -xf - && /opt/test/scripts/%s", api.Assemble)},
+		},
+		"paramDestination&paramScripts": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config:          &docker.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  true,
+			paramDestination: "/opt/test",
+			paramScriptsURL:  "http://my.test.url/test?param=one",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/test -xf - && /opt/test/scripts/%s", api.Assemble)},
+		},
+		"scriptsInsideImageEnvironment": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Env: []string{ScriptsURLEnvironment + "=image:///opt/bin/"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: false,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageLabel": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Labels: map[string]string{ScriptsURLLabel: "image:///opt/bin/"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: false,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageEnvironmentWithParamDestination": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Env: []string{ScriptsURLEnvironment + "=image:///opt/bin"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  false,
+			paramDestination: "/opt/sti",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/sti -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageLabelWithParamDestination": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Labels: map[string]string{ScriptsURLLabel: "image:///opt/bin"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  false,
+			paramDestination: "/opt/sti",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/sti -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"paramDestinationFromImageEnvironment": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Env: []string{LocationEnvironment + "=/opt", ScriptsURLEnvironment + "=http://my.test.url/test?param=one"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt -xf - && /opt/scripts/%s", api.Assemble)},
+		},
+		"paramDestinationFromImageLabel": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{
+					Labels: map[string]string{DestinationLabel: "/opt", ScriptsURLLabel: "http://my.test.url/test?param=one"},
+				},
+				Config: &docker.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt -xf - && /opt/scripts/%s", api.Assemble)},
+		},
+		"usageCommand": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config:          &docker.Config{},
+			},
+			cmd:             api.Usage,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /tmp/scripts/%s", api.Usage)},
+		},
+		"otherCommand": {
+			image: docker.Image{
+				ContainerConfig: docker.Config{},
+				Config:          &docker.Config{},
+			},
+			cmd:             api.Run,
+			externalScripts: true,
+			cmdExpected:     []string{fmt.Sprintf("/tmp/scripts/%s", api.Run)},
+		},
+	}
+
+	for desc, tst := range tests {
+		fakeDocker := &test.FakeDockerClient{
+			InspectImageResult: []*docker.Image{&tst.image},
+			Container: &docker.Container{
+				ID: "12345-test",
+			},
+			AttachToContainerSleep: 200 * time.Millisecond,
+		}
+		dh := getDocker(fakeDocker)
+		err := dh.RunContainer(RunContainerOptions{
+			Image:           "test/image",
+			PullImage:       true,
+			ExternalScripts: tst.externalScripts,
+			ScriptsURL:      tst.paramScriptsURL,
+			Destination:     tst.paramDestination,
+			Command:         tst.cmd,
+			Env:             []string{"Key1=Value1", "Key2=Value2"},
+			Stdin:           os.Stdin,
+			Stdout:          os.Stdout,
+			Stderr:          os.Stdout,
+		})
+		if err != nil {
+			t.Errorf("%s: Unexpected error: %v", desc, err)
+		}
+		// Validate the CreateContainer parameters
+		createConfig := fakeDocker.CreateContainerOpts.Config
+		if createConfig.Image != "test/image:latest" {
+			t.Errorf("%s: Unexpected create config image: %s", desc, createConfig.Image)
+		}
+		if !reflect.DeepEqual(createConfig.Cmd, tst.cmdExpected) {
+			t.Errorf("%s: Unexpected create config command: %#v", desc, createConfig.Cmd)
+		}
+		if !reflect.DeepEqual(createConfig.Env, []string{"Key1=Value1", "Key2=Value2"}) {
+			t.Errorf("%s: Unexpected create config env: %#v", desc, createConfig.Env)
+		}
+		if !createConfig.OpenStdin || !createConfig.StdinOnce {
+			t.Errorf("%s: Unexpected stdin flags for createConfig: OpenStdin - %v"+
+				" StdinOnce - %v", desc, createConfig.OpenStdin, createConfig.StdinOnce)
+		}
+
+		// Verify that remove container was called
+		if fakeDocker.RemoveContainerOpts.ID != "12345-test" {
+			t.Errorf("%s: RemoveContainer was not called with the expected container ID", desc)
+		}
+
+		// Verify that AttachToContainer was called twice (Stdin/Stdout)
+		if len(fakeDocker.AttachToContainerOpts) != 1 {
+			t.Errorf("%s: AttachToContainer was not called the expected number of times.", desc)
+		}
+		// Make sure AttachToContainer was not called with both Stdin & Stdout
+		for _, opt := range fakeDocker.AttachToContainerOpts {
+			if opt.InputStream == nil || opt.OutputStream == nil {
+				t.Errorf("%s: AttachToContainer was not called with both Stdin and Stdout: %#v", desc, opt)
+			}
+			if !opt.Stdin || !opt.Stdout {
+				t.Errorf("%s: AttachToContainer was not called with both Stdin and Stdout flags: %#v", desc, opt)
+			}
+		}
+	}
+}
+
+func TestGetImageID(t *testing.T) {
+	fakeDocker := &test.FakeDockerClient{
+		InspectImageResult: []*docker.Image{{ID: "test-abcd"}},
+	}
+	dh := getDocker(fakeDocker)
+	id, err := dh.GetImageID("test/image")
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	} else if id != "test-abcd" {
+		t.Errorf("Unexpected image id returned: %s", id)
+	}
+}
+
+func TestGetImageIDError(t *testing.T) {
+	expected := fmt.Errorf("Image Error")
+	fakeDocker := &test.FakeDockerClient{
+		InspectImageErr: []error{expected},
+	}
+	dh := getDocker(fakeDocker)
+	id, err := dh.GetImageID("test/image")
+	if err != expected {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if id != "" {
+		t.Errorf("Unexpected image id returned: %s", id)
+	}
+}
+
+func TestRemoveImage(t *testing.T) {
+	fakeDocker := &test.FakeDockerClient{}
+	dh := getDocker(fakeDocker)
+	err := dh.RemoveImage("test-image-id")
+	if err != nil {
+		t.Errorf("Unexpected error removing image: %s", err)
+	}
+	if fakeDocker.RemoveImageName != "test-image-id" {
+		t.Errorf("Unexpected image removed: %s", fakeDocker.RemoveImageName)
+	}
+}
+
+func TestGetImageName(t *testing.T) {
+	type runtest struct {
+		name     string
+		expected string
+	}
+	tests := []runtest{
+		{"test/image", "test/image:latest"},
+		{"test/image:latest", "test/image:latest"},
+		{"test/image:tag", "test/image:tag"},
+		{"repository/test/image", "repository/test/image:latest"},
+		{"repository/test/image:latest", "repository/test/image:latest"},
+		{"repository/test/image:tag", "repository/test/image:tag"},
+	}
+
+	for _, tc := range tests {
+		if e, a := tc.expected, getImageName(tc.name); e != a {
+			t.Errorf("Expected image name %s, but got %s!", e, a)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/util.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/util.go
@@ -192,8 +192,12 @@ func PullImage(name string, d Docker, policy api.PullPolicy, force bool) (*PullR
 	return &PullResult{Image: image, OnBuild: d.IsImageOnBuild(name)}, err
 }
 
-// CheckAllowedUser checks if the Docker image contains allowed users
-// FIXME: @cswong this need better godoc
+// CheckAllowedUser retrieves the user for a Docker image and checks that user against
+// an allowed range of uids.
+// - If the range of users is not empty, then the user on the Docker image needs to be a numeric user
+// - The user's uid must be contained by the range(s) specified by the uids Rangelist
+// - If the image contains ONBUILD instructions and those instructions also contain a USER directive,
+//   then the user specified by that USER directive must meet the uid range criteria as well.
 func CheckAllowedUser(d Docker, imageName string, uids user.RangeList, isOnbuild bool) error {
 	if uids == nil || uids.Empty() {
 		return nil

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/util_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/util_test.go
@@ -1,0 +1,96 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/util/user"
+)
+
+func rangeList(str string) *user.RangeList {
+	l, err := user.ParseRangeList(str)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
+func TestCheckAllowedUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedUIDs *user.RangeList
+		user        string
+		onbuild     []string
+		expectErr   bool
+	}{
+		{
+			name:        "AllowedUIDs is not set",
+			allowedUIDs: rangeList(""),
+			user:        "root",
+			onbuild:     []string{},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, non-numeric user",
+			allowedUIDs: rangeList("0"),
+			user:        "default",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "0",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, non-numeric onbuild",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "100",
+			onbuild:     []string{"COPY test test", "USER default"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, no onbuild user directive",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "200",
+			onbuild:     []string{"VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive",
+			allowedUIDs: rangeList("200,500-"),
+			user:        "200",
+			onbuild:     []string{"USER 500", "VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER 0"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive, upper bound range",
+			allowedUIDs: rangeList("-1000"),
+			user:        "80",
+			onbuild:     []string{"USER 501", "VOLUME /data"},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		docker := &FakeDocker{
+			GetImageUserResult: tc.user,
+			OnBuildResult:      tc.onbuild,
+		}
+		err := CheckAllowedUser(docker, "", *tc.allowedUIDs, len(tc.onbuild) > 0)
+		if err != nil && !tc.expectErr {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s: expected error, but did not get any", tc.name)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/ignore/ignore_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/ignore/ignore_test.go
@@ -1,0 +1,220 @@
+package ignore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/util"
+	"os"
+)
+
+func getLogLevel() (level int) {
+	for level = 5; level >= 0; level-- {
+		if glog.V(glog.Level(level)) == true {
+			break
+		}
+	}
+	return
+}
+
+func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep []string) {
+
+	// create working dir
+	workingDir, werr := util.NewFileSystem().CreateWorkingDirectory()
+	if werr != nil {
+		t.Errorf("problem allocating working dir %v \n", werr)
+	} else {
+		t.Logf("working directory is %s \n", workingDir)
+	}
+	defer func() {
+		// clean up test
+		cleanerr := os.RemoveAll(workingDir)
+		if cleanerr != nil {
+			t.Errorf("problem cleaning up %v \n", cleanerr)
+		}
+	}()
+
+	c := &api.Config{WorkingDir: workingDir}
+
+	// create source repo dir for .s2iignore that matches where ignore.go looks
+	dpath := filepath.Join(c.WorkingDir, "upload", "src")
+	derr := os.MkdirAll(dpath, 0777)
+	if derr != nil {
+		t.Errorf("Problem creating source repo dir %s with  %v \n", dpath, derr)
+	}
+
+	c.WorkingSourceDir = dpath
+	t.Logf("working source dir %s \n", dpath)
+
+	// create s2iignore file
+	ipath := filepath.Join(dpath, api.IgnoreFile)
+	ifile, ierr := os.Create(ipath)
+	defer ifile.Close()
+	if ierr != nil {
+		t.Errorf("Problem creating .s2iignore at %s with  %v \n", ipath, ierr)
+	}
+
+	// write patterns to remove into s2ignore, but save ! exclusions
+	filesToIgnore := make(map[string]string)
+	for _, pattern := range patterns {
+		t.Logf("storing pattern %s \n", pattern)
+		_, serr := ifile.WriteString(pattern)
+
+		if serr != nil {
+			t.Errorf("Problem setting .s2iignore %v \n", serr)
+		}
+		if strings.HasPrefix(pattern, "!") {
+			pattern = strings.Replace(pattern, "!", "", 1)
+			t.Logf("Noting ignore pattern  %s \n", pattern)
+			filesToIgnore[pattern] = pattern
+		}
+	}
+
+	// create slices the store files to create, maps for files which should be deleted, files which should be kept
+	filesToCreate := make([]string, 0)
+	filesToDelCheck := make(map[string]string)
+	for _, fileToDel := range filesToDel {
+		filesToDelCheck[fileToDel] = fileToDel
+		filesToCreate = append(filesToCreate, fileToDel)
+	}
+	filesToKeepCheck := make(map[string]string)
+	for _, fileToKeep := range filesToKeep {
+		filesToKeepCheck[fileToKeep] = fileToKeep
+		filesToCreate = append(filesToCreate, fileToKeep)
+	}
+
+	// create files for test
+	for _, fileToCreate := range filesToCreate {
+		fbpath := filepath.Join(dpath, fileToCreate)
+
+		// ensure any subdirs off working dir exist
+		dirpath := filepath.Dir(fbpath)
+		derr := os.MkdirAll(dirpath, 0777)
+		if derr != nil && !os.IsExist(derr) {
+			t.Errorf("Problem creating subdirs %s with %v \n", dirpath, derr)
+		}
+		t.Logf("Going to create file %s given supplied suffix %s \n", fbpath, fileToCreate)
+		fbfile, fberr := os.Create(fbpath)
+		defer fbfile.Close()
+		if fberr != nil {
+			t.Errorf("Problem creating test file %v \n", fberr)
+		}
+	}
+
+	// run ignorer algorithm
+	ignorer := &DockerIgnorer{}
+	ignorer.Ignore(c)
+
+	// check if filesToDel, minus ignores, are gone, and filesToKeep are still there
+	for _, fileToCheck := range filesToCreate {
+		fbpath := filepath.Join(dpath, fileToCheck)
+		t.Logf("Evaluating file %s from dir %s and file to check %s \n", fbpath, dpath, fileToCheck)
+
+		// see if file still exists or not
+		ofile, oerr := os.Open(fbpath)
+		defer ofile.Close()
+		var fileExists bool
+		if oerr == nil {
+			fileExists = true
+			t.Logf("The file %s exists after Ignore was run \n", fbpath)
+		} else {
+			if os.IsNotExist(oerr) {
+				t.Logf("The file %s does not exist after Ignore was run \n", fbpath)
+				fileExists = false
+			} else {
+				t.Errorf("Could not verify existence of %s because of %v \n", fbpath, oerr)
+			}
+		}
+
+		_, iok := filesToIgnore[fileToCheck]
+		_, kok := filesToKeepCheck[fileToCheck]
+		_, dok := filesToDelCheck[fileToCheck]
+
+		// if file present, verify it is in ignore or keep list, and not in del list
+		if fileExists {
+			if iok {
+				t.Logf("validated ignored file is still present %s \n ", fileToCheck)
+				continue
+			}
+
+			if kok {
+				t.Logf("validated file to keep is still present %s \n", fileToCheck)
+				continue
+			}
+
+			if dok {
+				t.Errorf("file which was cited to be deleted by caller to runTest exists %s \n", fileToCheck)
+				continue
+			}
+
+			// if here, something unexpected
+			t.Errorf("file not in ignore / keep / del list  !?!?!?!?  %s \n", fileToCheck)
+
+		} else {
+			if dok {
+				t.Logf("file which should have been deleted is in fact gone %s \n", fileToCheck)
+				continue
+			}
+
+			if iok {
+				t.Errorf("file put into ignore list does not exist %s \n ", fileToCheck)
+				continue
+			}
+
+			if kok {
+				t.Errorf("file passed in with keep list does not exist %s \n", fileToCheck)
+				continue
+			}
+
+			// if here, then something unexpected happened
+			t.Errorf("file not in ignore / keep / del list  !?!?!?!?  %s \n", fileToCheck)
+
+		}
+
+	}
+
+}
+
+func TestSingleIgnore(t *testing.T) {
+	baseTest(t, []string{"foo.bar\n"}, []string{"foo.bar"}, []string{})
+}
+
+func TestWildcardIgnore(t *testing.T) {
+	baseTest(t, []string{"foo.*\n"}, []string{"foo.a", "foo.b"}, []string{})
+}
+
+func TestExclusion(t *testing.T) {
+	baseTest(t, []string{"foo.*\n", "!foo.a"}, []string{"foo.b"}, []string{"foo.a"})
+}
+
+func TestSubDirs(t *testing.T) {
+	baseTest(t, []string{"*/foo.a\n"}, []string{"asdf/foo.a"}, []string{"foo.a"})
+}
+
+func TestBasicDelKeepMix(t *testing.T) {
+	baseTest(t, []string{"foo.bar\n"}, []string{"foo.bar"}, []string{"bar.foo"})
+}
+
+/*
+Per the docker user guide, with a docker ignore list of:
+
+    LICENCSE.*
+    !LICENCSE.md
+    *.md
+
+LICENSE.MD will NOT be kept, as *.md overrides !LICENCSE.md
+*/
+func TestExcludeOverride(t *testing.T) {
+	baseTest(t, []string{"LICENCSE.*\n", "!LICENCSE.md\n", "*.md"}, []string{"LICENCSE.foo", "LICENCSE.md"}, []string{"foo.bar"})
+}
+
+func TestExclusionWithWildcard(t *testing.T) {
+	baseTest(t, []string{"*.bar\n", "!foo.*"}, []string{"boo.bar", "bar.bar"}, []string{"foo.bar"})
+}
+
+func TestHopelessExclusion(t *testing.T) {
+	baseTest(t, []string{"!LICENSE.md\n", "LICENSE.*"}, []string{"LICENSE.md"}, []string{})
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/clone_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/clone_test.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+func TestCloneWithContext(t *testing.T) {
+	gh := New().(*stiGit)
+	cr := &test.FakeCmdRunner{}
+	gh.runner = cr
+	fs := &test.FakeFileSystem{}
+	c := &Clone{gh, fs}
+
+	fakeConfig := &api.Config{
+		Source:           "https://foo/bar.git",
+		ContextDir:       "subdir",
+		Ref:              "ref1",
+		DisableRecursive: true,
+	}
+	info, err := c.Download(fakeConfig)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if info == nil {
+		t.Fatalf("Expected info to be not nil")
+	}
+	if fs.CopySource != "upload/tmp/subdir/." {
+		t.Errorf("The source directory should be 'upload/tmp/subdir', it is %v", fs.CopySource)
+	}
+	if fs.CopyDest != "upload/src" {
+		t.Errorf("The target directory should be 'upload/src', it is %v", fs.CopyDest)
+	}
+	if fs.RemoveDirName != "upload/tmp" {
+		t.Errorf("Expected to remove the upload/tmp directory")
+	}
+	if !reflect.DeepEqual(cr.Args, []string{"checkout", "ref1"}) {
+		t.Errorf("Unexpected command arguments: %#v\n", cr.Args)
+	}
+}
+
+func TestCloneLocalWithContext(t *testing.T) {
+	gh := New().(*stiGit)
+	cr := &test.FakeCmdRunner{}
+	gh.runner = cr
+	fs := &test.FakeFileSystem{ExistsResult: map[string]bool{"source/subdir/.": true}}
+	c := &Clone{gh, fs}
+
+	fakeConfig := &api.Config{
+		Source:     "source",
+		ContextDir: "subdir",
+		Ref:        "ref1",
+	}
+	_, err := c.Download(fakeConfig)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if fs.CopySource != "source/subdir/." {
+		t.Errorf("The source directory should be 'source/subdir', it is %v", fs.CopySource)
+	}
+	if fs.CopyDest != "upload/src" {
+		t.Errorf("The target directory should be 'upload/src', it is %v", fs.CopyDest)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/git_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/git_test.go
@@ -1,0 +1,297 @@
+package git
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/test"
+)
+
+func createLocalGitDirectory(t *testing.T) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "s2i-test")
+	if err != nil {
+		t.Error(err)
+	}
+	os.Mkdir(filepath.Join(dir, ".git"), 0600)
+	return dir
+}
+
+func TestIsLocalGitRepository(t *testing.T) {
+	d := createLocalGitDirectory(t)
+	defer os.RemoveAll(d)
+	if isLocalGitRepository(d) == false {
+		t.Errorf("The %q directory is git repository", d)
+	}
+	os.RemoveAll(filepath.Join(d, ".git"))
+	if isLocalGitRepository(d) == true {
+		t.Errorf("The %q directory is not git repository", d)
+	}
+}
+
+func TestValidCloneSpec(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+
+	valid := []string{"git@github.com:user/repo.git",
+		"git://github.com/user/repo.git",
+		"git://github.com/user/repo",
+		"http://github.com/user/repo.git",
+		"http://github.com/user/repo",
+		"https://github.com/user/repo.git",
+		"https://github.com/user/repo",
+		"file://" + gitLocalDir,
+		gitLocalDir,
+		"git@192.168.122.1:repositories/authooks",
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git",
+		"ssh://git@[2001:db8::1]/repository.git",
+		"ssh://git@mydomain.com:8080/foo/bar",
+		"git@[2001:db8::1]:repository.git",
+		"git@[2001:db8::1]:/repository.git",
+		"g_m@foo.bar:foo/bar",
+		"g-m@foo.bar:foo/bar",
+		"g.m@foo.bar:foo/bar",
+		"github.com:openshift/origin.git",
+		"http://github.com/user/repo#1234",
+	}
+	invalid := []string{"g&m@foo.bar:foo.bar",
+		"~git@test.server/repo.git",
+		"some/lo:cal/path", // a local path that does not exist, but "some/lo" is not a valid host name
+		"http://github.com/user/repo#%%%%",
+	}
+
+	gh := New()
+
+	for _, scenario := range valid {
+		result := gh.ValidCloneSpec(scenario)
+		if result == false {
+			t.Error(scenario)
+		}
+	}
+	for _, scenario := range invalid {
+		result := gh.ValidCloneSpec(scenario)
+		if result {
+			t.Error(scenario)
+		}
+	}
+}
+
+func TestValidCloneSpecRemoteOnly(t *testing.T) {
+	valid := []string{"git://github.com/user/repo.git",
+		"git://github.com/user/repo",
+		"http://github.com/user/repo.git",
+		"http://github.com/user/repo",
+		"https://github.com/user/repo.git",
+		"https://github.com/user/repo",
+		"ssh://git@[2001:db8::1]/repository.git",
+		"ssh://git@mydomain.com:8080/foo/bar",
+		"git@github.com:user/repo.git",
+		"git@192.168.122.1:repositories/authooks",
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git",
+		"git@[2001:db8::1]:repository.git",
+		"git@[2001:db8::1]:/repository.git",
+	}
+	invalid := []string{"file:///home/user/code/repo.git",
+		"/home/user/code/repo.git",
+	}
+
+	gh := New()
+
+	for _, scenario := range valid {
+		result := gh.ValidCloneSpecRemoteOnly(scenario)
+		if result == false {
+			t.Error(scenario)
+		}
+	}
+	for _, scenario := range invalid {
+		result := gh.ValidCloneSpecRemoteOnly(scenario)
+		if result {
+			t.Error(scenario)
+		}
+	}
+}
+
+func TestMungeNoProtocolURL(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+
+	gh := New()
+
+	tests := map[string]url.URL{
+		"git@github.com:user/repo.git": {
+			Scheme: "ssh",
+			Host:   "github.com",
+			User:   url.User("git"),
+			Path:   "user/repo.git",
+		},
+		"git://github.com/user/repo.git": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"git://github.com/user/repo": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"http://github.com/user/repo.git": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"http://github.com/user/repo": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"https://github.com/user/repo.git": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"https://github.com/user/repo": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"file://" + gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		"git@192.168.122.1:repositories/authooks": {
+			Scheme: "ssh",
+			Host:   "192.168.122.1",
+			User:   url.User("git"),
+			Path:   "repositories/authooks",
+		},
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git": {
+			Scheme: "ssh",
+			Host:   "build.ulx.hu",
+			User:   url.User("mbalazs"),
+			Path:   "/var/git/eap-ulx.git",
+		},
+		"ssh://git@[2001:db8::1]/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+		"ssh://git@mydomain.com:8080/foo/bar": {
+			Scheme: "ssh",
+			Host:   "mydomain.com:8080",
+			User:   url.User("git"),
+			Path:   "/foo/bar",
+		},
+		"git@[2001:db8::1]:repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "repository.git",
+		},
+		"git@[2001:db8::1]:/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+	}
+
+	for scenario, test := range tests {
+		uri, err := url.Parse(scenario)
+		if err != nil {
+			t.Errorf("Could not parse url %s", scenario)
+		}
+
+		err = gh.MungeNoProtocolURL(scenario, uri)
+		if err != nil {
+			t.Errorf("MungeNoProtocolURL returned err: %v", err)
+		}
+
+		// reflect.DeepEqual was not dealing with url.URL correctly, have to check each field individually
+		// First, the easy string compares
+		equal := uri.Scheme == test.Scheme && uri.Opaque == test.Opaque && uri.Host == test.Host && uri.Path == test.Path && uri.RawQuery == test.RawQuery && uri.Fragment == test.Fragment
+		if equal {
+			// now deal with User, a Userinfo struct ptr
+			if uri.User == nil && test.User != nil {
+				equal = false
+			} else if uri.User != nil && test.User == nil {
+				equal = false
+			} else if uri.User != nil && test.User != nil {
+				equal = uri.User.String() == test.User.String()
+			}
+		}
+		if !equal {
+			t.Errorf("For URL string %s, field by field check for scheme %v opaque %v host %v path %v rawq %v frag %v out user nil %v test user nil %v out scheme  %s out opaque %s out host %s out path %s  out raw query %s out frag %s", scenario,
+				uri.Scheme == test.Scheme, uri.Opaque == test.Opaque, uri.Host == test.Host, uri.Path == test.Path, uri.RawQuery == test.RawQuery,
+				uri.Fragment == test.Fragment, uri.User == nil, test.User == nil, uri.Scheme, uri.Opaque, uri.Host, uri.Path, uri.RawQuery, uri.Fragment)
+		}
+	}
+}
+
+func getGit() (*stiGit, *test.FakeCmdRunner) {
+	gh := New().(*stiGit)
+	cr := &test.FakeCmdRunner{}
+	gh.runner = cr
+
+	return gh, cr
+}
+
+func TestGitClone(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Clone("source1", "target1", api.CloneConfig{Quiet: true, Recursive: true})
+	if err != nil {
+		t.Errorf("Unexpected error returned from clone: %v\n", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %s\n", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"clone", "--quiet", "--recursive", "source1", "target1"}) {
+		t.Errorf("Unexpected command arguments: %#v\n", ch.Args)
+	}
+}
+
+func TestGitCloneError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Clone("source1", "target1", api.CloneConfig{})
+	if err != runErr {
+		t.Errorf("Unexpected error returned from clone: %v\n", err)
+	}
+}
+
+func TestGitCheckout(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Checkout("repo1", "ref1")
+	if err != nil {
+		t.Errorf("Unexpected error returned from checkout: %v\n", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %s\n", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"checkout", "ref1"}) {
+		t.Errorf("Unexpected command arguments: %#v\n", ch.Args)
+	}
+	if ch.Opts.Dir != "repo1" {
+		t.Errorf("Unexpected value in exec directory: %s\n", ch.Opts.Dir)
+	}
+}
+
+func TestGitCheckoutError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Checkout("repo1", "ref1")
+	if err != runErr {
+		t.Errorf("Unexpected error returned from checkout: %v\n", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
@@ -1,0 +1,82 @@
+package scm
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func createLocalGitDirectory(t *testing.T) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "gitdir-s2i-test")
+	if err != nil {
+		t.Error(err)
+	}
+	os.Mkdir(filepath.Join(dir, ".git"), 0600)
+	return dir
+}
+
+func TestDownloaderForSource(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	localDir, _ := ioutil.TempDir(os.TempDir(), "localdir-s2i-test")
+	defer os.RemoveAll(localDir)
+
+	tc := map[string]string{
+		// Valid GIT clone specs
+		"git://github.com/bar":       "git.Clone",
+		"https://github.com/bar":     "git.Clone",
+		"git@github.com:foo/bar.git": "git.Clone",
+		// Non-existing local path (it is not git repository, so it is file
+		// download)
+		"file://foo/bar": "error",
+		"/foo/bar":       "error",
+		// Local directory with valid GIT repository
+		gitLocalDir:             "git.Clone",
+		"file://" + gitLocalDir: "git.Clone",
+		// Local directory that exists but it is not GIT repository
+		localDir:               "file.File",
+		"file://" + localDir:   "file.File",
+		"foo://github.com/bar": "error",
+		"./foo":                "error",
+	}
+
+	for s, expected := range tc {
+		r, filePathUpdate, err := DownloaderForSource(s)
+		if err != nil {
+			if expected != "error" {
+				t.Errorf("Unexpected error %q for %q, expected %q", err, s, expected)
+			}
+			continue
+		}
+
+		if s == gitLocalDir || s == localDir {
+			if !strings.HasPrefix(filePathUpdate, "file://") {
+				t.Errorf("input %s should have produced a file path update starting with file:// but produced:  %s", s, filePathUpdate)
+			}
+		}
+
+		expected = "*" + expected
+		if reflect.TypeOf(r).String() != expected {
+			t.Errorf("Expected %q for %q, got %q", expected, s, reflect.TypeOf(r).String())
+		}
+	}
+}
+
+func TestDownloaderForSourceOnRelativeGit(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	os.Chdir(gitLocalDir)
+	r, s, err := DownloaderForSource(".")
+	if err != nil {
+		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "git.Clone")
+	}
+	if !strings.HasPrefix(s, "file://") {
+		t.Errorf("Expected source to have 'file://' prefix, it is %q", s)
+	}
+	if reflect.TypeOf(r).String() != "*git.Clone" {
+		t.Errorf("Expected %q for %q, got %q", "*git.Clone", ".", reflect.TypeOf(r).String())
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/download_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/download_test.go
@@ -1,0 +1,146 @@
+package scripts
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/errors"
+)
+
+type FakeHTTPGet struct {
+	url        string
+	content    string
+	err        error
+	body       io.ReadCloser
+	statusCode int
+}
+
+func (f *FakeHTTPGet) get(url string) (*http.Response, error) {
+	f.url = url
+	f.body = ioutil.NopCloser(strings.NewReader(f.content))
+	return &http.Response{
+		Body:       f.body,
+		StatusCode: f.statusCode,
+	}, f.err
+}
+
+func getHTTPReader() (*HttpURLReader, *FakeHTTPGet) {
+	sr := &HttpURLReader{}
+	g := &FakeHTTPGet{content: "test content", statusCode: 200}
+	sr.Get = g.get
+	return sr, g
+}
+
+func TestHTTPRead(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	rc, err := sr.Read(u)
+	if rc != fg.body {
+		t.Errorf("Unexpected readcloser returned: %#v", rc)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+}
+
+func TestHTTPReadGetError(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	fg.err = fmt.Errorf("URL Error")
+	rc, err := sr.Read(u)
+	if rc != nil {
+		t.Errorf("Unexpected stream returned: %#v", rc)
+	}
+	if err != fg.err {
+		t.Errorf("Unexpected error returned: %#v", err)
+	}
+}
+
+func TestHTTPReadErrorCode(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	fg.statusCode = 500
+	rc, err := sr.Read(u)
+	if rc != nil {
+		t.Errorf("Unexpected stream returned: %#v", rc)
+	}
+	if err == nil {
+		t.Errorf("Error expeccted and not returned")
+	}
+}
+
+type FakeSchemeReader struct {
+	content string
+	err     error
+}
+
+func (f *FakeSchemeReader) Read(url *url.URL) (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader(f.content)), f.err
+}
+
+func getDownloader() (Downloader, *FakeSchemeReader) {
+	fakeReader := &FakeSchemeReader{}
+	return &downloader{
+		schemeReaders: map[string]schemeReader{
+			"http":  fakeReader,
+			"https": fakeReader,
+			"file":  fakeReader,
+		},
+	}, fakeReader
+}
+
+func TestDownload(t *testing.T) {
+	dl, fr := getDownloader()
+	fr.content = "test file content"
+	temp, err := ioutil.TempFile("", "testdownload")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	defer os.Remove(temp.Name())
+	u, _ := url.Parse("http://www.test.url/a/file")
+	temp.Close()
+	info, err := dl.Download(u, temp.Name())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(info.Location) == 0 {
+		t.Errorf("Expected info.Location to be set, got %v", info)
+	}
+	content, _ := ioutil.ReadFile(temp.Name())
+	if string(content) != fr.content {
+		t.Errorf("Unexpected file content: %s", string(content))
+	}
+}
+
+func TestNoDownload(t *testing.T) {
+	dl := &downloader{
+		schemeReaders: map[string]schemeReader{
+			"image": &ImageReader{},
+		},
+	}
+	u, _ := url.Parse("image:///tmp/testfile")
+	_, err := dl.Download(u, "")
+	if err == nil {
+		t.Error("Expected error with information about scripts inside the image!")
+	}
+	if e, ok := err.(errors.Error); !ok || e.ErrorCode != errors.ScriptsInsideImageError {
+		t.Errorf("Unexpected error %v", err)
+	}
+}
+
+func TestNoDownloader(t *testing.T) {
+	dl := &downloader{
+		schemeReaders: map[string]schemeReader{},
+	}
+	u, _ := url.Parse("http://www.test.url/a/file")
+	_, err := dl.Download(u, "")
+	if err == nil {
+		t.Errorf("Expected error, got nil!")
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
@@ -1,0 +1,16 @@
+package scripts
+
+import "testing"
+
+func TestConvertEnvironment(t *testing.T) {
+	env := []Environment{
+		{"FOO", "BAR"},
+	}
+	result := ConvertEnvironment(env)
+	if len(result) != 1 {
+		t.Errorf("Expected 1 item, got %d", len(result))
+	}
+	if result[0] != "FOO=BAR" {
+		t.Errorf("Expected FOO=BAR, got %v", result)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/install_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/install_test.go
@@ -1,0 +1,281 @@
+package scripts
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dockerClient "github.com/fsouza/go-dockerclient"
+	"github.com/openshift/source-to-image/pkg/api"
+	dockerpkg "github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+	"github.com/openshift/source-to-image/pkg/util"
+)
+
+type fakeScriptManagerConfig struct {
+	download Downloader
+	docker   dockerpkg.Docker
+	fs       util.FileSystem
+	url      string
+}
+
+func newFakeConfig() *fakeScriptManagerConfig {
+	return &fakeScriptManagerConfig{
+		docker:   &dockerpkg.FakeDocker{},
+		download: &test.FakeDownloader{},
+		fs:       &test.FakeFileSystem{},
+		url:      "http://the.scripts.url/s2i/bin",
+	}
+}
+
+func newFakeInstaller(config *fakeScriptManagerConfig) Installer {
+	m := DefaultScriptSourceManager{
+		Image:      "test-image",
+		ScriptsURL: config.url,
+		docker:     config.docker,
+		fs:         config.fs,
+		download:   config.download,
+	}
+	m.Add(&UrlScriptHandler{URL: m.ScriptsURL, download: m.download, fs: m.fs})
+	m.Add(&SourceScriptHandler{fs: m.fs})
+	defaultURL, err := m.docker.GetScriptsURL(m.Image)
+	if err == nil && defaultURL != "" {
+		m.Add(&UrlScriptHandler{URL: defaultURL, download: m.download, fs: m.fs})
+	}
+	return &m
+}
+
+func isValidInstallResult(result api.InstallResult, t *testing.T) {
+	if len(result.Script) == 0 {
+		t.Errorf("expected the Script not be empty")
+	}
+	if result.Error != nil {
+		t.Errorf("unexpected the error %v for the %q script in install result", result.Error, result.Script)
+	}
+	if !result.Downloaded {
+		t.Errorf("expected the %q script install result to be downloaded", result.Script)
+	}
+	if !result.Installed {
+		t.Errorf("expected the %q script install result to be installed", result.Script)
+	}
+	if len(result.URL) == 0 {
+		t.Errorf("expected the %q script install result to have valid URL", result.Script)
+	}
+}
+
+func TestInstallOptionalFromURL(t *testing.T) {
+	config := newFakeConfig()
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	results := inst.InstallOptional(scripts, "/output")
+	for _, r := range results {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		downloaded := false
+		targets := config.download.(*test.FakeDownloader).Target
+		for _, t := range targets {
+			if t == "/output/upload/scripts/"+s {
+				downloaded = true
+			}
+		}
+		if !downloaded {
+			t.Errorf("the script %q was not downloaded properly (%#v)", s, targets)
+		}
+		validURL := false
+		urls := config.download.(*test.FakeDownloader).URL
+		for _, u := range urls {
+			if u.String() == config.url+"/"+s {
+				validURL = true
+			}
+		}
+		if !validURL {
+			t.Errorf("the script %q was downloaded from invalid URL (%+v), s, urls")
+		}
+	}
+}
+
+func TestInstallRequiredFromURL(t *testing.T) {
+	config := newFakeConfig()
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble: fmt.Errorf("download error"),
+	}
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	_, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected assemble to fail install")
+	}
+}
+
+func TestInstallRequiredFromDocker(t *testing.T) {
+	config := newFakeConfig()
+	// We fail the download for assemble, which means the Docker image default URL
+	// should be used instead.
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble: fmt.Errorf("not available"),
+	}
+	defaultDockerURL := "image:///usr/libexec/s2i/bin"
+	config.docker.(*dockerpkg.FakeDocker).DefaultURLResult = defaultDockerURL
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	results, err := inst.InstallRequired(scripts, "/output")
+	if err != nil {
+		t.Errorf("unexpected error, assemble should be installed from docker image url")
+	}
+	for _, r := range results {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		validURL := false
+		urls := config.download.(*test.FakeDownloader).URL
+		for _, u := range urls {
+			url := config.url
+			// The assemble script should be downloaded from image default URL
+			if s == api.Assemble {
+				url = defaultDockerURL
+			}
+			if u.String() == url+"/"+s {
+				validURL = true
+			}
+		}
+		if !validURL {
+			t.Errorf("the script %q was downloaded from invalid URL (%+v), s, urls")
+		}
+	}
+}
+
+func TestInstallRequiredFromSource(t *testing.T) {
+	config := newFakeConfig()
+	// There is no other script source than the source code
+	config.url = ""
+	deprecatedSourceScripts := strings.Replace(api.SourceScripts, ".s2i", ".sti", -1)
+	config.fs.(*test.FakeFileSystem).ExistsResult = map[string]bool{
+		filepath.Join("/workdir", api.SourceScripts, api.Assemble):  true,
+		filepath.Join("/workdir", deprecatedSourceScripts, api.Run): true,
+	}
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	result, err := inst.InstallRequired(scripts, "/workdir")
+	if err != nil {
+		t.Errorf("unexpected error, assemble should be installed from docker image url: %v", err)
+	}
+	for _, r := range result {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		validResultURL := false
+		for _, r := range result {
+			// The api.Run use deprecated path, but it should still work.
+			if s == api.Run && r.URL == sourcesRootAbbrev+".sti/bin/"+s {
+				validResultURL = true
+			}
+			if r.URL == sourcesRootAbbrev+".s2i/bin/"+s {
+				validResultURL = true
+			}
+		}
+		if !validResultURL {
+			t.Errorf("expected %q has result URL "+sourcesRootAbbrev+".s2i/bin/script>, got %#v", s, result)
+		}
+		chmodCalled := false
+		fs := config.fs.(*test.FakeFileSystem)
+		for _, f := range fs.ChmodFile {
+			if f == "/workdir/upload/scripts/"+s {
+				chmodCalled = true
+			}
+		}
+		if !chmodCalled {
+			t.Errorf("expected chmod called on /workdir/upload/scripts/%s", s)
+		}
+	}
+}
+
+// TestInstallRequiredOrder tests the proper order for retrieving the source
+// scripts.
+// The scenario here is that the assemble script does not exists in provided
+// scripts url, but it exists in source code directory. The save-artifacts does
+// not exists at provided url nor in source code, so the docker image default
+// URL should be used.
+func TestInstallRequiredOrder(t *testing.T) {
+	config := newFakeConfig()
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble:      fmt.Errorf("not available"),
+		config.url + "/" + api.SaveArtifacts: fmt.Errorf("not available"),
+	}
+	config.fs.(*test.FakeFileSystem).ExistsResult = map[string]bool{
+		filepath.Join("/workdir", api.SourceScripts, api.Assemble):      true,
+		filepath.Join("/workdir", api.SourceScripts, api.Run):           false,
+		filepath.Join("/workdir", api.SourceScripts, api.SaveArtifacts): false,
+	}
+	defaultDockerURL := "http://the.docker.url/s2i"
+	config.docker.(*dockerpkg.FakeDocker).DefaultURLResult = defaultDockerURL
+	scripts := []string{api.Assemble, api.Run, api.SaveArtifacts}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/workdir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	for _, r := range result {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		found := false
+		for _, r := range result {
+			if r.Script == s && r.Script == api.Assemble && r.URL == sourcesRootAbbrev+".s2i/bin/assemble" {
+				found = true
+			}
+			if r.Script == s && r.Script == api.Run && r.URL == config.url+"/"+api.Run {
+				found = true
+			}
+			if r.Script == s && r.Script == api.SaveArtifacts && r.URL == defaultDockerURL+"/"+api.SaveArtifacts {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("the %q script installed in wrong order: %+v", s, result)
+		}
+	}
+}
+
+func TestInstallRequiredError(t *testing.T) {
+	config := newFakeConfig()
+	config.url = ""
+	scripts := []string{api.Assemble, api.Run}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected error, got %+v", result)
+	}
+}
+
+func TestInstallRequiredFromInvalidURL(t *testing.T) {
+	config := newFakeConfig()
+	config.url = "../invalid-url"
+	scripts := []string{api.Assemble}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected error, got %+v", result)
+	}
+}
+
+func TestNewInstaller(t *testing.T) {
+	docker := &dockerpkg.FakeDocker{DefaultURLResult: "image://docker"}
+	inst := NewInstaller("test-image", "http://foo.bar", docker, dockerClient.AuthConfiguration{})
+	sources := inst.(*DefaultScriptSourceManager).sources
+	firstHandler, ok := sources[0].(*UrlScriptHandler)
+	if !ok {
+		t.Errorf("expected first handler to be script url handler, got %#v", inst.(*DefaultScriptSourceManager).sources)
+	}
+	if firstHandler.URL != "http://foo.bar" {
+		t.Errorf("expected first handler to handle the script url, got %+v", firstHandler)
+	}
+	lastHandler, ok := sources[len(sources)-1].(*UrlScriptHandler)
+	if !ok {
+		t.Errorf("expected last handler to be docker url handler, got %#v", inst.(*DefaultScriptSourceManager).sources)
+	}
+	if lastHandler.URL != "image://docker" {
+		t.Errorf("expected last handler to handle the docker default url, got %+v", lastHandler)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/tar/tar_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/tar/tar_test.go
@@ -1,0 +1,360 @@
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openshift/source-to-image/pkg/errors"
+)
+
+type fileDesc struct {
+	name         string
+	modifiedDate time.Time
+	mode         os.FileMode
+	content      string
+	shouldSkip   bool
+	target       string
+}
+
+type linkDesc struct {
+	linkName string
+	fileName string
+}
+
+func createTestFiles(baseDir string, files []fileDesc) error {
+	for _, fd := range files {
+		fileName := filepath.Join(baseDir, fd.name)
+		if err := os.MkdirAll(filepath.Dir(fileName), 0700); err != nil {
+			return err
+		}
+		file, err := os.Create(fileName)
+		if err != nil {
+			return err
+		}
+		file.WriteString(fd.content)
+		file.Chmod(fd.mode)
+		file.Close()
+		os.Chtimes(fileName, fd.modifiedDate, fd.modifiedDate)
+	}
+	return nil
+}
+
+func createTestLinks(baseDir string, links []linkDesc) error {
+	for _, ld := range links {
+		linkName := filepath.Join(baseDir, ld.linkName)
+		if err := os.MkdirAll(filepath.Dir(linkName), 0700); err != nil {
+			return err
+		}
+		if err := os.Symlink(ld.fileName, linkName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyTarFile(t *testing.T, filename string, files []fileDesc, links []linkDesc) {
+	filesToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		if !fd.shouldSkip {
+			filesToVerify[fd.name] = fd
+		}
+	}
+	linksToVerify := make(map[string]linkDesc)
+	for _, ld := range links {
+		linksToVerify[ld.linkName] = ld
+	}
+
+	file, err := os.Open(filename)
+	defer file.Close()
+	if err != nil {
+		t.Fatalf("Cannot open tar file to verify: %s, %v\n", filename, err)
+	}
+	tr := tar.NewReader(file)
+	for {
+		hdr, err := tr.Next()
+		if hdr == nil {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Error reading tar %s: %v\n", filename, err)
+		}
+		finfo := hdr.FileInfo()
+		if fd, ok := filesToVerify[hdr.Name]; ok {
+			delete(filesToVerify, hdr.Name)
+			if finfo.Mode().Perm() != fd.mode {
+				t.Errorf("File %s from tar %s does not match expected mode. Expected: %v, actual: %v\n",
+					hdr.Name, filename, fd.mode, finfo.Mode().Perm())
+			}
+			if !fd.modifiedDate.IsZero() && finfo.ModTime().UTC() != fd.modifiedDate {
+				t.Errorf("File %s from tar %s does not match expected modified date. Expected: %v, actual: %v\n",
+					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
+			}
+			fileBytes, err := ioutil.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("Error reading tar %s: %v\n", filename, err)
+			}
+			fileContent := string(fileBytes)
+			if fileContent != fd.content {
+				t.Errorf("Content for file %s in tar %s doesn't match expected value. Expected: %s, Actual: %s",
+					finfo.Name(), filename, fd.content, fileContent)
+			}
+		} else if ld, ok := linksToVerify[hdr.Name]; ok {
+			delete(linksToVerify, hdr.Name)
+			if finfo.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("Incorrect link %s", finfo.Name())
+			}
+			if hdr.Linkname != ld.fileName {
+				t.Errorf("Incorrect link location. Expected: %s, Actual %s", ld.fileName, hdr.Linkname)
+			}
+		} else {
+			t.Errorf("Cannot find file %s from tar in files to verify.\n", hdr.Name)
+		}
+	}
+
+	if len(filesToVerify) > 0 || len(linksToVerify) > 0 {
+		t.Errorf("Did not find all expected files in tar: %v, %v", filesToVerify, linksToVerify)
+	}
+}
+
+func TestCreateTarStreamIncludeParentDir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+	}
+	if err := createTestFiles(tempDir, testFiles); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+	th := New()
+	tarFile, err := ioutil.TempFile("", "testtarout")
+	if err != nil {
+		t.Fatalf("Unable to create temporary file %v", err)
+	}
+	defer os.Remove(tarFile.Name())
+	err = th.CreateTarStream(tempDir, true, tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create tar file %v", err)
+	}
+	tarFile.Close()
+	for i := range testFiles {
+		testFiles[i].name = filepath.Join(filepath.Base(tempDir), testFiles[i].name)
+	}
+	verifyTarFile(t, tarFile.Name(), testFiles, []linkDesc{})
+
+}
+
+func TestCreateTar(t *testing.T) {
+	th := New()
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+	}
+	if err := createTestFiles(tempDir, testFiles); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/errdirlink", "../dir01/.git"},
+	}
+	if err := createTestLinks(tempDir, testLinks); err != nil {
+		t.Fatalf("Cannot create link files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testFiles, testLinks)
+}
+
+func createTestTar(files []fileDesc, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+	for _, fd := range files {
+		if isSymLink(fd.mode) {
+			if err := addSymLink(tw, &fd); err != nil {
+				msg := "unable to add symbolic link %q (points to %q) to archive: %v"
+				return fmt.Errorf(msg, fd.name, fd.target, err)
+			}
+			continue
+		}
+		if err := addRegularFile(tw, &fd); err != nil {
+			return fmt.Errorf("unable to add file %q to archive: %v", fd.name, err)
+		}
+	}
+	return nil
+}
+
+func addRegularFile(tw *tar.Writer, fd *fileDesc) error {
+	contentBytes := []byte(fd.content)
+	hdr := &tar.Header{
+		Name:       fd.name,
+		Mode:       int64(fd.mode),
+		Size:       int64(len(contentBytes)),
+		Typeflag:   tar.TypeReg,
+		AccessTime: time.Now(),
+		ModTime:    fd.modifiedDate,
+		ChangeTime: fd.modifiedDate,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := tw.Write(contentBytes)
+	return err
+}
+
+func addSymLink(tw *tar.Writer, fd *fileDesc) error {
+	if len(fd.target) == 0 {
+		return fmt.Errorf("link %q must point to somewhere, but target wasn't defined", fd.name)
+	}
+
+	hdr := &tar.Header{
+		Name:     fd.name,
+		Linkname: fd.target,
+		Mode:     int64(fd.mode & os.ModePerm),
+		Typeflag: tar.TypeSymlink,
+		ModTime:  fd.modifiedDate,
+	}
+
+	return tw.WriteHeader(hdr)
+}
+
+func isSymLink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink == os.ModeSymlink
+}
+
+func verifyDirectory(t *testing.T, dir string, files []fileDesc) {
+	filesToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		filesToVerify[fd.name] = fd
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			relpath := path[len(dir)+1:]
+			if fd, ok := filesToVerify[relpath]; ok {
+				if info.Mode() != fd.mode {
+					t.Errorf("File mode is not equal for %q. Expected: %v, Actual: %v\n",
+						relpath, fd.mode, info.Mode())
+				}
+				// TODO: check modification time for symlinks when extractLink() will support it
+				if info.ModTime().UTC() != fd.modifiedDate && !isSymLink(fd.mode) {
+					t.Errorf("File modified date is not equal for %q. Expected: %v, Actual: %v\n",
+						relpath, fd.modifiedDate, info.ModTime())
+				}
+				contentBytes, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Errorf("Error reading file %q: %v", path, err)
+					return err
+				}
+				content := string(contentBytes)
+				if content != fd.content {
+					t.Errorf("File content is not equal for %q. Expected: %s, Actual: %s\n",
+						relpath, fd.content, content)
+				}
+				if isSymLink(fd.mode) {
+					target, err := os.Readlink(path)
+					if err != nil {
+						t.Errorf("Error reading symlink %q: %v", path, err)
+						return err
+					}
+					if target != fd.target {
+						msg := "Symbolic link %q points to wrong path. Expected: %s, Actual: %s\n"
+						t.Errorf(msg, fd.name, fd.target, target)
+					}
+				}
+			} else {
+				t.Errorf("Unexpected file found: %q", relpath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Error walking directory %q: %v", dir, err)
+	}
+}
+
+func TestExtractTarStream(t *testing.T) {
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/symlink", modificationDate, os.ModeSymlink | 0777, "Test3 file content", false, "../dir01/dir03/test3.txt"},
+	}
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v\n", err)
+	}
+	defer os.RemoveAll(destDir)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	th := New()
+
+	go func() {
+		defer wg.Done()
+		if err := createTestTar(testFiles, writer); err != nil {
+			t.Fatal(err)
+		}
+		writer.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		th.ExtractTarStream(destDir, reader)
+	}()
+	wg.Wait()
+	verifyDirectory(t, destDir, testFiles)
+}
+
+func TestExtractTarStreamTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v\n", err)
+	}
+	defer os.RemoveAll(destDir)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	th := New()
+	th.(*stiTar).timeout = 10 * time.Millisecond
+	go func() {
+		defer wg.Done()
+		time.Sleep(20 * time.Millisecond)
+		writer.Close()
+	}()
+	extractError := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		extractError <- th.ExtractTarStream(destDir, reader)
+	}()
+	wg.Wait()
+	err = <-extractError
+	if e, ok := err.(errors.Error); err == nil || (ok && e.ErrorCode != errors.TarTimeoutError) {
+		t.Errorf("Did not get the expected timeout error. err = %v\n", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/callback_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/callback_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type FakePost struct {
+	err      error
+	response http.Response
+	body     []byte
+	url      string
+}
+
+func (f *FakePost) post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	f.url = url
+	f.body, _ = ioutil.ReadAll(body)
+	return &f.response, f.err
+}
+
+func TestExecuteCallback(t *testing.T) {
+	fp := FakePost{}
+	cb := callbackInvoker{
+		postFunc: fp.post,
+	}
+
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	cb.ExecuteCallback("http://the.callback.url/test", true, labels, []string{"msg1", "msg2"})
+
+	type postBody struct {
+		Labels  map[string]string
+		Payload string
+		Success bool
+	}
+	var pb postBody
+	json.Unmarshal(fp.body, &pb)
+	if pb.Payload != "msg1\nmsg2\n" {
+		t.Errorf("Unexpected payload: %s", pb.Payload)
+	}
+	if len(pb.Labels) == 0 {
+		t.Errorf("Expected labels to be present in payload")
+	}
+	if pb.Labels["foo"] != "bar" {
+		t.Errorf("Expected 'foo' to be 'bar', got %q", pb.Labels["foo"])
+	}
+	if pb.Success != true {
+		t.Errorf("Unexpected success flag: %v", pb.Success)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/injection_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/injection_test.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestCreateInjectedFilesRemovalScript(t *testing.T) {
+	files := []string{
+		"/foo",
+		"/bar/bar",
+	}
+	name, err := CreateInjectedFilesRemovalScript(files, "/tmp/rm-foo")
+	defer os.Remove(name)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", name)
+	}
+	_, err = os.Stat(name)
+	if err != nil {
+		t.Errorf("Expected file %q to exists, got: %v", name, err)
+	}
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		t.Errorf("Unable to read %q: %v", name, err)
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("truncate -s0 %q", "/foo")) {
+		t.Errorf("Expected script to contain truncate -s0 \"/foo\", got: %q", string(data))
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("truncate -s0 %q", "/tmp/rm-foo")) {
+		t.Errorf("Expected script to truncate itself, got: %q", string(data))
+	}
+}
+
+func TestExpandInjectedFiles(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "s2i-test-")
+	tmpNested, err := ioutil.TempDir(tmp, "nested")
+	if err != nil {
+		t.Errorf("Unable to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	list := api.InjectionList{{SourcePath: tmp, DestinationDir: "/foo"}}
+	f1, _ := ioutil.TempFile(tmp, "foo")
+	f2, _ := ioutil.TempFile(tmpNested, "bar")
+	files, err := ExpandInjectedFiles(list)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := []string{"/foo/" + filepath.Base(f1.Name()), filepath.Join("/foo", filepath.Base(tmpNested), filepath.Base(f2.Name()))}
+	for _, exp := range expected {
+		found := false
+		for _, f := range files {
+			if f == exp {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected %q in resulting file list, got %+v", exp, files)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/user/range_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/user/range_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"testing"
+)
+
+func validRange(r *Range, err error) *Range {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func TestParseRange(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *Range
+		errExpected bool
+	}{
+		{
+			str:      "1-5",
+			expected: validRange(NewRange(1, 5)),
+		},
+		{
+			str:      "7",
+			expected: validRange(NewRange(7, 7)),
+		},
+		{
+			str:      "1-",
+			expected: validRange(NewRangeFrom(1)),
+		},
+		{
+			str:      "-1000",
+			expected: validRange(NewRangeTo(1000)),
+		},
+		{
+			str:      "",
+			expected: &Range{},
+		},
+		{
+			str:         "--",
+			errExpected: true,
+		},
+		{
+			str:         "4-5-1",
+			errExpected: true,
+		},
+		{
+			str:         "-1-5",
+			errExpected: true,
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+	}
+	for _, tc := range tests {
+		actual, err := ParseRange(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Did not get expected error for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range for input %s. Expected: %v. Got: %v", tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *Range
+		expected bool
+	}{
+		{
+			uid:      0,
+			r:        validRange(NewRange(0, 4)),
+			expected: true,
+		},
+		{
+			uid:      0,
+			r:        validRange(NewRangeFrom(1)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(5001)),
+			expected: true,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(4999)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &Range{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/user/rangelist_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/user/rangelist_test.go
@@ -1,0 +1,123 @@
+package user
+
+import (
+	"testing"
+)
+
+func TestParseRangeList(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *RangeList
+		errExpected bool
+	}{
+		{
+			str: "1-5,5,2-",
+			expected: &RangeList{
+				validRange(NewRange(1, 5)),
+				validRange(NewRange(5, 5)),
+				validRange(NewRangeFrom(2)),
+			},
+		},
+		{
+			str: ",4-5,0-",
+			expected: &RangeList{
+				&Range{},
+				validRange(NewRange(4, 5)),
+				validRange(NewRangeFrom(0)),
+			},
+		},
+		{
+			str: "5",
+			expected: &RangeList{
+				validRange(NewRange(5, 5)),
+			},
+		},
+		{
+			str: "1-",
+			expected: &RangeList{
+				validRange(NewRangeFrom(1)),
+			},
+		},
+		{
+			str: "-5",
+			expected: &RangeList{
+				validRange(NewRangeTo(5)),
+			},
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+		{
+			str:         "{1-5}",
+			errExpected: true,
+		},
+		{
+			str:         "1-5-,2-",
+			errExpected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := ParseRangeList(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Expected error but did not get one for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range list for input %s. Expected: %v, Got: %v",
+				tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestRangeListContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *RangeList
+		expected bool
+	}{
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRange(0, 9)),
+				validRange(NewRange(10, 10)),
+				validRange(NewRange(20, 30)),
+			},
+			expected: true,
+		},
+		{
+			uid: 5,
+			r: &RangeList{
+				validRange(NewRange(3, 4)),
+				validRange(NewRange(6, 7)),
+			},
+			expected: false,
+		},
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRangeFrom(11)),
+				validRange(NewRangeFrom(20)),
+			},
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &RangeList{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -24,6 +24,12 @@ const (
 	// OriginVersion is an environment variable key that indicates the version of origin that
 	// created this build definition.
 	OriginVersion = "ORIGIN_VERSION"
+	// AllowedUIDs is an environment variable that contains ranges of UIDs that are allowed in
+	// Source builder images
+	AllowedUIDs = "ALLOWED_UIDS"
+	// DropCapabilities is an environment variable that contains a list of capabilities to drop when
+	// executing a Source build
+	DropCapabilities = "DROP_CAPS"
 )
 
 // Build encapsulates the inputs needed to produce a new deployable image, as well as

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -190,13 +191,18 @@ func (s *S2IBuilder) Build() error {
 	}
 	config.PreviousImagePullPolicy = s2iapi.PullAlways
 
-	allowedUIDs := os.Getenv("ALLOWED_UIDS")
-	glog.V(2).Infof("The value of ALLOWED_UIDS is [%s]", allowedUIDs)
+	allowedUIDs := os.Getenv(api.AllowedUIDs)
+	glog.V(2).Infof("The value of %s is [%s]", api.AllowedUIDs, allowedUIDs)
 	if len(allowedUIDs) > 0 {
 		err := config.AllowedUIDs.Set(allowedUIDs)
 		if err != nil {
 			return err
 		}
+	}
+	dropCaps := os.Getenv(api.DropCapabilities)
+	glog.V(2).Infof("The value of %s is [%s]", api.DropCapabilities, dropCaps)
+	if len(dropCaps) > 0 {
+		config.DropCapabilities = strings.Split(dropCaps, ",")
 	}
 
 	if errs := s.validator.ValidateConfig(config); len(errs) != 0 {

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -224,8 +224,7 @@ func (c *MasterConfig) RunBuildController() {
 			Codec: codec,
 		},
 		SourceBuildStrategy: &buildstrategy.SourceBuildStrategy{
-			Image:                stiImage,
-			TempDirectoryCreator: buildstrategy.STITempDirectoryCreator,
+			Image: stiImage,
 			// TODO: this will be set to --storage-version (the internal schema we use)
 			Codec:            codec,
 			AdmissionControl: admissionControl,

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -1,0 +1,67 @@
+package builds
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[builds][Slow] Capabilities should be dropped for s2i builders", func() {
+	defer g.GinkgoRecover()
+	var (
+		s2ibuilderFixture      = exutil.FixturePath("..", "extended", "fixtures", "s2i-dropcaps", "rootable-ruby")
+		rootAccessBuildFixture = exutil.FixturePath("..", "extended", "fixtures", "s2i-dropcaps", "root-access-build.yaml")
+		oc                     = exutil.NewCLI("build-s2i-dropcaps", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.Describe("s2i build with a rootable builder", func() {
+		g.It("should not be able to switch to root with an assemble script", func() {
+
+			g.By("calling oc new-build for rootable-builder")
+			err := oc.Run("new-build").Args("--binary", "--name=rootable-ruby").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting the rootable-ruby build with --wait flag")
+			err = oc.Run("start-build").Args("rootable-ruby", fmt.Sprintf("--from-dir=%s", s2ibuilderFixture),
+				"--wait").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating a build that tries to gain root access via su")
+			err = oc.Run("create").Args("-f", rootAccessBuildFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("start the root-access-build with the --wait flag")
+			err = oc.Run("start-build").Args("root-access-build", "--wait").Execute()
+			o.Expect(err).To(o.HaveOccurred())
+
+			g.By("verifying the build status")
+			builds, err := oc.REST().Builds(oc.Namespace()).List(kapi.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(builds.Items).ToNot(o.BeEmpty())
+
+			// Find the build
+			var build *buildapi.Build
+			for i := range builds.Items {
+				if builds.Items[i].Name == "root-access-build-1" {
+					build = &builds.Items[i]
+					break
+				}
+			}
+			o.Expect(build).NotTo(o.BeNil())
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseFailed))
+		})
+	})
+
+})

--- a/test/extended/fixtures/s2i-dropcaps/root-access-build.yaml
+++ b/test/extended/fixtures/s2i-dropcaps/root-access-build.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      build: root-access-build
+    name: root-access-build
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: root-access-build:latest
+    postCommit: {}
+    resources: {}
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      secrets: []
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: rootable-ruby:latest
+      type: Source
+    triggers: []
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      build: root-access-build
+    name: root-access-build
+  spec: {}
+kind: List
+metadata: {}

--- a/test/extended/fixtures/s2i-dropcaps/rootable-ruby/Dockerfile
+++ b/test/extended/fixtures/s2i-dropcaps/rootable-ruby/Dockerfile
@@ -1,0 +1,7 @@
+FROM centos/ruby-22-centos7:latest
+USER root
+RUN yum -y install expect
+RUN echo "root:redhat" | chpasswd
+USER 1001
+COPY ./adduser /usr/libexec/s2i/
+COPY ./assemble /usr/libexec/s2i/

--- a/test/extended/fixtures/s2i-dropcaps/rootable-ruby/adduser
+++ b/test/extended/fixtures/s2i-dropcaps/rootable-ruby/adduser
@@ -1,0 +1,16 @@
+#!/usr/bin/expect
+
+spawn su
+expect "Password:" {
+    send "redhat\r"
+}
+
+expect "#" {
+    send "adduser mytestuser\r"
+}
+
+expect "#" {
+    send "exit\r"
+}
+
+expect "$" {}

--- a/test/extended/fixtures/s2i-dropcaps/rootable-ruby/assemble
+++ b/test/extended/fixtures/s2i-dropcaps/rootable-ruby/assemble
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+/usr/libexec/s2i/adduser
+cat /etc/passwd
+grep "mytestuser" /etc/passwd


### PR DESCRIPTION
The container that is launched by s2i (outside of Kube control) currently allows an escalation of privilege via su or sudo. We can prevent this by dropping the same capabilities that are dropped for regular pods when running under the restricted SCC. 

Fixes BZ 1315187