### PR TITLE
Integration tests should use docker.ClientFromEnv()

### DIFF
--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -44,11 +44,6 @@ const (
 	statsPassword = "e2e"
 )
 
-// init ensures docker exists for this test
-func init() {
-	testutil.RequireDocker()
-}
-
 // TestRouter is the table based test for routers.  It will initialize a fake master/client and expect to deploy
 // a router image in docker.  It then sends watch events through the simulator and makes http client requests that
 // should go through the deployed router and return data from the client simulator.

--- a/test/util/docker.go
+++ b/test/util/docker.go
@@ -1,13 +1,9 @@
 package util
 
 import (
-	"os"
-
 	dockerClient "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 )
-
-const defaultDockerEndpoint = "unix:///var/run/docker.sock"
 
 // RequireDocker ensures that a new docker client can be created and that a ListImages command can be run on the client
 // or it fails with glog.Fatal
@@ -29,11 +25,5 @@ func RequireDocker() {
 // newDockerClient creates a docker client using the env var DOCKER_ENDPOINT or, if not supplied, uses the default
 // docker endpoint /var/run/docker.sock
 func NewDockerClient() (*dockerClient.Client, error) {
-	endpoint := os.Getenv("DOCKER_ENDPOINT")
-
-	if len(endpoint) == 0 {
-		endpoint = defaultDockerEndpoint
-	}
-
-	return dockerClient.NewClient(endpoint)
+	return dockerClient.NewClientFromEnv()
 }

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -37,11 +37,10 @@ import (
 // controllers to start up, and populate the service accounts in the test namespace
 const ServiceAccountWaitTimeout = 30 * time.Second
 
-// RequireServer verifies if the etcd, docker and the OpenShift server are
-// available and you can successfully connected to them.
+// RequireServer verifies if the etcd and the OpenShift server are
+// available and you can successfully connect to them.
 func RequireServer(t *testing.T) {
 	util.RequireEtcd(t)
-	util.RequireDocker()
 	if _, err := util.GetClusterAdminClient(util.KubeConfigPath()); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
router_test.go doesn't need to call RequireDocker() in init, instead
each test will fail if not present.

[test]