### PR TITLE
remove old double escape validation

### DIFF
--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -126,28 +126,7 @@ func validateTLS(route *routeapi.Route, fldPath *field.Path) field.ErrorList {
 		result = append(result, err)
 	}
 
-	result = append(result, validateNoDoubleEscapes(tls)...)
 	return result
-}
-
-// validateNoDoubleEscapes ensures double escaped newlines are not in the certificates.  Double
-// escaped newlines may be a remnant of old code which used to replace them for the user unnecessarily.
-// TODO this is a temporary validation to reject any of our examples with double slashes.  Remove this quickly.
-func validateNoDoubleEscapes(tls *routeapi.TLSConfig) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if strings.Contains(tls.CACertificate, "\\n") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("caCertificate"), tls.CACertificate, `double escaped new lines (\\n) are invalid`))
-	}
-	if strings.Contains(tls.Certificate, "\\n") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("certificate"), tls.Certificate, `double escaped new lines (\\n) are invalid`))
-	}
-	if strings.Contains(tls.Key, "\\n") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("key"), tls.Key, `double escaped new lines (\\n) are invalid`))
-	}
-	if strings.Contains(tls.DestinationCACertificate, "\\n") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("destinationCACertificate"), tls.DestinationCACertificate, `double escaped new lines (\\n) are invalid`))
-	}
-	return allErrs
 }
 
 // validateInsecureEdgeTerminationPolicy tests fields for different types of

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -392,21 +392,6 @@ func TestValidateTLS(t *testing.T) {
 			},
 			expectedErrors: 1,
 		},
-		{
-			name: "Double escaped newlines",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
-						Certificate:              "d\\nef",
-						Key:                      "g\\nhi",
-						CACertificate:            "j\\nkl",
-						DestinationCACertificate: "j\\nkl",
-					},
-				},
-			},
-			expectedErrors: 4,
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/2441

@liggitt - enough time has passed, ok with removing this now?