### PR TITLE
Add table-bordered styles to service port table

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -188,18 +188,11 @@
 }
 
 .service-table {
-  border: 0;
-  margin: 10px 0 5px;
-  table {
-    .table;
-    .table-condensed;
-    .text-center;
-    .small;
-    margin-bottom: 0;
-    thead {
-      tr th {
-        .text-center;
-      }
+  .text-center;
+  max-width: 650px;
+  thead {
+    tr th {
+      .text-center;
     }
   }
 }

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -73,18 +73,25 @@
                         <span ng-repeat="ingress in resource.status.loadBalancer.ingress"
                           >{{ingress.ip}}<span ng-if="!$last">, </span></span>
                       </dd>
+                      <dt>Routes:</dt>
+                      <dd>
+                        <span ng-if="!routesForService.length">
+                          <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}">Create route</a>
+                        </span>
+                        <span ng-repeat="route in routesForService">
+                            <span ng-if="route | isWebRoute"><a ng-href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>
+                            <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
+                            <span ng-show="!$last">, </span>
+                        </span>
+                      </dd>
                     </dl>
-                    <div class="service-table table-responsive">
-                      <table ng-if="service.spec.ports.length" style="max-width: 650px;">
+                    <div ng-if="service.spec.ports.length" class="table-responsive">
+                      <table class="table table-bordered small service-table">
                         <thead>
                           <tr>
                             <th>Node Port</th>
                             <th role="presentation"></th>
-                            <th>
-                              Service Port
-                              <!-- Show cluster IP in column header instead of table body at small screen widths to save space. -->
-                              <span class="visible-xs">({{service.spec.clusterIP}})</span>
-                            </th>
+                            <th>Service Port</th>
                             <th role="presentation"></th>
                             <th>Target Port</th>
                           </tr>
@@ -104,20 +111,6 @@
                         </tbody>
                       </table>
                     </div>
-                    <!-- No bottom margin so Create Route link is close to content. -->
-                    <dl class="dl-horizontal left" style="margin-bottom: 0;">
-                      <dt>Routes:</dt>
-                      <dd>
-                        <span ng-if="!routesForService.length">
-                          <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}">Create route</a>
-                        </span>
-                        <span ng-repeat="route in routesForService">
-                            <span ng-if="route | isWebRoute"><a ng-href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>
-                            <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
-                            <span ng-show="!$last">, </span>
-                        </span>
-                      </dd>
-                    </dl>
                     <annotations annotations="service.metadata.annotations"></annotations>
                   </div>
                 </uib-tab>


### PR DESCRIPTION
@jwforres Thoughts on this change? Trying to bring the table style in line with other pages.

Before:

<img width="699" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13623911/068ca64a-e578-11e5-8bc8-1ccfa4aeb233.png">

After:

<img width="707" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13623909/ffd5043c-e577-11e5-8b93-59b8a7d923e2.png">
