### PR TITLE
refactor to not use dot imports for heredoc

### DIFF
--- a/pkg/api/kubegraph/analysis/pod.go
+++ b/pkg/api/kubegraph/analysis/pod.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/MakeNowJust/heredoc/dot"
+	"github.com/MakeNowJust/heredoc"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -44,7 +44,7 @@ func FindRestartingPods(g osgraph.Graph, f osgraph.Namer, logsCommandName, secur
 				var suggestion string
 				switch {
 				case containerIsNonRoot(pod, containerStatus.Name):
-					suggestion = Df(`
+					suggestion = heredoc.Docf(`
 						The container is starting and exiting repeatedly. This usually means the container is unable
 						to start, misconfigured, or limited by security restrictions. Check the container logs with
 
@@ -57,7 +57,7 @@ func FindRestartingPods(g osgraph.Graph, f osgraph.Namer, logsCommandName, secur
 						  %s
 						`, logsCommandName, pod.Name, containerStatus.Name, fmt.Sprintf(securityPolicyCommandPattern, pod.Namespace, pod.Spec.ServiceAccountName))
 				default:
-					suggestion = Df(`
+					suggestion = heredoc.Docf(`
 						The container is starting and exiting repeatedly. This usually means the container is unable
 						to start, misconfigured, or limited by security restrictions. Check the container logs with
 

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/MakeNowJust/heredoc/dot"
+	"github.com/MakeNowJust/heredoc"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -613,7 +613,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		if t.Input.Token != nil && t.Input.Token.ServiceAccount {
 			groups.Add(
 				"explicit-access-installer",
-				D(`
+				heredoc.Doc(`
 					WARNING: This will allow the pod to create and manage resources within your namespace -
 					ensure you trust the image with those permissions before you continue.
 
@@ -625,7 +625,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		} else {
 			groups.Add(
 				"explicit-access-you",
-				D(`
+				heredoc.Doc(`
 					WARNING: This will allow the pod to act as you across the entire cluster - ensure you
 					trust the image with those permissions before you continue.
 
@@ -639,7 +639,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 	case newapp.ErrNoMatch:
 		groups.Add(
 			"no-matches",
-			Df(`
+			heredoc.Docf(`
 				The '%[1]s' command will match arguments to the following types:
 
 				  1. Images tagged into image streams in the current project or the 'openshift' project
@@ -664,7 +664,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		}
 		groups.Add(
 			"multiple-matches",
-			Df(`
+			heredoc.Docf(`
 					The argument %[1]q could apply to the following Docker images or OpenShift image streams:
 
 					%[2]s`, t.Value, buf.String(),
@@ -680,7 +680,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 
 		groups.Add(
 			"partial-match",
-			Df(`
+			heredoc.Docf(`
 					The argument %[1]q only partially matched the following Docker image or OpenShift image stream:
 
 					%[2]s`, t.Value, buf.String(),
@@ -694,7 +694,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		fmt.Fprintf(buf, "  Use --allow-missing-imagestream-tags to use this image stream\n\n")
 		groups.Add(
 			"no-tags",
-			Df(`
+			heredoc.Docf(`
 					The image stream %[1]q exists, but it has no tags.
 
 					%[2]s`, t.Match.Name, buf.String(),

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	. "github.com/MakeNowJust/heredoc/dot"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -242,7 +242,7 @@ func transformBuildError(err error, c *cobra.Command, fullName string, groups er
 	case newapp.ErrNoMatch:
 		groups.Add(
 			"no-matches",
-			Df(`
+			heredoc.Docf(`
 				The '%[1]s' command will match arguments to the following types:
 
 				  1. Images tagged into image streams in the current project or the 'openshift' project

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	. "github.com/MakeNowJust/heredoc/dot"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	ocutil "github.com/openshift/origin/pkg/cmd/util"
@@ -23,7 +23,7 @@ var concepts = []concept{
 	{
 		"Containers",
 		"",
-		D(`
+		heredoc.Doc(`
       A definition of how to run one or more processes inside of a portable Linux
       environment. Containers are started from an Image and are usually isolated
       from other containers on the same machine.
@@ -32,7 +32,7 @@ var concepts = []concept{
 	{
 		"Image",
 		"",
-		D(`
+		heredoc.Doc(`
       A layered Linux filesystem that contains application code, dependencies,
       and any supporting operating system libraries. An image is identified by
       a name that can be local to the current cluster or point to a remote Docker
@@ -41,7 +41,7 @@ var concepts = []concept{
 	}, {
 		"Pods",
 		"pod",
-		D(`
+		heredoc.Doc(`
       A set of one or more containers that are deployed onto a Node together and
       share a unique IP and Volumes (persistent storage). Pods also define the
       security and runtime policy for each container.
@@ -49,7 +49,7 @@ var concepts = []concept{
 	}, {
 		"Labels",
 		"",
-		D(`
+		heredoc.Doc(`
       Labels are key value pairs that can be assigned to any resource in the
       system for grouping and selection. Many resources use labels to identify
       sets of other resources.
@@ -57,7 +57,7 @@ var concepts = []concept{
 	}, {
 		"Volumes",
 		"",
-		D(`
+		heredoc.Doc(`
       Containers are not persistent by default - on restart their contents are
       cleared. Volumes are mounted filesystems available to Pods and their
       containers which may be backed by a number of host-local or network
@@ -69,14 +69,14 @@ var concepts = []concept{
 	}, {
 		"Nodes",
 		"node",
-		D(`
+		heredoc.Doc(`
       Machines set up in the cluster to run containers. Usually managed
       by administrators and not by end users.
     `),
 	}, {
 		"Services",
 		"svc",
-		D(`
+		heredoc.Doc(`
       A name representing a set of pods (or external servers) that are
       accessed by other pods. The service gets an IP and a DNS name, and can be
       exposed externally to the cluster via a port or a Route. It's also easy
@@ -86,7 +86,7 @@ var concepts = []concept{
 	}, {
 		"Routes",
 		"route",
-		D(`
+		heredoc.Doc(`
       A route is an external DNS entry (either a top level domain or a
       dynamically allocated name) that is created to point to a service so that
       it can be accessed outside the cluster. The administrator may configure
@@ -97,7 +97,7 @@ var concepts = []concept{
 	{
 		"Replication Controllers",
 		"rc",
-		D(`
+		heredoc.Doc(`
       A replication controller maintains a specific number of pods based on a
       template that match a set of labels. If pods are deleted (because the
       node they run on is taken out of service) the controller creates a new
@@ -109,7 +109,7 @@ var concepts = []concept{
 	{
 		"Deployment Configuration",
 		"dc",
-		D(`
+		heredoc.Doc(`
       Defines the template for a pod and manages deploying new images or
       configuration changes whenever those change. A single deployment
       configuration is usually analogous to a single micro-service. Can support
@@ -121,7 +121,7 @@ var concepts = []concept{
 	{
 		"Build Configuration",
 		"bc",
-		D(`
+		heredoc.Doc(`
       Contains a description of how to build source code and a base image into a
       new image - the primary method for delivering changes to your application.
       Builds can be source based and use builder images for common languages like
@@ -133,7 +133,7 @@ var concepts = []concept{
 	{
 		"Builds",
 		"build",
-		D(`
+		heredoc.Doc(`
       Builds create a new image from source code, other images, Dockerfiles, or
       binary input. A build is run inside of a container and has the same
       restrictions normal pods have. A build usually results in an image pushed
@@ -144,7 +144,7 @@ var concepts = []concept{
 	{
 		"Image Streams and Image Stream Tags",
 		"is,istag",
-		D(`
+		heredoc.Doc(`
       An image stream groups sets of related images under tags - analogous to a
       branch in a source code repository. Each image stream may have one or
       more tags (the default tag is called "latest") and those tags may point
@@ -157,7 +157,7 @@ var concepts = []concept{
 	{
 		"Secrets",
 		"secret",
-		D(`
+		heredoc.Doc(`
       The secret resource can hold text or binary secrets for delivery into
       your pods. By default, every container is given a single secret which
       contains a token for accessing the API (with limited privileges) at
@@ -170,7 +170,7 @@ var concepts = []concept{
 	{
 		"Projects",
 		"project",
-		D(`
+		heredoc.Doc(`
       All of the above resources (except Nodes) exist inside of a project.
       Projects have a list of members and their roles, like viewer, editor,
       or admin, as well as a set of security controls on the running pods, and
@@ -194,7 +194,7 @@ func writeConcept(w io.Writer, c concept) {
 }
 
 var (
-	typesLong = D(`
+	typesLong = heredoc.Doc(`
     Concepts and Types
 
     Kubernetes and OpenShift help developers and operators build, test, and deploy


### PR DESCRIPTION
This refactors imports to not use the `.` dot import, for the same reasons we decided not to do this for `ginkgo` in the extended tests - it's clearer to read, seems to not trip up tools that find method definitions, etc.

@deads2k PTAL