### PR TITLE
cite potential builds for oc status missing input streams

### DIFF
--- a/pkg/api/graph/graph.go
+++ b/pkg/api/graph/graph.go
@@ -41,8 +41,12 @@ func (n UniqueName) UniqueName() string {
 	return string(n)
 }
 
+func (n UniqueName) String() string {
+	return string(n)
+}
+
 type uniqueNamer interface {
-	UniqueName() string
+	UniqueName() UniqueName
 }
 
 type NodeFinder interface {
@@ -122,7 +126,7 @@ var DefaultNamer Namer = namer{}
 func (namer) ResourceName(obj interface{}) string {
 	switch t := obj.(type) {
 	case uniqueNamer:
-		return t.UniqueName()
+		return t.UniqueName().String()
 	default:
 		return reflect.TypeOf(obj).String()
 	}
@@ -562,7 +566,7 @@ func (g typedGraph) Name(node graph.Node) string {
 	case fmt.Stringer:
 		return t.String()
 	case uniqueNamer:
-		return t.UniqueName()
+		return t.UniqueName().String()
 	default:
 		return fmt.Sprintf("<unknown:%d>", node.ID())
 	}

--- a/pkg/api/graph/test/prereq-image-present-notag.yaml
+++ b/pkg/api/graph/test/prereq-image-present-notag.yaml
@@ -7,11 +7,13 @@ items:
     labels:
       app: ruby
     name: ruby-hello-world
+    namespace: openshift
   spec:
     output:
       to:
         kind: ImageStreamTag
         name: ruby-hello-world:latest
+        namespace: openshift
     resources: {}
     source:
       git:
@@ -21,6 +23,39 @@ items:
       dockerStrategy:
         from:
           kind: ImageStreamTag
+          name: ruby-20-centos7:latest
+          namespace: openshift
+      type: Docker
+    triggers:
+    - github:
+        secret: LyddbeCAaw1a0x08xz9n
+      type: GitHub
+    - generic:
+        secret: ZnYJJeEvo1ri0Gk0f6YY
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-20-centos7:latest
+        namespace: openshift
+    resources: {}
+    source: {}
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerReference
           name: ruby-20-centos7:latest
           namespace: openshift
       type: Docker
@@ -117,7 +152,7 @@ items:
         kind: ImageStreamTag
         name: test2:latest
     resources: {}
-    source:
+    source: 
       git:
         uri: https://github.com/openshift/origin
       type: Git
@@ -160,7 +195,7 @@ items:
       sourceStrategy:
         from:
           kind: ImageStream
-          name: ruby-20-centos7
+          name: test3-base
           namespace: openshift
       type: Docker
     triggers:

--- a/pkg/build/graph/analysis/bc_test.go
+++ b/pkg/build/graph/analysis/bc_test.go
@@ -1,6 +1,7 @@
 package analysis
 
 import (
+	"strings"
 	"testing"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
@@ -106,10 +107,33 @@ func TestImageStreamTagMissing(t *testing.T) {
 		t.Fatalf("expected %v, got %v", e, a)
 	}
 
+	var actualImportOrBuild, actualImportOnly, actualSpecificHex int
+	expectedImportOrBuild := 2
+	expectedImportOnly := 1
+	expectedSpecificHex := 1
 	for _, marker := range markers {
 		if got, expected1, expected2 := marker.Key, MissingImageStreamImageWarning, MissingImageStreamTagWarning; got != expected1 && got != expected2 {
 			t.Fatalf("expected marker key %q or %q, got %q", expected1, expected2, got)
+		} else {
+			if strings.Contains(marker.Suggestion.String(), "oc start-build") {
+				actualImportOrBuild++
+			}
+			if strings.Contains(marker.Suggestion.String(), "needs to be imported.") {
+				actualImportOnly++
+			}
+			if strings.Contains(marker.Suggestion.String(), "hexadecimal ID") {
+				actualSpecificHex++
+			}
 		}
+	}
+	if actualImportOnly != expectedImportOnly {
+		t.Fatalf("expected %d import only suggestions but got %d", expectedImportOnly, actualImportOnly)
+	}
+	if actualImportOrBuild != expectedImportOrBuild {
+		t.Fatalf("expected %d import or build suggestions but got %d", expectedImportOrBuild, actualImportOrBuild)
+	}
+	if actualSpecificHex != expectedSpecificHex {
+		t.Fatalf("expected %d import specific image suggestions but got %d", expectedSpecificHex, actualSpecificHex)
 	}
 }
 

--- a/pkg/build/graph/nodes/types.go
+++ b/pkg/build/graph/nodes/types.go
@@ -33,6 +33,10 @@ func (n BuildConfigNode) String() string {
 	return string(BuildConfigNodeName(n.BuildConfig))
 }
 
+func (n BuildConfigNode) UniqueName() osgraph.UniqueName {
+	return BuildConfigNodeName(n.BuildConfig)
+}
+
 func (*BuildConfigNode) Kind() string {
 	return BuildConfigNodeKind
 }
@@ -75,6 +79,10 @@ func (n BuildNode) Object() interface{} {
 
 func (n BuildNode) String() string {
 	return string(BuildNodeName(n.Build))
+}
+
+func (n BuildNode) UniqueName() osgraph.UniqueName {
+	return BuildNodeName(n.Build)
 }
 
 func (*BuildNode) Kind() string {

--- a/pkg/image/graph/nodes/types.go
+++ b/pkg/image/graph/nodes/types.go
@@ -42,6 +42,10 @@ func (n ImageStreamNode) String() string {
 	return string(ImageStreamNodeName(n.ImageStream))
 }
 
+func (n ImageStreamNode) UniqueName() osgraph.UniqueName {
+	return ImageStreamNodeName(n.ImageStream)
+}
+
 func (*ImageStreamNode) Kind() string {
 	return ImageStreamNodeKind
 }
@@ -79,6 +83,10 @@ func (n ImageStreamTagNode) String() string {
 	return string(ImageStreamTagNodeName(n.ImageStreamTag))
 }
 
+func (n ImageStreamTagNode) UniqueName() osgraph.UniqueName {
+	return ImageStreamTagNodeName(n.ImageStreamTag)
+}
+
 func (*ImageStreamTagNode) Kind() string {
 	return ImageStreamTagNodeKind
 }
@@ -104,6 +112,10 @@ func (n ImageStreamImageNode) String() string {
 
 func (n ImageStreamImageNode) ResourceString() string {
 	return "isimage/" + n.Name
+}
+
+func (n ImageStreamImageNode) UniqueName() osgraph.UniqueName {
+	return ImageStreamImageNodeName(n.ImageStreamImage)
 }
 
 func (*ImageStreamImageNode) Kind() string {
@@ -135,6 +147,10 @@ func (*DockerImageRepositoryNode) Kind() string {
 	return DockerRepositoryNodeKind
 }
 
+func (n DockerImageRepositoryNode) UniqueName() osgraph.UniqueName {
+	return DockerImageRepositoryNodeName(n.Ref)
+}
+
 func ImageNodeName(o *imageapi.Image) osgraph.UniqueName {
 	return osgraph.GetUniqueRuntimeObjectNodeName(ImageNodeKind, o)
 }
@@ -150,6 +166,10 @@ func (n ImageNode) Object() interface{} {
 
 func (n ImageNode) String() string {
 	return string(ImageNodeName(n.Image))
+}
+
+func (n ImageNode) UniqueName() osgraph.UniqueName {
+	return ImageNodeName(n.Image)
 }
 
 func (*ImageNode) Kind() string {

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -358,7 +358,7 @@ func addImageStreamsToGraph(g graph.Graph, streams *imageapi.ImageStreamList, al
 					continue
 				}
 
-				glog.V(4).Infof("Adding edge (kind=%s) from %q to %q", kind, imageStreamNode.UniqueName.UniqueName(), imageNode.UniqueName.UniqueName())
+				glog.V(4).Infof("Adding edge (kind=%s) from %q to %q", kind, imageStreamNode.UniqueName(), imageNode.UniqueName())
 				g.AddEdge(imageStreamNode, imageNode, kind)
 
 				glog.V(4).Infof("Adding stream->layer references")


### PR DESCRIPTION
Fixes #7822 

@bparees @kargakis @deads2k PTAL if you get the chance.

@bparees I'll try to mark this milestone 1.2.x but I suspect I won't have permission to do so.

quick FYI, in addition to the items noted in the associated issue, my unit testing found a problem with the uniqueNamer / UniqueName code and getting that code executed by the name ResourceName() code instead of using the default reflection code.

Note - I decided to only modify the code to search the output of other BuildConfig's to modify the suggestion for missing inputs to BuildConfigs.

I'm deferring (again, and moving forward pending further evolution of this component) on the other item in this issue:  adding an edge between a ImageStreamImageNode and the corresponding DockerImageRepositoryNode.  My rational simply stems from the additional code cost (DockerImageRepositoryNode exists as a type in the code but not as a node in the graph that is built today) vs. the small amount of code needed to iterate over a single image streams tags.