### PR TITLE
oc status must show monopods

### DIFF
--- a/pkg/api/graph/graphview/pod.go
+++ b/pkg/api/graph/graphview/pod.go
@@ -1,0 +1,39 @@
+package graphview
+
+import (
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+)
+
+type Pod struct {
+	Pod *kubegraph.PodNode
+}
+
+// AllPods returns all Pods and the set of covered NodeIDs
+func AllPods(g osgraph.Graph, excludeNodeIDs IntSet) ([]Pod, IntSet) {
+	covered := IntSet{}
+	pods := []Pod{}
+
+	for _, uncastNode := range g.NodesByKind(kubegraph.PodNodeKind) {
+		if excludeNodeIDs.Has(uncastNode.ID()) {
+			continue
+		}
+
+		pod, covers := NewPod(g, uncastNode.(*kubegraph.PodNode))
+		covered.Insert(covers.List()...)
+		pods = append(pods, pod)
+	}
+
+	return pods, covered
+}
+
+// NewPod returns the Pod and a set of all the NodeIDs covered by the Pod
+func NewPod(g osgraph.Graph, podNode *kubegraph.PodNode) (Pod, IntSet) {
+	covered := IntSet{}
+	covered.Insert(podNode.ID())
+
+	podView := Pod{}
+	podView.Pod = podNode
+
+	return podView, covered
+}

--- a/pkg/api/graph/graphview/service_group.go
+++ b/pkg/api/graph/graphview/service_group.go
@@ -97,6 +97,11 @@ func NewServiceGroup(g osgraph.Graph, serviceNode *kubegraph.ServiceNode) (Servi
 		service.ReplicationControllers = append(service.ReplicationControllers, rcView)
 	}
 
+	for _, fulfillingPod := range service.FulfillingPods {
+		_, podCovers := NewPod(g, fulfillingPod)
+		covered.Insert(podCovers.List()...)
+	}
+
 	return service, covered
 }
 

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -293,6 +293,20 @@ func TestProjectStatus(t *testing.T) {
 				`View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.`,
 			},
 		},
+		"monopod": {
+			Path: "../../../../test/fixtures/app-scenarios/k8s-lonely-pod.json",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example on server https://example.com:8443\n",
+				"pod/lonely-pod runs openshift/hello-openshift",
+				"You have no services, deployment configs, or build configs.",
+			},
+		},
 	}
 	oldTimeFn := timeNowFn
 	defer func() { timeNowFn = oldTimeFn }()


### PR DESCRIPTION
Single pods (not part of deployments or builds and not directly exposed by a service) must also appear in `oc status`, like they do in the web console overview page. 

Fixes https://github.com/openshift/origin/issues/1696.

@deads2k PTAL. I'm doing this in describe level since it seems like a display-only change, no changes required to the actual graph (pods are actually already there).

Sample output:

```
In project test1 on server https://192.168.2.200:8443

svc/database - 172.30.196.168:5434 -> 3306
  dc/database deploys docker.io/openshift/mysql-55-centos7:latest 
    deployment #2 deployed 3 days ago - 1 pod
    deployment #1 deployed 3 days ago

https://www.example.com (svc/frontend)
  dc/frontend deploys istag/origin-ruby-sample:latest <-
    bc/ruby-sample-build builds https://github.com/openshift/ruby-hello-world.git with test1/ruby-22-centos7:latest 
      build #1 succeeded 5 days ago - bd94cbb: Merge pull request #52 from bparees/stdout (Ben Parees <bparees@users.noreply.github.com>)
    deployment #3 pending on image or update
    deployment #7 deployed 3 days ago - 0 pods
    deployment #3 deployed 3 days ago - 2 pods
    deployment #2 failed 3 days ago: cancelled as a newer deployment was found running

svc/hello-openshift - 172.30.40.82:8080
  pod/hello-openshift runs openshift/hello-openshift

pod/pod-volume-downward-api runs fedora/nginx

pod/pod-volume-config-map runs fedora/nginx

(...)
```