### PR TITLE
improve systemd unit ordering

### DIFF
--- a/contrib/systemd/atomic-openshift-master.service
+++ b/contrib/systemd/atomic-openshift-master.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Atomic OpenShift Master
 Documentation=https://github.com/openshift/origin
-After=network.target
+After=network-online.target
 After=etcd.service
 Before=atomic-openshift-node.service
-Requires=network.target
+Requires=network-online.target
 
 [Service]
 Type=notify

--- a/contrib/systemd/atomic-openshift-node.service
+++ b/contrib/systemd/atomic-openshift-node.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Atomic OpenShift Node
 After=docker.service
-After=atomic-openshift-master.service
+After=openvswitch.service
 Wants=docker.service
 Documentation=https://github.com/openshift/origin
 

--- a/contrib/systemd/containerized/openvswitch.service
+++ b/contrib/systemd/containerized/openvswitch.service
@@ -1,6 +1,7 @@
 [Unit]
 After=docker.service
 Requires=docker.service
+PartOf=docker.service
 
 [Service]
 ExecStartPre=-/usr/bin/docker rm -f openvswitch

--- a/contrib/systemd/containerized/origin-master.service
+++ b/contrib/systemd/containerized/origin-master.service
@@ -1,7 +1,9 @@
 [Unit]
 After=docker.service
 Before=origin-node.service
+PartOf=docker.service
 Requires=docker.service
+After=etcd.service
 
 
 [Service]
@@ -14,3 +16,4 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=origin-node.service

--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -2,8 +2,8 @@
 Requires=docker.service
 Wants=openvswitch.service
 After=docker.service
-After=origin-master.service
 After=openvswitch.service
+PartOf=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node

--- a/contrib/systemd/origin-master.service
+++ b/contrib/systemd/origin-master.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Origin Master Service
 Documentation=https://github.com/openshift/origin
-After=network.target
+After=network-online.target
 After=etcd.service
 Before=origin-node.service
-Requires=network.target
+Requires=network-online.target
 
 [Service]
 Type=notify

--- a/contrib/systemd/origin-node.service
+++ b/contrib/systemd/origin-node.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Origin Node
 After=docker.service
-After=origin-master.service
 Wants=docker.service
 Documentation=https://github.com/openshift/origin
 


### PR DESCRIPTION
- Use network-online.target instead of network.target
- Use Wants in node units instead of WantedBy in master units
- Remove node from Before in master units, since the nodes already have After
  for master units
- Add Wants for etcd service to master unit.