### PR TITLE
scoped tokens

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/deep_copy_generated.go
@@ -147,6 +147,19 @@ func DeepCopy_authorization_SubjectAccessReviewSpec(in SubjectAccessReviewSpec, 
 	} else {
 		out.Groups = nil
 	}
+	if in.Extra != nil {
+		in, out := in.Extra, &out.Extra
+		*out = make(map[string][]string)
+		for key, val := range in {
+			if newVal, err := c.DeepCopy(val); err != nil {
+				return err
+			} else {
+				(*out)[key] = newVal.([]string)
+			}
+		}
+	} else {
+		out.Extra = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/types.go
@@ -101,6 +101,9 @@ type SubjectAccessReviewSpec struct {
 	User string
 	// Groups is the groups you're testing for.
 	Groups []string
+	// Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer
+	// it needs a reflection here.
+	Extra map[string][]string
 }
 
 // SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAttributes

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/deep_copy_generated.go
@@ -147,6 +147,19 @@ func DeepCopy_v1beta1_SubjectAccessReviewSpec(in SubjectAccessReviewSpec, out *S
 	} else {
 		out.Groups = nil
 	}
+	if in.Extra != nil {
+		in, out := in.Extra, &out.Extra
+		*out = make(map[string][]string)
+		for key, val := range in {
+			if newVal, err := c.DeepCopy(val); err != nil {
+				return err
+			} else {
+				(*out)[key] = newVal.([]string)
+			}
+		}
+	} else {
+		out.Extra = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/types.go
@@ -100,6 +100,9 @@ type SubjectAccessReviewSpec struct {
 	User string `json:"user,omitempty"`
 	// Groups is the groups you're testing for.
 	Groups []string `json:"group,omitempty"`
+	// Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer
+	// it needs a reflection here.
+	Extra map[string][]string `json:"extra,omitempty"`
 }
 
 // SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/authorization/v1beta1/types_swagger_doc_generated.go
@@ -98,6 +98,7 @@ var map_SubjectAccessReviewSpec = map[string]string{
 	"nonResourceAttributes": "NonResourceAttributes describes information for a non-resource access request",
 	"user":                  "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
 	"group":                 "Groups is the groups you're testing for.",
+	"extra":                 "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
 }
 
 func (SubjectAccessReviewSpec) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/user/user.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/user/user.go
@@ -27,6 +27,16 @@ type Info interface {
 	GetUID() string
 	// GetGroups returns the names of the groups the user is a member of
 	GetGroups() []string
+
+	// GetExtra can contain any additional information that the authenticator
+	// thought was interesting.  One example would be scopes on a token.
+	// Keys in this map should be namespaced to the authenticator or
+	// authenticator/authorizer pair making use of them.
+	// For instance: "example.org/foo" instead of "foo"
+	// This is a map[string][]string because it needs to be serializeable into
+	// a SubjectAccessReviewSpec.authorization.k8s.io for proper authorization
+	// delegation flows
+	GetExtra() map[string][]string
 }
 
 // DefaultInfo provides a simple user information exchange object
@@ -35,6 +45,7 @@ type DefaultInfo struct {
 	Name   string
 	UID    string
 	Groups []string
+	Extra  map[string][]string
 }
 
 func (i *DefaultInfo) GetName() string {
@@ -47,4 +58,8 @@ func (i *DefaultInfo) GetUID() string {
 
 func (i *DefaultInfo) GetGroups() []string {
 	return i.Groups
+}
+
+func (i *DefaultInfo) GetExtra() map[string][]string {
+	return i.Extra
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/integration/service_account_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/integration/service_account_test.go
@@ -355,7 +355,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	// 2. A ServiceAccountToken authenticator that validates ServiceAccount tokens
 	rootTokenAuth := authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
 		if token == rootToken {
-			return &user.DefaultInfo{rootUserName, "", []string{}}, true, nil
+			return &user.DefaultInfo{Name: rootUserName}, true, nil
 		}
 		return nil, false, nil
 	})

--- a/pkg/auth/group/group_adder.go
+++ b/pkg/auth/group/group_adder.go
@@ -22,6 +22,7 @@ func (g *GroupAdder) AuthenticateRequest(req *http.Request) (user.Info, bool, er
 		Name:   u.GetName(),
 		UID:    u.GetUID(),
 		Groups: append(u.GetGroups(), g.Groups...),
+		Extra:  u.GetExtra(),
 	}, true, nil
 }
 

--- a/pkg/auth/oauth/registry/tokenauthenticator.go
+++ b/pkg/auth/oauth/registry/tokenauthenticator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/auth/userregistry/identitymapper"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/user/registry/user"
 	"k8s.io/kubernetes/pkg/api"
@@ -61,5 +62,8 @@ func (a *TokenAuthenticator) AuthenticateToken(value string) (kuser.Info, bool, 
 		Name:   u.Name,
 		UID:    string(u.UID),
 		Groups: groupNames,
+		Extra: map[string][]string{
+			authorizationapi.ScopesKey: token.Scopes,
+		},
 	}, true, nil
 }

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -22,6 +22,9 @@ const (
 	VerbAll        = "*"
 	NonResourceAll = "*"
 
+	ScopesKey           = "authorization.openshift.io/scopes"
+	ScopesAllNamespaces = "*"
+
 	UserKind           = "User"
 	GroupKind          = "Group"
 	ServiceAccountKind = "ServiceAccount"
@@ -109,6 +112,21 @@ var (
 		NonEscalatingResourcesGroupName: {OpenshiftNonEscalatingViewableGroupName, KubeNonEscalatingViewableGroupName},
 	}
 )
+
+// DiscoveryRule is a rule that allows a client to discover the API resources available on this server
+var DiscoveryRule = PolicyRule{
+	Verbs: sets.NewString("get"),
+	NonResourceURLs: sets.NewString(
+		// Server version checking
+		"/version",
+
+		// API discovery/negotiation
+		"/api", "/api/*",
+		"/apis", "/apis/*",
+		"/oapi", "/oapi/*",
+		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
+	),
+}
 
 func init() {
 	// set the non-escalating groups

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -19,7 +19,7 @@ func NewAuthorizer(ruleResolver rulevalidation.AuthorizationRuleResolver, forbid
 }
 
 func (a *openshiftAuthorizer) Authorize(ctx kapi.Context, passedAttributes AuthorizationAttributes) (bool, string, error) {
-	attributes := coerceToDefaultAuthorizationAttributes(passedAttributes)
+	attributes := CoerceToDefaultAuthorizationAttributes(passedAttributes)
 
 	// keep track of errors in case we are unable to authorize the action.
 	// It is entirely possible to get an error and be able to continue determine authorization status in spite of it.
@@ -88,7 +88,7 @@ func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes Au
 }
 
 func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.Context, passedAttributes AuthorizationAttributes) (sets.String, sets.String, error) {
-	attributes := coerceToDefaultAuthorizationAttributes(passedAttributes)
+	attributes := CoerceToDefaultAuthorizationAttributes(passedAttributes)
 
 	errs := []error{}
 
@@ -130,7 +130,7 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 // but errors are not always fatal to the authorization process.  It is entirely possible to get an error and be able to continue determine authorization
 // status in spite of it.  This is most common when a bound role is missing, but enough roles are still present and bound to authorize the request.
 func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, passedAttributes AuthorizationAttributes) (bool, string, error) {
-	attributes := coerceToDefaultAuthorizationAttributes(passedAttributes)
+	attributes := CoerceToDefaultAuthorizationAttributes(passedAttributes)
 
 	allRules, ruleRetrievalError := a.ruleResolver.GetEffectivePolicyRules(ctx)
 
@@ -153,7 +153,7 @@ func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, pass
 
 // TODO this may or may not be the behavior we want for managing rules.  As a for instance, a verb might be specified
 // that our attributes builder will never satisfy.  For now, I think gets us close.  Maybe a warning message of some kind?
-func coerceToDefaultAuthorizationAttributes(passedAttributes AuthorizationAttributes) *DefaultAuthorizationAttributes {
+func CoerceToDefaultAuthorizationAttributes(passedAttributes AuthorizationAttributes) *DefaultAuthorizationAttributes {
 	attributes, ok := passedAttributes.(*DefaultAuthorizationAttributes)
 	if !ok {
 		attributes = &DefaultAuthorizationAttributes{

--- a/pkg/authorization/authorizer/scope/authorizer.go
+++ b/pkg/authorization/authorizer/scope/authorizer.go
@@ -1,0 +1,65 @@
+package scope
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	defaultauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+)
+
+type scopeAuthorizer struct {
+	delegate            defaultauthorizer.Authorizer
+	clusterPolicyGetter rulevalidation.ClusterPolicyGetter
+}
+
+func NewAuthorizer(delegate defaultauthorizer.Authorizer, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) defaultauthorizer.Authorizer {
+	return &scopeAuthorizer{delegate: delegate, clusterPolicyGetter: clusterPolicyGetter}
+}
+
+func (a *scopeAuthorizer) Authorize(ctx kapi.Context, passedAttributes defaultauthorizer.AuthorizationAttributes) (bool, string, error) {
+	user, exists := kapi.UserFrom(ctx)
+	if !exists {
+		return false, "", fmt.Errorf("user missing from context")
+	}
+
+	scopes := user.GetExtra()[authorizationapi.ScopesKey]
+	if len(scopes) == 0 {
+		return a.delegate.Authorize(ctx, passedAttributes)
+	}
+
+	nonFatalErrors := []error{}
+
+	namespace, _ := kapi.NamespaceFrom(ctx)
+	// scopeResolutionErrors aren't fatal.  If any of the scopes we find allow this, then the overall scope limits allow it
+	rules, err := ScopesToRules(scopes, namespace, a.clusterPolicyGetter)
+	if err != nil {
+		nonFatalErrors = append(nonFatalErrors, err)
+	}
+
+	attributes := defaultauthorizer.CoerceToDefaultAuthorizationAttributes(passedAttributes)
+
+	for _, rule := range rules {
+		// check rule against attributes
+		matches, err := attributes.RuleMatches(rule)
+		if err != nil {
+			nonFatalErrors = append(nonFatalErrors, err)
+			continue
+		}
+		if matches {
+			return a.delegate.Authorize(ctx, passedAttributes)
+		}
+	}
+
+	return false, fmt.Sprintf("scopes %v, do not allow this action", scopes), kerrors.NewAggregate(nonFatalErrors)
+}
+
+// TODO remove this. We don't logically need it, but it requires splitting our interface
+// GetAllowedSubjects returns the subjects it knows can perform the action.
+func (a *scopeAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes defaultauthorizer.AuthorizationAttributes) (sets.String, sets.String, error) {
+	return a.delegate.GetAllowedSubjects(ctx, attributes)
+}

--- a/pkg/authorization/authorizer/scope/authorizer_test.go
+++ b/pkg/authorization/authorizer/scope/authorizer_test.go
@@ -1,0 +1,122 @@
+package scope
+
+import (
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	defaultauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+func TestAuthorize(t *testing.T) {
+	testCases := []struct {
+		name                string
+		user                user.Info
+		attributes          defaultauthorizer.DefaultAuthorizationAttributes
+		delegateAuthAllowed bool
+		expectedCalled      bool
+		expectedAllowed     bool
+		expectedErr         string
+		expectedMsg         string
+	}{
+		{
+			name:        "no user",
+			expectedErr: `user missing from context`,
+		},
+		{
+			name:           "no extra",
+			user:           &user.DefaultInfo{},
+			expectedCalled: true,
+		},
+		{
+			name:           "empty extra",
+			user:           &user.DefaultInfo{Extra: map[string][]string{}},
+			expectedCalled: true,
+		},
+		{
+			name:           "empty scopes",
+			user:           &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {}}},
+			expectedCalled: true,
+		},
+		{
+			name:        "bad scope",
+			user:        &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"does-not-exist"}}},
+			expectedMsg: `scopes [does-not-exist], do not allow this action`,
+			expectedErr: `no scope evaluator found for "does-not-exist"`,
+		},
+		{
+			name:        "bad scope 2",
+			user:        &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:dne"}}},
+			expectedMsg: `scopes [user:dne], do not allow this action`,
+			expectedErr: `unrecognized scope: user:dne`,
+		},
+		{
+			name:        "scope doesn't cover",
+			user:        &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:info"}}},
+			expectedMsg: `scopes [user:info], do not allow this action`,
+		},
+		{
+			name:           "scope covers",
+			user:           &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:info"}}},
+			attributes:     defaultauthorizer.DefaultAuthorizationAttributes{Verb: "get", Resource: "users", ResourceName: "~"},
+			expectedCalled: true,
+		},
+		{
+			name:           "scope covers for discovery",
+			user:           &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:info"}}},
+			attributes:     defaultauthorizer.DefaultAuthorizationAttributes{Verb: "get", NonResourceURL: true, URL: "/api"},
+			expectedCalled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		delegate := &fakeAuthorizer{allowed: tc.delegateAuthAllowed}
+		authorizer := NewAuthorizer(delegate, nil)
+
+		ctx := kapi.WithNamespace(kapi.NewContext(), "ns")
+		if tc.user != nil {
+			ctx = kapi.WithUser(ctx, tc.user)
+
+		}
+
+		actualAllowed, actualMsg, actualErr := authorizer.Authorize(ctx, tc.attributes)
+		switch {
+		case len(tc.expectedErr) == 0 && actualErr == nil:
+		case len(tc.expectedErr) == 0 && actualErr != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case len(tc.expectedErr) != 0 && actualErr == nil:
+			t.Errorf("%s: missing error: %v", tc.name, tc.expectedErr)
+		case len(tc.expectedErr) != 0 && actualErr != nil:
+			if !strings.Contains(actualErr.Error(), tc.expectedErr) {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedErr, actualErr)
+			}
+		}
+		if tc.expectedMsg != actualMsg {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedMsg, actualMsg)
+		}
+		if tc.expectedAllowed != actualAllowed {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedAllowed, actualAllowed)
+		}
+		if tc.expectedCalled != delegate.called {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedCalled, delegate.called)
+		}
+	}
+}
+
+type fakeAuthorizer struct {
+	allowed bool
+	called  bool
+}
+
+func (a *fakeAuthorizer) Authorize(ctx kapi.Context, passedAttributes defaultauthorizer.AuthorizationAttributes) (bool, string, error) {
+	a.called = true
+	return a.allowed, "", nil
+}
+
+func (a *fakeAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes defaultauthorizer.AuthorizationAttributes) (sets.String, sets.String, error) {
+	return nil, nil, nil
+}

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -1,0 +1,129 @@
+package scope
+
+import (
+	"fmt"
+	"strings"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+// ScopesToRules takes the scopes and return the rules back.  We ALWAYS add the discovery rules and it is possible to get some rules and and
+// an error since errors aren't fatal to evaluation
+func ScopesToRules(scopes []string, namespace string, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) ([]authorizationapi.PolicyRule, error) {
+	rules := append([]authorizationapi.PolicyRule{}, authorizationapi.DiscoveryRule)
+
+	errors := []error{}
+	for _, scope := range scopes {
+		found := false
+
+		for prefix, evaluator := range scopeEvaluators {
+			if strings.HasPrefix(scope, prefix) {
+				found = true
+				currRules, err := evaluator(scope, namespace, clusterPolicyGetter)
+				if err != nil {
+					errors = append(errors, err)
+					continue
+				}
+
+				rules = append(rules, currRules...)
+			}
+		}
+
+		if !found {
+			errors = append(errors, fmt.Errorf("no scope evaluator found for %q", scope))
+		}
+	}
+
+	return rules, kutilerrors.NewAggregate(errors)
+}
+
+const (
+	UserIndicator          = "user:"
+	ClusterRoleIndicator   = "role:"
+	ClusterWideIndicator   = "clusterwide:"
+	NamespaceWideIndicator = "namespace:"
+)
+
+// scopeEvaluator takes a scope and returns the rules that express it
+type scopeEvaluator func(scope, namespace string, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) ([]authorizationapi.PolicyRule, error)
+
+// scopeEvaluators map prefixes to a function that handles that prefix
+var scopeEvaluators = map[string]scopeEvaluator{
+	UserIndicator:        userEvaluator,
+	ClusterRoleIndicator: clusterRoleEvaluator,
+}
+
+// scopes are in the format
+// <indicator><indicator choice>
+// we have the following formats:
+// user:<scope name>
+// role:<clusterrole name>:<namespace to allow the cluster role, * means all>
+// TODO
+// cluster:<comma-delimited verbs>:<comma-delimited resources>
+// namespace:<namespace name>:<comma-delimited verbs>:<comma-delimited resources>
+
+const (
+	UserInfo        = "info"
+	UserAccessCheck = "check-access"
+)
+
+// user:<scope name>
+func userEvaluator(scope, namespace string, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) ([]authorizationapi.PolicyRule, error) {
+	switch scope {
+	case UserIndicator + UserInfo:
+		return []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("get"), APIGroups: []string{userapi.GroupName}, Resources: sets.NewString("users"), ResourceNames: sets.NewString("~")},
+		}, nil
+	case UserIndicator + UserAccessCheck:
+		return []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unrecognized scope: %v", scope)
+	}
+}
+
+// role:<clusterrole name>:<namespace to allow the cluster role, * means all>
+func clusterRoleEvaluator(scope, namespace string, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) ([]authorizationapi.PolicyRule, error) {
+	tokens := strings.SplitN(scope, ":", 2)
+	if len(tokens) != 2 {
+		return nil, fmt.Errorf("bad format for scope %v", scope)
+	}
+
+	// namespaces can't have colons, but roles can.  pick last.
+	lastColonIndex := strings.LastIndex(tokens[1], ":")
+	if lastColonIndex <= 0 || lastColonIndex == (len(tokens[1])-1) {
+		return nil, fmt.Errorf("bad format for scope %v", scope)
+	}
+	roleName := tokens[1][0:lastColonIndex]
+	scopeNamespace := tokens[1][lastColonIndex+1:]
+
+	// if the scope limit on the clusterrole doesn't match, then don't add any rules, but its not an error
+	if !(scopeNamespace == authorizationapi.ScopesAllNamespaces || scopeNamespace == namespace) {
+		return []authorizationapi.PolicyRule{}, nil
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	policy, err := clusterPolicyGetter.GetClusterPolicy(ctx, "default")
+	if err != nil {
+		return nil, err
+	}
+	role, exists := policy.Roles[roleName]
+	if !exists {
+		return nil, kapierrors.NewNotFound(authorizationapi.Resource("clusterrole"), roleName)
+	}
+
+	rules := []authorizationapi.PolicyRule{}
+	for _, rule := range role.Rules {
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
+}

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -1,0 +1,211 @@
+package scope
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func TestUserEvaluator(t *testing.T) {
+	testCases := []struct {
+		name     string
+		scopes   []string
+		err      string
+		numRules int
+	}{
+		{
+			name:     "missing-part",
+			scopes:   []string{UserIndicator},
+			err:      "unrecognized scope",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name:     "bad-part",
+			scopes:   []string{UserIndicator + "foo"},
+			err:      "unrecognized scope",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name:     "info",
+			scopes:   []string{UserIndicator + UserInfo},
+			numRules: 2,
+		},
+		{
+			name:     "one-error",
+			scopes:   []string{UserIndicator, UserIndicator + UserInfo},
+			err:      "unrecognized scope",
+			numRules: 2,
+		},
+		{
+			name:     "access",
+			scopes:   []string{UserIndicator + UserAccessCheck},
+			numRules: 2,
+		},
+		{
+			name:     "both",
+			scopes:   []string{UserIndicator + UserInfo, UserIndicator + UserAccessCheck},
+			numRules: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		actualRules, actualErr := ScopesToRules(tc.scopes, "namespace", nil)
+		switch {
+		case len(tc.err) == 0 && actualErr == nil:
+		case len(tc.err) == 0 && actualErr != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case len(tc.err) != 0 && actualErr == nil:
+			t.Errorf("%s: missing error: %v", tc.name, tc.err)
+		case len(tc.err) != 0 && actualErr != nil:
+			if !strings.Contains(actualErr.Error(), tc.err) {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+			}
+		}
+
+		if len(actualRules) != tc.numRules {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.numRules, len(actualRules))
+		}
+	}
+}
+
+func TestClusterRoleEvaluator(t *testing.T) {
+	testCases := []struct {
+		name            string
+		scopes          []string
+		namespace       string
+		clusterRoles    []authorizationapi.ClusterRole
+		policyGetterErr error
+		numRules        int
+		err             string
+	}{
+		{
+			name:     "bad-format-1",
+			scopes:   []string{ClusterRoleIndicator},
+			err:      "bad format for",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name:     "bad-format-2",
+			scopes:   []string{ClusterRoleIndicator + "foo"},
+			err:      "bad format for",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name:     "bad-format-3",
+			scopes:   []string{ClusterRoleIndicator + ":ns"},
+			err:      "bad format for",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name:     "bad-format-4",
+			scopes:   []string{ClusterRoleIndicator + "foo:"},
+			err:      "bad format for",
+			numRules: 1, // we always add the discovery rules
+		},
+		{
+			name: "missing-role",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin"},
+					Rules:      []authorizationapi.PolicyRule{{}},
+				},
+			},
+			scopes:   []string{ClusterRoleIndicator + "missing:*"},
+			err:      `clusterrole "missing" not found`,
+			numRules: 1,
+		},
+		{
+			name: "mismatched-namespace",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin"},
+					Rules:      []authorizationapi.PolicyRule{{}},
+				},
+			},
+			namespace: "current-ns",
+			scopes:    []string{ClusterRoleIndicator + "admin:mismatch"},
+			numRules:  1,
+		},
+		{
+			name: "all-namespaces",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin"},
+					Rules:      []authorizationapi.PolicyRule{{}},
+				},
+			},
+			namespace: "current-ns",
+			scopes:    []string{ClusterRoleIndicator + "admin:*"},
+			numRules:  2,
+		},
+		{
+			name: "matching-namespaces",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin"},
+					Rules:      []authorizationapi.PolicyRule{{}},
+				},
+			},
+			namespace: "current-ns",
+			scopes:    []string{ClusterRoleIndicator + "admin:current-ns"},
+			numRules:  2,
+		},
+		{
+			name: "colon-role",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin:two"},
+					Rules:      []authorizationapi.PolicyRule{{}},
+				},
+			},
+			namespace: "current-ns",
+			scopes:    []string{ClusterRoleIndicator + "admin:two:current-ns"},
+			numRules:  2,
+		},
+		{
+			name:            "getter-error",
+			policyGetterErr: fmt.Errorf("some bad thing happened"),
+			namespace:       "current-ns",
+			scopes:          []string{ClusterRoleIndicator + "admin:two:current-ns"},
+			err:             `some bad thing happened`,
+			numRules:        1,
+		},
+	}
+
+	for _, tc := range testCases {
+		actualRules, actualErr := ScopesToRules(tc.scopes, tc.namespace, &fakePolicyGetter{clusterRoles: tc.clusterRoles, err: tc.policyGetterErr})
+		switch {
+		case len(tc.err) == 0 && actualErr == nil:
+		case len(tc.err) == 0 && actualErr != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+		case len(tc.err) != 0 && actualErr == nil:
+			t.Errorf("%s: missing error: %v", tc.name, tc.err)
+		case len(tc.err) != 0 && actualErr != nil:
+			if !strings.Contains(actualErr.Error(), tc.err) {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.err, actualErr)
+			}
+		}
+
+		if len(actualRules) != tc.numRules {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.numRules, len(actualRules))
+		}
+	}
+}
+
+type fakePolicyGetter struct {
+	clusterRoles []authorizationapi.ClusterRole
+	err          error
+}
+
+func (f *fakePolicyGetter) GetClusterPolicy(ctx kapi.Context, id string) (*authorizationapi.ClusterPolicy, error) {
+	ret := &authorizationapi.ClusterPolicy{}
+	ret.Roles = map[string]*authorizationapi.ClusterRole{}
+	for i := range f.clusterRoles {
+		ret.Roles[f.clusterRoles[i].Name] = &f.clusterRoles[i]
+	}
+	return ret, f.err
+}

--- a/pkg/client/oauthaccesstoken.go
+++ b/pkg/client/oauthaccesstoken.go
@@ -1,5 +1,9 @@
 package client
 
+import (
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+)
+
 // OAuthAccessTokensInterface has methods to work with OAuthAccessTokens resources in a namespace
 type OAuthAccessTokensInterface interface {
 	OAuthAccessTokens() OAuthAccessTokenInterface
@@ -7,6 +11,7 @@ type OAuthAccessTokensInterface interface {
 
 // OAuthAccessTokenInterface exposes methods on OAuthAccessTokens resources.
 type OAuthAccessTokenInterface interface {
+	Create(token *oauthapi.OAuthAccessToken) (*oauthapi.OAuthAccessToken, error)
 	Delete(name string) error
 }
 
@@ -23,5 +28,11 @@ func newOAuthAccessTokens(c *Client) *oauthAccessTokenInterface {
 // Delete removes the OAuthAccessToken on server
 func (c *oauthAccessTokenInterface) Delete(name string) (err error) {
 	err = c.r.Delete().Resource("oAuthAccessTokens").Name(name).Do().Error()
+	return
+}
+
+func (c *oauthAccessTokenInterface) Create(token *oauthapi.OAuthAccessToken) (result *oauthapi.OAuthAccessToken, err error) {
+	result = &oauthapi.OAuthAccessToken{}
+	err = c.r.Post().Resource("oAuthAccessTokens").Body(token).Do().Into(result)
 	return
 }

--- a/pkg/client/testclient/fake_oauthaccesstoken.go
+++ b/pkg/client/testclient/fake_oauthaccesstoken.go
@@ -16,3 +16,12 @@ func (c *FakeOAuthAccessTokens) Delete(name string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("oauthaccesstokens", name), &oauthapi.OAuthAccessToken{})
 	return err
 }
+
+func (c *FakeOAuthAccessTokens) Create(inObj *oauthapi.OAuthAccessToken) (*oauthapi.OAuthAccessToken, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("oauthaccesstokens", inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*oauthapi.OAuthAccessToken), err
+}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -47,6 +47,7 @@ func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Ro
 	return roles
 
 }
+
 func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 	roles := []authorizationapi.ClusterRole{
 		{
@@ -358,17 +359,9 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					NonResourceURLs: sets.NewString(
 						// Health
 						"/healthz", "/healthz/*",
-
-						// Server version checking
-						"/version",
-
-						// API discovery/negotiation
-						"/api", "/api/*",
-						"/apis", "/apis/*",
-						"/oapi", "/oapi/*",
-						"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
 					),
 				},
+				authorizationapi.DiscoveryRule,
 			},
 		},
 		{
@@ -747,19 +740,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: DiscoveryRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs: sets.NewString("get"),
-					NonResourceURLs: sets.NewString(
-						// Server version checking
-						"/version",
-
-						// API discovery/negotiation
-						"/api", "/api/*",
-						"/apis", "/apis/*",
-						"/oapi", "/oapi/*",
-						"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
-					),
-				},
+				authorizationapi.DiscoveryRule,
 			},
 		},
 

--- a/pkg/image/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/registry/imagestream/etcd/etcd_test.go
@@ -194,6 +194,10 @@ func (u *fakeUser) GetGroups() []string {
 	return []string{"group1"}
 }
 
+func (u *fakeUser) GetExtra() map[string][]string {
+	return map[string][]string{}
+}
+
 // func TestCreateImageStreamOK(t *testing.T) {
 // 	_, helper := newStorage(t)
 // 	storage, _, _ := NewREST(helper, noDefaultRegistry, &fakeSubjectAccessReviewRegistry{})

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -33,6 +33,10 @@ func (u *fakeUser) GetGroups() []string {
 	return []string{"group1"}
 }
 
+func (u *fakeUser) GetExtra() map[string][]string {
+	return map[string][]string{}
+}
+
 type fakeDefaultRegistry struct {
 	registry string
 }

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -57,6 +57,10 @@ func (u *fakeUser) GetGroups() []string {
 	return []string{"group1"}
 }
 
+func (u *fakeUser) GetExtra() map[string][]string {
+	return map[string][]string{}
+}
+
 func setup(t *testing.T) (etcd.KeysAPI, *etcdtesting.EtcdTestServer, *REST) {
 
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -736,12 +736,18 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     nonResourceURLs:
+    - /healthz
+    - /healthz/*
+    resources: []
+    verbs:
+    - get
+  - apiGroups: null
+    attributeRestrictions: null
+    nonResourceURLs:
     - /api
     - /api/*
     - /apis
     - /apis/*
-    - /healthz
-    - /healthz/*
     - /oapi
     - /oapi/*
     - /osapi

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -1,0 +1,94 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestScopedTokens(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	projectName := "hammer-project"
+	userName := "harold"
+	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := haroldClient.Builds(projectName).List(kapi.ListOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	haroldUser, err := haroldClient.Users().Get("~")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	whoamiOnlyToken := &oauthapi.OAuthAccessToken{
+		ObjectMeta: kapi.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
+		ClientName: "any-client",
+		ExpiresIn:  200,
+		Scopes:     []string{scope.UserIndicator + scope.UserInfo},
+		UserName:   userName,
+		UserUID:    string(haroldUser.UID),
+	}
+	if _, err := clusterAdminClient.OAuthAccessTokens().Create(whoamiOnlyToken); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	whoamiConfig := clientcmd.AnonymousClientConfig(clusterAdminClientConfig)
+	whoamiConfig.BearerToken = whoamiOnlyToken.Name
+	whoamiClient, err := client.New(&whoamiConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := whoamiClient.Builds(projectName).List(kapi.ListOptions{}); !kapierrors.IsForbidden(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	user, err := whoamiClient.Users().Get("~")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.Name != userName {
+		t.Fatalf("expected %v, got %v", userName, user.Name)
+	}
+
+	// try to impersonate a service account using this token
+	whoamiConfig.Impersonate = serviceaccount.MakeUsername(projectName, "default")
+	impersonatingClient, err := client.New(&whoamiConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	impersonatedUser, err := impersonatingClient.Users().Get("~")
+	if !kapierrors.IsForbidden(err) {
+		t.Fatalf("missing error: %v got user %#v", err, impersonatedUser)
+	}
+}


### PR DESCRIPTION
This demonstrates how scopes could be attached to a user token and then filtered by an authorizer that wraps our existing authorizer.  It creates: 
 1. `special:whoami` - call users/~ to prove identity
 2. `special:access-check` - call self-SARs to check access of the user (not the token)
 3. `clusterrole:<clusterrole name>:<namespace to allow the cluster role, * means all>` - allows access based on cluster role rules, but only within the specified namespace.  (I might make that a comma-delimited list.)

If we like the general approach, I can finish off the list:
 - [x] unit tests
 - [x] integration tests that create scoped tokens

And do the followups:
 - [x] make SARs scope aware https://trello.com/c/o0pWuPmd/698-5-auth-scopes-scoped-access-checks-sars-tsars
 - [x] make TSARs for checking a token https://trello.com/c/o0pWuPmd/698-5-auth-scopes-scoped-access-checks-sars-tsars
 - [ ] add the other two scope types (namespace-wide and cluster-wide explicit)

 - [x] tighten clusterrole/role name validation to the set of characters allowed in scope names? may not be possible... failing validation on one role would prevent the entire policy from being persisted  Won't do this, but the scope validation prevents people from using them in a scope.  If you want a scope for it, rename your role.
 - [x] expand scope evaluator interface to provide human descriptions for scopes (used in grant flow) https://github.com/openshift/origin/pull/8807
 - [x] expand scope evaluator interface to provide validation (used when requesting scopes or validating a user-created token) https://github.com/openshift/origin/pull/8805
 - [ ] prevent escalating resources from being included by default:
remove *, secrets, oauthtokens, oauthauthorizationtokens, etc
 - [ ] decide how a scope that grants a role including escalating resources would be specified

@pweil- @liggitt @smarterclayton 
@jwforres @jimmidyson @stefwalter you guys knew people who were looking to get openshift API tokens to perform actions for a user, right?