### PR TITLE
remove erroneous '' from templates

### DIFF
--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -97,7 +97,7 @@
                   "initialDelaySeconds": 5,
                   "exec": {
                     "command": [ "/bin/sh", "-i", "-c",
-                      "MYSQL_PWD='$MYSQL_PASSWORD' mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                      "MYSQL_PWD=$MYSQL_PASSWORD mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                   }
                 },
                 "livenessProbe": {

--- a/examples/db-templates/mysql-persistent-template.json
+++ b/examples/db-templates/mysql-persistent-template.json
@@ -114,7 +114,7 @@
                   "initialDelaySeconds": 5,
                   "exec": {
                     "command": [ "/bin/sh", "-i", "-c",
-                      "MYSQL_PWD='$MYSQL_PASSWORD' mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                      "MYSQL_PWD=$MYSQL_PASSWORD mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
                   }
                 },
                 "livenessProbe": {


### PR DESCRIPTION
pods readiness failed until these '' were removed 