### PR TITLE
Load environment files in containerized systemd units

### DIFF
--- a/contrib/systemd/containerized/origin-master.service
+++ b/contrib/systemd/containerized/origin-master.service
@@ -7,7 +7,7 @@ Requires=docker.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/origin-master
 ExecStartPre=-/usr/bin/docker rm -f origin-master
-ExecStart=/usr/bin/docker run --rm --privileged --net=host --name origin-master -v /var/lib/origin:/var/lib/origin -v /var/run/docker.sock:/var/run/docker.sock -v /etc/origin:/etc/origin --entrypoint /usr/bin/openshift openshift/origin start master --config=${CONFIG_FILE} ${OPTIONS}
+ExecStart=/usr/bin/docker run --rm --privileged --net=host --name origin-master --env-file=/etc/sysconfig/origin-master -v /var/lib/origin:/var/lib/origin -v /var/run/docker.sock:/var/run/docker.sock -v /etc/origin:/etc/origin --entrypoint /usr/bin/openshift openshift/origin start master --config=${CONFIG_FILE} ${OPTIONS}
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-master
 Restart=always

--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -8,7 +8,7 @@ After=openvswitch.service
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node
 ExecStartPre=-/usr/bin/docker rm -f origin-node
-ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -e CONFIG_FILE=${CONFIG_FILE} -e OPTIONS=${OPTIONS} -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
+ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always


### PR DESCRIPTION
Replicate https://github.com/openshift/openshift-ansible/pull/1624 in contrib files, fixes loading of all environment variables defined in the sysconfig environment files