### PR TITLE
Add RunOnceDuration and ProjectRequestLimit plugins to default plugin chains

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -45,7 +45,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"NamespaceLifecycle", "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
+var AdmissionPlugins = []string{"RunOnceDuration", "NamespaceLifecycle", "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -175,7 +175,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{"OriginNamespaceLifecycle", "PodNodeConstraints", "BuildByStrategy", "OriginResourceQuota"}
+	admissionControlPluginNames := []string{"ProjectRequestLimit", "OriginNamespaceLifecycle", "PodNodeConstraints", "BuildByStrategy", "OriginResourceQuota"}
 	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
 		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
 	}

--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -61,6 +61,9 @@ var _ = oadmission.Validator(&projectRequestLimit{})
 
 // Admit ensures that only a configured number of projects can be requested by a particular user.
 func (o *projectRequestLimit) Admit(a admission.Attributes) (err error) {
+	if o.config == nil {
+		return nil
+	}
 	if a.GetResource() != projectapi.Resource("projectrequests") {
 		return nil
 	}

--- a/pkg/project/admission/requestlimit/admission_test.go
+++ b/pkg/project/admission/requestlimit/admission_test.go
@@ -212,6 +212,10 @@ func TestAdmit(t *testing.T) {
 			config: singleDefaultConfig(),
 			user:   "user1",
 		},
+		{
+			config: nil,
+			user:   "user3",
+		},
 	}
 
 	for _, tc := range tests {

--- a/test/integration/project_reqlimit_test.go
+++ b/test/integration/project_reqlimit_test.go
@@ -26,7 +26,6 @@ func setupProjectRequestLimitTest(t *testing.T, pluginConfig *requestlimit.Proje
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
-	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"OriginNamespaceLifecycle", "BuildByStrategy", "ProjectRequestLimit"}
 	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"ProjectRequestLimit": {
 			Configuration: pluginConfig,

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -10,7 +10,6 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	kubemaster "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	pluginapi "github.com/openshift/origin/pkg/quota/admission/runonceduration/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -68,8 +67,6 @@ func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurat
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
-	plugins := append([]string{"RunOnceDuration"}, kubemaster.AdmissionPlugins...)
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = plugins
 	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"RunOnceDuration": {
 			Configuration: pluginConfig,


### PR DESCRIPTION
Adding these plugins to the default admission control chain means less maintenance for installations that use them.