### PR TITLE
Fix certificate display on mobile

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -881,6 +881,8 @@ a.disabled-link {
 }
 pre.clipped {
   display: inline-block;
+  margin-top: 10px;
+  max-width: 100%;
 }
 
 .k8s-label {

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -111,24 +111,44 @@
                     <dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>
                     <dt>Certificate:</dt>
                     <dd>
-                      <span ng-if="route.spec.tls.certificate" click-to-reveal><pre class="clipped">{{route.spec.tls.certificate}}</pre></span>
+                      <span ng-show="route.spec.tls.certificate && !reveal.certificate">
+                        <a href="" ng-click="reveal.certificate = true">Show</a>
+                      </span>
                       <span ng-if="!route.spec.tls.certificate"><em>none</em></span>
                     </dd>
+                    <div ng-if="reveal.certificate">
+                      <pre class="clipped">{{route.spec.tls.certificate}}</pre>
+                    </div>
                     <dt>Key:</dt>
                     <dd>
-                      <span ng-if="route.spec.tls.key" click-to-reveal><pre class="clipped">{{route.spec.tls.key}}</pre></span>
+                      <span ng-if="route.spec.tls.key && !reveal.key">
+                        <a href="" ng-click="reveal.key = true">Show</a>
+                      </span>
                       <span ng-if="!route.spec.tls.key"><em>none</em></span>
                     </dd>
+                    <div ng-if="reveal.key">
+                      <pre class="clipped">{{route.spec.tls.key}}</pre>
+                    </div>
                     <dt>CA Certificate:</dt>
                     <dd>
-                      <span ng-if="route.spec.tls.caCertificate" click-to-reveal><pre class="clipped">{{route.spec.tls.caCertificate}}</pre></span>
+                      <span ng-show="route.spec.tls.caCertificate && !reveal.caCertificate">
+                        <a href="" ng-click="reveal.caCertificate = true">Show</a>
+                      </span>
                       <span ng-if="!route.spec.tls.caCertificate"><em>none</em></span>
                     </dd>
+                    <div ng-if="reveal.caCertificate">
+                      <pre class="clipped">{{route.spec.tls.caCertificate}}</pre>
+                    </div>
                     <dt>Destination CA Cert:</dt>
                     <dd>
-                      <span ng-if="route.spec.tls.destinationCACertificate" click-to-reveal><pre class="clipped">{{route.spec.tls.destinationCACertificate}}</pre></span>
+                      <span ng-show="route.spec.tls.destinationCACertificate && !reveal.destinationCACertificate">
+                        <a href="" ng-click="reveal.destinationCACertificate = true">Show</a>
+                      </span>
                       <span ng-if="!route.spec.tls.destinationCACertificate"><em>none</em></span>
                     </dd>
+                    <div ng-if="reveal.destinationCACertificate">
+                      <pre class="clipped">{{route.spec.tls.destinationCACertificate}}</pre>
+                    </div>
                   </dl>
                   <div ng-if="!route.spec.tls"><em>TLS is not enabled for this route</em></div>
                 </div>


### PR DESCRIPTION
Fixes #8086 

If the certificate content is too wide for the window, you can scroll inside the `pre`.

<img width="522" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13861754/7f14746e-ec65-11e5-89bd-b99f836dae56.png">


