### PR TITLE
Allow perFSGroup local quota in config on first node start.

### DIFF
--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -23,7 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/oom"
-	"k8s.io/kubernetes/pkg/volume"
 
 	osdnapi "github.com/openshift/openshift-sdn/plugins/osdn/api"
 	"github.com/openshift/openshift-sdn/plugins/osdn/factory"
@@ -33,7 +31,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
-	"github.com/openshift/origin/pkg/volume/empty_dir"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
@@ -170,49 +167,6 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 	cfg, err := kubeletapp.UnsecuredKubeletConfig(server)
 	if err != nil {
 		return nil, err
-	}
-
-	// Replace the standard k8s emptyDir volume plugin with a wrapper version
-	// which offers XFS quota functionality, but only if the node config
-	// specifies an empty dir quota to apply to projects:
-	if options.VolumeConfig.LocalQuota.PerFSGroup != nil {
-		glog.V(2).Info("Replacing empty-dir volume plugin with quota wrapper")
-		wrappedEmptyDirPlugin := false
-
-		quotaApplicator, err := empty_dir.NewQuotaApplicator(options.VolumeDirectory)
-		if err != nil {
-			return nil, err
-		}
-
-		// Create a volume spec with emptyDir we can use to search for the
-		// emptyDir plugin with CanSupport:
-		emptyDirSpec := &volume.Spec{
-			Volume: &kapi.Volume{
-				VolumeSource: kapi.VolumeSource{
-					EmptyDir: &kapi.EmptyDirVolumeSource{},
-				},
-			},
-		}
-
-		for idx, plugin := range cfg.VolumePlugins {
-			// Can't really do type checking or use a constant here as they are not exported:
-			if plugin.CanSupport(emptyDirSpec) {
-				wrapper := empty_dir.EmptyDirQuotaPlugin{
-					Wrapped:         plugin,
-					Quota:           *options.VolumeConfig.LocalQuota.PerFSGroup,
-					QuotaApplicator: quotaApplicator,
-				}
-				cfg.VolumePlugins[idx] = &wrapper
-				wrappedEmptyDirPlugin = true
-			}
-		}
-		// Because we can't look for the k8s emptyDir plugin by any means that would
-		// survive a refactor, error out if we couldn't find it:
-		if !wrappedEmptyDirPlugin {
-			return nil, errors.New("unable to wrap emptyDir volume plugin for quota support")
-		}
-	} else {
-		glog.V(2).Info("Skipping replacement of empty-dir volume plugin with quota wrapper, no local fsGroup quota specified")
 	}
 
 	// provide any config overrides

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -301,6 +301,7 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 		config.EnsureKubeletAccess()
 		config.EnsureVolumeDir()
 		config.EnsureDocker(docker.NewHelper())
+		config.EnsureLocalQuota(nodeConfig) // must be performed after EnsureVolumeDir
 	}
 
 	// TODO: SDN plugin depends on the Kubelet registering as a Node and doesn't retry cleanly,

--- a/pkg/volume/emptydir/empty_dir_quota.go
+++ b/pkg/volume/emptydir/empty_dir_quota.go
@@ -1,4 +1,4 @@
-package empty_dir
+package emptydir
 
 import (
 	"k8s.io/kubernetes/pkg/api"

--- a/pkg/volume/emptydir/quota.go
+++ b/pkg/volume/emptydir/quota.go
@@ -1,4 +1,4 @@
-package empty_dir
+package emptydir
 
 import (
 	"bytes"

--- a/pkg/volume/emptydir/quota_test.go
+++ b/pkg/volume/emptydir/quota_test.go
@@ -1,4 +1,4 @@
-package empty_dir
+package emptydir
 
 import (
 	"errors"

--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -12,7 +12,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	"github.com/openshift/origin/pkg/volume/empty_dir"
+	"github.com/openshift/origin/pkg/volume/emptydir"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -58,7 +58,7 @@ func lookupFSGroup(oc *exutil.CLI, project string) (int, error) {
 func lookupXFSQuota(oc *exutil.CLI, fsGroup int, volDir string) (int, error) {
 
 	// First lookup the filesystem device the volumeDir resides on:
-	fsDevice, err := empty_dir.GetFSDevice(volDir)
+	fsDevice, err := emptydir.GetFSDevice(volDir)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Fixes a bug where if perFSGroup localStorage quota was specified in
node-config.yaml the first time the node was run, the volumeDirectory did not
actually exist yet and all XFS / mount option checks would fail.

Move the wrapping of the emptyDir volume plugin and associated checks out of
the node config creation, and into start node where they can be performed
*after* the volume directory is known to exist.