### PR TITLE
make who-can handle resource strings

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -116,6 +116,13 @@ echo "groups: ok"
 os::cmd::expect_success 'oadm policy who-can get pods'
 os::cmd::expect_success 'oadm policy who-can get pods -n default'
 os::cmd::expect_success 'oadm policy who-can get pods --all-namespaces'
+# check to make sure that the resource arg conforms to resource rules
+os::cmd::expect_success_and_text 'oadm policy who-can get Pod' "Resource:  pods"
+os::cmd::expect_success_and_text 'oadm policy who-can get PodASDF' "Resource:  PodASDF"
+os::cmd::expect_success_and_text 'oadm policy who-can get hpa.autoscaling -n default' "Resource:  horizontalpodautoscalers.autoscaling"
+os::cmd::expect_success_and_text 'oadm policy who-can get hpa.v1.autoscaling -n default' "Resource:  horizontalpodautoscalers.autoscaling"
+os::cmd::expect_success_and_text 'oadm policy who-can get hpa.extensions -n default' "Resource:  horizontalpodautoscalers.extensions"
+os::cmd::expect_success_and_text 'oadm policy who-can get hpa -n default' "Resource:  horizontalpodautoscalers.extensions"
 
 os::cmd::expect_success 'oadm policy add-role-to-group cluster-admin system:unauthenticated'
 os::cmd::expect_success 'oadm policy add-role-to-user cluster-admin system:no-user'

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -49,19 +49,22 @@ os::cmd::expect_success "oc config view --raw > $new_kubeconfig"
 os::cmd::expect_success "oc login -u alternate-cluster-admin-user -p anything --config=${new_kubeconfig}"
 
 # alternate-cluster-admin should default to having star rights, so he should be able to update his role to that
-resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+os::cmd::try_until_text "oc policy who-can update clusterrroles" "alternate-cluster-admin-user"
+resourceversion=$(oc get clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
 cp ${OS_ROOT}/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml ${workingdir}
 os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_cluster_admin.yaml
 os::cmd::expect_success "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml"
 
 # alternate-cluster-admin can restrict himself to no groups
-resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+os::cmd::try_until_text "oc policy who-can update clusterrroles" "alternate-cluster-admin-user"
+resourceversion=$(oc get clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
 cp ${OS_ROOT}/test/fixtures/bootstrappolicy/cluster_admin_without_apigroups.yaml ${workingdir}
 os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/cluster_admin_without_apigroups.yaml
 os::cmd::expect_success "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/cluster_admin_without_apigroups.yaml"
 
 # alternate-cluster-admin should NOT have the power add back star now
-resourceversion=$(oc get  clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
+os::cmd::try_until_failure "oc policy who-can update hpa.extensions | grep -q alternate-cluster-admin-user"
+resourceversion=$(oc get clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
 cp ${OS_ROOT}/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml ${workingdir}
 os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_cluster_admin.yaml
 os::cmd::expect_failure_and_text "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml" "attempt to grant extra privileges"


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7831

This updates `oc policy who-can` so you can do things like `oc policy who-can update hpa` or `oc policy who-can create hpa.extensions` and get the results you expect.

The upstream pick is part of a much larger pull that is already merged.  Its a parse function that I could duplicate in origin, but that would be uglier.

@pweil- ptal or nominate.