### PR TITLE
elevate privilegs when removing etcd binary store

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -30,7 +30,7 @@ function cleanup()
     echo
 
     # we keep a JSON dump of etcd data so we do not need to keep the binary store
-    rm -rf "${ETCD_DATA_DIR}"
+    sudo rm -rf "${ETCD_DATA_DIR}"
 
     if [ $out -ne 0 ]; then
         echo "[FAIL] !!!!! Test Failed !!!!"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -565,7 +565,7 @@ function cleanup_openshift {
 		fi
 
 		echo "[INFO] Pruning etcd data directory..."
-		rm -rf "${ETCD_DATA_DIR}"
+		sudo rm -rf "${ETCD_DATA_DIR}"
 
 		set -u
 	fi


### PR DESCRIPTION
It seems like elevated privileges are necessary to remove the entirety of the etcd binary store, as can be seen in the output of tests for #8341 

@danmcp PTAL