### PR TITLE
Don't show chromeless log link and start/end if log not available

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -45,7 +45,8 @@ angular.module('openshiftConsole')
           context: '=',
           options: '=?',
           chromeless: '=?',
-          run: '=?'         // boolean, logs will not run until this is truthy
+          empty: '=?',        // boolean, let the parent know when the log is empty
+          run: '=?'           // boolean, logs will not run until this is truthy
         },
         controller: [
           '$scope',
@@ -59,6 +60,7 @@ angular.module('openshiftConsole')
             var $affixableNode;
             var html = document.documentElement;
 
+            $scope.empty = true;
 
             // are we going to scroll the window, or the DOM node?
             var detectScrollableNode = function() {
@@ -248,11 +250,12 @@ angular.module('openshiftConsole')
 
               streamer.onMessage(function(msg, raw, cumulativeBytes) {
                 // ensures the digest loop will catch the state change.
-                if($scope.state !== 'logs') {
-                  $scope.$evalAsync(function() {
+                $scope.$evalAsync(function() {
+                  $scope.empty = false;
+                  if($scope.state !== 'logs') {
                     $scope.state = 'logs';
-                  });
-                }
+                  }
+                });
 
                 if (options.limitBytes && cumulativeBytes >= options.limitBytes) {
                   $scope.$evalAsync(function() {

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -104,6 +104,7 @@
                         name="build.metadata.name"
                         context="projectContext"
                         options="logOptions"
+                        empty="logEmpty"
                         run="logCanRun">
 
                         <div row cross-axis="center">
@@ -112,7 +113,7 @@
                             <status-icon status="build.status.phase"></status-icon>
                             <span class="space-after">{{build.status.phase}}</span>
 
-                            <span ng-if="build.status.startTimestamp">
+                            <span ng-if="build.status.startTimestamp && !logEmpty">
                               &mdash; Log from {{build.status.startTimestamp  | date : 'short'}}
                               <span ng-if="build.status.completionTimestamp">
                                 to {{build.status.completionTimestamp  | date : 'short'}}

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -90,6 +90,7 @@
                       name="deploymentConfigName"
                       context="projectContext"
                       options="logOptions"
+                      empty="logEmpty"
                       run="logCanRun">
 
                       <div row cross-axis="center">
@@ -99,7 +100,7 @@
                             <status-icon status="deployment | deploymentStatus"></status-icon>
                             {{deployment | deploymentStatus}}
                           </div>
-                          <div ng-if="deployment.metadata.creationTimestamp">
+                          <div ng-if="deployment.metadata.creationTimestamp && !logEmpty">
                             <div ng-if="(deployment | deploymentStatus) !== 'Deployed'">
                               &mdash; Log from {{deployment.metadata.creationTimestamp  | date : 'short'}}
                             </div>

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -103,6 +103,7 @@
                       name="pod.metadata.name"
                       context="projectContext"
                       options="logOptions"
+                      empty="logEmpty"
                       run="logCanRun">
 
                       <div row mobile="column" tablet="column">
@@ -111,7 +112,7 @@
                           <status-icon status="containerStateReason || containerStatusKey"></status-icon>
                           <span class="space-after">{{containerStateReason || containerStatusKey | sentenceCase}}</span>
                         </div>
-                        <div ng-if="containerStartTime">
+                        <div ng-if="containerStartTime && !logEmpty">
                           &mdash;
                           <span ng-if="lasStatusKey">
                             Last {{lasStatusKey}} log

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -6,7 +6,10 @@
   style="margin-bottom: 10px;">
   <div ng-transclude flex><!-- expect start time, end time, status details --></div>
   <div row class="text-right text-xs-left">
-    <a href="" ng-click="goChromeless(options)" style="margin-right: 10px;">
+    <a ng-if="state !== 'empty'"
+       href=""
+       ng-click="goChromeless(options)"
+       style="margin-right: 10px;">
       Open full view of log <i class="fa fa-external-link"></i>
     </a>
     <div ng-if="kibanaAuthUrl">


### PR DESCRIPTION
Don't show the start and end times until there is log content to avoid flicker, but leave the chromeless log link until there is an error so you can click it while logs are still pending.

@jawnsy Hope you don't mind. I wanted to get a fix in for 1.2.
@jwforres PTAL

Fixes #7848