### PR TITLE
dind: only wait for Ready non-sdn nodes

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -324,11 +324,12 @@ os::provision::install-cmds ${DEPLOYED_ROOT}"
 }
 
 function nodes-are-ready() {
-    local node_count=$(${DOCKER_CMD} exec -t "${MASTER_NAME}" bash -c "\
+  # Skip the SDN node since nothing is intended to be scheduled on it.
+  local node_count=$(${DOCKER_CMD} exec -t "${MASTER_NAME}" bash -c "\
 KUBECONFIG=${DEPLOYED_CONFIG_ROOT}/openshift.local.config/master/admin.kubeconfig \
-oc get nodes | grep Ready | wc -l")
-    node_count=$(echo "${node_count}" | tr -d '\r')
-    test "${node_count}" -ge "${NODE_COUNT}"
+oc get nodes | grep -v ${SDN_NODE_NAME} | grep -v NotReady | grep Ready | wc -l")
+  node_count=$(echo "${node_count}" | tr -d '\r')
+  test "${node_count}" -ge "${NODE_COUNT}"
 }
 
 function wait-for-cluster() {


### PR DESCRIPTION
The 'wait-for-cluster' command of hack/dind-cluster.sh was previously
evaluating all nodes when determining whether the cluster's nodes were
seen to be 'Ready' and not excluding 'NotReady'.  The command now
excludes the sdn node, whose state is not relevant for determining
cluster readiness, and ensures that NotReady nodes are properly
excluded.

This should fix test flakes when the first networking test(s) lack for nodes.