### PR TITLE
Add the ability to configure an HAPROXY router to send log messages to a syslog address

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -8,6 +8,9 @@
 global
   # maxconn 4096
   daemon
+{{ with (env "ROUTER_SYSLOG_ADDRESS" "") }}
+  log {{.}} local1 {{env "ROUTER_LOG_LEVEL" "warning"}}
+{{ end}}
   ca-base /etc/ssl
   crt-base /etc/ssl
   stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
@@ -32,6 +35,10 @@ global
 defaults
   # maxconn 4096
   # Add x-forwarded-for header.
+{{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
+  option httplog
+  log global
+{{ end }}
   timeout connect 5s
   timeout client 30s
   timeout server 30s
@@ -220,6 +227,9 @@ backend be_edge_http_{{$cfgIdx}}
 
             {{ if eq $cfg.TLSTermination "passthrough" }}
 backend be_tcp_{{$cfgIdx}}
+{{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
+  option tcplog
+{{ end }}
   balance source
   hash-type consistent
   timeout check 5000ms


### PR DESCRIPTION

Using two environment variables:
ROUTER_SYSLOG_ADDRESS
ROUTER_LOG_LEVEL

configure an HAProxy router pod  for logging frontend and backend requests received/sent by the HAProxy
router over udp. Can pass the enviroment variables to a running router
via

  $ oadm router ...
  $ oc env dc/router ROUTER_SYSLOG_ADDRESS=<address>  #  address == ip[:port]

if not given a port HAProxy uses 514 as default