### PR TITLE
Bump kubernetes-container-terminal to 0.0.11

### DIFF
--- a/assets/bower.json
+++ b/assets/bower.json
@@ -27,7 +27,7 @@
     "messenger": "1.4.1",
     "kubernetes-label-selector": "0.0.18",
     "kubernetes-topology-graph": "0.0.21",
-    "kubernetes-container-terminal": "0.0.7",
+    "kubernetes-container-terminal": "0.0.11",
     "openshift-object-describer": "1.1.2",
     "layout.attrs": "1.1.2",
     "bootstrap-hover-dropdown": "2.1.3",


### PR DESCRIPTION
Pulls in term.js 0.0.7, which has fixes for mobile and copy/paste bugs.