### PR TITLE
Show consistent pod status in web console as CLI

### DIFF
--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -862,11 +862,11 @@ angular.module('openshiftConsole')
   .filter('podStatus', function() {
     // Return results that match kubernetes/pkg/kubectl/resource_printer.go
     return function(pod) {
-      if (!pod || (!pod.deletionTimestamp && !pod.status)) {
+      if (!pod || (!pod.metadata.deletionTimestamp && !pod.status)) {
         return '';
       }
 
-      if (pod.deletionTimestamp) {
+      if (pod.metadata.deletionTimestamp) {
         return 'Terminating';
       }
 

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -3,12 +3,20 @@
     <div class="col-lg-6">
       <h3>Status</h3>
       <dl class="dl-horizontal left">
-        <dt>Phase:</dt>
+        <dt>Status:</dt>
         <dd>
-          <status-icon status="pod.status.phase"></status-icon>
-          {{pod.status.phase}}
-          <span ng-if="pod.status.reason">
-            ({{pod.status.reason}})
+          <status-icon status="pod | podStatus"></status-icon>
+          {{pod | podStatus | sentenceCase}}
+          <span ng-if="pod.metadata.deletionTimestamp">(expires {{pod.metadata.deletionTimestamp | date : 'medium'}})</span>
+        </dd>
+        <dt ng-if-start="pod.metadata.deletionTimestamp && pod.spec.terminationGracePeriodSeconds">Grace Period:</dt>
+        <dd ng-if-end>
+          <!-- Don't show "a few seconds" for small values. -->
+          <span ng-if="pod.spec.terminationGracePeriodSeconds < 60">
+            {{pod.spec.terminationGracePeriodSeconds}} seconds
+          </span>
+          <span ng-if="pod.spec.terminationGracePeriodSeconds >= 60">
+            {{pod.spec.terminationGracePeriodSeconds | humanizeDurationValue : 'seconds'}}
           </span>
         </dd>
         <dt ng-if-start="pod.status.message">Message:</dt>
@@ -21,7 +29,13 @@
         <dd>{{pod.spec.restartPolicy || 'Always'}}</dd>
         <dt ng-if-start="pod.spec.activeDeadlineSeconds">Active Deadline:</dt>
         <dd ng-if-end>
-          {{pod.spec.activeDeadlineSeconds | humanizeDurationValue : 'seconds'}}
+          <!-- Don't show "a few seconds" for small values. -->
+          <span ng-if="pod.spec.activeDeadlineSeconds < 60">
+            {{pod.spec.activeDeadlineSeconds}} seconds
+          </span>
+          <span ng-if="pod.spec.activeDeadlineSeconds >= 60">
+            {{pod.spec.activeDeadlineSeconds | humanizeDurationValue : 'seconds'}}
+          </span>
           <span ng-if="pod.status.phase === 'Running' && pod.status.startTime" class="text-muted">
             (<duration-until-now timestamp="pod.status.startTime"></duration-until-now> elapsed)
           </span>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1318681

Show status consistent with the CLI. Properly handle `pod.metadata.deletionTimestamp` and show termination grace period, but only when the pod is terminating.

This change does remove `pod.status.reason` from the view, which I've never seen set. I believe it applies to phase, but we're using the container state reason.

![screen shot 2016-03-18 at 11 54 51 am](https://cloud.githubusercontent.com/assets/1167259/13883596/893dbcc0-ed00-11e5-8809-f54c87e170ec.png)

![screen shot 2016-03-18 at 11 55 39 am](https://cloud.githubusercontent.com/assets/1167259/13883599/8d659638-ed00-11e5-97aa-9b84798e7e95.png)

@jwforres PTAL
