### PR TITLE
Add /version/openshift

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -43,7 +43,7 @@ var DiscoveryRule = PolicyRule{
 	Verbs: sets.NewString("get"),
 	NonResourceURLs: sets.NewString(
 		// Server version checking
-		"/version",
+		"/version", "/version/*",
 
 		// API discovery/negotiation
 		"/api", "/api/*",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1160,6 +1160,7 @@ items:
     - /osapi
     - /osapi/
     - /version
+    - /version/*
     resources: []
     verbs:
     - get
@@ -1705,6 +1706,7 @@ items:
     - /osapi
     - /osapi/
     - /version
+    - /version/*
     resources: []
     verbs:
     - get


### PR DESCRIPTION
Fixes #1828

Adds a `/version/openshift` endpoint to the server to report the openshift version.

@jwforres per-request
@openshift/api-review This is needed for PD and predictability purposes. It will allow us to properly report client-side which server-version we're interacting with and it allows for neat things like: "get this version of a client" or "do some other cool thing client-side with this knowledge".

I didn't have a good idea for the name of the endpoint.  Also, would we like our version reporting to be versioned in some way?