### PR TITLE
WIP: Add experimental command to install/remove OpenShift on Kube

### DIFF
--- a/pkg/cmd/experimental/onkubernetes/install/helpers.go
+++ b/pkg/cmd/experimental/onkubernetes/install/helpers.go
@@ -1,0 +1,88 @@
+package install
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// copyFile copies the source file to the specified target
+func copyFile(src, target string) error {
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(target, data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createNamespaceIfNotFound creates the namespace if it does not yet exist.
+func createNamespaceIfNotFound(output io.Writer, kubeClient kubeclient.Interface, item *kapi.Namespace) error {
+	fmt.Fprintf(output, "-- Check if namespace %s exists ... ", item.Name)
+	if _, err := kubeClient.Namespaces().Get(item.Name); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		if _, err = kubeClient.Namespaces().Create(item); err != nil {
+			return err
+		}
+		fmt.Fprintf(output, "\n-- Created namespace\n")
+	}
+	fmt.Fprintf(output, "   OK\n")
+	return nil
+}
+
+// createReplicationControllerIfNotFound creates the object if it doesn't exist.
+func createReplicationControllerIfNotFound(output io.Writer, client kubeclient.ReplicationControllerInterface, item *kapi.ReplicationController) error {
+	fmt.Fprintf(output, "-- Check if replication controller %s exists ... ", item.Name)
+	if _, err := client.Get(item.Name); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		if _, err = client.Create(item); err != nil {
+			return err
+		}
+		fmt.Fprintf(output, "\n-- Created replication controller\n")
+	}
+	fmt.Fprintf(output, "   OK\n")
+	return nil
+}
+
+// createServiceIfNotFound creates the object if it doesn't exist.
+func createServiceIfNotFound(output io.Writer, client kubeclient.ServiceInterface, item *kapi.Service) error {
+	fmt.Fprintf(output, "-- Check if service %s exists ... ", item.Name)
+	if _, err := client.Get(item.Name); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		if _, err = client.Create(item); err != nil {
+			return err
+		}
+		fmt.Fprintf(output, "\n-- Created service\n")
+	}
+	fmt.Fprintf(output, "   OK\n")
+	return nil
+}
+
+// createSecretIfNotFound creates the object if it doesn't exist.
+func createSecretIfNotFound(output io.Writer, client kubeclient.SecretsInterface, item *kapi.Secret) error {
+	fmt.Fprintf(output, "-- Check if secret %s exists ... ", item.Name)
+	if _, err := client.Get(item.Name); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return err
+		}
+		if _, err = client.Create(item); err != nil {
+			return err
+		}
+		fmt.Fprintf(output, "\n-- Created secret\n")
+	}
+	fmt.Fprintf(output, "   OK\n")
+	return nil
+}

--- a/pkg/cmd/experimental/onkubernetes/install/install.go
+++ b/pkg/cmd/experimental/onkubernetes/install/install.go
@@ -1,0 +1,331 @@
+package install
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kclientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	klatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+	"k8s.io/kubernetes/pkg/kubectl"
+	kcmdconfig "k8s.io/kubernetes/pkg/kubectl/cmd/config"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	"github.com/openshift/origin/pkg/cmd/flagtypes"
+	"github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"github.com/openshift/origin/pkg/cmd/server/start"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+// InstallRecommendedCommandName is the recommended command name
+const InstallRecommendedCommandName = "install"
+
+const (
+	installLong = `
+Installs OpenShift on a Kubernetes cluster.
+
+It installs the following:
+ * etcd discovery
+ * etcd 
+ * openshift master`
+)
+
+const (
+	openshiftName     = "openshift"
+	etcdDiscoveryName = "etcd-discovery"
+	etcdName          = "etcd"
+	// TODO: pass as flag, generate it, hold it in a secret?
+	etcdClusterToken   = "hw6yi4w4x4mlih44acymeq1yh53uimem463rm0kd"
+	etcdDiscoveryToken = "etcd-cluster-kxzol"
+)
+
+// NewCmdInstall installs OpenShift on a Kubernetes cluster.
+func NewCmdInstall(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := NewDefaultOptions(out)
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Install OpenShift on a Kubernetes cluster.",
+		Long:  installLong,
+		Run: func(c *cobra.Command, args []string) {
+			kcmdutil.CheckErr(options.Complete(f, c, args, out))
+			kcmdutil.CheckErr(options.Validate(args))
+			if err := options.Install(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(c.Out(), "error: Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatalf("Installation of OpenShift could not complete: %v", err)
+			}
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&options.ServiceAccountPublicKeyFilePath, "service-account-public-key", "", "", "")
+	start.BindKubeConnectionArgs(options.KubeConnectionArgs, flags, "")
+	return cmd
+}
+
+// Options describes how OpenShift is installed on Kubernetes.
+type Options struct {
+	// Location to output results from command
+	Output io.Writer
+	// How to connect to the kubernetes cluster
+	KubeConnectionArgs *start.KubeConnectionArgs
+	// Namespace to create and provision OpenShift within.
+	Namespace string
+	// The public key file to use for service accounts.
+	ServiceAccountPublicKeyFilePath string
+}
+
+// NewDefaultOptions creates an options object with default values.
+func NewDefaultOptions(out io.Writer) *Options {
+	return &Options{
+		Output:             out,
+		KubeConnectionArgs: start.NewDefaultKubeConnectionArgs(),
+	}
+}
+
+// Validate validates install options.
+func (o *Options) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported for install")
+	}
+	if len(o.Namespace) == 0 {
+		return fmt.Errorf("namespace must be known")
+	}
+	if len(o.ServiceAccountPublicKeyFilePath) == 0 {
+		return fmt.Errorf("service account public key file path must be specified")
+	}
+	return nil
+}
+
+// Complete finishes configuration of install options.
+func (o *Options) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	o.Namespace = namespace
+	return nil
+}
+
+// buildKubernetesClient returns a Kubernetes client.
+func (o *Options) buildKubernetesClient() (kubeclient.Interface, error) {
+	config, err := o.KubeConnectionArgs.ClientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubeclient.New(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// createEtcdClusterIfNotFound creates the etcd resources if they do not yet exist.
+func (o *Options) createEtcdClusterIfNotFound(kubeClient kubeclient.Interface) error {
+	if err := createServiceIfNotFound(o.Output, kubeClient.Services(o.Namespace), newEtcdDiscoveryService(etcdDiscoveryName)); err != nil {
+		return err
+	}
+	if err := createReplicationControllerIfNotFound(o.Output, kubeClient.ReplicationControllers(o.Namespace), newEtcdDiscoveryController(etcdDiscoveryName)); err != nil {
+		return err
+	}
+	if err := createServiceIfNotFound(o.Output, kubeClient.Services(o.Namespace), newEtcdService(etcdName)); err != nil {
+		return err
+	}
+	if err := createReplicationControllerIfNotFound(o.Output, kubeClient.ReplicationControllers(o.Namespace), newEtcdController(etcdName, 1, etcdClusterToken, etcdDiscoveryToken)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeOpenShiftConfig will generate configuration for openshift using the specified public ip.
+// it returns the location of the directory it output the generated config, or an error if it was unable to succeed.
+func (o *Options) writeOpenShiftConfig(configDir, openshiftPublicIP string) error {
+	// we need to minify, flatten, and merge the provided kubeconfig into a standalone file for ingestion by OpenShift.
+	mergeFlag := util.BoolFlag{}
+	mergeFlag.Set("true")
+	viewOptions := &kcmdconfig.ViewOptions{
+		ConfigAccess: kcmdconfig.NewDefaultPathOptions(),
+		Merge:        mergeFlag,
+		Flatten:      true,
+		Minify:       true,
+	}
+	printer, _, err := kubectl.GetPrinter("yaml", "")
+	if err != nil {
+		return err
+	}
+	printer = kubectl.NewVersionedPrinter(printer, kclientcmdapi.Scheme, klatest.ExternalVersion)
+	buffer := bytes.NewBuffer([]byte{})
+	err = viewOptions.Run(buffer, printer)
+	if err != nil {
+		return err
+	}
+	kubeConfigFile := configDir + "/kubeconfig"
+	err = ioutil.WriteFile(kubeConfigFile, buffer.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+
+	// generate configuration for OpenShift
+	startMasterOptions := &start.MasterOptions{Output: ioutil.Discard, CreateCertificates: true}
+	startMasterOptions.MasterArgs = start.NewDefaultMasterArgs()
+
+	masterAddr := flagtypes.Addr{}
+	masterAddr.Set("https://localhost:8443")
+	startMasterOptions.MasterArgs.MasterAddr = masterAddr
+
+	etcdAddr := flagtypes.Addr{}
+	etcdAddr.Set("http://etcd:2379")
+	startMasterOptions.MasterArgs.EtcdAddr = etcdAddr
+
+	masterPublicAddr := flagtypes.Addr{}
+	masterPublicAddr.Set("https://" + openshiftPublicIP + ":8443")
+	startMasterOptions.MasterArgs.MasterPublicAddr = masterPublicAddr
+
+	kubeConnectionArgs := start.NewDefaultKubeConnectionArgs()
+	kubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath = kubeConfigFile
+	startMasterOptions.MasterArgs.KubeConnectionArgs = kubeConnectionArgs
+
+	writeConfig := util.NewStringFlag("")
+	writeConfig.Set(configDir)
+	startMasterOptions.MasterArgs.ConfigDir = &writeConfig
+	if err = startMasterOptions.MasterArgs.Validate(); err != nil {
+		return err
+	}
+	if err = startMasterOptions.RunMaster(); err != nil {
+		return err
+	}
+
+	// copy the service account public key into our config dir
+	serviceAccountPublicKeyFile := "serviceaccounts.public.key"
+	serviceAccountPublicKeyFilePath := configDir + "/" + serviceAccountPublicKeyFile
+	err = copyFile(o.ServiceAccountPublicKeyFilePath, serviceAccountPublicKeyFilePath)
+	if err != nil {
+		return err
+	}
+
+	// fixup the master-config to use our service account public key
+	masterConfigFile := configDir + "/master-config.yaml"
+	masterConfig, err := latest.ReadMasterConfig(masterConfigFile)
+	if err != nil {
+		return err
+	}
+
+	masterConfig.ServiceAccountConfig.PublicKeyFiles = []string{serviceAccountPublicKeyFile}
+	data, err := latest.WriteYAML(masterConfig)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(masterConfigFile, data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// createOpenShiftIfNotFound creates the openshift resources if they do not yet exist.
+func (o *Options) createOpenShiftIfNotFound(kubeClient kubeclient.Interface) error {
+	if err := createServiceIfNotFound(o.Output, kubeClient.Services(o.Namespace), newOpenShiftService(openshiftName)); err != nil {
+		return err
+	}
+
+	// wait for the public IP to be assigned by Kubernetes.
+	openshiftPublicIP := ""
+	poll := 2 * time.Second
+	timeout := 2 * time.Minute
+	fmt.Fprintf(o.Output, "-- Detecting public IP for service %s ", openshiftName)
+	wait.Poll(poll, timeout, func() (bool, error) {
+		serviceObj, err := kubeClient.Services(o.Namespace).Get(openshiftName)
+		if err != nil {
+			return false, err
+		}
+		for _, ingress := range serviceObj.Status.LoadBalancer.Ingress {
+			if len(ingress.IP) > 0 {
+				openshiftPublicIP = ingress.IP
+				return true, nil
+			}
+		}
+		fmt.Fprintf(o.Output, ".")
+		return false, nil
+	})
+	if len(openshiftPublicIP) == 0 {
+		return fmt.Errorf("Unable to find a public IP for service: %v", openshiftName)
+	}
+	fmt.Fprintf(o.Output, " OK\n")
+
+	// we create a temp directory locally to hold content we generate.
+	// the calling function is responsible for cleaning this dir up after bundling the secret
+	configDir, err := ioutil.TempDir("", "openshift-config")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(configDir)
+	err = o.writeOpenShiftConfig(configDir, openshiftPublicIP)
+	if err != nil {
+		return err
+	}
+	secretGenerator := kubectl.SecretGeneratorV1{
+		Name:        openshiftName,
+		FileSources: []string{configDir},
+	}
+	runtimeObj, err := secretGenerator.StructuredGenerate()
+	if err != nil {
+		return err
+	}
+	secretObj := runtimeObj.(*kapi.Secret)
+	if err := createSecretIfNotFound(o.Output, kubeClient.Secrets(o.Namespace), secretObj); err != nil {
+		return err
+	}
+
+	// run openshift
+	if err := createReplicationControllerIfNotFound(o.Output, kubeClient.ReplicationControllers(o.Namespace), newOpenShiftController(openshiftName)); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Output, "-- Server Information ...\n")
+	fmt.Fprintf(o.Output, "   OpenShift server starting...\n")
+	fmt.Fprintf(o.Output, "   The server is accessible via web console at:\n")
+	fmt.Fprintf(o.Output, "   https://%s:8443\n", openshiftPublicIP)
+
+	return nil
+}
+
+// Install installs OpenShift on Kubernetes.
+func (o *Options) Install() error {
+	kubeClient, err := o.buildKubernetesClient()
+	if err != nil {
+		return err
+	}
+	namespace := &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: o.Namespace,
+		},
+	}
+	if err = createNamespaceIfNotFound(o.Output, kubeClient, namespace); err != nil {
+		return err
+	}
+	if err = o.createEtcdClusterIfNotFound(kubeClient); err != nil {
+		return err
+	}
+	if err = o.createOpenShiftIfNotFound(kubeClient); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/experimental/onkubernetes/install/models.go
+++ b/pkg/cmd/experimental/onkubernetes/install/models.go
@@ -1,0 +1,240 @@
+package install
+
+import (
+	"strconv"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/intstr"
+)
+
+// newOpenShiftController returns a controller for openshift.
+// TODO: pass tag
+func newOpenShiftController(name string) *kapi.ReplicationController {
+	labels := map[string]string{"name": name}
+	return &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ReplicationControllerSpec{
+			Replicas: 1,
+			Selector: labels,
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "origin",
+							Image: "openshift/origin:latest",
+							Args: []string{
+								"start",
+								"master",
+								"--config=/config/master-config.yaml",
+							},
+							Ports: []kapi.ContainerPort{
+								{
+									ContainerPort: 8443,
+								},
+							},
+							VolumeMounts: []kapi.VolumeMount{
+								{
+									Name:      "config",
+									ReadOnly:  true,
+									MountPath: "/config",
+								},
+							},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        kapi.PullIfNotPresent,
+						},
+					},
+					DNSPolicy: kapi.DNSClusterFirst,
+					Volumes: []kapi.Volume{
+						{
+							Name: "config",
+							VolumeSource: kapi.VolumeSource{
+								Secret: &kapi.SecretVolumeSource{
+									SecretName: "openshift",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newOpenShiftService returns a service for openshift
+// TODO: need to handle clusters that dont have load balancers
+func newOpenShiftService(name string) *kapi.Service {
+	labels := map[string]string{"name": name}
+	return &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ServiceSpec{
+			Type:     kapi.ServiceTypeLoadBalancer,
+			Selector: labels,
+			Ports: []kapi.ServicePort{
+				{
+					Name:       "openshift",
+					Port:       8443,
+					TargetPort: intstr.FromInt(8443),
+				},
+			},
+		},
+	}
+}
+
+// newEtcdDiscoveryService returns a service for etcd-discovery
+func newEtcdDiscoveryService(name string) *kapi.Service {
+	labels := map[string]string{"name": name}
+	return &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ServiceSpec{
+			Type:     kapi.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []kapi.ServicePort{
+				{
+					Port:       2379,
+					TargetPort: intstr.FromInt(2379),
+				},
+			},
+		},
+	}
+}
+
+// newEtcdDiscoveryService returns a controller for etcd-discovery
+func newEtcdDiscoveryController(name string) *kapi.ReplicationController {
+	labels := map[string]string{"name": name}
+	return &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ReplicationControllerSpec{
+			Replicas: 1,
+			Selector: labels,
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "discovery",
+							Image: "openshift/etcd-20-centos7",
+							Args:  []string{"etcd-discovery.sh"},
+							Ports: []kapi.ContainerPort{
+								{
+									Name:          "client",
+									ContainerPort: 2379,
+									Protocol:      kapi.ProtocolTCP,
+								},
+							},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        kapi.PullIfNotPresent,
+						},
+					},
+					DNSPolicy: kapi.DNSClusterFirst,
+				},
+			},
+		},
+	}
+}
+
+// newEtcdService returns a service for etcd
+func newEtcdService(name string) *kapi.Service {
+	labels := map[string]string{"name": name}
+	return &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ServiceSpec{
+			Type:     kapi.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []kapi.ServicePort{
+				{
+					Name:       "client",
+					Port:       2379,
+					TargetPort: intstr.FromInt(2379),
+				},
+				{
+					Name:       "server",
+					Port:       2380,
+					TargetPort: intstr.FromInt(2380),
+				},
+			},
+			SessionAffinity: kapi.ServiceAffinityNone,
+		},
+	}
+}
+
+// newEtcdController returns a controller for etcd
+func newEtcdController(name string, numMembers int, clusterToken, discoveryToken string) *kapi.ReplicationController {
+	labels := map[string]string{"name": name}
+	return &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapi.ReplicationControllerSpec{
+			Replicas: numMembers,
+			Selector: labels,
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "member",
+							Image: "openshift/etcd-20-centos7",
+							Args:  []string{"etcd-discovery.sh"},
+							Ports: []kapi.ContainerPort{
+								{
+									ContainerPort: 2379,
+									Protocol:      kapi.ProtocolTCP,
+								},
+								{
+									ContainerPort: 2380,
+									Protocol:      kapi.ProtocolTCP,
+								},
+							},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        kapi.PullIfNotPresent,
+							Env: []kapi.EnvVar{
+								{
+									Name:  "ETCD_NUM_MEMBERS", // maximum number of members to launch, must match number of replicas
+									Value: strconv.Itoa(numMembers),
+								},
+								{
+									Name:  "ETCD_INITIAL_CLUSTER_STATE",
+									Value: "new",
+								},
+								{
+									Name:  "ETCD_INITIAL_CLUSTER_TOKEN",
+									Value: etcdClusterToken,
+								},
+								{
+									Name:  "ETCD_DISCOVERY_TOKEN",
+									Value: etcdDiscoveryToken,
+								},
+								{
+									Name:  "ETCD_DISCOVERY_URL",
+									Value: "http://etcd-discovery:2379",
+								},
+								{
+									Name:  "ETCDCTL_PEERS",
+									Value: "http://etcd:2379",
+								},
+							},
+						},
+					},
+					DNSPolicy: kapi.DNSClusterFirst,
+				},
+			},
+		},
+	}
+}

--- a/pkg/cmd/experimental/onkubernetes/onkubernetes.go
+++ b/pkg/cmd/experimental/onkubernetes/onkubernetes.go
@@ -1,0 +1,37 @@
+package onkubernetes
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/admin"
+	"github.com/openshift/origin/pkg/cmd/experimental/onkubernetes/install"
+	"github.com/openshift/origin/pkg/cmd/experimental/onkubernetes/remove"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	onKubernetesLong = `The commands grouped here allow you to run OpenShift on an exiting Kubernetes cluster.`
+)
+
+// OnKubernetesRecommendedCommandName is the recommended command name
+const OnKubernetesRecommendedCommandName = "on-kubernetes"
+
+// NewCmdOnKubernetes groups commands that let you run OpenShift on an existing Kubernetes cluster.
+func NewCmdOnKubernetes(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Manage OpenShift on Kubernetes.",
+		Long:  "The commands grouped here allow you to run OpenShift on an exiting Kubernetes cluster.",
+		BashCompletionFunction: admin.BashCompletionFunc,
+		Run: func(c *cobra.Command, args []string) {
+			c.SetOutput(out)
+			c.Help()
+		},
+	}
+
+	cmd.AddCommand(install.NewCmdInstall(install.InstallRecommendedCommandName, fullName+" "+install.InstallRecommendedCommandName, f, out))
+	cmd.AddCommand(remove.NewCmdRemove(remove.RemoveRecommendedCommandName, fullName+" "+remove.RemoveRecommendedCommandName, f, out))
+	return cmd
+}

--- a/pkg/cmd/experimental/onkubernetes/remove/remove.go
+++ b/pkg/cmd/experimental/onkubernetes/remove/remove.go
@@ -1,0 +1,169 @@
+package remove
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/cmd/server/start"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+)
+
+// RemoveRecommendedCommandName is the recommended command name
+const RemoveRecommendedCommandName = "remove"
+
+const (
+	removeLong = `
+Removes OpenShift on a Kubernetes cluster.
+
+It does the following:
+ * delete the namespace that had OpenShift
+ * remove all OpenShift finalizer tokens from any namespace in Kubernetes`
+)
+
+// NewCmdRemove removes OpenShift from a Kubernetes cluster.
+func NewCmdRemove(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := NewDefaultOptions(out)
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Remove OpenShift from a Kubernetes cluster.",
+		Long:  removeLong,
+		Run: func(c *cobra.Command, args []string) {
+			kcmdutil.CheckErr(options.Complete(f, c, args, out))
+			kcmdutil.CheckErr(options.Validate(args))
+			if err := options.Remove(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(c.Out(), "error: Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatalf("Removal of OpenShift could not complete: %v", err)
+			}
+		},
+	}
+	flags := cmd.Flags()
+	start.BindKubeConnectionArgs(options.KubeConnectionArgs, flags, "")
+	return cmd
+}
+
+// Options describes how OpenShift is removed from Kubernetes.
+type Options struct {
+	// Location to output results from command
+	Output io.Writer
+	// How to connect to the kubernetes cluster
+	KubeConnectionArgs *start.KubeConnectionArgs
+	// Namespace to delete.
+	Namespace string
+}
+
+// NewDefaultOptions creates an options object with default values.
+func NewDefaultOptions(out io.Writer) *Options {
+	return &Options{
+		Output:             out,
+		KubeConnectionArgs: start.NewDefaultKubeConnectionArgs(),
+	}
+}
+
+// Validate validates install options.
+func (o *Options) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported for install")
+	}
+	if len(o.Namespace) == 0 {
+		return fmt.Errorf("namespace must be known")
+	}
+	return nil
+}
+
+// Complete finishes configuration of install options.
+func (o *Options) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	o.Namespace = namespace
+	return nil
+}
+
+// buildKubernetesClient returns a Kubernetes client.
+func (o *Options) buildKubernetesClient() (kubeclient.Interface, error) {
+	config, err := o.KubeConnectionArgs.ClientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubeclient.New(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// Remove removes OpenShift from Kubernetes by deleting the current namespace.
+// In addition, it removes the openshift finalizer from each namespace in cluster.
+func (o *Options) Remove() error {
+	kubeClient, err := o.buildKubernetesClient()
+	if err != nil {
+		return err
+	}
+	// clean-up
+	nsToDelete := []string{o.Namespace, "openshift", "openshift-infra"}
+	for _, ns := range nsToDelete {
+		err = kubeClient.Namespaces().Delete(ns)
+		if err != nil && !kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+	// remove our finalizer tokens on anything
+	nsList, err := kubeClient.Namespaces().List(api.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range nsList.Items {
+		_, err = finalizeNamespace(kubeClient, &nsList.Items[i], projectapi.FinalizerOrigin)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// finalizeNamespace removes the specified finalizerToken and finalizes the namespace
+// TODO: make this public in namespace controller utils upstream...
+func finalizeNamespace(kubeClient kubeclient.Interface, namespace *api.Namespace, finalizerToken api.FinalizerName) (*api.Namespace, error) {
+	namespaceFinalize := api.Namespace{}
+	namespaceFinalize.ObjectMeta = namespace.ObjectMeta
+	namespaceFinalize.Spec = namespace.Spec
+	finalizerSet := sets.NewString()
+	for i := range namespace.Spec.Finalizers {
+		if namespace.Spec.Finalizers[i] != finalizerToken {
+			finalizerSet.Insert(string(namespace.Spec.Finalizers[i]))
+		}
+	}
+	namespaceFinalize.Spec.Finalizers = make([]api.FinalizerName, 0, len(finalizerSet))
+	for _, value := range finalizerSet.List() {
+		namespaceFinalize.Spec.Finalizers = append(namespaceFinalize.Spec.Finalizers, api.FinalizerName(value))
+	}
+	namespace, err := kubeClient.Namespaces().Finalize(&namespaceFinalize)
+	if err != nil {
+		// it was removed already, so life is good
+		if kerrors.IsNotFound(err) {
+			return namespace, nil
+		}
+	}
+	return namespace, err
+}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/experimental/buildchain"
 	exipfailover "github.com/openshift/origin/pkg/cmd/experimental/ipfailover"
+	"github.com/openshift/origin/pkg/cmd/experimental/onkubernetes"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/infra/builder"
 	"github.com/openshift/origin/pkg/cmd/infra/deployer"
@@ -156,6 +157,7 @@ func newExperimentalCommand(name, fullName string) *cobra.Command {
 	experimental.AddCommand(validate.NewCommandValidate(validate.ValidateRecommendedName, fullName+" "+validate.ValidateRecommendedName, out))
 	experimental.AddCommand(exipfailover.NewCmdIPFailoverConfig(f, fullName, "ipfailover", out))
 	experimental.AddCommand(buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, out))
+	experimental.AddCommand(onkubernetes.NewCmdOnKubernetes(onkubernetes.OnKubernetesRecommendedCommandName, fullName+" "+onkubernetes.OnKubernetesRecommendedCommandName, f, out))
 	deprecatedDiag := diagnostics.NewCmdDiagnostics(diagnostics.DiagnosticsRecommendedName, fullName+" "+diagnostics.DiagnosticsRecommendedName, out)
 	deprecatedDiag.Deprecated = fmt.Sprintf(`use "oadm %[1]s" to run diagnostics instead.`, diagnostics.DiagnosticsRecommendedName)
 	experimental.AddCommand(deprecatedDiag)


### PR DESCRIPTION
This command is functional, but could use some clean-up.

To use the command, you need the following:
- a kubernetes cluster
- the public key file for that cluster to secure service accounts
- the cluster must support LoadBalancer services

So to use against Kubernetes on GCE:

```
# spin up a kubernetes cluster
$ cd go/src/k8s.io/kubenetes
$ make quick-release
$ export KUBERNETES_PROVIDER=gce
$ export KUBE_GCE_INSTANCE_PREFIX="derek"
$ cluster/kube-up.sh

# get the key
$ export ZONE=$(gcloud compute instances list | grep "${KUBE_GCE_INSTANCE_PREFIX}\-master" | awk '{print $2}' | head -1)
$ echo "sudo cat /srv/kubernetes/server.key; exit;" | gcloud compute ssh ${KUBE_GCE_INSTANCE_PREFIX}-master --zone ${ZONE} | grep -Ex "(^\-.*\-$|^\S+$)" > /tmp/serviceaccounts.private.key

# deploy openshift into the demo namespace
$ openshift ex on-kubernetes install \
--kubeconfig=/home/decarr/.kube/config \
--namespace=demo \
--service-account-public-key=/tmp/serviceaccounts.private.key

# clean-up openshift
$ openshift ex on-kubernetes remove \
--namespace=demo \
--kubeconfig=/home/decarr/.kube/config
```

Things this command could use:
- actual output to the terminal explaining what happens!
- ability to specify ephemeral or pvc backed storage for etcd
- populate default templates

/cc @smarterclayton @csrwng @bparees @paralin 
