### PR TITLE
add system:image-auditor

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -63,6 +63,7 @@ const (
 	RegistryViewerRoleName = "registry-viewer"
 	RegistryEditorRoleName = "registry-editor"
 
+	ImageAuditorRoleName      = "system:image-auditor"
 	ImagePullerRoleName       = "system:image-puller"
 	ImagePusherRoleName       = "system:image-pusher"
 	ImageBuilderRoleName      = "system:image-builder"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Role {
@@ -299,6 +300,18 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 						"/oapi", "/oapi/*",
 						"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
 					),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ImageAuditorRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{imageapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "patch", "update"),
+					Resources: sets.NewString("images"),
 				},
 			},
 		},

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -675,6 +675,23 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: system:image-auditor
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - images
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: system:image-puller
   rules:
   - apiGroups: null


### PR DESCRIPTION
Adds a `system:image-auditor` role for components that want to monitor new images in the docker registry and annotate the image as "good" or "bad" based on scan results.

@smarterclayton Approval? I think this is low risk and helps teams trying to integrate with us.

@simon3z @moolitayer Comments on whether this satisfies your use-case?