### PR TITLE
Fix new-app template search with multiple matches

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -665,7 +665,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		groups.Add(
 			"multiple-matches",
 			heredoc.Docf(`
-					The argument %[1]q could apply to the following Docker images or OpenShift image streams:
+					The argument %[1]q could apply to the following Docker images, OpenShift image streams, or templates:
 
 					%[2]s`, t.Value, buf.String(),
 			),
@@ -681,7 +681,7 @@ func transformError(err error, c *cobra.Command, fullName string, groups errorGr
 		groups.Add(
 			"partial-match",
 			heredoc.Docf(`
-					The argument %[1]q only partially matched the following Docker image or OpenShift image stream:
+					The argument %[1]q only partially matched the following Docker image, OpenShift image stream, or template:
 
 					%[2]s`, t.Value, buf.String(),
 			),

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -331,7 +331,7 @@ func (c *AppConfig) addReferenceBuilderComponents(b *app.ReferenceBuilder) {
 		input.Argument = fmt.Sprintf("--template=%q", input.From)
 		input.Searcher = c.TemplateSearcher
 		if c.TemplateSearcher != nil {
-			input.Resolver = app.HighestScoreResolver{Searcher: c.TemplateSearcher}
+			input.Resolver = app.HighestUniqueScoreResolver{Searcher: c.TemplateSearcher}
 		}
 		return input
 	})


### PR DESCRIPTION
When multiple templates match the search string, only the first match is displayed. Also, the text on the error is wrong because it only mentions images or image streams, but not templates.