### PR TITLE
handle readonly files and system:admin kubeconfigs in oc login

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -348,6 +348,7 @@ _oc_login()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--force")
     flags+=("--password=")
     two_word_flags+=("-p")
     flags+=("--username=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -3897,6 +3897,7 @@ _openshift_cli_login()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--force")
     flags+=("--password=")
     two_word_flags+=("-p")
     flags+=("--username=")

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -60,6 +60,7 @@ type LoginOptions struct {
 	Token string
 
 	PathOptions *kcmdconfig.PathOptions
+	Force       bool
 }
 
 // Gather all required information in a comprehensive order.

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -104,7 +104,6 @@ os::cmd::expect_success "dig @${API_HOST} docker-registry.default.local. A"
 # Client setup (log in as e2e-user and set 'test' as the default project)
 # This is required to be able to push to the registry!
 echo "[INFO] Logging in as a regular user (e2e-user:pass) with project 'test'..."
-os::cmd::expect_success 'oc login -u e2e-user -p pass'
 os::cmd::expect_success_and_text 'oc whoami' 'e2e-user'
 
 # make sure viewers can see oc status
@@ -130,7 +129,7 @@ docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough
 
 # check to make sure an image-pusher can push an image
 os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher pusher'
-os::cmd::expect_success 'oc login -u pusher -p pass'
+os::cmd::expect_success 'oc login --force -u pusher -p pass'
 pusher_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
 os::cmd::expect_success_and_text "echo ${pusher_token}" '.+'
 
@@ -160,7 +159,7 @@ os::cmd::expect_success "oc process -n docker -f examples/sample-app/application
 os::cmd::expect_success "oc process -n custom -f examples/sample-app/application-template-custombuild.json > '${CUSTOM_CONFIG_FILE}'"
 
 echo "[INFO] Back to 'test' context with 'e2e-user' user"
-os::cmd::expect_success 'oc login -u e2e-user'
+os::cmd::expect_success 'oc login --force -u e2e-user'
 os::cmd::expect_success 'oc project test'
 os::cmd::expect_success 'oc whoami'
 
@@ -352,7 +351,7 @@ os::cmd::expect_success "oc exec -p ${registry_pod} du /registry > '${LOG_DIR}/p
 
 # set up pruner user
 os::cmd::expect_success 'oadm policy add-cluster-role-to-user system:image-pruner e2e-pruner'
-os::cmd::expect_success 'oc login -u e2e-pruner -p pass'
+os::cmd::expect_success 'oc login --force -u e2e-pruner -p pass'
 
 # run image pruning
 os::cmd::expect_success "oadm prune images --keep-younger-than=0 --keep-tag-revisions=1 --confirm &> '${LOG_DIR}/prune-images.log'"


### PR DESCRIPTION
Adds a check that stops people from messing with admin.kubeconfig unless they mean it.  Also does a short-circuit check on pre-existing read-only config files being used. 

Adds a `--force` flag for people who really want to try to login anyways, even though in one case it will likely fail and in the other it will like screw them over.

@stevekuznetsov @legionus ptal.