### PR TITLE
UPSTREAM docker/distribution: <carry>: Remove links creation

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/blobwriter.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/blobwriter.go
@@ -64,10 +64,6 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
-	if err := bw.blobStore.linkBlob(ctx, canonical, desc.Digest); err != nil {
-		return distribution.Descriptor{}, err
-	}
-
 	if err := bw.removeResources(ctx); err != nil {
 		return distribution.Descriptor{}, err
 	}

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/revisionstore.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/revisionstore.go
@@ -88,11 +88,6 @@ func (rs *revisionStore) put(ctx context.Context, sm *schema1.SignedManifest) (d
 		return distribution.Descriptor{}, err
 	}
 
-	// Link the revision into the repository.
-	if err := rs.blobStore.linkBlob(ctx, revision); err != nil {
-		return distribution.Descriptor{}, err
-	}
-
 	// Grab each json signature and store them.
 	signatures, err := sm.Signatures()
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/tagstore.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/tagstore.go
@@ -68,23 +68,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 // tag tags the digest with the given tag, updating the the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {
-	currentPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name(),
-		tag:  tag,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	nbs := ts.linkedBlobStore(ts.ctx, tag)
-	// Link into the index
-	if err := nbs.linkBlob(ts.ctx, distribution.Descriptor{Digest: revision}); err != nil {
-		return err
-	}
-
-	// Overwrite the current link
-	return ts.blobStore.link(ts.ctx, currentPath, revision)
+	return nil
 }
 
 // resolve the current revision for name and tag.


### PR DESCRIPTION
All image metadata stored in etcd. We already know whether the blob belongs to
the repository - because it's referenced by the manifest. We don't need to create
layer links. We already know what layers we have access to.

More info https://github.com/openshift/origin/issues/7792