### PR TITLE
Add the openshift/origin-egress-router image

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -104,6 +104,7 @@ image openshift/origin                       images/origin
 image openshift/origin-haproxy-router        images/router/haproxy
 image openshift/origin-keepalived-ipfailover images/ipfailover/keepalived
 image openshift/origin-docker-registry       images/dockerregistry
+image openshift/origin-egress-router         images/router/egress
 # images that depend on openshift/origin
 image openshift/origin-deployer              images/deployer
 image openshift/origin-recycler              images/recycler

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -49,6 +49,7 @@ images=(
   openshift/origin-sti-builder
   openshift/origin-haproxy-router
   openshift/origin-f5-router
+  openshift/origin-egress-router
   openshift/origin-recycler
   openshift/origin-gitserver
   openshift/hello-openshift

--- a/images/router/egress/Dockerfile
+++ b/images/router/egress/Dockerfile
@@ -1,0 +1,10 @@
+#
+# This is the egress router for OpenShift Origin
+#
+# The standard name for this image is openshift/origin-egress-router
+
+FROM openshift/origin-base
+
+ADD egress-router.sh /bin/egress-router.sh
+
+ENTRYPOINT /bin/egress-router.sh

--- a/images/router/egress/README.md
+++ b/images/router/egress/README.md
@@ -1,0 +1,90 @@
+# OpenShift Egress Router
+
+The OpenShift egress router runs a service that redirects traffic to a
+specified remote server, using a private source IP address which is
+not used for anything else. This can be used to allow pods to talk to
+servers that are set up to only allow access from whitelisted IP
+addresses.
+
+## Deploying the egress router pod
+
+The Pod definition for an egress router will look something like this:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-1
+  labels:
+    name: egress-1
+  annotations:
+    pod.network.openshift.io/assign-macvlan: true
+spec:
+  containers:
+  - name: egress-router
+    image: openshift/origin-egress-router
+    securityContext:
+      privileged: true
+    env:
+    - name: EGRESS_SOURCE
+      value: 192.168.12.99
+    - name: EGRESS_GATEWAY
+      value: 192.168.12.1
+    - name: EGRESS_DESTINATION
+      value: 203.0.113.25
+  nodeSelector:
+    site: springfield-1
+```
+
+The `pod.network.openshift.io/assign-macvlan` annotation tells
+OpenShift to create a macvlan network interface on the primary network
+interface, and then move it into the pod's network namespace before
+starting the egress-router container.
+
+The pod contains a single container, using the
+`openshift/origin-egress-router` image, and that container is run
+privileged so that it can configure the macvlan interface and set up
+iptables rules.
+
+The environment variables tell the egress-router image what addresses
+to use; it will configure the macvlan interface to use `EGRESS_SOURCE`
+as its IP address, with `EGRESS_GATEWAY` as its gateway. (The
+EGRESS_SOURCE is an IP address on the node subnet reserved by the
+cluster administrator for use by this pod. The EGRESS_GATEWAY is the
+same as the default gateway used by the node itself.). It will then
+set up NAT rules so that connections to any TCP or UDP port on the
+pod's cluster IP address will be redirected to the same port on
+`EGRESS_DESTINATION`. In this example, connections to the pod will be
+redirected to **203.0.113.25**, with a source IP address of
+**192.168.12.99**.
+
+If only some of the nodes in your cluster are capable of claiming the
+specified source IP address and using the specified gateway, you can
+specify a `nodeName` or `nodeSelector` indicating which nodes are
+acceptable. In this example, the pod will only be deployed to nodes
+with the label **site: springfield-1**.
+
+## Deploying an egress router service
+
+Though not strictly necessary, you will normally want to create a
+service pointing to the egress router:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: egress-1
+spec:
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443
+  type: ClusterIP
+  selector:
+    name: egress-1
+```
+
+Your pods can now connect to this service, and their connections will
+be redirected to the corresponding ports on the external server, using
+the reserved egress IP address.

--- a/images/router/egress/egress-router.sh
+++ b/images/router/egress/egress-router.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -ex
+
+if [ -z "${EGRESS_SOURCE}" ]; then
+    echo "No EGRESS_SOURCE specified"
+    exit 1
+fi
+if [ -z "${EGRESS_DESTINATION}" ]; then
+    echo "No EGRESS_DESTINATION specified"
+    exit 1
+fi
+if [ -z "${EGRESS_GATEWAY}" ]; then
+    echo "No EGRESS_GATEWAY specified"
+    exit 1
+fi
+
+# The pod may die and get restarted; only try to add the
+# address/route/rules if they are not already there.
+if ! ip route get ${EGRESS_DESTINATION} | grep -q macvlan0; then
+    ip addr add ${EGRESS_SOURCE}/32 dev macvlan0
+    ip link set up dev macvlan0
+    ip route add ${EGRESS_GATEWAY}/32 dev macvlan0
+    ip route add ${EGRESS_DESTINATION}/32 via ${EGRESS_GATEWAY} dev macvlan0
+
+    iptables -t nat -A PREROUTING -i eth0 -j DNAT --to-destination ${EGRESS_DESTINATION}
+    iptables -t nat -A POSTROUTING -j SNAT --to-source ${EGRESS_SOURCE}
+fi
+
+# Update neighbor ARP caches in case another node previously had the IP. (This is
+# the same code ifup uses.)
+arping -q -A -c 1 -I macvlan0 ${EGRESS_SOURCE}
+( sleep 2;
+  arping -q -U -c 1 -I macvlan0 ${EGRESS_SOURCE} || true ) > /dev/null 2>&1 < /dev/null &
+
+# Now we just wait until we are killed...
+#
+# Kubernetes will use SIGTERM to kill us, but bash ignores SIGTERM by
+# default in interactive shells, and it thinks this shell is
+# interactive due to the way in which docker invokes it. We can get
+# bash to react to SIGTERM if we explicitly set a trap for it, except
+# that bash doesn't process signal traps while it is waiting for a
+# process to finish, and we have to be waiting for a process to finish
+# because there's no way to sleep forever within bash.
+#
+# Fortunately, signal traps do interrupt the "wait" builtin. So...
+# set up a SIGTERM trap, run a command that sleeps forever *in the
+# background*, and then wait for either the command to finish or the
+# signal to arrive.
+
+trap "exit" TERM
+tail -f /dev/null &
+wait
+
+# We don't have to do any cleanup because deleting the network
+# namespace will clean everything up for us.


### PR DESCRIPTION
This adds an "egress router" image which can be used, along with the feature added by https://github.com/openshift/openshift-sdn/pull/271, to connect to an external IP from a pod using a fixed source IP address. (https://trello.com/c/3mQOsCBm)

@openshift/networking @smarterclayton 
