### PR TITLE
Add unique suffix to build post-hook containers

### DIFF
--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -111,12 +111,14 @@ const containerNamePrefix = "openshift"
 // containerName creates names for Docker containers launched by a build. It is
 // meant to resemble Kubernetes' pkg/kubelet/dockertools.BuildDockerName.
 func containerName(strategyName, buildName, namespace, containerPurpose string) string {
-	return fmt.Sprintf("%s_%s-build_%s_%s_%s",
+	uid := fmt.Sprintf("%08x", rand.Uint32())
+	return fmt.Sprintf("%s_%s-build_%s_%s_%s_%s",
 		containerNamePrefix,
 		strategyName,
 		buildName,
 		namespace,
-		containerPurpose)
+		containerPurpose,
+		uid)
 }
 
 // execPostCommitHook uses the client to execute a command based on the

--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -94,8 +94,9 @@ func TestRandomBuildTagNoDupes(t *testing.T) {
 }
 
 func TestContainerName(t *testing.T) {
+	rand.Seed(0)
 	got := containerName("test-strategy", "my-build", "ns", "hook")
-	want := "openshift_test-strategy-build_my-build_ns_hook"
+	want := "openshift_test-strategy-build_my-build_ns_hook_f1f85ff5"
 	if got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}


### PR DESCRIPTION
This makes it closer to `pkg/kubelet/dockertools.BuildDockerName`, as documented and as originally intended (original discussion in https://github.com/openshift/origin/pull/6715#discussion_r51599456).

We had removed the suffix during code review, and now agreed that it should be there to avoid bugging users with errors because of a container name clash.

Fixes #8266.