### PR TITLE
Prevent last catalog tile from stretching to 100% width

### DIFF
--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -155,6 +155,9 @@
                           version="image.version"
                           ng-repeat="image in filteredNonBuilders | orderBy : ['name', 'imageStream.metadata.namespace']">
                       </catalog-image>
+
+                      <!-- Add an empty item to keep the last tile from stretching to 100% width. -->
+                      <div style="height: 0;" class="tile-image"></div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #7415 

/cc @jwforres @benjaminapetersen @sg00dwin

<img width="1153" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13656344/032f3000-e634-11e5-80f4-acad0a951392.png">
