### PR TITLE
Suppress router reload during sync

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -55,10 +55,14 @@ testexec="${testdir}/${name}.test"
 mkdir -p "${testdir}"
 
 # build the test executable (cgo must be disabled to have the symbol table available)
-pushd "${testdir}" &>/dev/null
-echo "Building test executable..."
-CGO_ENABLED=0 go test -c -tags="${tags}" "${OS_GO_PACKAGE}/${package}"
-popd &>/dev/null
+if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
+  echo "WARNING: Skipping build due to OPENSHIFT_SKIP_BUILD"
+else
+  pushd "${testdir}" &>/dev/null
+    echo "Building test executable..."
+    CGO_ENABLED=0 go test -c -tags="${tags}" "${OS_GO_PACKAGE}/${package}"
+  popd &>/dev/null
+fi
 
 os::log::start_system_logger
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -67,7 +67,7 @@ function exectest() {
 
 	result=1
 	if [ -n "${VERBOSE-}" ]; then
-		"${testexec}" -vmodule=*=5 -test.v -test.timeout=4m -test.run="^$1$" "${@:2}" 2>&1
+		out=$("${testexec}" -vmodule=*=5 -test.v -test.timeout=4m -test.run="^$1$" "${@:2}" 2>&1)
 		result=$?
 	else
 		out=$("${testexec}" -test.timeout=4m -test.run="^$1$" "${@:2}" 2>&1)

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -70,7 +70,11 @@ function exectest() {
 	echo "Running $1..."
 
 	result=1
-	if [ -n "${VERBOSE-}" ]; then
+	if [ -n "${DEBUG-}" ]; then
+		dlv exec "${testexec}" -- -test.run="^$1$" "${@:2}"
+		result=$?
+		out=
+	elif [ -n "${VERBOSE-}" ]; then
 		out=$("${testexec}" -vmodule=*=5 -test.v -test.timeout=4m -test.run="^$1$" "${@:2}" 2>&1)
 		result=$?
 	else

--- a/pkg/client/cache/eventqueue_test.go
+++ b/pkg/client/cache/eventqueue_test.go
@@ -171,3 +171,37 @@ func TestEventQueue_modifyEventsFromReplace(t *testing.T) {
 		t.Fatalf("expected %s, got %s", watch.Modified, event)
 	}
 }
+
+func TestEventQueue_ListConsumed(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queue creation")
+	}
+
+	q.Replace([]interface{}{}, "1")
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after Replace() without items")
+	}
+
+	items := []interface{}{
+		cacheable{"foo", 2},
+	}
+	q.Replace(items, "1")
+	if q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be false after Replace() with items")
+	}
+
+	// Delete() only results in the removal of a queued item if it is
+	// of event type watch.Add.  Since items added by Replace() are of
+	// type watch.Modified, calling Delete() on those items will
+	// change the event type but not remove them from the queue.
+	q.Delete(items[0])
+	if q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be false after Delete()")
+	}
+
+	q.Pop()
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queued items read")
+	}
+}

--- a/pkg/router/controller/controller_test.go
+++ b/pkg/router/controller/controller_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+type fakeRouterPlugin struct {
+	lastSyncProcessed bool
+}
+
+func (p *fakeRouterPlugin) HandleRoute(t watch.EventType, route *routeapi.Route) error {
+	return nil
+}
+func (p *fakeRouterPlugin) HandleEndpoints(watch.EventType, *kapi.Endpoints) error {
+	return nil
+}
+func (p *fakeRouterPlugin) HandleNamespaces(namespaces sets.String) error {
+	return nil
+}
+func (p *fakeRouterPlugin) SetLastSyncProcessed(processed bool) error {
+	p.lastSyncProcessed = processed
+	return nil
+}
+
+type fakeNamespaceLister struct {
+}
+
+func (n fakeNamespaceLister) NamespaceNames() (sets.String, error) {
+	return sets.NewString("foo"), nil
+}
+
+func TestRouterController_updateLastSyncProcessed(t *testing.T) {
+	p := fakeRouterPlugin{}
+	routesListConsumed := true
+	c := RouterController{
+		Plugin: &p,
+		NextEndpoints: func() (watch.EventType, *kapi.Endpoints, error) {
+			return watch.Modified, &kapi.Endpoints{}, nil
+		},
+		NextRoute: func() (watch.EventType, *routeapi.Route, error) {
+			return watch.Modified, &routeapi.Route{}, nil
+		},
+		EndpointsListConsumed: func() bool {
+			return true
+		},
+		RoutesListConsumed: func() bool {
+			return routesListConsumed
+		},
+		Namespaces:       fakeNamespaceLister{},
+		NamespaceRetries: 1,
+	}
+
+	// Simulate the initial sync
+	c.HandleNamespaces()
+	if p.lastSyncProcessed {
+		t.Fatalf("last sync not expected to have been processed")
+	}
+	c.HandleEndpoints()
+	if p.lastSyncProcessed {
+		t.Fatalf("last sync not expected to have been processed")
+	}
+	c.HandleRoute()
+	if !p.lastSyncProcessed {
+		t.Fatalf("last sync expected to have been processed")
+	}
+
+	// Simulate a relist
+	routesListConsumed = false
+	c.HandleRoute()
+	if p.lastSyncProcessed {
+		t.Fatalf("last sync not expected to have been processed")
+	}
+	routesListConsumed = true
+	c.HandleRoute()
+	if !p.lastSyncProcessed {
+		t.Fatalf("last sync expected to have been processed")
+	}
+
+}

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -73,3 +73,7 @@ func (p *ExtendedValidator) HandleRoute(eventType watch.EventType, route *routea
 func (p *ExtendedValidator) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
+
+func (p *ExtendedValidator) SetLastSyncProcessed(processed bool) error {
+	return p.plugin.SetLastSyncProcessed(processed)
+}

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -81,6 +81,12 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin) *controller
 			}
 			return eventType, obj.(*routeapi.Route), nil
 		},
+		EndpointsListConsumed: func() bool {
+			return endpointsEventQueue.ListConsumed()
+		},
+		RoutesListConsumed: func() bool {
+			return routeEventQueue.ListConsumed()
+		},
 		Namespaces: factory.Namespaces,
 		// check namespaces a bit more often than we resync events, so that we aren't always waiting
 		// the maximum interval for new items to come into the list

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -302,3 +302,7 @@ func (a *StatusAdmitter) HandleEndpoints(eventType watch.EventType, route *kapi.
 func (a *StatusAdmitter) HandleNamespaces(namespaces sets.String) error {
 	return a.plugin.HandleNamespaces(namespaces)
 }
+
+func (a *StatusAdmitter) SetLastSyncProcessed(processed bool) error {
+	return a.plugin.SetLastSyncProcessed(processed)
+}

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -34,6 +34,9 @@ func (p *fakePlugin) HandleEndpoints(watch.EventType, *kapi.Endpoints) error {
 func (p *fakePlugin) HandleNamespaces(namespaces sets.String) error {
 	return fmt.Errorf("not expected")
 }
+func (p *fakePlugin) SetLastSyncProcessed(processed bool) error {
+	return fmt.Errorf("not expected")
+}
 
 func TestStatusNoOp(t *testing.T) {
 	now := nowFn()

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -212,6 +212,10 @@ func (p *UniqueHost) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
+func (p *UniqueHost) SetLastSyncProcessed(processed bool) error {
+	return p.plugin.SetLastSyncProcessed(processed)
+}
+
 // routeKey returns the internal router key to use for the given Route.
 func routeKey(route *routeapi.Route) string {
 	return fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)

--- a/pkg/router/f5/plugin.go
+++ b/pkg/router/f5/plugin.go
@@ -542,3 +542,8 @@ func (p *F5Plugin) HandleRoute(eventType watch.EventType,
 
 	return nil
 }
+
+// No-op since f5 configuration can be updated piecemeal
+func (p *F5Plugin) SetLastSyncProcessed(processed bool) error {
+	return nil
+}

--- a/pkg/router/interfaces.go
+++ b/pkg/router/interfaces.go
@@ -15,4 +15,5 @@ type Plugin interface {
 	HandleEndpoints(watch.EventType, *kapi.Endpoints) error
 	// If sent, filter the list of accepted routes and endpoints to this set
 	HandleNamespaces(namespaces sets.String) error
+	SetLastSyncProcessed(processed bool) error
 }

--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -1,12 +1,14 @@
 package templaterouter
 
-// newFakeTemplateRouter provides an empty template router with a simple certificate manager
+// NewFakeTemplateRouter provides an empty template router with a simple certificate manager
 // backed by a fake cert writer for testing
-func newFakeTemplateRouter() *templateRouter {
+func NewFakeTemplateRouter() *templateRouter {
 	fakeCertManager, _ := newSimpleCertificateManager(newFakeCertificateManagerConfig(), &fakeCertWriter{})
 	return &templateRouter{
-		state:       map[string]ServiceUnit{},
-		certManager: fakeCertManager,
+		state:                        map[string]ServiceUnit{},
+		certManager:                  fakeCertManager,
+		rateLimitedCommitFunction:    nil,
+		rateLimitedCommitStopChannel: make(chan struct{}),
 	}
 }
 

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -53,6 +53,10 @@ type routerInterface interface {
 	// frontend key is used; all call sites make certain the frontend
 	// is created.
 
+	// HasServiceUnit indicates whether the router has a service unit
+	// for the given key.
+	HasServiceUnit(key string) bool
+
 	// CreateServiceUnit creates a new service named with the given id.
 	CreateServiceUnit(id string)
 	// FindServiceUnit finds the service with the given id.

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -74,6 +74,9 @@ type routerInterface interface {
 	// Commit applies the changes in the background. It kicks off a rate-limited
 	// commit (persist router state + refresh the backend) that coalesces multiple changes.
 	Commit()
+
+	// SetSkipCommit indicates to the router whether commits should be skipped
+	SetSkipCommit(skipCommit bool)
 }
 
 func env(name, defaultValue string) string {
@@ -188,6 +191,11 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 func (p *TemplatePlugin) HandleNamespaces(namespaces sets.String) error {
 	p.Router.FilterNamespaces(namespaces)
 	p.Router.Commit()
+	return nil
+}
+
+func (p *TemplatePlugin) SetLastSyncProcessed(processed bool) error {
+	p.Router.SetSkipCommit(!processed)
 	return nil
 }
 

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -229,6 +229,10 @@ func (r *TestRouter) Commit() {
 func (r *TestRouter) SetSkipCommit(skipCommit bool) {
 }
 
+func (r *TestRouter) HasServiceUnit(key string) bool {
+	return false
+}
+
 // TestHandleEndpoints test endpoint watch events
 func TestHandleEndpoints(t *testing.T) {
 	testCases := []struct {

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -226,6 +226,9 @@ func (r *TestRouter) Commit() {
 	r.Committed = true
 }
 
+func (r *TestRouter) SetSkipCommit(skipCommit bool) {
+}
+
 // TestHandleEndpoints test endpoint watch events
 func TestHandleEndpoints(t *testing.T) {
 	testCases := []struct {

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestCreateServiceUnit tests creating a service unit and finding it in router state
 func TestCreateServiceUnit(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit("test")
 
@@ -22,7 +22,7 @@ func TestCreateServiceUnit(t *testing.T) {
 
 // TestDeleteServiceUnit tests that deleted service units no longer exist in state
 func TestDeleteServiceUnit(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -39,7 +39,7 @@ func TestDeleteServiceUnit(t *testing.T) {
 
 // TestAddEndpoints test adding endpoints to service units
 func TestAddEndpoints(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -74,7 +74,7 @@ func TestAddEndpoints(t *testing.T) {
 
 // Test that AddEndpoints returns true and false correctly for changed endpoints.
 func TestAddEndpointDuplicates(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 	if _, ok := router.FindServiceUnit(suKey); !ok {
@@ -144,7 +144,7 @@ func TestAddEndpointDuplicates(t *testing.T) {
 
 // TestDeleteEndpoints tests removing endpoints from service units
 func TestDeleteEndpoints(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -185,7 +185,7 @@ func TestDeleteEndpoints(t *testing.T) {
 
 // TestRouteKey tests that route keys are created as expected
 func TestRouteKey(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -283,7 +283,7 @@ func TestRouteKey(t *testing.T) {
 
 // TestAddRoute tests adding a service alias config to a service unit
 func TestAddRoute(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -363,7 +363,7 @@ func findCert(cert string, certs map[string]Certificate, isPrivateKey bool, t *t
 
 // TestRemoveRoute tests removing a ServiceAliasConfig from a ServiceUnit
 func TestRemoveRoute(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -470,7 +470,7 @@ func TestShouldWriteCertificates(t *testing.T) {
 		},
 	}
 
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	for _, tc := range testCases {
 		result := router.shouldWriteCerts(tc.cfg)
 		if result != tc.shouldWriteCerts {
@@ -565,7 +565,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 	}
 
 	// setup the router
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 	routeWithBadServiceKey := routeKey(routeWithBadService)
 	routeWithBadServiceCfgKey := router.routeKey(routeWithBadService)
 	routeWithGoodServiceKey := routeKey(routeWithGoodService)
@@ -633,7 +633,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 // TestAddRouteEdgeTerminationInsecurePolicy tests adding an insecure edge
 // terminated routes to a service unit
 func TestAddRouteEdgeTerminationInsecurePolicy(t *testing.T) {
-	router := newFakeTemplateRouter()
+	router := NewFakeTemplateRouter()
 
 	testCases := []struct {
 		Name           string

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -1,0 +1,285 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	"github.com/openshift/origin/pkg/router"
+	"github.com/openshift/origin/pkg/router/controller"
+	controllerfactory "github.com/openshift/origin/pkg/router/controller/factory"
+	templateplugin "github.com/openshift/origin/pkg/router/template"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+// TestRouterReloadSuppressionOnSync validates that the router will
+// not be reloaded until all events from the initial sync have been
+// processed.  Reload should similarly suppressed on subsequent
+// resyncs.
+func TestRouterReloadSuppressionOnSync(t *testing.T) {
+	stressRouter(
+		t,
+		// Allow the test to be configured to enable experimentation
+		// without a costly (~60s+) go build.
+		cmdutil.EnvInt("OS_TEST_NAMESPACE_COUNT", 1, 1),
+		cmdutil.EnvInt("OS_TEST_ROUTES_PER_NAMESPACE", 10, 10),
+		cmdutil.EnvInt("OS_TEST_ROUTER_COUNT", 1, 1),
+		cmdutil.EnvInt("OS_TEST_MAX_ROUTER_DELAY", 10, 10),
+	)
+}
+
+func stressRouter(t *testing.T, namespaceCount, routesPerNamespace, routerCount, maxRouterDelay int32) {
+	testutil.RequireEtcd(t)
+
+	oc, kc, err := launchApi()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Keep track of created routes to be able to verify against
+	// the processed router state.
+	routes := []*routeapi.Route{}
+
+	// Create initial state
+	for i := int32(0); i < namespaceCount; i++ {
+
+		// Create a namespace
+		namespaceProperties := createNamespaceProperties()
+		namespace, err := kc.Namespaces().Create(namespaceProperties)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for j := int32(0); j < routesPerNamespace; j++ {
+
+			// Create a service for the route
+			serviceProperties := createServiceProperties()
+			service, err := kc.Services(namespace.Name).Create(serviceProperties)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Create endpoints
+			endpointsProperties := createEndpointsProperties(service.Name)
+			_, err = kc.Endpoints(namespace.Name).Create(endpointsProperties)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Create a route
+			routeProperties := createRouteProperties(service.Name)
+			route, err := oc.Routes(namespace.Name).Create(routeProperties)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			routes = append(routes, route)
+		}
+	}
+
+	// Keep track of the plugins to allow access to the router state
+	// after processing.
+	plugins := []*templateplugin.TemplatePlugin{}
+
+	// Don't coalesce reloads to validate reload suppression during sync.
+	reloadInterval := 0
+
+	// Track reload counts indexed by router name.
+	reloadCounts := make(map[string]int)
+
+	// Create the routers
+	for i := int32(0); i < routerCount; i++ {
+		routerName := fmt.Sprintf("router_%d", i)
+		router := launchRouter(oc, kc, maxRouterDelay, routerName, reloadInterval, reloadCounts)
+		plugins = append(plugins, router)
+	}
+
+	// Wait until the routers have processed all the routes.  The test
+	// runner is assumed enforce a timeout that ensures termination in
+	// the event of a failure.
+	expectedRouteCount := len(routes)
+	for {
+		routeCount := 0
+		for _, plugin := range plugins {
+			for _, route := range routes {
+				key := routeKey(route)
+				if plugin.Router.HasServiceUnit(key) {
+					routeCount++
+				}
+			}
+		}
+		if routeCount == expectedRouteCount {
+			break
+		} else {
+			time.Sleep(1)
+		}
+	}
+
+	for _, reloadCount := range reloadCounts {
+		if reloadCount > 1 {
+			t.Fatalf("One or more routers reloaded more than once")
+		}
+	}
+}
+
+// TODO(marun) reuse a public definition instead of copying.
+func routeKey(route *routeapi.Route) string {
+	return fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
+}
+
+func createNamespaceProperties() *kapi.Namespace {
+	return &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			GenerateName: "namespace-",
+		},
+		Status: kapi.NamespaceStatus{},
+	}
+}
+
+func createServiceProperties() *kapi.Service {
+	return &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			GenerateName: "service-",
+		},
+		Spec: kapi.ServiceSpec{
+			Ports: []kapi.ServicePort{{
+				Protocol: "TCP",
+				Port:     8080,
+			}},
+		},
+	}
+}
+
+func createEndpointsProperties(serviceName string) *kapi.Endpoints {
+	return &kapi.Endpoints{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: serviceName,
+		},
+		Subsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{
+				IP: "1.2.3.4",
+			}},
+			Ports: []kapi.EndpointPort{{
+				Port: 8080,
+			}},
+		}},
+	}
+}
+
+func createRouteProperties(serviceName string) *routeapi.Route {
+	return &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			GenerateName: "route-",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "www.example.com",
+			Path: "",
+			To: kapi.ObjectReference{
+				Name: serviceName,
+			},
+			TLS: nil,
+		},
+	}
+}
+
+// launchAPI launches an api server and returns clients configured to
+// access it.
+func launchApi() (osclient.Interface, kclient.Interface, error) {
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kc, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	oc, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return oc, kc, nil
+}
+
+// DelayPlugin implements the router.Plugin interface to introduce
+// random delay into plugin handlers to simulate variation in
+// processing time when a router is under load.
+type DelayPlugin struct {
+	plugin   router.Plugin
+	maxDelay int32
+}
+
+func NewDelayPlugin(plugin router.Plugin, maxDelay int32) *DelayPlugin {
+	rand.Seed(time.Now().UTC().UnixNano())
+	return &DelayPlugin{
+		plugin:   plugin,
+		maxDelay: maxDelay,
+	}
+}
+
+func (p *DelayPlugin) delay() {
+	time.Sleep(time.Duration(p.maxDelay) * time.Millisecond)
+}
+
+func (p *DelayPlugin) HandleRoute(eventType watch.EventType, route *routeapi.Route) error {
+	p.delay()
+	return p.plugin.HandleRoute(eventType, route)
+}
+
+func (p *DelayPlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+	p.delay()
+	return p.plugin.HandleEndpoints(eventType, endpoints)
+}
+
+func (p *DelayPlugin) HandleNamespaces(namespaces sets.String) error {
+	p.delay()
+	return p.plugin.HandleNamespaces(namespaces)
+}
+
+func (p *DelayPlugin) SetLastSyncProcessed(processed bool) error {
+	return p.plugin.SetLastSyncProcessed(processed)
+}
+
+// launchRouter launches a template router that communicates with the
+// api via the provided clients.
+func launchRouter(oc osclient.Interface, kc kclient.Interface, maxDelay int32, name string, reloadInterval int, reloadCounts map[string]int) (templatePlugin *templateplugin.TemplatePlugin) {
+	r := templateplugin.NewFakeTemplateRouter()
+
+	reloadCounts[name] = 0
+	r.EnableRateLimiter(reloadInterval, func() error {
+		reloadCounts[name]++
+		return nil
+	})
+
+	templatePlugin = &templateplugin.TemplatePlugin{Router: r}
+
+	statusPlugin := controller.NewStatusAdmitter(templatePlugin, oc, name)
+
+	validationPlugin := controller.NewExtendedValidator(statusPlugin, controller.RejectionRecorder(statusPlugin))
+
+	uniquePlugin := controller.NewUniqueHost(validationPlugin, controller.HostForRoute, controller.RejectionRecorder(statusPlugin))
+
+	var plugin router.Plugin = uniquePlugin
+	if maxDelay > 0 {
+		plugin = NewDelayPlugin(plugin, maxDelay)
+	}
+
+	factory := controllerfactory.NewDefaultRouterControllerFactory(oc, kc)
+	controller := factory.Create(plugin)
+	controller.Run()
+
+	return
+}


### PR DESCRIPTION
Reloading HAProxy can result in dropped connections so the number of reloads would ideally be minimized.  This PR proposes to prevent reloads during a sync event to address the problem reported in #7409 and [bz 1320233](https://bugzilla.redhat.com/show_bug.cgi?id=1320233).

The chosen approach:
 
- Updates EventQueue to be able to indicate when the objects added by the last call to Replace have been read.
- Composes a sync state from the queue state of endpoints and routes and whether namespace filtering has been performed.
- Propagates the sync state to the router where it can be used to allow or prevent reloads.

I've manually tested by reducing the reload interval to 1s and adding time.Sleep() calls to increase the duration of a sync.  With this patch, only the initial reload and post-sync reload are seen.  Without this patch, a reload is seen at least once per reload interval.

I'm holding off on adding automated tests pending consensus that the chosen approach is acceptable.

cc: @smarterclayton @liggitt @ramr @openshift/networking