### PR TITLE
Add explicit emptyDir volumes where possible

### DIFF
--- a/examples/etcd/template.json
+++ b/examples/etcd/template.json
@@ -133,6 +133,14 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ],
             "containers": [
               {
                 "name": "discovery",
@@ -144,6 +152,12 @@
                   {
                     "containerPort": 2379,
                     "protocol": "TCP"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/etcd"
                   }
                 ],
                 "resources": {},
@@ -191,6 +205,14 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ],
             "containers": [
               {
                 "name": "member",
@@ -229,6 +251,12 @@
                   {
                     "name": "ETCDCTL_PEERS",
                     "value": "http://etcd:2379"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/etcd"
                   }
                 ],
                 "resources": {},

--- a/examples/gitserver/gitserver.yaml
+++ b/examples/gitserver/gitserver.yaml
@@ -143,6 +143,7 @@ items:
             name: git
         volumes:
         - name: git
+          emptyDir: {}
     triggers:
     - type: ConfigChange
 

--- a/examples/project-quota/application-template-with-resources.json
+++ b/examples/project-quota/application-template-with-resources.json
@@ -356,6 +356,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "ruby-helloworld-database",
@@ -378,6 +384,12 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "resources": {

--- a/examples/quickstarts/cakephp-mysql.json
+++ b/examples/quickstarts/cakephp-mysql.json
@@ -303,6 +303,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "mysql",
@@ -310,6 +316,12 @@
                 "ports": [
                   {
                     "containerPort": 3306
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "readinessProbe": {

--- a/examples/quickstarts/dancer-mysql.json
+++ b/examples/quickstarts/dancer-mysql.json
@@ -277,6 +277,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "mysql",
@@ -284,6 +290,12 @@
                 "ports": [
                   {
                     "containerPort": 3306
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "readinessProbe": {

--- a/examples/quickstarts/django-postgresql.json
+++ b/examples/quickstarts/django-postgresql.json
@@ -287,6 +287,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "postgresql",
@@ -308,6 +314,12 @@
                   {
                     "name": "POSTGRESQL_DATABASE",
                     "value": "${DATABASE_NAME}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/pgsql/data"
                   }
                 ],
                 "readinessProbe": {

--- a/examples/quickstarts/nodejs-mongodb.json
+++ b/examples/quickstarts/nodejs-mongodb.json
@@ -282,6 +282,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "mongodb",
@@ -289,6 +295,12 @@
                 "ports": [
                   {
                     "containerPort": 27017
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/mongodb/data"
                   }
                 ],
                 "env": [

--- a/examples/quickstarts/rails-postgresql.json
+++ b/examples/quickstarts/rails-postgresql.json
@@ -314,6 +314,12 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "data",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
                 "name": "postgresql",
@@ -337,6 +343,12 @@
                     "port": 5432
                   }
                 },
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/var/lib/pgsql/data"
+                  }
+                ],
                 "env": [
                   {
                     "name": "POSTGRESQL_USER",

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -321,7 +321,8 @@
                     "value": "custom_value1"
                   }
                 ],
-                "containerName": "ruby-helloworld-database"
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
               }
             },
             "post": {
@@ -336,7 +337,8 @@
                     "value": "custom_value2"
                   }
                 ],
-                "containerName": "ruby-helloworld-database"
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
               }
             }
           },

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -331,7 +331,8 @@
                     "value": "custom_value1"
                   }
                 ],
-                "containerName": "ruby-helloworld-database"
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
               }
             },
             "mid": {
@@ -346,7 +347,8 @@
                     "value": "custom_value2"
                   }
                 ],
-                "containerName": "ruby-helloworld-database"
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
               }
             },
             "post": {
@@ -361,7 +363,8 @@
                     "value": "custom_value2"
                   }
                 ],
-                "containerName": "ruby-helloworld-database"
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
               }
             }
           },

--- a/examples/zookeeper/template.json
+++ b/examples/zookeeper/template.json
@@ -210,6 +210,20 @@
         }
       },
       "spec": {
+        "volumes": [
+          {
+            "name": "conf",
+            "emptyDir": {}
+          },
+          {
+            "name": "data",
+            "emptyDir": {}
+          },
+          {
+            "name": "log",
+            "emptyDir": {}
+          }
+        ],
         "containers": [
           {
             "name": "server",
@@ -232,6 +246,20 @@
               {
                 "name": "SERVER_ID",
                 "value": "1"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "conf",
+                "mountPath": "/opt/zookeeper/conf"
+              },
+              {
+                "name": "data",
+                "mountPath": "/opt/zookeeper/data"
+              },
+              {
+                "name": "log",
+                "mountPath": "/opt/zookeeper/log"
               }
             ],
             "resources": {},
@@ -260,6 +288,20 @@
         }
       },
       "spec": {
+        "volumes": [
+          {
+            "name": "conf",
+            "emptyDir": {}
+          },
+          {
+            "name": "data",
+            "emptyDir": {}
+          },
+          {
+            "name": "log",
+            "emptyDir": {}
+          }
+        ],
         "containers": [
           {
             "name": "server",
@@ -282,6 +324,20 @@
               {
                 "name": "SERVER_ID",
                 "value": "2"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "conf",
+                "mountPath": "/opt/zookeeper/conf"
+              },
+              {
+                "name": "data",
+                "mountPath": "/opt/zookeeper/data"
+              },
+              {
+                "name": "log",
+                "mountPath": "/opt/zookeeper/log"
               }
             ],
             "resources": {},
@@ -310,6 +366,20 @@
         }
       },
       "spec": {
+        "volumes": [
+          {
+            "name": "conf",
+            "emptyDir": {}
+          },
+          {
+            "name": "data",
+            "emptyDir": {}
+          },
+          {
+            "name": "log",
+            "emptyDir": {}
+          }
+        ],
         "containers": [
           {
             "name": "server",
@@ -332,6 +402,20 @@
               {
                 "name": "SERVER_ID",
                 "value": "3"
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "conf",
+                "mountPath": "/opt/zookeeper/conf"
+              },
+              {
+                "name": "data",
+                "mountPath": "/opt/zookeeper/data"
+              },
+              {
+                "name": "log",
+                "mountPath": "/opt/zookeeper/log"
               }
             ],
             "resources": {},


### PR DESCRIPTION
For templates which use images backed by ephemeral storage using
the implicit VOLUME directive in a Dockerfile, replace the implicit
usage with explicit emptyDir volumes/mounts in the pod specs. This
makes the templates compatible with any OpenShift deployment, even
those which have disabled Docker's implicit VOLUME functionality.