### PR TITLE
oc describe build output improvements

### DIFF
--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -132,7 +132,7 @@ func formatMeta(out *tabwriter.Writer, m api.ObjectMeta) {
 	if !m.CreationTimestamp.IsZero() {
 		formatTime(out, "Created", m.CreationTimestamp.Time)
 	}
-	formatString(out, "Labels", formatLabels(m.Labels))
+	formatMapStringString(out, "Labels", m.Labels)
 	formatAnnotations(out, m, "")
 }
 


### PR DESCRIPTION
Trello card: https://trello.com/c/l8CyWprA/863-3-clean-up-the-build-describe-output
Fix #5247

PTAL @bparees @jwforres @smarterclayton 

Note: build config describer mostly unchanged.

Example output:
```console
$ oc describe build ruby-hello-world-1 
Name:			ruby-hello-world-1
Created:		58 seconds ago
Labels:			app=ruby-hello-world
				buildconfig=ruby-hello-world
				openshift.io/build-config.name=ruby-hello-world
Annotations:	openshift.io/build.number=1
				openshift.io/build.pod-name=ruby-hello-world-1-build

Status:			Complete
Started:		Fri, 01 Apr 2016 14:22:36 UTC
Duration:		46s
Build Config:	ruby-hello-world
Build Pod:		ruby-hello-world-1-build

Strategy:			Source
URL:				https://github.com/openshift/ruby-hello-world.git
Commit:				bd94cbb (Merge pull request #52 from bparees/stdout)
Author/Committer:	Ben Parees
From Image:			DockerImage centos/ruby-22-centos7@sha256:990326b8ad8c4ae2619b24d019b7871bb10ab08c41e9d5b19d0b72cb0200e28c
Output to:			ImageStreamTag ruby-hello-world:latest
Push Secret:		builder-dockercfg-m9x7z

Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath			Type		Reason		Message
  ---------	--------	-----	----				-------------			--------	------		-------
  58s		58s		1	{default-scheduler }						Normal		Scheduled	Successfully assigned ruby-hello-world-1-build to localhost.localdomain
  57s		57s		1	{kubelet localhost.localdomain}	spec.containers{sti-build}	Normal		Pulled		Container image "openshift/origin-sti-builder:v1.1.4" already present on machine
  56s		56s		1	{kubelet localhost.localdomain}	spec.containers{sti-build}	Normal		Created		Created container with docker id 328f9f39f368
  56s		56s		1	{kubelet localhost.localdomain}	spec.containers{sti-build}	Normal		Started		Started container with docker id 328f9f39f368
```

```console
$ oc describe bc/ruby-hello-world
Name:			ruby-hello-world
Created:		11 minutes ago
Labels:			app=ruby-hello-world
Annotations:	openshift.io/generated-by=OpenShiftNewApp
Latest Version:	1

Strategy:			Source
URL:				https://github.com/openshift/ruby-hello-world.git
From Image:			ImageStreamTag ruby-22-centos7:latest
Output to:			ImageStreamTag ruby-hello-world:latest
Triggered by:		Config, ImageChange
Webhook GitHub:		https://localhost:8443/oapi/v1/namespaces/test/buildconfigs/ruby-hello-world/webhooks/Fbklht-OP-w1EMEWOJXY/github
Webhook Generic:	https://localhost:8443/oapi/v1/namespaces/test/buildconfigs/ruby-hello-world/webhooks/xshVl6kq2OYcdLJYabPl/generic

Build				Status		Duration	Creation Time
ruby-hello-world-1 	complete 	46s 		2016-04-01 14:22:33 +0000 UTC
```
