### PR TITLE
Improve log text highlighting in Firefox

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -128,6 +128,13 @@
   white-space: pre-wrap;
   width: 100%;
   .word-break();
+  // Invert colors on selection in Firefox. Change the background style for
+  // Firefox only since it's illegible with its defaults and our log colors.
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/::selection
+  &::-moz-selection {
+    color: @log-bg-color;
+    background: lighten(#d1d1d1, 8%);
+  }
 }
 
 .table-log-pods {


### PR DESCRIPTION
Fixes #7916

<img width="962" alt="screen shot 2016-03-09 at 8 43 17 pm" src="https://cloud.githubusercontent.com/assets/1167259/13656772/e98e726a-e637-11e5-8427-8da925b07e28.png">

/cc @jwforres @sg00dwin 