### PR TITLE
Set terminal max-width to 100% for mobile

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -190,6 +190,10 @@
 .pod-container-terminal {
   margin-top: 15px;
   margin-bottom: 15px;
+  kubernetes-container-terminal .terminal-wrapper {
+    max-width: 100%;
+    overflow-x: auto;
+  }
 }
 .builds-no-service {
   .builds-block {


### PR DESCRIPTION
Low risk fix for 1.2. I think we should use #7639 instead for a better experience post 1.2. Scrolling the terminal works with this change.

@jwforres ptal, cc @benjaminapetersen 

<img width="487" alt="screen shot 2016-03-18 at 4 01 26 pm" src="https://cloud.githubusercontent.com/assets/1167259/13890685/2f1270d8-ed23-11e5-8446-4c8e379ec5b1.png">