### PR TITLE
add oc create policybinding

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -6686,6 +6686,47 @@ _oc_create_route()
     must_have_one_noun=()
 }
 
+_oc_create_policybinding()
+{
+    last_command="oc_create_policybinding"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--api-version=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oc_create()
 {
     last_command="oc_create"
@@ -6695,6 +6736,7 @@ _oc_create()
     commands+=("configmap")
     commands+=("serviceaccount")
     commands+=("route")
+    commands+=("policybinding")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -10235,6 +10235,47 @@ _openshift_cli_create_route()
     must_have_one_noun=()
 }
 
+_openshift_cli_create_policybinding()
+{
+    last_command="openshift_cli_create_policybinding"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--api-version=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_cli_create()
 {
     last_command="openshift_cli_create"
@@ -10244,6 +10285,7 @@ _openshift_cli_create()
     commands+=("configmap")
     commands+=("serviceaccount")
     commands+=("route")
+    commands+=("policybinding")
 
     flags=()
     two_word_flags=()

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -811,6 +811,19 @@ Create a namespace with the specified name.
 ====
 
 
+== oc create policybinding
+Create a policy binding that references the policy in the targetted namespace.
+
+====
+
+[options="nowrap"]
+----
+  # Create a policy binding in namespace "foo" that references the policy in namespace "bar"
+  $ oc create policybinding bar -n foo
+----
+====
+
+
 == oc create route edge
 Create a route that uses edge TLS termination
 

--- a/pkg/cmd/cli/cmd/create/policy_binding.go
+++ b/pkg/cmd/cli/cmd/create/policy_binding.go
@@ -1,0 +1,129 @@
+package create
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	PolicyBindingRecommendedName = "policybinding"
+
+	policyBindingLong = `
+Create a policy binding that references the policy in the targetted namespace.`
+
+	policyBindingExample = `  # Create a policy binding in namespace "foo" that references the policy in namespace "bar"
+  $ %[1]s bar -n foo`
+)
+
+type CreatePolicyBindingOptions struct {
+	BindingNamespace string
+	PolicyNamespace  string
+
+	BindingClient client.PolicyBindingsNamespacer
+
+	Mapper       meta.RESTMapper
+	OutputFormat string
+	Out          io.Writer
+	Printer      ObjectPrinter
+}
+
+type ObjectPrinter func(runtime.Object, io.Writer) error
+
+// NewCmdCreateServiceAccount is a macro command to create a new service account
+func NewCmdCreatePolicyBinding(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	o := &CreatePolicyBindingOptions{Out: out}
+
+	cmd := &cobra.Command{
+		Use:     name + " TARGET_POLICY_NAMESPACE",
+		Short:   "Create a policy binding that references the policy in the targetted namespace.",
+		Long:    policyBindingLong,
+		Example: fmt.Sprintf(policyBindingExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(cmd, f, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+	cmdutil.AddOutputFlagsForMutation(cmd)
+	return cmd
+}
+
+func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("exactly one argument (policy namespace) is supported, not: %v", args)
+	}
+	o.PolicyNamespace = args[0]
+
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	o.BindingNamespace = namespace
+
+	client, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.BindingClient = client
+
+	o.Mapper, _ = f.Object(false)
+	o.OutputFormat = cmdutil.GetFlagString(cmd, "output")
+
+	o.Printer = func(obj runtime.Object, out io.Writer) error {
+		return f.PrintObject(cmd, o.Mapper, obj, out)
+	}
+
+	return nil
+}
+
+func (o *CreatePolicyBindingOptions) Validate() error {
+	if len(o.BindingNamespace) == 0 {
+		return fmt.Errorf("destination namespace is required")
+	}
+	if len(o.PolicyNamespace) == 0 {
+		return fmt.Errorf("referenced policy namespace is required")
+	}
+	if o.BindingClient == nil {
+		return fmt.Errorf("BindingClient is required")
+	}
+	if o.Mapper == nil {
+		return fmt.Errorf("Mapper is required")
+	}
+	if o.Out == nil {
+		return fmt.Errorf("Out is required")
+	}
+	if o.Printer == nil {
+		return fmt.Errorf("Printer is required")
+	}
+
+	return nil
+}
+
+func (o *CreatePolicyBindingOptions) Run() error {
+	binding := &authorizationapi.PolicyBinding{}
+	binding.PolicyRef.Namespace = o.PolicyNamespace
+	binding.PolicyRef.Name = authorizationapi.PolicyName
+	binding.Name = authorizationapi.GetPolicyBindingName(binding.PolicyRef.Namespace)
+
+	actualBinding, err := o.BindingClient.PolicyBindings(o.BindingNamespace).Create(binding)
+	if err != nil {
+		return err
+	}
+
+	if useShortOutput := o.OutputFormat == "name"; useShortOutput || len(o.OutputFormat) == 0 {
+		cmdutil.PrintSuccess(o.Mapper, useShortOutput, o.Out, "policybinding", actualBinding.Name, "created")
+		return nil
+	}
+
+	return o.Printer(actualBinding, o.Out)
+}

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -13,6 +13,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kvalidation "k8s.io/kubernetes/pkg/util/validation"
 
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/create"
 	cmdconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -157,6 +158,7 @@ func NewCmdCreate(parentName string, f *clientcmd.Factory, out io.Writer) *cobra
 
 	// create subcommands
 	cmd.AddCommand(NewCmdCreateRoute(parentName, f, out))
+	cmd.AddCommand(create.NewCmdCreatePolicyBinding(create.PolicyBindingRecommendedName, parentName+" create "+create.PolicyBindingRecommendedName, f, out))
 
 	adjustCmdExamples(cmd, parentName, "create")
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -353,6 +353,25 @@ os::cmd::expect_success_and_not_text 'oc get scc/restricted -o yaml' 'topic: my-
 echo "reconcile-scc: ok"
 os::test::junit::declare_suite_end
 
+
+os::test::junit::declare_suite_start "cmd/admin/policybinding-required"
+# Admin can't bind local roles without cluster-admin permissions
+os::cmd::expect_success "oc create -f test/extended/fixtures/roles/empty-role.yaml -n cmd-admin"
+os::cmd::expect_success "oc delete policybinding/cmd-admin:default -n cmd-admin"
+os::cmd::expect_success 'oadm policy add-role-to-user admin local-admin  -n cmd-admin'
+os::cmd::try_until_text "oc policy who-can get policybindings -n cmd-admin" "local-admin"
+os::cmd::expect_success 'oc login -u local-admin -p pw'
+os::cmd::expect_failure 'oc policy add-role-to-user empty-role other --role-namespace=cmd-admin'
+os::cmd::expect_success 'oc login -u system:admin'
+os::cmd::expect_success "oc create policybinding cmd-admin -n cmd-admin"
+os::cmd::expect_success 'oc login -u local-admin -p pw'
+os::cmd::expect_success 'oc policy add-role-to-user empty-role other --role-namespace=cmd-admin -n cmd-admin'
+os::cmd::expect_success 'oc login -u system:admin'
+os::cmd::expect_success "oc delete role/empty-role -n cmd-admin"
+echo "policybinding-required: ok"
+os::test::junit::declare_suite_end
+
+
 os::test::junit::declare_suite_start "cmd/admin/user-group-cascade"
 # Create test users/identities and groups
 os::cmd::expect_success 'oc login -u cascaded-user -p pw'

--- a/test/extended/fixtures/roles/empty-role.yaml
+++ b/test/extended/fixtures/roles/empty-role.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Role
+metadata:
+  name: empty-role


### PR DESCRIPTION
Adds
```bash
Usage:
  oc create policybinding TARGET_POLICY_NAMESPACE [options]

Examples:
  # Create a policy binding in namespace "foo" that references the policy in namespace "bar"
  $ oc create policybinding bar -n foo
```

This will allow a cluster-admin to easily create a policybinding object to allow a project admin to bind roles that are not `clusterroles`.

@pweil- @miheer @nhr Each of you asked about this in the past 24 hours.  This makes it easier to follow the directions here https://docs.openshift.com/enterprise/3.1/architecture/additional_concepts/authorization.html#roles that describe the policybinding interplay, `"If you find that these roles do not suit you, a cluster-admin user can create a policyBinding object named <projectname>:default with the CLI using a JSON file. This allows the project admin to bind users to roles that are defined only in the <projectname> local policy."`