### PR TITLE
[WIP] Update catalog builder image icon and text

### DIFF
--- a/assets/app/views/catalog/_image.html
+++ b/assets/app/views/catalog/_image.html
@@ -31,11 +31,11 @@
     <!-- Unset title attribute to prevent two tooltips. -->
     <div title="" ng-if="isBuilder">
       <i
-        class="pficon pficon-image tile-badge-icon"
+        class="fa fa-code tile-badge-icon"
         aria-hidden="true"
         data-toggle="tooltip"
-        data-original-title="Builder Image"></i>
-      <span class="sr-only">Builder Image</span>
+        data-original-title="Source Builder"></i>
+      <span class="sr-only">Source Builder</span>
     </div>
   </div>
 </div>

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -33,10 +33,10 @@
 
                 <!-- Show an abbreviated message if only non-builders exist in the project.
                      We show a link to view the non-builder images below. -->
-                <p ng-if="emptyCatalog && loaded && nonBuilderImages.length">No builder images or templates.</p>
+                <p ng-if="emptyCatalog && loaded && nonBuilderImages.length">No source builders or templates.</p>
 
                 <div ng-show="!emptyCatalog">
-                  <h1>Select Image or Template</h1>
+                  <h1>Add Components to Your Project</h1>
 
                   <div class="row">
                     <!-- Right padding to line up cleanly with the left column tiles. -->
@@ -91,7 +91,7 @@
                     <div class="col-sm-6 catalog-legend">
                       <dl aria-hidden="true" class="text-muted">
                         <dt>
-                          <i class="pficon pficon-image fa-fw"></i> Builder Image
+                          <i class="fa fa-code fa-fw"></i> Source Builder
                         </dt>
                         <dd>Builds images from source code in a Git repository.</dd>
                         <dt>
@@ -107,7 +107,7 @@
                   </div>
 
                   <div ng-if="filteredCategoryTags.length === 0 && !emptyCatalog && loaded" style="margin-top: 5px;">
-                    All builder images and templates are hidden by the current filter.
+                    All source builders and templates are hidden by the current filter.
                     <a href="" ng-click="filter.keyword = ''; filter.tag = ''">Clear filter</a>
                   </div>
 


### PR DESCRIPTION
Looking for opinions on this change. I'm trying to make it obvious what choices build source code in the web console catalog. Updates the icon and text. Thoughts?

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/13711313/d7fe2d42-e78b-11e5-9c7a-d880511abba2.png)

Also updates the catalog heading to what we decided in the design review. (@jhadvig is already using the new heading.)

@jwforres @bparees @smarterclayton @thesteve0 @sspeiche @jhadvig 

Before:

![screen shot 2016-03-11 at 1 14 24 pm](https://cloud.githubusercontent.com/assets/1167259/13711239/8d2a05f2-e78b-11e5-90ee-a23e949f4a1e.png)

After:

![screen shot 2016-03-11 at 1 26 41 pm](https://cloud.githubusercontent.com/assets/1167259/13711513/f8543e14-e78c-11e5-97c8-a52ae57b6bd8.png)

