### PR TITLE
Fixes [options] in usage

### DIFF
--- a/pkg/cmd/templates/templater.go
+++ b/pkg/cmd/templates/templater.go
@@ -128,6 +128,7 @@ func (templater *templater) UsageFunc(exposedFlags ...string) func(*cobra.Comman
 			"rootCmd":             templater.rootCmdName,
 			"isRootCmd":           templater.isRootCmd,
 			"optionsCmdFor":       templater.optionsCmdFor,
+			"usageLine":           templater.usageLine,
 			"exposed": func(c *cobra.Command) *flag.FlagSet {
 				exposed := flag.NewFlagSet("exposed", flag.ContinueOnError)
 				if len(exposedFlags) > 0 {
@@ -199,6 +200,15 @@ func (t *templater) optionsCmdFor(c *cobra.Command) string {
 		}
 	}
 	return ""
+}
+
+func (t *templater) usageLine(c *cobra.Command) string {
+	usage := c.UseLine()
+	suffix := "[options]"
+	if c.HasFlags() && !strings.Contains(usage, suffix) {
+		usage += " " + suffix
+	}
+	return usage
 }
 
 func flagsUsages(f *flag.FlagSet) string {

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -30,14 +30,15 @@ const (
 		`{{$rootCmd := rootCmd .}}` +
 		`{{$visibleFlags := visibleFlags (flagsNotIntersected .LocalFlags .PersistentFlags)}}` +
 		`{{$explicitlyExposedFlags := exposed .}}` +
-		`{{$optionsCmdFor := optionsCmdFor .}}`
+		`{{$optionsCmdFor := optionsCmdFor .}}` +
+		`{{$usageLine := usageLine .}}`
 
 	mainHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
 	mainUsageTemplate = vars + `{{if and .Runnable (ne .UseLine "") (ne .UseLine $rootCmd)}}
 Usage:
-  {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{if .HasExample}}
+  {{$usageLine}}{{if .HasExample}}
 
 Examples:
 {{ .Example | trimRight}}

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -48,8 +48,8 @@ os::cmd::expect_success_and_text 'oadm' 'Basic Commands:'
 os::cmd::expect_success_and_text 'oadm' 'Install Commands:'
 os::cmd::expect_success_and_text 'oadm ca' 'Manage certificates'
 os::cmd::expect_success_and_text 'openshift start kubernetes' 'Kubernetes server components'
-os::cmd::expect_success_and_text 'oc exec --help' '\[options\] \-\- COMMAND'
-os::cmd::expect_success_and_text 'oc rsh --help' '\[options\] \[COMMAND\]'
+os::cmd::expect_success_and_text 'oc exec --help' '\[options\] \-\- COMMAND \[args\.\.\.\]$'
+os::cmd::expect_success_and_text 'oc rsh --help' '\[options\] \[COMMAND\]$'
 
 # check deprecated admin cmds for backward compatibility
 os::cmd::expect_success_and_text 'oadm create-master-certs -h' 'Create keys and certificates'


### PR DESCRIPTION
Must only add `[options]` to the end of the usage line if it's not there yet. Some commands that take `COMMAND` in the end (`oc rsh`, `oc exec`) can't take flags in the end.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1263609
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1248463
Fixes https://github.com/openshift/origin/issues/6620

@smarterclayton minor usability stuff.