### PR TITLE
Show related hpa in dc description

### DIFF
--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -222,7 +222,7 @@ func (o *RollbackOptions) Run() error {
 
 	// If this is a dry run, print and exit.
 	if o.DryRun {
-		describer := describe.NewDeploymentConfigDescriberForConfig(o.oc, o.kc, newConfig)
+		describer := describe.NewDeploymentConfigDescriber(o.oc, o.kc, newConfig)
 		description, err := describer.Describe(newConfig.Namespace, newConfig.Name)
 		if err != nil {
 			return err

--- a/pkg/cmd/cli/describe/deployments_test.go
+++ b/pkg/cmd/cli/describe/deployments_test.go
@@ -1,0 +1,108 @@
+package describe
+
+import (
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapitest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func TestDeploymentConfigDescriber(t *testing.T) {
+	config := deployapitest.OkDeploymentConfig(1)
+	deployment, _ := deployutil.MakeDeployment(config, kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
+	podList := &kapi.PodList{}
+
+	fake := &testclient.Fake{}
+	fake.PrependReactor("get", "deploymentconfigs", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, config, nil
+	})
+	kFake := &ktestclient.Fake{}
+	kFake.PrependReactor("list", "horizontalpodautoscalers", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &extensions.HorizontalPodAutoscalerList{
+			Items: []extensions.HorizontalPodAutoscaler{
+				*deployapitest.OkHPAForDeploymentConfig(config, 1, 3),
+			}}, nil
+	})
+	kFake.PrependReactor("get", "replicationcontrollers", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, deployment, nil
+	})
+	kFake.PrependReactor("list", "replicationcontrollers", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &kapi.ReplicationControllerList{}, nil
+	})
+	kFake.PrependReactor("list", "pods", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, podList, nil
+	})
+	kFake.PrependReactor("list", "events", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &kapi.EventList{}, nil
+	})
+
+	d := &DeploymentConfigDescriber{
+		osClient:   fake,
+		kubeClient: kFake,
+	}
+
+	describe := func() string {
+		output, err := d.Describe("test", "deployment")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+			return ""
+		}
+		t.Logf("describer output:\n%s\n", output)
+		return output
+	}
+
+	podList.Items = []kapi.Pod{*mkPod(kapi.PodRunning, 0)}
+	out := describe()
+	substr := "Autoscaling:\tbetween 1 and 3 replicas"
+	if !strings.Contains(out, substr) {
+		t.Fatalf("expected %q in output:\n%s", substr, out)
+	}
+
+	config.Spec.Triggers = append(config.Spec.Triggers, deployapitest.OkConfigChangeTrigger())
+	describe()
+
+	config.Spec.Strategy = deployapitest.OkCustomStrategy()
+	describe()
+
+	config.Spec.Triggers[0].ImageChangeParams.From = kapi.ObjectReference{Name: "imagestream"}
+	describe()
+
+	config.Spec.Strategy = deployapitest.OkStrategy()
+	config.Spec.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{
+		Pre: &deployapi.LifecycleHook{
+			FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+			ExecNewPod: &deployapi.ExecNewPodHook{
+				ContainerName: "container",
+				Command:       []string{"/command1", "args"},
+				Env: []kapi.EnvVar{
+					{
+						Name:  "KEY1",
+						Value: "value1",
+					},
+				},
+			},
+		},
+		Post: &deployapi.LifecycleHook{
+			FailurePolicy: deployapi.LifecycleHookFailurePolicyIgnore,
+			ExecNewPod: &deployapi.ExecNewPodHook{
+				ContainerName: "container",
+				Command:       []string{"/command2", "args"},
+				Env: []kapi.EnvVar{
+					{
+						Name:  "KEY2",
+						Value: "value2",
+					},
+				},
+			},
+		},
+	}
+	describe()
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -37,7 +37,7 @@ func describerMap(c *client.Client, kclient kclient.Interface, host string) map[
 	m := map[unversioned.GroupKind]kctl.Describer{
 		buildapi.Kind("Build"):                        &BuildDescriber{c, kclient},
 		buildapi.Kind("BuildConfig"):                  &BuildConfigDescriber{c, host},
-		deployapi.Kind("DeploymentConfig"):            NewDeploymentConfigDescriber(c, kclient),
+		deployapi.Kind("DeploymentConfig"):            &DeploymentConfigDescriber{c, kclient, nil},
 		authorizationapi.Kind("Identity"):             &IdentityDescriber{c},
 		imageapi.Kind("Image"):                        &ImageDescriber{c},
 		imageapi.Kind("ImageStream"):                  &ImageStreamDescriber{c},

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -10,9 +10,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/units"
 
-	"github.com/docker/docker/pkg/parsers"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/kubectl"
-	"k8s.io/kubernetes/pkg/runtime"
 
 	api "github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -21,8 +20,6 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
-	deployapitest "github.com/openshift/origin/pkg/deploy/api/test"
-	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
@@ -141,86 +138,6 @@ func TestDescribers(t *testing.T) {
 			t.Errorf("unexpected out: %s", out)
 		}
 	}
-}
-
-func TestDeploymentConfigDescriber(t *testing.T) {
-	config := deployapitest.OkDeploymentConfig(1)
-	deployment, _ := deployutil.MakeDeployment(config, kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
-	podList := &kapi.PodList{}
-
-	fake := &testclient.Fake{}
-	fake.PrependReactor("get", "deploymentconfigs", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, config, nil
-	})
-	kFake := &ktestclient.Fake{}
-	kFake.PrependReactor("get", "replicationcontrollers", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, deployment, nil
-	})
-	kFake.PrependReactor("list", "replicationcontrollers", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &kapi.ReplicationControllerList{}, nil
-	})
-	kFake.PrependReactor("list", "pods", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, podList, nil
-	})
-	kFake.PrependReactor("list", "events", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &kapi.EventList{}, nil
-	})
-
-	d := &DeploymentConfigDescriber{
-		osClient:   fake,
-		kubeClient: kFake,
-	}
-
-	describe := func() {
-		if output, err := d.Describe("test", "deployment"); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		} else {
-			t.Logf("describer output:\n%s\n", output)
-		}
-	}
-
-	podList.Items = []kapi.Pod{*mkPod(kapi.PodRunning, 0)}
-	describe()
-
-	config.Spec.Triggers = append(config.Spec.Triggers, deployapitest.OkConfigChangeTrigger())
-	describe()
-
-	config.Spec.Strategy = deployapitest.OkCustomStrategy()
-	describe()
-
-	config.Spec.Triggers[0].ImageChangeParams.From = kapi.ObjectReference{Name: "imageRepo"}
-	describe()
-
-	config.Spec.Strategy = deployapitest.OkStrategy()
-	config.Spec.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{
-		Pre: &deployapi.LifecycleHook{
-			FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
-			ExecNewPod: &deployapi.ExecNewPodHook{
-				ContainerName: "container",
-				Command:       []string{"/command1", "args"},
-				Env: []kapi.EnvVar{
-					{
-						Name:  "KEY1",
-						Value: "value1",
-					},
-				},
-			},
-		},
-		Post: &deployapi.LifecycleHook{
-			FailurePolicy: deployapi.LifecycleHookFailurePolicyIgnore,
-			ExecNewPod: &deployapi.ExecNewPodHook{
-				ContainerName: "container",
-				Command:       []string{"/command2", "args"},
-				Env: []kapi.EnvVar{
-					{
-						Name:  "KEY2",
-						Value: "value2",
-					},
-				},
-			},
-		},
-	}
-	describe()
 }
 
 func TestDescribeBuildDuration(t *testing.T) {

--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -129,6 +129,7 @@ func FormatRelativeTime(t time.Time) string {
 
 func formatMeta(out *tabwriter.Writer, m api.ObjectMeta) {
 	formatString(out, "Name", m.Name)
+	formatString(out, "Namespace", m.Namespace)
 	if !m.CreationTimestamp.IsZero() {
 		formatTime(out, "Created", m.CreationTimestamp.Time)
 	}

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -3,6 +3,7 @@ package test
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -176,4 +177,18 @@ func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
 func TestDeploymentConfig(config *deployapi.DeploymentConfig) *deployapi.DeploymentConfig {
 	config.Spec.Test = true
 	return config
+}
+
+func OkHPAForDeploymentConfig(config *deployapi.DeploymentConfig, min, max int) *extensions.HorizontalPodAutoscaler {
+	return &extensions.HorizontalPodAutoscaler{
+		ObjectMeta: kapi.ObjectMeta{Name: config.Name, Namespace: config.Namespace},
+		Spec: extensions.HorizontalPodAutoscalerSpec{
+			ScaleRef: extensions.SubresourceReference{
+				Name: config.Name,
+				Kind: "DeploymentConfig",
+			},
+			MinReplicas: &min,
+			MaxReplicas: max,
+		},
+	}
 }


### PR DESCRIPTION
Changes in this PR:
* Addition of namespace
* Autoscaling info
* Factored out custom interfaces

```
[vagrant@localhost sample-app]$ oc describe dc
Name:		docker-registry
Namespace:	default
Created:	6 minutes ago
Labels:		docker-registry=default
Annotations:	<none>
Latest Version:	2
Selector:	docker-registry=default
Replicas:	1
Autoscaled:	min: 1, max: 3, targeting 80% cpu
Triggers:	Config
Strategy:	Rolling
Template:
  Labels:	docker-registry=default
  Containers:
  registry:
    Image:	openshift/origin-docker-registry:latest
    Port:	5000/TCP
    QoS Tier:
      memory:	BestEffort
      cpu:	BestEffort
    Liveness:	http-get http://:5000/healthz delay=10s timeout=5s period=10s #success=1 #failure=3
[ ... ]
```

@smarterclayton @ironcladlou @DirectXMan12 PTAL

cc: @jwforres @fabianofranz 