### PR TITLE
Ensure stable route admission

### DIFF
--- a/pkg/route/api/helper.go
+++ b/pkg/route/api/helper.go
@@ -15,3 +15,16 @@ func IngressConditionStatus(ingress *RouteIngress, t RouteIngressConditionType) 
 	}
 	return kapi.ConditionUnknown, RouteIngressCondition{}
 }
+
+func RouteLessThan(route1, route2 *Route) bool {
+	if route1.CreationTimestamp.Before(route2.CreationTimestamp) {
+		return true
+	}
+	if route1.CreationTimestamp == route2.CreationTimestamp && route1.UID < route2.UID {
+		return true
+	}
+	if route1.Namespace < route2.Namespace {
+		return true
+	}
+	return route1.Name < route2.Name
+}

--- a/pkg/route/api/helper_test.go
+++ b/pkg/route/api/helper_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+func TestRouteLessThan(t *testing.T) {
+	r := Route{
+		ObjectMeta: kapi.ObjectMeta{
+			CreationTimestamp: unversioned.Now().Rfc3339Copy(),
+			UID:               "alpha",
+			Namespace:         "alpha",
+			Name:              "alpha",
+		},
+	}
+	tcs := []struct {
+		r        Route
+		expected bool
+	}{
+		{Route{
+			ObjectMeta: kapi.ObjectMeta{
+				CreationTimestamp: unversioned.Time{
+					Time: r.CreationTimestamp.Add(time.Minute),
+				},
+			},
+		}, true},
+		{Route{
+			ObjectMeta: kapi.ObjectMeta{
+				CreationTimestamp: r.CreationTimestamp,
+				UID:               "beta",
+			},
+		}, true},
+		{Route{
+			ObjectMeta: kapi.ObjectMeta{
+				CreationTimestamp: r.CreationTimestamp,
+				UID:               r.UID,
+				Namespace:         "beta",
+			},
+		}, true},
+		{Route{
+			ObjectMeta: kapi.ObjectMeta{
+				CreationTimestamp: r.CreationTimestamp,
+				UID:               r.UID,
+				Namespace:         r.Namespace,
+				Name:              "beta",
+			},
+		}, true},
+		{r, false},
+	}
+
+	for _, tc := range tcs {
+		if RouteLessThan(&r, &tc.r) != tc.expected {
+			var msg string
+			if tc.expected {
+				msg = "Expected %v to be less than %v"
+			} else {
+				msg = "Expected %v to not be less than %v"
+			}
+			t.Errorf(msg, r, tc.r)
+		}
+	}
+}

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -173,13 +173,7 @@ type routeAge []routeapi.Route
 func (r routeAge) Len() int      { return len(r) }
 func (r routeAge) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r routeAge) Less(i, j int) bool {
-	if r[i].CreationTimestamp.Before(r[j].CreationTimestamp) {
-		return true
-	}
-	if r[i].Namespace < r[j].Namespace {
-		return true
-	}
-	return r[i].Name < r[j].Name
+	return routeapi.RouteLessThan(&r[i], &r[j])
 }
 
 func oldestRoute(routes []interface{}) *routeapi.Route {

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -114,7 +114,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 			added := false
 			for i := range old {
 				if old[i].Spec.Path == route.Spec.Path {
-					if old[i].CreationTimestamp.Before(route.CreationTimestamp) {
+					if routeapi.RouteLessThan(old[i], route) {
 						glog.V(4).Infof("Route %s cannot take %s from %s", routeName, host, routeNameKey(oldest))
 						err := fmt.Errorf("route %s already exposes %s and is older", oldest.Name, host)
 						p.recorder.RecordRouteRejection(route, "HostAlreadyClaimed", err.Error())
@@ -132,14 +132,14 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 				}
 			}
 			if !added {
-				if route.CreationTimestamp.Before(oldest.CreationTimestamp) {
+				if routeapi.RouteLessThan(route, oldest) {
 					p.hostToRoute[host] = append([]*routeapi.Route{route}, old...)
 				} else {
 					p.hostToRoute[host] = append(old, route)
 				}
 			}
 		} else {
-			if oldest.CreationTimestamp.Before(route.CreationTimestamp) {
+			if routeapi.RouteLessThan(oldest, route) {
 				glog.V(4).Infof("Route %s cannot take %s from %s", routeName, host, routeNameKey(oldest))
 				err := fmt.Errorf("a route in another namespace holds %s and is older than %s", host, route.Name)
 				p.recorder.RecordRouteRejection(route, "HostAlreadyClaimed", err.Error())


### PR DESCRIPTION
Route ordering for the purposes of admission was previously based on the
route creation timestamp, which is only accurate to the second.  For
routes created in the same second, admission order would depend on the
arbitrary ordering of the List operation.  This change ensures that if
timestamps are equal, a comparison is made of the routes' uid to ensure
a stable ordering.