### PR TITLE
Fix template use to generate javaconsole link in a pod template

### DIFF
--- a/assets/app/scripts/extensions/javaLink.js
+++ b/assets/app/scripts/extensions/javaLink.js
@@ -19,12 +19,23 @@ angular.module('openshiftConsoleExtensions', ['openshiftConsole'])
     };
   })
   .run(function(ProxyPod, BaseHref, HawtioExtension, $templateCache, $compile, AuthService) {
-    var template =
-      '<span class="connect-link" ng-show="jolokiaUrl" title="Connect to container">' +
-      '  <a ng-click="gotoContainerView($event, container, jolokiaUrl)" ng-href="jolokiaUrl">' +
-      '    <i class="fa fa-sign-in"></i>Connect' +
-      '  </a>' +
-      '</span>';
+
+    var template = [
+      '<div row ',
+        'class="icon-row" ',
+        'ng-show="jolokiaUrl" ',
+        'title="Connect to container">',
+        '<div>',
+          '<i class="fa fa-share" aria-hidden="true"></i>',
+        '</div>',
+        '<div flex>',
+          '<a ng-click="gotoContainerView($event, container, jolokiaUrl)" ng-href="jolokiaUrl">',
+            'Open Java Console',
+          '</a>',
+        '</div>',
+      '</div>'
+    ].join('');
+
     HawtioExtension.add('container-links', function ($scope) {
       var container = $scope.container;
       if (!container) {


### PR DESCRIPTION
Fixes issue #7948

@spadgett @jwforres @sg00dwin 

![screen shot 2016-03-14 at 10 20 42 am](https://cloud.githubusercontent.com/assets/280512/13747495/dc0bbc84-e9ce-11e5-811f-67015434f62c.png)
