### PR TITLE
[WIP] F5: handle HTTP 409 responses gracefully

### DIFF
--- a/pkg/router/f5/f5.go
+++ b/pkg/router/f5/f5.go
@@ -494,13 +494,19 @@ func (f5 *f5LTM) ensurePolicyExists(policyName string) error {
 
 	err = f5.post(policiesUrl, policyPayload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error creating policy %s"+
+				" because it already exists (HTTP 409)."+
+				" Adding no-op rule...", policyName)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("Policy %s created.  Adding no-op rule...", policyName)
 	}
 
 	// We need a rule in the policy in order to be able to add the policy to the
 	// vservers, so create a no-op rule now.
-
-	glog.V(4).Infof("Policy %s created.  Adding no-op rule...", policyName)
 
 	rulesUrl := fmt.Sprintf("https://%s/mgmt/tm/ltm/policy/%s/rules",
 		f5.host, policyName)
@@ -511,10 +517,15 @@ func (f5 *f5LTM) ensurePolicyExists(policyName string) error {
 
 	err = f5.post(rulesUrl, rulesPayload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error adding no-op rule to policy %s"+
+				" because it already exists (HTTP 409).", policyName)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("No-op rule added to policy %s.", policyName)
 	}
-
-	glog.V(4).Infof("No-op rule added to policy %s.", policyName)
 
 	return nil
 }
@@ -554,10 +565,15 @@ func (f5 *f5LTM) ensureVserverHasPolicy(vserverName, policyName string) error {
 
 	err = f5.post(vserverPoliciesUrl, vserverPoliciesPayload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error adding policy %s to vserver %s"+
+				" because it already exists (HTTP 409).", policyName, vserverName)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("Policy %s added to vserver %s.", policyName, vserverName)
 	}
-
-	glog.V(4).Infof("Policy %s added to vserver %s.", policyName, vserverName)
 
 	return nil
 }
@@ -597,10 +613,15 @@ func (f5 *f5LTM) ensureDatagroupExists(datagroupName string) error {
 
 	err = f5.post(datagroupsUrl, datagroupPayload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error creating datagroup %s"+
+				" because it already exists (HTTP 409).", datagroupName)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("Datagroup %s created.", datagroupName)
 	}
-
-	glog.V(4).Infof("Datagroup %s created.", datagroupName)
 
 	return nil
 }
@@ -634,10 +655,15 @@ func (f5 *f5LTM) ensureIRuleExists(iRuleName, iRule string) error {
 
 	err = f5.post(iRulesUrl, iRulePayload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error creating iRule %s"+
+				" because it already exists (HTTP 409).", iRuleName)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("IRule %s created.", iRuleName)
 	}
-
-	glog.V(4).Infof("IRule %s created.", iRuleName)
 
 	return nil
 }
@@ -849,7 +875,14 @@ func (f5 *f5LTM) CreatePool(poolname string) error {
 
 	err := f5.post(url, payload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error creating pool %s"+
+				" because it already exists (HTTP 409).", poolname)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("Pool %s created.", poolname)
 	}
 
 	// We don't really need to initialise f5.poolMembers[poolname] because
@@ -857,8 +890,6 @@ func (f5 *f5LTM) CreatePool(poolname string) error {
 	// initialising it to an empty map here saves a REST call later the first
 	// time f5.PoolHasMember is invoked with poolname.
 	f5.poolMembers[poolname] = map[string]bool{}
-
-	glog.V(4).Infof("Pool %s created.", poolname)
 
 	return nil
 }
@@ -963,7 +994,14 @@ func (f5 *f5LTM) AddPoolMember(poolname, member string) error {
 
 	err = f5.post(url, payload, nil)
 	if err != nil {
-		return err
+		if err.(F5Error).httpStatusCode == 409 {
+			glog.Warningf("Error adding pool member %s to pool %s"+
+				" because it already exists (HTTP 409).", poolname, member)
+		} else {
+			return err
+		}
+	} else {
+		glog.V(4).Infof("Added pool member %s to pool %s.", member, poolname)
 	}
 
 	members, err := f5.GetPoolMembers(poolname)
@@ -972,9 +1010,6 @@ func (f5 *f5LTM) AddPoolMember(poolname, member string) error {
 	}
 
 	members[member] = true
-
-	glog.V(4).Infof("Added pool member %s to pool %s.",
-		member, poolname)
 
 	return nil
 }
@@ -1133,6 +1168,9 @@ func (f5 *f5LTM) addRoute(policyname, routename, poolname, hostname,
 
 	err = f5.post(conditionUrl, conditionPayload, nil)
 	if err != nil {
+		// We check for HTTP 409 elsewhere but here, even if we get a 409
+		// (indicating that the condition already exists), we cannot be sure that
+		// the condition is correct (because the name is simply "0").
 		return err
 	}
 
@@ -1151,6 +1189,10 @@ func (f5 *f5LTM) addRoute(policyname, routename, poolname, hostname,
 			conditionPayload.Values = []string{segment}
 			err = f5.post(conditionUrl, conditionPayload, nil)
 			if err != nil {
+				// We check for HTTP 409 elsewhere but here, even if we get a 409
+				// (indicating that the condition already exists), we cannot be sure
+				// that the condition is correct (because condition names are
+				// non-descriptive).
 				return err
 			}
 		}
@@ -1170,6 +1212,9 @@ func (f5 *f5LTM) addRoute(policyname, routename, poolname, hostname,
 
 	err = f5.post(actionUrl, actionPayload, nil)
 	if err != nil {
+		// We check for HTTP 409 elsewhere but here, even if we get a 409
+		// (indicating that the condition already exists), we cannot be sure that
+		// the action is correct (because the name is simply "0").
 		return err
 	}
 


### PR DESCRIPTION
Because of an API change between F5 BIG-IP 11.5 and 11.6, the existence checks for certain resources can return false negatives, in which case we will get HTTP 409 error responses when we try to create those resources. Instead of treating such responses as errors, log them, and then continue as if we had created the resources successfully.

Make this change for resources that we create on initialization: policies, associations between vservers and policies, iRules, and datagroups, as well as pools and pool members.  The reasoning is that these resources have distinctive, descriptive names, and it is improbable that a different resource will exist with the same name.  On the other hand, policy rules and rule conditions and actions have non-descriptive numeric names, and keys and certificates are named based on the route name (not the key or certificate data), so it is more probable that an existing resource of any of these types will be different from the resource we want to exist.  Thus we still treat HTTP 409 responses as errors for these resources.

This commit fixes https://github.com/openshift/origin/issues/7566
## 

[test]
## 

@ramr, what do you think? I'm tagging this "WIP" because I anticipate some discussion about when exactly it makes sense to handle HTTP 409, as well as some bikeshedding over log messages and code style.

• Is the reasoning above about when to handle HTTP 409 sound?
• Are we handling it in the correct places? I could put the logic into the `post` method for fewer LOCs, but then we would need a flag to be able to indicate when we _didn't_ want any special handling for HTTP 409, and it feels icky to allow that logic to leak into the lower-level methods.
• These changes tug our coverage down from 73.2% to 71.7%; shall I add some test cases for HTTP 409 responses?
