### PR TITLE
Export OS_OUTPUT_GOPATH=1 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@
 
 OUT_DIR = _output
 OUT_PKG_DIR = Godeps/_workspace/pkg
+OS_OUTPUT_GOPATH ?= 1
 
 export GOFLAGS
 export TESTFLAGS
+export OS_OUTPUT_GOPATH
 
 # Build code.
 #


### PR DESCRIPTION
As suggested in #7477, we set OS_OUTPUT_GOPATH=1 in make
so the 'old skool' build tools work as expected.