### PR TITLE
Improve deployment name wrapping on overview page

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -141,6 +141,7 @@
     }
     &.deployment-block {
       margin: 0 0 6px 6px;
+      overflow: hidden;
       padding: 5px 15px;
       &.none {
         background-color: transparent;

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -29,7 +29,11 @@
     <div class="component">
       <div class="component-label">
         <span>Deployment: </span>
-        <a class="subtle-link" ng-href="{{deploymentConfigId | navigateResourceURL : 'DeploymentConfig' : rc.metadata.namespace}}">{{deploymentConfigId}}</a>, <a class="subtle-link" ng-href="{{rc | navigateResourceURL}}">#{{rc | annotation:'deploymentVersion'}}</a>
+        <span class="nowrap">
+          <a class="subtle-link"
+             ng-href="{{deploymentConfigId | navigateResourceURL : 'DeploymentConfig' : rc.metadata.namespace}}">{{deploymentConfigId}}</a>,
+          <a class="subtle-link" ng-href="{{rc | navigateResourceURL}}">#{{rc | annotation:'deploymentVersion'}}</a>
+        </span>
         <span ng-if="deploymentConfigMissing" data-toggle="tooltip" data-placement="right"
             title="The deployment config this deployment was created from no longer exists." class="pficon pficon-warning-triangle-o" style="cursor: help;"></span>
         <span ng-if="deploymentConfigDifferentService" data-toggle="tooltip" data-placement="right"
@@ -67,7 +71,10 @@
   <!-- Header for replication controllers. Name and timestamp only. -->
   <div class="component-block component-meta" ng-if="!isDeployment">
     <div class="component">
-      <div class="component-label">Replication Controller: <a class="subtle-link" ng-href="{{rc | navigateResourceURL}}">{{rc.metadata.name}}</a></div>
+      <div class="component-label">
+        Replication Controller:
+        <a class="subtle-link nowrap" ng-href="{{rc | navigateResourceURL}}">{{rc.metadata.name}}</a>
+      </div>
     </div>
     <div class="component meta-data">
       created <relative-timestamp timestamp="rc.metadata.creationTimestamp"></relative-timestamp>


### PR DESCRIPTION
Before:

<img width="352" alt="screen shot 2016-03-08 at 3 14 58 pm" src="https://cloud.githubusercontent.com/assets/1167259/13615493/91c57cf8-e543-11e5-8d05-f1bb21881d97.png">

After:

<img width="340" alt="screen shot 2016-03-08 at 3 15 23 pm" src="https://cloud.githubusercontent.com/assets/1167259/13615495/960d8832-e543-11e5-844b-dafb0f69c7d2.png">

@jwforres 