### PR TITLE
Allow unit testing packages under godeps

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -158,10 +158,16 @@ done
 gotest_flags+=" $*"
 
 # Determine packages to test
+godeps_package_prefix="Godeps/_workspace/src/"
 test_packages=
 if [[ -n "${package_args}" ]]; then
     for package in ${package_args}; do
-        test_packages="${test_packages} ${OS_GO_PACKAGE}/${package}"
+        # If we're trying to recursively test a package under Godeps, strip the Godeps prefix so go test can find the packages correctly
+        if [[ "${package}" == "${godeps_package_prefix}"*"/..." ]]; then
+            test_packages="${test_packages} ${package:${#godeps_package_prefix}}"
+        else
+            test_packages="${test_packages} ${OS_GO_PACKAGE}/${package}"
+        fi
     done
 else
     # If no packages are given to test, we need to generate a list of all packages with unit tests


### PR DESCRIPTION
If a path under Godeps/_workspace/src is passed, this will strip that prefix, rather than auto-adding the openshift package prefix

Allows 
```
hack/test-go.sh Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/... pkg/build/api/...
```