### PR TITLE
Bump source-to-image

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -922,47 +922,47 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v1.0.5-6-g0278ed9",
-			"Rev": "fb7794026064c5a7b83905674a5244916a07fef9"
+			"Rev": "625b58aa422549df9338fdaced1b9444d2313a15"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
@@ -148,6 +148,11 @@ type Config struct {
 	// (default: false).
 	Quiet bool
 
+	// ForceCopy results in only the file SCM plugin being used (i.e. no `git clone`); allows for empty directories to be included
+	// in resulting image (since git does not support that).
+	// (default: false).
+	ForceCopy bool
+
 	// Specify a relative directory inside the application repository that should
 	// be used as a root directory for the application.
 	ContextDir string

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
@@ -55,7 +55,7 @@ func New(config *api.Config, overrides build.Overrides) (*OnBuild, error) {
 
 	downloader := overrides.Downloader
 	if downloader == nil {
-		d, sourceURL, err := scm.DownloaderForSource(config.Source)
+		d, sourceURL, err := scm.DownloaderForSource(config.Source, config.ForceCopy)
 		if err != nil {
 			return nil, err
 		}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker/test"
@@ -423,7 +422,6 @@ func TestRunContainer(t *testing.T) {
 			Container: &docker.Container{
 				ID: "12345-test",
 			},
-			AttachToContainerSleep: 200 * time.Millisecond,
 		}
 		dh := getDocker(fakeDocker)
 		err := dh.RunContainer(RunContainerOptions{
@@ -460,20 +458,6 @@ func TestRunContainer(t *testing.T) {
 		// Verify that remove container was called
 		if fakeDocker.RemoveContainerOpts.ID != "12345-test" {
 			t.Errorf("%s: RemoveContainer was not called with the expected container ID", desc)
-		}
-
-		// Verify that AttachToContainer was called twice (Stdin/Stdout)
-		if len(fakeDocker.AttachToContainerOpts) != 1 {
-			t.Errorf("%s: AttachToContainer was not called the expected number of times.", desc)
-		}
-		// Make sure AttachToContainer was not called with both Stdin & Stdout
-		for _, opt := range fakeDocker.AttachToContainerOpts {
-			if opt.InputStream == nil || opt.OutputStream == nil {
-				t.Errorf("%s: AttachToContainer was not called with both Stdin and Stdout: %#v", desc, opt)
-			}
-			if !opt.Stdin || !opt.Stdout {
-				t.Errorf("%s: AttachToContainer was not called with both Stdin and Stdout flags: %#v", desc, opt)
-			}
 		}
 	}
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
@@ -1,10 +1,6 @@
 package docker
 
-import (
-	"sync"
-
-	dockerclient "github.com/fsouza/go-dockerclient"
-)
+import dockerclient "github.com/fsouza/go-dockerclient"
 
 // FakeDocker provides a fake docker interface
 type FakeDocker struct {
@@ -43,8 +39,6 @@ type FakeDocker struct {
 	IsOnBuildImage               string
 	Labels                       map[string]string
 	LabelsError                  error
-
-	mutex sync.Mutex
 }
 
 // IsImageInLocalRegistry checks if the image exists in the fake local registry

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm.go
@@ -13,7 +13,7 @@ import (
 
 // DownloaderForSource determines what SCM plugin should be used for downloading
 // the sources from the repository.
-func DownloaderForSource(s string) (build.Downloader, string, error) {
+func DownloaderForSource(s string, forceCopy bool) (build.Downloader, string, error) {
 	glog.V(4).Infof("DownloadForSource %s", s)
 
 	details, mods := git.ParseFile(s)
@@ -35,7 +35,7 @@ func DownloaderForSource(s string) (build.Downloader, string, error) {
 		}
 	}
 
-	if details.FileExists && details.UseCopy {
+	if details.FileExists && (details.UseCopy || forceCopy) {
 		return &file.File{util.NewFileSystem()}, s, nil
 	}
 

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
@@ -44,7 +44,7 @@ func TestDownloaderForSource(t *testing.T) {
 	}
 
 	for s, expected := range tc {
-		r, filePathUpdate, err := DownloaderForSource(s)
+		r, filePathUpdate, err := DownloaderForSource(s, false)
 		if err != nil {
 			if expected != "error" {
 				t.Errorf("Unexpected error %q for %q, expected %q", err, s, expected)
@@ -69,7 +69,7 @@ func TestDownloaderForSourceOnRelativeGit(t *testing.T) {
 	gitLocalDir := createLocalGitDirectory(t)
 	defer os.RemoveAll(gitLocalDir)
 	os.Chdir(gitLocalDir)
-	r, s, err := DownloaderForSource(".")
+	r, s, err := DownloaderForSource(".", false)
 	if err != nil {
 		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "git.Clone")
 	}
@@ -78,5 +78,21 @@ func TestDownloaderForSourceOnRelativeGit(t *testing.T) {
 	}
 	if reflect.TypeOf(r).String() != "*git.Clone" {
 		t.Errorf("Expected %q for %q, got %q", "*git.Clone", ".", reflect.TypeOf(r).String())
+	}
+}
+
+func TestDownloaderForceCopy(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	os.Chdir(gitLocalDir)
+	r, s, err := DownloaderForSource(".", true)
+	if err != nil {
+		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "*file.File")
+	}
+	if !strings.HasPrefix(s, "file://") {
+		t.Errorf("Expected source to have 'file://' prefix, it is %q", s)
+	}
+	if reflect.TypeOf(r).String() != "*file.File" {
+		t.Errorf("Expected %q for %q, got %q", "*file.File", ".", reflect.TypeOf(r).String())
 	}
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/timeout.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/timeout.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+// TimeoutError is error returned after timeout occured.
+type TimeoutError struct {
+	after time.Duration
+}
+
+// Error implements the Go error interface.
+func (t *TimeoutError) Error() string {
+	return fmt.Sprintf("calling the function timeout after %v", t.after)
+}
+
+// TimeoutAfter executes the provide function and return the TimeoutError in
+// case when the execution time of the provided function is bigger than provided
+// time duration.
+func TimeoutAfter(t time.Duration, fn func() error) error {
+	c := make(chan error, 1)
+	go func() {
+		defer close(c)
+		c <- fn()
+	}()
+	select {
+	case err := <-c:
+		return err
+	case <-time.After(t):
+		return &TimeoutError{after: t}
+	}
+}
+
+// IsTimeoutError checks if the provided error is timeout.
+func IsTimeoutError(e error) bool {
+	_, ok := e.(*TimeoutError)
+	return ok
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/timeout_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/util/timeout_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTimeoutAfter(t *testing.T) {
+	type testCase struct {
+		fn      func() error
+		timeout time.Duration
+		expect  interface{}
+	}
+	table := []testCase{
+		{
+			fn:      func() error { time.Sleep(1 * time.Second); return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  &TimeoutError{after: 50 * time.Millisecond},
+		},
+		{
+			fn:      func() error { return fmt.Errorf("foo") },
+			timeout: 50 * time.Millisecond,
+			expect:  fmt.Errorf("foo"),
+		},
+		{
+			fn:      func() error { return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  nil,
+		},
+	}
+	for _, item := range table {
+		got := TimeoutAfter(item.timeout, item.fn)
+		if !reflect.DeepEqual(item.expect, got) {
+			t.Errorf("expected %+v, got %+v", item.expect, got)
+		}
+		if _, ok := item.expect.(*TimeoutError); ok {
+			if !IsTimeoutError(got) {
+				t.Errorf("expected %+v to be timeout error", got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Bring in recent changes with bug fixes and new option:

1. Changes to the `RunContainer` implementation, fixing concurrency issues and hanging of incremental builds. https://github.com/openshift/source-to-image/pull/430

  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1315607.


2. Limit some calls to the Docker API with timeouts. https://github.com/openshift/source-to-image/pull/429

  Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1318395.

3. Add option to only attempt copy command on source URL. https://github.com/openshift/source-to-image/pull/428