### PR TITLE
Bug 1310062 - Fallback to https if status code is not 2xx when deleting layers

### DIFF
--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -916,6 +916,11 @@ func deleteFromRegistry(registryClient *http.Client, url string) error {
 		}
 		defer resp.Body.Close()
 
+		// non-2xx/3xx response doesn't cause an error, so we need to check for it
+		// manually and return it to caller
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf(resp.Status)
+		}
 		if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {
 			glog.V(1).Infof("Unexpected status code in response: %d", resp.StatusCode)
 			decoder := json.NewDecoder(resp.Body)


### PR DESCRIPTION
This addresses the problem described in [here](https://bugzilla.redhat.com/show_bug.cgi?id=1310062). We need to manually check non-2xx responses since these are not returned as errors and that causes the logic not to fallback to try against http.

@miminar ptal
@ncdc @kargakis fyi

Any idea how to write unit test for this? I've tried several approaches but failed in the end :(