### PR TITLE
Don't autofocus catalog filter input

### DIFF
--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -69,7 +69,6 @@
                         <div style="overflow: hidden; padding-right: 10px;">
                           <input
                              ng-model="filter.keyword"
-                             autofocus
                              type="search"
                              id="search"
                              placeholder="Filter by keyword"


### PR DESCRIPTION
This is annoying on mobile because it popups up the software keyboard, obscuring the catalog content.

@jwforres ptal