### PR TITLE
Increase sdn node provisioning timeout

### DIFF
--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -326,7 +326,7 @@ os::provision::wait-for-condition() {
   # condition should be a string that can be eval'd.  When eval'd, it
   # should not output anything to stderr or stdout.
   local condition=$2
-  local timeout=${3:-30}
+  local timeout=${3:-60}
 
   local start_msg="Waiting for ${msg}"
   local error_msg="[ERROR] Timeout waiting for ${msg}"


### PR DESCRIPTION
The post-merge ci job is failing some of the time due to the sdn node
not registering within 30s.  Increase the timeout to 60s in the hopes
that this will be enough to avoid job failure.