### PR TITLE
PVCs should not be editable once bound

### DIFF
--- a/assets/app/views/browse/persistent-volume-claim.html
+++ b/assets/app/views/browse/persistent-volume-claim.html
@@ -28,7 +28,7 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
-                  <li>
+                  <li ng-if="!pvc.spec.volumeName">
                     <edit-link
                       resource="pvc"
                       kind="PersistentVolumeClaim"
@@ -47,7 +47,7 @@
               </div>
             </h1>
             <labels labels="pvc.metadata.labels" clickable="true" kind="storage" project-name="{{pvc.metadata.namespace}}" limit="3"></labels>
-          </div><!-- /deployment -->          
+          </div><!-- /deployment -->
         </div>
       </div><!-- /middle-header-->
       <div class="middle-content">


### PR DESCRIPTION
Hide the "edit" action from the PVC page once it has been bound. Fixes https://github.com/openshift/origin/issues/8106.

@jwforres PTAL