### PR TITLE
Use smaller log font size for mobile

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -71,7 +71,10 @@
     right: 0;
   }
   .log-view-output {
-    font-size: 12px;
+    font-size: 11px;
+    @media (min-width: @screen-sm-min) {
+      font-size: 12px;
+    }
     padding: 30px 0 30px;
     .ellipsis-loader {
       // Give space between log output and loader
@@ -122,6 +125,7 @@
   vertical-align: top;
   white-space: nowrap;
   width: 60px;
+  color: #72767b;
 }
 .log-line-text {
   padding: 0 10px;


### PR DESCRIPTION
Switch to an 11px font <768px to show more log content on mobile devices (but keep 12px for desktop). Also dim the line numbers some to differentiate them from the log content.

/cc @jwforres @sg00dwin @benjaminapetersen 

Mobile:

![screen shot 2016-03-18 at 14 20 17](https://cloud.githubusercontent.com/assets/1167259/13887903/acad745c-ed14-11e5-8fdf-79cae921f4ae.png)

Desktop:

![screen shot 2016-03-18 at 14 20 49](https://cloud.githubusercontent.com/assets/1167259/13887905/b0f37d90-ed14-11e5-8d00-014f4959d1cb.png)
