### PR TITLE
Registry quota reworked

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
@@ -177,6 +177,16 @@ func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
 		return nil
 	}
 
+	// Usage of some resources cannot be counted in isolation. For example when
+	// the resource represents a number of unique references to external
+	// resource. In such a case an evaluator needs to process other objects in
+	// the same namespace which needs to be known.
+	if om, err := api.ObjectMetaFor(inputObject); namespace != "" && err == nil {
+		if om.Namespace == "" {
+			om.Namespace = namespace
+		}
+	}
+
 	// there is at least one quota that definitely matches our object
 	// as a result, we need to measure the usage of this object for quota
 	// on updates, we need to subtract the previous measured usage

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
@@ -27,10 +27,15 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/testing/fake"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/evaluator/core"
+	"k8s.io/kubernetes/pkg/quota/generic"
 	"k8s.io/kubernetes/pkg/quota/install"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -564,5 +569,77 @@ func TestHasUsageStats(t *testing.T) {
 		if result := hasUsageStats(&testCase.a); result != testCase.expected {
 			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, result)
 		}
+	}
+}
+
+// TestAdmissionSetsMissingNamespace verifies that if an object lacks a
+// namespace, it will be set.
+func TestAdmissionSetsMissingNamespace(t *testing.T) {
+	namespace := "test"
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{Name: "quota", Namespace: namespace, ResourceVersion: "124"},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU: resource.MustParse("3"),
+			},
+			Used: api.ResourceList{
+				api.ResourceCPU: resource.MustParse("1"),
+			},
+		},
+	}
+	kubeClient := fake.NewSimpleClientset(resourceQuota)
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+
+	computeResources := []api.ResourceName{
+		api.ResourcePods,
+		api.ResourceCPU,
+	}
+
+	usageFunc := func(object runtime.Object) api.ResourceList {
+		pod, ok := object.(*api.Pod)
+		if !ok {
+			t.Fatalf("Expected pod, got %T", object)
+		}
+		if pod.Namespace != namespace {
+			t.Errorf("Expected pod with different namespace: %q != %q", pod.Namespace, namespace)
+		}
+		return core.PodUsageFunc(pod)
+	}
+
+	podEvaluator := &generic.GenericEvaluator{
+		Name:              "Test-Evaluator.Pod",
+		InternalGroupKind: api.Kind("Pod"),
+		InternalOperationResources: map[admission.Operation][]api.ResourceName{
+			admission.Create: computeResources,
+		},
+		ConstraintsFunc:      core.PodConstraintsFunc,
+		MatchedResourceNames: computeResources,
+		MatchesScopeFunc:     core.PodMatchesScopeFunc,
+		UsageFunc:            usageFunc,
+	}
+
+	registry := &generic.GenericRegistry{
+		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
+			podEvaluator.GroupKind(): podEvaluator,
+		},
+	}
+	handler := &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create, admission.Update),
+		client:   kubeClient,
+		indexer:  indexer,
+		registry: registry,
+	}
+	handler.indexer.Add(resourceQuota)
+	newPod := validPod("pod-without-namespace", 1, getResourceRequirements(getResourceList("1", "2Gi"), getResourceList("", "")))
+
+	// unset the namespace
+	newPod.ObjectMeta.Namespace = ""
+
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+	if newPod.Namespace != namespace {
+		t.Errorf("Got unexpected pod namespace: %q != %q", newPod.Namespace, namespace)
 	}
 }

--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -8,7 +8,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/watch"
@@ -71,7 +70,6 @@ type ImportImageOptions struct {
 	// helpers
 	out      io.Writer
 	osClient client.Interface
-	kClient  kclient.Interface
 	isClient client.ImageStreamInterface
 }
 
@@ -88,12 +86,11 @@ func (o *ImportImageOptions) Complete(f *clientcmd.Factory, args []string, out i
 	}
 	o.Namespace = namespace
 
-	osClient, kClient, err := f.Clients()
+	osClient, _, err := f.Clients()
 	if err != nil {
 		return err
 	}
 	o.osClient = osClient
-	o.kClient = kClient
 	o.isClient = osClient.ImageStreams(namespace)
 	o.out = out
 
@@ -143,7 +140,7 @@ func (o *ImportImageOptions) Run() error {
 		fmt.Fprint(o.out, "The import completed successfully.\n\n")
 
 		// optimization, use the image stream returned by the call
-		d := describe.ImageStreamDescriber{OSClient: o.osClient, KubeClient: o.kClient}
+		d := describe.ImageStreamDescriber{Interface: o.osClient}
 		info, err := d.Describe(o.Namespace, stream.Name)
 		if err != nil {
 			return err
@@ -188,7 +185,7 @@ func (o *ImportImageOptions) Run() error {
 
 	fmt.Fprint(o.out, "The import completed successfully.\n\n")
 
-	d := describe.ImageStreamDescriber{OSClient: o.osClient, KubeClient: o.kClient}
+	d := describe.ImageStreamDescriber{Interface: o.osClient}
 	info, err := d.Describe(updatedStream.Namespace, updatedStream.Name)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -29,7 +29,6 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
-
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
@@ -42,7 +41,7 @@ func describerMap(c *client.Client, kclient kclient.Interface, host string) map[
 		deployapi.Kind("DeploymentConfig"):            NewDeploymentConfigDescriber(c, kclient),
 		authorizationapi.Kind("Identity"):             &IdentityDescriber{c},
 		imageapi.Kind("Image"):                        &ImageDescriber{c},
-		imageapi.Kind("ImageStream"):                  &ImageStreamDescriber{c, kclient},
+		imageapi.Kind("ImageStream"):                  &ImageStreamDescriber{c},
 		imageapi.Kind("ImageStreamTag"):               &ImageStreamTagDescriber{c},
 		imageapi.Kind("ImageStreamImage"):             &ImageStreamImageDescriber{c},
 		routeapi.Kind("Route"):                        &RouteDescriber{c, kclient},
@@ -587,13 +586,12 @@ func (d *ImageStreamImageDescriber) Describe(namespace, name string) (string, er
 
 // ImageStreamDescriber generates information about a ImageStream
 type ImageStreamDescriber struct {
-	OSClient   client.Interface
-	KubeClient kclient.Interface
+	client.Interface
 }
 
 // Describe returns the description of an imageStream
 func (d *ImageStreamDescriber) Describe(namespace, name string) (string, error) {
-	c := d.OSClient.ImageStreams(namespace)
+	c := d.ImageStreams(namespace)
 	imageStream, err := c.Get(name)
 	if err != nil {
 		return "", err
@@ -602,7 +600,6 @@ func (d *ImageStreamDescriber) Describe(namespace, name string) (string, error) 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
 		formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
-		formatImageStreamQuota(out, d.OSClient, d.KubeClient, imageStream)
 		formatImageStreamTags(out, imageStream)
 		return nil
 	})

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -121,7 +121,7 @@ func TestDescribers(t *testing.T) {
 		&BuildDescriber{c, fakeKube},
 		&BuildConfigDescriber{c, ""},
 		&ImageDescriber{c},
-		&ImageStreamDescriber{c, fakeKube},
+		&ImageStreamDescriber{c},
 		&ImageStreamTagDescriber{c},
 		&ImageStreamImageDescriber{c},
 		&RouteDescriber{c, fakeKube},

--- a/pkg/cmd/cli/describe/helpers_test.go
+++ b/pkg/cmd/cli/describe/helpers_test.go
@@ -6,11 +6,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func TestFormatImageStreamTags(t *testing.T) {
@@ -80,46 +78,4 @@ func TestFormatImageStreamTags(t *testing.T) {
 	out.Flush()
 	actual := string(buf.String())
 	t.Logf("\n%s", actual)
-}
-
-func TestFormatQuantity(t *testing.T) {
-	testCases := []struct {
-		value    int64
-		scale    scale
-		expected string
-	}{
-		{
-			value:    1 << 30,
-			scale:    giga,
-			expected: "1GiB",
-		},
-		{
-			value:    1 << 20,
-			scale:    mega,
-			expected: "1MiB",
-		},
-		{
-			value:    10 * (1 << 20),
-			scale:    giga,
-			expected: "0.01GiB",
-		},
-		{
-			value:    (1 << 30) + (1 << 20),
-			scale:    giga,
-			expected: "1GiB",
-		},
-		{
-			value:    (1 << 30) + 10*(1<<20),
-			scale:    giga,
-			expected: "1.01GiB",
-		},
-	}
-
-	for idx, test := range testCases {
-		quantity := resource.NewQuantity(test.value, resource.BinarySI)
-		actual := formatQuantity(quantity, test.scale)
-		if actual != test.expected {
-			t.Errorf("(%d) expected '%s', got '%s'", idx, test.expected, actual)
-		}
-	}
 }

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -447,7 +447,7 @@ func (c *MasterConfig) RunResourceQuotaManager(cm *cmapp.CMServer) {
 	}
 
 	osClient, kClient := c.ResourceQuotaManagerClients()
-	resourceQuotaRegistry := quota.NewRegistry(osClient)
+	resourceQuotaRegistry := quota.NewRegistry(osClient, false)
 	resourceQuotaControllerOptions := &kresourcequota.ResourceQuotaControllerOptions{
 		KubeClient:            kClient,
 		ResyncPeriod:          controller.StaticResyncPeriodFunc(resourceQuotaSyncPeriod),

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -31,15 +31,8 @@ const (
 	// DefaultImageTag is used when an image tag is needed and the configuration does not specify a tag to use.
 	DefaultImageTag = "latest"
 
-	// ResourceProjectImagesSize stands for a sum of sizes of all images stored in an internal registry under
-	// a single namespace. Used as a resource quota key.
-	ResourceProjectImagesSize kapi.ResourceName = "openshift.io/projectimagessize"
-	// ResourceImageStreamSize stands for a sum of sizes of all images stored in an internal registry within
-	// a single image stream (aka. repository). Used as a resource quota key.
-	ResourceImageStreamSize kapi.ResourceName = "openshift.io/imagestreamsize"
-	// ResourceImageSize stands for a size of an image stored in an internal registry. Used as a resource
-	// quota key. If set, bigger images will be refused during a push.
-	ResourceImageSize kapi.ResourceName = "openshift.io/imagesize"
+	// ResourceImages represents a number of images in a project.
+	ResourceImages kapi.ResourceName = "openshift.io/images"
 )
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.

--- a/pkg/quota/admission/resourcequota/admission.go
+++ b/pkg/quota/admission/resourcequota/admission.go
@@ -54,7 +54,7 @@ func (a *originQuotaAdmission) Admit(as admission.Attributes) error {
 }
 
 func (a *originQuotaAdmission) SetOpenshiftClient(osClient osclient.Interface) {
-	registry := quota.NewRegistry(osClient)
+	registry := quota.NewRegistry(osClient, true)
 	quotaAdmission, err := resourcequota.NewResourceQuota(a.kClient, registry)
 	if err != nil {
 		glog.Fatalf("failed to initialize %s plugin: %v", pluginName, err)

--- a/pkg/quota/image/imagestreammapping_evaluator.go
+++ b/pkg/quota/image/imagestreammapping_evaluator.go
@@ -16,32 +16,28 @@ import (
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
 
+const imageStreamMappingName = "Evaluator.ImageStreamMapping"
+
 // NewImageStreamMappingEvaluator computes resource usage for ImageStreamMapping objects. This particular kind
-// is a virtual resource. It depends on ImageStream usage evaluator to compute project image size accross all
-// image streams in the namespace.
+// is a virtual resource. It depends on ImageStream usage evaluator to compute image numbers before the
+// the admission can work.
 func NewImageStreamMappingEvaluator(osClient osclient.Interface) kquota.Evaluator {
 	computeResources := []kapi.ResourceName{
-		imageapi.ResourceProjectImagesSize,
-		imageapi.ResourceImageStreamSize,
-		imageapi.ResourceImageSize,
+		imageapi.ResourceImages,
 	}
 
 	matchesScopeFunc := func(kapi.ResourceQuotaScope, runtime.Object) bool { return true }
-	listFuncByNamespace := func(namespace string, options kapi.ListOptions) (runtime.Object, error) {
-		// we don't want to be called on image stream changes; ImageStreamEvaluator will do the job
-		return &kapi.List{Items: []runtime.Object{}}, nil
-	}
 
 	return quotautil.NewSharedContextEvaluator(
-		"ImageStreamMapping evaluator",
+		imageStreamMappingName,
 		kapi.Kind("ImageStreamMapping"),
 		map[admission.Operation][]kapi.ResourceName{admission.Create: computeResources},
+		computeResources,
 		matchesScopeFunc,
 		nil,
-		listFuncByNamespace,
+		nil,
 		imageStreamMappingConstraintsFunc,
-		makeImageStreamMappingUsageComputerFactory(osClient),
-	)
+		makeImageStreamMappingUsageComputerFactory(osClient))
 }
 
 // imageStreamMappingConstraintsFunc checks that given object is an image stream
@@ -55,92 +51,31 @@ func imageStreamMappingConstraintsFunc(required []kapi.ResourceName, object runt
 func makeImageStreamMappingUsageComputerFactory(osClient osclient.Interface) quotautil.UsageComputerFactory {
 	return func() quotautil.UsageComputer {
 		return &imageStreamMappingUsageComputer{
-			osClient:         osClient,
-			imageStreamCache: make(map[string]*imageapi.ImageStream),
-			imageCache:       make(map[string]*imageapi.Image),
+			GenericImageStreamUsageComputer: *NewGenericImageStreamUsageComputer(osClient, false, true),
 		}
 	}
 }
 
 // imageStreamMappingUsageComputer is used to compute usage for ImageStreamMapping.
 type imageStreamMappingUsageComputer struct {
-	osClient osclient.Interface
-	// imageStreamCache maps image stream names to image stream objects. Used in case of evaluation of all
-	// ImageStreamMapping object in a namespace. Which will hardly ever happen unless list function returns
-	// non-empty lists.
-	imageStreamCache map[string]*imageapi.ImageStream
-	// imageCache maps image names to image objects. Used to reduce repeated resource fetches.
-	imageCache map[string]*imageapi.Image
+	GenericImageStreamUsageComputer
 }
 
-// Usage computes usage of image stream mapping objects. There are two scenarios when this can be called:
-//
-//  1. admission check for CREATE on ImageStreamMapping object
-//  2. evaluation of image stream mapping objects for a namespace triggered by resource quota controller
-//
-// In the former case, we are expected to return size increments for all the resources. For image size and
-// image stream size it means to return their whole size because their quota usage is always 0.
-//
-// In the latter case, we return only project images size which is scoped to namespace and thus its usage
-// should be accumulated. This scenario actually shouldn't happen because it is covered by image stream
-// evaluator.
+// Usage computes usage of image stream mapping objects. It is being used solely in the context of admission
+// check for CREATE operation on ImageStreamMapping object.
 func (c *imageStreamMappingUsageComputer) Usage(object runtime.Object) kapi.ResourceList {
 	ism, ok := object.(*imageapi.ImageStreamMapping)
 	if !ok {
 		return kapi.ResourceList{}
 	}
 
-	var isSize *resource.Quantity
-	var err error
-	is, isLoaded := c.imageStreamCache[ism.Name]
-
-	res := map[kapi.ResourceName]resource.Quantity{
-		imageapi.ResourceProjectImagesSize: *resource.NewQuantity(0, resource.BinarySI),
-		imageapi.ResourceImageStreamSize:   *resource.NewQuantity(0, resource.BinarySI),
-		imageapi.ResourceImageSize:         *resource.NewQuantity(0, resource.BinarySI),
+	_, imagesIncrement, err := c.GetProjectImagesUsageIncrement(ism.Namespace, nil, &ism.Image)
+	if err != nil {
+		glog.Errorf("Failed to get project images size increment of %q caused by an image %q: %v", ism.Namespace, ism.Image.Name, err)
+		return map[kapi.ResourceName]resource.Quantity{}
 	}
 
-	if !isLoaded {
-		is, err = c.osClient.ImageStreams(ism.Namespace).Get(ism.Name)
-		if err != nil {
-			glog.Errorf("Failed to get image stream %s/%s: %v", ism.Namespace, ism.Name, err)
-			return map[kapi.ResourceName]resource.Quantity{}
-		}
-		isSize = GetImageStreamSize(c.osClient, is, c.imageCache)
+	return map[kapi.ResourceName]resource.Quantity{
+		imageapi.ResourceImages: *imagesIncrement,
 	}
-
-	img, imgLoaded := c.imageCache[ism.Image.Name]
-
-	if isLoaded && imgLoaded {
-		// quota evaluation; image stream has been already processed
-		return res
-	}
-
-	if !imgLoaded {
-		// handling CREATE admission check - image is about to be created
-		img = &ism.Image
-
-		if value, exists := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !exists || value != "true" {
-			return res
-		}
-
-		_, sizeIncrement, err2 := GetImageStreamSizeIncrement(c.osClient, is, img, c.imageCache)
-		if err2 != nil {
-			glog.Errorf("Failed to get repository size increment of %s/%s with an image %q: %v", ism.Namespace, ism.Name, img.Name, err2)
-			return map[kapi.ResourceName]resource.Quantity{}
-		}
-
-		// Values for repository size and image size resources don't accumulate, that's why we return whole usage.
-		isSize.Add(*sizeIncrement)
-		res[imageapi.ResourceImageStreamSize] = *isSize
-		res[imageapi.ResourceImageSize] = *resource.NewQuantity(img.DockerImageMetadata.Size, resource.BinarySI)
-		// Caller expects us to return usage increments for the CREATE operation.
-		res[imageapi.ResourceProjectImagesSize] = *sizeIncrement
-
-	} else {
-		// handling quota evaluation
-		res[imageapi.ResourceProjectImagesSize] = *isSize
-	}
-
-	return res
 }

--- a/pkg/quota/image/imagestreamtag_evaluator.go
+++ b/pkg/quota/image/imagestreamtag_evaluator.go
@@ -1,0 +1,135 @@
+package image
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	quotautil "github.com/openshift/origin/pkg/quota/util"
+)
+
+const imageStreamTagEvaluatorName = "Evaluator.ImageStreamTag"
+
+// NewImageStreamTagEvaluator computes resource usage of ImageStreamsTags. It's sole purpose is to handle
+// UPDATE admission operations on imageStreamTags resource.
+func NewImageStreamTagEvaluator(osClient osclient.Interface) kquota.Evaluator {
+	computeResources := []kapi.ResourceName{
+		imageapi.ResourceImages,
+	}
+
+	matchesScopeFunc := func(kapi.ResourceQuotaScope, runtime.Object) bool { return true }
+	getFuncByNamespace := func(namespace, id string) (runtime.Object, error) {
+		nameParts := strings.SplitN(id, ":", 2)
+		if len(nameParts) != 2 {
+			return nil, fmt.Errorf("%q is an invalid id for an imagestreamtag. Must be in form <name>:<tag>.", id)
+		}
+
+		obj, err := osClient.ImageStreamTags(namespace).Get(nameParts[0], nameParts[1])
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				return nil, err
+			}
+			obj = &imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: namespace,
+					Name:      id,
+				},
+			}
+		}
+		return obj, nil
+	}
+
+	return quotautil.NewSharedContextEvaluator(
+		imageStreamTagEvaluatorName,
+		kapi.Kind("ImageStreamTag"),
+		map[admission.Operation][]kapi.ResourceName{admission.Update: computeResources},
+		computeResources,
+		matchesScopeFunc,
+		getFuncByNamespace,
+		nil,
+		imageStreamTagConstraintsFunc,
+		makeImageStreamTagUsageComputerFactory(osClient))
+}
+
+// imageStreamTagConstraintsFunc checks that given object is an image stream tag
+func imageStreamTagConstraintsFunc(required []kapi.ResourceName, object runtime.Object) error {
+	if _, ok := object.(*imageapi.ImageStreamTag); !ok {
+		return fmt.Errorf("Unexpected input object %v", object)
+	}
+	return nil
+}
+
+// makeImageStreamTagUsageComputerFactory returns an object used during computation of image quota across all
+// repositories in a namespace.
+func makeImageStreamTagUsageComputerFactory(osClient osclient.Interface) quotautil.UsageComputerFactory {
+	return func() quotautil.UsageComputer {
+		return &imageStreamTagUsageComputer{
+			GenericImageStreamUsageComputer: *NewGenericImageStreamUsageComputer(osClient, false, true),
+		}
+	}
+}
+
+// imageStreamUsageComputer is a context object for use in SharedContextEvaluator.
+type imageStreamTagUsageComputer struct {
+	GenericImageStreamUsageComputer
+}
+
+// Usage returns a usage for an image stream tag.
+func (c *imageStreamTagUsageComputer) Usage(object runtime.Object) kapi.ResourceList {
+	ist, ok := object.(*imageapi.ImageStreamTag)
+	if !ok {
+		return kapi.ResourceList{}
+	}
+
+	res := map[kapi.ResourceName]resource.Quantity{
+		imageapi.ResourceImages: *resource.NewQuantity(0, resource.BinarySI),
+	}
+
+	if ist.Tag == nil {
+		glog.V(4).Infof("Nothing to tag to %s/%s", ist.Namespace, ist.Name)
+		return res
+	}
+
+	nameParts := strings.Split(ist.Name, ":")
+	if len(nameParts) != 2 {
+		glog.Errorf("failed to parse name of image stream tag %q", ist.Name)
+		return kapi.ResourceList{}
+	}
+
+	if ist.Tag.From == nil {
+		glog.V(2).Infof("from unspecified in tag reference of istag %s/%s, skipping", ist.Namespace, ist.Name)
+		return res
+	}
+
+	ref, err := c.getImageReferenceForObjectReference(ist.Namespace, ist.Tag.From)
+	if err != nil {
+		glog.Errorf("failed to get source docker image reference for istag %s/%s: %v", ist.Namespace, nameParts[0], err)
+		return res
+	}
+
+	img, err := c.getImage(ref.ID)
+	if err != nil {
+		glog.Errorf("failed to get an image %s: %v", ref.ID, err)
+		return res
+	}
+
+	_, imagesIncrement, err := c.GetProjectImagesUsageIncrement(ist.Namespace, nil, img)
+	if err != nil {
+		glog.Errorf("Failed to get namespace size increment of %q with an image %q: %v", ist.Namespace, img.Name, err)
+		return res
+	}
+
+	res[imageapi.ResourceImages] = *imagesIncrement
+
+	return res
+}

--- a/pkg/quota/image/imagestreamtag_evaluator_test.go
+++ b/pkg/quota/image/imagestreamtag_evaluator_test.go
@@ -1,0 +1,359 @@
+package image
+
+import (
+	"fmt"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kquota "k8s.io/kubernetes/pkg/quota"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func TestImageStreamTagEvaluatorUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		iss            []imageapi.ImageStream
+		ist            imageapi.ImageStreamTag
+		expectedImages int64
+	}{
+		{
+			name: "empty image stream",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "is",
+					},
+					Status: imageapi.ImageStreamStatus{},
+				},
+			},
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is:dest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "dest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamImage",
+						Namespace: "shared",
+						Name:      "is@" + miscImageDigest,
+					},
+				},
+			},
+			expectedImages: 1,
+		},
+
+		{
+			name: "no image stream",
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is:dest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "dest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamImage",
+						Namespace: "shared",
+						Name:      "is@" + miscImageDigest,
+					},
+				},
+			},
+			expectedImages: 1,
+		},
+
+		{
+			name: "no image stream using image stream tag",
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is:dest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "dest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "shared",
+						Name:      "is:latest",
+					},
+				},
+			},
+			expectedImages: 1,
+		},
+
+		{
+			name: "no tag given",
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is:dest",
+				},
+				Image: imageapi.Image{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:        miscImageDigest,
+						Annotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+					},
+					DockerImageReference: fmt.Sprintf("registry.example.org/%s/%s@%s", "shared", "is", miscImageDigest),
+					DockerImageManifest:  miscImageDigest,
+				},
+			},
+			expectedImages: 0,
+		},
+
+		{
+			name: "missing from",
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "is:dest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "dest",
+				},
+				Image: imageapi.Image{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:        miscImageDigest,
+						Annotations: map[string]string{imageapi.ManagedByOpenShiftAnnotation: "true"},
+					},
+					DockerImageReference: fmt.Sprintf("registry.example.org/%s/%s@%s", "test", "dest", miscImageDigest),
+					DockerImageManifest:  miscImage,
+				},
+			},
+			expectedImages: 0,
+		},
+
+		{
+			name: "update existing tag",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "havingtag",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/havingtag@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "havingtag:latest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "latest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamImage",
+						Namespace: "shared",
+						Name:      "is@" + childImageWith2LayersDigest,
+					},
+				},
+			},
+			expectedImages: 1,
+		},
+
+		{
+			name: "add a new tag with with 2 image streams",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "destis",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/destis@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", miscImageDigest),
+										Image:                miscImageDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "other",
+						Name:      "is2",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", baseImageWith2LayersDigest),
+										Image:                baseImageWith2LayersDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "destis:latest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "latest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "other",
+						Name:      "is2:latest",
+					},
+				},
+			},
+			expectedImages: 1,
+		},
+
+		{
+			name: "tag an image already present using image stream image",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "destis",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/destis@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", miscImageDigest),
+										Image:                miscImageDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "destis:latest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "latest",
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamImage",
+						Namespace: "shared",
+						Name:      "is@" + baseImageWith1LayerDigest,
+					},
+				},
+			},
+			expectedImages: 0,
+		},
+
+		{
+			name: "tag an image already present using image stream tag",
+			iss: []imageapi.ImageStream{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "test",
+						Name:      "destis",
+					},
+					Status: imageapi.ImageStreamStatus{
+						Tags: map[string]imageapi.TagEventList{
+							"latest": {
+								Items: []imageapi.TagEvent{
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/destis@%s", baseImageWith1LayerDigest),
+										Image:                baseImageWith1LayerDigest,
+									},
+									{
+										DockerImageReference: fmt.Sprintf("172.30.12.34:5000/test/is2@%s", miscImageDigest),
+										Image:                miscImageDigest,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ist: imageapi.ImageStreamTag{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "test",
+					Name:      "another:latest",
+				},
+				Tag: &imageapi.TagReference{
+					Name: "latest",
+					// shared is has name of baseImageWith1Layer at the first place in event list
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "shared",
+						Name:      "is:latest",
+					},
+				},
+			},
+			expectedImages: 0,
+		},
+	} {
+
+		fakeClient := &testclient.Fake{}
+		fakeClient.AddReactor("get", "images", getFakeImageGetHandler(t, "ns"))
+		fakeClient.AddReactor("get", "imagestreams", getFakeImageStreamGetHandler(t, tc.iss...))
+		fakeClient.AddReactor("list", "imagestreams", getFakeImageStreamListHandler(t, tc.iss...))
+		fakeClient.AddReactor("get", "imagestreamimages", getFakeImageStreamImageGetHandler(t, tc.iss...))
+
+		evaluator := NewImageStreamTagEvaluator(fakeClient)
+
+		usage := evaluator.Usage(&tc.ist)
+
+		expectedUsage := kapi.ResourceList{
+			imageapi.ResourceImages: *resource.NewQuantity(tc.expectedImages, resource.DecimalSI),
+		}
+
+		if len(usage) != len(expectedUsage) {
+			t.Errorf("[%s]: got unexpected number of computed resources: %d != %d", tc.name, len(usage), len(expectedResources))
+		}
+
+		masked := kquota.Mask(usage, expectedResources)
+
+		if len(masked) != len(expectedUsage) {
+			for k := range usage {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: got unexpected resource %q from Usage() method", tc.name, k)
+				}
+			}
+
+			for k := range expectedUsage {
+				if _, exists := masked[k]; !exists {
+					t.Errorf("[%s]: expected resource %q not computed", tc.name, k)
+				}
+			}
+		}
+
+		for rname, expectedValue := range expectedUsage {
+			if v, exists := masked[rname]; exists {
+				if v.Cmp(expectedValue) != 0 {
+					t.Errorf("[%s]: got unexpected usage for %q: %s != %s", tc.name, rname, v.String(), expectedValue.String())
+				}
+			}
+		}
+	}
+}

--- a/pkg/quota/image/registry.go
+++ b/pkg/quota/image/registry.go
@@ -1,3 +1,13 @@
+// Package image implements evaluators of usage for images stored in an internal registry. They are supposed
+// to be passed to resource quota controller and origin resource quota admission plugin. As opposed to
+// kubernetes evaluators that can be used both with the controller and an admission plugin, these cannot.
+// That's because they're counting a number of unique images which aren't namespaced. In order to do that they
+// always need to enumerate all image streams in the project to see whether the newly tagged images are new to
+// the project or not. The resource quota controller iterates over them implicitly while the admission plugin
+// invokes the evaluator just once on a single object. Thus different usage implementations.
+//
+// To instantiate a registry for use with the resource quota controller, use NewImageRegistry. To instantiate a
+// registry for use with the origin resource quota admission plugin, use NewImageRegistryForAdmission.
 package image
 
 import (
@@ -8,15 +18,32 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 )
 
-// NewImageRegistry returns a registry for quota evaluation of OpenShift resources related to images and image
-// streams.
+// NewImageRegistry returns a registry for quota evaluation of OpenShift resources related to images in
+// internal registry. It evaluates only image streams. This registry is supposed to be used with resource
+// quota controller. Contained evaluators aren't usable for admission because they assume the Usage method to
+// be called on all images in the project.
 func NewImageRegistry(osClient osclient.Interface) quota.Registry {
 	imageStream := NewImageStreamEvaluator(osClient)
+	return &generic.GenericRegistry{
+		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
+			imageStream.GroupKind(): imageStream,
+		},
+	}
+}
+
+// NewImageRegistryForAdmission returns a registry for quota evaluation of OpenShift resources related to
+// images in internal registry. Returned registry is supposed to be used with origin resource quota admission
+// plugin. It evaluates image streams, image stream mappings and image stream tags. It cannot be passed to
+// resource quota controller because contained evaluators return just usage increments.
+func NewImageRegistryForAdmission(osClient osclient.Interface) quota.Registry {
+	imageStream := NewImageStreamAdmissionEvaluator(osClient)
 	imageStreamMapping := NewImageStreamMappingEvaluator(osClient)
+	imageStreamTag := NewImageStreamTagEvaluator(osClient)
 	return &generic.GenericRegistry{
 		InternalEvaluators: map[unversioned.GroupKind]quota.Evaluator{
 			imageStream.GroupKind():        imageStream,
 			imageStreamMapping.GroupKind(): imageStreamMapping,
+			imageStreamTag.GroupKind():     imageStreamTag,
 		},
 	}
 }

--- a/pkg/quota/image/usage.go
+++ b/pkg/quota/image/usage.go
@@ -1,8 +1,11 @@
 package image
 
 import (
+	"fmt"
 	"github.com/golang/glog"
+	"strings"
 
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/util/sets"
 
@@ -10,139 +13,400 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-// GetImageStreamSize computes a sum of sizes of image layers occupying given image stream. Each layer
-// is added just once even if it occurs in multiple images.
-func GetImageStreamSize(osClient osclient.Interface, is *imageapi.ImageStream, imageCache map[string]*imageapi.Image) *resource.Quantity {
-	size := resource.NewQuantity(0, resource.BinarySI)
+// internalRegistryNames is a set of all registry names referencing internal docker registry.
+var internalRegistryNames sets.String
 
-	processedImages := make(map[string]sets.Empty)
-	processedLayers := make(map[string]sets.Empty)
-
-	for _, history := range is.Status.Tags {
-		for i := range history.Items {
-			imgName := history.Items[i].Image
-			if len(history.Items[i].DockerImageReference) == 0 || len(imgName) == 0 {
-				continue
-			}
-
-			if _, exists := processedImages[imgName]; exists {
-				continue
-			}
-			processedImages[imgName] = sets.Empty{}
-
-			img, exists := imageCache[imgName]
-			if !exists {
-				imi, err := osClient.ImageStreamImages(is.Namespace).Get(is.Name, imgName)
-				if err != nil {
-					glog.Errorf("Failed to get image %s of image stream %s/%s: %v", imgName, is.Namespace, is.Name, err)
-					continue
-				}
-				img = &imi.Image
-				imageCache[imgName] = img
-			}
-
-			if value, ok := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !ok || value != "true" {
-				glog.V(5).Infof("Image %q with DockerImageReference %q belongs to an external registry - skipping", img.Name, img.DockerImageReference)
-				continue
-			}
-
-			if len(img.DockerImageLayers) == 0 || img.DockerImageMetadata.Size == 0 {
-				if err := imageapi.ImageWithMetadata(img); err != nil {
-					glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", img.Name, img.DockerImageReference, err)
-					continue
-				}
-			}
-
-			for _, layer := range img.DockerImageLayers {
-				if _, ok := processedLayers[layer.Name]; ok {
-					continue
-				}
-				size.Add(*resource.NewQuantity(layer.Size, resource.BinarySI))
-				processedLayers[layer.Name] = sets.Empty{}
-			}
-		}
-	}
-
-	return size
+func init() {
+	internalRegistryNames = sets.NewString()
 }
 
-// GetImageStreamSizeIncrement computes a sum of sizes of image layers occupying given image stream.
-// Additionally it returns an increment which will be added to the size when the given image will be tagged
-// into the image stream. In case the is is nil, returned size will be 0 and returned increment will equal to
-// the image size.
-//
-// Size increment will always be less or equal to the image size. Less means, that some of image's layers are
-// already stored in a registry.
-func GetImageStreamSizeIncrement(osClient osclient.Interface, is *imageapi.ImageStream, image *imageapi.Image, imageCache map[string]*imageapi.Image) (isSize, sizeIncrement *resource.Quantity, err error) {
-	if len(image.DockerImageLayers) == 0 || image.DockerImageMetadata.Size == 0 {
-		if err = imageapi.ImageWithMetadata(image); err != nil {
-			glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", image.Name, image.DockerImageReference, err)
-			return nil, nil, err
+// GenericImageStreamUsageComputer allows to compute number of images stored
+// in an internal registry in particular namespace.
+type GenericImageStreamUsageComputer struct {
+	osClient osclient.Interface
+	// says whether to account for images stored in image stream's spec
+	processSpec bool
+	// Whether to verify that referenced image belongs to its supposed source image stream when fetching it
+	// from etcd. Set to true if the image stream corresponds to its counterpart stored in etcd.
+	fetchImagesFromImageStream bool
+	// maps image name to an image object. It holds only images stored in the registry to avoid multiple
+	// fetches of the same object.
+	imageCache map[string]*imageapi.Image
+	// maps image stream name prefixed by its namespace to the image stream object
+	imageStreamCache map[string]*imageapi.ImageStream
+}
+
+// NewGenericImageStreamUsageComputer returns an instance of GenericImageStreamUsageComputer.
+// Returned object can be used just once and must be thrown away afterwards.
+func NewGenericImageStreamUsageComputer(osClient osclient.Interface, processSpec bool, fetchImagesFromImageStream bool) *GenericImageStreamUsageComputer {
+	return &GenericImageStreamUsageComputer{
+		osClient,
+		processSpec,
+		fetchImagesFromImageStream,
+		make(map[string]*imageapi.Image),
+		make(map[string]*imageapi.ImageStream),
+	}
+}
+
+// GetImageStreamUsage counts number of unique internally managed images occupying given image stream. Each
+// Images given in processedImages won't be taken into account. The set will be updated with new images found.
+func (c *GenericImageStreamUsageComputer) GetImageStreamUsage(
+	is *imageapi.ImageStream,
+	processedImages sets.String,
+) *resource.Quantity {
+	images := resource.NewQuantity(0, resource.DecimalSI)
+
+	c.processImageStreamImages(is, func(_, _ string, img *imageapi.Image) error {
+		if processedImages.Has(img.Name) {
+			return nil
 		}
+		processedImages.Insert(img.Name)
+		images.Set(images.Value() + 1)
+		return nil
+	})
+
+	return images
+}
+
+// GetProjectImagesUsage returns a number of internally managed images tagged in the given namespace.
+func (c *GenericImageStreamUsageComputer) GetProjectImagesUsage(namespace string) (*resource.Quantity, error) {
+	processedImages := sets.NewString()
+
+	iss, err := c.listImageStreams(namespace)
+	if err != nil {
+		return nil, err
 	}
-	isSize = resource.NewQuantity(0, resource.BinarySI)
-	if value, ok := image.Annotations[imageapi.ManagedByOpenShiftAnnotation]; ok && value == "true" {
-		sizeIncrement = resource.NewQuantity(image.DockerImageMetadata.Size, resource.BinarySI)
-	} else {
-		sizeIncrement = resource.NewQuantity(0, resource.BinarySI)
+
+	images := resource.NewQuantity(0, resource.DecimalSI)
+
+	for _, is := range iss.Items {
+		c.processImageStreamImages(&is, func(_, _ string, img *imageapi.Image) error {
+			if !processedImages.Has(img.Name) {
+				processedImages.Insert(img.Name)
+				images.Set(images.Value() + 1)
+			}
+			return nil
+		})
 	}
-	if is == nil {
+
+	return images, err
+}
+
+// GetProjectImagesUsageIncrement computes image count in the namespace for given image
+// stream (new or updated) and new image. It returns:
+//
+//  1. number of images currently tagged in the namespace; the image and images tagged in the given is don't
+//     count unless they are tagged in other is as well
+//  2. number of new internally managed images referenced either by the is or by the image
+//  3. an error if something goes wrong
+func (c *GenericImageStreamUsageComputer) GetProjectImagesUsageIncrement(
+	namespace string,
+	is *imageapi.ImageStream,
+	image *imageapi.Image,
+) (images, imagesIncrement *resource.Quantity, err error) {
+	processedImages := sets.NewString()
+
+	iss, err := c.listImageStreams(namespace)
+	if err != nil {
 		return
 	}
 
-	processedImages := make(map[string]sets.Empty)
-	processedLayers := make(map[string]sets.Empty)
+	imagesIncrement = resource.NewQuantity(0, resource.DecimalSI)
 
-	for _, history := range is.Status.Tags {
+	for _, imageStream := range iss.Items {
+		if is != nil && imageStream.Name == is.Name {
+			continue
+		}
+		c.processImageStreamImages(&imageStream, func(_, _ string, img *imageapi.Image) error {
+			processedImages.Insert(img.Name)
+			return nil
+		})
+	}
+
+	if is != nil {
+		c.processImageStreamImages(is, func(_, _ string, img *imageapi.Image) error {
+			if !processedImages.Has(img.Name) {
+				processedImages.Insert(img.Name)
+				imagesIncrement.Set(imagesIncrement.Value() + 1)
+			}
+			return nil
+		})
+	}
+
+	if image != nil && !processedImages.Has(image.Name) {
+		if value, ok := image.Annotations[imageapi.ManagedByOpenShiftAnnotation]; ok && value == "true" {
+			if !processedImages.Has(image.Name) {
+				imagesIncrement.Set(imagesIncrement.Value() + 1)
+			}
+		}
+	}
+
+	images = resource.NewQuantity(int64(len(processedImages)), resource.DecimalSI)
+
+	return
+}
+
+// processImageStreamImages is a utility method that calls a given handler for every image of the given image
+// stream that belongs to internal registry. It process image stream status and optionally spec.
+func (c *GenericImageStreamUsageComputer) processImageStreamImages(
+	is *imageapi.ImageStream,
+	handler func(tag string, dockerImageReference string, image *imageapi.Image) error,
+) error {
+	processedImages := sets.NewString()
+
+	for tag, history := range is.Status.Tags {
 		for i := range history.Items {
 			imageName := history.Items[i].Image
 			if len(history.Items[i].DockerImageReference) == 0 || len(imageName) == 0 {
 				continue
 			}
 
-			if _, exists := processedImages[imageName]; exists {
-				continue
+			var (
+				err error
+				img *imageapi.Image
+			)
+			if c.fetchImagesFromImageStream {
+				img, err = c.getImageStreamImage(is.Namespace, is.Name+"@"+imageName)
+				if err != nil {
+					glog.Errorf("Failed to get image %s of image stream %s/%s: %v", imageName, is.Namespace, is.Name, err)
+					continue
+				}
+			} else {
+				img, err = c.getImage(imageName)
+				if err != nil {
+					glog.Errorf("Failed to get image %s: %v", imageName, err)
+					continue
+				}
 			}
-			processedImages[imageName] = sets.Empty{}
 
-			imi, err2 := osClient.ImageStreamImages(is.Namespace).Get(is.Name, imageName)
-			if err2 != nil {
-				glog.Errorf("Failed to get image %s of image stream %s/%s: %v", image.Name, is.Namespace, is.Name, err2)
+			if processedImages.Has(imageName) {
+				glog.V(4).Infof("Skipping image %q - already processed", imageName)
 				continue
 			}
-			img := &imi.Image
+			processedImages.Insert(imageName)
 
 			if value, ok := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !ok || value != "true" {
 				glog.V(5).Infof("Image %q with DockerImageReference %q belongs to an external registry - skipping", img.Name, img.DockerImageReference)
 				continue
 			}
 
-			if len(img.DockerImageLayers) == 0 || img.DockerImageMetadata.Size == 0 {
-				if err2 := imageapi.ImageWithMetadata(img); err2 != nil {
-					glog.Errorf("Failed to parse metadata of image %q with DockerImageReference %q: %v", img.Name, img.DockerImageReference, err2)
-					continue
-				}
-			}
+			cacheInternalRegistryName(img.DockerImageReference)
 
-			for _, layer := range img.DockerImageLayers {
-				if _, exists := processedLayers[layer.Name]; exists {
-					continue
-				}
-				isSize.Add(*resource.NewQuantity(layer.Size, resource.BinarySI))
-				processedLayers[layer.Name] = sets.Empty{}
+			if err := handler(tag, history.Items[i].DockerImageReference, img); err != nil {
+				return err
 			}
 		}
 	}
 
-	for _, layer := range image.DockerImageLayers {
-		if _, exists := processedLayers[layer.Name]; exists {
-			sizeIncrement.Sub(*resource.NewQuantity(layer.Size, resource.BinarySI))
-			if sizeIncrement.Value() <= 0 {
-				sizeIncrement.Set(0)
-				break
+	if c.processSpec {
+		return c.processImageStreamSpecImages(is, processedImages, handler)
+	}
+
+	return nil
+}
+
+// processImageStreamSpecImages is a utility method that calls a given handler on every image of the given image
+// stream that belongs to internal registry. It process image stream's spec only.
+func (c *GenericImageStreamUsageComputer) processImageStreamSpecImages(
+	is *imageapi.ImageStream,
+	processedImages sets.String,
+	handler func(tag string, dockerImageReference string, image *imageapi.Image) error,
+) error {
+	for tag, tagRef := range is.Spec.Tags {
+		if tagRef.From == nil {
+			continue
+		}
+
+		ref, err := c.getImageReferenceForObjectReference(is.Namespace, tagRef.From)
+		if err != nil {
+			glog.V(4).Infof("Could not process object reference: %v", err)
+			continue
+		}
+
+		img, exists := c.imageCache[ref.ID]
+		if !exists {
+			if c.fetchImagesFromImageStream || len(ref.ID) == 0 {
+				if len(ref.ID) > 0 {
+					img, err = c.getImageStreamImage(ref.Namespace, is.Name+"@"+ref.ID)
+					if err != nil {
+						glog.Errorf("Failed to get image stream image %s/%s@%s: %v", ref.Namespace, ref.Name, ref.ID, err)
+						continue
+					}
+
+				} else {
+					tag = ref.Tag
+					if len(tag) == 0 {
+						tag = "latest"
+					}
+					ist, err2 := c.osClient.ImageStreamTags(ref.Namespace).Get(ref.Name, tag)
+					if err2 != nil {
+						glog.Errorf("Failed to get image stream tag %s/%s:%s: %v", ref.Namespace, ref.Name, tag, err2)
+						continue
+					}
+					img = &ist.Image
+					c.imageCache[ref.ID] = img
+				}
+
+			} else {
+				img, err = c.getImage(ref.ID)
+				if err != nil {
+					glog.Errorf("Failed to get image %s: %v", ref.ID, err)
+					continue
+				}
 			}
+		}
+
+		if processedImages.Has(img.Name) {
+			glog.V(4).Infof("Skipping image %q - already processed", img.Name)
+			continue
+		}
+		processedImages.Insert(img.Name)
+
+		if value, ok := img.Annotations[imageapi.ManagedByOpenShiftAnnotation]; !ok || value != "true" {
+			glog.V(4).Infof("Image %q with DockerImageReference %q belongs to an external registry - skipping", img.Name, img.DockerImageReference)
+			continue
+		}
+
+		cacheInternalRegistryName(img.DockerImageReference)
+
+		if err := handler(tag, img.DockerImageReference, img); err != nil {
+			return err
 		}
 	}
 
-	return
+	return nil
+}
+
+// getImageReferenceForObjectReference returns corresponding docker image reference for the given object
+// reference representing either an image stream image or image stream tag or docker image.
+func (c *GenericImageStreamUsageComputer) getImageReferenceForObjectReference(
+	namespace string,
+	objRef *kapi.ObjectReference,
+) (imageapi.DockerImageReference, error) {
+	switch objRef.Kind {
+	case "ImageStreamImage":
+		nameParts := strings.Split(objRef.Name, "@")
+		if len(nameParts) != 2 {
+			return imageapi.DockerImageReference{}, fmt.Errorf("failed to parse name of imageStreamImage %q", objRef.Name)
+		}
+		res, err := imageapi.ParseDockerImageReference(objRef.Name)
+		if err != nil {
+			return imageapi.DockerImageReference{}, err
+		}
+		if res.Namespace == "" {
+			res.Namespace = objRef.Namespace
+		}
+		if res.Namespace == "" {
+			res.Namespace = namespace
+		}
+		return res, nil
+
+	case "ImageStreamTag":
+		// This is really fishy. An admission check can be easily worked around by setting a tag reference
+		// to an ImageStreamTag with no or small image and then tagging a large image to the source tag.
+		// TODO: Shall we refuse an ImageStreamTag set in the spec if the quota is set?
+		nameParts := strings.Split(objRef.Name, ":")
+		if len(nameParts) != 2 {
+			return imageapi.DockerImageReference{}, fmt.Errorf("failed to parse name of imageStreamTag %q", objRef.Name)
+		}
+
+		ns := namespace
+		if len(objRef.Namespace) > 0 {
+			ns = objRef.Namespace
+		}
+
+		isName := nameParts[0]
+		is, err := c.getImageStream(ns, isName)
+		if err != nil {
+			return imageapi.DockerImageReference{}, fmt.Errorf("failed to get imageStream for ImageStreamTag %s/%s: %v", ns, objRef.Name, err)
+		}
+
+		event := imageapi.LatestTaggedImage(is, nameParts[1])
+		if event == nil || len(event.DockerImageReference) == 0 {
+			return imageapi.DockerImageReference{}, fmt.Errorf("%q is not currently pointing to an image, cannot use it as the source of a tag", objRef.Name)
+		}
+		return imageapi.ParseDockerImageReference(event.DockerImageReference)
+
+	case "DockerImage":
+		managedByOS, ref := imageReferenceBelongsToInternalRegistry(objRef.Name)
+		if !managedByOS {
+			return imageapi.DockerImageReference{}, fmt.Errorf("DockerImage %s does not belong to internal registry", objRef.Name)
+		}
+		return ref, nil
+	}
+
+	return imageapi.DockerImageReference{}, fmt.Errorf("unsupported object reference kind %s", objRef.Kind)
+}
+
+// getImageStream gets an image stream object from etcd and caches the result for the following queries.
+func (c *GenericImageStreamUsageComputer) getImageStream(namespace, name string) (*imageapi.ImageStream, error) {
+	key := fmt.Sprintf("%s/%s", namespace, name)
+	if is, exists := c.imageStreamCache[key]; exists {
+		return is, nil
+	}
+	is, err := c.osClient.ImageStreams(namespace).Get(name)
+	if err == nil {
+		c.imageStreamCache[key] = is
+	}
+	return is, err
+}
+
+// getImage gets image object from etcd and caches the result for the following queries.
+func (c *GenericImageStreamUsageComputer) getImage(name string) (*imageapi.Image, error) {
+	if image, exists := c.imageCache[name]; exists {
+		return image, nil
+	}
+	image, err := c.osClient.Images().Get(name)
+	if err == nil {
+		c.imageCache[name] = image
+	}
+	return image, err
+}
+
+// getImageStreamImage gets an image belonging to a given image stream object from etcd and caches the result for the following queries.
+func (c *GenericImageStreamUsageComputer) getImageStreamImage(namespace, name string) (*imageapi.Image, error) {
+	nameParts := strings.SplitN(name, "@", 2)
+	if len(nameParts) != 2 {
+		return nil, fmt.Errorf("failed to parse image stream image name %q, expected exactly one '@'", name)
+	}
+	image, exists := c.imageCache[nameParts[1]]
+	if exists {
+		return image, nil
+	}
+	isi, err := c.osClient.ImageStreamImages(namespace).Get(nameParts[0], nameParts[1])
+	if err == nil {
+		image = &isi.Image
+		c.imageCache[name] = image
+	}
+	return image, err
+}
+
+// listImageStreams returns a list of image streams of the given namespace and caches them for later access.
+func (c *GenericImageStreamUsageComputer) listImageStreams(namespace string) (*imageapi.ImageStreamList, error) {
+	iss, err := c.osClient.ImageStreams(namespace).List(kapi.ListOptions{})
+	if err == nil {
+		for _, is := range iss.Items {
+			c.imageStreamCache[fmt.Sprintf("%s/%s", namespace, is.Name)] = &is
+		}
+	}
+	return iss, err
+}
+
+// cacheInternalRegistryName caches registry name of the given docker image reference of an image stored in an
+// internal registry.
+func cacheInternalRegistryName(dockerImageReference string) {
+	ref, err := imageapi.ParseDockerImageReference(dockerImageReference)
+	if err == nil && len(ref.Registry) > 0 {
+		internalRegistryNames.Insert(ref.Registry)
+	}
+}
+
+// imageReferenceBelongsToInternalRegistry returns true if the given docker image reference refers to an
+// image in an internal registry.
+func imageReferenceBelongsToInternalRegistry(dockerImageReference string) (bool, imageapi.DockerImageReference) {
+	ref, err := imageapi.ParseDockerImageReference(dockerImageReference)
+	if err != nil || len(ref.Registry) == 0 || len(ref.Namespace) == 0 || len(ref.Name) == 0 {
+		return false, ref
+	}
+	return internalRegistryNames.Has(ref.Registry), ref
 }

--- a/pkg/quota/registry.go
+++ b/pkg/quota/registry.go
@@ -8,6 +8,13 @@ import (
 )
 
 // NewRegistry returns a registry object that knows how to evaluate quota usage of OpenShift resources.
-func NewRegistry(osClient osclient.Interface) kquota.Registry {
-	return image.NewImageRegistry(osClient)
+// Registry for resource quota controller cannot be used with resource quota admission plugin and
+// vice versa. If the registry will be used in admission plugin, pass true to forAdmission.
+// See a package documentation of pkg/quota/image for more details.
+func NewRegistry(osClient osclient.Interface, forAdmission bool) kquota.Registry {
+	if forAdmission {
+		return image.NewImageRegistryForAdmission(osClient)
+	} else {
+		return image.NewImageRegistry(osClient)
+	}
 }

--- a/pkg/quota/util/sharedcontextevaluator.go
+++ b/pkg/quota/util/sharedcontextevaluator.go
@@ -29,6 +29,7 @@ func NewSharedContextEvaluator(
 	name string,
 	groupKind unversioned.GroupKind,
 	operationResources map[admission.Operation][]kapi.ResourceName,
+	matchedResourceNames []kapi.ResourceName,
 	matchesScopeFunc generic.MatchesScopeFunc,
 	getFuncByNamespace generic.GetFuncByNamespace,
 	listFuncByNamespace generic.ListFuncByNamespace,
@@ -40,13 +41,10 @@ func NewSharedContextEvaluator(
 	for _, resourceNames := range operationResources {
 		rnSet.Insert(quota.ToSet(resourceNames).List()...)
 	}
-	matchedResourceNames := make([]kapi.ResourceName, 0, len(rnSet))
-	for resourceName := range rnSet {
-		matchedResourceNames = append(matchedResourceNames, kapi.ResourceName(resourceName))
-	}
 
 	return &SharedContextEvaluator{
 		GenericEvaluator: &generic.GenericEvaluator{
+			Name:                       name,
 			InternalGroupKind:          groupKind,
 			InternalOperationResources: operationResources,
 			MatchedResourceNames:       matchedResourceNames,

--- a/test/extended/images/quota_admission.go
+++ b/test/extended/images/quota_admission.go
@@ -6,35 +6,26 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/quota"
+	kerrutil "k8s.io/kubernetes/pkg/util/errors"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	exutil "github.com/openshift/origin/test/extended/util"
-	testutil "github.com/openshift/origin/test/util"
 )
 
 const (
-	// There are coefficients used to multiply layer data size to get a rough size of uploaded blob.
-	layerSizeMultiplierForDocker18     = 2.0
-	layerSizeMultiplierForLatestDocker = 0.8
+	imageSize = 100
 
-	imageSizeHardQuota        = "10000"
-	imageStreamSizeHardQuota  = "20000"
-	projectImageSizeHardQuota = "30000"
+	quotaName = "all-quota-set"
 
-	bigImageSize    = 14000
-	middleImageSize = 8000
-	tinyImageSize   = 1000
+	waitTimeout = time.Second * 5
 )
 
 var _ = g.Describe("[images] openshift image resource quota", func() {
@@ -47,18 +38,48 @@ var _ = g.Describe("[images] openshift image resource quota", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding quota"), func() {
+	g.AfterEach(func() {
+		g.By(fmt.Sprintf("Deleting quota %s", quotaName))
+		oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Delete(quotaName)
+
+		g.By("Deleting images")
+		iss, err := oc.AdminREST().ImageStreams(oc.Namespace()).List(kapi.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, is := range iss.Items {
+			for _, history := range is.Status.Tags {
+				for i := range history.Items {
+					oc.AdminREST().Images().Delete(history.Items[i].Image)
+				}
+			}
+			for _, tagRef := range is.Spec.Tags {
+				switch tagRef.From.Kind {
+				case "ImageStreamImage":
+					nameParts := strings.Split(tagRef.From.Name, "@")
+					if len(nameParts) != 2 {
+						continue
+					}
+					imageName := nameParts[1]
+					oc.AdminREST().Images().Delete(imageName)
+				}
+			}
+			err := oc.AdminREST().ImageStreams(is.Namespace).Delete(is.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("Deleting shared project")
+		oc.AdminREST().Projects().Delete(oc.Namespace() + "-shared")
+	})
+
+	g.It("should deny a push of image exceeding quota", func() {
 		oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 		rq := &kapi.ResourceQuota{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: "all-quota-set",
+				Name: quotaName,
 			},
 			Spec: kapi.ResourceQuotaSpec{
 				Hard: kapi.ResourceList{
-					imageapi.ResourceImageSize:         resource.MustParse(imageSizeHardQuota),
-					imageapi.ResourceImageStreamSize:   resource.MustParse(imageStreamSizeHardQuota),
-					imageapi.ResourceProjectImagesSize: resource.MustParse(projectImageSizeHardQuota),
+					imageapi.ResourceImages: resource.MustParse("0"),
 				},
 			},
 		}
@@ -66,78 +87,329 @@ var _ = g.Describe("[images] openshift image resource quota", func() {
 		g.By("resource quota needs to be created")
 		_, err := oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Create(rq)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		g.By("trying to push image exceeding imagesize quota")
-		buildImageOfSize(oc, "sized", "big", bigImageSize, 3, true)
+		g.By(fmt.Sprintf("trying to push image exceeding %s=%d quota", imageapi.ResourceImages, 0))
+		buildAndPushImage(oc, oc.Namespace(), "sized", "refused", true)
 
-		g.By("trying to push image below imagesize quota")
-		buildImageOfSize(oc, "sized", "middle", middleImageSize, 2, false)
-		expected := kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)}
-		used, err := waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		g.By(fmt.Sprintf("bump the %q quota to %d", imageapi.ResourceImages, 1))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("1")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("trying to push image below imagesize quota")
-		buildImageOfSize(oc, "sized", "middle2", middleImageSize, 2, false)
-		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
-		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		g.By(fmt.Sprintf("trying to push image below %s=%d quota", imageapi.ResourceImages, 1))
+		buildAndPushImage(oc, oc.Namespace(), "sized", "first", false)
+		used, err := waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to push image exceeding %s=%d quota", imageapi.ResourceImages, 1))
+		buildAndPushImage(oc, oc.Namespace(), "sized", "second", true)
+
+		g.By(fmt.Sprintf("trying to push image exceeding %s=%q quota to another repository", imageapi.ResourceImages, 1))
+		buildAndPushImage(oc, oc.Namespace(), "other", "third", true)
+
+		g.By(fmt.Sprintf("bump the %q quota to %d", imageapi.ResourceImages, 2))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("2")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("trying to push image exceeding imagestreamsize quota")
-		buildImageOfSize(oc, "sized", "middle3", middleImageSize, 2, true)
-
-		g.By("trying to push image below imagestreamsize quota")
-		buildImageOfSize(oc, "sized", "tiny", tinyImageSize, 1, false)
-		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(tinyImageSize/2, resource.BinarySI)})
-		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		g.By(fmt.Sprintf("trying to push image below %s=%d quota", imageapi.ResourceImages, 2))
+		buildAndPushImage(oc, oc.Namespace(), "other", "second", false)
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
 
-		g.By("trying to push image below projectimagessize quota")
-		buildImageOfSize(oc, "other", "middle", middleImageSize, 2, false)
-		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
-		used, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By(fmt.Sprintf("trying to push image exceeding %s=%d quota", imageapi.ResourceImages, 2))
+		buildAndPushImage(oc, oc.Namespace(), "other", "refused", true)
 
-		g.By("trying to push image exceeding projectimagessize quota")
-		buildImageOfSize(oc, "other", "middle2", middleImageSize, 2, true)
+		g.By(fmt.Sprintf("trying to push image exceeding %s=%d quota to a new repository", imageapi.ResourceImages, 2))
+		buildAndPushImage(oc, oc.Namespace(), "new", "refused", true)
 
-		expected = quota.Subtract(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
-		g.By("removing image sized:middle")
-		err = oc.REST().ImageStreamTags(oc.Namespace()).Delete("sized", "middle")
+		g.By("removing image sized:first")
+		err = oc.REST().ImageStreamTags(oc.Namespace()).Delete("sized", "first")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// expect usage decrement
 		used, err = exutil.WaitForResourceQuotaSync(
 			oc.KubeREST().ResourceQuotas(oc.Namespace()),
-			"all-quota-set",
-			expected,
+			quotaName,
+			kapi.ResourceList{imageapi.ResourceImages: resource.MustParse("1")},
 			true,
-			time.Second*5,
-		)
+			time.Second*5)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("trying to re-push the image")
-		buildImageOfSize(oc, "sized", "reloaded", middleImageSize, 2, false)
-		expected = quota.Add(used, kapi.ResourceList{imageapi.ResourceProjectImagesSize: *resource.NewQuantity(middleImageSize/2, resource.BinarySI)})
-		_, err = waitForResourceQuotaSync(oc, "all-quota-set", expected)
+		g.By(fmt.Sprintf("trying to push image below %s=%d quota", imageapi.ResourceImages, 2))
+		buildAndPushImage(oc, oc.Namespace(), "sized", "foo", false)
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should deny a tagging of an image exceeding quota", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		projectName := oc.Namespace()
+		sharedProjectName := projectName + "-shared"
+		g.By(fmt.Sprintf("create a new project %s to store shared images", sharedProjectName))
+		err := oc.Run("new-project").Args(sharedProjectName).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.SetNamespace(sharedProjectName)
+
+		tag2Image := make(map[string]imageapi.Image)
+		for i := 1; i <= 5; i++ {
+			tag := fmt.Sprintf("%d", i)
+			buildAndPushImage(oc, sharedProjectName, "src", tag, false)
+			ist, err := oc.REST().ImageStreamTags(sharedProjectName).Get("src", tag)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			tag2Image[tag] = ist.Image
+		}
+
+		g.By(fmt.Sprintf("switch back to the original project %s", projectName))
+		err = oc.Run("project").Args(projectName).Execute()
+		oc.SetNamespace(projectName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rq := &kapi.ResourceQuota{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: quotaName,
+			},
+			Spec: kapi.ResourceQuotaSpec{Hard: kapi.ResourceList{imageapi.ResourceImages: resource.MustParse("0")}},
+		}
+
+		g.By(fmt.Sprintf("creating resource quota with a limit %s=%d", imageapi.ResourceImages, 0))
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Create(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+
+		g.By("waiting for resource quota to get in sync")
+		err = waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to tag an image exceeding %s=%d quota", imageapi.ResourceImages, 0))
+		out, err := oc.Run("tag").Args(sharedProjectName+"/src:1", "is:1").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).Should(o.MatchRegexp("(?i)exceeded quota"))
+		o.Expect(out).Should(o.ContainSubstring(string(imageapi.ResourceImages)))
+
+		g.By(fmt.Sprintf("bump the %s quota to %d", imageapi.ResourceImages, 1))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("1")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to tag an image below %s=%d quota", imageapi.ResourceImages, 1))
+		out, err = oc.Run("tag").Args(sharedProjectName+"/src:1", "is:1").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err := waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to tag an image exceeding %s=%d quota", imageapi.ResourceImages, 1))
+		out, err = oc.Run("tag").Args(sharedProjectName+"/src:2", "is:2").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).Should(o.MatchRegexp("(?i)exceeded quota"))
+		o.Expect(out).Should(o.ContainSubstring(string(imageapi.ResourceImages)))
+
+		g.By("re-tagging the image under different tag")
+		out, err = oc.Run("tag").Args(sharedProjectName+"/src:1", "is:1again").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("bump the %s quota to %d", imageapi.ResourceImages, 2))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("2")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to alias tag a second image below %s=%d quota", imageapi.ResourceImages, 2))
+		out, err = oc.Run("tag").Args("--alias", "--source=istag", sharedProjectName+"/src:2", "other:2").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to alias tag a second image exceeding %s=%d quota", imageapi.ResourceImages, 2))
+		out, err = oc.Run("tag").Args("--alias", "--source=istag", sharedProjectName+"/src:3", "other:3").Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(out).Should(o.MatchRegexp("(?i)exceeded quota"))
+		o.Expect(out).Should(o.ContainSubstring(string(imageapi.ResourceImages)))
+
+		g.By("re-tagging the image under different tag")
+		out, err = oc.Run("tag").Args("--alias", "--source=istag", sharedProjectName+"/src:2", "another:2again").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("bump the %s quota to %d", imageapi.ResourceImages, 3))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("3")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to create ImageStreamTag referencing isimage below %s=%d limit", imageapi.ResourceImages, 3))
+		ist := &imageapi.ImageStreamTag{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "dest:3",
+			},
+			Tag: &imageapi.TagReference{
+				Name: "3",
+				From: &kapi.ObjectReference{
+					Kind:      "ImageStreamImage",
+					Namespace: sharedProjectName,
+					Name:      "src@" + tag2Image["3"].Name,
+				},
+			},
+		}
+		ist, err = oc.REST().ImageStreamTags(oc.Namespace()).Update(ist)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to create ImageStreamTag referencing isimage exceeding %s=%d quota", imageapi.ResourceImages, 3))
+		ist = &imageapi.ImageStreamTag{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "dest:4",
+			},
+			Tag: &imageapi.TagReference{
+				Name: "4",
+				From: &kapi.ObjectReference{
+					Kind:      "ImageStreamImage",
+					Namespace: sharedProjectName,
+					Name:      "src@" + tag2Image["4"].Name,
+				},
+			},
+		}
+		_, err = oc.REST().ImageStreamTags(oc.Namespace()).Update(ist)
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(err.Error()).Should(o.MatchRegexp("(?i)exceeded quota"))
+
+		g.By(fmt.Sprintf("bump the %s quota to %d", imageapi.ResourceImages, 4))
+		rq, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Get(quotaName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rq.Spec.Hard[imageapi.ResourceImages] = resource.MustParse("4")
+		_, err = oc.AdminKubeREST().ResourceQuotas(oc.Namespace()).Update(rq)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForLimitSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to create ImageStreamTag referencing istag below %s=%d limit", imageapi.ResourceImages, 4))
+		ist = &imageapi.ImageStreamTag{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "dest:4",
+			},
+			Tag: &imageapi.TagReference{
+				Name: "4",
+				From: &kapi.ObjectReference{
+					Kind:      "ImageStreamTag",
+					Namespace: sharedProjectName,
+					Name:      "src:4",
+				},
+			},
+		}
+		ist, err = oc.REST().ImageStreamTags(oc.Namespace()).Update(ist)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to create ImageStreamTag referencing istag exceeding %s=%d quota", imageapi.ResourceImages, 4))
+		ist = &imageapi.ImageStreamTag{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "dest:5",
+			},
+			Tag: &imageapi.TagReference{
+				Name: "5",
+				From: &kapi.ObjectReference{
+					Kind:      "ImageStreamTag",
+					Namespace: sharedProjectName,
+					Name:      "src:5",
+				},
+			},
+		}
+		_, err = oc.REST().ImageStreamTags(oc.Namespace()).Update(ist)
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(err.Error()).Should(o.MatchRegexp("(?i)exceeded quota"))
+
+		/** Test referencing using DockerImage.
+		 *
+		 * TODO: this is now failing during the image import with following status:
+		 *   Reason:"Unauthorized", Message:"you may not have access to the Docker image \"172.30.163.69:5000/extended-test-imagequota-admission-6znr2-shared/src@sha256:bb08da7a0b99af72aebe0ead77009d28771a30dbe4d99f49bf3d29407c72e48f\""
+		 * Uncomment once resolved (issue #7985).
+		 * The import seems to be working when the source and destination namespaces are the same.
+
+		g.By(fmt.Sprintf("trying to tag a docker image below %s=%d quota", imageapi.ResourceImages, 3))
+		err = oc.Run("import-image").Args("stream:dockerimage", "--confirm", "--insecure", "--from", name2Image["3"].DockerImageReference).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("trying to tag a docker image exceeding %s=%d quota", imageapi.ResourceImages, 3))
+		err = waitForAnImageStreamTag(oc, "stream", "dockerimage")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		is, err := oc.REST().ImageStreams(oc.Namespace()).Get("stream")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		is.Spec.Tags["foo"] = imageapi.TagReference{
+			Name: "foo",
+			From: &kapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: name2Image["4"].DockerImageReference,
+			},
+			ImportPolicy: imageapi.TagImportPolicy{
+				Insecure: true,
+			},
+		}
+		_, err = oc.REST().ImageStreams(oc.Namespace()).Update(is)
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(kerrors.IsForbidden(err)).To(o.Equal(true))
+
+		g.By("re-tagging the image under different tag")
+		is, err = oc.REST().ImageStreams(oc.Namespace()).Get("stream")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		is.Spec.Tags["duplicate"] = imageapi.TagReference{
+			Name: "duplicate",
+			From: &kapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: name2Image["3"].DockerImageReference,
+			},
+			ImportPolicy: imageapi.TagImportPolicy{
+				Insecure: true,
+			},
+		}
+		_, err = oc.REST().ImageStreams(oc.Namespace()).Update(is)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForAnImageStreamTag(oc, "stream", "duplicate")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		used, err = waitForResourceQuotaSync(oc, quotaName, rq.Spec.Hard)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(assertQuotasEqual(used, rq.Spec.Hard)).NotTo(o.HaveOccurred())
+		*/
 	})
 })
 
-// buildImageOfSize tries to build an image of wanted size and number of layers. Built image is stored as an
-// image stream tag <name>:<tag>. If shouldBeDenied is true, a build will be expected to fail with a denied
-// error. Note the size is only approximate. Resulting image size will be different depending on used
-// compression algorithm and metadata overhead.
-func buildImageOfSize(oc *exutil.CLI, name, tag string, size uint64, numberOfLayers int, shouldBeDenied bool) {
+// buildAndPushImage tries to build an image. The image is stored as an image stream tag <name>:<tag>. If
+// shouldBeDenied is true, a build will be expected to fail with a denied error.
+func buildAndPushImage(oc *exutil.CLI, namespace, name, tag string, shouldBeDenied bool) {
 	istName := name
 	if tag != "" {
 		istName += ":" + tag
 	}
-	g.By(fmt.Sprintf("building an image %q of size %d", istName, size))
+	g.By(fmt.Sprintf("building an image %q", istName))
 
-	bc, err := oc.REST().BuildConfigs(oc.Namespace()).Get(name)
+	bc, err := oc.REST().BuildConfigs(namespace).Get(name)
 	if err == nil {
 		g.By(fmt.Sprintf("changing build config %s to store result into %s", name, istName))
 		o.Expect(bc.Spec.BuildSpec.Output.To.Kind).To(o.Equal("ImageStreamTag"))
 		bc.Spec.BuildSpec.Output.To.Name = istName
-		_, err := oc.REST().BuildConfigs(oc.Namespace()).Update(bc)
+		_, err := oc.REST().BuildConfigs(namespace).Update(bc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	} else {
 		g.By(fmt.Sprintf("creating a new build config %s with output to %s ", name, istName))
@@ -151,17 +423,9 @@ func buildImageOfSize(oc *exutil.CLI, name, tag string, size uint64, numberOfLay
 	tempDir, err := ioutil.TempDir("", "name-build")
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	dataSize := calculateRoughDataSize(size, numberOfLayers)
-
-	lines := make([]string, numberOfLayers+1)
-	lines[0] = "FROM scratch"
-	for i := 1; i <= numberOfLayers; i++ {
-		blobName := fmt.Sprintf("data%d", i)
-		err := createRandomBlob(path.Join(tempDir, blobName), dataSize)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		lines[i] = fmt.Sprintf("COPY %s /%s", blobName, blobName)
-	}
-	err = ioutil.WriteFile(path.Join(tempDir, "Dockerfile"), []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	err = createRandomBlob(path.Join(tempDir, "data"), imageSize)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = ioutil.WriteFile(path.Join(tempDir, "Dockerfile"), []byte("FROM scratch\nCOPY data /data\n"), 0644)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	err = oc.Run("start-build").Args(name, "--from-dir", tempDir, "--wait").Execute()
@@ -175,15 +439,41 @@ func buildImageOfSize(oc *exutil.CLI, name, tag string, size uint64, numberOfLay
 	}
 }
 
+// assertQuotasEqual compares two quota sets and returns an error with proper description when they don't match
+func assertQuotasEqual(a, b kapi.ResourceList) error {
+	errs := []error{}
+	if len(a) != len(b) {
+		errs = append(errs, fmt.Errorf("number of items does not match (%d != %d)", len(a), len(b)))
+	}
+
+	for k, av := range a {
+		if bv, exists := b[k]; exists {
+			if av.Cmp(bv) != 0 {
+				errs = append(errs, fmt.Errorf("a[%s] != b[%s] (%s != %s)", k, k, av.String(), bv.String()))
+			}
+		} else {
+			errs = append(errs, fmt.Errorf("resource %q not present in b", k))
+		}
+	}
+
+	for k := range b {
+		if _, exists := a[k]; !exists {
+			errs = append(errs, fmt.Errorf("resource %q not present in a", k))
+		}
+	}
+
+	return kerrutil.NewAggregate(errs)
+}
+
 // waitForResourceQuotaSync waits until a usage of a quota reaches given limit with a short timeout
 func waitForResourceQuotaSync(oc *exutil.CLI, name string, expectedResources kapi.ResourceList) (kapi.ResourceList, error) {
 	g.By(fmt.Sprintf("waiting for resource quota %s to get updated", name))
 	used, err := exutil.WaitForResourceQuotaSync(
 		oc.KubeREST().ResourceQuotas(oc.Namespace()),
-		"all-quota-set",
+		quotaName,
 		expectedResources,
 		false,
-		time.Second*5,
+		waitTimeout,
 	)
 	if err != nil {
 		return nil, err
@@ -191,8 +481,47 @@ func waitForResourceQuotaSync(oc *exutil.CLI, name string, expectedResources kap
 	return used, nil
 }
 
+// waitForAnImageStreamTag waits until an image stream with given name has non-empty history for given tag
+func waitForAnImageStreamTag(oc *exutil.CLI, name, tag string) error {
+	g.By(fmt.Sprintf("waiting for an is importer to import a tag %s into a stream %s", tag, name))
+	start := time.Now()
+	c := make(chan error)
+	go func() {
+		err := exutil.WaitForAnImageStream(
+			oc.REST().ImageStreams(oc.Namespace()),
+			name,
+			func(is *imageapi.ImageStream) bool {
+				if history, exists := is.Status.Tags[tag]; !exists || len(history.Items) == 0 {
+					return false
+				}
+				return true
+			},
+			func(is *imageapi.ImageStream) bool {
+				return time.Now().After(start.Add(waitTimeout))
+			})
+		c <- err
+	}()
+
+	select {
+	case e := <-c:
+		return e
+	case <-time.After(waitTimeout):
+		return fmt.Errorf("timed out while waiting of an image stream tag %s/%s:%s", oc.Namespace(), name, tag)
+	}
+}
+
+// waitForResourceQuotaSync waits until a usage of a quota reaches given limit with a short timeout
+func waitForLimitSync(oc *exutil.CLI, name string, hardLimit kapi.ResourceList) error {
+	g.By(fmt.Sprintf("waiting for resource quota %s to get updated", name))
+	return exutil.WaitForResourceQuotaLimitSync(
+		oc.KubeREST().ResourceQuotas(oc.Namespace()),
+		quotaName,
+		hardLimit,
+		waitTimeout)
+}
+
 // createRandomBlob creates a random data with bytes from `letters` in order to let docker take advantage of
-// compression
+// compression. Resulting layer size will be different due to file metadata overhead and compression.
 func createRandomBlob(dest string, size uint64) error {
 	var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
@@ -213,51 +542,4 @@ func createRandomBlob(dest string, size uint64) error {
 
 	f.Write(data)
 	return nil
-}
-
-// dockerVersion is a cached version string of Docker daemon
-var dockerVersion = ""
-
-// getDockerVersion returns a version of running Docker daemon which is questioned only during the first
-// invocation.
-func getDockerVersion() (major, minor int, version string, err error) {
-	reVersion := regexp.MustCompile(`^(\d+)\.(\d+)`)
-
-	if dockerVersion == "" {
-		client, err2 := testutil.NewDockerClient()
-		if err = err2; err != nil {
-			return
-		}
-		env, err2 := client.Version()
-		if err = err2; err != nil {
-			return
-		}
-		dockerVersion = env.Get("Version")
-		g.By(fmt.Sprintf("using docker version %s", version))
-	}
-	version = dockerVersion
-
-	matches := reVersion.FindStringSubmatch(version)
-	if len(matches) < 3 {
-		return 0, 0, "", fmt.Errorf("failed to parse version string %s", version)
-	}
-	major, _ = strconv.Atoi(matches[1])
-	minor, _ = strconv.Atoi(matches[2])
-	return
-}
-
-// calculateRoughDataSize returns a rough size of data blob to generate in order to build an image of wanted
-// size. Image is comprised of numberOfLayers layers of the same size.
-func calculateRoughDataSize(wantedImageSize uint64, numberOfLayers int) uint64 {
-	major, minor, version, err := getDockerVersion()
-	if err != nil {
-		g.By(fmt.Sprintf("failed to get docker version: %s", version))
-	}
-	if (major >= 1 && minor >= 9) || version == "" {
-		// running Docker version 1.9+
-		return uint64(float64(wantedImageSize) / (float64(numberOfLayers) * layerSizeMultiplierForLatestDocker))
-	}
-
-	// running Docker daemon < 1.9
-	return uint64(float64(wantedImageSize) / (float64(numberOfLayers) * layerSizeMultiplierForDocker18))
 }

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -302,7 +302,8 @@ func WaitForResourceQuotaSync(
 	name string,
 	expectedUsage kapi.ResourceList,
 	expectedIsUpperLimit bool,
-	timeout time.Duration) (kapi.ResourceList, error) {
+	timeout time.Duration,
+) (kapi.ResourceList, error) {
 
 	startTime := time.Now()
 	endTime := startTime.Add(timeout)
@@ -346,6 +347,74 @@ func WaitForResourceQuotaSync(
 		}
 	}
 	return nil, wait.ErrWaitTimeout
+}
+
+func isLimitSynced(received, expected kapi.ResourceList) bool {
+	resourceNames := quota.ResourceNames(expected)
+	masked := quota.Mask(received, resourceNames)
+	if len(masked) != len(expected) {
+		return false
+	}
+	if le, _ := quota.LessThanOrEqual(masked, expected); !le {
+		return false
+	}
+	if le, _ := quota.LessThanOrEqual(expected, masked); !le {
+		return false
+	}
+	return true
+}
+
+// WaitForResourceQuotaSync watches given resource quota until its hard limit is updated to match the desired
+// spec or timeout occurs.
+func WaitForResourceQuotaLimitSync(
+	client kclient.ResourceQuotaInterface,
+	name string,
+	hardLimit kapi.ResourceList,
+	timeout time.Duration,
+) error {
+
+	startTime := time.Now()
+	endTime := startTime.Add(timeout)
+
+	expectedResourceNames := quota.ResourceNames(hardLimit)
+
+	list, err := client.List(kapi.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector()})
+	if err != nil {
+		return err
+	}
+
+	for i := range list.Items {
+		used := quota.Mask(list.Items[i].Status.Hard, expectedResourceNames)
+		if isLimitSynced(used, hardLimit) {
+			return nil
+		}
+	}
+
+	rv := list.ResourceVersion
+	w, err := client.Watch(kapi.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector(), ResourceVersion: rv})
+	if err != nil {
+		return err
+	}
+	defer w.Stop()
+
+	for time.Now().Before(endTime) {
+		select {
+		case val, ok := <-w.ResultChan():
+			if !ok {
+				// reget and re-watch
+				continue
+			}
+			if rq, ok := val.Object.(*kapi.ResourceQuota); ok {
+				used := quota.Mask(rq.Status.Hard, expectedResourceNames)
+				if isLimitSynced(used, hardLimit) {
+					return nil
+				}
+			}
+		case <-time.After(endTime.Sub(time.Now())):
+			return wait.ErrWaitTimeout
+		}
+	}
+	return wait.ErrWaitTimeout
 }
 
 // CheckDeploymentCompletedFn returns true if the deployment completed


### PR DESCRIPTION
Covers:

- Removes size counting from quota evaluation
- `openshift.io/projectimagessize` removed completely
- `openshift.io/imagestreamsize` removed completely.
- `openshift.io/imagesize` removed from quota evaluation.
- Added a new resource `openshift.io/images` that allows to limit number of images tagged into a project.
- ~~Improves error messages of failed builds.~~

~~So instead of:~~

    Error: build error: Failed to push image: unknown: requested access to the resource is denied

~~It will now show:~~

    Error: build error: Failed to push image: Refusing to write blob exceeding quota: openshift.io/images limited to {4.000 DecimalSI} by {1.000 DecimalSI}~~

Improved error messages will come in another follow-up.

Does **NOT** cover:

- `openshift.io/imagesize` being checked in limit range admission plugin
- `openshift.io/imagesize` being checked in the registry

TODO:

- [x] - fix extended test
- [x] - remove `openshift.io/projectimagessize` as well