### PR TITLE
[WIP]: Improve pod-template styling in the web console

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -3,8 +3,7 @@
 // --------------------------------------------------
 
 .components {
-  border-left: 3px solid #ccc;
-  border-left-style: dotted;
+  border-left: 3px dotted #ccc;
   margin-bottom: 30px;
   &:last-child {
     margin-bottom: 10px; // reduce margin since the .container-fluid parent already has bottom margin
@@ -160,24 +159,45 @@
   }
 }
 
-.pod-template-block {
-  border-radius: 3px;
+.pod-block {
   margin-bottom: 10px;
-  margin-right: 10px;
+}
+
+.pod-template-block {
+  + .pod-template-block {
+    margin-top: 15px;
+  }
+  .component-label {
+    font-size: @component-label;
+    padding: 0 10px 4px 0;
+    text-transform: uppercase;
+  }
   .pod-template {
-    border: 1px dotted @border-color-light-grey;
-    border-radius: @border-radius-md;
-    max-width: 600px;
-    padding: 5px 10px;
     // so that .word-break() on children works
     [flex] {
       min-width: 0;
     }
-    h4 {
-      margin: 5px 0;
+    [row] {
+      border-left: 3px solid @gray-lighter;
+      padding: 2px 0 0 2px;
+    }
+    .fa,
+    .pficon,
+    span[data-icon] {
+      color: #888;
+    }
+    .hash {
+      font-family: @font-family-monospace;
+      font-size: (@font-size-base - 1);
     }
     .pod-template-build {
       .word-break();
+    }
+    .pod-template-key {
+      font-weight: bold;
+      .components & {
+        font-weight: 600;
+      }
     }
   }
 }
@@ -185,6 +205,13 @@
 // so that .word-break() on children works
 .pod-template-column {
   min-width: 0;
+}
+
+.pod-template-container {
+  margin: 0 0 20px;
+  .components & {
+    margin-bottom: 0;
+  }
 }
 
 .pod-container-terminal {
@@ -266,7 +293,7 @@
 .pod-block {
   .overview-pods {
     margin-right: 10px;
-    min-width: 190px;
+    min-width: 200px;
     .scaling-controls {
       font-size: 24px;
       a {

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -13,11 +13,11 @@
           <span class="pficon pficon-image" aria-hidden="true"></span>
         </div>
         <div flex>
-          Image:
+          <span class="pod-template-key">Image:</span>
           <span ng-if="!imagesByDockerReference[container.image]">{{container.image | imageStreamName}}</span>
           <span ng-if="imagesByDockerReference[container.image]">
             <a ng-href="{{imagesByDockerReference[container.image].imageStreamName | navigateResourceURL : 'ImageStream' : imagesByDockerReference[container.image].imageStreamNamespace}}">{{container.image | imageStreamName}}</a>
-            (<span title="{{imagesByDockerReference[container.image].metadata.name}}">{{imagesByDockerReference[container.image].metadata.name | stripSHAPrefix | limitTo: 7}}</span>)
+            <span class="hash" title="{{imagesByDockerReference[container.image].metadata.name}}">{{imagesByDockerReference[container.image].metadata.name | stripSHAPrefix | limitTo: 7}}</span>
           </span>
         </div>
       </div>
@@ -26,7 +26,8 @@
           <div>
             <span class="fa fa-refresh" aria-hidden="true"></span>
           </div>
-          <div flex>Build:
+          <div flex>
+            <span class="pod-template-key">Build:</span>
             <span ng-if="build.metadata.labels.buildconfig">
               <a ng-href="{{build.metadata.labels.buildconfig | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}">{{build.metadata.labels.buildconfig}}</a>,
             </span>
@@ -40,14 +41,16 @@
           <div>
             <span class="fa fa-code" aria-hidden="true"></span>
           </div>
-          <div flex>Source:
+          <div flex>
+            <span class="pod-template-key">Source:</span>
             <span ng-switch="build.spec.source.type">
               <span ng-switch-when="Git">
                 <span ng-if="build.spec.revision.git.commit">
                   {{build.spec.revision.git.message}}
-                  (<osc-git-link
+                  <osc-git-link
+                    class="hash"
                     uri="build.spec.source.git.uri"
-                    commit="build.spec.revision.git.commit">{{build.spec.revision.git.commit | limitTo:7}}</osc-git-link>)
+                    commit="build.spec.revision.git.commit">{{build.spec.revision.git.commit | limitTo:7}}</osc-git-link>
                   <span ng-if="detailed && build.spec.revision.git.author">
                     authored by {{build.spec.revision.git.author.name}}
                   </span>
@@ -69,7 +72,7 @@
           <span data-icon="" aria-hidden="true" style="font-size:16px;line-height:normal"></span>
         </div>
         <div flex>
-          Ports:
+          <span class="pod-template-key">Ports:</span>
           <span ng-repeat="port in container.ports | orderBy: 'containerPort'">
             <span class="nowrap">{{port.containerPort}}/{{port.protocol}}<span ng-if="port.name">&thinsp;({{port.name}})</span><span ng-if="port.hostPort">&thinsp;<span class="port-icon">&#8594;</span>&thinsp;{{port.hostPort}}</span></span><span ng-if="!$last">, </span>
           </span>
@@ -81,7 +84,7 @@
           <span aria-hidden="true" class="fa fa-database"></span>
         </div>
         <div flex>
-          Mount:
+          <span class="pod-template-key">Mount:</span>
           <span>
             {{mount.name}}&#8201;&#8594;&#8201;<span class="word-break">{{mount.mountPath}}</span>
           </span>
@@ -93,7 +96,7 @@
           <i class="fa fa-area-chart" aria-hidden="true"></i>
         </div>
         <div flex>
-          CPU:
+          <span class="pod-template-key">CPU:</span>
           <span ng-if="container.resources.requests.cpu && container.resources.limits.cpu">
             {{container.resources.requests.cpu | usageWithUnits: 'cpu'}} to {{container.resources.limits.cpu | usageWithUnits: 'cpu'}}
           </span>
@@ -111,7 +114,7 @@
           <i class="fa fa-area-chart" aria-hidden="true"></i>
         </div>
         <div flex>
-          Memory:
+          <span class="pod-template-key">Memory:</span>
           <span ng-if="container.resources.requests.memory && container.resources.limits.memory">
             {{container.resources.requests.memory | usageWithUnits: 'memory'}} to {{container.resources.limits.memory | usageWithUnits: 'memory'}}
           </span>

--- a/assets/app/views/browse/_deployment-details.html
+++ b/assets/app/views/browse/_deployment-details.html
@@ -83,16 +83,20 @@
   </div>
 </div>
 <annotations annotations="deployment.metadata.annotations"></annotations>
-<div class="deployment-detail">
-  <span>Pod template:</span>
-  <pod-template
-    pod-template="deployment.spec.template"
-    images-by-docker-reference="imagesByDockerReference"
-    builds="builds"
-    detailed="true"></pod-template>
-  <h4 style="margin-top: 20px;">Volumes</h4>
-  <p ng-if="!deployment.spec.template.spec.volumes.length">
-    <a ng-href="project/{{project.metadata.name}}/attach-pvc?deployment={{deployment.metadata.name}}">Attach storage</a>
-  </p>
-  <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
+<div class="row">
+  <div class="col-lg-6">
+    <div class="deployment-detail">
+      <h3>Template</h3>
+      <pod-template
+        pod-template="deployment.spec.template"
+        images-by-docker-reference="imagesByDockerReference"
+        builds="builds"
+        detailed="true"></pod-template>
+      <h4>Volumes</h4>
+      <p ng-if="!deployment.spec.template.spec.volumes.length">
+        <a ng-href="project/{{project.metadata.name}}/attach-pvc?deployment={{deployment.metadata.name}}">Attach storage</a>
+      </p>
+      <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
+    </div>
+  </div>
 </div>

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -68,7 +68,7 @@
         detailed="true">
       </pod-template>
       <div ng-if="pod.spec.volumes.length">
-        <h4 style="margin-top: 20px;">Volumes</h4>
+        <h4>Volumes</h4>
         <p ng-if="(pod | annotation:'deploymentConfig') && !pod.spec.volumes.length">
           <a ng-href="project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{pod | annotation:'deploymentConfig'}}">Attach storage and redeploy</a>
         </p>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -82,6 +82,12 @@
                         <div class="col-lg-6">
                           <h3>Configuration</h3>
                           <dl class="dl-horizontal left">
+                            <dt>Selectors:</dt><dd ng-if="!deploymentConfig.spec.selector">none</dd>
+                            <dd ng-repeat="(selectorLabel, selectorValue) in deploymentConfig.spec.selector">{{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></dd>
+                            <dt>Replicas:</dt>
+                            <dd>
+                              <replicas spec="deploymentConfig.spec.replicas" scale-fn="scale(replicas)"></replicas>
+                            </dd>
                             <div ng-if="deploymentConfig.spec.strategy.type">
                                 <dt>Strategy:</dt>
                                 <dd>{{deploymentConfig.spec.strategy.type}}</dd>
@@ -101,22 +107,12 @@
                             <!-- TODO: Surface the parameters for the recreate and custom strategies -->
                           </dl>
                           <h3>Template</h3>
-                          <dl class="dl-horizontal left">
-                            <dt>Selectors:</dt><dd ng-if="!deploymentConfig.spec.selector">none</dd>
-                            <dd ng-repeat="(selectorLabel, selectorValue) in deploymentConfig.spec.selector">{{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></dd>
-                            <dt>Replicas:</dt>
-                            <dd>
-                              <replicas spec="deploymentConfig.spec.replicas" scale-fn="scale(replicas)"></replicas>
-                            </dd>
-                            <dt>Pod template:</dt>
-                            <dd>&nbsp;</dd>
-                            <pod-template
-                                  pod-template="deploymentConfig.spec.template"
-                                  images-by-docker-reference="imagesByDockerReference"
-                                  builds="builds"
-                                  detailed="true"></pod-template>
-                          </dl>
-                          <h4 style="margin-top: 20px;">Volumes</h4>
+                          <pod-template
+                              pod-template="deploymentConfig.spec.template"
+                              images-by-docker-reference="imagesByDockerReference"
+                              builds="builds"
+                              detailed="true"></pod-template>
+                          <h4>Volumes</h4>
                           <p ng-if="!deploymentConfig.spec.template.spec.volumes.length">
                             <a ng-href="project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{deploymentConfig.metadata.name}}">Attach storage</a>
                           </p>


### PR DESCRIPTION
This is a first pass at improving the styling of the pod template in the web console.

Goals:

* better alignment with the new look and feel of the console and PatternFly without a complete overhaul (at least not yet)
* improved legibility

Actions:

* removed dotted border and rounded corners styling since we don't use these elsewhere
* removed max-width on pod template to remove negative space along right edge at large resolutions (note:  i expect debate on this one!  ;-) )
* increased spacing between elements and left justified all content
* softened the icon color to help differentiate it from other content per examples found in PatternFly [1][2]
* bolded the key in key value pairs so it's consistent with how we display keys elsewhere
* removed parenthesis around hash values and set the values in monospaced font to differentiate them without the need for the parens

[1]  ![aerogear-applist_2015-01-16](https://cloud.githubusercontent.com/assets/895728/13674371/3f0efcdc-e6ab-11e5-8abd-5f66d4e5e5bd.png)

[2]  ![object-tablet_2015-02-02](https://cloud.githubusercontent.com/assets/895728/13674383/49b9fc36-e6ab-11e5-84fc-6775936b55f3.png)

Screenshots:

Note:  the overview page screenshots contain an unrelated bug with the "--o"

Before:
![openshift web console 1](https://cloud.githubusercontent.com/assets/895728/13674401/58d2804e-e6ab-11e5-872e-4f3d36187422.png)

After:
![openshift web console 2](https://cloud.githubusercontent.com/assets/895728/13674403/5b97fe26-e6ab-11e5-9cb3-5d32f03f9b38.png)

Before:
![openshift web console 3](https://cloud.githubusercontent.com/assets/895728/13674433/72aef06a-e6ab-11e5-89fa-2cc2a5358324.png)

After:
![openshift web console 4](https://cloud.githubusercontent.com/assets/895728/13674431/72ac6f16-e6ab-11e5-9d9e-79373094982e.png)

Before:
![openshift web console 5](https://cloud.githubusercontent.com/assets/895728/13674432/72ae3e2c-e6ab-11e5-89e3-f1f88822496a.png)

After:
![openshift web console 6](https://cloud.githubusercontent.com/assets/895728/13674434/72b01f8a-e6ab-11e5-9855-5f50a89934df.png)

What do you think, @jwforres, @spadgett, @sg00dwin, @benjaminapetersen, @ajacobs21e, @fabianofranz, et al.?

