### PR TITLE
Test resource discovery, remove v1beta3 from discovery doc, disambiguate origin generators

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/genericapiserver/genericapiserver.go
@@ -743,6 +743,12 @@ func (s *GenericAPIServer) installAPIGroup(apiGroupInfo *APIGroupInfo) error {
 	// Install REST handlers for all the versions in this group.
 	apiVersions := []string{}
 	for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
+		// Don't serve any versions other than v1 from the legacy group
+		// TODO: plumb API-enabled versions here, so we can choose to enable/disable particular versions in an API group
+		if apiGroupInfo.IsLegacyGroup && groupVersion.Group == "" && groupVersion.Version != "v1" {
+			continue
+		}
+
 		apiVersions = append(apiVersions, groupVersion.Version)
 
 		apiGroupVersion, err := s.getAPIGroupVersion(apiGroupInfo, groupVersion, apiPrefix)

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -306,7 +306,7 @@ const (
 	runLong = `Create and run a particular image, possibly replicated
 
 Creates a deployment config to manage the created container(s). You can choose to run in the
-foreground for an interactive container execution.  You may pass 'run-controller/v1' to
+foreground for an interactive container execution.  You may pass 'run/v1' to
 --generator to create a replication controller instead of a deployment config.`
 
 	runExample = `  # Starts a single instance of nginx.
@@ -337,13 +337,13 @@ foreground for an interactive container execution.  You may pass 'run-controller
 
 // NewCmdRun is a wrapper for the Kubernetes cli run command
 func NewCmdRun(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
-	opts := &kcmd.RunOptions{DefaultRestartAlwaysGenerator: kcmdutil.RunV1GeneratorName, DefaultGenerator: kcmdutil.RunPodV1GeneratorName}
+	opts := &kcmd.RunOptions{DefaultRestartAlwaysGenerator: "deploymentconfig/v1", DefaultGenerator: kcmdutil.RunPodV1GeneratorName}
 	cmd := kcmd.NewCmdRunWithOptions(f.Factory, opts, in, out, errout)
 	cmd.Long = runLong
 	cmd.Example = fmt.Sprintf(runExample, fullName)
 	cmd.SuggestFor = []string{"image"}
 	cmd.Flags().Set("generator", "")
-	cmd.Flag("generator").Usage = "The name of the API generator to use.  Default is 'run/v1' if --restart=Always, otherwise the default is 'run-pod/v1'."
+	cmd.Flag("generator").Usage = "The name of the API generator to use.  Default is 'deploymentconfig/v1' if --restart=Always, otherwise the default is 'run-pod/v1'."
 	cmd.Flag("generator").DefValue = ""
 	cmd.Flag("generator").Changed = false
 	return cmd

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -144,8 +144,8 @@ type Factory struct {
 func DefaultGenerators(cmdName string) map[string]kubectl.Generator {
 	generators := map[string]map[string]kubectl.Generator{}
 	generators["run"] = map[string]kubectl.Generator{
-		cmdutil.RunV1GeneratorName: deploygen.BasicDeploymentConfigController{},
-		"run-controller/v1":        kubectl.BasicReplicationController{},
+		"deploymentconfig/v1": deploygen.BasicDeploymentConfigController{},
+		"run-controller/v1":   kubectl.BasicReplicationController{}, // legacy alias for run/v1
 	}
 	generators["expose"] = map[string]kubectl.Generator{
 		"route/v1": routegen.RouteGenerator{},
@@ -289,10 +289,6 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		ret := map[string]kubectl.Generator{}
 		for k, v := range kubeGenerators {
 			ret[k] = v
-		}
-		// TODO: enable once deployments are supported in origin
-		if cmdName == "run" {
-			delete(ret, cmdutil.DeploymentV1Beta1GeneratorName)
 		}
 		for k, v := range originGenerators {
 			ret[k] = v

--- a/pkg/cmd/util/clientcmd/factory_test.go
+++ b/pkg/cmd/util/clientcmd/factory_test.go
@@ -19,10 +19,18 @@ func TestRunGenerators(t *testing.T) {
 	f := NewFactory(nil)
 
 	// Contains the run generators we expect to see
-	// If new generators appear from upstream, make sure we support the underlying types
-	// If we do (like Job, Pod, etc), add them to the expected list here
-	// If we do not support in oc yet (like upstream Deployments), remove them in our factory's Generators function in factory.go
-	expectedRunGenerators := sets.NewString("job/v1", "job/v1beta1", "run-controller/v1", "run-pod/v1", "run/v1").List()
+	expectedRunGenerators := sets.NewString(
+		// kube generators
+		"run/v1",
+		"run-pod/v1",
+		"deployment/v1beta1",
+		"job/v1",
+		"job/v1beta1",
+
+		// origin generators
+		"run-controller/v1", // legacy alias for run/v1
+		"deploymentconfig/v1",
+	).List()
 
 	runGenerators := sets.StringKeySet(f.Generators("run")).List()
 	if !reflect.DeepEqual(expectedRunGenerators, runGenerators) {

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -237,11 +237,12 @@ os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-templa
 os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --restart=Never'                'Pod v1'
 # TODO: version ordering is unstable between Go 1.4 and Go 1.6 because of import order
 os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --output-version=extensions/v1beta1 --generator=job/v1beta1'        'Job extensions/v1beta1'
-os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=job/v1'             'Job batch/v1'
-os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run/v1'             'DeploymentConfig v1'
-os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run-controller/v1'  'ReplicationController v1'
-os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run-pod/v1'         'Pod v1'
-os::cmd::expect_failure_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=deployment/v1beta1' 'not found'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=job/v1'              'Job batch/v1'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=deploymentconfig/v1' 'DeploymentConfig v1'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run-controller/v1'   'ReplicationController v1'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run/v1'              'ReplicationController v1'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=run-pod/v1'          'Pod v1'
+os::cmd::expect_success_and_text 'oc run --dry-run foo --image=bar -o "go-template={{.kind}} {{.apiVersion}}" --generator=deployment/v1beta1'  'Deployment extensions/v1beta1'
 
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-stibuild.json -l name=mytemplate | oc create -f -'
 os::cmd::expect_success 'oc delete all -l name=mytemplate'

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -1,0 +1,57 @@
+// +build integration
+
+package integration
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestDiscoveryGroupVersions(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error starting test master: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resources, err := clusterAdminKubeClient.Discovery().ServerResources()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, resource := range resources {
+		gv, err := unversioned.ParseGroupVersion(resource.GroupVersion)
+		if err != nil {
+			continue
+		}
+		allowedVersions := sets.NewString(configapi.KubeAPIGroupsToAllowedVersions[gv.Group]...)
+		if !allowedVersions.Has(gv.Version) {
+			t.Errorf("Disallowed group/version found in discovery: %#v", gv)
+		}
+	}
+
+	expectedGroupVersions := sets.NewString()
+	for group, versions := range configapi.KubeAPIGroupsToAllowedVersions {
+		for _, version := range versions {
+			expectedGroupVersions.Insert(unversioned.GroupVersion{Group: group, Version: version}.String())
+		}
+	}
+
+	discoveredGroupVersions := sets.StringKeySet(resources)
+	if !reflect.DeepEqual(discoveredGroupVersions, expectedGroupVersions) {
+		t.Fatalf("Expected %#v, got %#v", expectedGroupVersions.List(), discoveredGroupVersions.List())
+	}
+
+}


### PR DESCRIPTION
Fixes #8263

* Ensures v1beta3 doesn't appear in discovery docs for legacy API
* Renames origin deployment config generator to `run-deploymentconfig/v1` to avoid overwriting upstream generator name (needs a release note)
* Restores `deployment/v1beta1` generator (primarily for kubectl)

@ncdc PTAL