### PR TITLE
[WIP] Add support for route config validation

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -6,6 +6,7 @@
 FROM openshift/origin-haproxy-router-base
 
 ADD conf/ /var/lib/haproxy/conf/
+ADD validate-config /var/lib/haproxy/validate-config
 ADD reload-haproxy /var/lib/haproxy/reload-haproxy
 ADD bin/openshift /usr/bin/openshift
 
@@ -22,5 +23,6 @@ WORKDIR /var/lib/haproxy/conf
 
 EXPOSE 80
 ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
-    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy \
+    VALIDATE_SCRIPT=/var/lib/haproxy/validate-config
 ENTRYPOINT ["/usr/bin/openshift-router"]

--- a/images/router/haproxy/validate-config
+++ b/images/router/haproxy/validate-config
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o nounset
+
+config_file=${1:-"/var/lib/haproxy/conf/haproxy.config"}
+
+# Exit code is used to make a determination if the given config is good or
+# not. So ensure that we exit with the status of the haproxy -c command.
+haproxy -c -f "$config_file"
+exit $?

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -72,6 +72,8 @@ type RouteIngressConditionType string
 const (
 	// RouteAdmitted means the route is able to service requests for the provided Host
 	RouteAdmitted RouteIngressConditionType = "Admitted"
+	// RouteConfigError means the route configuration is invalid
+	RouteConfigError RouteIngressConditionType = "ConfigError"
 	// TODO: add other route condition types
 )
 

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -167,7 +167,13 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 			}
 		}
 		p.routeToHost[routeName] = host
-		return p.plugin.HandleRoute(eventType, route)
+		err := p.plugin.HandleRoute(eventType, route)
+		if err != nil {
+			glog.V(4).Infof("Route %s config error for host %s, recording rejection: %s",
+				routeName, host, err)
+			p.recorder.RecordRouteRejection(route, "RouteConfigError", err.Error())
+		}
+		return err
 
 	case watch.Deleted:
 		glog.V(4).Infof("Deleting routes for %s", key)

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -73,7 +73,7 @@ func (r *TestRouter) DeleteEndpoints(id string) {
 }
 
 // AddRoute adds a ServiceAliasConfig for the route to the ServiceUnit identified by id
-func (r *TestRouter) AddRoute(id string, route *routeapi.Route, host string) bool {
+func (r *TestRouter) AddRoute(id string, route *routeapi.Route, host string, skipValidation bool) bool {
 	r.Committed = false //expect any call to this method to subsequently call commit
 	su, _ := r.FindServiceUnit(id)
 	routeKey := r.routeKey(route)
@@ -83,6 +83,7 @@ func (r *TestRouter) AddRoute(id string, route *routeapi.Route, host string) boo
 		Path: route.Spec.Path,
 	}
 
+	//  TODO: add test for validation + skip validation
 	su.ServiceAliasConfigs[routeKey] = config
 	r.State[id] = su
 	return true

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -258,10 +258,10 @@ func TestRouteKey(t *testing.T) {
 			},
 		}
 
-		// add route always returns true
-		added := router.AddRoute(suKey, route, route.Spec.Host)
-		if !added {
-			t.Fatalf("expected AddRoute to return true but got false")
+		// add route always returns no error if we skip the validation
+		err := router.AddRoute(suKey, route, route.Spec.Host, true)
+		if err != nil {
+			t.Fatalf("expected AddRoute to return no error but got %s", err)
 		}
 
 		routeKey := router.routeKey(route)
@@ -302,10 +302,10 @@ func TestAddRoute(t *testing.T) {
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
-	// add route always returns true
-	added := router.AddRoute(suKey, route, route.Spec.Host)
-	if !added {
-		t.Fatalf("expected AddRoute to return true but got false")
+	// add route always returns no error if we skip the validation
+	err := router.AddRoute(suKey, route, route.Spec.Host, true)
+	if err != nil {
+		t.Fatalf("expected AddRoute to return no error but got %s", err)
 	}
 
 	su, ok := router.FindServiceUnit(suKey)
@@ -383,8 +383,8 @@ func TestRemoveRoute(t *testing.T) {
 	suKey := "test"
 
 	router.CreateServiceUnit(suKey)
-	router.AddRoute(suKey, route, route.Spec.Host)
-	router.AddRoute(suKey, route2, route2.Spec.Host)
+	router.AddRoute(suKey, route, route.Spec.Host, true)
+	router.AddRoute(suKey, route2, route2.Spec.Host, true)
 
 	su, ok := router.FindServiceUnit(suKey)
 	if !ok {
@@ -575,7 +575,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 	router.CreateServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
 
 	// add the route with the bad service name, it should add fine
-	router.AddRoute(routeWithBadServiceKey, routeWithBadService, routeWithBadService.Spec.Host)
+	router.AddRoute(routeWithBadServiceKey, routeWithBadService, routeWithBadService.Spec.Host, true)
 	route, ok := router.FindServiceUnit(routeWithBadServiceKey)
 
 	if !ok {
@@ -588,7 +588,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 
 	// now add the same route with a modified service name, it should exists under the new service
 	// and no longer exist under the old service
-	router.AddRoute(routeWithGoodServiceKey, routeWithGoodService, routeWithGoodService.Spec.Host)
+	router.AddRoute(routeWithGoodServiceKey, routeWithGoodService, routeWithGoodService.Spec.Host, true)
 	route, ok = router.FindServiceUnit(routeWithGoodServiceKey)
 	if !ok {
 		t.Fatalf("unable to find route %s after adding", routeWithGoodServiceKey)
@@ -608,7 +608,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 	}
 
 	// add a route with the same name but under a different namespace.
-	router.AddRoute(routeWithGoodServiceDifferentNamespaceKey, routeWithGoodServiceDifferentNamespace, routeWithGoodServiceDifferentNamespace.Spec.Host)
+	router.AddRoute(routeWithGoodServiceDifferentNamespaceKey, routeWithGoodServiceDifferentNamespace, routeWithGoodServiceDifferentNamespace.Spec.Host, true)
 	route, ok = router.FindServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
 	if !ok {
 		t.Fatalf("unable to find route %s after adding", routeWithGoodServiceDifferentNamespaceKey)
@@ -682,10 +682,10 @@ func TestAddRouteEdgeTerminationInsecurePolicy(t *testing.T) {
 		suKey := fmt.Sprintf("%s-test", tc.Name)
 		router.CreateServiceUnit(suKey)
 
-		// add route always returns true
-		added := router.AddRoute(suKey, route, route.Spec.Host)
-		if !added {
-			t.Fatalf("InsecureEdgeTerminationPolicy test %s: expected AddRoute to return true but got false", tc.Name)
+		// add route always returns no error if we skip the validation
+		err := router.AddRoute(suKey, route, route.Spec.Host, true)
+		if err != nil {
+			t.Fatalf("InsecureEdgeTerminationPolicy test %s: expected AddRoute to return no error but got %s", tc.Name, err)
 		}
 
 		su, ok := router.FindServiceUnit(suKey)

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -15,6 +15,8 @@ type ServiceUnit struct {
 	EndpointTable []Endpoint
 	// ServiceAliasConfigs is a collection of unique routes that support this service, keyed by host + path
 	ServiceAliasConfigs map[string]ServiceAliasConfig
+	// InvalidServiceAliasConfigs is a collection of unique routes that support this service, keyed by host + path that have configuration errors.
+	InvalidServiceAliasConfigs map[string]ServiceAliasConfig
 }
 
 // ServiceAliasConfig is a route for a service.  Uniquely identified by host + path.


### PR DESCRIPTION
Add an option VALIDATE_ROUTES (or `--validate-routes`) to support validating configuration generated for routes. If a route has invalid TLS configuration - fails validation, then we don't add the route to the service alias config and so don't generate the template config for that route. 
Work in progress - still needs tests but @smarterclayton  can you verify this is a good start.  Thx