### PR TITLE
Add flag to disable dynamic provisioning

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -132,13 +132,19 @@ type NodeConfig struct {
 	IPTablesSyncPeriod string
 
 	// VolumeConfig contains options for configuring volumes on the node.
-	VolumeConfig VolumeConfig
+	VolumeConfig NodeVolumeConfig
 }
 
-// VolumeConfig contains options for configuring volumes on the node.
-type VolumeConfig struct {
+// NodeVolumeConfig contains options for configuring volumes on the node.
+type NodeVolumeConfig struct {
 	// LocalQuota contains options for controlling local volume quota on the node.
 	LocalQuota LocalQuota
+}
+
+// MasterVolumeConfig contains options for configuring volume plugins in the master node.
+type MasterVolumeConfig struct {
+	// DynamicProvisioningEnabled is a boolean that toggles dynamic provisioning off when false, defaults to true
+	DynamicProvisioningEnabled bool
 }
 
 // LocalQuota contains options for controlling local volume quota on the node.
@@ -279,6 +285,9 @@ type MasterConfig struct {
 
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig MasterNetworkConfig
+
+	// VolumeConfig contains options for configuring volumes on the node.
+	VolumeConfig MasterVolumeConfig
 }
 
 type ImagePolicyConfig struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -307,6 +307,15 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 			out.Location = in.Location
 			return nil
 		},
+		func(in *MasterVolumeConfig, out *internal.MasterVolumeConfig, s conversion.Scope) error {
+			out.DynamicProvisioningEnabled = (in.DynamicProvisioningEnabled == nil) || (*in.DynamicProvisioningEnabled)
+			return nil
+		},
+		func(in *internal.MasterVolumeConfig, out *MasterVolumeConfig, s conversion.Scope) error {
+			enabled := in.DynamicProvisioningEnabled
+			out.DynamicProvisioningEnabled = &enabled
+			return nil
+		},
 		api.Convert_resource_Quantity_To_resource_Quantity,
 	)
 	if err != nil {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -408,6 +408,7 @@ var map_MasterConfig = map[string]string{
 	"projectConfig":          "ProjectConfig holds information about project creation and defaults",
 	"routingConfig":          "RoutingConfig holds information about routing and route generation",
 	"networkConfig":          "NetworkConfig to be passed to the compiled in network plugin",
+	"volumeConfig":           "MasterVolumeConfig contains options for configuring volume plugins in the master node.",
 }
 
 func (MasterConfig) SwaggerDoc() map[string]string {
@@ -425,6 +426,15 @@ var map_MasterNetworkConfig = map[string]string{
 
 func (MasterNetworkConfig) SwaggerDoc() map[string]string {
 	return map_MasterNetworkConfig
+}
+
+var map_MasterVolumeConfig = map[string]string{
+	"": "MasterVolumeConfig contains options for configuring volume plugins in the master node.",
+	"dynamicProvisioningEnabled": "DynamicProvisioningEnabled is a boolean that toggles dynamic provisioning off when false, defaults to true",
+}
+
+func (MasterVolumeConfig) SwaggerDoc() map[string]string {
+	return map_MasterVolumeConfig
 }
 
 var map_NamedCertificate = map[string]string{
@@ -482,6 +492,15 @@ var map_NodeNetworkConfig = map[string]string{
 
 func (NodeNetworkConfig) SwaggerDoc() map[string]string {
 	return map_NodeNetworkConfig
+}
+
+var map_NodeVolumeConfig = map[string]string{
+	"":           "NodeVolumeConfig contains options for configuring volumes on the node.",
+	"localQuota": "LocalQuota contains options for controlling local volume quota on the node.",
+}
+
+func (NodeVolumeConfig) SwaggerDoc() map[string]string {
+	return map_NodeVolumeConfig
 }
 
 var map_OAuthConfig = map[string]string{
@@ -760,13 +779,4 @@ var map_UserAgentMatchingConfig = map[string]string{
 
 func (UserAgentMatchingConfig) SwaggerDoc() map[string]string {
 	return map_UserAgentMatchingConfig
-}
-
-var map_VolumeConfig = map[string]string{
-	"":           "VolumeConfig contains options for configuring volumes on the node.",
-	"localQuota": "LocalQuota contains options for controlling local volume quota on the node.",
-}
-
-func (VolumeConfig) SwaggerDoc() map[string]string {
-	return map_VolumeConfig
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -71,13 +71,19 @@ type NodeConfig struct {
 	IPTablesSyncPeriod string `json:"iptablesSyncPeriod"`
 
 	// VolumeConfig contains options for configuring volumes on the node.
-	VolumeConfig VolumeConfig `json:"volumeConfig"`
+	VolumeConfig NodeVolumeConfig `json:"volumeConfig"`
 }
 
-// VolumeConfig contains options for configuring volumes on the node.
-type VolumeConfig struct {
+// NodeVolumeConfig contains options for configuring volumes on the node.
+type NodeVolumeConfig struct {
 	// LocalQuota contains options for controlling local volume quota on the node.
 	LocalQuota LocalQuota `json:"localQuota"`
+}
+
+// MasterVolumeConfig contains options for configuring volume plugins in the master node.
+type MasterVolumeConfig struct {
+	// DynamicProvisioningEnabled is a boolean that toggles dynamic provisioning off when false, defaults to true
+	DynamicProvisioningEnabled *bool `json:"dynamicProvisioningEnabled"`
 }
 
 // LocalQuota contains options for controlling local volume quota on the node.
@@ -219,6 +225,9 @@ type MasterConfig struct {
 
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig MasterNetworkConfig `json:"networkConfig"`
+
+	// MasterVolumeConfig contains options for configuring volume plugins in the master node.
+	VolumeConfig MasterVolumeConfig `json:"volumeConfig"`
 }
 
 // ImagePolicyConfig holds the necessary configuration options for limits and behavior for importing images

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -458,6 +458,8 @@ servingInfo:
     keyFile: ""
     names: null
   requestTimeoutSeconds: 0
+volumeConfig:
+  dynamicProvisioningEnabled: false
 `
 )
 
@@ -663,6 +665,9 @@ func TestMasterConfig(t *testing.T) {
 				},
 			},
 			PluginOrderOverride: []string{"plugin"}, // explicitly set this field because it's omitempty
+		},
+		VolumeConfig: internal.MasterVolumeConfig{
+			DynamicProvisioningEnabled: false,
 		},
 	}
 	serializedConfig, err := writeYAML(config)

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -116,7 +116,7 @@ func ValidateKubeletExtendedArguments(config api.ExtendedArguments, fldPath *fie
 	return ValidateExtendedArguments(config, kubeletoptions.NewKubeletServer().AddFlags, fldPath)
 }
 
-func ValidateVolumeConfig(config api.VolumeConfig, fldPath *field.Path) field.ErrorList {
+func ValidateVolumeConfig(config api.NodeVolumeConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if config.LocalQuota.PerFSGroup != nil && config.LocalQuota.PerFSGroup.Value() < 0 {

--- a/pkg/cmd/server/api/validation/node_test.go
+++ b/pkg/cmd/server/api/validation/node_test.go
@@ -66,7 +66,7 @@ func TestFailingKubeletArgs(t *testing.T) {
 func TestInvalidProjectEmptyDirQuota(t *testing.T) {
 	negQuota := resource.MustParse("-1000Mi")
 	nodeCfg := configapi.NodeConfig{
-		VolumeConfig: configapi.VolumeConfig{
+		VolumeConfig: configapi.NodeVolumeConfig{
 			LocalQuota: configapi.LocalQuota{
 				PerFSGroup: &negQuota,
 			},

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -253,6 +253,10 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			HostSubnetLength:   args.NetworkArgs.HostSubnetLength,
 			ServiceNetworkCIDR: args.NetworkArgs.ServiceNetworkCIDR,
 		},
+
+		VolumeConfig: configapi.MasterVolumeConfig{
+			DynamicProvisioningEnabled: true,
+		},
 	}
 
 	if args.ListenArg.UseTLS() {

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -607,7 +607,9 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunEndpointController()
 		kc.RunNamespaceController(namespaceControllerClientSet, namespaceControllerClientPool)
 		kc.RunPersistentVolumeClaimBinder(binderClient)
-		kc.RunPersistentVolumeProvisioner(provisionerClient)
+		if oc.Options.VolumeConfig.DynamicProvisioningEnabled {
+			kc.RunPersistentVolumeProvisioner(provisionerClient)
+		}
 		kc.RunPersistentVolumeClaimRecycler(oc.ImageFor("recycler"), recyclerClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
 		kc.RunGCController(gcClient)
 


### PR DESCRIPTION
1.  Refactor "VolumeConfig" to "NodeVolumeConfig"
2.  Add MasterVolumeConfig w/ boolean to turn off DP
3.  Only start provisioning controller when the flag is true.
4.  Set true by default

OpenShift Online would like to disable the default dynamic provisioning inherent in Kube.  We're implementing our own provisioning controller that will run in a pod on the cluster.

@liggitt @deads2k @ironcladlou @abhgupta 

@smarterclayton approved this new boolean config item.
