### PR TITLE
implemented miscellaneous iprovements for test-cmd

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -231,8 +231,8 @@ function os::cmd::internal::describe_call() {
 	echo "${full_name}"
 }
 
-# os::cmd::internal::determine_caller determines the file and line number of the function call to
-# the outer os::cmd wrapper function
+# os::cmd::internal::determine_caller determines the file relative to the OpenShift Origin root directory
+# and line number of the function call to the outer os::cmd wrapper function
 function os::cmd::internal::determine_caller() {
 	local call_depth=
 	local len_sources="${#BASH_SOURCE[@]}"
@@ -244,6 +244,13 @@ function os::cmd::internal::determine_caller() {
 	done
 
 	local caller_file="${BASH_SOURCE[${call_depth}]}"
+	if which realpath >&/dev/null; then
+		# if the caller has `realpath`, we can use it to make our file names cleaner by
+		# trimming the absolute file path up to `...openshift/origin/` and showing only
+		# the relative path from the Origin root directory
+		caller_file="$( realpath "${caller_file}" )"
+		caller_file="${caller_file//*openshift\/origin\/}"
+	fi
 	local caller_line="${BASH_LINENO[${call_depth}-1]}"
 	echo "${caller_file}:${caller_line}"
 }

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -15,6 +15,7 @@ source "${OS_ROOT}/hack/lib/log.sh"
 source "${OS_ROOT}/hack/lib/util/environment.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
+os::util::environment::setup_time_vars
 
 function cleanup()
 {

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -137,26 +137,26 @@ echo "routes: ok"
 # Validate the probe command
 arg="-f examples/hello-openshift/hello-pod.json"
 os::cmd::expect_failure_and_text "oc set probe" "error: one or more resources"
-os::cmd::expect_failure_and_text "oc set probe $arg" "error: you must specify one of --readiness or --liveness"
-os::cmd::expect_success_and_text "oc set probe $arg --liveness -o yaml" 'livenessProbe: \{\}'
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --initial-delay-seconds=10 -o yaml" "livenessProbe:"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --initial-delay-seconds=10 -o yaml" "initialDelaySeconds: 10"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness -- echo test" "livenessProbe:"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --readiness -- echo test" "readinessProbe:"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness -- echo test" "exec:"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness -- echo test" "\- echo"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness -- echo test" "\- test"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --open-tcp=3306" "tcpSocket:"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --open-tcp=3306" "port: 3306"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --open-tcp=port" "port: port"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:port/path" "port: port"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:8080/path" "port: 8080"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1/path" 'port: ""'
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:port/path" "path: /path"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:port/path" "scheme: HTTPS"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=http://127.0.0.1:port/path" "scheme: HTTP"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:port/path" "host: 127.0.0.1"
-os::cmd::expect_success_and_text "oc set probe $arg -o yaml --liveness --get-url=https://127.0.0.1:port/path" "port: port"
+os::cmd::expect_failure_and_text "oc set probe ${arg}" "error: you must specify one of --readiness or --liveness"
+os::cmd::expect_success_and_text "oc set probe ${arg} --liveness -o yaml" 'livenessProbe: \{\}'
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --initial-delay-seconds=10 -o yaml" "livenessProbe:"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --initial-delay-seconds=10 -o yaml" "initialDelaySeconds: 10"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness -- echo test" "livenessProbe:"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --readiness -- echo test" "readinessProbe:"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness -- echo test" "exec:"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness -- echo test" "\- echo"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness -- echo test" "\- test"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --open-tcp=3306" "tcpSocket:"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --open-tcp=3306" "port: 3306"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --open-tcp=port" "port: port"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:port/path" "port: port"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:8080/path" "port: 8080"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1/path" 'port: ""'
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:port/path" "path: /path"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:port/path" "scheme: HTTPS"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=http://127.0.0.1:port/path" "scheme: HTTP"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:port/path" "host: 127.0.0.1"
+os::cmd::expect_success_and_text "oc set probe ${arg} -o yaml --liveness --get-url=https://127.0.0.1:port/path" "port: port"
 os::cmd::expect_success "oc create -f test/integration/fixtures/test-deployment-config.yaml"
 os::cmd::expect_failure_and_text "oc set probe dc/test-deployment-config --liveness" "Required value: must specify a handler type"
 os::cmd::expect_success_and_text "oc set probe dc test-deployment-config --liveness --open-tcp=8080" "updated"
@@ -247,8 +247,7 @@ os::cmd::expect_failure 'oc get dc/ruby-hello-world'
 echo "delete all: ok"
 
 # service accounts should not be allowed to request new projects
-SA_TOKEN=`oc get sa/builder --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | os::util::base64decode -`
-os::cmd::expect_failure_and_text "oc new-project --token=${SA_TOKEN} will-fail" 'Error from server: You may not request a new project via this API'
+os::cmd::expect_failure_and_text "oc new-project --token="$( oc sa get-token builder )" will-fail" 'Error from server: You may not request a new project via this API'
 
 
 # Validate patching works correctly

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -168,7 +168,6 @@ os::cmd::expect_success_and_text "oc describe is/newrepo" '\* tag is scheduled'
 os::cmd::expect_success 'oc tag --source=docker mysql:5.7 newrepo:latest --insecure'
 os::cmd::expect_success_and_text "oc describe is/newrepo" '\! tag is insecure'
 os::cmd::expect_success_and_not_text "oc describe is/newrepo" '\* tag is scheduled'
-oc get -o yaml is/newrepo
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 0).importPolicy.insecure}}'" 'true'
 
 # test creating streams that don't exist

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -15,7 +15,7 @@ os::log::install_errexit
   oc delete all,templates --all
   oc delete template/ruby-helloworld-sample -n openshift
   oc delete project test-template-project
-  os::cmd::try_until_failure 'oc get project test-template-project'
+  wait_for_command '! oc get project test-template-project'
   exit 0
 ) &>/dev/null
 
@@ -80,8 +80,8 @@ echo "template data precision: ok"
 os::cmd::expect_success 'oc create -f examples/sample-app/application-template-dockerbuild.json -n openshift'
 os::cmd::expect_success 'oc policy add-role-to-user admin test-user'
 new="$(mktemp -d)/tempconfig"
-os::cmd::expect_success "oc config view --raw > $new"
-export KUBECONFIG=$new
+os::cmd::expect_success "oc config view --raw > ${new}"
+export KUBECONFIG=${new}
 os::cmd::expect_success 'oc login -u test-user -p password'
 os::cmd::expect_success 'oc new-project test-template-project'
 # make sure the permissions on the new project are set up


### PR DESCRIPTION
This PR contains:
 - fixes to make expansion safer (`$var` --> `${var}`)
 - update to use `oc sa get-token`
 - change cleanup script to not use `os::cmd`, which will imminently emit output for jUnit, which we don't expect cleanup to do
 - update `os::cmd` to emit paths relative to the `origin` root 
 - remove a debug line

@deads2k PTAL