### PR TITLE
Minor fix to rsh usage

### DIFF
--- a/pkg/cmd/cli/cmd/rsh.go
+++ b/pkg/cmd/cli/cmd/rsh.go
@@ -62,7 +62,7 @@ func NewCmdRsh(name string, parent string, f *clientcmd.Factory, in io.Reader, o
 	}
 
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s POD [options] [COMMAND]", name),
+		Use:     fmt.Sprintf("%s [options] POD [COMMAND]", name),
 		Short:   "Start a shell session in a pod",
 		Long:    fmt.Sprintf(rshLong, parent),
 		Example: fmt.Sprintf(rshExample, parent+" "+name),

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -169,7 +169,7 @@ const (
 // NewCmdExec is a wrapper for the Kubernetes cli exec command
 func NewCmdExec(fullName string, f *clientcmd.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdExec(f.Factory, cmdIn, cmdOut, cmdErr)
-	cmd.Use = "exec POD [-c CONTAINER] [options] -- COMMAND [args...]"
+	cmd.Use = "exec [options] POD [-c CONTAINER] -- COMMAND [args...]"
 	cmd.Long = execLong
 	cmd.Example = fmt.Sprintf(execExample, fullName)
 	return cmd

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -48,8 +48,8 @@ os::cmd::expect_success_and_text 'oadm' 'Basic Commands:'
 os::cmd::expect_success_and_text 'oadm' 'Install Commands:'
 os::cmd::expect_success_and_text 'oadm ca' 'Manage certificates'
 os::cmd::expect_success_and_text 'openshift start kubernetes' 'Kubernetes server components'
-os::cmd::expect_success_and_text 'oc exec --help' '\[options\] \-\- COMMAND \[args\.\.\.\]$'
-os::cmd::expect_success_and_text 'oc rsh --help' '\[options\] \[COMMAND\]$'
+os::cmd::expect_success_and_text 'oc exec --help' '\[options\] POD \[\-c CONTAINER\] \-\- COMMAND \[args\.\.\.\]$'
+os::cmd::expect_success_and_text 'oc rsh --help' '\[options\] POD \[COMMAND\]$'
 
 # check deprecated admin cmds for backward compatibility
 os::cmd::expect_success_and_text 'oadm create-master-certs -h' 'Create keys and certificates'


### PR DESCRIPTION
`oc rsh` can't take options after the pod argument.