### PR TITLE
Improved next steps page for bcs using sample repos

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -100,6 +100,10 @@ angular.module("openshiftConsole")
             scope.buildConfig.contextDir = annotations.sampleContextDir || "";
           };
 
+          scope.usingSampleRepo = function() {
+            return scope.buildConfig.sourceUrl === _.get(scope, 'image.metadata.annotations.sampleRepo');
+          };
+
           DataService.get("imagestreams", scope.imageName, {namespace: (scope.namespace || $routeParams.project)}).then(function(imageStream){
               scope.imageStream = imageStream;
               var imageName = scope.imageTag;
@@ -252,7 +256,7 @@ angular.module("openshiftConsole")
                   };
               }
             );
-          Navigate.toNextSteps($scope.name, $scope.projectName);
+          Navigate.toNextSteps($scope.name, $scope.projectName, $scope.usingSampleRepo() ? {"fromSample": true} : null);
         };
 
         var elseShowWarning = function(){

--- a/assets/app/scripts/controllers/create/nextSteps.js
+++ b/assets/app/scripts/controllers/create/nextSteps.js
@@ -22,6 +22,7 @@ angular.module("openshiftConsole")
     var imageName = $routeParams.imageName;
     var imageTag = $routeParams.imageTag;
     var namespace = $routeParams.namespace;
+    $scope.fromSampleRepo = $routeParams.fromSample;
 
     var name = $routeParams.name;
     var nameLink = "";
@@ -66,15 +67,11 @@ angular.module("openshiftConsole")
         }));
 
         $scope.createdBuildConfigWithGitHubTrigger = function() {
-          var created = false;
-          if ($scope.createdBuildConfig) {
-            angular.forEach($scope.createdBuildConfig.spec.triggers, function(trigger) {
-              if (trigger.type == "GitHub") {
-                created = true;
-              }
-            });
-          }
-          return created;
+          return _.some(_.get($scope, 'createdBuildConfig.spec.triggers'), {type: 'GitHub'});
+        };
+
+        $scope.createdBuildConfigWithConfigChangeTrigger = function() {
+          return _.some(_.get($scope, 'createdBuildConfig.spec.triggers'), {type: 'ConfigChange'});
         };
 
         $scope.allTasksSuccessful = function(tasks) {

--- a/assets/app/scripts/services/navigate.js
+++ b/assets/app/scripts/services/navigate.js
@@ -44,8 +44,13 @@ angular.module("openshiftConsole")
        * @param {type} projectName  the project name
        * @returns {undefined}
        */
-      toNextSteps: function(name, projectName){
-        $location.path("project/" + encodeURIComponent(projectName) + "/create/next").search("name", name);
+      toNextSteps: function(name, projectName, searchPart){
+        var search = $location.search();
+        search.name = name;
+        if (_.isObject(searchPart)) {
+          _.extend(search, searchPart);
+        }
+        $location.path("project/" + encodeURIComponent(projectName) + "/create/next").search(search);
       },
 
       toPodsForDeployment: function(deployment) {

--- a/assets/app/views/create/next-steps.html
+++ b/assets/app/views/create/next-steps.html
@@ -68,11 +68,23 @@ oc status</pre>
                 <p>For more information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
               </div>
 
-              <div ng-if="createdBuildConfigWithGitHubTrigger()" class="col-md-6">
+              <div ng-if="createdBuildConfig" class="col-md-6">
                 <h2>Making code changes</h2>
+                <p ng-if="fromSampleRepo">
+                  You are set up to use the example git repository. If you would like to modify the source code, fork the <a target="_blank" href="{{createdBuildConfig.spec.source.git.uri | githubLink}}">{{createdBuildConfig.spec.source.git.uri | githubLink}}</a> repository to an OpenShift-visible git account and <a href="{{createdBuildConfig | editResourceURL}}">edit the <strong>{{createdBuildConfig.metadata.name}}</strong> build config</a> to point to your fork.
+                  <span ng-if="createdBuildConfigWithConfigChangeTrigger()">Note that this will start a new build.</span>
+                </p>
                 <div ng-repeat="trigger in createdBuildConfig.spec.triggers" ng-if="trigger.type == 'GitHub'">
-                  <p>A GitHub <a target="_blank" href="{{'webhooks' | helpLink}}">webhook trigger</a> has been created for the <strong>{{createdBuildConfig.metadata.name}}</strong> build config. You can now set up the webhook in your GitHub repository settings in <a target="_blank" href="{{createdBuildConfig.spec.source.git.uri | githubLink}}/settings/hooks">{{createdBuildConfig.spec.source.git.uri | githubLink}}/settings/hooks</a>, using the following payload URL:</p>
-                  <pre class="code">{{createdBuildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : projectName}}</pre>
+                  <p>
+                    A GitHub <a target="_blank" href="{{'webhooks' | helpLink}}">webhook trigger</a> has been created for the <strong>{{createdBuildConfig.metadata.name}}</strong> build config.
+                  </p>
+                  <p ng-if="fromSampleRepo">
+                  	You can configure the webhook in the forked repository's settings, using the following payload URL:
+                  </p>
+                  <p ng-if="!fromSampleRepo">
+                    You can now set up the webhook in the GitHub repository settings if you own it, in <a target="_blank" href="{{createdBuildConfig.spec.source.git.uri | githubLink}}/settings/hooks">{{createdBuildConfig.spec.source.git.uri | githubLink}}/settings/hooks</a>, using the following payload URL:
+                  </p>
+									<pre class="code">{{createdBuildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : projectName}}</pre>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
When creating from image on the web console, make the "Next Steps" page smart enough to know when it's being created from one of the sample repositories suggested in the creation flow, and if so, adjust the suggestions about setting up webhooks on GitHub properly.

Sample: creating from own repo
![next-steps-own-repo](https://cloud.githubusercontent.com/assets/158611/13650617/43b7a24a-e622-11e5-984d-1ae5ab0680f0.png)

Sample: creating from sample repo
![next-steps-sample-repo](https://cloud.githubusercontent.com/assets/158611/13650629/4df66368-e622-11e5-8f7f-b96f7e3fe806.png)

Fixes https://github.com/openshift/origin/issues/7865

@jwforres PTAL, feel free to suggest changes. Notice I'm relying on a route param so we don't have to get the image again in the next steps page.