### PR TITLE
loosen exec to allow SA checks for privileges

### DIFF
--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -40,9 +40,8 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 		return admission.NewForbidden(a, err)
 	}
 
-	// create a synthentic admission attribute to check SCC admission status for this pod
-	// clear the SA name, so that any permissions MUST be based on your user's power, not the SAs power.
-	pod.Spec.ServiceAccountName = ""
+	// TODO, if we want to actually limit who can use which service account, then we'll need to add logic here to make sure that
+	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
 	createAttributes := admission.NewAttributesRecord(pod, kapi.Kind("Pod"), a.GetNamespace(), a.GetName(), a.GetResource(), a.GetSubresource(), admission.Create, a.GetUserInfo())
 	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
 		return admission.NewForbidden(a, err)

--- a/pkg/security/admission/scc_exec_test.go
+++ b/pkg/security/admission/scc_exec_test.go
@@ -110,10 +110,5 @@ func TestExecAdmit(t *testing.T) {
 			t.Errorf("%s: no actions found", k)
 		}
 
-		if v.shouldHaveClientAction {
-			if len(v.pod.Spec.ServiceAccountName) != 0 {
-				t.Errorf("%s: sa name should have been cleared: %v", k, v.pod.Spec.ServiceAccountName)
-			}
-		}
 	}
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -293,9 +293,6 @@ os::cmd::try_until_text "oc get endpoints router --output-version=v1beta3 --temp
 echo "[INFO] Validating privileged pod exec"
 router_pod=$(oc get pod -n default -l deploymentconfig=router --template='{{(index .items 0).metadata.name}}')
 os::cmd::expect_success 'oc policy add-role-to-user admin e2e-default-admin'
-# login as a user that can't run privileged pods
-os::cmd::expect_success 'oc login -u e2e-default-admin -p pass'
-os::cmd::expect_failure_and_text "oc exec -n default -tip ${router_pod} ls" 'unable to validate against any security context constraint'
 # system:admin should be able to exec into it
 os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
 os::cmd::expect_success "oc exec -n default -tip ${router_pod} ls"


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/6504.

The previous behavior looks intentional and the comment is mine, but unless you're going to control who can use which SAs in a given namespace, clearing that field doesn't make sense.

@csrwng @liggitt 