### PR TITLE
changed find behavior for OSX compatibility

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -139,7 +139,7 @@ function list_test_packages_under() {
               -o -path '*assets/node_modules' \
               -o -path '*test/*'              \
         \) -prune                             \
-    \) -name '*_test.go' -print0 | xargs -0n1 dirname -z | sort -uz | xargs -0n1 printf "${OS_GO_PACKAGE}/%s\n"
+    \) -name '*_test.go' | xargs -n1 dirname | sort -u | xargs -n1 printf "${OS_GO_PACKAGE}/%s\n"
 }
 
 # Break up the positional arguments into packages that need to be tested and arguments that need to be passed to `go test`
@@ -181,7 +181,7 @@ else
             -o -path "${kubernetes_path}/test/e2e"                                                    \
             -o -path "${kubernetes_path}/cmd/libs/go2idl/client-gen/testoutput/testgroup/unversioned" \
           \) -prune                                                                                   \
-        \) -name '*_test.go' -print0 | xargs -0n1 dirname -z | sort -uz | xargs -0n1 printf "${OS_GO_PACKAGE}/%s\n")"
+        \) -name '*_test.go' | xargs -n1 dirname | sort -u | xargs -n1 printf "${OS_GO_PACKAGE}/%s\n")"
 
         test_packages="${test_packages} ${optional_kubernetes_packages}"
     fi


### PR DESCRIPTION
@liggitt @smarterclayton PTAL

This is *not* a regression as previously some of the members of the pipe were not configured to understand the `-print0` output and therefore the final output of the pipe was not `-print0` compliant anyway. Regardless, I'd love to hear a good way to test this other than just running it on Jenkins and having you two do it locally.