### PR TITLE
Hide extra close buttons for task lists

### DIFF
--- a/assets/app/scripts/directives/alerts.js
+++ b/assets/app/scripts/directives/alerts.js
@@ -5,7 +5,8 @@ angular.module('openshiftConsole')
     return {
       restrict: 'E',
       scope: {
-        alerts: '='
+        alerts: '=',
+        hideCloseButton: '=?'
       },
       templateUrl: 'views/_alerts.html'
     };

--- a/assets/app/views/_alerts.html
+++ b/assets/app/views/_alerts.html
@@ -5,7 +5,7 @@
     'alert-success': alert.type === 'success',
     'alert-info': !alert.type || alert.type === 'info'
   }">
-    <button ng-click="alert.hidden = true" type="button" class="close">
+    <button ng-if="!hideCloseButton" ng-click="alert.hidden = true" type="button" class="close">
       <span class="pficon pficon-close" aria-hidden="true"></span>
       <span class="sr-only">Close</span>
     </button>

--- a/assets/app/views/_tasks.html
+++ b/assets/app/views/_tasks.html
@@ -24,7 +24,8 @@
             </a>
           </div>
           <div ng-show="!task.hasErrors || expanded">
-            <alerts alerts="task.alerts"></alerts>
+            <!-- Don't show a close button for each alert since we have one above for all tasks. -->
+            <alerts alerts="task.alerts" hide-close-button="true"></alerts>
           </div>
       </div>
     </div>


### PR DESCRIPTION
Since we have a button that dismisses all task alerts, hide the close buttons on individual alerts. It looks odd to have more than one, particularly when everything completes successfully.

Before:

<img width="699" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13917799/58083136-ef39-11e5-97fd-ff90ecf159ab.png">

After:

<img width="570" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/13917744/061458f0-ef39-11e5-965b-ef250272b69b.png">

@jwforres ptal
