### PR TITLE
Tolerate local Git repositories without an origin set

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -875,6 +875,10 @@ func describeSourceInPipeline(source *buildapi.BuildSource) (string, bool) {
 		return fmt.Sprintf("%s#%s", source.Git.URI, source.Git.Ref), true
 	case source.Dockerfile != nil:
 		return "Dockerfile", true
+	case source.Binary != nil:
+		return "uploaded code", true
+	case len(source.Images) > 0:
+		return "contents in other images", true
 	}
 	return "", false
 }


### PR DESCRIPTION
It is not required for a Git repository to have any remotes, and we fail in incorrect ways today when it happens. When running new-build, if the user provides a Git repo without a remote the source repository can only be built by binary push.  This PR does not make that an error condition (although it's possible it should)

Updated describers to take into account additional types of input and give slightly better messages.