### PR TITLE
Handle fallback to docker.io for 1.9 docker, which uses docker.io in .docker/config.json

### DIFF
--- a/pkg/image/importer/credentials.go
+++ b/pkg/image/importer/credentials.go
@@ -139,6 +139,11 @@ func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, targe
 			glog.V(5).Infof("Being asked for %s, trying %s for legacy behavior", target, "index.docker.io/v1")
 			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "index.docker.io", Path: "/v1"})
 		}
+		// docker 1.9 saves 'docker.io' in config in f23, see https://bugzilla.redhat.com/show_bug.cgi?id=1309739
+		if value == "index.docker.io" {
+			glog.V(5).Infof("Being asked for %s, trying %s for legacy behavior", target, "docker.io")
+			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "docker.io"})
+		}
 		glog.V(5).Infof("Unable to find a secret to match %s (%s)", target, value)
 		return "", ""
 	}

--- a/pkg/image/importer/credentials_test.go
+++ b/pkg/image/importer/credentials_test.go
@@ -42,7 +42,7 @@ func (k *mockKeyring) Lookup(image string) ([]docker.AuthConfiguration, bool) {
 func TestHubFallback(t *testing.T) {
 	k := &mockKeyring{}
 	basicCredentialsFromKeyring(k, &url.URL{Host: "auth.docker.io", Path: "/token"})
-	if !reflect.DeepEqual([]string{"auth.docker.io/token", "index.docker.io"}, k.calls) {
+	if !reflect.DeepEqual([]string{"auth.docker.io/token", "index.docker.io", "docker.io"}, k.calls) {
 		t.Errorf("unexpected calls: %v", k.calls)
 	}
 }


### PR DESCRIPTION
Fixes #7580 

@smarterclayton ptal, apparently there's a bug in docker 1.9 (definitely in f23) that uses `docker.io` instead of `https://index.docker.io/v1/` when saving config file upon `docker login`. I've added one more fallback for that case. I've tested that against docker 1.10 - there's no such problem anymore. Still I don't want people having problems like I did. The case that was fixed upstream, that you've mentioned in the original issue, is handling `v1`/`v2` parts of the URL.