### PR TITLE
Fixing BZ1291521 where long project name spills out of modal

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -96,7 +96,7 @@
 }
 .filter .navbar-filter-widget {
  @media(min-width: @screen-sm-min) {
-   white-space: nowrap; // prevent button wrap in Safari when not at mobile resolutions 
+   white-space: nowrap; // prevent button wrap in Safari when not at mobile resolutions
  }
  .label-filter-add.btn {
    margin-right: 0;
@@ -776,6 +776,7 @@ a.disabled-link {
     font-size: 21px;
     font-weight: 500;
     margin-bottom: 20px;
+    .word-break();
   }
   p {
     font-size: @font-size-large + 1;


### PR DESCRIPTION
@spadgett or @jwforres, review and merge, please?

Before:

<img width="857" alt="screen shot 2016-03-09 at 10 45 22 am" src="https://cloud.githubusercontent.com/assets/895728/13640958/b81d7e22-e5e4-11e5-9877-2103ced326ac.PNG">

After:

<img width="666" alt="screen shot 2016-03-09 at 10 45 03 am" src="https://cloud.githubusercontent.com/assets/895728/13640956/b53db230-e5e4-11e5-9eab-65b206b29b88.PNG">
