### PR TITLE
remove test file cruft

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -94,17 +94,6 @@ os::cmd::expect_success 'diff secret.data secret.file-in-file-out.decrypted'
 os::cmd::expect_success 'diff secret.data secret.file-in-pipe-out.decrypted'
 os::cmd::expect_success 'diff secret.data secret.pipe-in-pipe-out.decrypted'
 
-os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
-# os::cmd::expect_success_and_text 'oadm manage-node --list-pods' 'hello-openshift'
-# os::cmd::expect_success_and_text 'oadm manage-node --list-pods' '(unassigned|assigned)'
-# os::cmd::expect_success_and_text 'oadm manage-node --evacuate --dry-run' 'hello-openshift'
-# os::cmd::expect_success_and_text 'oadm manage-node --schedulable=false' 'SchedulingDisabled'
-# os::cmd::expect_failure_and_text 'oadm manage-node --evacuate' 'Unable to evacuate'
-# os::cmd::expect_success_and_text 'oadm manage-node --evacuate --force' 'hello-openshift'
-# os::cmd::expect_success_and_text 'oadm manage-node --list-pods' 'hello-openshift'
-os::cmd::expect_success 'oc delete pods hello-openshift'
-echo "manage-node: ok"
-
 os::cmd::expect_success 'oadm groups new group1 foo bar'
 os::cmd::expect_success_and_text 'oc get groups/group1 --no-headers' 'foo, bar'
 os::cmd::expect_success 'oadm groups add-users group1 baz'

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -106,12 +106,6 @@ os::cmd::expect_success_and_text 'openshift help start master' 'Start a master'
 os::cmd::expect_success_and_text 'openshift help start node' 'Start a node'
 os::cmd::expect_success_and_text 'oc help project' 'Switch to another project'
 os::cmd::expect_success_and_text 'oc help projects' 'Switch to another project'
-# TODO: fix these tests
-# os::cmd::expect_success_and_text 'openshift cli help update' 'Update a resource'
-# os::cmd::expect_success_and_text 'openshift cli help replace' 'Replace a resource'
-# os::cmd::expect_success_and_text 'openshift cli help patch' 'Update field\(s\) of a resource'
-# os::cmd::expect_success_and_text 'openshift cli help project' 'Switch to another project'
-# os::cmd::expect_success_and_text 'openshift cli help projects' 'Switch to another project'
 
 # runnable commands with required flags must error consistently
 os::cmd::expect_failure_and_text 'oc get' 'Required resource not specified'


### PR DESCRIPTION
@smarterclayton the changes in `test/cmd/admin` remove your previous comments

@fabianofranz the changes in `test/cmd/help` get rid of tests for `openshift cli help` which looks to have been deprecated?