### PR TITLE
UPSTREAM: 23145: use versioned object as schema when computing patch on conflict retry

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go
@@ -567,11 +567,11 @@ func patchResource(ctx api.Context, admit updateAdmissionFunc, timeout time.Dura
 				return nil, err
 			}
 
-			currentPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, currentObjectJS, patcher.New())
+			currentPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, currentObjectJS, versionedObj)
 			if err != nil {
 				return nil, err
 			}
-			originalPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, originalPatchedObjJS, patcher.New())
+			originalPatch, err := strategicpatch.CreateStrategicMergePatch(originalObjJS, originalPatchedObjJS, versionedObj)
 			if err != nil {
 				return nil, err
 			}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler_test.go
@@ -202,7 +202,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 			continue
 
 		case api.StrategicMergePatchType:
-			patch, err = strategicpatch.CreateStrategicMergePatch(originalObjJS, changedJS, &api.Pod{})
+			patch, err = strategicpatch.CreateStrategicMergePatch(originalObjJS, changedJS, versionedObj)
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 				return

--- a/test/integration/patch_test.go
+++ b/test/integration/patch_test.go
@@ -1,0 +1,121 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pborman/uuid"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/apiserver"
+	"k8s.io/kubernetes/pkg/client/restclient"
+
+	templatesapi "github.com/openshift/origin/pkg/template/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestPatchConflicts(t *testing.T) {
+
+	testutil.RequireEtcd(t)
+
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	objName := "myobj"
+	ns := "patch-namespace"
+
+	if _, err := clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: ns}}); err != nil {
+		t.Fatalf("Error creating namespace:%v", err)
+	}
+	if _, err := clusterAdminKubeClient.Secrets(ns).Create(&kapi.Secret{ObjectMeta: kapi.ObjectMeta{Name: objName}}); err != nil {
+		t.Fatalf("Error creating k8s resource:%v", err)
+	}
+	if _, err := clusterAdminClient.Templates(ns).Create(&templatesapi.Template{ObjectMeta: kapi.ObjectMeta{Name: objName}}); err != nil {
+		t.Fatalf("Error creating origin resource:%v", err)
+	}
+
+	testcases := []struct {
+		client   *restclient.RESTClient
+		resource string
+	}{
+		{
+			client:   clusterAdminKubeClient.RESTClient,
+			resource: "secrets",
+		},
+		{
+			client:   clusterAdminClient.RESTClient,
+			resource: "templates",
+		},
+	}
+
+	for _, tc := range testcases {
+		successes := int32(0)
+
+		// Force patch to deal with resourceVersion conflicts applying non-conflicting patches
+		// ensure it handles reapplies without internal errors
+		wg := sync.WaitGroup{}
+		for i := 0; i < (2 * apiserver.MaxPatchConflicts); i++ {
+			wg.Add(1)
+			go func(labelName string) {
+				defer wg.Done()
+				labelValue := uuid.NewRandom().String()
+
+				obj, err := tc.client.Patch(kapi.StrategicMergePatchType).
+					Namespace(ns).
+					Resource(tc.resource).
+					Name(objName).
+					Body([]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, labelName, labelValue))).
+					Do().
+					Get()
+
+				if kapierrs.IsConflict(err) {
+					t.Logf("tolerated conflict error patching %s: %v", tc.resource, err)
+					return
+				}
+				if err != nil {
+					t.Errorf("error patching %s: %v", tc.resource, err)
+					return
+				}
+
+				accessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Errorf("error getting object from %s: %v", tc.resource, err)
+					return
+				}
+				if accessor.GetLabels()[labelName] != labelValue {
+					t.Errorf("patch of %s was ineffective, expected %s=%s, got labels %#v", tc.resource, labelName, labelValue, accessor.GetLabels())
+					return
+				}
+
+				atomic.AddInt32(&successes, 1)
+			}(fmt.Sprintf("label-%d", i))
+		}
+		wg.Wait()
+
+		if successes < apiserver.MaxPatchConflicts {
+			t.Errorf("Expected at least %d successful patches for %s, got %d", apiserver.MaxPatchConflicts, tc.resource, successes)
+		} else {
+			t.Logf("Got %d successful patches for %s", successes, tc.resource)
+		}
+	}
+}


### PR DESCRIPTION
fixes #6435