### PR TITLE
clean up jenkins master/slave parameters

### DIFF
--- a/examples/jenkins-master/README.md
+++ b/examples/jenkins-master/README.md
@@ -25,6 +25,8 @@ plugin and define the sample job used by the tutorial.
 
 Steps
 ------
+Before you begin, ensure you have created the [default imagestreams](https://docs.openshift.org/latest/install_config/imagestreams_templates.html#creating-image-streams-for-openshift-images) in the openshift namespace.
+
 1. Create new OpenShift project, where the Jenkins server will run:
 ```
 $ oc new-project ci

--- a/examples/jenkins-master/jenkins-master-template.json
+++ b/examples/jenkins-master/jenkins-master-template.json
@@ -26,12 +26,6 @@
       "value": "password"
     },
     {
-      "name": "JENKINS_IMAGE",
-      "displayName": "Jenkins Image",
-      "description": "Jenkins Docker image to use.",
-      "value": "openshift/jenkins-1-centos7"
-    },
-    {
       "name": "JENKINS_REPO_URL",
       "displayName": "Jenkins URL",
       "description": "The repository to use to customize the Jenkins server.",
@@ -48,6 +42,12 @@
       "displayName": "Jenkins Reference",
       "description": "The git ref or tag to use for customization.",
       "value": "master"
+    },
+    {
+      "name": "NAMESPACE",
+      "displayName": "Namespace",
+      "description": "The OpenShift Namespace where the ImageStream resides.",
+      "value": "openshift"
     }
   ],
   "objects": [
@@ -147,8 +147,9 @@
           "type": "Source",
           "sourceStrategy": {
             "from": {
-              "kind": "DockerImage",
-              "name": "${JENKINS_IMAGE}"
+                "kind": "ImageStreamTag",
+                "name": "jenkins:latest",
+                "namespace": "${NAMESPACE}"
             }
           }
         },

--- a/examples/jenkins-master/jenkins-slave-template.json
+++ b/examples/jenkins-master/jenkins-slave-template.json
@@ -15,9 +15,16 @@
   },
   "parameters": [
     {
+      "name": "IMAGE_NAME",
+      "displayName": "Image Name",
+      "description": "The name of an image to convert.",
+      "value": "centos/ruby-22-centos7",
+      "required": true
+    },
+    {
       "name": "IMAGE_STREAM_NAME",
       "displayName": "ImageStream Name",
-      "description": "The name of an image stream to convert.",
+      "description": "The name of the imagestream to create for the newly built slave image.",
       "value": "ruby-22-centos7",
       "required": true
     },
@@ -45,16 +52,6 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "${IMAGE_STREAM_NAME}"
-      },
-      "spec": {
-        "dockerImageRepository": "openshift/${IMAGE_STREAM_NAME}"
-      }
-    },
-    {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
         "name": "${IMAGE_STREAM_NAME}-jenkins-slave",
         "annotations": {
           "slave-label": "${IMAGE_STREAM_NAME}",
@@ -70,9 +67,9 @@
       "kind": "BuildConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "${IMAGE_STREAM_NAME}-slave",
+        "name": "${IMAGE_STREAM_NAME}-jenkins-slave",
         "annotations": {
-          "description": "Modifies the ${IMAGE_STREAM_NAME} to run as Jenkins slave"
+          "description": "Modifies the ${IMAGE_NAME} to run as Jenkins slave"
         },
         "labels": {
           "name": "${IMAGE_STREAM_NAME}-slave"
@@ -80,10 +77,6 @@
       },
       "spec": {
         "triggers": [
-          {
-            "type": "imageChange",
-            "imageChange": {}
-          },
           {
             "type": "ConfigChange"
           }
@@ -100,8 +93,8 @@
           "type": "Docker",
           "dockerStrategy": {
             "from": {
-              "kind": "ImageStreamTag",
-              "name": "${IMAGE_STREAM_NAME}:latest"
+              "kind": "DockerImage",
+              "name": "${IMAGE_NAME}"
             }
           }
         },


### PR DESCRIPTION
@mfojtik @gabemontero ptal.  only thing i don't like about this change is we no longer create an imagestream for the input to the slave-build-config, so you can't trigger that build via imagechange, but it makes the parameters much simpler (don't have to worry about a namespace for the input imagestream name), i think it's probably ok for an example.
