### PR TITLE
make userAgentMatching take a set of required and deny regexes

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/discovery_client.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/discovery_client.go
@@ -211,6 +211,9 @@ func setDiscoveryDefaults(config *Config) error {
 	config.APIPath = ""
 	config.GroupVersion = nil
 	config.Codec = runtime.NoopEncoder{api.Codecs.UniversalDecoder()}
+	if config.UserAgent == "" {
+		config.UserAgent = DefaultKubernetesUserAgent()
+	}
 	return nil
 }
 

--- a/pkg/cmd/server/api/serialization_test.go
+++ b/pkg/cmd/server/api/serialization_test.go
@@ -81,15 +81,6 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 				obj.PodEvictionTimeout = "5m"
 			}
 		},
-		func(obj *configapi.LegacyClientPolicyConfig, c fuzz.Continue) {
-			c.FuzzNoCustom(obj)
-			if len(obj.LegacyClientPolicy) == 0 {
-				obj.LegacyClientPolicy = configapi.AllowAll
-			}
-			if len(obj.RestrictedHTTPVerbs) == 0 {
-				obj.RestrictedHTTPVerbs = []string{"PUT", "POST"}
-			}
-		},
 		func(obj *configapi.NodeConfig, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
 			// Defaults/migrations for NetworkConfig

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -318,28 +318,38 @@ type PolicyConfig struct {
 	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
 	OpenShiftInfrastructureNamespace string
 
-	// LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
-	LegacyClientPolicyConfig LegacyClientPolicyConfig
+	// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	UserAgentMatchingConfig UserAgentMatchingConfig
 }
 
-type LegacyClientPolicyConfig struct {
-	// LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
-	// The default is AllowAll
-	LegacyClientPolicy LegacyClientPolicy
-	// RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST
-	RestrictedHTTPVerbs []string
+// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+type UserAgentMatchingConfig struct {
+	// If this list is non-empty, then a User-Agent must match one of the UserAgentRegexes to be allowed
+	RequiredClients []UserAgentMatchRule
+
+	// If this list is non-empty, then a User-Agent must not match any of the UserAgentRegexes
+	DeniedClients []UserAgentDenyRule
+
+	// DefaultRejectionMessage is the message shown when rejecting a client.  If it is not a set, a generic message is given.
+	DefaultRejectionMessage string
 }
 
-type LegacyClientPolicy string
+// UserAgentMatchRule describes how to match a given request based on User-Agent and HTTPVerb
+type UserAgentMatchRule struct {
+	// UserAgentRegex is a regex that is checked against the User-Agent.
+	Regex string
 
-var (
-	// AllowAll does not prevent any kinds of client version skew
-	AllowAll LegacyClientPolicy = "allow-all"
-	// DenyOldClients prevents older clients (but not newer ones) from issuing stomping requests
-	DenyOldClients LegacyClientPolicy = "deny-old-clients"
-	// DenySkewedClients prevents any non-matching client from issuing stomping requests
-	DenySkewedClients LegacyClientPolicy = "deny-skewed-clients"
-)
+	// HTTPVerbs specifies which HTTP verbs should be matched.  An empty list means "match all verbs".
+	HTTPVerbs []string
+}
+
+// UserAgentDenyRule adds a rejection message that can be used to help a user figure out how to get an approved client
+type UserAgentDenyRule struct {
+	UserAgentMatchRule
+
+	// RejectionMessage is the message shown when rejecting a client.  If it is not a set, the default message is used.
+	RejectionMessage string
+}
 
 // MasterNetworkConfig to be passed to the compiled in network plugin
 type MasterNetworkConfig struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -65,14 +65,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				obj.PodEvictionTimeout = "5m"
 			}
 		},
-		func(obj *LegacyClientPolicyConfig) {
-			if len(obj.LegacyClientPolicy) == 0 {
-				obj.LegacyClientPolicy = AllowAll
-			}
-			if obj.LegacyClientPolicy != AllowAll && len(obj.RestrictedHTTPVerbs) == 0 {
-				obj.RestrictedHTTPVerbs = []string{"PUT", "POST"}
-			}
-		},
 		func(obj *NodeConfig) {
 			// Defaults/migrations for NetworkConfig
 			if len(obj.NetworkConfig.NetworkPluginName) == 0 {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -362,16 +362,6 @@ func (LDAPSyncConfig) SwaggerDoc() map[string]string {
 	return map_LDAPSyncConfig
 }
 
-var map_LegacyClientPolicyConfig = map[string]string{
-	"":                    "LegacyClientPolicyConfig holds configuration options for preventing *opt-in* clients using some HTTP verbs when talking to the API",
-	"legacyClientPolicy":  "LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS! The default is AllowAll",
-	"restrictedHTTPVerbs": "RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST",
-}
-
-func (LegacyClientPolicyConfig) SwaggerDoc() map[string]string {
-	return map_LegacyClientPolicyConfig
-}
-
 var map_MasterClients = map[string]string{
 	"": "MasterClients holds references to `.kubeconfig` files that qualify master clients for OpenShift and Kubernetes",
 	"openshiftLoopbackKubeConfig":  "OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master",
@@ -565,7 +555,7 @@ var map_PolicyConfig = map[string]string{
 	"bootstrapPolicyFile":               "BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace",
 	"openshiftSharedResourcesNamespace": "OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)",
 	"openshiftInfrastructureNamespace":  "OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)",
-	"legacyClientPolicyConfig":          "LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!",
+	"userAgentMatchingConfig":           "UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!",
 }
 
 func (PolicyConfig) SwaggerDoc() map[string]string {
@@ -729,4 +719,34 @@ var map_TokenConfig = map[string]string{
 
 func (TokenConfig) SwaggerDoc() map[string]string {
 	return map_TokenConfig
+}
+
+var map_UserAgentDenyRule = map[string]string{
+	"":                 "UserAgentDenyRule adds a rejection message that can be used to help a user figure out how to get an approved client",
+	"rejectionMessage": "RejectionMessage is the message shown when rejecting a client.  If it is not a set, the default message is used.",
+}
+
+func (UserAgentDenyRule) SwaggerDoc() map[string]string {
+	return map_UserAgentDenyRule
+}
+
+var map_UserAgentMatchRule = map[string]string{
+	"":          "UserAgentMatchRule describes how to match a given request based on User-Agent and HTTPVerb",
+	"regex":     "UserAgentRegex is a regex that is checked against the User-Agent. Known variants of oc clients 1. oc accessing kube resources: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d 2. oc accessing openshift resources: oc/v1.1.3 (linux/amd64) openshift/b348c2f 3. openshift kubectl accessing kube resources:  openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d 4. openshit kubectl accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f 5. oadm accessing kube resources: oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d 6. oadm accessing openshift resources: oadm/v1.1.3 (linux/amd64) openshift/b348c2f 7. openshift cli accessing kube resources: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d 8. openshift cli accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f",
+	"httpVerbs": "HTTPVerbs specifies which HTTP verbs should be matched.  An empty list means \"match all verbs\".",
+}
+
+func (UserAgentMatchRule) SwaggerDoc() map[string]string {
+	return map_UserAgentMatchRule
+}
+
+var map_UserAgentMatchingConfig = map[string]string{
+	"":                        "UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!",
+	"requiredClients":         "If this list is non-empty, then a User-Agent must match one of the UserAgentRegexes to be allowed",
+	"deniedClients":           "If this list is non-empty, then a User-Agent must not match any of the UserAgentRegexes",
+	"defaultRejectionMessage": "DefaultRejectionMessage is the message shown when rejecting a client.  If it is not a set, a generic message is given.",
+}
+
+func (UserAgentMatchingConfig) SwaggerDoc() map[string]string {
+	return map_UserAgentMatchingConfig
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -270,29 +270,47 @@ type PolicyConfig struct {
 	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
 	OpenShiftInfrastructureNamespace string `json:"openshiftInfrastructureNamespace"`
 
-	// LegacyClientPolicyConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
-	LegacyClientPolicyConfig LegacyClientPolicyConfig `json:"legacyClientPolicyConfig"`
+	// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+	UserAgentMatchingConfig UserAgentMatchingConfig `json:"userAgentMatchingConfig"`
 }
 
-// LegacyClientPolicyConfig holds configuration options for preventing *opt-in* clients using some HTTP verbs when talking to the API
-type LegacyClientPolicyConfig struct {
-	// LegacyClientPolicy controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
-	// The default is AllowAll
-	LegacyClientPolicy LegacyClientPolicy `json:"legacyClientPolicy"`
-	// RestrictedHTTPVerbs specifies which HTTP verbs are restricted.  By default this is PUT and POST
-	RestrictedHTTPVerbs []string `json:"restrictedHTTPVerbs"`
+// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
+type UserAgentMatchingConfig struct {
+	// If this list is non-empty, then a User-Agent must match one of the UserAgentRegexes to be allowed
+	RequiredClients []UserAgentMatchRule `json:"requiredClients"`
+
+	// If this list is non-empty, then a User-Agent must not match any of the UserAgentRegexes
+	DeniedClients []UserAgentDenyRule `json:"deniedClients"`
+
+	// DefaultRejectionMessage is the message shown when rejecting a client.  If it is not a set, a generic message is given.
+	DefaultRejectionMessage string `json:"defaultRejectionMessage"`
 }
 
-type LegacyClientPolicy string
+// UserAgentMatchRule describes how to match a given request based on User-Agent and HTTPVerb
+type UserAgentMatchRule struct {
+	// UserAgentRegex is a regex that is checked against the User-Agent.
+	// Known variants of oc clients
+	// 1. oc accessing kube resources: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d
+	// 2. oc accessing openshift resources: oc/v1.1.3 (linux/amd64) openshift/b348c2f
+	// 3. openshift kubectl accessing kube resources:  openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+	// 4. openshit kubectl accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f
+	// 5. oadm accessing kube resources: oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d
+	// 6. oadm accessing openshift resources: oadm/v1.1.3 (linux/amd64) openshift/b348c2f
+	// 7. openshift cli accessing kube resources: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+	// 8. openshift cli accessing openshift resources: openshift/v1.1.3 (linux/amd64) openshift/b348c2f
+	Regex string `json:"regex"`
 
-var (
-	// AllowAll does not prevent any kinds of client version skew
-	AllowAll LegacyClientPolicy = "allow-all"
-	// DenyOldClients prevents older clients (but not newer ones) from issuing stomping requests
-	DenyOldClients LegacyClientPolicy = "deny-old-clients"
-	// DenySkewedClients prevents any non-matching client from issuing stomping requests
-	DenySkewedClients LegacyClientPolicy = "deny-skewed-clients"
-)
+	// HTTPVerbs specifies which HTTP verbs should be matched.  An empty list means "match all verbs".
+	HTTPVerbs []string `json:"httpVerbs"`
+}
+
+// UserAgentDenyRule adds a rejection message that can be used to help a user figure out how to get an approved client
+type UserAgentDenyRule struct {
+	UserAgentMatchRule `json:", inline"`
+
+	// RejectionMessage is the message shown when rejecting a client.  If it is not a set, the default message is used.
+	RejectionMessage string `json:"rejectionMessage"`
+}
 
 // RoutingConfig holds the necessary configuration options for routing to subdomains
 type RoutingConfig struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -421,11 +421,12 @@ oauthConfig:
 pauseControllers: false
 policyConfig:
   bootstrapPolicyFile: ""
-  legacyClientPolicyConfig:
-    legacyClientPolicy: ""
-    restrictedHTTPVerbs: null
   openshiftInfrastructureNamespace: ""
   openshiftSharedResourcesNamespace: ""
+  userAgentMatchingConfig:
+    defaultRejectionMessage: ""
+    deniedClients: null
+    requiredClients: null
 projectConfig:
   defaultNodeSelector: ""
   projectRequestMessage: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -497,6 +497,19 @@ func ValidatePolicyConfig(config api.PolicyConfig, fldPath *field.Path) field.Er
 	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftSharedResourcesNamespace, fldPath.Child("openShiftSharedResourcesNamespace"))...)
 	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftInfrastructureNamespace, fldPath.Child("openShiftInfrastructureNamespace"))...)
 
+	for i, matchingRule := range config.UserAgentMatchingConfig.DeniedClients {
+		_, err := regexp.Compile(matchingRule.Regex)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("userAgentMatchingConfig", "deniedClients").Index(i), matchingRule.Regex, err.Error()))
+		}
+	}
+	for i, matchingRule := range config.UserAgentMatchingConfig.RequiredClients {
+		_, err := regexp.Compile(matchingRule.Regex)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("userAgentMatchingConfig", "requiredClients").Index(i), matchingRule.Regex, err.Error()))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utilwait "k8s.io/kubernetes/pkg/util/wait"
-	kversion "k8s.io/kubernetes/pkg/version"
 
 	"github.com/openshift/origin/pkg/api/v1"
 	"github.com/openshift/origin/pkg/api/v1beta3"
@@ -105,7 +104,6 @@ import (
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	routeplugin "github.com/openshift/origin/pkg/route/allocation/simple"
-	"github.com/openshift/origin/pkg/version"
 )
 
 const (
@@ -161,7 +159,7 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 		}
 		extra = append(extra, msgs...)
 	}
-	handler := c.versionSkewFilter(version.Get(), kversion.Get(), safe)
+	handler := c.versionSkewFilter(safe)
 	handler = c.authorizationFilter(handler)
 	handler = authenticationHandlerFilter(handler, c.Authenticator, c.getRequestContextMapper())
 	handler = namespacingFilter(handler, c.getRequestContextMapper())


### PR DESCRIPTION
The previous implementation didn't handle OSE clients to origin servers and vice-versa.  Since the config never escaped in a release, I've simply changed it to take a series of required user agent regexes and denied regexes where required is evaluated first and denied second.

I had to have both because the golang regexp evaluator doesn't do negative look arounds and one requirement is to handle "no skew allowed" cases.

@pweil- ptal
@smarterclayton fyi

example config:
```yaml
  userAgentMatchingConfig:
    defaultRejectionMessage: "Your client is too old.  Go to https://example.org to update it."
    deniedClients: 
    - regex: '\w+/v(?:(?:1\.1\.1)|(?:1\.0\.1)) \(.+/.+\) openshift/\w{7}'
    - regex: '\w+/v(?:1\.1\.3) \(.+/.+\) openshift/\w{7}'
    - regex: '\w+/v1\.2\.0 \(.+/.+\) kubernetes/\w{7}'
    requiredClients: null
```

```yaml
  userAgentMatchingConfig:
    defaultRejectionMessage: "Your client is too old.  Go to https://example.org to update it."
    deniedClients: []
    requiredClients: 
    - regex: '\w+/v1\.1\.3 \(.+/.+\) openshift/\w{7}'
    - regex: '\w+/v1\.2\.0 \(.+/.+\) kubernetes/\w{7}'
```
