### PR TITLE
Fix word-break in Firefox

### DIFF
--- a/assets/app/styles/_mixins.less
+++ b/assets/app/styles/_mixins.less
@@ -41,8 +41,7 @@
 
 .word-break() {
  -ms-word-break: break-all; // ms
-     word-break: break-all; // firefox
-     word-break: break-word; // webkit
+     word-wrap: break-word;
   overflow-wrap: break-word; // new name as per the CSS3 spec
 }
 


### PR DESCRIPTION
We were using `word-break: break-word`, but it should be `word-wrap: break-word`. This is why it didn't work on Firefox.

https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
https://developer.mozilla.org/en-US/docs/Web/CSS/word-wrap

Tested in Chrome, Firefox, IE, Safari, and iOS Simulator. Long lines are all broken correctly in the logs. Also tested the pod template and sidebar where we use the mixin.

@jwforres PTAL
/cc @sg00dwin 

<img width="1510" alt="screen shot 2016-03-09 at 7 12 03 am" src="https://cloud.githubusercontent.com/assets/1167259/13635189/33efa470-e5c8-11e5-9d52-ffe083ceb12d.png">

![screen shot 2016-03-09 at 7 15 38 am](https://cloud.githubusercontent.com/assets/1167259/13635195/39c93c6c-e5c8-11e5-8a87-ecf3b9181e64.png)

![screen shot 2016-03-09 at 7 16 42 am](https://cloud.githubusercontent.com/assets/1167259/13635206/456403cc-e5c8-11e5-99ee-b303d2f93763.png)
 
<img width="487" alt="screen shot 2016-03-09 at 7 19 45 am" src="https://cloud.githubusercontent.com/assets/1167259/13635215/5006af64-e5c8-11e5-9f4b-1583cb0f2315.png">

<img width="900" alt="dashboard" src="https://cloud.githubusercontent.com/assets/1167259/13635221/567cc176-e5c8-11e5-929b-03cb35d67e4d.png">
