### PR TITLE
deployment controller: cancel deployers on new cancelled deployments

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -62,7 +62,7 @@ func LabelForDeployment(deployment *api.ReplicationController) string {
 
 // LabelForDeploymentConfig builds a string identifier for a DeploymentConfig.
 func LabelForDeploymentConfig(config *deployapi.DeploymentConfig) string {
-	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.Status.LatestVersion)
+	return fmt.Sprintf("%s/%s", config.Namespace, config.Name)
 }
 
 // DeploymentNameForConfigVersion returns the name of the version-th deployment


### PR DESCRIPTION
Deployer pods may stay around due to an unavailable node and get scheduled
after a cancelled deployment has been transitioned from New to Failed.

Found out in https://github.com/openshift/origin/issues/8403

@pweil- @smarterclayton @ironcladlou 