### PR TITLE
removed etcd data dir from artifacts

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -564,6 +564,9 @@ function cleanup_openshift {
 			fi
 		fi
 
+		echo "[INFO] Pruning etcd data directory..."
+		rm -rf "${ETCD_DATA_DIR}"
+
 		set -u
 	fi
 


### PR DESCRIPTION
This keeps the `$ETCD_DATA_DIR` so we can continue to deconflict etcd setups for different tests, but removes the directory on teardown so we don't download it on Jenkins.

@deads2k @danmcp PTAL