### PR TITLE
Enable extensions storage for batch/autoscaling

### DIFF
--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"testing"
-	"time"
 
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -12,8 +11,129 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	expapi "k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/util/wait"
 )
+
+func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
+	const projName = "ext-disabled-batch-enabled-proj"
+
+	testutil.RequireEtcd(t)
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Disable all extensions API versions
+	// Leave autoscaling/batch APIs enabled
+	masterConfig.KubernetesMasterConfig.DisabledAPIGroupVersions = map[string][]string{"extensions": {"*"}}
+
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// create the containing project
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+		t.Fatalf("unexpected error creating the project: %v", err)
+	}
+	projectAdminClient, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error getting project admin client: %v", err)
+	}
+	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
+		t.Fatalf("unexpected error waiting for policy update: %v", err)
+	}
+
+	validHPA := &expapi.HorizontalPodAutoscaler{
+		ObjectMeta: kapi.ObjectMeta{Name: "myjob"},
+		Spec: expapi.HorizontalPodAutoscalerSpec{
+			ScaleRef:    expapi.SubresourceReference{Name: "foo", Kind: "ReplicationController", Subresource: "scale"},
+			MaxReplicas: 1,
+		},
+	}
+	validJob := &expapi.Job{
+		ObjectMeta: kapi.ObjectMeta{Name: "myjob"},
+		Spec: expapi.JobSpec{
+			Template: kapi.PodTemplateSpec{
+				Spec: kapi.PodSpec{
+					Containers:    []kapi.Container{{Name: "mycontainer", Image: "myimage"}},
+					RestartPolicy: kapi.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	// make sure extensions API objects cannot be listed or created
+	if _, err := projectAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).List(kapi.ListOptions{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error listing HPA, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).Create(validHPA); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error creating HPA, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().Jobs(projName).List(kapi.ListOptions{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error listing jobs, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().Jobs(projName).Create(validJob); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error creating job, got %v", err)
+	}
+
+	// make sure autoscaling and batch API objects can be listed and created
+	if _, err := projectAdminKubeClient.Autoscaling().HorizontalPodAutoscalers(projName).List(kapi.ListOptions{}); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	if _, err := projectAdminKubeClient.Autoscaling().HorizontalPodAutoscalers(projName).Create(validHPA); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	if _, err := projectAdminKubeClient.Batch().Jobs(projName).List(kapi.ListOptions{}); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	if _, err := projectAdminKubeClient.Batch().Jobs(projName).Create(validJob); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	// Delete the containing project
+	if err := testutil.DeleteAndWaitForNamespaceTermination(clusterAdminKubeClient, projName); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	// recreate the containing project
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+		t.Fatalf("unexpected error creating the project: %v", err)
+	}
+	projectAdminClient, projectAdminKubeClient, _, err = testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error getting project admin client: %v", err)
+	}
+	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
+		t.Fatalf("unexpected error waiting for policy update: %v", err)
+	}
+
+	// make sure the created objects got cleaned up by namespace deletion
+	if hpas, err := projectAdminKubeClient.Autoscaling().HorizontalPodAutoscalers(projName).List(kapi.ListOptions{}); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	} else if len(hpas.Items) > 0 {
+		t.Fatalf("expected 0 HPA objects, got %#v", hpas.Items)
+	}
+	if jobs, err := projectAdminKubeClient.Batch().Jobs(projName).List(kapi.ListOptions{}); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	} else if len(jobs.Items) > 0 {
+		t.Fatalf("expected 0 Job objects, got %#v", jobs.Items)
+	}
+}
 
 func TestExtensionsAPIDisabled(t *testing.T) {
 	const projName = "ext-disabled-proj"
@@ -73,17 +193,8 @@ func TestExtensionsAPIDisabled(t *testing.T) {
 		t.Fatalf("expected NotFound error creating job, got %v", err)
 	}
 
-	if err := clusterAdminClient.Projects().Delete(projName); err != nil {
-		t.Fatalf("unexpected error deleting the project: %v", err)
-	}
-	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-		_, err := clusterAdminKubeClient.Namespaces().Get(projName)
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		t.Fatalf("unexpected error while waiting for project to delete: %v", err)
+	// Delete the containing project
+	if err := testutil.DeleteAndWaitForNamespaceTermination(clusterAdminKubeClient, projName); err != nil {
+		t.Fatalf("unexpected error: %#v", err)
 	}
 }


### PR DESCRIPTION
Enables extensions storage if either autoscaling or batch API groups are enabled (since they use extensions storage currently).

Adds a test to make sure autoscaling and batch both work with the extensions API disabled (and that the namespace controller correctly cleans up resources in those API groups)