### PR TITLE
Allow to specify runPolicy for BuildConfig

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -17512,6 +17512,10 @@
       },
       "description": "triggers determine how new Builds can be launched from a BuildConfig. If no triggers are defined, a new build can only occur as a result of an explicit client build creation."
      },
+     "runPolicy": {
+      "type": "string",
+      "description": "RunPolicy describes how the new build created from this build configuration will be scheduled for execution. This is optional, if not specified we default to \"Serial\"."
+     },
      "serviceAccount": {
       "type": "string",
       "description": "serviceAccount is the name of the ServiceAccount to use to run the pod created by this build. The pod will be allowed to use secrets referenced by the ServiceAccount"

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -770,6 +770,7 @@ func deepCopy_api_BuildConfigSpec(in buildapi.BuildConfigSpec, out *buildapi.Bui
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = in.RunPolicy
 	if err := deepCopy_api_BuildSpec(in.BuildSpec, &out.BuildSpec, c); err != nil {
 		return err
 	}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -197,6 +197,10 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 				j.From.Kind = specs[c.Intn(len(specs))]
 			}
 		},
+		func(j *build.BuildConfigSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			j.RunPolicy = build.BuildRunPolicySerial
+		},
 		func(j *build.SourceBuildStrategy, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
 			j.From.Kind = "ImageStreamTag"

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1041,6 +1041,7 @@ func autoConvert_api_BuildConfigSpec_To_v1_BuildConfigSpec(in *buildapi.BuildCon
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = v1.BuildRunPolicy(in.RunPolicy)
 	if err := Convert_api_BuildSpec_To_v1_BuildSpec(&in.BuildSpec, &out.BuildSpec, s); err != nil {
 		return err
 	}
@@ -1906,6 +1907,7 @@ func autoConvert_v1_BuildConfigSpec_To_api_BuildConfigSpec(in *v1.BuildConfigSpe
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = buildapi.BuildRunPolicy(in.RunPolicy)
 	if err := Convert_v1_BuildSpec_To_api_BuildSpec(&in.BuildSpec, &out.BuildSpec, s); err != nil {
 		return err
 	}

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -790,6 +790,7 @@ func deepCopy_v1_BuildConfigSpec(in apiv1.BuildConfigSpec, out *apiv1.BuildConfi
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = in.RunPolicy
 	if err := deepCopy_v1_BuildSpec(in.BuildSpec, &out.BuildSpec, c); err != nil {
 		return err
 	}

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1049,6 +1049,7 @@ func autoConvert_api_BuildConfigSpec_To_v1beta3_BuildConfigSpec(in *buildapi.Bui
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = v1beta3.BuildRunPolicy(in.RunPolicy)
 	if err := Convert_api_BuildSpec_To_v1beta3_BuildSpec(&in.BuildSpec, &out.BuildSpec, s); err != nil {
 		return err
 	}
@@ -1812,6 +1813,7 @@ func autoConvert_v1beta3_BuildConfigSpec_To_api_BuildConfigSpec(in *v1beta3.Buil
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = buildapi.BuildRunPolicy(in.RunPolicy)
 	if err := Convert_v1beta3_BuildSpec_To_api_BuildSpec(&in.BuildSpec, &out.BuildSpec, s); err != nil {
 		return err
 	}

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -798,6 +798,7 @@ func deepCopy_v1beta3_BuildConfigSpec(in apiv1beta3.BuildConfigSpec, out *apiv1b
 	} else {
 		out.Triggers = nil
 	}
+	out.RunPolicy = in.RunPolicy
 	if err := deepCopy_v1beta3_BuildSpec(in.BuildSpec, &out.BuildSpec, c); err != nil {
 		return err
 	}

--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -218,6 +218,11 @@ func Convert_v1_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddDefaultingFuncs(
+		func(config *BuildConfigSpec) {
+			if len(config.RunPolicy) == 0 {
+				config.RunPolicy = BuildRunPolicySerial
+			}
+		},
 		func(source *BuildSource) {
 			if (source != nil) && (source.Type == BuildSourceBinary) && (source.Binary == nil) {
 				source.Binary = &BinaryBuildSource{}

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -63,8 +63,9 @@ func (BuildConfigList) SwaggerDoc() map[string]string {
 }
 
 var map_BuildConfigSpec = map[string]string{
-	"":         "BuildConfigSpec describes when and how builds are created",
-	"triggers": "triggers determine how new Builds can be launched from a BuildConfig. If no triggers are defined, a new build can only occur as a result of an explicit client build creation.",
+	"":          "BuildConfigSpec describes when and how builds are created",
+	"triggers":  "triggers determine how new Builds can be launched from a BuildConfig. If no triggers are defined, a new build can only occur as a result of an explicit client build creation.",
+	"runPolicy": "RunPolicy describes how the new build created from this build configuration will be scheduled for execution. This is optional, if not specified we default to \"Serial\".",
 }
 
 func (BuildConfigSpec) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -546,9 +546,33 @@ type BuildConfigSpec struct {
 	// are defined, a new build can only occur as a result of an explicit client build creation.
 	Triggers []BuildTriggerPolicy `json:"triggers"`
 
+	// RunPolicy describes how the new build created from this build
+	// configuration will be scheduled for execution.
+	// This is optional, if not specified we default to "Serial".
+	RunPolicy BuildRunPolicy `json:"runPolicy,omitempty"`
+
 	// BuildSpec is the desired build specification
 	BuildSpec `json:",inline"`
 }
+
+// BuildRunPolicy defines the behaviour of how the new builds are executed
+// from the existing build configuration.
+type BuildRunPolicy string
+
+const (
+	// BuildRunPolicyParallel schedules new builds immediately after they are
+	// created. Builds will be executed in parallel.
+	BuildRunPolicyParallel BuildRunPolicy = "Parallel"
+
+	// BuildRunPolicySerial schedules new builds to execute in a sequence as
+	// they are created. Every build gets queued up and will execute when the
+	// previous build completes. This is the default policy.
+	BuildRunPolicySerial BuildRunPolicy = "Serial"
+
+	// BuildRunPolicySerialLatestOnly schedules only the latest build to execute,
+	// cancelling all the previously queued build.
+	BuildRunPolicySerialLatestOnly BuildRunPolicy = "SerialLatestOnly"
+)
 
 // BuildConfigStatus contains current state of the build config object.
 type BuildConfigStatus struct {

--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -220,6 +220,11 @@ func Convert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *newer.BuildStrategy,
 
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddDefaultingFuncs(
+		func(config *BuildConfigSpec) {
+			if len(config.RunPolicy) == 0 {
+				config.RunPolicy = BuildRunPolicySerial
+			}
+		},
 		func(strategy *BuildStrategy) {
 			if (strategy != nil) && (strategy.Type == DockerBuildStrategyType) {
 				//  initialize DockerStrategy to a default state if it's not set.

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -510,8 +510,32 @@ type BuildConfigSpec struct {
 	// are defined, a new build can only occur as a result of an explicit client build creation.
 	Triggers []BuildTriggerPolicy `json:"triggers"`
 
+	// RunPolicy describes how the new build created from this build
+	// configuration will be scheduled for execution.
+	// This is optional, if not specified we default to "Serial".
+	RunPolicy BuildRunPolicy `json:"runPolicy,omitempty"`
+
 	BuildSpec `json:",inline"`
 }
+
+// BuildRunPolicy defines the behaviour of how the new builds are executed
+// from the existing build configuration.
+type BuildRunPolicy string
+
+const (
+	// BuildRunPolicyParallel schedules new builds immediately after they are
+	// created. Builds will be executed in parallel.
+	BuildRunPolicyParallel BuildRunPolicy = "Parallel"
+
+	// BuildRunPolicySerial schedules new builds to execute in a sequence as
+	// they are created. Every build gets queued up and will execute when the
+	// previous build completes. This is the default policy.
+	BuildRunPolicySerial BuildRunPolicy = "Serial"
+
+	// BuildRunPolicySerialLatestOnly schedules only the latest build to execute,
+	// cancelling all the previously queued build.
+	BuildRunPolicySerialLatestOnly BuildRunPolicy = "SerialLatestOnly"
+)
 
 // BuildConfigStatus contains current state of the build config object.
 type BuildConfigStatus struct {

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -82,6 +82,13 @@ func ValidateBuildConfig(config *buildapi.BuildConfig) field.ErrorList {
 		fromRefs[fromKey] = struct{}{}
 	}
 
+	switch config.Spec.RunPolicy {
+	case buildapi.BuildRunPolicyParallel, buildapi.BuildRunPolicySerial, buildapi.BuildRunPolicySerialLatestOnly:
+	default:
+		allErrs = append(allErrs, field.Invalid(specPath.Child("runPolicy"), config.Spec.RunPolicy,
+			"run policy must Parallel, Serial, or SerialLatestOnly"))
+	}
+
 	allErrs = append(allErrs, validateBuildSpec(&config.Spec.BuildSpec, specPath)...)
 
 	return allErrs

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -137,6 +137,7 @@ func TestBuildConfigEmptySource(t *testing.T) {
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 			Spec: buildapi.BuildConfigSpec{
+				RunPolicy: buildapi.BuildRunPolicySerial,
 				BuildSpec: buildapi.BuildSpec{
 					Source: buildapi.BuildSource{},
 					Strategy: buildapi.BuildStrategy{
@@ -159,6 +160,7 @@ func TestBuildConfigEmptySource(t *testing.T) {
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 			Spec: buildapi.BuildConfigSpec{
+				RunPolicy: buildapi.BuildRunPolicySerial,
 				BuildSpec: buildapi.BuildSpec{
 					Source: buildapi.BuildSource{},
 					Strategy: buildapi.BuildStrategy{
@@ -188,6 +190,7 @@ func TestBuildConfigEmptySource(t *testing.T) {
 	badBuildConfig := buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{},
 				Strategy: buildapi.BuildStrategy{
@@ -384,6 +387,7 @@ func TestBuildConfigGitSourceWithProxyFailure(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Git: &buildapi.GitBuildSource{
@@ -424,6 +428,7 @@ func TestBuildConfigDockerStrategyImageChangeTrigger(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Git: &buildapi.GitBuildSource{
@@ -467,6 +472,7 @@ func TestBuildConfigValidationFailureRequiredName(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "", Namespace: "foo"},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Git: &buildapi.GitBuildSource{
@@ -738,6 +744,7 @@ func TestBuildConfigImageChangeTriggers(t *testing.T) {
 		buildConfig := &buildapi.BuildConfig{
 			ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "foo"},
 			Spec: buildapi.BuildConfigSpec{
+				RunPolicy: buildapi.BuildRunPolicySerial,
 				BuildSpec: buildapi.BuildSpec{
 					Source: buildapi.BuildSource{
 						Git: &buildapi.GitBuildSource{
@@ -782,6 +789,7 @@ func TestBuildConfigValidationOutputFailure(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: ""},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Git: &buildapi.GitBuildSource{

--- a/pkg/build/client/clients.go
+++ b/pkg/build/client/clients.go
@@ -3,6 +3,7 @@ package client
 import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	osclient "github.com/openshift/origin/pkg/client"
+	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 // BuildConfigGetter provides methods for getting BuildConfigs
@@ -41,6 +42,11 @@ type BuildUpdater interface {
 	Update(namespace string, build *buildapi.Build) error
 }
 
+// BuildLister provides methods for listing the Builds.
+type BuildLister interface {
+	List(namespace string, opts kapi.ListOptions) (*buildapi.BuildList, error)
+}
+
 // OSClientBuildClient deletes build create and update operations to the OpenShift client interface
 type OSClientBuildClient struct {
 	Client osclient.Interface
@@ -55,6 +61,11 @@ func NewOSClientBuildClient(client osclient.Interface) *OSClientBuildClient {
 func (c OSClientBuildClient) Update(namespace string, build *buildapi.Build) error {
 	_, e := c.Client.Builds(namespace).Update(build)
 	return e
+}
+
+// List lists the builds using the OpenShift client.
+func (c OSClientBuildClient) List(namespace string, opts kapi.ListOptions) (*buildapi.BuildList, error) {
+	return c.Client.Builds(namespace).List(opts)
 }
 
 // BuildCloner provides methods for cloning builds

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -21,6 +21,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildcontroller "github.com/openshift/origin/pkg/build/controller"
+	"github.com/openshift/origin/pkg/build/controller/policy"
 	strategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -63,6 +64,7 @@ type BuildControllerFactory struct {
 	OSClient            osclient.Interface
 	KubeClient          kclient.Interface
 	BuildUpdater        buildclient.BuildUpdater
+	BuildLister         buildclient.BuildLister
 	DockerBuildStrategy *strategy.DockerBuildStrategy
 	SourceBuildStrategy *strategy.SourceBuildStrategy
 	CustomBuildStrategy *strategy.CustomBuildStrategy
@@ -81,8 +83,10 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 	client := ControllerClient{factory.KubeClient, factory.OSClient}
 	buildController := &buildcontroller.BuildController{
 		BuildUpdater:      factory.BuildUpdater,
+		BuildLister:       factory.BuildLister,
 		ImageStreamClient: client,
 		PodManager:        client,
+		RunPolicies:       policy.GetAllRunPolicies(factory.BuildLister, factory.BuildUpdater),
 		BuildStrategy: &typeBasedFactoryStrategy{
 			DockerBuildStrategy: factory.DockerBuildStrategy,
 			SourceBuildStrategy: factory.SourceBuildStrategy,

--- a/pkg/build/controller/policy/errors.go
+++ b/pkg/build/controller/policy/errors.go
@@ -1,0 +1,35 @@
+package policy
+
+import (
+	"fmt"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// NoBuildConfigLabelError represents an error caused by the build not having
+// the required build config label.
+type NoBuildConfigLabelError struct {
+	build *buildapi.Build
+}
+
+func NewNoBuildConfigLabelError(build *buildapi.Build) error {
+	return NoBuildConfigLabelError{build: build}
+}
+
+func (e NoBuildConfigLabelError) Error() string {
+	return fmt.Sprintf("build %s/%s does not have required %q label set", e.build.Namespace, e.build.Name, buildapi.BuildConfigLabel)
+}
+
+// NoBuildNumberLabelError represents an error caused by the build not having
+// the required build number annotation.
+type NoBuildNumberAnnotationError struct {
+	build *buildapi.Build
+}
+
+func NewNoBuildNumberAnnotationError(build *buildapi.Build) error {
+	return NoBuildNumberAnnotationError{build: build}
+}
+
+func (e NoBuildNumberAnnotationError) Error() string {
+	return fmt.Sprintf("build %s/%s does not have required %q annotation set", e.build.Namespace, e.build.Name, buildapi.BuildNumberAnnotation)
+}

--- a/pkg/build/controller/policy/parallel.go
+++ b/pkg/build/controller/policy/parallel.go
@@ -1,0 +1,32 @@
+package policy
+
+import (
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+)
+
+// ParallelPolicy implements the RunPolicy interface. Build created using this
+// run policy will always run as soon as they are created.
+// This run policy does not guarantee that the builds will complete in same
+// order as they were created and using this policy might cause unpredictable
+// behavior.
+type ParallelPolicy struct {
+	BuildLister  buildclient.BuildLister
+	BuildUpdater buildclient.BuildUpdater
+}
+
+// IsRunnable implements the RunPolicy interface. The parallel builds are run as soon
+// as they are created. There is no build queue as all build run asynchronously.
+func (s *ParallelPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
+	bcName := buildutil.ConfigNameForBuild(build)
+	if len(bcName) == 0 {
+		return false, NewNoBuildConfigLabelError(build)
+	}
+	return !hasRunningSerialBuild(s.BuildLister, build.Namespace, bcName), nil
+}
+
+// OnComplete implements the RunPolicy interface.
+func (s *ParallelPolicy) OnComplete(build *buildapi.Build) error {
+	return handleComplete(s.BuildLister, s.BuildUpdater, build)
+}

--- a/pkg/build/controller/policy/parallel_test.go
+++ b/pkg/build/controller/policy/parallel_test.go
@@ -1,0 +1,64 @@
+package policy
+
+import (
+	"testing"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func TestParallelIsRunnableNewBuilds(t *testing.T) {
+	allNewBuilds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+	}
+	client := newTestClient(allNewBuilds)
+	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	for _, build := range allNewBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !runnable {
+			t.Errorf("expected build %s runnable, is not", build.Name)
+		}
+	}
+}
+
+func TestParallelIsRunnableMixedBuilds(t *testing.T) {
+	mixedBuilds := []buildapi.Build{
+		addBuild("build-4", "sample-bc", buildapi.BuildPhaseRunning, buildapi.BuildRunPolicyParallel),
+		addBuild("build-6", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+		addBuild("build-5", "sample-bc", buildapi.BuildPhasePending, buildapi.BuildRunPolicyParallel),
+	}
+	client := newTestClient(mixedBuilds)
+	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	for _, build := range mixedBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !runnable {
+			t.Errorf("expected build %s runnable, is not", build.Name)
+		}
+	}
+}
+
+func TestParallelIsRunnableWithSerialRunning(t *testing.T) {
+	mixedBuilds := []buildapi.Build{
+		addBuild("build-7", "sample-bc", buildapi.BuildPhaseRunning, buildapi.BuildRunPolicySerial),
+		addBuild("build-8", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+		addBuild("build-9", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+	}
+	client := newTestClient(mixedBuilds)
+	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	for _, build := range mixedBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if runnable {
+			t.Errorf("expected build %s as not runnable", build.Name)
+		}
+	}
+}

--- a/pkg/build/controller/policy/policy.go
+++ b/pkg/build/controller/policy/policy.go
@@ -1,0 +1,140 @@
+package policy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+// RunPolicy is an interface that define handler for the build runPolicy field.
+// The run policy controls how and when the new builds are 'run'.
+type RunPolicy interface {
+	// IsRunnable returns true of the given build should be executed.
+	IsRunnable(*buildapi.Build) (bool, error)
+
+	// OnComplete allows policy to execute action when the given build just
+	// completed.
+	OnComplete(*buildapi.Build) error
+}
+
+// GetAllRunPolicies returns a set of all run policies.
+func GetAllRunPolicies(lister buildclient.BuildLister, updater buildclient.BuildUpdater) []RunPolicy {
+	return []RunPolicy{
+		&ParallelPolicy{BuildLister: lister, BuildUpdater: updater},
+		&SerialPolicy{BuildLister: lister, BuildUpdater: updater},
+		&SerialLatestOnlyPolicy{BuildLister: lister, BuildUpdater: updater},
+	}
+}
+
+// ForBuild picks the appropriate run policy for the given build.
+func ForBuild(build *buildapi.Build, policies []RunPolicy) RunPolicy {
+	for _, s := range policies {
+		switch buildutil.BuildRunPolicy(build) {
+		case buildapi.BuildRunPolicyParallel:
+			if _, ok := s.(*ParallelPolicy); ok {
+				glog.V(5).Infof("Using %T run policy for build %s/%s", s, build.Namespace, build.Name)
+				return s
+			}
+		case buildapi.BuildRunPolicySerial:
+			if _, ok := s.(*SerialPolicy); ok {
+				glog.V(5).Infof("Using %T run policy for build %s/%s", s, build.Namespace, build.Name)
+				return s
+			}
+		case buildapi.BuildRunPolicySerialLatestOnly:
+			if _, ok := s.(*SerialLatestOnlyPolicy); ok {
+				glog.V(5).Infof("Using %T run policy for build %s/%s", s, build.Namespace, build.Name)
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+// hasRunningSerialBuild indicates that there is a running or pending serial
+// build. This function is used to prevent running parallel builds because
+// serial builds should always run alone.
+func hasRunningSerialBuild(lister buildclient.BuildLister, namespace, buildConfigName string) bool {
+	var hasRunningBuilds bool
+	buildutil.BuildConfigBuilds(lister, namespace, buildConfigName, func(b buildapi.Build) bool {
+		switch b.Status.Phase {
+		case buildapi.BuildPhasePending, buildapi.BuildPhaseRunning:
+			switch buildutil.BuildRunPolicy(&b) {
+			case buildapi.BuildRunPolicySerial, buildapi.BuildRunPolicySerialLatestOnly:
+				hasRunningBuilds = true
+			}
+		}
+		return false
+	})
+	return hasRunningBuilds
+}
+
+// GetNextConfigBuild returns the build that will be executed next for the given
+// build configuration. It also returns the indication whether there are
+// currently running builds, to make sure there is no race-condition between
+// re-listing the builds.
+func GetNextConfigBuild(lister buildclient.BuildLister, namespace, buildConfigName string) (*buildapi.Build, bool, error) {
+	var (
+		nextBuild           *buildapi.Build
+		hasRunningBuilds    bool
+		previousBuildNumber int64
+	)
+	builds, err := buildutil.BuildConfigBuilds(lister, namespace, buildConfigName, func(b buildapi.Build) bool {
+		switch b.Status.Phase {
+		case buildapi.BuildPhasePending, buildapi.BuildPhaseRunning:
+			hasRunningBuilds = true
+			return false
+		}
+		// Only 'new' build can be scheduled to run next
+		return b.Status.Phase == buildapi.BuildPhaseNew
+	})
+	if err != nil {
+		return nil, hasRunningBuilds, err
+	}
+
+	for i, b := range builds.Items {
+		buildNumber, err := buildutil.BuildNumber(&b)
+		if err != nil {
+			return nil, hasRunningBuilds, err
+		}
+		if previousBuildNumber == 0 || buildNumber < previousBuildNumber {
+			nextBuild = &builds.Items[i]
+			previousBuildNumber = buildNumber
+		}
+	}
+	return nextBuild, hasRunningBuilds, nil
+}
+
+// handleComplete represents the default OnComplete handler. This Handler will
+// check which build should be run next and update the StartTimestamp field for
+// that build. That will trigger HandleBuild() to process that build immediately
+// and as a result the build is immediately executed.
+func handleComplete(lister buildclient.BuildLister, updater buildclient.BuildUpdater, build *buildapi.Build) error {
+	bcName := buildutil.ConfigNameForBuild(build)
+	if len(bcName) == 0 {
+		return NewNoBuildConfigLabelError(build)
+	}
+	nextBuild, hasRunningBuilds, err := GetNextConfigBuild(lister, build.Namespace, bcName)
+	if err != nil {
+		return fmt.Errorf("unable to get the next build for %s/%s: %v", build.Namespace, build.Name, err)
+	}
+	if hasRunningBuilds || nextBuild == nil {
+		return nil
+	}
+	now := unversioned.Now()
+	nextBuild.Status.StartTimestamp = &now
+	return wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+		err := updater.Update(nextBuild.Namespace, nextBuild)
+		if err != nil && errors.IsConflict(err) {
+			glog.V(5).Infof("Error updating build %s/%s: %v (will retry)", nextBuild.Namespace, nextBuild.Name, err)
+			return false, nil
+		}
+		return true, err
+	})
+}

--- a/pkg/build/controller/policy/policy_test.go
+++ b/pkg/build/controller/policy/policy_test.go
@@ -1,0 +1,122 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"errors"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+)
+
+type fakeBuildClient struct {
+	builds         *buildapi.BuildList
+	updateErrCount int
+}
+
+func newTestClient(builds []buildapi.Build) *fakeBuildClient {
+	return &fakeBuildClient{builds: &buildapi.BuildList{Items: builds}}
+}
+
+func (f *fakeBuildClient) List(namespace string, opts kapi.ListOptions) (*buildapi.BuildList, error) {
+	return f.builds, nil
+}
+
+func (f *fakeBuildClient) Update(namespace string, build *buildapi.Build) error {
+	// Make sure every update fails at least once with conflict to ensure build updates are
+	// retried.
+	if f.updateErrCount == 0 {
+		f.updateErrCount = 1
+		return kerrors.NewConflict(kapi.Resource("builds"), build.Name, errors.New("confict"))
+	} else {
+		f.updateErrCount = 0
+	}
+	for i, item := range f.builds.Items {
+		if build.Name == item.Name {
+			f.builds.Items[i] = *build
+		}
+	}
+	return nil
+}
+
+func addBuild(name, bcName string, phase buildapi.BuildPhase, policy buildapi.BuildRunPolicy) buildapi.Build {
+	parts := strings.Split(name, "-")
+	return buildapi.Build{
+		Spec: buildapi.BuildSpec{},
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      name,
+			Namespace: "test",
+			Labels: map[string]string{
+				buildapi.BuildRunPolicyLabel: string(policy),
+				buildapi.BuildConfigLabel:    bcName,
+			},
+			Annotations: map[string]string{
+				buildapi.BuildNumberAnnotation: parts[len(parts)-1],
+			},
+		},
+		Status: buildapi.BuildStatus{Phase: phase},
+	}
+}
+
+func TestForBuild(t *testing.T) {
+	builds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+	}
+	client := newTestClient(builds)
+	policies := GetAllRunPolicies(client, client)
+
+	if policy := ForBuild(&builds[0], policies); policy != nil {
+		if _, ok := policy.(*ParallelPolicy); !ok {
+			t.Errorf("expected Parallel policy for build-1, got %T", policy)
+		}
+	} else {
+		t.Errorf("expected Parallel policy for build-1, got nil")
+	}
+
+	if policy := ForBuild(&builds[1], policies); policy != nil {
+		if _, ok := policy.(*SerialPolicy); !ok {
+			t.Errorf("expected Serial policy for build-2, got %T", policy)
+		}
+	} else {
+		t.Errorf("expected Serial policy for build-2, got nil")
+	}
+
+	if policy := ForBuild(&builds[2], policies); policy != nil {
+		if _, ok := policy.(*SerialLatestOnlyPolicy); !ok {
+			t.Errorf("expected SerialLatestOnly policy for build-3, got %T", policy)
+		}
+	} else {
+		t.Errorf("expected SerialLatestOnly policy for build-3, got nil")
+	}
+}
+
+func TestHandleComplete(t *testing.T) {
+	builds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseComplete, buildapi.BuildRunPolicySerial),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+	}
+
+	client := newTestClient(builds)
+
+	if err := handleComplete(client, client, &builds[0]); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	resultBuilds, err := client.List("test", kapi.ListOptions{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if resultBuilds.Items[1].Status.StartTimestamp == nil {
+		t.Errorf("build-2 should have Status.StartTimestamp set to trigger it")
+	}
+
+	if resultBuilds.Items[2].Status.StartTimestamp != nil {
+		t.Errorf("build-3 should not have Status.StartTimestamp set")
+	}
+}

--- a/pkg/build/controller/policy/serial.go
+++ b/pkg/build/controller/policy/serial.go
@@ -1,0 +1,32 @@
+package policy
+
+import (
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+)
+
+// SerialPolicy implements the RunPolicy interface. Using this run policy, every
+// created build is put into a queue. The serial run policy guarantees that
+// all builds are executed synchroniously in the same order as they were
+// created. This will produce consistent results, but block the build execution until the
+// previous builds are complete.
+type SerialPolicy struct {
+	BuildLister  buildclient.BuildLister
+	BuildUpdater buildclient.BuildUpdater
+}
+
+// IsRunnable implements the RunPolicy interface.
+func (s *SerialPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
+	bcName := buildutil.ConfigNameForBuild(build)
+	if len(bcName) == 0 {
+		return false, NewNoBuildConfigLabelError(build)
+	}
+	nextBuild, runningBuilds, err := GetNextConfigBuild(s.BuildLister, build.Namespace, bcName)
+	return !runningBuilds && (nextBuild != nil && nextBuild.Name == build.Name), err
+}
+
+// OnComplete implements the RunPolicy interface.
+func (s *SerialPolicy) OnComplete(build *buildapi.Build) error {
+	return handleComplete(s.BuildLister, s.BuildUpdater, build)
+}

--- a/pkg/build/controller/policy/serial_latest_only.go
+++ b/pkg/build/controller/policy/serial_latest_only.go
@@ -1,0 +1,95 @@
+package policy
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	"github.com/golang/glog"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+)
+
+// SerialLatestOnlyPolicy implements the RunPolicy interface. This variant of
+// the serial build policy makes sure that builds are executed in same order as
+// they were created, but when a new build is created, the previous, queued
+// build is cancelled, always making the latest created build run as next. This
+// will produce consistent results, but might not suit the CI/CD flow where user
+// expect that every commit is built.
+type SerialLatestOnlyPolicy struct {
+	BuildUpdater buildclient.BuildUpdater
+	BuildLister  buildclient.BuildLister
+}
+
+// IsRunnable implements the RunPolicy interface.
+// Calling this function on a build mean that any previous build that is in
+// 'new' phase will be automatically cancelled. This will also cancel any
+// "serial" build (when you changed the build config run policy on-the-fly).
+func (s *SerialLatestOnlyPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
+	bcName := buildutil.ConfigNameForBuild(build)
+	if len(bcName) == 0 {
+		return false, NewNoBuildConfigLabelError(build)
+	}
+	if err := kerrors.NewAggregate(s.cancelPreviousBuilds(build)); err != nil {
+		return false, err
+	}
+	nextBuild, runningBuilds, err := GetNextConfigBuild(s.BuildLister, build.Namespace, bcName)
+	if err != nil || runningBuilds {
+		return false, err
+	}
+	return nextBuild != nil && nextBuild.Name == build.Name, err
+}
+
+// IsRunnable implements the Scheduler interface.
+func (s *SerialLatestOnlyPolicy) OnComplete(build *buildapi.Build) error {
+	return handleComplete(s.BuildLister, s.BuildUpdater, build)
+}
+
+// cancelPreviousBuilds cancels all queued builds that have the build sequence number
+// lower than the given build. It retries the cancellation in case of conflict.
+func (s *SerialLatestOnlyPolicy) cancelPreviousBuilds(build *buildapi.Build) []error {
+	bcName := buildutil.ConfigNameForBuild(build)
+	if len(bcName) == 0 {
+		return []error{NewNoBuildConfigLabelError(build)}
+	}
+	currentBuildNumber, err := buildutil.BuildNumber(build)
+	if err != nil {
+		return []error{NewNoBuildNumberAnnotationError(build)}
+	}
+	builds, err := buildutil.BuildConfigBuilds(s.BuildLister, build.Namespace, bcName, func(b buildapi.Build) bool {
+		// Do not cancel the complete builds, builds that were already cancelled, or
+		// running builds.
+		if buildutil.IsBuildComplete(&b) || b.Status.Phase == buildapi.BuildPhaseRunning {
+			return false
+		}
+
+		// Prevent race-condition when there is a newer build than this and we don't
+		// want to cancel it. The HandleBuild() function that runs for that build
+		// will cancel this build.
+		buildNumber, _ := buildutil.BuildNumber(&b)
+		return buildNumber < currentBuildNumber
+	})
+	if err != nil {
+		return []error{err}
+	}
+	var result = []error{}
+	for _, b := range builds.Items {
+		err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+			b.Status.Cancelled = true
+			err := s.BuildUpdater.Update(b.Namespace, &b)
+			if err != nil && errors.IsConflict(err) {
+				glog.V(5).Infof("Error cancelling build %s/%s: %v (will retry)", b.Namespace, b.Name, err)
+				return false, nil
+			}
+			return true, err
+		})
+		if err != nil {
+			result = append(result, err)
+		}
+	}
+	return result
+}

--- a/pkg/build/controller/policy/serial_latest_only_test.go
+++ b/pkg/build/controller/policy/serial_latest_only_test.go
@@ -1,0 +1,144 @@
+package policy
+
+import (
+	"testing"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestSerialLatestOnlyIsRunnableNewBuilds(t *testing.T) {
+	allNewBuilds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+	}
+	client := newTestClient(allNewBuilds)
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+	runnableBuilds := []string{
+		"build-1",
+	}
+	shouldRun := func(name string) bool {
+		for _, b := range runnableBuilds {
+			if b == name {
+				return true
+			}
+		}
+		return false
+	}
+	shouldNotRun := func(name string) bool {
+		return !shouldRun(name)
+	}
+	for _, build := range allNewBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if runnable && shouldNotRun(build.Name) {
+			t.Errorf("%s should not be runnable", build.Name)
+		}
+		if !runnable && shouldRun(build.Name) {
+			t.Errorf("%s should be runnable, it is not", build.Name)
+		}
+	}
+	builds, err := client.List("test", kapi.ListOptions{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !builds.Items[1].Status.Cancelled {
+		t.Errorf("expected build-2 to be cancelled")
+	}
+}
+
+func TestSerialLatestOnlyIsRunnableMixed(t *testing.T) {
+	allNewBuilds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseComplete, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseCancelled, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseRunning, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-4", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+	}
+	client := newTestClient(allNewBuilds)
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+	for _, build := range allNewBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if runnable {
+			t.Errorf("%s should not be runnable", build.Name)
+		}
+	}
+	builds, err := client.List("test", kapi.ListOptions{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if builds.Items[0].Status.Cancelled {
+		t.Errorf("expected build-1 is complete and should not be cancelled")
+	}
+	if builds.Items[2].Status.Cancelled {
+		t.Errorf("expected build-3 is running and should not be cancelled")
+	}
+	if builds.Items[3].Status.Cancelled {
+		t.Errorf("expected build-4 will run next and should not be cancelled")
+	}
+}
+
+func TestSerialLatestOnlyIsRunnableBuildsWithErrors(t *testing.T) {
+	builds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
+	}
+
+	// The build-1 will lack required labels
+	builds[0].ObjectMeta.Labels = map[string]string{}
+
+	// The build-2 will lack the build config label
+	builds[1].ObjectMeta.Labels = map[string]string{
+		buildapi.BuildRunPolicyLabel: "SerialLatestOnly",
+	}
+
+	// The build-3 will lack the build number annotation
+	builds[2].ObjectMeta.Annotations = map[string]string{}
+
+	client := newTestClient(builds)
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+
+	if _, err := policy.IsRunnable(&builds[0]); err != nil {
+		if _, ok := err.(NoBuildConfigLabelError); !ok {
+			t.Errorf("expected NoBuildConfigLabelError, got %T", err)
+		}
+	} else {
+		t.Errorf("expected error for build-1")
+	}
+	if _, err := policy.IsRunnable(&builds[1]); err != nil {
+		if _, ok := err.(NoBuildConfigLabelError); !ok {
+			t.Errorf("expected NoBuildConfigLabelError, got %T", err)
+		}
+	} else {
+		t.Errorf("expected error for build-2")
+	}
+	// No type-check as this error is returned as kerrors.aggregate
+	if _, err := policy.IsRunnable(&builds[2]); err == nil {
+		t.Errorf("expected error for build-3")
+	}
+
+	if err := policy.OnComplete(&builds[0]); err != nil {
+		if _, ok := err.(NoBuildConfigLabelError); !ok {
+			t.Errorf("expected NoBuildConfigLabelError, got %T", err)
+		}
+	} else {
+		t.Errorf("expected error for build-1")
+	}
+	if err := policy.OnComplete(&builds[1]); err != nil {
+		if _, ok := err.(NoBuildConfigLabelError); !ok {
+			t.Errorf("expected NoBuildConfigLabelError, got %T", err)
+		}
+	} else {
+		t.Errorf("expected error for build-2")
+	}
+	// No type-check as this error is returned as kerrors.aggregate
+	if err := policy.OnComplete(&builds[2]); err == nil {
+		t.Errorf("expected error for build-3")
+	}
+}

--- a/pkg/build/controller/policy/serial_test.go
+++ b/pkg/build/controller/policy/serial_test.go
@@ -1,0 +1,43 @@
+package policy
+
+import (
+	"testing"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func TestSerialIsRunnableNewBuilds(t *testing.T) {
+	allNewBuilds := []buildapi.Build{
+		addBuild("build-1", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+		addBuild("build-2", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
+	}
+	client := newTestClient(allNewBuilds)
+	policy := SerialPolicy{BuildLister: client, BuildUpdater: client}
+	runnableBuilds := []string{
+		"build-1",
+	}
+	shouldRun := func(name string) bool {
+		for _, b := range runnableBuilds {
+			if b == name {
+				return true
+			}
+		}
+		return false
+	}
+	shouldNotRun := func(name string) bool {
+		return !shouldRun(name)
+	}
+	for _, build := range allNewBuilds {
+		runnable, err := policy.IsRunnable(&build)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if runnable && shouldNotRun(build.Name) {
+			t.Errorf("%s should not be runnable", build.Name)
+		}
+		if !runnable && shouldRun(build.Name) {
+			t.Errorf("%s should be runnable, it is not", build.Name)
+		}
+	}
+}

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -421,6 +421,7 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 	}
 	build.Labels[buildapi.BuildConfigLabelDeprecated] = bcCopy.Name
 	build.Labels[buildapi.BuildConfigLabel] = bcCopy.Name
+	build.Labels[buildapi.BuildRunPolicyLabel] = string(bc.Spec.RunPolicy)
 
 	builderSecrets, err := g.FetchServiceAccountSecrets(bc.Namespace, serviceAccount)
 	if err != nil {

--- a/pkg/build/registry/buildconfig/etcd/etcd_test.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd_test.go
@@ -29,6 +29,7 @@ func validBuildConfig() *api.BuildConfig {
 	return &api.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "configid"},
 		Spec: api.BuildConfigSpec{
+			RunPolicy: api.BuildRunPolicySerial,
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
 					Git: &api.GitBuildSource{

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -19,6 +19,7 @@ func TestBuildConfigStrategy(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
 			Triggers: []buildapi.BuildTriggerPolicy{
 				{
 					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -429,6 +429,7 @@ func (d *BuildConfigDescriber) Describe(namespace, name string) (string, error) 
 			formatString(out, "Latest Version", strconv.Itoa(buildConfig.Status.LastVersion))
 		}
 		describeBuildSpec(buildConfig.Spec.BuildSpec, out)
+		formatString(out, "\nBuild Run Policy", string(buildConfig.Spec.RunPolicy))
 		d.DescribeTriggers(buildConfig, out)
 		if len(buildList.Items) == 0 {
 			return nil

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -220,9 +220,10 @@ func (c *MasterConfig) RunBuildController() {
 
 	osclient, kclient := c.BuildControllerClients()
 	factory := buildcontrollerfactory.BuildControllerFactory{
-		OSClient:     osclient,
 		KubeClient:   kclient,
+		OSClient:     osclient,
 		BuildUpdater: buildclient.NewOSClientBuildClient(osclient),
+		BuildLister:  buildclient.NewOSClientBuildClient(osclient),
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
 			Image: dockerImage,
 			// TODO: this will be set to --storage-version (the internal schema we use)

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -1,0 +1,257 @@
+package builds
+
+import (
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+var _ = g.Describe("[builds][Slow] using build configuration runPolicy", func() {
+	defer g.GinkgoRecover()
+	var (
+		// Use invalid source here as we don't care about the result
+		oc = exutil.NewCLI("cli-build-run-policy", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Create all fixtures
+		oc.Run("create").Args("-f", exutil.FixturePath("..", "extended", "fixtures", "run_policy")).Execute()
+	})
+
+	g.Describe("build configuration with Parallel build run policy", func() {
+		g.It("runs the builds in parallel", func() {
+			g.By("starting multiple builds")
+			var (
+				startedBuilds []string
+				counter       int
+			)
+			bcName := "sample-parallel-build"
+
+			buildWatch, err := oc.REST().Builds(oc.Namespace()).Watch(kapi.ListOptions{
+				LabelSelector: buildutil.BuildConfigSelector(bcName),
+			})
+			defer buildWatch.Stop()
+
+			// Start first build
+			out, err := oc.Run("start-build").Args(bcName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(strings.TrimSpace(out)).ShouldNot(o.HaveLen(0))
+			startedBuilds = append(startedBuilds, strings.TrimSpace(out))
+
+			// Wait for it to become running
+			for {
+				event := <-buildWatch.ResultChan()
+				build := event.Object.(*buildapi.Build)
+				o.Expect(buildutil.IsBuildComplete(build)).Should(o.BeFalse())
+				if build.Name == startedBuilds[0] && build.Status.Phase == buildapi.BuildPhaseRunning {
+					break
+				}
+			}
+
+			for i := 0; i < 2; i++ {
+				out, err := oc.Run("start-build").Args(bcName).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(strings.TrimSpace(out)).ShouldNot(o.HaveLen(0))
+				startedBuilds = append(startedBuilds, strings.TrimSpace(out))
+			}
+
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			for {
+				event := <-buildWatch.ResultChan()
+				build := event.Object.(*buildapi.Build)
+				if build.Name == startedBuilds[0] {
+					if buildutil.IsBuildComplete(build) {
+						break
+					}
+					continue
+				}
+				// When the the other two builds we started after waiting for the first
+				// build to become running are Pending, verify the first build is still
+				// running (so the other two builds are started in parallel with first
+				// build).
+				// TODO: This might introduce flakes in case the first build complete
+				// sooner or fail.
+				if build.Status.Phase == buildapi.BuildPhasePending {
+					c := buildclient.NewOSClientBuildClient(oc.REST())
+					firstBuildRunning := false
+					_, err := buildutil.BuildConfigBuilds(c, oc.Namespace(), bcName, func(b buildapi.Build) bool {
+						if b.Name == startedBuilds[0] && b.Status.Phase == buildapi.BuildPhaseRunning {
+							firstBuildRunning = true
+						}
+						return false
+					})
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(firstBuildRunning).Should(o.BeTrue())
+					counter++
+				}
+				// When the build failed or completed prematurely, fail the test
+				o.Expect(buildutil.IsBuildComplete(build)).Should(o.BeFalse())
+				if counter == 2 {
+					break
+				}
+			}
+			o.Expect(counter).Should(o.BeEquivalentTo(2))
+		})
+	})
+
+	g.Describe("build configuration with Serial build run policy", func() {
+		g.It("runs the builds in serial order", func() {
+			g.By("starting multiple builds")
+			var (
+				startedBuilds []string
+				counter       int
+			)
+
+			bcName := "sample-serial-build"
+			buildVerified := map[string]bool{}
+
+			for i := 0; i < 3; i++ {
+				out, err := oc.Run("start-build").Args(bcName).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				startedBuilds = append(startedBuilds, strings.TrimSpace(out))
+			}
+
+			buildWatch, err := oc.REST().Builds(oc.Namespace()).Watch(kapi.ListOptions{
+				LabelSelector: buildutil.BuildConfigSelector(bcName),
+			})
+			defer buildWatch.Stop()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			for {
+				event := <-buildWatch.ResultChan()
+				build := event.Object.(*buildapi.Build)
+				if build.Status.Phase == buildapi.BuildPhaseRunning {
+					// Ignore events from complete builds (if there are any) if we already
+					// verified the build.
+					if _, exists := buildVerified[build.Name]; exists {
+						continue
+					}
+					// Verify there are no other running or pending builds than this
+					// build as serial build always runs alone.
+					c := buildclient.NewOSClientBuildClient(oc.REST())
+					builds, err := buildutil.BuildConfigBuilds(c, oc.Namespace(), bcName, func(b buildapi.Build) bool {
+						if b.Name == build.Name {
+							return false
+						}
+						if b.Status.Phase == buildapi.BuildPhaseRunning || b.Status.Phase == buildapi.BuildPhasePending {
+							return true
+						}
+						return false
+					})
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(builds.Items).Should(o.BeEmpty())
+
+					// The builds should start in the same order as they were created.
+					o.Expect(build.Name).Should(o.BeEquivalentTo(startedBuilds[counter]))
+
+					buildVerified[build.Name] = true
+					counter++
+				}
+				if counter == len(startedBuilds) {
+					break
+				}
+			}
+		})
+	})
+
+	g.Describe("build configuration with SerialLatestOnly build run policy", func() {
+		g.It("runs the builds in serial order but cancel previous builds", func() {
+			g.By("starting multiple builds")
+			var (
+				startedBuilds []string
+				counter       int
+				wasCancelled  bool
+			)
+
+			bcName := "sample-serial-latest-only-build"
+			buildVerified := map[string]bool{}
+			buildWatch, err := oc.REST().Builds(oc.Namespace()).Watch(kapi.ListOptions{
+				LabelSelector: buildutil.BuildConfigSelector(bcName),
+			})
+			defer buildWatch.Stop()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			out, err := oc.Run("start-build").Args(bcName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			startedBuilds = append(startedBuilds, strings.TrimSpace(out))
+			// Wait for the first build to become running
+			for {
+				event := <-buildWatch.ResultChan()
+				build := event.Object.(*buildapi.Build)
+				if build.Name == startedBuilds[0] {
+					if build.Status.Phase == buildapi.BuildPhaseRunning {
+						break
+					}
+					o.Expect(buildutil.IsBuildComplete(build)).Should(o.BeFalse())
+				}
+			}
+			// Trigger another two builds
+			for i := 0; i < 2; i++ {
+				out, err := oc.Run("start-build").Args(bcName).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				startedBuilds = append(startedBuilds, strings.TrimSpace(out))
+			}
+			// Verify that the first build will complete and the next build to run
+			// will be the last build created.
+			for {
+				event := <-buildWatch.ResultChan()
+				build := event.Object.(*buildapi.Build)
+				// The second build should be cancelled
+				if build.Status.Phase == buildapi.BuildPhaseCancelled {
+					if build.Name == startedBuilds[1] {
+						buildVerified[build.Name] = true
+						wasCancelled = true
+						counter++
+					}
+				}
+				// Only first and third build should actually run (serially).
+				if build.Status.Phase == buildapi.BuildPhaseRunning {
+					// Ignore events from complete builds (if there are any) if we already
+					// verified the build.
+					if _, exists := buildVerified[build.Name]; exists {
+						continue
+					}
+					// Verify there are no other running or pending builds than this
+					// build as serial build always runs alone.
+					c := buildclient.NewOSClientBuildClient(oc.REST())
+					builds, err := buildutil.BuildConfigBuilds(c, oc.Namespace(), bcName, func(b buildapi.Build) bool {
+						fmt.Printf("[%s] build %s is %s", build.Name, b.Name, b.Status.Phase)
+						if b.Name == build.Name {
+							return false
+						}
+						if b.Status.Phase == buildapi.BuildPhaseRunning || b.Status.Phase == buildapi.BuildPhasePending {
+							return true
+						}
+						return false
+					})
+					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(builds.Items).Should(o.BeEmpty())
+
+					// The builds should start in the same order as they were created.
+					o.Expect(build.Name).Should(o.BeEquivalentTo(startedBuilds[counter]))
+
+					buildVerified[build.Name] = true
+					counter++
+				}
+				if len(buildVerified) == len(startedBuilds) {
+					break
+				}
+			}
+
+			o.Expect(wasCancelled).Should(o.BeEquivalentTo(true))
+		})
+	})
+
+})

--- a/test/extended/fixtures/run_policy/parallel-bc.yaml
+++ b/test/extended/fixtures/run_policy/parallel-bc.yaml
@@ -1,0 +1,39 @@
+---
+  kind: "List"
+  apiVersion: "v1"
+  metadata: {}
+  items: 
+    - 
+      kind: "ImageStream"
+      apiVersion: "v1"
+      metadata: 
+        name: "origin-ruby-sample"
+        creationTimestamp: null
+      spec: {}
+      status: 
+        dockerImageRepository: ""
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "sample-parallel-build"
+      spec: 
+        runPolicy: "Parallel"
+        triggers: 
+          - 
+            type: "imageChange"
+            imageChange: {}
+        source: 
+          type: "Git"
+          git: 
+            uri: "git://github.com/openshift/ruby-hello-world.git"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "DockerImage"
+              name: "centos/ruby-22-centos7"
+        resources: {}
+      status: 
+        lastVersion: 0
+

--- a/test/extended/fixtures/run_policy/serial-bc.yaml
+++ b/test/extended/fixtures/run_policy/serial-bc.yaml
@@ -1,0 +1,30 @@
+---
+  kind: "List"
+  apiVersion: "v1"
+  metadata: {}
+  items: 
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "sample-serial-build"
+      spec: 
+        runPolicy: "Serial"
+        triggers: 
+          - 
+            type: "imageChange"
+            imageChange: {}
+        source: 
+          type: "Git"
+          git: 
+            uri: "git://github.com/openshift/ruby-hello-world.git"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "DockerImage"
+              name: "centos/ruby-22-centos7"
+        resources: {}
+      status: 
+        lastVersion: 0
+

--- a/test/extended/fixtures/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/fixtures/run_policy/serial-latest-only-bc.yaml
@@ -1,0 +1,30 @@
+---
+  kind: "List"
+  apiVersion: "v1"
+  metadata: {}
+  items: 
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "sample-serial-latest-only-build"
+      spec: 
+        runPolicy: "SerialLatestOnly"
+        triggers: 
+          - 
+            type: "imageChange"
+            imageChange: {}
+        source: 
+          type: "Git"
+          git: 
+            uri: "git://github.com/openshift/ruby-hello-world.git"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "DockerImage"
+              name: "centos/ruby-22-centos7"
+        resources: {}
+      status: 
+        lastVersion: 0
+

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -125,7 +125,12 @@ func admissionTestPod() *kapi.Pod {
 }
 
 func admissionTestBuild() *buildapi.Build {
-	build := &buildapi.Build{}
+	build := &buildapi.Build{ObjectMeta: kapi.ObjectMeta{
+		Labels: map[string]string{
+			buildapi.BuildConfigLabel:    "mock-build-config",
+			buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
+		},
+	}}
 	build.Name = "test-build"
 	build.Spec.Source.Git = &buildapi.GitBuildSource{URI: "http://build.uri/build"}
 	build.Spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -249,6 +249,10 @@ func strategyForType(t *testing.T, strategy string) buildapi.BuildStrategy {
 
 func createBuild(t *testing.T, buildInterface client.BuildInterface, strategy string) (*buildapi.Build, error) {
 	build := &buildapi.Build{}
+	build.ObjectMeta.Labels = map[string]string{
+		buildapi.BuildConfigLabel:    "mock-build-config",
+		buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
+	}
 	build.GenerateName = strings.ToLower(string(strategy)) + "-build-"
 	build.Spec.Strategy = strategyForType(t, strategy)
 	build.Spec.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
@@ -263,6 +267,7 @@ func updateBuild(t *testing.T, buildInterface client.BuildInterface, build *buil
 
 func createBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface, strategy string) (*buildapi.BuildConfig, error) {
 	buildConfig := &buildapi.BuildConfig{}
+	buildConfig.Spec.RunPolicy = buildapi.BuildRunPolicyParallel
 	buildConfig.GenerateName = strings.ToLower(string(strategy)) + "-buildconfig-"
 	buildConfig.Spec.Strategy = strategyForType(t, strategy)
 	buildConfig.Spec.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -51,8 +51,10 @@ func mockBuild() *buildapi.Build {
 		ObjectMeta: kapi.ObjectMeta{
 			GenerateName: "mock-build",
 			Labels: map[string]string{
-				"label1": "value1",
-				"label2": "value2",
+				"label1":                     "value1",
+				"label2":                     "value2",
+				buildapi.BuildConfigLabel:    "mock-build-config",
+				buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
 			},
 		},
 		Spec: buildapi.BuildSpec{

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -92,7 +92,12 @@ func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
 }
 
 func buildPodAdmissionTestCustomBuild() *buildapi.Build {
-	build := &buildapi.Build{}
+	build := &buildapi.Build{ObjectMeta: kapi.ObjectMeta{
+		Labels: map[string]string{
+			buildapi.BuildConfigLabel:    "mock-build-config",
+			buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
+		},
+	}}
 	build.Name = "test-custom-build"
 	build.Spec.Source.Git = &buildapi.GitBuildSource{URI: "http://test/src"}
 	build.Spec.Strategy.CustomStrategy = &buildapi.CustomBuildStrategy{}
@@ -102,7 +107,12 @@ func buildPodAdmissionTestCustomBuild() *buildapi.Build {
 }
 
 func buildPodAdmissionTestDockerBuild() *buildapi.Build {
-	build := &buildapi.Build{}
+	build := &buildapi.Build{ObjectMeta: kapi.ObjectMeta{
+		Labels: map[string]string{
+			buildapi.BuildConfigLabel:    "mock-build-config",
+			buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
+		},
+	}}
 	build.Name = "test-build"
 	build.Spec.Source.Git = &buildapi.GitBuildSource{URI: "http://test/src"}
 	build.Spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -113,6 +113,7 @@ func imageChangeBuildConfig(name string, strategy buildapi.BuildStrategy) *build
 			Labels:    map[string]string{"testlabel": "testvalue"},
 		},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicyParallel,
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Git: &buildapi.GitBuildSource{

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -116,7 +116,14 @@ func TestProjectMustExist(t *testing.T) {
 	}
 
 	build := &buildapi.Build{
-		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "buildid",
+			Namespace: "default",
+			Labels: map[string]string{
+				buildapi.BuildConfigLabel:    "mock-build-config",
+				buildapi.BuildRunPolicyLabel: string(buildapi.BuildRunPolicyParallel),
+			},
+		},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
 				Git: &buildapi.GitBuildSource{

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -298,6 +298,7 @@ func mockBuildConfigImageParms(imageName, imageStream, imageTag string) *buildap
 			Name: "pushbuild",
 		},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicyParallel,
 			Triggers: []buildapi.BuildTriggerPolicy{
 				{
 					Type: buildapi.GitHubWebHookBuildTriggerType,
@@ -338,6 +339,7 @@ func mockBuildConfigImageStreamParms(imageName, imageStream, imageTag string) *b
 			Name: "pushbuild",
 		},
 		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicyParallel,
 			Triggers: []buildapi.BuildTriggerPolicy{
 				{
 					Type: buildapi.GitHubWebHookBuildTriggerType,


### PR DESCRIPTION
* Add `runPolicy=Parallel | Serial | SerialLatestOnly` into the `BuildConfig`.
  * The `Parallel` represents current behavior.
  * The `Serial` means the builds will be execute sequentially.
  * The `SerialLatestOnly` means that only the latest build will be executed and previous non-running builds will be cancelled.

The `Serial` will be default when this PR gets merged. This will be documented for users.