### PR TITLE
Bug fix so that table-mobile will word-wrap: break-word

### DIFF
--- a/assets/app/styles/_tables.less
+++ b/assets/app/styles/_tables.less
@@ -16,7 +16,7 @@
     &.table-bordered-columns {
       > thead >tr > th, > tbody > tr > td {
         border: 1px solid @table-border-color;
-      }    
+      }
     }
   }
 }
@@ -45,12 +45,12 @@
   }
 }
 
-.table-borderless>tbody>tr>th, 
-.table-borderless>tfoot>tr>th, 
-.table-borderless>thead>tr>td, 
-.table-borderless>tbody>tr>td, 
+.table-borderless>tbody>tr>th,
+.table-borderless>tfoot>tr>th,
+.table-borderless>thead>tr>td,
+.table-borderless>tbody>tr>td,
 .table-borderless>tfoot>tr>td {
-  border-top: none; 
+  border-top: none;
 }
 
 .table .pull-spec {
@@ -96,6 +96,8 @@
 @media (max-width: @screen-xs-max) {
   .table-mobile {
     border-top: 2px solid @table-border-color;
+    // so that .word-break() will work
+    table-layout: fixed;
     thead, tbody, th, td, tr {
       display: block;
     }
@@ -123,8 +125,8 @@
             position: absolute;
             top: 8px;
             left: 6px;
-            width: 35%; 
-            padding-right: 10px; 
+            width: 35%;
+            padding-right: 10px;
             white-space: nowrap;
           }
         }


### PR DESCRIPTION
Fixes #8052

This bug resulted from [the changing of .word-break()](https://github.com/openshift/origin/commit/083629f44c8aa231d1bd441034aaaeeae767218f), which now declares word-wrap and overflow-wrap instead of word-break (which is "[for requiring a particular behaviour with CJK (Chinese, Japanese, and Korean text](http://stackoverflow.com/a/1795878)").

@spadgett, @jwforres:  PTAL