### PR TITLE
More networking tests

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/util.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -2917,4 +2918,91 @@ func ensureGCELoadBalancerResourcesDeleted(ip, portRange string) error {
 		}
 		return true, nil
 	})
+}
+
+// GetReadyNodes retrieves a list of schedulable nodes whose condition
+// is Ready.  An error will be returned if no such nodes are found.
+func GetReadyNodes(f *Framework) (nodes *api.NodeList, err error) {
+	nodes = ListSchedulableNodesOrDie(f.Client)
+	// previous tests may have cause failures of some nodes. Let's skip
+	// 'Not Ready' nodes, just in case (there is no need to fail the test).
+	filterNodes(nodes, func(node api.Node) bool {
+		return !node.Spec.Unschedulable && isNodeConditionSetAsExpected(&node, api.NodeReady, true)
+	})
+
+	if len(nodes.Items) == 0 {
+		return nil, errors.New("No Ready nodes found.")
+	}
+	return nodes, nil
+}
+
+// LaunchWebserverPod launches a pod serving http on port 8080 to act
+// as the target for networking connectivity checks.  The ip address
+// of the created pod will be returned if the pod is launched
+// successfully.
+func LaunchWebserverPod(f *Framework, podName, nodeName string) (ip string) {
+	containerName := fmt.Sprintf("%s-container", podName)
+	port := 8080
+	pod := &api.Pod{
+		TypeMeta: unversioned.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: podName,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:  containerName,
+					Image: "gcr.io/google_containers/porter:cd5cb5791ebaa8641955f0e8c2a9bed669b1eaab",
+					Env:   []api.EnvVar{{Name: fmt.Sprintf("SERVE_PORT_%d", port), Value: "foo"}},
+					Ports: []api.ContainerPort{{ContainerPort: port}},
+				},
+			},
+			NodeName:      nodeName,
+			RestartPolicy: api.RestartPolicyNever,
+		},
+	}
+	podClient := f.Client.Pods(f.Namespace.Name)
+	_, err := podClient.Create(pod)
+	expectNoError(err)
+	expectNoError(f.WaitForPodRunning(podName))
+	createdPod, err := podClient.Get(podName)
+	expectNoError(err)
+	ip = fmt.Sprintf("%s:%d", createdPod.Status.PodIP, port)
+	Logf("Target pod IP:port is %s", ip)
+	return
+}
+
+// CheckConnectivityToHost launches a pod running wget on the
+// specified node to test connectivity to the specified host.  An
+// error will be returned if the host is not reachable from the pod.
+func CheckConnectivityToHost(f *Framework, nodeName, podName, host string) error {
+	contName := fmt.Sprintf("%s-container", podName)
+	pod := &api.Pod{
+		TypeMeta: unversioned.TypeMeta{
+			Kind: "Pod",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: podName,
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:    contName,
+					Image:   "gcr.io/google_containers/busybox:1.24",
+					Command: []string{"wget", "-s", host},
+				},
+			},
+			NodeName:      nodeName,
+			RestartPolicy: api.RestartPolicyNever,
+		},
+	}
+	podClient := f.Client.Pods(f.Namespace.Name)
+	_, err := podClient.Create(pod)
+	if err != nil {
+		return err
+	}
+	defer podClient.Delete(podName, nil)
+	return waitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
 }

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -1,6 +1,7 @@
 package networking
 
 import (
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/test/e2e"
 
 	. "github.com/onsi/ginkgo"
@@ -13,23 +14,35 @@ var _ = Describe("[networking] network isolation plugin", func() {
 	f1 := e2e.NewFramework("net-isolation1")
 	f2 := e2e.NewFramework("net-isolation2")
 
-	It("should prevent communication between pods in different namespaces", func() {
-		By("Picking multiple nodes")
-		nodes := getMultipleNodes(f1)
-		node1 := nodes.Items[0]
-		node2 := nodes.Items[1]
+	It("should prevent communication between pods in different namespaces on the same node", func() {
+		checkPodIsolation(f1, f2, false)
+	})
 
-		By("Running a webserver in one namespace")
-		podName := "isolation-webserver"
-		defer f1.Client.Pods(f1.Namespace.Name).Delete(podName, nil)
-		ip := e2e.LaunchWebserverPod(f1, podName, node1.Name)
-
-		By("Checking that the webserver is not accessible from a pod in a different namespace on the same node")
-		err := checkConnectivityToHost(f2, node1.Name, "isolation-same-node-wget", ip, 10)
-		Expect(err).To(HaveOccurred())
-
-		By("Checking that the webserver is not accessible from a pod in a different namespace on a different node")
-		err = checkConnectivityToHost(f2, node2.Name, "isolation-different-node-wget", ip, 10)
-		Expect(err).To(HaveOccurred())
+	It("should prevent communication between pods in different namespaces on different nodes", func() {
+		checkPodIsolation(f1, f2, true)
 	})
 })
+
+func checkPodIsolation(f1, f2 *e2e.Framework, differentNodes bool) {
+	nodes, err := e2e.GetReadyNodes(f1)
+	if err != nil {
+		e2e.Failf("Failed to list nodes: %v", err)
+	}
+	var serverNode, clientNode *api.Node
+	serverNode = &nodes.Items[0]
+	if differentNodes {
+		if len(nodes.Items) == 1 {
+			e2e.Skipf("Only one node is available in this environment")
+		}
+		clientNode = &nodes.Items[1]
+	} else {
+		clientNode = serverNode
+	}
+
+	podName := "isolation-webserver"
+	defer f1.Client.Pods(f1.Namespace.Name).Delete(podName, nil)
+	ip := e2e.LaunchWebserverPod(f1, podName, serverNode.Name)
+
+	err = checkConnectivityToHost(f2, clientNode.Name, "isolation-wget", ip, 10)
+	Expect(err).To(HaveOccurred())
+}

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -22,7 +22,7 @@ var _ = Describe("[networking] network isolation plugin", func() {
 		By("Running a webserver in one namespace")
 		podName := "isolation-webserver"
 		defer f1.Client.Pods(f1.Namespace.Name).Delete(podName, nil)
-		ip := launchWebserverPod(f1, podName, node1.Name)
+		ip := e2e.LaunchWebserverPod(f1, podName, node1.Name)
 
 		By("Checking that the webserver is not accessible from a pod in a different namespace on the same node")
 		err := checkConnectivityToHost(f2, node1.Name, "isolation-same-node-wget", ip, 10)

--- a/test/extended/networking/sanity.go
+++ b/test/extended/networking/sanity.go
@@ -1,7 +1,6 @@
 package networking
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/test/e2e"
 
 	. "github.com/onsi/ginkgo"
@@ -14,9 +13,8 @@ var _ = Describe("[networking] basic openshift networking", func() {
 	f := e2e.NewFramework(svcname)
 
 	It("should function for pod communication on a single node", func() {
-
 		By("Picking a node")
-		nodes, err := f.Client.Nodes().List(api.ListOptions{})
+		nodes, err := e2e.GetReadyNodes(f)
 		if err != nil {
 			e2e.Failf("Failed to list nodes: %v", err)
 		}
@@ -32,11 +30,16 @@ var _ = Describe("[networking] basic openshift networking", func() {
 	})
 
 	It("should function for pod communication between nodes", func() {
-
 		podClient := f.Client.Pods(f.Namespace.Name)
 
 		By("Picking multiple nodes")
-		nodes := getMultipleNodes(f)
+		nodes, err := e2e.GetReadyNodes(f)
+		if err != nil {
+			e2e.Failf("Failed to list nodes: %v", err)
+		}
+		if len(nodes.Items) == 1 {
+			e2e.Skipf("Only one node is available in this environment")
+		}
 		node1 := nodes.Items[0]
 		node2 := nodes.Items[1]
 

--- a/test/extended/networking/sanity.go
+++ b/test/extended/networking/sanity.go
@@ -25,7 +25,7 @@ var _ = Describe("[networking] basic openshift networking", func() {
 		By("Creating a webserver pod")
 		podName := "same-node-webserver"
 		defer f.Client.Pods(f.Namespace.Name).Delete(podName, nil)
-		ip := launchWebserverPod(f, podName, node.Name)
+		ip := e2e.LaunchWebserverPod(f, podName, node.Name)
 
 		By("Checking that the webserver is accessible from a pod on the same node")
 		expectNoError(checkConnectivityToHost(f, node.Name, "same-node-wget", ip, timeout))
@@ -43,7 +43,7 @@ var _ = Describe("[networking] basic openshift networking", func() {
 		By("Creating a webserver pod")
 		podName := "different-node-webserver"
 		defer podClient.Delete(podName, nil)
-		ip := launchWebserverPod(f, podName, node1.Name)
+		ip := e2e.LaunchWebserverPod(f, podName, node1.Name)
 
 		By("Checking that the webserver is accessible from a pod on a different node")
 		expectNoError(checkConnectivityToHost(f, node2.Name, "different-node-wget", ip, timeout))

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -1,0 +1,67 @@
+package networking
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[networking] services", func() {
+	f1 := e2e.NewFramework("net-services2")
+	f2 := e2e.NewFramework("net-services2")
+
+	It("should allow connections to another pod on the same node via a service IP", func() {
+		Expect(checkServiceConnectivity(f1, f1, 1)).To(Succeed())
+	})
+
+	It("should allow connections to another pod on a different node via a service IP", func() {
+		Expect(checkServiceConnectivity(f1, f1, 2)).To(Succeed())
+	})
+
+	Specify("single-tenant plugins should allow connections to pods in different namespaces on the same node via service IPs", func() {
+		skipIfMultiTenant()
+		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+	})
+
+	Specify("single-tenant plugins should allow connections to pods in different namespaces on different nodes via service IPs", func() {
+		skipIfMultiTenant()
+		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+	})
+
+	Specify("multi-tenant plugins should prevent connections to pods in different namespaces on the same node via service IPs", func() {
+		skipIfSingleTenant()
+		err := checkServiceConnectivity(f1, f2, 1)
+		Expect(err).To(HaveOccurred())
+	})
+
+	Specify("multi-tenant plugins should prevent connections to pods in different namespaces on different nodes via service IPs", func() {
+		skipIfSingleTenant()
+		err := checkServiceConnectivity(f1, f2, 2)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+func checkServiceConnectivity(serverFramework, clientFramework *e2e.Framework, numNodes int) error {
+	nodes, err := e2e.GetReadyNodes(serverFramework)
+	if err != nil {
+		e2e.Failf("Failed to list nodes: %v", err)
+	}
+	var serverNode, clientNode *api.Node
+	serverNode = &nodes.Items[0]
+	if numNodes == 2 {
+		if len(nodes.Items) == 1 {
+			e2e.Skipf("Only one node is available in this environment")
+		}
+		clientNode = &nodes.Items[1]
+	} else {
+		clientNode = serverNode
+	}
+
+	podName := "service-webserver"
+	defer serverFramework.Client.Pods(serverFramework.Namespace.Name).Delete(podName, nil)
+	ip := launchWebserverService(serverFramework, podName, serverNode.Name)
+
+	return checkConnectivityToHost(clientFramework, clientNode.Name, "service-wget", ip, 10)
+}

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -2,15 +2,12 @@ package networking
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/test/e2e"
-
-	exutil "github.com/openshift/origin/test/extended/util"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -85,34 +82,6 @@ func waitForPodSuccessInNamespace(c *client.Client, podName string, contName str
 		}
 		return false, nil
 	})
-}
-
-func providerIs(providers ...string) bool {
-	for _, provider := range providers {
-		if strings.ToLower(provider) == strings.ToLower(exutil.TestContext.Provider) {
-			return true
-		}
-	}
-	return false
-}
-
-func getMultipleNodes(f *e2e.Framework) (nodes *api.NodeList) {
-	nodes, err := e2e.GetReadyNodes(f)
-	if err != nil {
-		e2e.Failf("Failed to list nodes: %v", err)
-	}
-
-	if len(nodes.Items) == 1 {
-		// in general, the test requires two nodes. But for local development, often a one node cluster
-		// is created, for simplicity and speed. (see issue #10012). We permit one-node test
-		// only in some cases
-		if !providerIs("local") {
-			e2e.Failf(fmt.Sprintf("The test requires two Ready nodes on %s, but found just one.", exutil.TestContext.Provider))
-		}
-		e2e.Logf("Only one ready node is detected. The test has limited scope in such setting. " +
-			"Rerun it with at least two nodes to get complete coverage.")
-	}
-	return
 }
 
 func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, host string, timeout int) error {

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -2,6 +2,7 @@ package networking
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -110,4 +111,20 @@ func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, 
 	expectNoError(err)
 	defer podClient.Delete(podName, nil)
 	return waitForPodSuccessInNamespace(f.Client, podName, contName, f.Namespace.Name)
+}
+
+func pluginIsolatesNamespaces() bool {
+	return os.Getenv("OPENSHIFT_NETWORK_ISOLATION") == "true"
+}
+
+func skipIfSingleTenant() {
+	if !pluginIsolatesNamespaces() {
+		e2e.Skipf("Not a multi-tenant plugin.")
+	}
+}
+
+func skipIfMultiTenant() {
+	if pluginIsolatesNamespaces() {
+		e2e.Skipf("Not a single-tenant plugin.")
+	}
 }


### PR DESCRIPTION
Makes the isolation test get run under both plugins (testing that things *aren't* isolated when using the flat plugin), and adds a basic service test and a service isolation test.

@marun PTAL