### PR TITLE
Install all required storage plugins

### DIFF
--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -8,7 +8,7 @@ After=openvswitch.service
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node
 ExecStartPre=-/usr/bin/docker rm -f origin-node
-ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -v /var/log:/var/log -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
+ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always

--- a/images/base/Dockerfile.rhel7
+++ b/images/base/Dockerfile.rhel7
@@ -6,5 +6,6 @@
 #
 FROM rhel7
 
-RUN yum install -y which git tar wget socat hostname sysvinit-tools util-linux ethtool bsdtar && \
+RUN yum install -y which git tar wget hostname sysvinit-tools util-linux bsdtar \
+    socat ethtool device-mapper iptables e2fsprogs xfsprogs && \
     yum clean all

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -16,8 +16,8 @@ MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 ADD https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo /etc/yum.repos.d/
 RUN yum install -y libmnl libnetfilter_conntrack openvswitch \
     libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
-    binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
-    && yum clean all
+    binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus && \
+    yum clean all
 
 RUN mkdir -p \
     /usr/lib/systemd/system/origin-node.service.d \

--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -2,6 +2,10 @@
 # This is the official OpenShift Origin image. It has as its entrypoint the OpenShift
 # all-in-one binary.
 #
+# While this image can be used for a simple node it does not support OVS based
+# SDN or storage plugins required for EBS, GCE, Gluster, Ceph, or iSCSI volume
+# management. For those features please use 'openshift/node' 
+#
 # The standard name for this image is openshift/origin
 #
 FROM openshift/origin-base


### PR DESCRIPTION
Add to RPM Requires for node rpm, no longer allowing them to be optionally installed.
Adds 111MB to origin image

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1316233
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1313210