### PR TITLE
(WIP) Hide link to "Open full view of log" when log is empty

### DIFF
--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -113,7 +113,7 @@
                             <status-icon status="build.status.phase"></status-icon>
                             <span class="space-after">{{build.status.phase}}</span>
 
-                            <span ng-if="build.status.startTimestamp">
+                            <span ng-if="build.status.startTimestamp && state === 'logs'">
                               &mdash; Log from {{build.status.startTimestamp  | date : 'short'}}
                               <span ng-if="build.status.completionTimestamp">
                                 to {{build.status.completionTimestamp  | date : 'short'}}

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -6,7 +6,7 @@
   style="margin-bottom: 10px;">
   <div ng-transclude flex><!-- expect start time, end time, status details --></div>
   <div row class="text-right text-xs-left">
-    <a href="" ng-click="goChromeless(options)" style="margin-right: 10px;">
+    <a href="" ng-click="goChromeless(options)" ng-if="state==='logs'" style="margin-right: 10px;">
       Open full view of log <i class="fa fa-external-link"></i>
     </a>
     <div ng-if="kibanaAuthUrl">


### PR DESCRIPTION
We currently show an "Open full view of log" link unconditionally, even if
the logs are empty.  We should hide this link as well as the "Logs from ..."
text, since it is not useful.

Closes: #7848

Signed-off-by: Jonathan Yu <jawnsy@redhat.com>