### PR TITLE
[RPMS] Add extended.test to /usr/libexec/origin/extended.test

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -87,6 +87,13 @@ Obsoletes:      openshift-master < %{package_refector_version}
 %description master
 %{summary}
 
+%package tests
+Summary: %{product_name} Test Suite
+Requires:       %{name} = %{version}-%{release}
+
+%description tests
+%{summary}
+
 %package node
 Summary:        %{product_name} Node
 Requires:       %{name} = %{version}-%{release}
@@ -193,6 +200,7 @@ for cmd in oc openshift dockerregistry recycle
 do
         go install -ldflags "%{ldflags}" %{import_path}/cmd/${cmd}
 done
+go test -c -o _build/bin/extended.test -ldflags "%{ldflags}" %{import_path}/test/extended
 
 %if 0%{?make_redistributable}
 # Build clients for other platforms
@@ -215,6 +223,8 @@ do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _build/bin/${bin} %{buildroot}%{_bindir}/${bin}
 done
+install -d %{buildroot}%{_libexecdir}/%{name}
+install -p -m 755 _build/bin/extended.test %{buildroot}%{_libexecdir}/%{name}/
 
 %if 0%{?make_redistributable}
 # Install client executable for windows and mac
@@ -331,6 +341,10 @@ if [ -d "%{_sharedstatedir}/openshift" ]; then
     ln -s %{_sharedstatedir}/openshift %{_sharedstatedir}/origin
   fi
 fi
+
+%files tests
+%{_libexecdir}/%{name}
+%{_libexecdir}/%{name}/extended.test
 
 
 %files master


### PR DESCRIPTION
Ship this via a subpackage as it's a 69MiB binary