### PR TITLE
Ensure ingress host matches route host

### DIFF
--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -45,8 +45,14 @@ func NewStatusAdmitter(plugin router.Plugin, client client.RoutesNamespacer, nam
 	}
 }
 
+// Return a time truncated to the second to ensure that in-memory and
+// serialized timestamps can be safely compared.
+func getRfc3339Timestamp() unversioned.Time {
+	return unversioned.Now().Rfc3339Copy()
+}
+
 // nowFn allows the package to be tested
-var nowFn = unversioned.Now
+var nowFn = getRfc3339Timestamp
 
 // findOrCreateIngress loops through the router status ingress array looking for an entry
 // that matches name. If there is no entry in the array, it creates one and appends it

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -36,7 +36,7 @@ func (p *fakePlugin) HandleNamespaces(namespaces sets.String) error {
 }
 
 func TestStatusNoOp(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
 	c := testclient.NewSimpleFake()
@@ -118,7 +118,7 @@ func TestStatusResetsHost(t *testing.T) {
 }
 
 func TestStatusAdmitsRouteOnForbidden(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
@@ -167,7 +167,7 @@ func TestStatusAdmitsRouteOnForbidden(t *testing.T) {
 }
 
 func TestStatusBackoffOnConflict(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
@@ -217,7 +217,7 @@ func TestStatusBackoffOnConflict(t *testing.T) {
 }
 
 func TestStatusRecordRejection(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	p := &fakePlugin{}
 	c := testclient.NewSimpleFake(&routeapi.Route{})
@@ -248,7 +248,7 @@ func TestStatusRecordRejection(t *testing.T) {
 }
 
 func TestStatusRecordRejectionNoChange(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
@@ -285,7 +285,7 @@ func TestStatusRecordRejectionNoChange(t *testing.T) {
 }
 
 func TestStatusRecordRejectionWithStatus(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
@@ -332,7 +332,7 @@ func TestStatusRecordRejectionWithStatus(t *testing.T) {
 }
 
 func TestStatusRecordRejectionConflict(t *testing.T) {
-	now := unversioned.Now()
+	now := nowFn()
 	nowFn = func() unversioned.Time { return now }
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}


### PR DESCRIPTION
The router status plugin compares ingress timestamps with cached
values to detect conflict with other router instances, and was falsely
detecting conflict when values with nanosecond accuracy were compared
to the same values that had been serialized to and from etcd in
RFC3339 format (accurate to the second).  The result of a conflict was
that an update to the host of a route would not be reflected in the
route's ingress record.

This change enures that ingress timestamps are truncated to the second
to ensure safe comparison between in-memory and serialized timestamps.