### PR TITLE
re-enable cgroups for builds, but set a lower maximum value for the "default(no limit)" behavior.

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -138,15 +138,13 @@ func (c *builderConfig) execute(b builder) error {
 	}
 	gitClient := git.NewRepositoryWithEnv(gitEnv)
 
-	/*
-		cgLimits, err := bld.GetCGroupLimits()
-		if err != nil {
-			return fmt.Errorf("failed to retrieve cgroup limits: %v", err)
-		}
-		glog.V(2).Infof("Running build with cgroup limits: %#v", *cgLimits)
-	*/
+	cgLimits, err := bld.GetCGroupLimits()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cgroup limits: %v", err)
+	}
+	glog.V(2).Infof("Running build with cgroup limits: %#v", *cgLimits)
 
-	if err := b.Build(c.dockerClient, c.dockerEndpoint, c.buildsClient, c.build, gitClient, nil); err != nil {
+	if err := b.Build(c.dockerClient, c.dockerEndpoint, c.buildsClient, c.build, gitClient, cgLimits); err != nil {
 		return fmt.Errorf("build error: %v", err)
 	}
 

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -144,12 +144,11 @@ func execPostCommitHook(client DockerClient, postCommitSpec api.BuildPostCommitS
 		args = append([]string{script, command[0]}, args...)
 	}
 
-	/*
-		limits, err := GetCGroupLimits()
-		if err != nil {
-			return fmt.Errorf("read cgroup limits: %v", err)
-		}
-	*/
+	limits, err := GetCGroupLimits()
+	if err != nil {
+		return fmt.Errorf("read cgroup limits: %v", err)
+	}
+
 	return dockerRun(client, docker.CreateContainerOptions{
 		Name: containerName,
 		Config: &docker.Config{
@@ -158,14 +157,12 @@ func execPostCommitHook(client DockerClient, postCommitSpec api.BuildPostCommitS
 			Cmd:        args,
 		},
 		HostConfig: &docker.HostConfig{
-		// Limit container's resource allocation.
-		/*
+			// Limit container's resource allocation.
 			CPUShares:  limits.CPUShares,
 			CPUPeriod:  limits.CPUPeriod,
 			CPUQuota:   limits.CPUQuota,
 			Memory:     limits.MemoryLimitBytes,
 			MemorySwap: limits.MemorySwap,
-		*/
 		},
 	}, docker.LogsOptions{
 		// Stream logs to stdout and stderr.

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -73,6 +73,12 @@ func GetCGroupLimits() (*s2iapi.CGroupLimits, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine cgroup limits: %v", err)
 	}
+	// math.MaxInt64 seems to give cgroups trouble, this value is
+	// still 92 terabytes, so it ought to be sufficiently large for
+	// our purposes.
+	if byteLimit > 92233720368547 {
+		byteLimit = 92233720368547
+	}
 
 	// different docker versions seem to use different cgroup directories,
 	// check for all of them.


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/8201
