### PR TITLE
Add e2fsprogs and xfsprogs to base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,5 +13,5 @@ FROM centos:centos7
 RUN yum swap -y -- remove systemd-container\* -- install systemd systemd-libs
 
 RUN yum install -y which git tar wget hostname sysvinit-tools util-linux bsdtar epel-release \
-    socat ethtool device-mapper iptables && \
+    socat ethtool device-mapper iptables e2fsprogs xfsprogs && \
     yum clean all


### PR DESCRIPTION
Necessary for containerized nodes mounting ebs volumes.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316233

CC: @rootfs 