### PR TITLE
Allow reencrypt routes to use the default certificate

### DIFF
--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -207,6 +207,21 @@ func TestRouter(t *testing.T) {
 			routerUrl: "0.0.0.0",
 		},
 		{
+			name:              "reencrypt-destcacert",
+			serviceName:       "example-reencrypt-destcacert",
+			endpoints:         []kapi.EndpointSubset{httpsEndpoint},
+			routeAlias:        "www.example.com",
+			endpointEventType: watch.Added,
+			routeEventType:    watch.Added,
+			protocol:          "https",
+			expectedResponse:  tr.HelloPodSecure,
+			routeTLS: &routeapi.TLSConfig{
+				Termination:              routeapi.TLSTerminationReencrypt,
+				DestinationCACertificate: tr.ExampleCACert,
+			},
+			routerUrl: "0.0.0.0",
+		},
+		{
 			name:              "reencrypt path",
 			serviceName:       "example-reencrypt-path",
 			endpoints:         []kapi.EndpointSubset{httpsEndpoint},


### PR DESCRIPTION
Fix for bugz https://bugzilla.redhat.com/show_bug.cgi?id=1316698 and issue #7444

Allow re-encrypt routes to specify just a destCACertificate and use the default cert for the edge termination.  

Test route: https://gist.github.com/ramr/3f8bd3c0412d0b2d5522

@pweil-  @knobunc @smarterclayton   PTAL  Thx