### PR TITLE
Improve leader leasing error return info

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -89,7 +89,7 @@ function exectest() {
 		exit 0
 	else
 		os::text::print_red "failed  $1"
-		echo "${out}"
+		echo "${out:-}"
 
 		exit 1
 	fi

--- a/pkg/cmd/server/origin/control.go
+++ b/pkg/cmd/server/origin/control.go
@@ -48,7 +48,7 @@ func initControllerRoutes(root *restful.WebService, path string, canStart bool, 
 	root.Route(root.DELETE(path).To(func(req *restful.Request, resp *restful.Response) {
 		resp.ResponseWriter.WriteHeader(http.StatusAccepted)
 		fmt.Fprintf(resp, "terminating")
-		plug.Stop()
+		plug.Stop(nil)
 	}).Doc("Stop the master").
 		Returns(http.StatusAccepted, "if the master will stop", nil).
 		Produces(restful.MIME_JSON))

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -520,8 +520,10 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		// when a manual shutdown (DELETE /controllers) or lease lost occurs, the process should exit
 		// this ensures no code is still running as a controller, and allows a process manager to reset
 		// the controller to come back into a candidate state and compete for the lease
-		oc.ControllerPlug.WaitForStop()
-		glog.Fatalf("Controller shutdown requested")
+		if err := oc.ControllerPlug.WaitForStop(); err != nil {
+			glog.Fatalf("Controller shutdown due to lease being lost: %v", err)
+		}
+		glog.Fatalf("Controller graceful shutdown requested")
 	}()
 
 	oc.ControllerPlug.WaitForStart()

--- a/pkg/util/leaderlease/leaderlease.go
+++ b/pkg/util/leaderlease/leaderlease.go
@@ -54,7 +54,7 @@ func NewEtcd(client *etcdclient.Client, key, value string, ttl uint64) Leaser {
 		value:  value,
 		ttl:    ttl,
 
-		waitFraction:         0.75,
+		waitFraction:         0.66,
 		pauseInterval:        time.Second,
 		maxRetries:           10,
 		minimumRetryInterval: 100 * time.Millisecond,

--- a/pkg/util/leaderlease/leaderlease.go
+++ b/pkg/util/leaderlease/leaderlease.go
@@ -19,7 +19,7 @@ type Leaser interface {
 	// lease is acquired, and the provided channel will be closed when the lease is lost. If the
 	// function returns true, the lease will be released on exit. If the function returns false,
 	// the lease will be held.
-	AcquireAndHold(chan struct{})
+	AcquireAndHold(chan error)
 	// Release returns any active leases
 	Release()
 }
@@ -62,7 +62,7 @@ func NewEtcd(client *etcdclient.Client, key, value string, ttl uint64) Leaser {
 }
 
 // AcquireAndHold implements an acquire and release of a lease.
-func (e *Etcd) AcquireAndHold(notify chan struct{}) {
+func (e *Etcd) AcquireAndHold(notify chan error) {
 	for {
 		ok, ttl, index, err := e.tryAcquire()
 		if err != nil {
@@ -76,12 +76,12 @@ func (e *Etcd) AcquireAndHold(notify chan struct{}) {
 		}
 
 		// notify
-		notify <- struct{}{}
+		notify <- nil
 		defer close(notify)
 
 		// hold the lease
 		if err := e.tryHold(ttl, index); err != nil {
-			utilruntime.HandleError(err)
+			notify <- err
 		}
 		break
 	}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"testing"
 	"time"
 
 	"github.com/golang/glog"
@@ -40,15 +39,6 @@ const ServiceAccountWaitTimeout = 30 * time.Second
 // PodCreationWaitTimeout is used to determine how long to wait after the service account token
 // is available for the admission control cache to catch up and allow pod creation
 const PodCreationWaitTimeout = 10 * time.Second
-
-// RequireServer verifies if the etcd and the OpenShift server are
-// available and you can successfully connect to them.
-func RequireServer(t *testing.T) {
-	util.RequireEtcd(t)
-	if _, err := util.GetClusterAdminClient(util.KubeConfigPath()); err != nil {
-		os.Exit(1)
-	}
-}
 
 // FindAvailableBindAddress returns a bind address on 127.0.0.1 with a free port in the low-high range.
 // If lowPort is 0, an ephemeral port is allocated.


### PR DESCRIPTION
Print more information at the appropriate spot when we lose a lease.

Start trying to renew the lease 2/3 of the way through the interval, rather than 1/4.

Fix some minor issues with logging.

@deads2k I think I caught all of the issues resulting from adding a buffered channel, but the code is more complex now.  We only *truly* need the lease renewal change for 1.2, but this was a good opportunity to refresh my familiarity with the code and double check the conditions.