### PR TITLE
add check for port contention to e2e

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -69,6 +69,9 @@ trap "cleanup" EXIT INT TERM
 
 os::log::start_system_logger
 
+# we are going to be messing with DNS so we can't have anyone bound to 53
+os::util::fail_if_port_bound 53
+
 out=$(
 	set +e
 	docker stop origin 2>&1

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -56,6 +56,9 @@ reset_tmp_dir
 
 os::log::start_system_logger
 
+# we are going to be messing with DNS so we can't have anyone bound to 53
+os::util::fail_if_port_bound 53
+
 configure_os_server
 start_os_server
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -825,3 +825,31 @@ os::util::get_object_assert() {
       return 1
   fi
 }
+
+# os::util::fail_if_port_bound checks that nothing is bound to port 53 and fails
+# if this is not the case. This function requires elevated privileges and will fail
+# if called without them
+#
+# Globals:
+#  - USE_SUDO
+# Arguments:
+#  - 1: the port to check
+# Returns:
+#  None
+function os::util::fail_if_port_bound() {
+	local port=$1
+
+	if [[ -z "${USE_SUDO:-}" ]]; then
+		echo "[ERROR] os::util::fail_if_port_taken requires elevated privileges, but was called without them."
+		exit 1
+	fi
+
+	if sudo lsof -i4 -n -s TCP:listen -P | grep -Eq ":${port} \(LISTEN\)"; then
+		echo "[ERROR] It seems as though something is bound to port ${port}."
+		echo "        This test changes DNS settings and therefore cannot be run"
+		echo "        in this state. The following programs are listening to the port:"
+		sudo lsof -i4 -n -s TCP:listen -P | grep -E "(COMMAND|:${port} \(LISTEN\))"
+		echo "[ERROR] Aborting..."
+		exit 1
+	fi
+}


### PR DESCRIPTION
This PR adds a check that nobody is listening to port 53 to the start of our end-to-end tests, as this is a hard precondition and deserves a good error message.

fixes https://github.com/openshift/origin/issues/8034 once we determine a "next steps" helptext for it

/cc @abutcher @sdodson 
@liggitt PTAL