### PR TITLE
bump to v1.2.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1205,63 +1205,1963 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-apiserver/app",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/cmd/kube-apiserver/app/options",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-controller-manager/app",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/cmd/kube-controller-manager/app/options",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-proxy/app",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/cmd/kube-proxy/app/options",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app/options",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/admission",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
-			"ImportPath": "k8s.io/kubernetes/plugin",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"ImportPath": "k8s.io/kubernetes/pkg/api/endpoints",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/errors",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/errors/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/meta",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/pod",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/resource",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/rest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/rest/resttest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/service",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/testapi",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/testing",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/unversioned",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/unversioned/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/v1beta3",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apimachinery",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apimachinery/registered",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/latest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/v0",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/v1beta1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/metrics/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/metrics/v1alpha1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apiserver",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apiserver/authenticator",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apiserver/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authenticator",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authenticator/bearertoken",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authorizer",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authorizer/abac",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authorizer/union",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/handlers",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/user",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/capabilities",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/cache",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/chaosclient",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_2",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/leaderelection",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/record",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/restclient",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/testing/core",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/transport",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/discovery",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/dynamic",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned/fake",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/core/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned/fake",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/extensions/v1beta1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/auth",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/clientcmd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/portforward",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/remotecommand",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned/testclient",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/mesos",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/daemon",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/deployment",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/endpoint",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/framework",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/gc",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/job",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/namespace",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/node",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/persistentvolume",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/podautoscaler",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/replicaset",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/replication",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/resourcequota",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/route",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/service",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/controller/serviceaccount",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/conversion",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/conversion/queryparams",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/aws",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/gcp",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/fieldpath",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/fields",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/genericapiserver",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/healthz",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/httplog",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/config",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/rollout",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/editor",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/jsonmerge",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/resource",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cadvisor",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/client",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/config",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/container",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/custommetrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockertools",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/envvars",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/leaky",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/lifecycle",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/cni",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/exec",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/hairpin",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/kubenet",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pleg",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pod",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober/results",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/rkt",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/portforward",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/stats",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/status",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/types",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/format",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/queue",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/labels",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/master",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/master/ports",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/probe",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/probe/exec",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/probe/http",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/probe/tcp",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/proxy",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/proxy/config",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/proxy/iptables",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/proxy/userspace",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/quota",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/quota/evaluator/core",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/quota/generic",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/quota/install",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/cachesize",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/componentstatus",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/configmap",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/configmap/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/controller",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/controller/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/daemonset",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/daemonset/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/deployment",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/deployment/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/endpoint",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/endpoint/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/event",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/event/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/experimental/controller/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/generic",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/generic/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/generic/rest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/ingress",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/ingress/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/job",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/job/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/limitrange",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/limitrange/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/namespace",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/namespace/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/node",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/node/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/node/rest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/persistentvolume",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/persistentvolume/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/persistentvolumeclaim",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/persistentvolumeclaim/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/pod",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/pod/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/pod/rest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/podsecuritypolicy",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/podsecuritypolicy/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/podtemplate",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/podtemplate/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/registrytest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/replicaset",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/replicaset/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/resourcequota",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/resourcequota/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/secret",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/secret/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/securitycontextconstraints",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/securitycontextconstraints/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/allocator",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/allocator/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/ipallocator",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/ipallocator/controller",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/portallocator",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/service/portallocator/controller",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/serviceaccount",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/serviceaccount/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/thirdpartyresource",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime/serializer",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime/serializer/json",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime/serializer/recognizer",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/runtime/serializer/versioning",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontext",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontextconstraints",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontextconstraints/group",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontextconstraints/selinux",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/securitycontextconstraints/user",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/serviceaccount",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/ssh",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/etcd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/etcd/etcdtest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/etcd/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/etcd/testing",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/etcd/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/storage/testing",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/types",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/atomic",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/bandwidth",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/chmod",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/chown",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/config",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/configz",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/dbus",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/deployment",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/errors",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/exec",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/flock",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/flushwriter",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/hash",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/homedir",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/httpstream",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/httpstream/spdy",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/integer",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/interrupt",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/intstr",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/io",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/iptables",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/json",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/jsonpath",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/keymutex",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/labels",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/limitwriter",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/mount",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/net",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/net/sets",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/node",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/oom",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/parsers",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/pod",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/procfs",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/proxy",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/rand",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/replicaset",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/runtime",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/selinux",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/sets",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/slice",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/strategicpatch",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/strings",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/sysctl",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/system",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/term",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/validation/field",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/wait",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/workqueue",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/wsstream",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/yaml",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/version",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/aws_ebs",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/azure_file",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/cephfs",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/cinder",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/configmap",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/downwardapi",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/empty_dir",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/fc",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/flexvolume",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/flocker",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/gce_pd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/git_repo",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/glusterfs",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/host_path",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/iscsi",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/nfs",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/persistent_claim",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/rbd",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/secret",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/volume/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/watch",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/watch/json",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/admit",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/deny",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/exec",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/initialresources",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/limitranger",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/password/passwordfile",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/basicauth",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/keystone",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/oidc",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/tokenfile",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authorizer/webhook",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities/util",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/latest",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/v1",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/validation",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/factory",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/metrics",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache",
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/json",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/reflect",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/golang/expansion",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/golang/netutil",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/golang/template",
-			"Comment": "v1.2.0-beta.1-28-g148dd34",
-			"Rev": "148dd34ab0e7daeb82582d6ea8e840c15a24e745"
+			"Comment": "v1.2.0-36-g4a3f9c5",
+			"Rev": "4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353"
 		},
 		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -560,158 +560,158 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1/test",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/machine",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.22.0",
-			"Rev": "e39fb02c89f2b39808bc1723108cde5bb510e102"
+			"Comment": "v0.22.2",
+			"Rev": "546a3771589bdb356777c646c6eca24914fdd48b"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",

--- a/Godeps/_workspace/src/github.com/google/cadvisor/container/libcontainer/helpers.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/container/libcontainer/helpers.go
@@ -92,29 +92,30 @@ func GetStats(cgroupManager cgroups.Manager, rootFs string, pid int, ignoreMetri
 	stats := toContainerStats(libcontainerStats)
 
 	// If we know the pid then get network stats from /proc/<pid>/net/dev
-	if pid > 0 {
-		if !ignoreMetrics.Has(container.NetworkUsageMetrics) {
-			netStats, err := networkStatsFromProc(rootFs, pid)
-			if err != nil {
-				glog.V(2).Infof("Unable to get network stats from pid %d: %v", pid, err)
-			} else {
-				stats.Network.Interfaces = append(stats.Network.Interfaces, netStats...)
-			}
+	if pid == 0 {
+		return stats, nil
+	}
+	if !ignoreMetrics.Has(container.NetworkUsageMetrics) {
+		netStats, err := networkStatsFromProc(rootFs, pid)
+		if err != nil {
+			glog.V(2).Infof("Unable to get network stats from pid %d: %v", pid, err)
+		} else {
+			stats.Network.Interfaces = append(stats.Network.Interfaces, netStats...)
 		}
-		if !ignoreMetrics.Has(container.NetworkTcpUsageMetrics) {
-			t, err := tcpStatsFromProc(rootFs, pid, "net/tcp")
-			if err != nil {
-				glog.V(2).Infof("Unable to get tcp stats from pid %d: %v", pid, err)
-			} else {
-				stats.Network.Tcp = t
-			}
+	}
+	if !ignoreMetrics.Has(container.NetworkTcpUsageMetrics) {
+		t, err := tcpStatsFromProc(rootFs, pid, "net/tcp")
+		if err != nil {
+			glog.V(2).Infof("Unable to get tcp stats from pid %d: %v", pid, err)
+		} else {
+			stats.Network.Tcp = t
+		}
 
-			t6, err := tcpStatsFromProc(rootFs, pid, "net/tcp6")
-			if err != nil {
-				glog.V(2).Infof("Unable to get tcp6 stats from pid %d: %v", pid, err)
-			} else {
-				stats.Network.Tcp6 = t6
-			}
+		t6, err := tcpStatsFromProc(rootFs, pid, "net/tcp6")
+		if err != nil {
+			glog.V(2).Infof("Unable to get tcp6 stats from pid %d: %v", pid, err)
+		} else {
+			stats.Network.Tcp6 = t6
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/google/cadvisor/info/v1/machine.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/info/v1/machine.go
@@ -121,11 +121,11 @@ type NetInfo struct {
 type CloudProvider string
 
 const (
-	GCE            CloudProvider = "GCE"
-	AWS                          = "AWS"
-	Azure                        = "Azure"
-	Baremetal                    = "Baremetal"
-	UnkownProvider               = "Unknown"
+	GCE             CloudProvider = "GCE"
+	AWS                           = "AWS"
+	Azure                         = "Azure"
+	Baremetal                     = "Baremetal"
+	UnknownProvider               = "Unknown"
 )
 
 type InstanceType string

--- a/Godeps/_workspace/src/github.com/google/cadvisor/utils/cloudinfo/aws.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/utils/cloudinfo/aws.go
@@ -15,6 +15,8 @@
 package cloudinfo
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -23,7 +25,13 @@ import (
 )
 
 func onAWS() bool {
-	client := ec2metadata.New(session.New(&aws.Config{}))
+	// the default client behavior retried the operation multiple times with a 5s timeout per attempt.
+	// if you were not on aws, you would block for 20s when invoking this operation.
+	// we reduce retries to 0 and set the timeout to 2s to reduce the time this blocks when not on aws.
+	client := ec2metadata.New(session.New(&aws.Config{MaxRetries: aws.Int(0)}))
+	if client.Config.HTTPClient != nil {
+		client.Config.HTTPClient.Timeout = time.Duration(2 * time.Second)
+	}
 	return client.Available()
 }
 

--- a/Godeps/_workspace/src/github.com/google/cadvisor/utils/cloudinfo/cloudinfo.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/utils/cloudinfo/cloudinfo.go
@@ -66,7 +66,7 @@ func detectCloudProvider() info.CloudProvider {
 	case onBaremetal():
 		return info.Baremetal
 	}
-	return info.UnkownProvider
+	return info.UnknownProvider
 }
 
 func detectInstanceType(cloudProvider info.CloudProvider) info.InstanceType {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/extensions_v1beta1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/extensions_v1beta1.json
@@ -8152,6 +8152,11 @@
       "format": "int32",
       "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replicaset."
+     },
      "observedGeneration": {
       "type": "integer",
       "format": "int64",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -18706,6 +18706,11 @@
       "format": "int32",
       "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replication controller."
+     },
      "observedGeneration": {
       "type": "integer",
       "format": "int64",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-gluster/spark-master-controller.yaml
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-gluster/spark-master-controller.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark-master:1.5.1_v2
+          image: gcr.io/google_containers/spark:1.5.2_v1
+          command: ["/start-master"]
           ports:
             - containerPort: 7077
           volumeMounts:

--- a/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-gluster/spark-worker-controller.yaml
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-gluster/spark-worker-controller.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark-worker:1.5.1_v2
+          image: gcr.io/google_containers/spark:1.5.2_v1
+          command: ["/start-worker"]
           ports:
             - containerPort: 8888
           volumeMounts:

--- a/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-master-controller.yaml
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-master-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark:1.5.1_v3
+          image: gcr.io/google_containers/spark:1.5.2_v1
           command: ["/start-master"]
           ports:
             - containerPort: 7077

--- a/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-worker-controller.yaml
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/spark-worker-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark:1.5.1_v3
+          image: gcr.io/google_containers/spark:1.5.2_v1
           command: ["/start-worker"]
           ports:
             - containerPort: 8081

--- a/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/zeppelin-controller.yaml
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/examples/spark/zeppelin-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: zeppelin
-          image: gcr.io/google_containers/zeppelin:v0.5.5_v2
+          image: gcr.io/google_containers/zeppelin:v0.5.6_v1
           ports:
             - containerPort: 8080
           resources:

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2429,6 +2429,7 @@ func DeepCopy_api_ReplicationControllerSpec(in ReplicationControllerSpec, out *R
 
 func DeepCopy_api_ReplicationControllerStatus(in ReplicationControllerStatus, out *ReplicationControllerStatus, c *conversion.Cloner) error {
 	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -1380,6 +1380,9 @@ type ReplicationControllerStatus struct {
 	// Replicas is the number of actual replicas.
 	Replicas int `json:"replicas"`
 
+	// The number of pods that have labels matching the labels of the pod template of the replication controller.
+	FullyLabeledReplicas int `json:"fullyLabeledReplicas,omitempty"`
+
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2633,6 +2633,7 @@ func autoConvert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStat
 		defaulting.(func(*api.ReplicationControllerStatus))(in)
 	}
 	out.Replicas = int32(in.Replicas)
+	out.FullyLabeledReplicas = int32(in.FullyLabeledReplicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
@@ -6078,6 +6079,7 @@ func autoConvert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStat
 		defaulting.(func(*ReplicationControllerStatus))(in)
 	}
 	out.Replicas = int(in.Replicas)
+	out.FullyLabeledReplicas = int(in.FullyLabeledReplicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2075,6 +2075,7 @@ func deepCopy_v1_ReplicationControllerSpec(in ReplicationControllerSpec, out *Re
 
 func deepCopy_v1_ReplicationControllerStatus(in ReplicationControllerStatus, out *ReplicationControllerStatus, c *conversion.Cloner) error {
 	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1687,6 +1687,9 @@ type ReplicationControllerStatus struct {
 	// More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller
 	Replicas int32 `json:"replicas"`
 
+	// The number of pods that have labels matching the labels of the pod template of the replication controller.
+	FullyLabeledReplicas int32 `json:"fullyLabeledReplicas,omitempty"`
+
 	// ObservedGeneration reflects the generation of the most recently observed replication controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -1360,9 +1360,10 @@ func (ReplicationControllerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicationControllerStatus = map[string]string{
-	"":                   "ReplicationControllerStatus represents the current status of a replication controller.",
-	"replicas":           "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
-	"observedGeneration": "ObservedGeneration reflects the generation of the most recently observed replication controller.",
+	"":                     "ReplicationControllerStatus represents the current status of a replication controller.",
+	"replicas":             "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
+	"fullyLabeledReplicas": "The number of pods that have labels matching the labels of the pod template of the replication controller.",
+	"observedGeneration":   "ObservedGeneration reflects the generation of the most recently observed replication controller.",
 }
 
 func (ReplicationControllerStatus) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -1866,6 +1866,7 @@ func ValidateReplicationControllerStatusUpdate(controller, oldController *api.Re
 	allErrs := ValidateObjectMetaUpdate(&controller.ObjectMeta, &oldController.ObjectMeta, field.NewPath("metadata"))
 	statusPath := field.NewPath("status")
 	allErrs = append(allErrs, ValidateNonnegativeField(int64(controller.Status.Replicas), statusPath.Child("replicas"))...)
+	allErrs = append(allErrs, ValidateNonnegativeField(int64(controller.Status.FullyLabeledReplicas), statusPath.Child("fullyLabeledReplicas"))...)
 	allErrs = append(allErrs, ValidateNonnegativeField(int64(controller.Status.ObservedGeneration), statusPath.Child("observedGeneration"))...)
 	return allErrs
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/types.go
@@ -815,6 +815,9 @@ type ReplicaSetStatus struct {
 	// Replicas is the number of actual replicas.
 	Replicas int `json:"replicas"`
 
+	// The number of pods that have labels matching the labels of the pod template of the replicaset.
+	FullyLabeledReplicas int `json:"fullyLabeledReplicas,omitempty"`
+
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -3217,6 +3217,7 @@ func autoConvert_extensions_ReplicaSetStatus_To_v1beta1_ReplicaSetStatus(in *ext
 		defaulting.(func(*extensions.ReplicaSetStatus))(in)
 	}
 	out.Replicas = int32(in.Replicas)
+	out.FullyLabeledReplicas = int32(in.FullyLabeledReplicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
@@ -4460,6 +4461,7 @@ func autoConvert_v1beta1_ReplicaSetStatus_To_extensions_ReplicaSetStatus(in *Rep
 		defaulting.(func(*ReplicaSetStatus))(in)
 	}
 	out.Replicas = int(in.Replicas)
+	out.FullyLabeledReplicas = int(in.FullyLabeledReplicas)
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -1777,6 +1777,7 @@ func deepCopy_v1beta1_ReplicaSetSpec(in ReplicaSetSpec, out *ReplicaSetSpec, c *
 
 func deepCopy_v1beta1_ReplicaSetStatus(in ReplicaSetStatus, out *ReplicaSetStatus, c *conversion.Cloner) error {
 	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
@@ -907,6 +907,9 @@ type ReplicaSetStatus struct {
 	// More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller
 	Replicas int32 `json:"replicas"`
 
+	// The number of pods that have labels matching the labels of the pod template of the replicaset.
+	FullyLabeledReplicas int32 `json:"fullyLabeledReplicas,omitempty"`
+
 	// ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -517,9 +517,10 @@ func (ReplicaSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetStatus = map[string]string{
-	"":                   "ReplicaSetStatus represents the current status of a ReplicaSet.",
-	"replicas":           "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
-	"observedGeneration": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+	"":                     "ReplicaSetStatus represents the current status of a ReplicaSet.",
+	"replicas":             "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
+	"fullyLabeledReplicas": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+	"observedGeneration":   "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
 }
 
 func (ReplicaSetStatus) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/validation/validation.go
@@ -687,6 +687,7 @@ func ValidateReplicaSetStatusUpdate(rs, oldRs *extensions.ReplicaSet) field.Erro
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&rs.ObjectMeta, &oldRs.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(rs.Status.Replicas), field.NewPath("status", "replicas"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(rs.Status.FullyLabeledReplicas), field.NewPath("status", "fullyLabeledReplicas"))...)
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(rs.Status.ObservedGeneration), field.NewPath("status", "observedGeneration"))...)
 	return allErrs
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/typed/discovery/discovery_client.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/typed/discovery/discovery_client.go
@@ -212,7 +212,7 @@ func setDiscoveryDefaults(config *restclient.Config) error {
 	config.APIPath = ""
 	config.GroupVersion = nil
 	config.Codec = runtime.NoopEncoder{api.Codecs.UniversalDecoder()}
-	if config.UserAgent == "" {
+	if len(config.UserAgent) == 0 {
 		config.UserAgent = restclient.DefaultKubernetesUserAgent()
 	}
 	return nil

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
@@ -80,6 +80,11 @@ const MaxReadThenCreateRetries = 30
 // need hardcoded defaults.
 const DefaultVolumeType = "gp2"
 
+// Amazon recommends having no more that 40 volumes attached to an instance,
+// and at least one of those is for the system root volume.
+// See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits
+const DefaultMaxEBSVolumes = 39
+
 // Used to call aws_credentials.Init() just once
 var once sync.Once
 
@@ -161,7 +166,7 @@ type EC2Metadata interface {
 
 type VolumeOptions struct {
 	CapacityGB int
-	Tags       *map[string]string
+	Tags       map[string]string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -902,10 +907,17 @@ type mountDevice string
 // TODO: Also return number of mounts allowed?
 func (self *awsInstanceType) getEBSMountDevices() []mountDevice {
 	// See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+	// We will generate "ba", "bb", "bc"..."bz", "ca", ..., up to DefaultMaxEBSVolumes
 	devices := []mountDevice{}
-	for c := 'f'; c <= 'p'; c++ {
-		devices = append(devices, mountDevice(fmt.Sprintf("%c", c)))
+	count := 0
+	for first := 'b'; count < DefaultMaxEBSVolumes; first++ {
+		for second := 'a'; count < DefaultMaxEBSVolumes && second <= 'z'; second++ {
+			device := mountDevice(fmt.Sprintf("%c%c", first, second))
+			devices = append(devices, device)
+			count++
+		}
 	}
+
 	return devices
 }
 
@@ -932,9 +944,10 @@ type awsInstance struct {
 
 	mutex sync.Mutex
 
-	// We must cache because otherwise there is a race condition,
-	// where we assign a device mapping and then get a second request before we attach the volume
-	deviceMappings map[mountDevice]string
+	// We keep an active list of devices we have assigned but not yet
+	// attached, to avoid a race condition where we assign a device mapping
+	// and then get a second request before we attach the volume
+	attaching map[mountDevice]string
 }
 
 // newAWSInstance creates a new awsInstance object
@@ -953,8 +966,7 @@ func newAWSInstance(ec2Service EC2, instance *ec2.Instance) *awsInstance {
 		subnetID:         aws.StringValue(instance.SubnetId),
 	}
 
-	// We lazy-init deviceMappings
-	self.deviceMappings = nil
+	self.attaching = make(map[mountDevice]string)
 
 	return self
 }
@@ -1001,31 +1013,31 @@ func (self *awsInstance) getMountDevice(volumeID string, assign bool) (assigned 
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
-	// We cache both for efficiency and correctness
-	if self.deviceMappings == nil {
-		info, err := self.describeInstance()
-		if err != nil {
-			return "", false, err
+	info, err := self.describeInstance()
+	if err != nil {
+		return "", false, err
+	}
+	deviceMappings := map[mountDevice]string{}
+	for _, blockDevice := range info.BlockDeviceMappings {
+		name := aws.StringValue(blockDevice.DeviceName)
+		if strings.HasPrefix(name, "/dev/sd") {
+			name = name[7:]
 		}
-		deviceMappings := map[mountDevice]string{}
-		for _, blockDevice := range info.BlockDeviceMappings {
-			name := aws.StringValue(blockDevice.DeviceName)
-			if strings.HasPrefix(name, "/dev/sd") {
-				name = name[7:]
-			}
-			if strings.HasPrefix(name, "/dev/xvd") {
-				name = name[8:]
-			}
-			if len(name) != 1 {
-				glog.Warningf("Unexpected EBS DeviceName: %q", aws.StringValue(blockDevice.DeviceName))
-			}
-			deviceMappings[mountDevice(name)] = aws.StringValue(blockDevice.Ebs.VolumeId)
+		if strings.HasPrefix(name, "/dev/xvd") {
+			name = name[8:]
 		}
-		self.deviceMappings = deviceMappings
+		if len(name) < 1 || len(name) > 2 {
+			glog.Warningf("Unexpected EBS DeviceName: %q", aws.StringValue(blockDevice.DeviceName))
+		}
+		deviceMappings[mountDevice(name)] = aws.StringValue(blockDevice.Ebs.VolumeId)
+	}
+
+	for mountDevice, volume := range self.attaching {
+		deviceMappings[mountDevice] = volume
 	}
 
 	// Check to see if this volume is already assigned a device on this machine
-	for mountDevice, mappingVolumeID := range self.deviceMappings {
+	for mountDevice, mappingVolumeID := range deviceMappings {
 		if volumeID == mappingVolumeID {
 			if assign {
 				glog.Warningf("Got assignment call for already-assigned volume: %s@%s", mountDevice, mappingVolumeID)
@@ -1042,7 +1054,7 @@ func (self *awsInstance) getMountDevice(volumeID string, assign bool) (assigned 
 	valid := instanceType.getEBSMountDevices()
 	chosen := mountDevice("")
 	for _, mountDevice := range valid {
-		_, found := self.deviceMappings[mountDevice]
+		_, found := deviceMappings[mountDevice]
 		if !found {
 			chosen = mountDevice
 			break
@@ -1050,31 +1062,31 @@ func (self *awsInstance) getMountDevice(volumeID string, assign bool) (assigned 
 	}
 
 	if chosen == "" {
-		glog.Warningf("Could not assign a mount device (all in use?).  mappings=%v, valid=%v", self.deviceMappings, valid)
-		return "", false, nil
+		glog.Warningf("Could not assign a mount device (all in use?).  mappings=%v, valid=%v", deviceMappings, valid)
+		return "", false, fmt.Errorf("Too many EBS volumes attached to node %s.", self.nodeName)
 	}
 
-	self.deviceMappings[chosen] = volumeID
+	self.attaching[chosen] = volumeID
 	glog.V(2).Infof("Assigned mount device %s -> volume %s", chosen, volumeID)
 
 	return chosen, false, nil
 }
 
-func (self *awsInstance) releaseMountDevice(volumeID string, mountDevice mountDevice) {
+func (self *awsInstance) endAttaching(volumeID string, mountDevice mountDevice) {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
-	existingVolumeID, found := self.deviceMappings[mountDevice]
+	existingVolumeID, found := self.attaching[mountDevice]
 	if !found {
-		glog.Errorf("releaseMountDevice on non-allocated device")
+		glog.Errorf("endAttaching on non-allocated device")
 		return
 	}
 	if volumeID != existingVolumeID {
-		glog.Errorf("releaseMountDevice on device assigned to different volume")
+		glog.Errorf("endAttaching on device assigned to different volume")
 		return
 	}
 	glog.V(2).Infof("Releasing mount device mapping: %s -> volume %s", mountDevice, volumeID)
-	delete(self.deviceMappings, mountDevice)
+	delete(self.attaching, mountDevice)
 }
 
 type awsDisk struct {
@@ -1144,6 +1156,8 @@ func (self *awsDisk) describeVolume() (*ec2.Volume, error) {
 	return volumes[0], nil
 }
 
+// waitForAttachmentStatus polls until the attachment status is the expected value
+// TODO(justinsb): return (bool, error)
 func (self *awsDisk) waitForAttachmentStatus(status string) error {
 	// TODO: There may be a faster way to get this when we're attaching locally
 	attempt := 0
@@ -1278,10 +1292,12 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 		ec2Device = "/dev/sd" + string(mountDevice)
 	}
 
-	attached := false
+	// attachEnded is set to true if the attach operation completed
+	// (successfully or not)
+	attachEnded := false
 	defer func() {
-		if !attached {
-			awsInstance.releaseMountDevice(disk.awsID, mountDevice)
+		if attachEnded {
+			awsInstance.endAttaching(disk.awsID, mountDevice)
 		}
 	}()
 
@@ -1294,6 +1310,7 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 
 		attachResponse, err := c.ec2.AttachVolume(request)
 		if err != nil {
+			attachEnded = true
 			// TODO: Check if the volume was concurrently attached?
 			return "", fmt.Errorf("Error attaching EBS volume: %v", err)
 		}
@@ -1306,7 +1323,7 @@ func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly boo
 		return "", err
 	}
 
-	attached = true
+	attachEnded = true
 
 	return hostDevice, nil
 }
@@ -1346,31 +1363,13 @@ func (aws *AWSCloud) DetachDisk(diskName string, instanceName string) (string, e
 		return "", errors.New("no response from DetachVolume")
 	}
 
-	// TODO: Fix this - just remove the cache?
-	// If we don't have a cache; we don't have to wait any more (the driver does it for us)
-	// Also, maybe we could get the locally connected drivers from the AWS metadata service?
-
-	// At this point we are waiting for the volume being detached. This
-	// releases the volume and invalidates the cache even when there is a timeout.
-	//
-	// TODO: A timeout leaves the cache in an inconsistent state. The volume is still
-	// detaching though the cache shows it as ready to be attached again. Subsequent
-	// attach operations will fail. The attach is being retried and eventually
-	// works though. An option would be to completely flush the cache upon timeouts.
-	//
-	defer func() {
-		// TODO: Not thread safe?
-		for mountDevice, existingVolumeID := range awsInstance.deviceMappings {
-			if existingVolumeID == disk.awsID {
-				awsInstance.releaseMountDevice(disk.awsID, mountDevice)
-				return
-			}
-		}
-	}()
-
 	err = disk.waitForAttachmentStatus("detached")
 	if err != nil {
 		return "", err
+	}
+
+	if mountDevice != "" {
+		awsInstance.endAttaching(disk.awsID, mountDevice)
 	}
 
 	hostDevicePath := "/dev/xvd" + string(mountDevice)
@@ -1400,8 +1399,17 @@ func (s *AWSCloud) CreateDisk(volumeOptions *VolumeOptions) (string, error) {
 	volumeName := "aws://" + az + "/" + awsID
 
 	// apply tags
-	if volumeOptions.Tags != nil {
-		if err := s.createTags(awsID, *volumeOptions.Tags); err != nil {
+	tags := make(map[string]string)
+	for k, v := range volumeOptions.Tags {
+		tags[k] = v
+	}
+
+	if s.getClusterName() != "" {
+		tags[TagNameKubernetesCluster] = s.getClusterName()
+	}
+
+	if len(tags) != 0 {
+		if err := s.createTags(awsID, tags); err != nil {
 			// delete the volume and hope it succeeds
 			_, delerr := s.DeleteDisk(volumeName)
 			if delerr != nil {
@@ -2314,8 +2322,7 @@ func findSecurityGroupForInstance(instance *ec2.Instance, taggedSecurityGroups m
 // Return all the security groups that are tagged as being part of our cluster
 func (s *AWSCloud) getTaggedSecurityGroups() (map[string]*ec2.SecurityGroup, error) {
 	request := &ec2.DescribeSecurityGroupsInput{}
-	filters := []*ec2.Filter{}
-	request.Filters = s.addFilters(filters)
+	request.Filters = s.addFilters(nil)
 	groups, err := s.ec2.DescribeSecurityGroups(request)
 	if err != nil {
 		return nil, fmt.Errorf("error querying security groups: %v", err)
@@ -2363,7 +2370,7 @@ func (s *AWSCloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalan
 	describeRequest.Filters = s.addFilters(filters)
 	actualGroups, err := s.ec2.DescribeSecurityGroups(describeRequest)
 	if err != nil {
-		return fmt.Errorf("error querying security groups: %v", err)
+		return fmt.Errorf("error querying security groups for ELB: %v", err)
 	}
 
 	taggedSecurityGroups, err := s.getTaggedSecurityGroups()
@@ -2510,7 +2517,7 @@ func (s *AWSCloud) EnsureLoadBalancerDeleted(name, region string) error {
 		}
 
 		// Loop through and try to delete them
-		timeoutAt := time.Now().Add(time.Second * 300)
+		timeoutAt := time.Now().Add(time.Second * 600)
 		for {
 			for securityGroupID := range securityGroupIDs {
 				request := &ec2.DeleteSecurityGroupInput{}
@@ -2538,12 +2545,17 @@ func (s *AWSCloud) EnsureLoadBalancerDeleted(name, region string) error {
 			}
 
 			if time.Now().After(timeoutAt) {
-				return fmt.Errorf("timed out waiting for load-balancer deletion: %s", name)
+				ids := []string{}
+				for id := range securityGroupIDs {
+					ids = append(ids, id)
+				}
+
+				return fmt.Errorf("timed out deleting ELB: %s. Could not delete security groups %v", name, strings.Join(ids, ","))
 			}
 
 			glog.V(2).Info("Waiting for load-balancer to delete so we can delete security groups: ", name)
 
-			time.Sleep(5 * time.Second)
+			time.Sleep(10 * time.Second)
 		}
 	}
 
@@ -2702,6 +2714,12 @@ func (s *AWSCloud) addFilters(filters []*ec2.Filter) []*ec2.Filter {
 	for k, v := range s.filterTags {
 		filters = append(filters, newEc2Filter("tag:"+k, v))
 	}
+	if len(filters) == 0 {
+		// We can't pass a zero-length Filters to AWS (it's an error)
+		// So if we end up with no filters; just return nil
+		return nil
+	}
+
 	return filters
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/deployment/deployment_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/deployment/deployment_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/integer"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	podutil "k8s.io/kubernetes/pkg/util/pod"
+	rsutil "k8s.io/kubernetes/pkg/util/replicaset"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/workqueue"
@@ -672,33 +674,31 @@ func lastRevision(allRSs []*extensions.ReplicaSet) int64 {
 
 // getOldReplicaSets returns two sets of old replica sets of the deployment. The first set of old replica sets doesn't include
 // the ones with no pods, and the second set of old replica sets include all old replica sets.
+// Note that the pod-template-hash will be added to adopted RSes and pods.
 func (dc *DeploymentController) getOldReplicaSets(deployment *extensions.Deployment) ([]*extensions.ReplicaSet, []*extensions.ReplicaSet, error) {
-	return deploymentutil.GetOldReplicaSetsFromLists(deployment, dc.client,
-		func(namespace string, options api.ListOptions) (*api.PodList, error) {
-			podList, err := dc.podStore.Pods(namespace).List(options.LabelSelector)
-			return &podList, err
-		},
-		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
-			return dc.rsStore.ReplicaSets(namespace).List(options.LabelSelector)
-		})
+	// List the deployment's RSes & Pods and apply pod-template-hash info to deployment's adopted RSes/Pods
+	rsList, podList, err := dc.rsAndPodsWithHashKeySynced(deployment)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error labeling replica sets and pods with pod-template-hash: %v", err)
+	}
+	return deploymentutil.FindOldReplicaSets(deployment, rsList, podList)
 }
 
-// Returns a replica set that matches the intent of the given deployment.
+// Returns a replica set that matches the intent of the given deployment. Returns nil if the new replica set doesn't exist yet.
 // 1. Get existing new RS (the RS that the given deployment targets, whose pod template is the same as deployment's).
 // 2. If there's existing new RS, update its revision number if it's smaller than (maxOldRevision + 1), where maxOldRevision is the max revision number among all old RSes.
 // 3. If there's no existing new RS and createIfNotExisted is true, create one with appropriate revision number (maxOldRevision + 1) and replicas.
+// Note that the pod-template-hash will be added to adopted RSes and pods.
 func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployment, maxOldRevision int64, oldRSs []*extensions.ReplicaSet, createIfNotExisted bool) (*extensions.ReplicaSet, error) {
 	// Calculate revision number for this new replica set
 	newRevision := strconv.FormatInt(maxOldRevision+1, 10)
 
-	existingNewRS, err := deploymentutil.GetNewReplicaSetFromList(deployment, dc.client,
-		func(namespace string, options api.ListOptions) (*api.PodList, error) {
-			podList, err := dc.podStore.Pods(namespace).List(options.LabelSelector)
-			return &podList, err
-		},
-		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
-			return dc.rsStore.ReplicaSets(namespace).List(options.LabelSelector)
-		})
+	// List the deployment's RSes and apply pod-template-hash info to deployment's adopted RSes/Pods
+	rsList, _, err := dc.rsAndPodsWithHashKeySynced(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("error labeling replica sets and pods with pod-template-hash: %v", err)
+	}
+	existingNewRS, err := deploymentutil.FindNewReplicaSet(deployment, rsList)
 	if err != nil {
 		return nil, err
 	} else if existingNewRS != nil {
@@ -752,6 +752,130 @@ func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployme
 	}
 
 	return createdRS, dc.updateDeploymentRevision(deployment, newRevision)
+}
+
+// rsAndPodsWithHashKeySynced returns the RSes and pods the given deployment targets, with pod-template-hash information synced.
+func (dc *DeploymentController) rsAndPodsWithHashKeySynced(deployment *extensions.Deployment) ([]extensions.ReplicaSet, *api.PodList, error) {
+	rsList, err := deploymentutil.ListReplicaSets(deployment,
+		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
+			return dc.rsStore.ReplicaSets(namespace).List(options.LabelSelector)
+		})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing ReplicaSets: %v", err)
+	}
+	syncedRSList := []extensions.ReplicaSet{}
+	for _, rs := range rsList {
+		// Add pod-template-hash information if it's not in the RS.
+		// Otherwise, new RS produced by Deployment will overlap with pre-existing ones
+		// that aren't constrained by the pod-template-hash.
+		syncedRS, err := dc.addHashKeyToRSAndPods(rs)
+		if err != nil {
+			return nil, nil, err
+		}
+		syncedRSList = append(syncedRSList, *syncedRS)
+	}
+	syncedPodList, err := deploymentutil.ListPods(deployment,
+		func(namespace string, options api.ListOptions) (*api.PodList, error) {
+			podList, err := dc.podStore.Pods(namespace).List(options.LabelSelector)
+			return &podList, err
+		})
+
+	if err != nil {
+		return nil, nil, err
+	}
+	return syncedRSList, syncedPodList, nil
+}
+
+// addHashKeyToRSAndPods adds pod-template-hash information to the given rs, if it's not already there, with the following steps:
+// 1. Add hash label to the rs's pod template, and make sure the controller sees this update so that no orphaned pods will be created
+// 2. Add hash label to all pods this rs owns, wait until replicaset controller reports rs.Status.FullyLabeledReplicas equal to the desired number of replicas
+// 3. Add hash label to the rs's label and selector
+func (dc *DeploymentController) addHashKeyToRSAndPods(rs extensions.ReplicaSet) (updatedRS *extensions.ReplicaSet, err error) {
+	updatedRS = &rs
+	// If the rs already has the new hash label in its selector, it's done syncing
+	if labelsutil.SelectorHasLabel(rs.Spec.Selector, extensions.DefaultDeploymentUniqueLabelKey) {
+		return
+	}
+	namespace := rs.Namespace
+	hash := rsutil.GetPodTemplateSpecHash(rs)
+	rsUpdated := false
+	// 1. Add hash template label to the rs. This ensures that any newly created pods will have the new label.
+	updatedRS, rsUpdated, err = rsutil.UpdateRSWithRetries(dc.client.Extensions().ReplicaSets(namespace), updatedRS,
+		func(updated *extensions.ReplicaSet) error {
+			// Precondition: the RS doesn't contain the new hash in its pod template label.
+			if updated.Spec.Template.Labels[extensions.DefaultDeploymentUniqueLabelKey] == hash {
+				return utilerrors.ErrPreconditionViolated
+			}
+			updated.Spec.Template.Labels = labelsutil.AddLabel(updated.Spec.Template.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("error updating %s %s/%s pod template label with template hash: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, err)
+	}
+	if !rsUpdated {
+		// If RS wasn't updated but didn't return error in step 1, we've hit a RS not found error.
+		// Return here and retry in the next sync loop.
+		return &rs, nil
+	}
+	// Make sure rs pod template is updated so that it won't create pods without the new label (orphaned pods).
+	if updatedRS.Generation > updatedRS.Status.ObservedGeneration {
+		if err = deploymentutil.WaitForReplicaSetUpdated(dc.client, updatedRS.Generation, namespace, updatedRS.Name); err != nil {
+			return nil, fmt.Errorf("error waiting for %s %s/%s generation %d observed by controller: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, updatedRS.Generation, err)
+		}
+	}
+	glog.V(4).Infof("Observed the update of %s %s/%s's pod template with hash %s.", rs.Kind, rs.Namespace, rs.Name, hash)
+
+	// 2. Update all pods managed by the rs to have the new hash label, so they will be correctly adopted.
+	selector, err := unversioned.LabelSelectorAsSelector(updatedRS.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("error in converting selector to label selector for replica set %s: %s", updatedRS.Name, err)
+	}
+	options := api.ListOptions{LabelSelector: selector}
+	podList, err := dc.podStore.Pods(namespace).List(options.LabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error in getting pod list for namespace %s and list options %+v: %s", namespace, options, err)
+	}
+	allPodsLabeled := false
+	if allPodsLabeled, err = deploymentutil.LabelPodsWithHash(&podList, updatedRS, dc.client, namespace, hash); err != nil {
+		return nil, fmt.Errorf("error in adding template hash label %s to pods %+v: %s", hash, podList, err)
+	}
+	// If not all pods are labeled but didn't return error in step 2, we've hit at least one pod not found error.
+	// Return here and retry in the next sync loop.
+	if !allPodsLabeled {
+		return updatedRS, nil
+	}
+
+	// We need to wait for the replicaset controller to observe the pods being
+	// labeled with pod template hash. Because previously we've called
+	// WaitForReplicaSetUpdated, the replicaset controller should have dropped
+	// FullyLabeledReplicas to 0 already, we only need to wait it to increase
+	// back to the number of replicas in the spec.
+	if err = deploymentutil.WaitForPodsHashPopulated(dc.client, updatedRS.Generation, namespace, updatedRS.Name); err != nil {
+		return nil, fmt.Errorf("%s %s/%s: error waiting for replicaset controller to observe pods being labeled with template hash: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, err)
+	}
+
+	// 3. Update rs label and selector to include the new hash label
+	// Copy the old selector, so that we can scrub out any orphaned pods
+	if updatedRS, rsUpdated, err = rsutil.UpdateRSWithRetries(dc.client.Extensions().ReplicaSets(namespace), updatedRS,
+		func(updated *extensions.ReplicaSet) error {
+			// Precondition: the RS doesn't contain the new hash in its label or selector.
+			if updated.Labels[extensions.DefaultDeploymentUniqueLabelKey] == hash && updated.Spec.Selector.MatchLabels[extensions.DefaultDeploymentUniqueLabelKey] == hash {
+				return utilerrors.ErrPreconditionViolated
+			}
+			updated.Labels = labelsutil.AddLabel(updated.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
+			updated.Spec.Selector = labelsutil.AddLabelToSelector(updated.Spec.Selector, extensions.DefaultDeploymentUniqueLabelKey, hash)
+			return nil
+		}); err != nil {
+		return nil, fmt.Errorf("error updating %s %s/%s label and selector with template hash: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, err)
+	}
+	if rsUpdated {
+		glog.V(4).Infof("Updated %s %s/%s's selector and label with hash %s.", rs.Kind, rs.Namespace, rs.Name, hash)
+	}
+	// If the RS isn't actually updated in step 3, that's okay, we'll retry in the next sync loop since its selector isn't updated yet.
+
+	// TODO: look for orphaned pods and label them in the background somewhere else periodically
+
+	return updatedRS, nil
 }
 
 // setNewReplicaSetAnnotations sets new replica set's annotations appropriately by updating its revision and

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/replication/replication_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/replication/replication_controller.go
@@ -540,8 +540,21 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 		rm.manageReplicas(filteredPods, &rc)
 	}
 
+	// Count the number of pods that have labels matching the labels of the pod
+	// template of the replication controller, the matching pods may have more
+	// labels than are in the template. Because the label of podTemplateSpec is
+	// a superset of the selector of the replication controller, so the possible
+	// matching pods must be part of the filteredPods.
+	fullyLabeledReplicasCount := 0
+	templateLabel := labels.Set(rc.Spec.Template.Labels).AsSelector()
+	for _, pod := range filteredPods {
+		if templateLabel.Matches(labels.Set(pod.Labels)) {
+			fullyLabeledReplicasCount++
+		}
+	}
+
 	// Always updates status as pods come up or die.
-	if err := updateReplicaCount(rm.kubeClient.Core().ReplicationControllers(rc.Namespace), rc, len(filteredPods)); err != nil {
+	if err := updateReplicaCount(rm.kubeClient.Core().ReplicationControllers(rc.Namespace), rc, len(filteredPods), fullyLabeledReplicasCount); err != nil {
 		// Multiple things could lead to this update failing. Requeuing the controller ensures
 		// we retry with some fairness.
 		glog.V(2).Infof("Failed to update replica count for controller %v/%v; requeuing; error: %v", rc.Namespace, rc.Name, err)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/replication/replication_controller_utils.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/replication/replication_controller_utils.go
@@ -19,17 +19,20 @@ limitations under the License.
 package replication
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	unversionedcore "k8s.io/kubernetes/pkg/client/typed/generated/core/unversioned"
 )
 
 // updateReplicaCount attempts to update the Status.Replicas of the given controller, with a single GET/PUT retry.
-func updateReplicaCount(rcClient unversionedcore.ReplicationControllerInterface, controller api.ReplicationController, numReplicas int) (updateErr error) {
+func updateReplicaCount(rcClient unversionedcore.ReplicationControllerInterface, controller api.ReplicationController, numReplicas, numFullyLabeledReplicas int) (updateErr error) {
 	// This is the steady state. It happens when the rc doesn't have any expectations, since
 	// we do a periodic relist every 30s. If the generations differ but the replicas are
 	// the same, a caller might've resized to the same replica count.
 	if controller.Status.Replicas == numReplicas &&
+		controller.Status.FullyLabeledReplicas == numFullyLabeledReplicas &&
 		controller.Generation == controller.Status.ObservedGeneration {
 		return nil
 	}
@@ -41,10 +44,12 @@ func updateReplicaCount(rcClient unversionedcore.ReplicationControllerInterface,
 
 	var getErr error
 	for i, rc := 0, &controller; ; i++ {
-		glog.V(4).Infof("Updating replica count for rc: %v, %d->%d (need %d), sequence No: %v->%v",
-			controller.Name, controller.Status.Replicas, numReplicas, controller.Spec.Replicas, controller.Status.ObservedGeneration, generation)
+		glog.V(4).Infof(fmt.Sprintf("Updating replica count for rc: %s/%s, ", controller.Namespace, controller.Name) +
+			fmt.Sprintf("replicas %d->%d (need %d), ", controller.Status.Replicas, numReplicas, controller.Spec.Replicas) +
+			fmt.Sprintf("fullyLabeledReplicas %d->%d, ", controller.Status.FullyLabeledReplicas, numFullyLabeledReplicas) +
+			fmt.Sprintf("sequence No: %v->%v", controller.Status.ObservedGeneration, generation))
 
-		rc.Status = api.ReplicationControllerStatus{Replicas: numReplicas, ObservedGeneration: generation}
+		rc.Status = api.ReplicationControllerStatus{Replicas: numReplicas, FullyLabeledReplicas: numFullyLabeledReplicas, ObservedGeneration: generation}
 		_, updateErr = rcClient.UpdateStatus(rc)
 		if updateErr == nil || i >= statusUpdateRetries {
 			return updateErr

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/cache/memory"
+	cadvisorMetrics "github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/events"
 	cadvisorfs "github.com/google/cadvisor/fs"
 	cadvisorhttp "github.com/google/cadvisor/http"
@@ -66,7 +67,7 @@ func New(port uint) (Interface, error) {
 	}
 
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisorMetrics.MetricSet{cadvisorMetrics.NetworkTcpUsageMetrics: struct{}{}})
 	if err != nil {
 		return nil, err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -807,7 +807,7 @@ func (dm *DockerManager) podInfraContainerChanged(pod *api.Pod, podInfraContaine
 			glog.V(4).Infof("host: %v, %v", pod.Spec.SecurityContext.HostNetwork, networkMode)
 			return true, nil
 		}
-	} else {
+	} else if dm.networkPlugin.Name() != "cni" && dm.networkPlugin.Name() != "kubenet" {
 		// Docker only exports ports from the pod infra container. Let's
 		// collect all of the relevant ports and export them.
 		for _, container := range pod.Spec.Containers {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	etcd "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	etcderrors "k8s.io/kubernetes/pkg/api/errors/etcd"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util"
@@ -128,6 +131,70 @@ func TestDelete(t *testing.T) {
 	scheduledPod := validNewPod()
 	scheduledPod.Spec.NodeName = "some-node"
 	test.TestDeleteGraceful(scheduledPod, 30)
+}
+
+type FailDeletionStorage struct {
+	storage.Interface
+	Called *bool
+}
+
+func (f FailDeletionStorage) Delete(ctx context.Context, key string, out runtime.Object) error {
+	*f.Called = true
+	return etcd.Error{Code: etcd.ErrorCodeKeyNotFound}
+}
+
+func newFailDeleteStorage(t *testing.T, called *bool) (*REST, *etcdtesting.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
+	failDeleteStorage := FailDeletionStorage{etcdStorage, called}
+	restOptions := generic.RESTOptions{failDeleteStorage, generic.UndecoratedStorage, 3}
+	storage := NewStorage(restOptions, nil, nil)
+	return storage.Pod, server
+}
+
+func TestIgnoreDeleteNotFound(t *testing.T) {
+	pod := validNewPod()
+	testContext := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
+	called := false
+	registry, server := newFailDeleteStorage(t, &called)
+	defer server.Terminate(t)
+
+	// should fail if pod A is not created yet.
+	_, err := registry.Delete(testContext, pod.Name, nil)
+	if !errors.IsNotFound(err) {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// create pod
+	_, err = registry.Create(testContext, pod)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// delete object with grace period 0, storage will return NotFound, but the
+	// registry shouldn't get any error since we ignore the NotFound error.
+	zero := int64(0)
+	opt := &api.DeleteOptions{GracePeriodSeconds: &zero}
+	obj, err := registry.Delete(testContext, pod.Name, opt)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !called {
+		t.Fatalf("expect the overriding Delete method to be called")
+	}
+	deletedPod, ok := obj.(*api.Pod)
+	if !ok {
+		t.Fatalf("expect a pod is returned")
+	}
+	if deletedPod.DeletionTimestamp == nil {
+		t.Errorf("expect the DeletionTimestamp to be set")
+	}
+	if deletedPod.DeletionGracePeriodSeconds == nil {
+		t.Fatalf("expect the DeletionGracePeriodSeconds to be set")
+	}
+	if *deletedPod.DeletionGracePeriodSeconds != 0 {
+		t.Errorf("expect the DeletionGracePeriodSeconds to be 0, got %d", *deletedPod.DeletionTimestamp)
+	}
 }
 
 func TestCreateSetsFields(t *testing.T) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/testing/utils.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/testing/utils.go
@@ -183,7 +183,7 @@ func (m *EtcdTestServer) launch(t *testing.T) error {
 	for _, ln := range m.ClientListeners {
 		hs := &httptest.Server{
 			Listener: ln,
-			Config:   &http.Server{Handler: etcdhttp.NewClientHandler(m.s, 30*time.Second)},
+			Config:   &http.Server{Handler: etcdhttp.NewClientHandler(m.s, m.ServerConfig.ReqTimeout())},
 		}
 		hs.Start()
 		m.hss = append(m.hss, hs)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment.go
@@ -34,7 +34,6 @@ import (
 	intstrutil "k8s.io/kubernetes/pkg/util/intstr"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	podutil "k8s.io/kubernetes/pkg/util/pod"
-	rsutil "k8s.io/kubernetes/pkg/util/replicaset"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
@@ -51,32 +50,87 @@ const (
 // GetOldReplicaSets returns the old replica sets targeted by the given Deployment; get PodList and ReplicaSetList from client interface.
 // Note that the first set of old replica sets doesn't include the ones with no pods, and the second set of old replica sets include all old replica sets.
 func GetOldReplicaSets(deployment *extensions.Deployment, c clientset.Interface) ([]*extensions.ReplicaSet, []*extensions.ReplicaSet, error) {
-	return GetOldReplicaSetsFromLists(deployment, c,
-		func(namespace string, options api.ListOptions) (*api.PodList, error) {
-			return c.Core().Pods(namespace).List(options)
-		},
+	rsList, err := ListReplicaSets(deployment,
 		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
 			rsList, err := c.Extensions().ReplicaSets(namespace).List(options)
 			return rsList.Items, err
 		})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing ReplicaSets: %v", err)
+	}
+	podList, err := ListPods(deployment,
+		func(namespace string, options api.ListOptions) (*api.PodList, error) {
+			return c.Core().Pods(namespace).List(options)
+		})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing Pods: %v", err)
+	}
+	return FindOldReplicaSets(deployment, rsList, podList)
+}
+
+// GetNewReplicaSet returns a replica set that matches the intent of the given deployment; get ReplicaSetList from client interface.
+// Returns nil if the new replica set doesn't exist yet.
+func GetNewReplicaSet(deployment *extensions.Deployment, c clientset.Interface) (*extensions.ReplicaSet, error) {
+	rsList, err := ListReplicaSets(deployment,
+		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
+			rsList, err := c.Extensions().ReplicaSets(namespace).List(options)
+			return rsList.Items, err
+		})
+	if err != nil {
+		return nil, fmt.Errorf("error listing ReplicaSets: %v", err)
+	}
+	return FindNewReplicaSet(deployment, rsList)
 }
 
 // TODO: switch this to full namespacers
 type rsListFunc func(string, api.ListOptions) ([]extensions.ReplicaSet, error)
 type podListFunc func(string, api.ListOptions) (*api.PodList, error)
 
-// GetOldReplicaSetsFromLists returns two sets of old replica sets targeted by the given Deployment; get PodList and ReplicaSetList with input functions.
+// ListReplicaSets returns a slice of RSes the given deployment targets.
+func ListReplicaSets(deployment *extensions.Deployment, getRSList rsListFunc) ([]extensions.ReplicaSet, error) {
+	// TODO: Right now we list replica sets by their labels. We should list them by selector, i.e. the replica set's selector
+	//       should be a superset of the deployment's selector, see https://github.com/kubernetes/kubernetes/issues/19830;
+	//       or use controllerRef, see https://github.com/kubernetes/kubernetes/issues/2210
+	namespace := deployment.Namespace
+	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	options := api.ListOptions{LabelSelector: selector}
+	return getRSList(namespace, options)
+}
+
+// ListPods returns a list of pods the given deployment targets.
+func ListPods(deployment *extensions.Deployment, getPodList podListFunc) (*api.PodList, error) {
+	namespace := deployment.Namespace
+	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	options := api.ListOptions{LabelSelector: selector}
+	return getPodList(namespace, options)
+}
+
+// FindNewReplicaSet returns the new RS this given deployment targets (the one with the same pod template).
+func FindNewReplicaSet(deployment *extensions.Deployment, rsList []extensions.ReplicaSet) (*extensions.ReplicaSet, error) {
+	newRSTemplate := GetNewReplicaSetTemplate(deployment)
+	for i := range rsList {
+		if api.Semantic.DeepEqual(rsList[i].Spec.Template, newRSTemplate) {
+			// This is the new ReplicaSet.
+			return &rsList[i], nil
+		}
+	}
+	// new ReplicaSet does not exist.
+	return nil, nil
+}
+
+// FindOldReplicaSets returns the old replica sets targeted by the given Deployment, with the given PodList and slice of RSes.
 // Note that the first set of old replica sets doesn't include the ones with no pods, and the second set of old replica sets include all old replica sets.
-func GetOldReplicaSetsFromLists(deployment *extensions.Deployment, c clientset.Interface, getPodList podListFunc, getRSList rsListFunc) ([]*extensions.ReplicaSet, []*extensions.ReplicaSet, error) {
+func FindOldReplicaSets(deployment *extensions.Deployment, rsList []extensions.ReplicaSet, podList *api.PodList) ([]*extensions.ReplicaSet, []*extensions.ReplicaSet, error) {
 	// Find all pods whose labels match deployment.Spec.Selector, and corresponding replica sets for pods in podList.
 	// All pods and replica sets are labeled with pod-template-hash to prevent overlapping
-	// TODO: Right now we list all replica sets and then filter. We should add an API for this.
 	oldRSs := map[string]extensions.ReplicaSet{}
 	allOldRSs := map[string]extensions.ReplicaSet{}
-	rsList, podList, err := rsAndPodsWithHashKeySynced(deployment, c, getRSList, getPodList)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error labeling replica sets and pods with pod-template-hash: %v", err)
-	}
 	newRSTemplate := GetNewReplicaSetTemplate(deployment)
 	for _, pod := range podList.Items {
 		podLabelsSelector := labels.Set(pod.ObjectMeta.Labels)
@@ -108,159 +162,7 @@ func GetOldReplicaSetsFromLists(deployment *extensions.Deployment, c clientset.I
 	return requiredRSs, allRSs, nil
 }
 
-// GetNewReplicaSet returns a replica set that matches the intent of the given deployment; get ReplicaSetList from client interface.
-// Returns nil if the new replica set doesn't exist yet.
-func GetNewReplicaSet(deployment *extensions.Deployment, c clientset.Interface) (*extensions.ReplicaSet, error) {
-	return GetNewReplicaSetFromList(deployment, c,
-		func(namespace string, options api.ListOptions) (*api.PodList, error) {
-			return c.Core().Pods(namespace).List(options)
-		},
-		func(namespace string, options api.ListOptions) ([]extensions.ReplicaSet, error) {
-			rsList, err := c.Extensions().ReplicaSets(namespace).List(options)
-			return rsList.Items, err
-		})
-}
-
-// GetNewReplicaSetFromList returns a replica set that matches the intent of the given deployment; get ReplicaSetList with the input function.
-// Returns nil if the new replica set doesn't exist yet.
-func GetNewReplicaSetFromList(deployment *extensions.Deployment, c clientset.Interface, getPodList podListFunc, getRSList rsListFunc) (*extensions.ReplicaSet, error) {
-	rsList, _, err := rsAndPodsWithHashKeySynced(deployment, c, getRSList, getPodList)
-	if err != nil {
-		return nil, fmt.Errorf("error listing ReplicaSets: %v", err)
-	}
-	newRSTemplate := GetNewReplicaSetTemplate(deployment)
-
-	for i := range rsList {
-		if api.Semantic.DeepEqual(rsList[i].Spec.Template, newRSTemplate) {
-			// This is the new ReplicaSet.
-			return &rsList[i], nil
-		}
-	}
-	// new ReplicaSet does not exist.
-	return nil, nil
-}
-
-// rsAndPodsWithHashKeySynced returns the RSs and pods the given deployment targets, with pod-template-hash information synced.
-func rsAndPodsWithHashKeySynced(deployment *extensions.Deployment, c clientset.Interface, getRSList rsListFunc, getPodList podListFunc) ([]extensions.ReplicaSet, *api.PodList, error) {
-	namespace := deployment.Namespace
-	selector, err := unversioned.LabelSelectorAsSelector(deployment.Spec.Selector)
-	if err != nil {
-		return nil, nil, err
-	}
-	options := api.ListOptions{LabelSelector: selector}
-	rsList, err := getRSList(namespace, options)
-	if err != nil {
-		return nil, nil, err
-	}
-	syncedRSList := []extensions.ReplicaSet{}
-	for _, rs := range rsList {
-		// Add pod-template-hash information if it's not in the RS.
-		// Otherwise, new RS produced by Deployment will overlap with pre-existing ones
-		// that aren't constrained by the pod-template-hash.
-		syncedRS, err := addHashKeyToRSAndPods(deployment, c, rs, getPodList)
-		if err != nil {
-			return nil, nil, err
-		}
-		syncedRSList = append(syncedRSList, *syncedRS)
-	}
-	syncedPodList, err := getPodList(namespace, options)
-	if err != nil {
-		return nil, nil, err
-	}
-	return syncedRSList, syncedPodList, nil
-}
-
-// addHashKeyToRSAndPods adds pod-template-hash information to the given rs, if it's not already there, with the following steps:
-// 1. Add hash label to the rs's pod template, and make sure the controller sees this update so that no orphaned pods will be created
-// 2. Add hash label to all pods this rs owns
-// 3. Add hash label to the rs's label and selector
-func addHashKeyToRSAndPods(deployment *extensions.Deployment, c clientset.Interface, rs extensions.ReplicaSet, getPodList podListFunc) (updatedRS *extensions.ReplicaSet, err error) {
-	updatedRS = &rs
-	// If the rs already has the new hash label in its selector, it's done syncing
-	if labelsutil.SelectorHasLabel(rs.Spec.Selector, extensions.DefaultDeploymentUniqueLabelKey) {
-		return
-	}
-	namespace := deployment.Namespace
-	meta := rs.Spec.Template.ObjectMeta
-	meta.Labels = labelsutil.CloneAndRemoveLabel(meta.Labels, extensions.DefaultDeploymentUniqueLabelKey)
-	hash := fmt.Sprintf("%d", podutil.GetPodTemplateSpecHash(api.PodTemplateSpec{
-		ObjectMeta: meta,
-		Spec:       rs.Spec.Template.Spec,
-	}))
-	rsUpdated := false
-	// 1. Add hash template label to the rs. This ensures that any newly created pods will have the new label.
-	updatedRS, rsUpdated, err = rsutil.UpdateRSWithRetries(c.Extensions().ReplicaSets(namespace), updatedRS,
-		func(updated *extensions.ReplicaSet) error {
-			// Precondition: the RS doesn't contain the new hash in its pod template label.
-			if updated.Spec.Template.Labels[extensions.DefaultDeploymentUniqueLabelKey] == hash {
-				return errors.ErrPreconditionViolated
-			}
-			updated.Spec.Template.Labels = labelsutil.AddLabel(updated.Spec.Template.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
-			return nil
-		})
-	if err != nil {
-		return nil, fmt.Errorf("error updating %s %s/%s pod template label with template hash: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, err)
-	}
-	if rsUpdated {
-		// Make sure rs pod template is updated so that it won't create pods without the new label (orphaned pods).
-		if updatedRS.Generation > updatedRS.Status.ObservedGeneration {
-			if err = waitForReplicaSetUpdated(c, updatedRS.Generation, namespace, updatedRS.Name); err != nil {
-				return nil, fmt.Errorf("error waiting for %s %s/%s generation %d observed by controller: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, updatedRS.Generation, err)
-			}
-		}
-		glog.V(4).Infof("Observed the update of %s %s/%s's pod template with hash %s.", rs.Kind, rs.Namespace, rs.Name, hash)
-	} else {
-		// If RS wasn't updated but didn't return error in step 1, we've hit a RS not found error.
-		// Return here and retry in the next sync loop.
-		return &rs, nil
-	}
-	glog.V(4).Infof("Observed the update of rs %s's pod template with hash %s.", rs.Name, hash)
-
-	// 2. Update all pods managed by the rs to have the new hash label, so they will be correctly adopted.
-	selector, err := unversioned.LabelSelectorAsSelector(updatedRS.Spec.Selector)
-	if err != nil {
-		return nil, fmt.Errorf("error in converting selector to label selector for replica set %s: %s", updatedRS.Name, err)
-	}
-	options := api.ListOptions{LabelSelector: selector}
-	podList, err := getPodList(namespace, options)
-	if err != nil {
-		return nil, fmt.Errorf("error in getting pod list for namespace %s and list options %+v: %s", namespace, options, err)
-	}
-	allPodsLabeled := false
-	if allPodsLabeled, err = labelPodsWithHash(podList, updatedRS, c, namespace, hash); err != nil {
-		return nil, fmt.Errorf("error in adding template hash label %s to pods %+v: %s", hash, podList, err)
-	}
-	// If not all pods are labeled but didn't return error in step 2, we've hit at least one pod not found error.
-	// Return here and retry in the next sync loop.
-	if !allPodsLabeled {
-		return updatedRS, nil
-	}
-
-	// 3. Update rs label and selector to include the new hash label
-	// Copy the old selector, so that we can scrub out any orphaned pods
-	if updatedRS, rsUpdated, err = rsutil.UpdateRSWithRetries(c.Extensions().ReplicaSets(namespace), updatedRS,
-		func(updated *extensions.ReplicaSet) error {
-			// Precondition: the RS doesn't contain the new hash in its label or selector.
-			if updated.Labels[extensions.DefaultDeploymentUniqueLabelKey] == hash && updated.Spec.Selector.MatchLabels[extensions.DefaultDeploymentUniqueLabelKey] == hash {
-				return errors.ErrPreconditionViolated
-			}
-			updated.Labels = labelsutil.AddLabel(updated.Labels, extensions.DefaultDeploymentUniqueLabelKey, hash)
-			updated.Spec.Selector = labelsutil.AddLabelToSelector(updated.Spec.Selector, extensions.DefaultDeploymentUniqueLabelKey, hash)
-			return nil
-		}); err != nil {
-		return nil, fmt.Errorf("error updating %s %s/%s label and selector with template hash: %v", updatedRS.Kind, updatedRS.Namespace, updatedRS.Name, err)
-	}
-	if rsUpdated {
-		glog.V(4).Infof("Updated %s %s/%s's selector and label with hash %s.", rs.Kind, rs.Namespace, rs.Name, hash)
-	}
-	// If the RS isn't actually updated in step 3, that's okay, we'll retry in the next sync loop since its selector isn't updated yet.
-
-	// TODO: look for orphaned pods and label them in the background somewhere else periodically
-
-	return updatedRS, nil
-}
-
-func waitForReplicaSetUpdated(c clientset.Interface, desiredGeneration int64, namespace, name string) error {
+func WaitForReplicaSetUpdated(c clientset.Interface, desiredGeneration int64, namespace, name string) error {
 	return wait.Poll(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
 		rs, err := c.Extensions().ReplicaSets(namespace).Get(name)
 		if err != nil {
@@ -270,9 +172,20 @@ func waitForReplicaSetUpdated(c clientset.Interface, desiredGeneration int64, na
 	})
 }
 
-// labelPodsWithHash labels all pods in the given podList with the new hash label.
+func WaitForPodsHashPopulated(c clientset.Interface, desiredGeneration int64, namespace, name string) error {
+	return wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+		rs, err := c.Extensions().ReplicaSets(namespace).Get(name)
+		if err != nil {
+			return false, err
+		}
+		return rs.Status.ObservedGeneration >= desiredGeneration &&
+			rs.Status.FullyLabeledReplicas == rs.Spec.Replicas, nil
+	})
+}
+
+// LabelPodsWithHash labels all pods in the given podList with the new hash label.
 // The returned bool value can be used to tell if all pods are actually labeled.
-func labelPodsWithHash(podList *api.PodList, rs *extensions.ReplicaSet, c clientset.Interface, namespace, hash string) (bool, error) {
+func LabelPodsWithHash(podList *api.PodList, rs *extensions.ReplicaSet, c clientset.Interface, namespace, hash string) (bool, error) {
 	allPodsLabeled := true
 	for _, pod := range podList.Items {
 		// Only label the pod that doesn't already have the new hash

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment_test.go
@@ -291,21 +291,25 @@ func TestGetNewRC(t *testing.T) {
 func TestGetOldRCs(t *testing.T) {
 	newDeployment := generateDeployment("nginx")
 	newRS := generateRS(newDeployment)
+	newRS.Status.FullyLabeledReplicas = newRS.Spec.Replicas
 	newPod := generatePodFromRS(newRS)
 
 	// create 2 old deployments and related replica sets/pods, with the same labels but different template
 	oldDeployment := generateDeployment("nginx")
 	oldDeployment.Spec.Template.Spec.Containers[0].Name = "nginx-old-1"
 	oldRS := generateRS(oldDeployment)
+	oldRS.Status.FullyLabeledReplicas = oldRS.Spec.Replicas
 	oldPod := generatePodFromRS(oldRS)
 	oldDeployment2 := generateDeployment("nginx")
 	oldDeployment2.Spec.Template.Spec.Containers[0].Name = "nginx-old-2"
 	oldRS2 := generateRS(oldDeployment2)
+	oldRS2.Status.FullyLabeledReplicas = oldRS2.Spec.Replicas
 	oldPod2 := generatePodFromRS(oldRS2)
 
 	// create 1 ReplicaSet that existed before the deployment, with the same labels as the deployment
 	existedPod := generatePod(newDeployment.Spec.Template.Labels, "foo")
 	existedRS := generateRSWithLabel(newDeployment.Spec.Template.Labels, "foo")
+	existedRS.Status.FullyLabeledReplicas = existedRS.Spec.Replicas
 
 	tests := []struct {
 		test     string

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/version/base.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/version/base.go
@@ -39,8 +39,8 @@ var (
 	// them irrelevant. (Next we'll take it out, which may muck with
 	// scripts consuming the kubectl version output - but most of
 	// these should be looking at gitVersion already anyways.)
-	gitMajor string = "1"  // major version, always numeric
-	gitMinor string = "2+" // minor version, numeric possibly followed by "+"
+	gitMajor string = "1" // major version, always numeric
+	gitMinor string = "2" // minor version, numeric possibly followed by "+"
 
 	// semantic version, dervied by build scripts (see
 	// https://github.com/kubernetes/kubernetes/blob/master/docs/design/versioning.md
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.2.0-beta.1+$Format:%h$"
+	gitVersion   string = "v1.2.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_util.go
@@ -148,7 +148,7 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (strin
 	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))
 	volumeOptions := &aws.VolumeOptions{
 		CapacityGB: requestGB,
-		Tags:       &tags,
+		Tags:       tags,
 	}
 
 	name, err := cloud.CreateDisk(volumeOptions)
@@ -170,6 +170,8 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (strin
 // Attaches the specified persistent disk device to node, verifies that it is attached, and retries if it fails.
 func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.String) (string, error) {
 	var awsCloud *aws.AWSCloud
+	var attachError error
+
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
 		var err error
 		if awsCloud == nil {
@@ -186,9 +188,10 @@ func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.Strin
 			glog.Warningf("Retrying attach for EBS Disk %q (retry count=%v).", b.volumeID, numRetries)
 		}
 
-		devicePath, err := awsCloud.AttachDisk(b.volumeID, "", b.readOnly)
-		if err != nil {
-			glog.Errorf("Error attaching PD %q: %v", b.volumeID, err)
+		var devicePath string
+		devicePath, attachError = awsCloud.AttachDisk(b.volumeID, "", b.readOnly)
+		if attachError != nil {
+			glog.Errorf("Error attaching PD %q: %v", b.volumeID, attachError)
 			time.Sleep(errorSleepDuration)
 			continue
 		}
@@ -212,6 +215,9 @@ func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.Strin
 		}
 	}
 
+	if attachError != nil {
+		return "", fmt.Errorf("Could not attach EBS Disk %q: %v", b.volumeID, attachError)
+	}
 	return "", fmt.Errorf("Could not attach EBS Disk %q. Timeout waiting for mount paths to be created.", b.volumeID)
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -57,6 +57,18 @@ func (l *lifecycle) Admit(a admission.Attributes) (err error) {
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
 	if len(a.GetNamespace()) == 0 || a.GetKind() == api.Kind("Namespace") {
+		// if a namespace is deleted, we want to prevent all further creates into it
+		// while it is undergoing termination.  to reduce incidences where the cache
+		// is slow to update, we forcefully remove the namespace from our local cache.
+		// this will cause a live lookup of the namespace to get its latest state even
+		// before the watch notification is received.
+		if a.GetOperation() == admission.Delete {
+			l.store.Delete(&api.Namespace{
+				ObjectMeta: api.ObjectMeta{
+					Name: a.GetName(),
+				},
+			})
+		}
 		return nil
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strconv"
 
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
@@ -30,10 +31,6 @@ import (
 
 	"github.com/golang/glog"
 )
-
-// Amazon recommends having no more that 40 volumes attached to an instance,
-// and at least one of those is for the system root volume.
-const DefaultMaxEBSVolumes = 39
 
 // GCE instances can have up to 16 PD volumes attached.
 const DefaultMaxGCEPDVolumes = 16
@@ -117,7 +114,7 @@ func defaultPredicates() sets.String {
 			"MaxEBSVolumeCount",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
 				// TODO: allow for generically parameterized scheduler predicates, because this is a bit ugly
-				maxVols := getMaxVols(DefaultMaxEBSVolumes)
+				maxVols := getMaxVols(aws.DefaultMaxEBSVolumes)
 				return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilter, maxVols, args.PVInfo, args.PVCInfo)
 			},
 		),

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/batch_v1_jobs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/batch_v1_jobs.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is very similar to ./job.go.  That one uses extensions/v1beta1, this one
+// uses batch/v1.  That one uses ManualSelectors, this one does not.  Keep them in sync.
+// Delete that one when Job removed from extensions/v1beta1.
+
+package e2e
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	// How long to wait for a job to finish.
+	v1JobTimeout = 15 * time.Minute
+
+	// Job selector name
+	v1JobSelectorKey = "job-name"
+)
+
+var _ = Describe("V1Job", func() {
+	f := NewDefaultFramework("v1job")
+	parallelism := 2
+	completions := 4
+	lotsOfFailures := 5 // more than completions
+
+	// Simplest case: all pods succeed promptly
+	It("should run a job to completion when tasks succeed", func() {
+		By("Creating a job")
+		job := newTestV1Job("succeed", "all-succeed", api.RestartPolicyNever, parallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job reaches completions")
+		err = waitForV1JobFinish(f.Client, f.Namespace.Name, job.Name, completions)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// Pods sometimes fail, but eventually succeed.
+	It("should run a job to completion when tasks sometimes fail and are locally restarted", func() {
+		By("Creating a job")
+		// One failure, then a success, local restarts.
+		// We can't use the random failure approach used by the
+		// non-local test below, because kubelet will throttle
+		// frequently failing containers in a given pod, ramping
+		// up to 5 minutes between restarts, making test timeouts
+		// due to successive failures too likely with a reasonable
+		// test timeout.
+		job := newTestV1Job("failOnce", "fail-once-local", api.RestartPolicyOnFailure, parallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job reaches completions")
+		err = waitForV1JobFinish(f.Client, f.Namespace.Name, job.Name, completions)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// Pods sometimes fail, but eventually succeed, after pod restarts
+	It("should run a job to completion when tasks sometimes fail and are not locally restarted", func() {
+		By("Creating a job")
+		// 50% chance of container success, local restarts.
+		// Can't use the failOnce approach because that relies
+		// on an emptyDir, which is not preserved across new pods.
+		// Worst case analysis: 15 failures, each taking 1 minute to
+		// run due to some slowness, 1 in 2^15 chance of happening,
+		// causing test flake.  Should be very rare.
+		job := newTestV1Job("randomlySucceedOrFail", "rand-non-local", api.RestartPolicyNever, parallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job reaches completions")
+		err = waitForV1JobFinish(f.Client, f.Namespace.Name, job.Name, completions)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should keep restarting failed pods", func() {
+		By("Creating a job")
+		job := newTestV1Job("fail", "all-fail", api.RestartPolicyNever, parallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job shows many failures")
+		err = wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+			curr, err := f.Client.Batch().Jobs(f.Namespace.Name).Get(job.Name)
+			if err != nil {
+				return false, err
+			}
+			return curr.Status.Failed > lotsOfFailures, nil
+		})
+	})
+
+	It("should scale a job up", func() {
+		startParallelism := 1
+		endParallelism := 2
+		By("Creating a job")
+		job := newTestV1Job("notTerminate", "scale-up", api.RestartPolicyNever, startParallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring active pods == startParallelism")
+		err = waitForAllPodsRunningV1(f.Client, f.Namespace.Name, job.Name, startParallelism)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("scale job up")
+		scaler, err := kubectl.ScalerFor(extensions.Kind("Job"), f.Client)
+		Expect(err).NotTo(HaveOccurred())
+		waitForScale := kubectl.NewRetryParams(5*time.Second, 1*time.Minute)
+		waitForReplicas := kubectl.NewRetryParams(5*time.Second, 5*time.Minute)
+		scaler.Scale(f.Namespace.Name, job.Name, uint(endParallelism), nil, waitForScale, waitForReplicas)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring active pods == endParallelism")
+		err = waitForAllPodsRunningV1(f.Client, f.Namespace.Name, job.Name, endParallelism)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should scale a job down", func() {
+		startParallelism := 2
+		endParallelism := 1
+		By("Creating a job")
+		job := newTestV1Job("notTerminate", "scale-down", api.RestartPolicyNever, startParallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring active pods == startParallelism")
+		err = waitForAllPodsRunningV1(f.Client, f.Namespace.Name, job.Name, startParallelism)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("scale job down")
+		scaler, err := kubectl.ScalerFor(extensions.Kind("Job"), f.Client)
+		Expect(err).NotTo(HaveOccurred())
+		waitForScale := kubectl.NewRetryParams(5*time.Second, 1*time.Minute)
+		waitForReplicas := kubectl.NewRetryParams(5*time.Second, 5*time.Minute)
+		err = scaler.Scale(f.Namespace.Name, job.Name, uint(endParallelism), nil, waitForScale, waitForReplicas)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring active pods == endParallelism")
+		err = waitForAllPodsRunningV1(f.Client, f.Namespace.Name, job.Name, endParallelism)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should delete a job", func() {
+		By("Creating a job")
+		job := newTestV1Job("notTerminate", "foo", api.RestartPolicyNever, parallelism, completions)
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring active pods == parallelism")
+		err = waitForAllPodsRunningV1(f.Client, f.Namespace.Name, job.Name, parallelism)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("delete a job")
+		reaper, err := kubectl.ReaperFor(extensions.Kind("Job"), f.Client)
+		Expect(err).NotTo(HaveOccurred())
+		timeout := 1 * time.Minute
+		err = reaper.Stop(f.Namespace.Name, job.Name, timeout, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job was deleted")
+		_, err = f.Client.Batch().Jobs(f.Namespace.Name).Get(job.Name)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should fail a job", func() {
+		By("Creating a job")
+		job := newTestV1Job("notTerminate", "foo", api.RestartPolicyNever, parallelism, completions)
+		activeDeadlineSeconds := int64(10)
+		job.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+		job, err := createV1Job(f.Client, f.Namespace.Name, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job was failed")
+		err = waitForV1JobFail(f.Client, f.Namespace.Name, job.Name)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+// newTestV1Job returns a job which does one of several testing behaviors.
+func newTestV1Job(behavior, name string, rPol api.RestartPolicy, parallelism, completions int) *extensions.Job {
+	job := &extensions.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Spec: extensions.JobSpec{
+			Parallelism: &parallelism,
+			Completions: &completions,
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{"somekey": "somevalue"},
+				},
+				Spec: api.PodSpec{
+					RestartPolicy: rPol,
+					Volumes: []api.Volume{
+						{
+							Name: "data",
+							VolumeSource: api.VolumeSource{
+								EmptyDir: &api.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					Containers: []api.Container{
+						{
+							Name:    "c",
+							Image:   "gcr.io/google_containers/busybox:1.24",
+							Command: []string{},
+							VolumeMounts: []api.VolumeMount{
+								{
+									MountPath: "/data",
+									Name:      "data",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	switch behavior {
+	case "notTerminate":
+		job.Spec.Template.Spec.Containers[0].Command = []string{"sleep", "1000000"}
+	case "fail":
+		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "exit 1"}
+	case "succeed":
+		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "exit 0"}
+	case "randomlySucceedOrFail":
+		// Bash's $RANDOM generates pseudorandom int in range 0 - 32767.
+		// Dividing by 16384 gives roughly 50/50 chance of success.
+		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "exit $(( $RANDOM / 16384 ))"}
+	case "failOnce":
+		// Fail the first the container of the pod is run, and
+		// succeed the second time. Checks for file on emptydir.
+		// If present, succeed.  If not, create but fail.
+		// Note that this cannot be used with RestartNever because
+		// it always fails the first time for a pod.
+		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "if [[ -r /data/foo ]] ; then exit 0 ; else touch /data/foo ; exit 1 ; fi"}
+	}
+	return job
+}
+
+func createV1Job(c *client.Client, ns string, job *extensions.Job) (*extensions.Job, error) {
+	return c.Batch().Jobs(ns).Create(job)
+}
+
+func deleteV1Job(c *client.Client, ns, name string) error {
+	return c.Batch().Jobs(ns).Delete(name, api.NewDeleteOptions(0))
+}
+
+// Wait for all pods to become Running.  Only use when pods will run for a long time, or it will be racy.
+func waitForAllPodsRunningV1(c *client.Client, ns, jobName string, parallelism int) error {
+	label := labels.SelectorFromSet(labels.Set(map[string]string{v1JobSelectorKey: jobName}))
+	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+		options := api.ListOptions{LabelSelector: label}
+		pods, err := c.Pods(ns).List(options)
+		if err != nil {
+			return false, err
+		}
+		count := 0
+		for _, p := range pods.Items {
+			if p.Status.Phase == api.PodRunning {
+				count++
+			}
+		}
+		return count == parallelism, nil
+	})
+}
+
+// Wait for job to reach completions.
+func waitForV1JobFinish(c *client.Client, ns, jobName string, completions int) error {
+	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+		curr, err := c.Batch().Jobs(ns).Get(jobName)
+		if err != nil {
+			return false, err
+		}
+		return curr.Status.Succeeded == completions, nil
+	})
+}
+
+// Wait for job fail.
+func waitForV1JobFail(c *client.Client, ns, jobName string) error {
+	return wait.Poll(poll, v1JobTimeout, func() (bool, error) {
+		curr, err := c.Batch().Jobs(ns).Get(jobName)
+		if err != nil {
+			return false, err
+		}
+		for _, c := range curr.Status.Conditions {
+			if c.Type == extensions.JobFailed && c.Status == api.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/e2e.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/e2e.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -36,7 +35,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/runtime"
@@ -125,21 +123,8 @@ func setupProviderConfig() error {
 		}
 
 	case "aws":
-		awsConfig := "[Global]\n"
 		if cloudConfig.Zone == "" {
 			return fmt.Errorf("gce-zone must be specified for AWS")
-		}
-		awsConfig += fmt.Sprintf("Zone=%s\n", cloudConfig.Zone)
-
-		if cloudConfig.ClusterTag == "" {
-			return fmt.Errorf("--cluster-tag must be specified for AWS")
-		}
-		awsConfig += fmt.Sprintf("KubernetesClusterTag=%s\n", cloudConfig.ClusterTag)
-
-		var err error
-		cloudConfig.Provider, err = cloudprovider.GetCloudProvider(testContext.Provider, strings.NewReader(awsConfig))
-		if err != nil {
-			return fmt.Errorf("Error building AWS provider: %v", err)
 		}
 
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pd.go
@@ -24,6 +24,10 @@ import (
 
 	"google.golang.org/api/googleapi"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/pkg/api"
@@ -320,14 +324,25 @@ func createPD() (string, error) {
 			return "", err
 		}
 		return pdName, nil
-	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(awscloud.Volumes)
-		if !ok {
-			return "", fmt.Errorf("Provider does not support volumes")
+	} else if testContext.Provider == "aws" {
+		client := ec2.New(session.New())
+
+		request := &ec2.CreateVolumeInput{}
+		request.AvailabilityZone = aws.String(cloudConfig.Zone)
+		request.Size = aws.Int64(10)
+		request.VolumeType = aws.String(awscloud.DefaultVolumeType)
+		response, err := client.CreateVolume(request)
+		if err != nil {
+			return "", err
 		}
-		volumeOptions := &awscloud.VolumeOptions{}
-		volumeOptions.CapacityGB = 10
-		return volumes.CreateDisk(volumeOptions)
+
+		az := aws.StringValue(response.AvailabilityZone)
+		awsID := aws.StringValue(response.VolumeId)
+
+		volumeName := "aws://" + az + "/" + awsID
+		return volumeName, nil
+	} else {
+		return "", fmt.Errorf("Provider does not support volume creation")
 	}
 }
 
@@ -349,20 +364,24 @@ func deletePD(pdName string) error {
 			Logf("Error deleting PD %q: %v", pdName, err)
 		}
 		return err
-	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(awscloud.Volumes)
-		if !ok {
-			return fmt.Errorf("Provider does not support volumes")
-		}
-		deleted, err := volumes.DeleteDisk(pdName)
+	} else if testContext.Provider == "aws" {
+		client := ec2.New(session.New())
+
+		tokens := strings.Split(pdName, "/")
+		awsVolumeID := tokens[len(tokens)-1]
+
+		request := &ec2.DeleteVolumeInput{VolumeId: aws.String(awsVolumeID)}
+		_, err := client.DeleteVolume(request)
 		if err != nil {
-			return err
-		} else {
-			if !deleted {
+			if awsError, ok := err.(awserr.Error); ok && awsError.Code() == "InvalidVolume.NotFound" {
 				Logf("Volume deletion implicitly succeeded because volume %q does not exist.", pdName)
+			} else {
+				return fmt.Errorf("error deleting EBS volumes: %v", err)
 			}
-			return nil
 		}
+		return nil
+	} else {
+		return fmt.Errorf("Provider does not support volume deletion")
 	}
 }
 
@@ -386,14 +405,23 @@ func detachPD(hostName, pdName string) error {
 		}
 
 		return err
+	} else if testContext.Provider == "aws" {
+		client := ec2.New(session.New())
 
-	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(awscloud.Volumes)
-		if !ok {
-			return fmt.Errorf("Provider does not support volumes")
+		tokens := strings.Split(pdName, "/")
+		awsVolumeID := tokens[len(tokens)-1]
+
+		request := ec2.DetachVolumeInput{
+			VolumeId: aws.String(awsVolumeID),
 		}
-		_, err := volumes.DetachDisk(pdName, hostName)
-		return err
+
+		_, err := client.DetachVolume(&request)
+		if err != nil {
+			return fmt.Errorf("error detaching EBS volume: %v", err)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("Provider does not support volume detaching")
 	}
 }
 

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -18710,6 +18710,11 @@
       "format": "int32",
       "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.2/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replication controller."
+     },
      "observedGeneration": {
       "type": "integer",
       "format": "int64",


### PR DESCRIPTION
bumps to https://github.com/liggitt/kubernetes/commit/4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353 (will push to openshift/kubernetes) which is based on https://github.com/kubernetes/kubernetes/releases/tag/v1.2.0

includes all UPSTREAM commits in origin from
https://github.com/openshift/origin/commit/b1d271f608e11cfcc41a0a272408ecb08bdccef2
to
https://github.com/openshift/origin/commit/ac3020f6d1e52064f194a8ae28194178ba7cc952

includes cadvisor 22.2 bump