### PR TITLE
Tooltip for multiple ImageSources in BC editor

### DIFF
--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -255,7 +255,12 @@
 
 
                             <div class="multiple-image-source" ng-if="sourceImages.length !== 1">
-                              <label for="imageSourceFrom">Image Source From</label>
+                              <label for="imageSourceFrom">Image Source From<span class="help action-inline">
+                                <a href>
+                                  <i class="pficon pficon-info" style="cursor: help;" aria-hidden="true" data-toggle="tooltip" data-original-title="This Build Config contains more then one Image Source. To edit them use the YAML editor.">
+                                </i>
+                                </a>
+                              </span></label>
                               <div ng-repeat="fromObject in imageSourceFromObjects" class="imageSourceItem">
                                 {{selectTypes[fromObject.kind]}}: {{fromObject | imageObjectRef : buildConfig.metadata.namespace}}
                               </div>


### PR DESCRIPTION
When BC has more then one ImageSource we are just listing them in the BC editor. Thats a result of a conpromise that we had to make. I that case we need to inform user how to edit those if necessary. 
@spadgett PTAL
![screenshot-27](https://cloud.githubusercontent.com/assets/1668218/13814052/1a57cd68-eb85-11e5-9ca9-614969319a70.png)
