### PR TITLE
Wrap oauth/login requests to clear in-memory session

### DIFF
--- a/pkg/cmd/server/origin/handler_wrapper.go
+++ b/pkg/cmd/server/origin/handler_wrapper.go
@@ -1,0 +1,26 @@
+package origin
+
+import (
+	"net/http"
+
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+)
+
+type handlerWrapper interface {
+	Wrap(http.Handler) http.Handler
+}
+
+// handlerWrapperMux wraps all handlers before registering them in the contained mux
+type handlerWrapperMux struct {
+	mux     cmdutil.Mux
+	wrapper handlerWrapper
+}
+
+var _ = cmdutil.Mux(&handlerWrapperMux{})
+
+func (m *handlerWrapperMux) Handle(pattern string, handler http.Handler) {
+	m.mux.Handle(pattern, m.wrapper.Wrap(handler))
+}
+func (m *handlerWrapperMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	m.mux.Handle(pattern, m.wrapper.Wrap(http.HandlerFunc(handler)))
+}


### PR DESCRIPTION
Adds wrappers around OAuth-specific endpoints to ensure we release session store memory when requests are complete