### PR TITLE
Handle env vars that use valueFrom

### DIFF
--- a/assets/app/views/directives/environment.html
+++ b/assets/app/views/directives/environment.html
@@ -1,10 +1,35 @@
 <div ng-if="envVars.length" class="table-responsive" style="margin-top: 5px;">
   <table class="table table-bordered environment-variables">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Value</th>
+      </tr>
+    </thead>
     <tbody>
       <tr ng-repeat="env in envVars">
         <td>{{env.name}}</td>
-        <td>
-          <truncate-long-text class="env-var-value" content="env.value" limit="200" newline-limit="3" expandable="true" prettify-json="true"></truncate-long-text>
+        <td ng-if="!env.valueFrom">
+            <truncate-long-text class="env-var-value" content="env.value" limit="200" newline-limit="3" expandable="true" prettify-json="true"></truncate-long-text>
+        </td>
+        <td ng-if="env.valueFrom">
+          <span class="fa fa-external-link-square" style="cursor: help;" data-toggle="popover" data-trigger="hover" data-content="This is a referenced value that will be generated when a container is created.  On running pods you can check the resolved values by going to the Terminal tab and echoing the environment variable."></span>
+          <span ng-repeat="(key, value) in env.valueFrom">
+            <span ng-switch on="key">
+              <span ng-switch-when="configMapKeyRef">
+                Set to the key <b>{{value.key}}</b> in secret <b>{{value.name}}</b>.
+              </span>
+              <span ng-switch-when="secretKeyRef">
+                Set to the key <b>{{value.key}}</b> in secret <b>{{value.name}}</b>.
+              </span>
+              <span ng-switch-when="fieldRef">
+                Set to the field <b>{{value.fieldPath}}</b> in the current object.
+              </span>
+              <span ng-switch-default>
+                Set to a reference on a <b>{{key}}</b>.
+              </span>
+            </span>
+          </span>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
When env vars have speciefied `valueFrom` instead of the `value` we need to render them as well in your `environments` directive.
Adding two proposed solutions that I've liked the most, but still not 100% sure about the solution. Think is that in case of the `configMapKeyRef` & `secretKeyRef` there could be more then 'key' and 'name' based on the https://github.com/kubernetes/kubernetes/blob/b45bf88105159cdbdd112e899bcb073e2b1ae573/pkg/api/types.go#L2048-L2050 so I didnt wanted to have a separate column for each field. On the other hand I wanted to stay by the table concept since the default original envVars are using it.
![screenshot-11](https://cloud.githubusercontent.com/assets/1668218/13678486/561cd842-e6ef-11e5-94aa-321cc7376c6a.png)
![screenshot-12](https://cloud.githubusercontent.com/assets/1668218/13678489/57d35f94-e6ef-11e5-8a27-498540c50e1e.png)
The code is not in the the best shape so for now please skip the code review.

@jwforres @spadgett @ajacobs21e thoughts?

closes https://github.com/openshift/origin/issues/7886