### PR TITLE
add Docker daemon log dump if we see it fail

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -564,7 +564,15 @@ function cleanup_openshift {
 			fi
 		fi
 
+		echo "[INFO] Pruning etcd data directory..."
+		rm -rf "${ETCD_DATA_DIR}"
+
 		set -u
+	fi
+
+	if grep -q 'no Docker socket found' "${LOG_DIR}/openshift.log"; then 
+		# the Docker daemon crashed, we need the logs
+		journalctl --unit docker.service --since -4hours > "${LOG_DIR}/docker.log"
 	fi
 
 	delete_empty_logs


### PR DESCRIPTION
@deads2k PTAL - this won't cover the cleanup for `test-cmd` but we shouldn't (??) be using Docker in that test, right?