### PR TITLE
Bug fix for long, unbroken words that don't wrap in pod template

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -169,6 +169,10 @@
     border-radius: @border-radius-md;
     max-width: 600px;
     padding: 5px 10px;
+    // so that .word-break() on children works
+    [flex] {
+      min-width: 0;
+    }
     h4 {
       margin: 5px 0;
     }
@@ -176,6 +180,11 @@
       .word-break();
     }
   }
+}
+
+// so that .word-break() on children works
+.pod-template-column {
+  min-width: 0;
 }
 
 .pod-container-terminal {


### PR DESCRIPTION
Fixes #7932

After:

<img width="499" alt="screen shot 2016-03-11 at 11 30 34 am" src="https://cloud.githubusercontent.com/assets/895728/13708645/c1bc7c72-e77d-11e5-9a15-08aab2f3e78a.PNG">
<img width="328" alt="screen shot 2016-03-11 at 11 30 44 am" src="https://cloud.githubusercontent.com/assets/895728/13708646/c1bc8e74-e77d-11e5-8745-5462ba968fdc.PNG">

@spadgett, PTAL
