### PR TITLE
Expose the Exporter

### DIFF
--- a/pkg/cmd/cli/cmd/export.go
+++ b/pkg/cmd/cli/cmd/export.go
@@ -51,7 +51,7 @@ to generate the API structure for a template to which you can add parameters and
 )
 
 func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
-	exporter := &defaultExporter{}
+	exporter := NewExporter()
 	var filenames []string
 	cmd := &cobra.Command{
 		Use:     "export RESOURCE/NAME ... [options]",

--- a/pkg/cmd/cli/cmd/exporter.go
+++ b/pkg/cmd/cli/cmd/exporter.go
@@ -40,6 +40,10 @@ type Exporter interface {
 
 type defaultExporter struct{}
 
+func NewExporter() Exporter {
+	return &defaultExporter{}
+}
+
 func (e *defaultExporter) AddExportOptions(flags *pflag.FlagSet) {
 }
 

--- a/pkg/cmd/cli/cmd/exporter_test.go
+++ b/pkg/cmd/cli/cmd/exporter_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestExport(t *testing.T) {
-	exporter := &defaultExporter{}
+	exporter := NewExporter()
 
 	baseSA := &kapi.ServiceAccount{}
 	baseSA.Name = "my-sa"


### PR DESCRIPTION
Hi,

would you consider exposing the defaultExporter used in the CLI ?

I'm building a tool that uses the Watch API to export some resources to an external system, and I'd like to re-use the defaultExporter.

Thanks,
Vincent
