### PR TITLE
Allow local reference to other image

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -18,3 +18,5 @@ middleware:
     - name: openshift
       options:
         pullthrough: true
+  storage:
+    - name: openshift

--- a/pkg/dockerregistry/server/localblobstore.go
+++ b/pkg/dockerregistry/server/localblobstore.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+const (
+	StorageGetContentNamespace = "openshift.storage.getcontent.namespace"
+	StorageGetContentName      = "openshift.storage.getcontent.name"
+)
+
+// Package server wraps repository objects of docker/distribution upstream.
+// Module forwards requests between local repositories in order to
+// serve requested blob living in other repository referenced in
+// corresponding image stream.
+type localBlobStore struct {
+	distribution.BlobStore
+
+	repo *repository
+}
+
+var _ distribution.BlobStore = &localBlobStore{}
+
+func (bs *localBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	desc, err := bs.BlobStore.Stat(ctx, dgst)
+	switch {
+	case err == distribution.ErrBlobUnknown:
+		// continue on to the code below and look up the blob in a local store
+	case err != nil:
+		context.GetLogger(bs.repo.ctx).Errorf("Failed to find blob %s: %#v", dgst.String(), err)
+		fallthrough
+	default:
+		return desc, err
+	}
+
+	is, err := bs.repo.getImageStream()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		}
+		context.GetLogger(bs.repo.ctx).Errorf("Error retrieving image stream for blob: %s", err)
+
+		if errors.IsForbidden(err) {
+			return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		}
+		return distribution.Descriptor{}, err
+	}
+
+	cached := bs.repo.cachedLayers.RepositoriesForDigest(dgst)
+
+	// look at the first level of tagged repositories first
+	search := bs.identifyCandidateRepositories(is, true)
+	if desc, err := bs.findCandidateRepository(ctx, search, cached, dgst); err == nil {
+		return desc, nil
+	}
+
+	// look at all other repositories tagged by the server
+	secondary := bs.identifyCandidateRepositories(is, false)
+	for k := range search {
+		delete(secondary, k)
+	}
+	if desc, err := bs.findCandidateRepository(ctx, secondary, cached, dgst); err == nil {
+		return desc, nil
+	}
+
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+func (bs *localBlobStore) crossStat(ctx context.Context, ref imageapi.DockerImageReference, dgst digest.Digest) (distribution.Descriptor, error) {
+	statCtx := context.WithValue(ctx, StorageGetContentNamespace, ref.Namespace)
+	statCtx = context.WithValue(statCtx, StorageGetContentName, ref.Name)
+
+	desc, err := bs.BlobStore.Stat(statCtx, dgst)
+	if err != nil {
+		if err != distribution.ErrBlobUnknown {
+			context.GetLogger(bs.repo.ctx).Errorf("Unable to stat %s from %q: %v", dgst, ref.Exact(), err)
+		}
+		return distribution.Descriptor{}, err
+	}
+
+	return desc, nil
+}
+
+// TODO(legion): Merge this function with pullthroughblobstore.
+func (bs *localBlobStore) identifyCandidateRepositories(is *imageapi.ImageStream, primary bool) map[string]*imageapi.DockerImageReference {
+	search := make(map[string]*imageapi.DockerImageReference)
+	for _, tagEvent := range is.Status.Tags {
+		var candidates []imageapi.TagEvent
+		if primary {
+			if len(tagEvent.Items) == 0 {
+				continue
+			}
+			candidates = tagEvent.Items[:1]
+		} else {
+			if len(tagEvent.Items) <= 1 {
+				continue
+			}
+			candidates = tagEvent.Items[1:]
+		}
+		for _, event := range candidates {
+			ref, err := imageapi.ParseDockerImageReference(event.DockerImageReference)
+			if err != nil {
+				continue
+			}
+			if bs.repo.registryAddr != ref.Registry {
+				continue
+			}
+			ref = ref.DockerClientDefaults()
+
+			// Use different key than pullthrough to avoid any intersections.
+			search[ref.RepositoryName()] = &ref
+		}
+	}
+	return search
+}
+
+// TODO(legion): Merge this function with pullthroughblobstore.
+func (bs *localBlobStore) findCandidateRepository(ctx context.Context, search map[string]*imageapi.DockerImageReference, cachedLayers []string, dgst digest.Digest) (distribution.Descriptor, error) {
+	if len(search) == 0 {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
+	for _, repo := range cachedLayers {
+		ref, ok := search[repo]
+		if !ok {
+			continue
+		}
+		desc, err := bs.crossStat(ctx, *ref, dgst)
+		if err != nil {
+			delete(search, repo)
+			continue
+		}
+		context.GetLogger(bs.repo.ctx).Infof("Found digest location from cache %s in %s", dgst, repo)
+		return desc, nil
+	}
+
+	for reponame, ref := range search {
+		desc, err := bs.crossStat(ctx, *ref, dgst)
+		if err != nil {
+			continue
+		}
+		bs.repo.cachedLayers.RememberDigest(dgst, reponame)
+		context.GetLogger(bs.repo.ctx).Infof("Found digest location by search %s in %s", dgst, reponame)
+		return desc, nil
+	}
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -135,10 +135,16 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 	repo := repository(*r)
 	repo.ctx = ctx
 
-	bs := &quotaRestrictedBlobStore{
+	quotaBS := &quotaRestrictedBlobStore{
 		BlobStore: r.Repository.Blobs(ctx),
 		repo:      &repo,
 	}
+
+	bs := &localBlobStore{
+		BlobStore: quotaBS,
+		repo:      &repo,
+	}
+
 	if !r.pullthrough {
 		return bs
 	}

--- a/pkg/dockerregistry/server/storagedriver.go
+++ b/pkg/dockerregistry/server/storagedriver.go
@@ -1,0 +1,54 @@
+// Package server wraps storage driver of docker/distribution. Module changes
+// repository name in read requests for objects in the repository.
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	context "github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	registrystorage "github.com/docker/distribution/registry/storage/driver/middleware"
+)
+
+func init() {
+	registrystorage.Register("openshift", registrystorage.InitFunc(newLocalStorageDriver))
+}
+
+type localStorageDriver struct {
+	storagedriver.StorageDriver
+}
+
+var _ storagedriver.StorageDriver = &localStorageDriver{}
+
+func newLocalStorageDriver(storageDriver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
+	return &localStorageDriver{storageDriver}, nil
+}
+
+func (s *localStorageDriver) GetContent(ctx context.Context, path string) ([]byte, error) {
+	reponame, forceReponame := ctx.Value(StorageGetContentName).(string)
+	namespace, forceNamespace := ctx.Value(StorageGetContentNamespace).(string)
+
+	if forceReponame || forceNamespace {
+		// Layout description is a private information inside the docker/distribution. So we support
+		// the layout of a particular version and hardcode it.
+		// Supported path: /docker/registry/v2/repositories/<name>/...
+		if !strings.HasPrefix(path, "/docker/registry/v2/") {
+			return nil, fmt.Errorf("Unsupported filesystem layout: %q", path)
+		}
+
+		pathParts := strings.Split(path, "/")
+
+		if pathParts[4] == "repositories" {
+			if forceNamespace {
+				pathParts[5] = namespace
+			}
+			if forceReponame {
+				pathParts[6] = reponame
+			}
+			path = strings.Join(pathParts, "/")
+		}
+	}
+
+	return s.StorageDriver.GetContent(ctx, path)
+}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -128,6 +128,48 @@ echo "[INFO] Pushed ruby-22-centos7"
 oc import-image --confirm --from=mysql:latest mysql:pullthrough
 docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough
 
+# verify we can pull from tagged image (using tag)
+echo "[INFO] Removing ruby-22-centos7 images before next pull"
+imageid=$(docker images | grep centos/ruby-22-centos7 | awk '{ print $3 }')
+
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7:latest to the same image stream and pulling it"
+os::cmd::expect_success "oc tag ruby-22-centos7:latest ruby-22-centos7:new-tag"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/cache/ruby-22-centos7:new-tag"
+echo "[INFO] The same image stream pull successful"
+
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7:latest to cross repository and pulling it"
+os::cmd::expect_success "oc tag ruby-22-centos7:latest cross:repo-pull"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/cache/cross:repo-pull"
+echo "[INFO] Cross repository pull successful"
+
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7:latest to cross namespace and pulling it"
+os::cmd::expect_success "oc tag cache/ruby-22-centos7:latest cross:namespace-pull -n custom"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull"
+echo "[INFO] Cross namespace pull successful"
+
+# verify we can pull from tagged image (using imageid)
+tagid=$(oc get istag ruby-22-centos7:latest --template={{.image.metadata.name}})
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7@${tagid} to the same image stream and pulling it"
+os::cmd::expect_success "oc tag ruby-22-centos7@${tagid} ruby-22-centos7:new-id-tag"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/cache/ruby-22-centos7:new-id-tag"
+echo "[INFO] The same image stream pull successful"
+
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7@${tagid} to cross repository and pulling it"
+os::cmd::expect_success "oc tag ruby-22-centos7@${tagid} cross:repo-pull-id"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/cache/cross:repo-pull-id"
+echo "[INFO] Cross repository pull successful"
+
+os::cmd::expect_success "docker rmi -f ${imageid}"
+echo "[INFO] Tagging ruby-22-centos7@${tagid} to cross namespace and pulling it"
+os::cmd::expect_success "oc tag cache/ruby-22-centos7@${tagid} cross:namespace-pull-id -n custom"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id"
+echo "[INFO] Cross namespace pull successful"
+
 # check to make sure an image-pusher can push an image
 os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher pusher'
 os::cmd::expect_success 'oc login -u pusher -p pass'


### PR DESCRIPTION
We create another middleware in order to be able to access to other repositories
without need for external queries. The name of new repository is passed through
the context.

We can't get access to the another repository from blob store wrapper. The whole generation of the paths is hidden in the linkedBlobStore (docker/distribution). All requests to blobs occur through this layer. So we can't avoid working with links.

We can leave the linkedBlobStore in peace and inject middleware after it. In this case, we have the ability to redirect requests to another repository on the filesystem.

More info #7792 

@miminar @pweil- @soltysh @liggitt @smarterclayton please review.