### PR TITLE
Adjust -webkit-scrollbar width and log-scroll-top affixed position.

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -59,7 +59,7 @@
   // this is toggled in JS
   .log-scroll-top.affix.target-logger-node {
     position: fixed;
-    right: 42px;
+    right: 45px;
     top: 60px !important;
   }
 

--- a/assets/app/styles/_scrollbars.less
+++ b/assets/app/styles/_scrollbars.less
@@ -8,7 +8,7 @@
 ::-webkit-scrollbar {
   height: 10px;
   overflow: visible;
-  width: 10px;
+  width: 14px;
 }
 ::-webkit-scrollbar-thumb {
   background-color: @scrollbar-thumb;


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7963

The variance between scrollbar widths is the culprit, thus position:fixed distance to viewport right edge is different. These changes make the widths of the scrollbars, mostly consistent.

<img width="249" alt="screen shot 2016-03-18 at 1 17 54 pm" src="https://cloud.githubusercontent.com/assets/1874151/13886251/7a09dffc-ed0c-11e5-9458-bbe99fbdcff8.png">

**chrome**
<img width="334" alt="screen shot 2016-03-18 at 1 17 04 pm" src="https://cloud.githubusercontent.com/assets/1874151/13886250/7a048444-ed0c-11e5-9e4f-65226e25b3c8.png">
 