### PR TITLE
Fix precision displaying percentages in quota chart tooltip

### DIFF
--- a/assets/app/scripts/directives/quotaUsageChart.js
+++ b/assets/app/scripts/directives/quotaUsageChart.js
@@ -55,8 +55,13 @@ angular.module('openshiftConsole')
           $scope.width = 175;
         }
 
-        // https://github.com/mbostock/d3/wiki/Formatting
-        var percentage = d3.format(".2p");
+        var percentage = function(value) {
+          if (!value) {
+            return "0%";
+          }
+
+          return (Number(value) * 100).toFixed(1) + "%";
+        };
 
         // Chart configuration, see http://c3js.org/reference.html
         $scope.chartID = _.uniqueId('quota-usage-chart-');

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -790,8 +790,10 @@ angular.module('openshiftConsole')
 
       var nameFormatMap = {
         'configmaps': 'Config Maps',
+        'cpu': 'CPU (Request)',
         'limits.cpu': 'CPU (Limit)',
         'limits.memory': 'Memory (Limit)',
+        'memory': 'Memory (Request)',
         'openshift.io/imagesize': 'Image Size',
         'openshift.io/imagestreamsize': 'Image Stream Size',
         'openshift.io/projectimagessize': 'Project Image Size',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1318934

`d3.format` was rounding to two _significant_ digits. So 0.015 was displayed as 1.5% and 0.985 was displayed as 99%. Use `Number.toFixed` instead so we always have the same number of decimal places.

We aren't using `d3.format` anywhere else.

Also add `"cpu"` and `"memory"` back to `humanizeQuotaResource`.

@jwforres PTAL