### PR TITLE
Remove large, unnecessary margin from bottom of create forms

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -385,7 +385,6 @@ label.checkbox {
 
 .create-from-template,
 .create-from-image {
-  margin-bottom: 100px; // needed space for hover help text near bottom
   .template-name {
     text-align: right;
     span.fa {


### PR DESCRIPTION
There's a large margin below our create from image and create from template forms. It's no longer necessary for hover text, even at mobile screen widths.

/cc @jwforres @sg00dwin 