### PR TITLE
Error on node startup using fsGroup quota, but mounted without grpquota.

### DIFF
--- a/pkg/volume/emptydir/quota.go
+++ b/pkg/volume/emptydir/quota.go
@@ -31,7 +31,16 @@ func NewQuotaApplicator(volumeDirectory string) (QuotaApplicator, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if isXFS {
+		mountedWithGrpquota, mountErr := isMountedWithGrpquota(cmdRunner, volumeDirectory)
+		if mountErr != nil {
+			return nil, mountErr
+		}
+		if !mountedWithGrpquota {
+			return nil, fmt.Errorf("%s is not on a filesystem mounted with the grpquota option", volumeDirectory)
+		}
+
 		// Make sure xfs_quota is on the PATH, otherwise we're not going to get very far:
 		_, pathErr := exec.LookPath("xfs_quota")
 		if pathErr != nil {
@@ -50,23 +59,24 @@ func NewQuotaApplicator(volumeDirectory string) (QuotaApplicator, error) {
 // quotaCommandRunner interface is used to abstract the actual running of
 // commands so we can unit test more behavior.
 type quotaCommandRunner interface {
-	RunFSTypeCommand(dir string) (string, string, error)
-	RunFSDeviceCommand(dir string) (string, string, error)
+	RunFSTypeCommand(dir string) (string, error)
+	RunFSDeviceCommand(dir string) (string, error)
 	RunApplyQuotaCommand(fsDevice string, quota resource.Quantity, fsGroup int64) (string, string, error)
+	RunMountOptionsCommand() (string, error)
 }
 
 type realQuotaCommandRunner struct {
 }
 
-func (cr *realQuotaCommandRunner) RunFSTypeCommand(dir string) (string, string, error) {
+func (cr *realQuotaCommandRunner) RunFSTypeCommand(dir string) (string, error) {
 	args := []string{"-f", "-c", "%T", dir}
 	outBytes, err := exec.Command("stat", args...).Output()
-	return string(outBytes), "", err
+	return string(outBytes), err
 }
 
-func (cr *realQuotaCommandRunner) RunFSDeviceCommand(dir string) (string, string, error) {
+func (cr *realQuotaCommandRunner) RunFSDeviceCommand(dir string) (string, error) {
 	outBytes, err := exec.Command("df", "--output=source", dir).Output()
-	return string(outBytes), "", err
+	return string(outBytes), err
 }
 
 func (cr *realQuotaCommandRunner) RunApplyQuotaCommand(fsDevice string, quota resource.Quantity, fsGroup int64) (string, string, error) {
@@ -82,6 +92,11 @@ func (cr *realQuotaCommandRunner) RunApplyQuotaCommand(fsDevice string, quota re
 	err := cmd.Run()
 	glog.V(5).Infof("Ran: xfs_quota %s", args)
 	return "", stderr.String(), err
+}
+
+func (cr *realQuotaCommandRunner) RunMountOptionsCommand() (string, error) {
+	outBytes, err := exec.Command("mount").Output()
+	return string(outBytes), err
 }
 
 // Apply sets the actual quota on a device for an emptyDir volume if possible. Will return an error
@@ -123,14 +138,19 @@ func (xqa *xfsQuotaApplicator) Apply(dir string, medium api.StorageMedium, pod *
 
 func (xqa *xfsQuotaApplicator) applyQuota(volDevice string, quota resource.Quantity, fsGroupID int64) error {
 	_, stderr, err := xqa.cmdRunner.RunApplyQuotaCommand(volDevice, quota, fsGroupID)
-	if err != nil {
-		return err
-	}
+
 	// xfs_quota is very happy to fail but return a success code, likely due to its
 	// interactive shell approach. Grab stderr, if we see anything written to it we'll
 	// consider this an error.
+	//
+	// If we exit non-zero *and* write to stderr, stderr is likely to have the details on what
+	// actually went wrong, so we'll use this as the error message instead.
 	if len(stderr) > 0 {
-		return fmt.Errorf("xfs_quota wrote to stderr: %s", stderr)
+		return fmt.Errorf("error applying quota: %s", stderr)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error applying quota: %v", err)
 	}
 
 	glog.V(4).Infof("XFS quota applied: device=%s, quota=%d, fsGroup=%d", volDevice, quota.Value(), fsGroupID)
@@ -149,9 +169,9 @@ func GetFSDevice(dir string) (string, error) {
 }
 
 func getFSDevice(dir string, cmdRunner quotaCommandRunner) (string, error) {
-	out, _, err := cmdRunner.RunFSDeviceCommand(dir)
+	out, err := cmdRunner.RunFSDeviceCommand(dir)
 	if err != nil {
-		return "", fmt.Errorf("unable to find filesystem device for emptyDir volume %s: %s", dir, err)
+		return "", fmt.Errorf("unable to find filesystem device for dir %s: %s", dir, err)
 	}
 	fsDevice, parseErr := parseFSDevice(out)
 	return fsDevice, parseErr
@@ -174,9 +194,44 @@ func parseFSDevice(dfOutput string) (string, error) {
 	return fsDevice, nil
 }
 
-// isXFS checks if the empty dir is on an XFS filesystem.
+// isMountedWithGrpquota checks if the device the given directory is on has been
+// mounted with the grpquota option.
+func isMountedWithGrpquota(cmdRunner quotaCommandRunner, dir string) (bool, error) {
+	fsDevice, fsDeviceErr := getFSDevice(dir, cmdRunner)
+	if fsDeviceErr != nil {
+		return false, fsDeviceErr
+	}
+
+	out, err := cmdRunner.RunMountOptionsCommand()
+	if err != nil {
+		return false, fmt.Errorf("unable to check mount options for dir %s: %s", dir, err)
+	}
+
+	// Keep this simple, locate a line in the mount output that matches the fs device
+	// the directory is on. Once found, make sure "grpquota" is present in the line.
+	// "gquota" is an alias for "grpquota", but if used "grpquota" will be what appears in
+	// mount output. (however check for both just in case)
+	//
+	// Use of "noquota" or "gqnoenforce" is mutually exclusive with the above, if some
+	// combination of these are specified, the last one wins, but there should be no way for
+	// them to all appear in the mount output, thus we just need to see one of the positive
+	// aliases.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		tokens := strings.Split(line, " ")
+		if len(tokens) > 0 && tokens[0] == fsDevice {
+			if strings.Contains(line, "grpquota") || strings.Contains(line, "gquota") {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+	return false, fmt.Errorf("unable to find device %s in mount output", fsDevice)
+}
+
+// isXFS checks if a dir is on an XFS filesystem.
 func isXFS(cmdRunner quotaCommandRunner, dir string) (bool, error) {
-	out, _, err := cmdRunner.RunFSTypeCommand(dir)
+	out, err := cmdRunner.RunFSTypeCommand(dir)
 	if err != nil {
 		return false, fmt.Errorf("unable to check filesystem type for emptydir volume %s: %s", dir, err)
 	}


### PR DESCRIPTION
Previously if you specify a perFSGroup quota, we check on node startup to
ensure that the volume directory is on an XFS filesystem. However we do not
check that that filesystem has been mounted with the grpquota option. As a
result when the node goes to create an emptyDir volume, it will fail with a
cryptic error "system exit 1" and be unable to mount the volume.

Modified to check mount options on node startup, and error out if you're trying
to use a perFSGroup quota on XFS, but are mounted without grpquota.

Additionally modified the xfs_quota calls to report stderr as the error message
whenever possible, rather than the cryptic system exit message previously.