### PR TITLE
deconflicted dns port for e2e

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -88,7 +88,7 @@ sudo docker run -d --name="origin" \
 	--privileged --net=host --pid=host \
 	-v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
 	-v "${VOLUME_DIR}:${VOLUME_DIR}" -v "${VOLUME_DIR}/etcd":/var/lib/origin/openshift.local.etcd:rw \
-	"openshift/origin:${TAG}" start --loglevel=4 --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}"
+	"openshift/origin:${TAG}" start --loglevel=4 --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}" --dns="tcp://0.0.0.0:8053"
 
 
 # the CA is in the container, log in as a different cluster admin to run the test

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -144,6 +144,7 @@ function start_os_server {
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
 	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start \
+	 --dns="tcp://0.0.0.0:8053" \
 	 --master-config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --node-config=${NODE_CONFIG_DIR}/node-config.yaml \
 	 --loglevel=4 \
@@ -197,6 +198,7 @@ function start_os_master {
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
 	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master \
+	 --dns="tcp://0.0.0.0:8053" \
 	 --config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --loglevel=4 \
 	&>"${LOG_DIR}/openshift.log" &

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -50,7 +50,7 @@ function wait_for_app() {
 
 # service dns entry is visible via master service
 # find the IP of the master service by asking the API_HOST to verify DNS is running there
-MASTER_SERVICE_IP="$(dig @${API_HOST} "kubernetes.default.svc.cluster.local." +short A | head -n 1)"
+MASTER_SERVICE_IP="$(dig @${API_HOST} -p 8053 "kubernetes.default.svc.cluster.local." +short A | head -n 1)"
 # find the IP of the master service again by asking the IP of the master service, to verify port 53 tcp/udp is routed by the service
 os::cmd::expect_success_and_text "dig +tcp @${MASTER_SERVICE_IP} kubernetes.default.svc.cluster.local. +short A | head -n 1" "${MASTER_SERVICE_IP}"
 os::cmd::expect_success_and_text "dig +notcp @${MASTER_SERVICE_IP} kubernetes.default.svc.cluster.local. +short A | head -n 1" "${MASTER_SERVICE_IP}"
@@ -91,7 +91,7 @@ oc logs rc/docker-registry-1 > /dev/null
 # services can end up on any IP.  Make sure we get the IP we need for the docker registry
 DOCKER_REGISTRY=$(oc get --output-version=v1beta3 --template="{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}" service docker-registry)
 
-registry="$(dig @${API_HOST} "docker-registry.default.svc.cluster.local." +short A | head -n 1)"
+registry="$(dig @${API_HOST} -p 8053 "docker-registry.default.svc.cluster.local." +short A | head -n 1)"
 [[ -n "${registry}" && "${registry}:5000" == "${DOCKER_REGISTRY}" ]]
 
 echo "[INFO] Verifying the docker-registry is up at ${DOCKER_REGISTRY}"
@@ -99,7 +99,7 @@ wait_for_url_timed "http://${DOCKER_REGISTRY}/" "[INFO] Docker registry says: " 
 # ensure original healthz route works as well
 os::cmd::expect_success "curl -f http://${DOCKER_REGISTRY}/healthz"
 
-os::cmd::expect_success "dig @${API_HOST} docker-registry.default.local. A"
+os::cmd::expect_success "dig @${API_HOST} -p 8053 docker-registry.default.local. A"
 
 # Client setup (log in as e2e-user and set 'test' as the default project)
 # This is required to be able to push to the registry!


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/8034

Should we ensure that `--dns=${API_HOST}:8053` or should we keep `0.0.0.0` ?

@liggitt @deads2k @abutcher PTAL