### PR TITLE
use RestartSec to avoid default rate limit in systemd

### DIFF
--- a/contrib/systemd/atomic-openshift-master.service
+++ b/contrib/systemd/atomic-openshift-master.service
@@ -16,6 +16,7 @@ LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-master
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/atomic-openshift-node.service
+++ b/contrib/systemd/atomic-openshift-node.service
@@ -15,6 +15,7 @@ LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-node
 Restart=always
+RestartSec=5s
 OOMScoreAdjust=-999
 
 [Install]

--- a/contrib/systemd/containerized/openvswitch.service
+++ b/contrib/systemd/containerized/openvswitch.service
@@ -7,6 +7,7 @@ ExecStartPre=-/usr/bin/docker rm -f openvswitch
 ExecStart=/usr/bin/docker run --name openvswitch --rm --privileged --net=host --pid=host -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /etc/origin/openvswitch:/etc/openvswitch openshift/openvswitch
 ExecStop=/usr/bin/docker stop openvswitch
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/containerized/origin-master.service
+++ b/contrib/systemd/containerized/origin-master.service
@@ -11,6 +11,7 @@ ExecStart=/usr/bin/docker run --rm --privileged --net=host --name origin-master 
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-master
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/origin-master.service
+++ b/contrib/systemd/origin-master.service
@@ -16,6 +16,7 @@ LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-master
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/origin-node.service
+++ b/contrib/systemd/origin-node.service
@@ -15,6 +15,7 @@ LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-node
 Restart=always
+RestartSec=5s
 OOMScoreAdjust=-999
 
 [Install]

--- a/images/atomic-registry-quickstart/atomic-openshift-master.service
+++ b/images/atomic-registry-quickstart/atomic-openshift-master.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/docker run --restart=no --rm --privileged --net=host --pid=ho
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-master
 Restart=always
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently all of our unit files are using `Restart=always` and not specifying a wait period. This means that they use the default `RestartSec` unless systemd has been customized.  The default value of `RestartSec` is 100ms.  

If a service fails and must be restarted but cannot restart for some reason it will retry every 100ms and will likely hit systemd's rate limiting features.  Once the `StartLimitBurst` (default is 5) is hit then the service will quit trying to restart and must be restarted manually.

By setting `RestartSec` to not hit rate limiting defaults we can ensure that we continuously try to restart (unless an admin has customized the default limiting settings).

Fixes https://github.com/openshift/origin/issues/8190

@smarterclayton @sdodson @brenton @knobunc 