### PR TITLE
Proxy /apis/ to kubernetes

### DIFF
--- a/pkg/cmd/server/kubernetes/proxy.go
+++ b/pkg/cmd/server/kubernetes/proxy.go
@@ -27,6 +27,7 @@ func (c *ProxyConfig) InstallAPI(container *restful.Container) ([]string, error)
 	}
 
 	container.Handle("/api/", proxy)
+	container.Handle("/apis/", proxy)
 
 	return []string{
 		"Started Kubernetes proxy at %s/api/",


### PR DESCRIPTION
When running against external kubernetes, /apis/ must be proxied to kube as well.

This may look different in the future when distributed API groups are working