### PR TITLE
Prevent fieldset from expanding due to content

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -69,6 +69,14 @@
   }
 }
 
+// Firefox-specific hack for preventing fieldset content causing the container to expand
+// see: https://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685
+@-moz-document url-prefix() {
+  .console-os fieldset {
+    display: table-cell;
+  }
+}
+
 /* Data toolbar
    - Includes customizations for label filter input and active filter
 ---------------------------------------------------------------------------- */


### PR DESCRIPTION
On Firefox, the width of a fieldset will expand according to its content,
causing text to spill outside the container.  A Firefox-specific hack is
required to correct this problem, as described in:

* http://getbootstrap.com/css/#tables-responsive
* https://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content/17863685#17863685

This change scopes the hack down to the .console-os class set on our body.

Closes: #7870

Signed-off-by: Jonathan Yu <jawnsy@redhat.com>