### PR TITLE
Include dockerImageManifest in the ImageStreamImage

### DIFF
--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -69,8 +69,6 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 	if err := api.ImageWithMetadata(image); err != nil {
 		return nil, err
 	}
-	image.DockerImageManifest = ""
-	image.DockerImageConfig = ""
 
 	isi := api.ImageStreamImage{
 		ObjectMeta: kapi.ObjectMeta{


### PR DESCRIPTION
This information is useful for users and not just admins. Interfaces use this info to render details about the layers that an image contains. Until this information is in another form it should be consistently visible with the ImageStreamImage.

Data needed per layer:
- The layer digest
- The size of the layer
- Description of what changed in the layer (eg: the DockerFile line for Docker image layers)
- Creation date of the layer

Justifications:
- Layer information is useful for users to identify, inspect images and the commonality between them. In Docker images (common) this information is currently represented in the `history[x].v1Compatibility` of the dockerImageManifest property of the Image kind.
- Users in roles other than "Cluster Admin" are (at least not by default) given access to list Image objects directly via the `/oapi/v1/images` endpoint. The layer information should be visible to people who don't have global access.

Example UI rendering this information:

![screenshot from 2016-03-10 07-29-40](https://cloud.githubusercontent.com/assets/795070/13661458/219d150c-e693-11e5-9b42-50977ef63c5b.png)
