### PR TITLE
Modify pullthrough import-image use case to use our cli framework

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -125,8 +125,9 @@ os::cmd::expect_success "docker push ${DOCKER_REGISTRY}/cache/ruby-22-centos7:la
 echo "[INFO] Pushed ruby-22-centos7"
 
 # verify remote images can be pulled directly from the local registry
-oc import-image --confirm --from=mysql:latest mysql:pullthrough
-docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough
+echo "[INFO] Docker pullthrough"
+os::cmd::expect_success "oc import-image --confirm --from=mysql:latest mysql:pullthrough"
+os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough"
 
 # check to make sure an image-pusher can push an image
 os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher pusher'


### PR DESCRIPTION
Relates to #8399. Currently only image-import pullthrough use case did not use our cli testing framework. I'm adding expectations around each invoke in there. Which will also return stderr, even when the command completes successfully. 