### PR TITLE
extended: Allow to focus on particular tests

### DIFF
--- a/test/extended/conformance.sh
+++ b/test/extended/conformance.sh
@@ -11,7 +11,7 @@ source "${OS_ROOT}/test/extended/setup.sh"
 cd "${OS_ROOT}"
 
 os::test::extended::setup
-os::test::extended::focus $@
+os::test::extended::focus "$@"
 
 function join { local IFS="$1"; shift; echo "$*"; }
 

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -12,7 +12,7 @@ source "${OS_ROOT}/test/extended/setup.sh"
 cd "${OS_ROOT}"
 
 os::test::extended::setup
-os::test::extended::focus $@
+os::test::extended::focus "$@"
 
 function join { local IFS="$1"; shift; echo "$*"; }
 

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -5,7 +5,7 @@
 # If invoked with arguments, executes the test directly.
 function os::test::extended::focus {
   if [[ $# -ne 0 ]]; then
-    echo "[INFO] Running custom: $@"
+    echo "[INFO] Running custom: $*"
     tests=$(TEST_REPORT_DIR= TEST_OUTPUT_QUIET=true ${EXTENDEDTEST} --ginkgo.dryRun --ginkgo.noColor "$@" | col -b | grep -v "35mskip0m" | grep "1mok0m" | wc -l)
     if [[ "${tests}" -eq 0 ]]; then
       echo "[ERROR] No tests would be run"


### PR DESCRIPTION
Focus usually involves string with spaces such as:

    ./test/extended/core.sh --ginkgo.focus='quota admission' --ginkgo.failFast

Replaces #8420