### PR TITLE
WIP - Support a loopback listener for in process communication

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2081,6 +2081,10 @@
 			"Rev": "1be70b5b8aa07acccd972146d84011b670af88b4"
 		},
 		{
+			"ImportPath": "github.com/smarterclayton/chanstream",
+			"Rev": "a13defa2faca99901cb7149d4b06754850b4b0f3"
+		},
+		{
 			"ImportPath": "github.com/spf13/cobra",
 			"Rev": "4c05eb1145f16d0e6bb4a3e1b6d769f4713cb41f"
 		},

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/config.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/config.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"fmt"
+	"net/http"
 	"path"
 	"sort"
 	"strings"
@@ -45,6 +46,7 @@ type ServerConfig struct {
 	NewCluster          bool
 	ForceNewCluster     bool
 	PeerTLSInfo         transport.TLSInfo
+	PeerTransport       http.RoundTripper
 
 	TickMs           uint
 	ElectionTicks    int
@@ -138,7 +140,7 @@ func (c *ServerConfig) electionTimeout() time.Duration {
 	return time.Duration(c.ElectionTicks) * time.Duration(c.TickMs) * time.Millisecond
 }
 
-func (c *ServerConfig) peerDialTimeout() time.Duration {
+func (c *ServerConfig) PeerDialTimeout() time.Duration {
 	// 1s for queue wait and system delay
 	// + one RTT, which is smaller than 1/5 election timeout
 	return time.Second + time.Duration(c.ElectionTicks)*time.Duration(c.TickMs)*time.Millisecond/5

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/server.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/server.go
@@ -236,9 +236,11 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	haveWAL := wal.Exist(cfg.WALDir())
 	ss := snap.New(cfg.SnapDir())
 
-	prt, err := rafthttp.NewRoundTripper(cfg.PeerTLSInfo, cfg.peerDialTimeout())
-	if err != nil {
-		return nil, err
+	prt := cfg.PeerTransport
+	if prt == nil {
+		if prt, err = rafthttp.NewRoundTripper(cfg.PeerTLSInfo, cfg.PeerDialTimeout()); err != nil {
+			return nil, err
+		}
 	}
 	var remotes []*membership.Member
 	switch {
@@ -386,7 +388,7 @@ func NewServer(cfg *ServerConfig) (*EtcdServer, error) {
 	// TODO: move transport initialization near the definition of remote
 	tr := &rafthttp.Transport{
 		TLSInfo:     cfg.PeerTLSInfo,
-		DialTimeout: cfg.peerDialTimeout(),
+		DialTimeout: cfg.PeerDialTimeout(),
 		ID:          id,
 		URLs:        cfg.PeerURLs,
 		ClusterID:   cl.ID(),

--- a/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/v3demo_server.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/etcdserver/v3demo_server.go
@@ -186,7 +186,7 @@ func (s *EtcdServer) LeaseRenew(id lease.LeaseID) (int64, error) {
 
 	for _, url := range leader.PeerURLs {
 		lurl := url + "/leases"
-		ttl, err = leasehttp.RenewHTTP(id, lurl, s.peerRt, s.cfg.peerDialTimeout())
+		ttl, err = leasehttp.RenewHTTP(id, lurl, s.peerRt, s.cfg.PeerDialTimeout())
 		if err == nil {
 			break
 		}

--- a/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport/keepalive_listener.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport/keepalive_listener.go
@@ -72,12 +72,13 @@ func (l *tlsKeepaliveListener) Accept() (c net.Conn, err error) {
 	if err != nil {
 		return
 	}
-	kac := c.(keepAliveConn)
-	// detection time: tcp_keepalive_time + tcp_keepalive_probes + tcp_keepalive_intvl
-	// default on linux:  30 + 8 * 30
-	// default on osx:    30 + 8 * 75
-	kac.SetKeepAlive(true)
-	kac.SetKeepAlivePeriod(30 * time.Second)
+	if kac, ok := c.(keepAliveConn); ok {
+		// detection time: tcp_keepalive_time + tcp_keepalive_probes + tcp_keepalive_intvl
+		// default on linux:  30 + 8 * 30
+		// default on osx:    30 + 8 * 75
+		kac.SetKeepAlive(true)
+		kac.SetKeepAlivePeriod(30 * time.Second)
+	}
 	c = tls.Server(c, l.config)
 	return
 }

--- a/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport/timeout_listener.go
+++ b/Godeps/_workspace/src/github.com/coreos/etcd/pkg/transport/timeout_listener.go
@@ -28,17 +28,21 @@ func NewTimeoutListener(addr string, scheme string, tlscfg *tls.Config, rdtimeou
 	if err != nil {
 		return nil, err
 	}
-	return &rwTimeoutListener{
-		Listener:   ln,
-		rdtimeoutd: rdtimeoutd,
-		wtimeoutd:  wtimeoutd,
-	}, nil
+	return NewTimeoutListenerWrapper(ln, rdtimeoutd, wtimeoutd), nil
 }
 
 type rwTimeoutListener struct {
 	net.Listener
 	wtimeoutd  time.Duration
 	rdtimeoutd time.Duration
+}
+
+func NewTimeoutListenerWrapper(listener net.Listener, rdtimeoutd, wtimeoutd time.Duration) net.Listener {
+	return &rwTimeoutListener{
+		Listener:   listener,
+		rdtimeoutd: rdtimeoutd,
+		wtimeoutd:  wtimeoutd,
+	}
 }
 
 func (rwln *rwTimeoutListener) Accept() (net.Conn, error) {

--- a/Godeps/_workspace/src/github.com/smarterclayton/chanstream/chanstream.go
+++ b/Godeps/_workspace/src/github.com/smarterclayton/chanstream/chanstream.go
@@ -1,0 +1,393 @@
+// Copyright 2014 Garrett D'Amore
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chanstream provides an API that is similar to that used for TCP
+// and Unix Domain sockets (see net.TCP), for use in intra-process
+// communication on top of Go channels.  This makes it easy to swap it for
+// another net.Conn interface.
+//
+// By using channels, we avoid exposing any
+// interface to other processors, or involving the kernel to perform data
+// copying.
+package chanstream
+
+import "net"
+import "sync"
+import "time"
+import "io"
+
+// ChanError implements the error and net.Error interfaces.
+type ChanError struct {
+	err string
+	tmo bool
+	tmp bool
+}
+
+// Error implements the error interface.
+func (e *ChanError) Error() string {
+	return e.err
+}
+
+// Timeout returns true if the error was a time out.
+func (e *ChanError) Timeout() bool {
+	return e.tmo
+}
+
+// Temporary returns true if the error was temporary in nature.  Operations
+// resulting in temporary errors might be expected to succeed at a later time.
+func (e *ChanError) Temporary() bool {
+	return e.tmp
+}
+
+var (
+	// ErrConnRefused is reported when no listener is present and
+	// a client attempts to connect via Dial.
+	ErrConnRefused = &ChanError{err: "Connection refused."}
+
+	// ErrAddrInUse is reported when a server tries to Listen but another
+	// Conn is already listening on the same address.
+	ErrAddrInUse = &ChanError{err: "Address in use."}
+
+	// ErrAcceptTimeout is reported when a request to Accept takes too
+	// long.  (Note that this is not normally reported -- the default
+	// is for no timeout to be used in Accept.)
+	ErrAcceptTimeout = &ChanError{err: "Accept timeout.", tmo: true}
+
+	// ErrListenQFull is reported if the listen backlog (default 32)
+	// is exhausted.  This normally occurs if a server goroutine does
+	// not call Accept often enough.
+	ErrListenQFull = &ChanError{err: "Listen queue full.", tmp: true}
+
+	// ErrConnClosed is reported when a peer closes the connection while
+	// trying to establish the connection or send data.
+	ErrConnClosed = &ChanError{err: "Connection closed."}
+
+	// ErrConnTimeout is reported when a connection takes too long to
+	// be established.
+	ErrConnTimeout = &ChanError{err: "Connection timeout.", tmo: true}
+
+	// ErrRdTimeout is reported when the read deadline on a connection
+	// expires whle trying to read.
+	ErrRdTimeout = &ChanError{err: "Read timeout.", tmo: true, tmp: true}
+
+	// ErrWrTimeout is reported when the write deadline on a connection
+	// expires whle trying to write.
+	ErrWrTimeout = &ChanError{err: "Write timeout.", tmo: true, tmp: true}
+)
+
+// listeners acts as a registry of listeners.
+var listeners struct {
+	mtx sync.Mutex
+	lst map[string]*ChanListener
+}
+
+// ChanAddr stores just the address, which will normally be something
+// like a path, but any valid string can be used as a key.  This implements
+// the net.Addr interface.
+type ChanAddr struct {
+	name string
+}
+
+// String returns the name of the end point -- the listen address.  This
+// is just an arbitrary string used as a lookup key.
+func (a *ChanAddr) String() string {
+	return a.name
+}
+
+// Network returns "chan".
+func (a *ChanAddr) Network() string {
+	return "chan"
+}
+
+// ChanConn represents a logical connection between two peers communication
+// using a pair of cross-connected go channels. This provides net.Conn
+// semantics on top of channels.
+type ChanConn struct {
+	fifo      chan []byte
+	fin       chan bool
+	rdeadline time.Time
+	wdeadline time.Time
+	peer      *ChanConn
+	pending   []byte
+	closed    bool
+	addr      *ChanAddr
+}
+
+type chanConnect struct {
+	conn      *ChanConn
+	connected chan bool
+}
+
+// ChanListener is used to listen to a socket.
+type ChanListener struct {
+	name     string
+	connect  chan *chanConnect
+	deadline time.Time
+}
+
+// ListenChan establishes the server address and receiving
+// channel where clients can connect.  This service address is backed
+// by a go channel.
+func ListenChan(name string) (*ChanListener, error) {
+	listeners.mtx.Lock()
+	defer listeners.mtx.Unlock()
+
+	if listeners.lst == nil {
+		listeners.lst = make(map[string]*ChanListener)
+	}
+	if _, ok := listeners.lst[name]; ok {
+		return nil, ErrAddrInUse
+	}
+
+	listener := new(ChanListener)
+	listener.name = name
+	// The listen backlog we support.. fairly arbitrary
+	listener.connect = make(chan *chanConnect, 32)
+	// Register listener on the service point
+	listeners.lst[name] = listener
+	return listener, nil
+}
+
+// AcceptChan accepts a client's connection request via Dial,
+// and returns the associated underlying connection.
+func (listener *ChanListener) AcceptChan() (*ChanConn, error) {
+
+	deadline := mkTimer(listener.deadline)
+
+	select {
+	case connect := <-listener.connect:
+		// Make a pair of channels, and twist them.  We keep
+		// the first pair, client gets the twisted pair.
+		// We support buffering up to 10 messages for efficiency
+		chan1 := make(chan []byte, 10)
+		chan2 := make(chan []byte, 10)
+		fin1 := make(chan bool)
+		fin2 := make(chan bool)
+		addr := &ChanAddr{name: listener.name}
+		server := &ChanConn{fifo: chan1, fin: fin1, addr: addr}
+		client := &ChanConn{fifo: chan2, fin: fin2, addr: addr}
+		server.peer = client
+		client.peer = server
+		// And send the client its info, and a wakeup
+		connect.conn = client
+		connect.connected <- true
+		return server, nil
+
+	case <-deadline:
+		// NB: its never possible to read from a nil channel.
+		// So this only counts if we have a timer running.
+		return nil, ErrAcceptTimeout
+	}
+}
+
+// Accept is a generic way to accept a connection.
+func (listener *ChanListener) Accept() (net.Conn, error) {
+	c, err := listener.AcceptChan()
+	return c, err
+}
+
+// DialChan is the client side, think connect().
+func DialChan(name string) (*ChanConn, error) {
+	var listener *ChanListener
+	listeners.mtx.Lock()
+	if listeners.lst != nil {
+		listener = listeners.lst[name]
+	}
+	listeners.mtx.Unlock()
+	if listener == nil {
+		return nil, ErrConnRefused
+	}
+
+	// TBD: This deadline is rather arbitrary
+	deadline := time.After(time.Second * 10)
+	creq := &chanConnect{conn: nil}
+	creq.connected = make(chan bool)
+
+	// Note: We assume the buffering is sufficient.  If the server
+	// side cannot keep up with connect requests, then we'll fail.  The
+	// connect is "non-blocking" in this regard.  As there is a reasonable
+	// listen backlog, this should only happen if lots of clients try to
+	// connect too fast.  In TCP world if this happens it becomes
+	// ECONNREFUSED.  We use ErrListenQFull.
+	select {
+	case listener.connect <- creq:
+
+	default:
+		return nil, ErrListenQFull
+	}
+
+	select {
+	case _, ok := <-creq.connected:
+		if !ok {
+			return nil, ErrConnClosed
+		}
+
+	case <-deadline:
+		return nil, ErrConnTimeout
+	}
+
+	return creq.conn, nil
+}
+
+// Close implements the io.Closer interface.  It closes the channel for
+// communications.  Messages that have already been sent may be received
+// by the peer before the peer closes its side of the connection.  A
+// notification is sent to the peer so it will close its side as well.
+func (conn *ChanConn) Close() error {
+	conn.CloseRead()
+	conn.CloseWrite()
+	return nil
+}
+
+// CloseRead closes the read side of the connection.  Addtionally, a
+// notification is sent to the peer, to begin an orderly shutdown of the
+// connection.  No further data may be read from the connection.
+func (conn *ChanConn) CloseRead() error {
+	close(conn.fin)
+	conn.closed = true
+	return nil
+}
+
+// CloseWrite closes the write side of the channel.  After this point, it
+// is illegal to write data on the connection.
+func (conn *ChanConn) CloseWrite() error {
+	close(conn.fifo)
+	return nil
+}
+
+// LocalAddr returns the local address.  For now, both client and server
+// use the same address, which is the key used for Listen or Dial.
+func (conn *ChanConn) LocalAddr() net.Addr {
+	return conn.addr
+}
+
+// RemoteAddr returns the peer's address.  For now, both client and server
+// use the same address, which is the key used for Listen or Dial.
+func (conn *ChanConn) RemoteAddr() net.Addr {
+	return conn.peer.addr
+}
+
+// SetDeadline sets the timeout for both read and write.
+func (conn *ChanConn) SetDeadline(t time.Time) error {
+	conn.rdeadline = t
+	conn.wdeadline = t
+	return nil
+}
+
+// SetReadDeadline sets the timeout for read (receive).
+func (conn *ChanConn) SetReadDeadline(t time.Time) error {
+	conn.rdeadline = t
+	return nil
+}
+
+// SetWriteDeadline sets the timeout for write (send).
+func (conn *ChanConn) SetWriteDeadline(t time.Time) error {
+	conn.wdeadline = t
+	return nil
+}
+
+// Read implements the io.Reader interface.
+func (conn *ChanConn) Read(b []byte) (int, error) {
+	b = b[0:0] // empty slice
+	for len(b) < cap(b) {
+
+		// get a byte slice from our peer if we don't have one yet
+		if conn.pending == nil || len(conn.pending) == 0 {
+			if len(b) > 0 {
+				return len(b), nil
+			}
+			timer := mkTimer(conn.rdeadline)
+			select {
+			case msg := <-conn.peer.fifo:
+				if msg != nil {
+					conn.pending = msg
+				} else if len(b) > 0 {
+					return len(b), nil
+				} else {
+					return 0, io.EOF
+				}
+
+			case <-timer:
+				// Timeout
+				return len(b), ErrRdTimeout
+			}
+		}
+
+		if conn.closed {
+			return len(b), io.EOF
+		}
+		want := cap(b) - len(b)
+		if want > len(conn.pending) {
+			want = len(conn.pending)
+		}
+		b = append(b, conn.pending[:want]...)
+		conn.pending = conn.pending[want:]
+	}
+	return len(b), nil
+}
+
+// Write implements the io.Writer interface.
+func (conn *ChanConn) Write(b []byte) (int, error) {
+	// Unlike Read, Write is quite a bit simpler, since
+	// we don't have to deal with buffers.  We just write to the
+	// channel/fifo.  We do have to respect when the peer has notified
+	// us that its side is closed, however.
+
+	// We have to make a copy to ensure that once a message is sent to
+	// us, we are insulated against later modification by the sender.
+	// Later we should consider limiting the size of this array to
+	// prevent someone from trying to send ridiculous message sizes all
+	// at once.  (E.g. avoid trying to alloc and copy 100 megabytes here!)
+	a := make([]byte, len(b))
+	copy(a, b)
+	b = a
+
+	deadline := mkTimer(conn.wdeadline)
+	n := len(b)
+
+	select {
+	case <-conn.peer.fin:
+		// Remote close
+		return n, ErrConnClosed
+
+	case conn.fifo <- b:
+		// Sent it
+		return n, nil
+
+	case <-deadline:
+		// Timeout
+		return n, ErrWrTimeout
+	}
+}
+
+// ReaderFrom, WriterTo interfaces can give some better performance,
+// but we skip that for now, they're optional interfaces
+// TO Add  Read, Write, (CloseRead, CloseWrite)
+// ReadFrom, WriteTo,
+func mkTimer(deadline time.Time) <-chan time.Time {
+
+	if deadline.IsZero() {
+		return nil
+	}
+
+	dur := deadline.Sub(time.Now())
+	if dur < 0 {
+		// a closed channel never blocks
+		tm := make(chan time.Time)
+		close(tm)
+		return tm
+	}
+
+	return time.After(dur)
+}

--- a/Godeps/_workspace/src/github.com/smarterclayton/chanstream/chanstream.go
+++ b/Godeps/_workspace/src/github.com/smarterclayton/chanstream/chanstream.go
@@ -153,7 +153,7 @@ func ListenChan(name string) (*ChanListener, error) {
 	listener := new(ChanListener)
 	listener.name = name
 	// The listen backlog we support.. fairly arbitrary
-	listener.connect = make(chan *chanConnect, 32)
+	listener.connect = make(chan *chanConnect, 64)
 	// Register listener on the service point
 	listeners.lst[name] = listener
 	return listener, nil

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/loopback"
 )
 
 var (
@@ -346,11 +347,11 @@ func GetOpenShiftClient(kubeConfigFile string) (*client.Client, *restclient.Conf
 func DefaultClientTransport(rt http.RoundTripper) http.RoundTripper {
 	transport := rt.(*http.Transport)
 	// TODO: this should be configured by the caller, not in this method.
-	dialer := &net.Dialer{
+	dialer := (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-	}
-	transport.Dial = dialer.Dial
+	}).Dial
+	transport.Dial = loopback.Dialer(dialer)
 	// Hold open more internal idle connections
 	// TODO: this should be configured by the caller, not in this method.
 	transport.MaxIdleConnsPerHost = 100

--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -17,6 +17,7 @@ import (
 	knet "k8s.io/kubernetes/pkg/util/net"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/util/loopback"
 )
 
 // GetAndTestEtcdClient creates an etcd client based on the provided config. It will attempt to
@@ -47,14 +48,17 @@ func EtcdClient(etcdClientInfo configapi.EtcdConnectionInfo) (*etcdclient.Client
 		return nil, err
 	}
 
+	dialer := (&net.Dialer{
+		// default from http.DefaultTransport
+		Timeout: 30 * time.Second,
+		// Lower the keep alive for connections.
+		KeepAlive: 1 * time.Second,
+	}).Dial
+
 	transport := knet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
-		Dial: (&net.Dialer{
-			// default from http.DefaultTransport
-			Timeout: 30 * time.Second,
-			// Lower the keep alive for connections.
-			KeepAlive: 1 * time.Second,
-		}).Dial,
+		// Use a loopback dialer
+		Dial: loopback.Dialer(dialer),
 		// Because watches are very bursty, defends against long delays in watch reconnections.
 		MaxIdleConnsPerHost: 500,
 	})
@@ -78,14 +82,17 @@ func MakeNewEtcdClient(etcdClientInfo configapi.EtcdConnectionInfo) (newetcdclie
 		return nil, err
 	}
 
+	dialer := (&net.Dialer{
+		// default from http.DefaultTransport
+		Timeout: 30 * time.Second,
+		// Lower the keep alive for connections.
+		KeepAlive: 1 * time.Second,
+	}).Dial
+
 	transport := knet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
-		Dial: (&net.Dialer{
-			// default from http.DefaultTransport
-			Timeout: 30 * time.Second,
-			// Lower the keep alive for connections.
-			KeepAlive: 1 * time.Second,
-		}).Dial,
+		// Use a loopback dialer
+		Dial: loopback.Dialer(dialer),
 		// Because watches are very bursty, defends against long delays in watch reconnections.
 		MaxIdleConnsPerHost: 500,
 	})

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -265,26 +265,32 @@ func (c *MasterConfig) serve(handler http.Handler, extra []string) {
 		MaxHeaderBytes: 1 << 20,
 	}
 
+	if c.TLS {
+		extraCerts, err := configapi.GetNamedCertificateMap(c.Options.ServingInfo.NamedCertificates)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		server.TLSConfig = crypto.SecureTLSConfig(&tls.Config{
+			// Populate PeerCertificates in requests, but don't reject connections without certificates
+			// This allows certificates to be validated by authenticators, while still allowing other auth types
+			ClientAuth: tls.RequestClientCert,
+			ClientCAs:  c.ClientCAs,
+			// Set SNI certificate func
+			GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
+		})
+		if err := cmdutil.AddCertKeyToTLSConfig(server.TLSConfig, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile); err != nil {
+			glog.Fatal(err)
+		}
+	}
+
 	go utilwait.Forever(func() {
 		for _, s := range extra {
 			glog.Infof(s, c.Options.ServingInfo.BindAddress)
 		}
 		if c.TLS {
-			extraCerts, err := configapi.GetNamedCertificateMap(c.Options.ServingInfo.NamedCertificates)
-			if err != nil {
-				glog.Fatal(err)
-			}
-			server.TLSConfig = crypto.SecureTLSConfig(&tls.Config{
-				// Populate PeerCertificates in requests, but don't reject connections without certificates
-				// This allows certificates to be validated by authenticators, while still allowing other auth types
-				ClientAuth: tls.RequestClientCert,
-				ClientCAs:  c.ClientCAs,
-				// Set SNI certificate func
-				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
-			})
-			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
+			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork))
 		} else {
-			glog.Fatal(server.ListenAndServe())
+			glog.Fatal(cmdutil.ListenAndServe(server, c.Options.ServingInfo.BindNetwork))
 		}
 	}, 0)
 }

--- a/pkg/cmd/util/loopback/loopback.go
+++ b/pkg/cmd/util/loopback/loopback.go
@@ -1,0 +1,142 @@
+package loopback
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/smarterclayton/chanstream"
+)
+
+// DialFunc returns a net.Conn for the provided network or address.
+type DialFunc func(network, address string) (net.Conn, error)
+
+// Dialer returns a DialFunc that always tries to connect via the provided
+// loopback device first, then invokes the provided DialFunc if a connection
+// cannot be established.
+func Dialer(fn DialFunc) DialFunc {
+	return func(network, address string) (net.Conn, error) {
+		if conn, err := chanstream.DialChan(address); err == nil {
+			return conn, nil
+		} else {
+			glog.V(4).Infof("Unable to connect to %s over loopback: %v", address, err)
+		}
+		return fn(network, address)
+	}
+}
+
+// NewListener creates a loopback listener on the provided loopback addresses (host:port
+// or other net.Addr).
+func NewListener(listener net.Listener, loopback ...string) (net.Listener, error) {
+	if len(loopback) == 0 {
+		return listener, nil
+	}
+	listeners := make([]net.Listener, 0, len(loopback)+1)
+	listeners = append(listeners, listener)
+	for _, addr := range loopback {
+		ln, err := chanstream.ListenChan(addr)
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, &listenerWithAddr{ln, listener.Addr()})
+	}
+	return NewMultiListener(listeners...), nil
+}
+
+type listenerWithAddr struct {
+	*chanstream.ChanListener
+	Address net.Addr
+}
+
+func (l *listenerWithAddr) Addr() net.Addr {
+	return l.Address
+}
+
+func (l *listenerWithAddr) Close() error {
+	return nil
+}
+
+type connPair struct {
+	conn net.Conn
+	err  error
+}
+
+var ErrListenerClosed = fmt.Errorf("loopback listener closed")
+
+type multiListener struct {
+	listeners []net.Listener
+	accept    chan connPair
+	stop      chan struct{}
+	once      sync.Once
+	wg        sync.WaitGroup
+}
+
+func NewMultiListener(listeners ...net.Listener) net.Listener {
+	l := &multiListener{
+		listeners: listeners,
+		accept:    make(chan connPair),
+		stop:      make(chan struct{}),
+	}
+	for i := range listeners {
+		l.wg.Add(1)
+		go l.Run(listeners[i])
+	}
+	return l
+}
+
+func (l *multiListener) Run(listener net.Listener) {
+	defer l.wg.Done()
+	for {
+		select {
+		case _, ok := <-l.stop:
+			if !ok {
+				return
+			}
+		default:
+		}
+		c, err := listener.Accept()
+		l.accept <- connPair{conn: c, err: err}
+	}
+}
+
+func (l *multiListener) Accept() (c net.Conn, err error) {
+	pair, ok := <-l.accept
+	if !ok {
+		return nil, ErrListenerClosed
+	}
+	return pair.conn, pair.err
+}
+
+// Close invokes close on each listener in the list, then signals to the
+// accept workers to close, starts a goroutine to drain any new accepts
+// while the workers complete, waits for the workers to exit, and finally
+// returns. Each listener will only be closed once.
+func (l *multiListener) Close() error {
+	var firstErr error
+	l.once.Do(func() {
+		for i, li := range l.listeners {
+			if i == 0 {
+				firstErr = li.Close()
+			} else {
+				li.Close()
+			}
+		}
+		close(l.stop)
+		go func() {
+			// drain any connections that may not have been accepted yet
+			for pair := range l.accept {
+				if pair.conn != nil {
+					pair.conn.Close()
+				}
+			}
+		}()
+		l.wg.Wait()
+		close(l.accept)
+	})
+	return firstErr
+}
+
+func (l *multiListener) Addr() net.Addr {
+	return l.listeners[0].Addr()
+}

--- a/pkg/cmd/util/loopback/loopback_test.go
+++ b/pkg/cmd/util/loopback/loopback_test.go
@@ -1,0 +1,120 @@
+package loopback
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+type fakeListener struct {
+	Called     int
+	Conn       net.Conn
+	Err        error
+	Closed     bool
+	ListenAddr net.Addr
+}
+
+func (l *fakeListener) Accept() (net.Conn, error) {
+	l.Called++
+	return l.Conn, l.Err
+}
+func (l *fakeListener) Close() error {
+	l.Closed = true
+	return l.Err
+}
+func (l *fakeListener) Addr() net.Addr {
+	return l.ListenAddr
+}
+
+type waitListener struct {
+	Called     int
+	Conn       net.Conn
+	Err        error
+	Closed     bool
+	ListenAddr net.Addr
+	Wait       chan struct{}
+}
+
+func (l *waitListener) Accept() (net.Conn, error) {
+	l.Called++
+	<-l.Wait
+	return l.Conn, l.Err
+}
+func (l *waitListener) Close() error {
+	l.Closed = true
+	close(l.Wait)
+	return l.Err
+}
+func (l *waitListener) Addr() net.Addr {
+	return l.ListenAddr
+}
+
+func TestMultiListener(t *testing.T) {
+	err1 := fmt.Errorf("error1")
+	err2 := fmt.Errorf("error2")
+	l1 := &fakeListener{Err: err1}
+	l2 := &fakeListener{Err: err2}
+	l := NewMultiListener(l1, l2).(*multiListener)
+
+	first, second := 0, 0
+	for i := 0; i < 100; i++ {
+		_, err := l.Accept()
+		switch {
+		case err == err1:
+			first++
+		case err == err2:
+			second++
+		default:
+			t.Errorf("received an unexpected error: %v", err)
+		}
+	}
+	if err := l.Close(); err != err1 {
+		t.Errorf("unexpected error on close: %v", err)
+	}
+	// the last accept is never received
+	first = l1.Called - first
+	if first == 1 {
+		first = 0
+	}
+	second = l2.Called - second
+	if second == 1 {
+		second = 0
+	}
+	if first != 0 || second != 0 {
+		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
+	}
+}
+
+// TestMultiListenerWait verifies that a listener that does not return until it is closed
+// will properly block the Close method of MultiListener
+func TestMultiListenerCloseWait(t *testing.T) {
+	err1 := fmt.Errorf("error1")
+	err2 := fmt.Errorf("error2")
+	l1 := &fakeListener{Err: err1}
+	l2 := &waitListener{Err: err2, Wait: make(chan struct{})}
+	l := NewMultiListener(l1, l2).(*multiListener)
+
+	first, second := 0, 0
+	for i := 0; i < 100; i++ {
+		_, err := l.Accept()
+		switch {
+		case err == err1:
+			first++
+		case err == err2:
+			second++
+		default:
+			t.Errorf("received an unexpected error: %v", err)
+		}
+	}
+	if err := l.Close(); err != err1 {
+		t.Errorf("unexpected error on close: %v", err)
+	}
+	// the last accept is never received
+	first = l1.Called - first
+	if first == 1 {
+		first = 0
+	}
+	if first != 0 || second != 0 {
+		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
+	}
+}

--- a/pkg/cmd/util/net.go
+++ b/pkg/cmd/util/net.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -23,6 +24,88 @@ func TryListen(network, hostPort string) (bool, error) {
 	}
 	defer l.Close()
 	return true, nil
+}
+
+type connPair struct {
+	conn net.Conn
+	err  error
+}
+
+type multiListener struct {
+	listeners []net.Listener
+	accept    chan connPair
+	stop      chan struct{}
+	once      sync.Once
+	wg        sync.WaitGroup
+}
+
+func NewMultiListener(listeners ...net.Listener) net.Listener {
+	l := &multiListener{
+		listeners: listeners,
+		accept:    make(chan connPair),
+		stop:      make(chan struct{}),
+	}
+	for i := range listeners {
+		l.wg.Add(1)
+		go l.Run(listeners[i])
+	}
+	return l
+}
+
+func (l *multiListener) Run(listener net.Listener) {
+	defer l.wg.Done()
+	for {
+		select {
+		case _, ok := <-l.stop:
+			if !ok {
+				return
+			}
+		default:
+		}
+		c, err := listener.Accept()
+		l.accept <- connPair{conn: c, err: err}
+	}
+}
+
+func (l *multiListener) Accept() (c net.Conn, err error) {
+	pair, ok := <-l.accept
+	if !ok {
+		return nil, fmt.Errorf("listener closed")
+	}
+	return pair.conn, pair.err
+}
+
+// Close invokes close on each listener in the list, then signals to the
+// accept workers to close, starts a goroutine to drain any new accepts
+// while the workers complete, waits for the workers to exit, and finally
+// returns. Each listener will only be closed once.
+func (l *multiListener) Close() error {
+	var firstErr error
+	l.once.Do(func() {
+		for i, li := range l.listeners {
+			if i == 0 {
+				firstErr = li.Close()
+			} else {
+				li.Close()
+			}
+		}
+		close(l.stop)
+		go func() {
+			// drain any connections that may not have been accepted yet
+			for pair := range l.accept {
+				if pair.conn != nil {
+					pair.conn.Close()
+				}
+			}
+		}()
+		l.wg.Wait()
+		close(l.accept)
+	})
+	return firstErr
+}
+
+func (l *multiListener) Addr() net.Addr {
+	return l.listeners[0].Addr()
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/pkg/cmd/util/net.go
+++ b/pkg/cmd/util/net.go
@@ -7,12 +7,13 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/loopback"
 )
 
 // TryListen tries to open a connection on the given port and returns true if it succeeded.
@@ -24,88 +25,6 @@ func TryListen(network, hostPort string) (bool, error) {
 	}
 	defer l.Close()
 	return true, nil
-}
-
-type connPair struct {
-	conn net.Conn
-	err  error
-}
-
-type multiListener struct {
-	listeners []net.Listener
-	accept    chan connPair
-	stop      chan struct{}
-	once      sync.Once
-	wg        sync.WaitGroup
-}
-
-func NewMultiListener(listeners ...net.Listener) net.Listener {
-	l := &multiListener{
-		listeners: listeners,
-		accept:    make(chan connPair),
-		stop:      make(chan struct{}),
-	}
-	for i := range listeners {
-		l.wg.Add(1)
-		go l.Run(listeners[i])
-	}
-	return l
-}
-
-func (l *multiListener) Run(listener net.Listener) {
-	defer l.wg.Done()
-	for {
-		select {
-		case _, ok := <-l.stop:
-			if !ok {
-				return
-			}
-		default:
-		}
-		c, err := listener.Accept()
-		l.accept <- connPair{conn: c, err: err}
-	}
-}
-
-func (l *multiListener) Accept() (c net.Conn, err error) {
-	pair, ok := <-l.accept
-	if !ok {
-		return nil, fmt.Errorf("listener closed")
-	}
-	return pair.conn, pair.err
-}
-
-// Close invokes close on each listener in the list, then signals to the
-// accept workers to close, starts a goroutine to drain any new accepts
-// while the workers complete, waits for the workers to exit, and finally
-// returns. Each listener will only be closed once.
-func (l *multiListener) Close() error {
-	var firstErr error
-	l.once.Do(func() {
-		for i, li := range l.listeners {
-			if i == 0 {
-				firstErr = li.Close()
-			} else {
-				li.Close()
-			}
-		}
-		close(l.stop)
-		go func() {
-			// drain any connections that may not have been accepted yet
-			for pair := range l.accept {
-				if pair.conn != nil {
-					pair.conn.Close()
-				}
-			}
-		}()
-		l.wg.Wait()
-		close(l.accept)
-	})
-	return firstErr
-}
-
-func (l *multiListener) Addr() net.Addr {
-	return l.listeners[0].Addr()
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
@@ -128,7 +47,7 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 
 // ListenAndServe starts a server that listens on the provided TCP mode (as supported
 // by net.Listen)
-func ListenAndServe(srv *http.Server, network string) error {
+func ListenAndServe(srv *http.Server, network string, addrs ...string) error {
 	addr := srv.Addr
 	if addr == "" {
 		addr = ":http"
@@ -138,7 +57,12 @@ func ListenAndServe(srv *http.Server, network string) error {
 		return err
 	}
 	ln = tcpKeepAliveListener{ln.(*net.TCPListener)}
-	return srv.Serve(ln)
+
+	all, err := loopback.NewListener(ln, addrs...)
+	if err != nil {
+		return err
+	}
+	return srv.Serve(all)
 }
 
 // AddCertKeyToTLSConfig loads an X509 certificate into the provided tls config.
@@ -156,7 +80,7 @@ func AddCertKeyToTLSConfig(config *tls.Config, certFile, keyFile string) error {
 
 // ListenAndServeTLS starts a server that listens on the provided TCP mode (as supported
 // by net.Listen).
-func ListenAndServeTLS(srv *http.Server, network string) error {
+func ListenAndServeTLS(srv *http.Server, network string, addrs ...string) error {
 	addr := srv.Addr
 	if addr == "" {
 		addr = ":https"
@@ -168,7 +92,12 @@ func ListenAndServeTLS(srv *http.Server, network string) error {
 	}
 	ln = tcpKeepAliveListener{ln.(*net.TCPListener)}
 
-	tlsListener := tls.NewListener(ln, srv.TLSConfig)
+	all, err := loopback.NewListener(ln, addrs...)
+	if err != nil {
+		return err
+	}
+
+	tlsListener := tls.NewListener(all, srv.TLSConfig)
 	return srv.Serve(tlsListener)
 }
 

--- a/pkg/cmd/util/net_test.go
+++ b/pkg/cmd/util/net_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"net"
 	"reflect"
 	"testing"
 )
@@ -71,5 +73,118 @@ func TestHostnameMatches(t *testing.T) {
 		if matches != tc.ExpectedMatch {
 			t.Errorf("%d: Expected match=%v, got %v (hostname=%s, specs=%v)", i, tc.ExpectedMatch, matches, tc.Hostname, tc.Spec)
 		}
+	}
+}
+
+type fakeListener struct {
+	Called     int
+	Conn       net.Conn
+	Err        error
+	Closed     bool
+	ListenAddr net.Addr
+}
+
+func (l *fakeListener) Accept() (net.Conn, error) {
+	l.Called++
+	return l.Conn, l.Err
+}
+func (l *fakeListener) Close() error {
+	l.Closed = true
+	return l.Err
+}
+func (l *fakeListener) Addr() net.Addr {
+	return l.ListenAddr
+}
+
+type waitListener struct {
+	Called     int
+	Conn       net.Conn
+	Err        error
+	Closed     bool
+	ListenAddr net.Addr
+	Wait       chan struct{}
+}
+
+func (l *waitListener) Accept() (net.Conn, error) {
+	l.Called++
+	<-l.Wait
+	return l.Conn, l.Err
+}
+func (l *waitListener) Close() error {
+	l.Closed = true
+	close(l.Wait)
+	return l.Err
+}
+func (l *waitListener) Addr() net.Addr {
+	return l.ListenAddr
+}
+
+func TestMultiListener(t *testing.T) {
+	err1 := fmt.Errorf("error1")
+	err2 := fmt.Errorf("error2")
+	l1 := &fakeListener{Err: err1}
+	l2 := &fakeListener{Err: err2}
+	l := NewMultiListener(l1, l2).(*multiListener)
+
+	first, second := 0, 0
+	for i := 0; i < 100; i++ {
+		_, err := l.Accept()
+		switch {
+		case err == err1:
+			first++
+		case err == err2:
+			second++
+		default:
+			t.Errorf("received an unexpected error: %v", err)
+		}
+	}
+	if err := l.Close(); err != err1 {
+		t.Errorf("unexpected error on close: %v", err)
+	}
+	// the last accept is never received
+	first = l1.Called - first
+	if first == 1 {
+		first = 0
+	}
+	second = l2.Called - second
+	if second == 1 {
+		second = 0
+	}
+	if first != 0 || second != 0 {
+		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
+	}
+}
+
+// TestMultiListenerWait verifies that a listener that does not return until it is closed
+// will properly block the Close method of MultiListener
+func TestMultiListenerCloseWait(t *testing.T) {
+	err1 := fmt.Errorf("error1")
+	err2 := fmt.Errorf("error2")
+	l1 := &fakeListener{Err: err1}
+	l2 := &waitListener{Err: err2, Wait: make(chan struct{})}
+	l := NewMultiListener(l1, l2).(*multiListener)
+
+	first, second := 0, 0
+	for i := 0; i < 100; i++ {
+		_, err := l.Accept()
+		switch {
+		case err == err1:
+			first++
+		case err == err2:
+			second++
+		default:
+			t.Errorf("received an unexpected error: %v", err)
+		}
+	}
+	if err := l.Close(); err != err1 {
+		t.Errorf("unexpected error on close: %v", err)
+	}
+	// the last accept is never received
+	first = l1.Called - first
+	if first == 1 {
+		first = 0
+	}
+	if first != 0 || second != 0 {
+		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
 	}
 }

--- a/pkg/cmd/util/net_test.go
+++ b/pkg/cmd/util/net_test.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-	"net"
 	"reflect"
 	"testing"
 )
@@ -73,118 +71,5 @@ func TestHostnameMatches(t *testing.T) {
 		if matches != tc.ExpectedMatch {
 			t.Errorf("%d: Expected match=%v, got %v (hostname=%s, specs=%v)", i, tc.ExpectedMatch, matches, tc.Hostname, tc.Spec)
 		}
-	}
-}
-
-type fakeListener struct {
-	Called     int
-	Conn       net.Conn
-	Err        error
-	Closed     bool
-	ListenAddr net.Addr
-}
-
-func (l *fakeListener) Accept() (net.Conn, error) {
-	l.Called++
-	return l.Conn, l.Err
-}
-func (l *fakeListener) Close() error {
-	l.Closed = true
-	return l.Err
-}
-func (l *fakeListener) Addr() net.Addr {
-	return l.ListenAddr
-}
-
-type waitListener struct {
-	Called     int
-	Conn       net.Conn
-	Err        error
-	Closed     bool
-	ListenAddr net.Addr
-	Wait       chan struct{}
-}
-
-func (l *waitListener) Accept() (net.Conn, error) {
-	l.Called++
-	<-l.Wait
-	return l.Conn, l.Err
-}
-func (l *waitListener) Close() error {
-	l.Closed = true
-	close(l.Wait)
-	return l.Err
-}
-func (l *waitListener) Addr() net.Addr {
-	return l.ListenAddr
-}
-
-func TestMultiListener(t *testing.T) {
-	err1 := fmt.Errorf("error1")
-	err2 := fmt.Errorf("error2")
-	l1 := &fakeListener{Err: err1}
-	l2 := &fakeListener{Err: err2}
-	l := NewMultiListener(l1, l2).(*multiListener)
-
-	first, second := 0, 0
-	for i := 0; i < 100; i++ {
-		_, err := l.Accept()
-		switch {
-		case err == err1:
-			first++
-		case err == err2:
-			second++
-		default:
-			t.Errorf("received an unexpected error: %v", err)
-		}
-	}
-	if err := l.Close(); err != err1 {
-		t.Errorf("unexpected error on close: %v", err)
-	}
-	// the last accept is never received
-	first = l1.Called - first
-	if first == 1 {
-		first = 0
-	}
-	second = l2.Called - second
-	if second == 1 {
-		second = 0
-	}
-	if first != 0 || second != 0 {
-		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
-	}
-}
-
-// TestMultiListenerWait verifies that a listener that does not return until it is closed
-// will properly block the Close method of MultiListener
-func TestMultiListenerCloseWait(t *testing.T) {
-	err1 := fmt.Errorf("error1")
-	err2 := fmt.Errorf("error2")
-	l1 := &fakeListener{Err: err1}
-	l2 := &waitListener{Err: err2, Wait: make(chan struct{})}
-	l := NewMultiListener(l1, l2).(*multiListener)
-
-	first, second := 0, 0
-	for i := 0; i < 100; i++ {
-		_, err := l.Accept()
-		switch {
-		case err == err1:
-			first++
-		case err == err2:
-			second++
-		default:
-			t.Errorf("received an unexpected error: %v", err)
-		}
-	}
-	if err := l.Close(); err != err1 {
-		t.Errorf("unexpected error on close: %v", err)
-	}
-	// the last accept is never received
-	first = l1.Called - first
-	if first == 1 {
-		first = 0
-	}
-	if first != 0 || second != 0 {
-		t.Errorf("did not receive expected call amounts %#v %#v, %d %d", l1, l2, first, second)
 	}
 }


### PR DESCRIPTION
This uses chanstream (a fork of github.com/gdamore/chanstream) to allow the
all-in-one to connect to itself (and etcd) over in process memory channels
rather than network connections. etcd and the master "listen" on a named
string equal to their public address, and then clients use a custom dialer
to try connecting to that public address via loopback rather than opening a
network connection.

The hardest part is putting the loopback listener before the TLS listener
is initialized, since etcd does a poor job of being
"wrappable", as do a few other servers.

Needs some more testing and experimentation to figure out whether this is
worthwhile. Avoids a lot of syscalls.