### PR TITLE
Add admission plugin to allow bind mounting binaries

### DIFF
--- a/pkg/cmd/server/api/install/install.go
+++ b/pkg/cmd/server/api/install/install.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api/install"
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration/api/install"
 	_ "github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints/api/install"
+	_ "github.com/openshift/origin/pkg/util/admission/bindmount/api/install"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/cmd/server/api"

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -46,7 +46,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
+var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions", "BinaryBindMount"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints"
 	_ "github.com/openshift/origin/pkg/security/admission"
+	_ "github.com/openshift/origin/pkg/util/admission/bindmount"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"

--- a/pkg/util/admission/bindmount/admission.go
+++ b/pkg/util/admission/bindmount/admission.go
@@ -1,0 +1,117 @@
+package bindmount
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"github.com/openshift/origin/pkg/util/admission/bindmount/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+)
+
+func init() {
+	admission.RegisterPlugin("BinaryBindMount", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		pluginConfig, err := readConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		return NewBinaryBindMount(pluginConfig), nil
+	})
+}
+
+func readConfig(reader io.Reader) (*api.BinaryBindMountConfig, error) {
+	obj, err := configlatest.ReadYAML(reader)
+	if err != nil {
+		return nil, err
+	}
+	if obj == nil {
+		return nil, nil
+	}
+	config, ok := obj.(*api.BinaryBindMountConfig)
+	if !ok {
+		return nil, fmt.Errorf("unexpected config object %#v", obj)
+	}
+	return config, nil
+}
+
+// NewBinaryBindMount creates a new BinaryBindMount admission control plugin using
+// the given configuration
+func NewBinaryBindMount(config *api.BinaryBindMountConfig) admission.Interface {
+	var mountsByImage map[string]*api.ImageBindMountSpec
+	if config != nil {
+		mountsByImage = map[string]*api.ImageBindMountSpec{}
+		for i := range config.Images {
+			mountsByImage[config.Images[i].Image] = &config.Images[i]
+		}
+	}
+	return &binaryBindMount{
+		Handler:       admission.NewHandler(admission.Create),
+		mountsByImage: mountsByImage,
+	}
+}
+
+type binaryBindMount struct {
+	*admission.Handler
+	mountsByImage map[string]*api.ImageBindMountSpec
+}
+
+// Admit will add volume mounts for pods including containers that use the
+// images specified in the configuration
+func (b *binaryBindMount) Admit(attributes admission.Attributes) error {
+	switch {
+	case b.mountsByImage == nil,
+		attributes.GetResource() != kapi.Resource("pods"),
+		len(attributes.GetSubresource()) > 0:
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*kapi.Pod)
+	if !ok {
+		return admission.NewForbidden(attributes, fmt.Errorf("unexpected object: %#v", attributes.GetObject()))
+	}
+	namer := mountNamer(0)
+	for i := range pod.Spec.Containers {
+		if mounts, hasImage := b.mountsByImage[pod.Spec.Containers[i].Image]; hasImage {
+			setupMounts(mounts, &pod.Spec.Containers[i], pod, &namer)
+		}
+	}
+
+	return nil
+}
+
+type mountNamer int
+
+func (n *mountNamer) Increment() {
+	(*n)++
+}
+
+func (n *mountNamer) Volume() string {
+	return fmt.Sprintf("bindmount-volume-%d", *n)
+}
+
+func setupMounts(spec *api.ImageBindMountSpec, container *kapi.Container, pod *kapi.Pod, namer *mountNamer) {
+	for _, mount := range spec.Mounts {
+		namer.Increment()
+		volume := kapi.Volume{
+			Name: namer.Volume(),
+			VolumeSource: kapi.VolumeSource{
+				HostPath: &kapi.HostPathVolumeSource{
+					Path: mount.Source,
+				},
+			},
+		}
+
+		volumeMount := kapi.VolumeMount{
+			Name:      namer.Volume(),
+			MountPath: mount.Destination,
+		}
+
+		pod.Spec.Volumes = append(pod.Spec.Volumes,
+			volume)
+		container.VolumeMounts =
+			append(container.VolumeMounts,
+				volumeMount)
+	}
+}

--- a/pkg/util/admission/bindmount/api/install/install.go
+++ b/pkg/util/admission/bindmount/api/install/install.go
@@ -1,0 +1,41 @@
+package install
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/util/admission/bindmount/api"
+	"github.com/openshift/origin/pkg/util/admission/bindmount/api/v1"
+)
+
+// availableVersions lists all known external versions for this group from most preferred to least preferred
+var availableVersions = []unversioned.GroupVersion{v1.SchemeGroupVersion}
+
+func init() {
+	if err := enableVersions(availableVersions); err != nil {
+		panic(err)
+	}
+}
+
+// TODO: enableVersions should be centralized rather than spread in each API group.
+func enableVersions(externalVersions []unversioned.GroupVersion) error {
+	addVersionsToScheme(externalVersions...)
+	return nil
+}
+
+func addVersionsToScheme(externalVersions ...unversioned.GroupVersion) {
+	// add the internal version to Scheme
+	api.AddToScheme(configapi.Scheme)
+	// add the enabled external versions to Scheme
+	for _, v := range externalVersions {
+		switch v {
+		case v1.SchemeGroupVersion:
+			v1.AddToScheme(configapi.Scheme)
+		default:
+			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
+			continue
+		}
+	}
+}

--- a/pkg/util/admission/bindmount/api/name.go
+++ b/pkg/util/admission/bindmount/api/name.go
@@ -1,0 +1,4 @@
+package api
+
+const PluginName = "BinaryBindMount"
+const ConfigKind = "BinaryBindMountConfig"

--- a/pkg/util/admission/bindmount/api/register.go
+++ b/pkg/util/admission/bindmount/api/register.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
+
+// Adds the list of known types to api.Scheme.
+func AddToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&BinaryBindMountConfig{},
+	)
+}
+
+func (obj *BinaryBindMountConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/util/admission/bindmount/api/types.go
+++ b/pkg/util/admission/bindmount/api/types.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// BinaryBindMountConfig is the configuration for the BinaryBindMount
+// admission controller which overrides binaries in certain images executed by the system
+type BinaryBindMountConfig struct {
+	unversioned.TypeMeta
+
+	Images []ImageBindMountSpec
+}
+
+type ImageBindMountSpec struct {
+	Image  string
+	Mounts []FileBindMountSpec
+}
+
+type FileBindMountSpec struct {
+	Source      string
+	Destination string
+}

--- a/pkg/util/admission/bindmount/api/v1/register.go
+++ b/pkg/util/admission/bindmount/api/v1/register.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = unversioned.GroupVersion{Group: "", Version: "v1"}
+
+// Adds the list of known types to api.Scheme.
+func AddToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&BinaryBindMountConfig{},
+	)
+}
+
+func (obj *BinaryBindMountConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/util/admission/bindmount/api/v1/types.go
+++ b/pkg/util/admission/bindmount/api/v1/types.go
@@ -1,0 +1,23 @@
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// BinaryBindMountConfig is the configuration for the BinaryBindMount
+// admission controller which overrides binaries in certain images executed by the system
+type BinaryBindMountConfig struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	Images []ImageBindMountSpec `json:"images"`
+}
+
+type ImageBindMountSpec struct {
+	Image  string              `json:"image"`
+	Mounts []FileBindMountSpec `json:"mounts"`
+}
+
+type FileBindMountSpec struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+}


### PR DESCRIPTION
The plugin accepts a config like:
```
kubernetesMasterConfig:
  admissionConfig:
    pluginConfig:
      BinaryBindMount:
        configuration:
          apiVersion: v1
          images:
          - image: openshift/origin-deployer:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/origin-recycler:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/origin-docker-builder:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/origin-gitserver:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/origin-sti-builder:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/origin-f5-router:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          - image: openshift/node:latest
            mounts:
            - destination: /usr/bin/openshift
              source: /var/lib/origin/source/_output/local/bin/linux/amd64/openshift
          kind: BinaryBindMountConfig
```
which allows images that are run by openshift to pick up the most recent binary on the host.