### PR TITLE
Remove project admin/edit ability to create daemonsets

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -151,7 +151,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets"),
 				},
 				{
 					Verbs:     sets.NewString("get", "list", "watch"),
@@ -210,7 +215,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets"),
 				},
 				{
 					Verbs:     sets.NewString("get", "list", "watch"),

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -271,7 +271,6 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
-    - daemonsets
     - horizontalpodautoscalers
     - jobs
     - replicationcontrollers/scale
@@ -283,6 +282,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups: null
     attributeRestrictions: null
@@ -436,7 +444,6 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
-    - daemonsets
     - horizontalpodautoscalers
     - jobs
     - replicationcontrollers/scale
@@ -448,6 +455,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups: null
     attributeRestrictions: null


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7716

Daemonset pods have higher eviction priority than pods that are directly created or are created from replicationcontrollers (c.f. https://github.com/openshift/origin/issues/7716#issuecomment-190850037). Pods with that power should not generally be given to project admin/editor roles.