### PR TITLE
Ensure we are clean to docker.io/* images during hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,6 +27,18 @@ if [[ "$(git name-rev --name-only --tags HEAD)" != "${tag}^0" ]]; then
   fi
 fi
 
+function removeimage() {
+  for i in $@; do
+    if docker inspect $i &>/dev/null; then
+      docker rmi $i
+    fi
+    if docker inspect docker.io/$i &>/dev/null; then
+      docker rmi docker.io/$i
+    fi
+  done
+}
+
+removeimage openshift/origin-base openshift/origin-release openshift/origin-haproxy-router-base
 docker pull openshift/origin-base
 docker pull openshift/origin-release
 docker pull openshift/origin-haproxy-router-base


### PR DESCRIPTION
Red Hat Docker patches don't guarantee an image tagged as
openshift/origin-base is updated on pull (since they prepend docker.io).
Start from a clean slate, every release.

[merge]