### PR TITLE
Fix resolver used for --image-stream param, annotation searcher output

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -320,7 +320,10 @@ func (c *AppConfig) addReferenceBuilderComponents(b *app.ReferenceBuilder) {
 		input.Argument = fmt.Sprintf("--image-stream=%q", input.From)
 		input.Searcher = c.ImageStreamSearcher
 		if c.ImageStreamSearcher != nil {
-			input.Resolver = app.FirstMatchResolver{Searcher: c.ImageStreamSearcher}
+			resolver := app.PerfectMatchWeightedResolver{
+				app.WeightedResolver{Searcher: c.ImageStreamSearcher},
+			}
+			input.Resolver = resolver
 		}
 		return input
 	})

--- a/pkg/generate/app/imagestreamlookup.go
+++ b/pkg/generate/app/imagestreamlookup.go
@@ -312,12 +312,17 @@ func (r *ImageStreamByAnnotationSearcher) annotationMatches(stream *imageapi.Ima
 
 		imageData := imageStream.Image
 		matchName := fmt.Sprintf("%s/%s", stream.Namespace, stream.Name)
+		description := fmt.Sprintf("Image stream %q in project %q", stream.Name, stream.Namespace)
+		if len(tag) > 0 {
+			matchName = fmt.Sprintf("%s:%s", matchName, tag)
+			description = fmt.Sprintf("Image stream %q (tag %q) in project %q", stream.Name, tag, stream.Namespace)
+		}
 		glog.V(5).Infof("ImageStreamAnnotationSearcher match found: %s for %s with score %f", matchName, value, score)
 		match := &ComponentMatch{
 			Value:       value,
 			Name:        fmt.Sprintf("%s", matchName),
 			Argument:    fmt.Sprintf("--image-stream=%q", matchName),
-			Description: fmt.Sprintf("Image stream %s in project %s", stream.Name, stream.Namespace),
+			Description: description,
 			Score:       score,
 
 			ImageStream: stream,


### PR DESCRIPTION
Fixes 2 issues with new-app image stream lookup:
1 - Using the --image-stream parameter results in a random image stream being picked if multiple matches found.

2 - The output of the search for the "supports" annotation does not include image stream tag names