### PR TITLE
Escape ANSI color codes in web console logs

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -21,6 +21,7 @@
   "unused": true,
   "globals": {
     "angular": false,
+    "ansi_up": false,
     "c3": false,
     "d3": false,
     "hawtioPluginLoader": false,

--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -100,6 +100,7 @@
     <script src="bower_components/yamljs/bin/yaml.js"></script>
     <script src="bower_components/clipboard/dist/clipboard.js"></script>
     <script src="bower_components/pathseg/pathseg.js"></script>
+    <script src="bower_components/ansi_up/ansi_up.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -27,7 +27,12 @@ angular.module('openshiftConsole')
         // this webkit bug with user-select: none;
         //   https://bugs.webkit.org/show_bug.cgi?id=80159
         line.firstChild.setAttribute('data-line-number', lineNumber);
-        line.lastChild.appendChild(document.createTextNode(text));
+
+        // Escape ANSI color codes
+        var escaped = ansi_up.escape_for_html(text);
+        var html = ansi_up.ansi_to_html(escaped);
+        var linkifiedHTML = ansi_up.linkify(html);
+        line.lastChild.innerHTML = linkifiedHTML;
 
         return line;
       };

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -36,7 +36,8 @@
     "yamljs": "0.1.5",
     "clipboard": "1.5.8",
     "pathseg": "1.0.2",
-    "fontawesome": "4.5.0"
+    "fontawesome": "4.5.0",
+    "ansi_up": "1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",


### PR DESCRIPTION
Escapes color codes and replaces links with anchor tags. Uses the ansi_up library.

https://github.com/drudru/ansi_up

See #5453
See #6931
https://trello.com/c/goZPKVEm

TODO

- [x] Assess performance for large logs
- [x] Look at carriage returns in Maven log output

<img width="894" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13658288/9f1c2658-e643-11e5-8a6f-8e6cb08e9900.png">

/cc @jwforres 