### PR TITLE
UPSTREAM: 23003: support CIDRs in NO_PROXY

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
@@ -36,6 +36,7 @@ import (
 
 	"golang.org/x/net/websocket"
 	"k8s.io/kubernetes/pkg/api/rest"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
 func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
@@ -381,7 +382,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}),
 		},
 		"https (valid hostname + RootCAs)": {
 			ServerFunc: func(h http.Handler) *httptest.Server {
@@ -396,7 +397,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 		},
 		"https (valid hostname + RootCAs + custom dialer)": {
 			ServerFunc: func(h http.Handler) *httptest.Server {
@@ -411,7 +412,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport/cache.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport/cache.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
 // TlsTransportCache caches TLS http.RoundTrippers different configurations. The
@@ -60,7 +62,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	}
 
 	// Cache a single transport for these options
-	c.transports[key] = &http.Transport{
+	c.transports[key] = utilnet.SetTransportDefaults(&http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     tlsConfig,
@@ -68,7 +70,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).Dial,
-	}
+	})
 	return c.transports[key], nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/client_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/client_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/mesos/mesos-go/detector"
 	"github.com/mesos/mesos-go/mesosutil"
 	"golang.org/x/net/context"
+
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
 // Test data
@@ -180,11 +182,11 @@ func makeHttpMocks() (*httptest.Server, *http.Client, *http.Transport) {
 	}))
 
 	// Intercept all client requests and feed them to the test server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(httpServer.URL)
 		},
-	}
+	})
 
 	httpClient := &http.Client{Transport: transport}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/credentialprovider/gcp/metadata_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/credentialprovider/gcp/metadata_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
 func TestDockerKeyringFromGoogleDockerConfigMetadata(t *testing.T) {
@@ -60,11 +61,11 @@ func TestDockerKeyringFromGoogleDockerConfigMetadata(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	keyring := &credentialprovider.BasicDockerKeyring{}
 	provider := &dockerConfigKeyProvider{
@@ -133,11 +134,11 @@ func TestDockerKeyringFromGoogleDockerConfigMetadataUrl(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	keyring := &credentialprovider.BasicDockerKeyring{}
 	provider := &dockerConfigUrlKeyProvider{
@@ -207,11 +208,11 @@ func TestContainerRegistryBasics(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	keyring := &credentialprovider.BasicDockerKeyring{}
 	provider := &containerRegistryProvider{
@@ -264,11 +265,11 @@ func TestContainerRegistryNoStorageScope(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	provider := &containerRegistryProvider{
 		metadataProvider{Client: &http.Client{Transport: transport}},
@@ -298,11 +299,11 @@ func TestComputePlatformScopeSubstitutesStorageScope(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	provider := &containerRegistryProvider{
 		metadataProvider{Client: &http.Client{Transport: transport}},
@@ -321,11 +322,11 @@ func TestAllProvidersNoMetadata(t *testing.T) {
 	// defer server.Close()
 
 	// Make a transport that reroutes all traffic to the example server
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
-	}
+	})
 
 	providers := []credentialprovider.DockerConfigProvider{
 		&dockerConfigKeyProvider{

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/probe/http/http.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/probe/http/http.go
@@ -25,13 +25,14 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/probe"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 
 	"github.com/golang/glog"
 )
 
 func New() HTTPProber {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	transport := &http.Transport{TLSClientConfig: tlsConfig, DisableKeepAlives: true}
+	transport := utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: tlsConfig, DisableKeepAlives: true})
 	return httpProber{transport}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
@@ -36,6 +36,7 @@ import (
 
 	"golang.org/x/net/websocket"
 
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/proxy"
 )
 
@@ -334,7 +335,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}),
 		},
 		"https (valid hostname + RootCAs)": {
 			ServerFunc: func(h http.Handler) *httptest.Server {
@@ -349,7 +350,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 		},
 		"https (valid hostname + RootCAs + custom dialer)": {
 			ServerFunc: func(h http.Handler) *httptest.Server {
@@ -364,7 +365,7 @@ func TestProxyUpgrade(t *testing.T) {
 				ts.StartTLS()
 				return ts
 			},
-			ProxyTransport: &http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+			ProxyTransport: utilnet.SetTransportDefaults(&http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}}),
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/etcd_helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/etcd_helper.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/storage/etcd/metrics"
 	etcdutil "k8s.io/kubernetes/pkg/storage/etcd/util"
 	"k8s.io/kubernetes/pkg/util"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/watch"
 
 	etcd "github.com/coreos/etcd/client"
@@ -102,7 +103,7 @@ func (c *EtcdConfig) newHttpTransport() (*http.Transport, error) {
 
 	// Copied from etcd.DefaultTransport declaration.
 	// TODO: Determine if transport needs optimization
-	tr := &http.Transport{
+	tr := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -111,7 +112,7 @@ func (c *EtcdConfig) newHttpTransport() (*http.Transport, error) {
 		TLSHandshakeTimeout: 10 * time.Second,
 		MaxIdleConnsPerHost: 500,
 		TLSClientConfig:     cfg,
-	}
+	})
 
 	return tr, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -55,8 +56,10 @@ var defaultTransport = http.DefaultTransport.(*http.Transport)
 // SetTransportDefaults applies the defaults from http.DefaultTransport
 // for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
 func SetTransportDefaults(t *http.Transport) *http.Transport {
-	if t.Proxy == nil {
-		t.Proxy = defaultTransport.Proxy
+	if t.Proxy == nil || isDefault(t.Proxy) {
+		// http.ProxyFromEnvironment doesn't respect CIDRs and that makes it impossible to exclude things like pod and service IPs from proxy settings
+		// ProxierWithNoProxyCIDR allows CIDR rules in NO_PROXY
+		t.Proxy = NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 	}
 	if t.Dial == nil {
 		t.Dial = defaultTransport.Dial
@@ -152,4 +155,57 @@ func GetClientIP(req *http.Request) net.IP {
 	// Fallback to Remote Address in request, which will give the correct client IP when there is no proxy.
 	ip := net.ParseIP(req.RemoteAddr)
 	return ip
+}
+
+var defaultProxyFuncPointer = fmt.Sprintf("%p", http.ProxyFromEnvironment)
+
+// isDefault checks to see if the transportProxierFunc is pointing to the default one
+func isDefault(transportProxier func(*http.Request) (*url.URL, error)) bool {
+	transportProxierPointer := fmt.Sprintf("%p", transportProxier)
+	return transportProxierPointer == defaultProxyFuncPointer
+}
+
+// NewProxierWithNoProxyCIDR constructs a Proxier function that respects CIDRs in NO_PROXY and delegates if
+// no matching CIDRs are found
+func NewProxierWithNoProxyCIDR(delegate func(req *http.Request) (*url.URL, error)) func(req *http.Request) (*url.URL, error) {
+	// we wrap the default method, so we only need to perform our check if the NO_PROXY envvar has a CIDR in it
+	noProxyEnv := os.Getenv("NO_PROXY")
+	noProxyRules := strings.Split(noProxyEnv, ",")
+
+	cidrs := []*net.IPNet{}
+	for _, noProxyRule := range noProxyRules {
+		_, cidr, _ := net.ParseCIDR(noProxyRule)
+		if cidr != nil {
+			cidrs = append(cidrs, cidr)
+		}
+	}
+
+	if len(cidrs) == 0 {
+		return delegate
+	}
+
+	return func(req *http.Request) (*url.URL, error) {
+		host := req.URL.Host
+		// for some urls, the Host is already the host, not the host:port
+		if net.ParseIP(host) == nil {
+			var err error
+			host, _, err = net.SplitHostPort(req.URL.Host)
+			if err != nil {
+				return delegate(req)
+			}
+		}
+
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return delegate(req)
+		}
+
+		for _, cidr := range cidrs {
+			if cidr.Contains(ip) {
+				return nil, nil
+			}
+		}
+
+		return delegate(req)
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/extender.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/extender.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
@@ -60,11 +61,11 @@ func makeTransport(config *schedulerapi.ExtenderConfig) (http.RoundTripper, erro
 		return nil, err
 	}
 	if tlsConfig != nil {
-		return &http.Transport{
+		return utilnet.SetTransportDefaults(&http.Transport{
 			TLSClientConfig: tlsConfig,
-		}, nil
+		}), nil
 	}
-	return http.DefaultTransport, nil
+	return utilnet.SetTransportDefaults(&http.Transport{}), nil
 }
 
 func NewHTTPExtender(config *schedulerapi.ExtenderConfig, apiVersion string) (algorithm.SchedulerExtender, error) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/ingress_utils.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/ingress_utils.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 )
 
 const (
@@ -110,13 +111,13 @@ func buildTransport(serverName string, rootCA []byte) (*http.Transport, error) {
 	if !ok {
 		return nil, fmt.Errorf("Unable to load serverCA.")
 	}
-	return &http.Transport{
+	return utilnet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: false,
 			ServerName:         serverName,
 			RootCAs:            pool,
 		},
-	}, nil
+	}), nil
 }
 
 // createSecret creates a secret containing TLS certificates for the given Ingress.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/kubectl.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/kubectl.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/labels"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 
@@ -1147,9 +1148,9 @@ func curlUnix(url string, path string) (string, error) {
 	dial := func(proto, addr string) (net.Conn, error) {
 		return net.Dial("unix", path)
 	}
-	transport := &http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Dial: dial,
-	}
+	})
 	return curlTransport(url, transport)
 }
 
@@ -1168,7 +1169,7 @@ func curlTransport(url string, transport *http.Transport) (string, error) {
 }
 
 func curl(url string) (string, error) {
-	return curlTransport(url, &http.Transport{})
+	return curlTransport(url, utilnet.SetTransportDefaults(&http.Transport{}))
 }
 
 func validateGuestbookApp(c *client.Client, ns string) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/kubeproxy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/kubeproxy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
@@ -129,7 +130,7 @@ func (config *KubeProxyTestConfig) hitLoadBalancer(epCount int) {
 	hostNames := make(map[string]bool)
 	tries := epCount*epCount + 5
 	for i := 0; i < tries; i++ {
-		transport := &http.Transport{}
+		transport := utilnet.SetTransportDefaults(&http.Transport{})
 		httpClient := createHTTPClient(transport)
 		resp, err := httpClient.Get(fmt.Sprintf("http://%s:%d/hostName", lbIP, loadBalancerHttpPort))
 		if err == nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/service.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/service.go
@@ -1442,9 +1442,9 @@ func verifyServeHostnameServiceDown(c *client.Client, host string, serviceIP str
 // This masks problems where the iptables rule has changed, but we don't see it
 // This is intended for relatively quick requests (status checks), so we set a short (5 seconds) timeout
 func httpGetNoConnectionPool(url string) (*http.Response, error) {
-	tr := &http.Transport{
+	tr := utilnet.SetTransportDefaults(&http.Transport{
 		DisableKeepAlives: true,
-	}
+	})
 	client := &http.Client{
 		Transport: tr,
 		Timeout:   5 * time.Second,

--- a/pkg/auth/server/grant/grant_test.go
+++ b/pkg/auth/server/grant/grant_test.go
@@ -12,6 +12,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/auth/user"
+	knet "k8s.io/kubernetes/pkg/util/net"
 
 	"github.com/openshift/origin/pkg/auth/server/csrf"
 	oapi "github.com/openshift/origin/pkg/oauth/api"
@@ -352,7 +353,7 @@ func TestGrant(t *testing.T) {
 }
 
 func postForm(url string, body url.Values) (resp *http.Response, err error) {
-	tr := &http.Transport{}
+	tr := knet.SetTransportDefaults(&http.Transport{})
 	req, err := http.NewRequest("POST", url, strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, err
@@ -362,7 +363,7 @@ func postForm(url string, body url.Values) (resp *http.Response, err error) {
 }
 
 func getURL(url string) (resp *http.Response, err error) {
-	tr := &http.Transport{}
+	tr := knet.SetTransportDefaults(&http.Transport{})
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/diagnostics/pod/auth.go
+++ b/pkg/diagnostics/pod/auth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/diagnostics/types"
 
 	"k8s.io/kubernetes/pkg/client/restclient"
+	knet "k8s.io/kubernetes/pkg/util/net"
 )
 
 const (
@@ -135,7 +136,7 @@ func (d PodCheckAuth) authenticateToRegistry(token string, r types.DiagnosticRes
 		Timeout: time.Second * 2,
 	}
 	secClient := noSecClient
-	secClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}
+	secClient.Transport = knet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}})
 	if secError := processRegistryRequest(&secClient, fmt.Sprintf("https://%s:%s/v2/", registryHostname, registryPort), token, r); secError == nil {
 		return // made the request successfully enough to diagnose
 	} else if strings.Contains(secError.Error(), "tls: oversized record received") {

--- a/test/integration/root_redirect_test.go
+++ b/test/integration/root_redirect_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	knet "k8s.io/kubernetes/pkg/util/net"
+
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -18,11 +20,11 @@ func TestRootRedirect(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	transport := &http.Transport{
+	transport := knet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 
 	req, err := http.NewRequest("GET", masterConfig.AssetConfig.MasterPublicURL, nil)
 	req.Header.Set("Accept", "*/*")

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1beta3"
 	"k8s.io/kubernetes/pkg/util/intstr"
+	knet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/watch"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
 
@@ -946,9 +947,9 @@ func TestRouterServiceUnavailable(t *testing.T) {
 		}
 
 		httpClient := &http.Client{
-			Transport: &http.Transport{
+			Transport: knet.SetTransportDefaults(&http.Transport{
 				TLSClientConfig: tlsConfig,
-			},
+			}),
 		}
 		req, err := http.NewRequest("GET", uri, nil)
 		if err != nil {
@@ -1043,9 +1044,9 @@ func getRoute(routerUrl string, hostName string, protocol string, headers map[st
 
 	switch protocol {
 	case "http", "https":
-		httpClient := &http.Client{Transport: &http.Transport{
+		httpClient := &http.Client{Transport: knet.SetTransportDefaults(&http.Transport{
 			TLSClientConfig: tlsConfig,
-		},
+		}),
 		}
 		req, err := http.NewRequest("GET", url, nil)
 
@@ -1263,7 +1264,7 @@ func validateServer(server *tr.TestHttpService, t *testing.T) {
 		t.Errorf("Error validating master addr %s : %v", server.MasterHttpAddr, err)
 	}
 
-	secureTransport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	secureTransport := knet.SetTransportDefaults(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}})
 	secureClient := &http.Client{Transport: secureTransport}
 	_, err = secureClient.Get("https://" + server.PodHttpsAddr)
 

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 
+	knet "k8s.io/kubernetes/pkg/util/net"
+
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/util"
 	testutil "github.com/openshift/origin/test/util"
@@ -203,14 +205,14 @@ func TestSNI(t *testing.T) {
 			continue
 		}
 
-		transport := &http.Transport{
+		transport := knet.SetTransportDefaults(&http.Transport{
 			// Custom Dial func to always dial the real master, no matter what host is asked for
 			Dial: func(network, addr string) (net.Conn, error) {
 				// t.Logf("%s: Dialing for %s", k, addr)
 				return net.Dial(network, masterPublicURL.Host)
 			},
 			TLSClientConfig: tc.TLSConfig,
-		}
+		})
 		resp, err := transport.RoundTrip(req)
 		if tc.ExpectedOK && err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -10,17 +10,19 @@ import (
 	"strings"
 	"testing"
 
+	knet "k8s.io/kubernetes/pkg/util/net"
+
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
 func tryAccessURL(t *testing.T, url string, expectedStatus int, expectedRedirectLocation string) *http.Response {
-	transport := &http.Transport{
+	transport := knet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 
 	req, err := http.NewRequest("GET", url, nil)
 	req.Header.Set("Accept", "text/html")

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 
+	knet "k8s.io/kubernetes/pkg/util/net"
+
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -164,11 +166,11 @@ func TestWebConsoleExtensions(t *testing.T) {
 		},
 	}
 
-	transport := &http.Transport{
+	transport := knet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
-	}
+	})
 
 	for k, tc := range testcases {
 		testURL := masterOptions.AssetConfig.PublicURL + tc.URL


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/7694

@liggitt is the proxy expert, but I think this picks ups locations where we use the built-in go proxy func and replaces it with one respects CIDRs in `NO_PROXY`, but otherwise delegates to the built-in func.