### PR TITLE
Make DNS conformant with upstream

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/dns.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/dns.go
@@ -41,6 +41,8 @@ var dnsServiceLabelSelector = labels.Set{
 	"kubernetes.io/cluster-service": "true",
 }.AsSelector()
 
+var ClusterDNSVerifier = verifyDNSPodIsRunning
+
 func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 	pod := &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
@@ -253,7 +255,7 @@ var _ = KubeDescribe("DNS", func() {
 	f := NewDefaultFramework("dns")
 
 	It("should provide DNS for the cluster [Conformance]", func() {
-		verifyDNSPodIsRunning(f)
+		ClusterDNSVerifier(f)
 
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
@@ -280,7 +282,7 @@ var _ = KubeDescribe("DNS", func() {
 	})
 
 	It("should provide DNS for services [Conformance]", func() {
-		verifyDNSPodIsRunning(f)
+		ClusterDNSVerifier(f)
 
 		// Create a test headless service.
 		By("Creating a test headless service")
@@ -330,7 +332,7 @@ var _ = KubeDescribe("DNS", func() {
 	})
 
 	It("should provide DNS for pods for Hostname and Subdomain Annotation", func() {
-		verifyDNSPodIsRunning(f)
+		ClusterDNSVerifier(f)
 
 		// Create a test headless service.
 		By("Creating a test headless service")

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -177,7 +177,7 @@ func (c *MasterConfig) RunDNSServer() {
 		glog.Fatalf("Could not start DNS: %v", err)
 	}
 	if port != "53" {
-		glog.Warningf("Binding DNS on port %v instead of 53 (you may need to run as root and update your config), using %s which will not resolve from all locations", port, c.Options.DNSConfig.BindAddress)
+		glog.Warningf("Binding DNS on port %v instead of 53, which may not be resolvable from all clients", port)
 	}
 
 	if ok, err := cmdutil.TryListen(c.Options.DNSConfig.BindNetwork, c.Options.DNSConfig.BindAddress); !ok {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -101,7 +101,7 @@ func NewDefaultMasterArgs() *MasterArgs {
 		MasterAddr:       flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
 		EtcdAddr:         flagtypes.Addr{Value: "0.0.0.0:4001", DefaultScheme: "https", DefaultPort: 4001}.Default(),
 		MasterPublicAddr: flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
-		DNSBindAddr:      flagtypes.Addr{Value: "0.0.0.0:53", DefaultScheme: "tcp", DefaultPort: 53, AllowPrefix: true}.Default(),
+		DNSBindAddr:      flagtypes.Addr{Value: "0.0.0.0:8053", DefaultScheme: "tcp", DefaultPort: 8053, AllowPrefix: true}.Default(),
 
 		ConfigDir: &util.StringFlag{},
 
@@ -209,6 +209,8 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		DNSConfig: &configapi.DNSConfig{
 			BindAddress: dnsServingInfo.BindAddress,
 			BindNetwork: dnsServingInfo.BindNetwork,
+
+			AllowRecursiveQueries: true,
 		},
 
 		MasterClients: configapi.MasterClients{
@@ -538,7 +540,7 @@ func (args MasterArgs) GetDNSBindAddress() (flagtypes.Addr, error) {
 	if args.DNSBindAddr.Provided {
 		return args.DNSBindAddr, nil
 	}
-	dnsAddr := flagtypes.Addr{Value: args.ListenArg.ListenAddr.Host, DefaultPort: 53}.Default()
+	dnsAddr := flagtypes.Addr{Value: args.ListenArg.ListenAddr.Host, DefaultPort: args.DNSBindAddr.DefaultPort}.Default()
 	return dnsAddr, nil
 }
 

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -206,13 +206,6 @@ func (o *AllInOneOptions) Complete() error {
 	o.NodeArgs.NodeName = strings.ToLower(o.NodeArgs.NodeName)
 	o.NodeArgs.MasterCertDir = o.MasterOptions.MasterArgs.ConfigDir.Value()
 
-	// in the all-in-one, default ClusterDNS to the master's address
-	if host, _, err := net.SplitHostPort(masterAddr.Host); err == nil {
-		if ip := net.ParseIP(host); ip != nil {
-			o.NodeArgs.ClusterDNS = ip
-		}
-	}
-
 	return nil
 }
 

--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -1,0 +1,291 @@
+package dns
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e"
+)
+
+func init() {
+	// Origin provides implicit cluster DNS
+	e2e.ClusterDNSVerifier = func(f *e2e.Framework) {}
+}
+
+func createDNSPod(namespace, probeCmd string) *api.Pod {
+	pod := &api.Pod{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: registered.GroupOrDie(api.GroupName).GroupVersion.String(),
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "dns-test-" + string(util.NewUUID()),
+			Namespace: namespace,
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyNever,
+			Containers: []api.Container{
+				{
+					Name:    "querier",
+					Image:   "gcr.io/google_containers/dnsutils:e2e",
+					Command: []string{"sh", "-c", probeCmd},
+				},
+			},
+		},
+	}
+	return pod
+}
+
+func digForNames(namesToResolve []string, expect sets.String) string {
+	fileNamePrefix := "test"
+	var probeCmd string
+	for _, name := range namesToResolve {
+		// Resolve by TCP and UDP DNS.  Use $$(...) because $(...) is
+		// expanded by kubernetes (though this won't expand so should
+		// remain a literal, safe > sorry).
+		lookup := "A"
+		if strings.HasPrefix(name, "_") {
+			lookup = "SRV"
+		}
+		fileName := fmt.Sprintf("%s_udp@%s", fileNamePrefix, name)
+		expect.Insert(fileName)
+		probeCmd += fmt.Sprintf(`test -n "$$(dig +notcp +noall +answer +search %s %s)" && echo %q;`, name, lookup, fileName)
+		fileName = fmt.Sprintf("%s_tcp@%s", fileNamePrefix, name)
+		expect.Insert(fileName)
+		probeCmd += fmt.Sprintf(`test -n "$$(dig +tcp +noall +answer +search %s %s)" && echo %q;`, name, lookup, fileName)
+	}
+	return probeCmd
+}
+
+func digForARecords(records map[string][]string, expect sets.String) string {
+	var probeCmd string
+	fileNamePrefix := "test"
+	for name, ips := range records {
+		fileName := fmt.Sprintf("%s_endpoints@%s", fileNamePrefix, name)
+		probeCmd += fmt.Sprintf(`[ "$$(dig +short +notcp +noall +answer +search %s A | sort | xargs echo)" = "%s" ] && echo %q;`, name, strings.Join(ips, " "), fileName)
+		expect.Insert(fileName)
+	}
+	return probeCmd
+}
+
+func digForPod(namespace string, expect sets.String) string {
+	var probeCmd string
+	fileNamePrefix := "test"
+	podARecByUDPFileName := fmt.Sprintf("%s_udp@PodARecord", fileNamePrefix)
+	podARecByTCPFileName := fmt.Sprintf("%s_tcp@PodARecord", fileNamePrefix)
+	probeCmd += fmt.Sprintf(`podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".%s.pod.cluster.local"}');`, namespace)
+	probeCmd += fmt.Sprintf(`test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo %q;`, podARecByUDPFileName)
+	probeCmd += fmt.Sprintf(`test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo %q;`, podARecByTCPFileName)
+	expect.Insert(podARecByUDPFileName, podARecByTCPFileName)
+	return probeCmd
+}
+
+func repeatCommand(times int, cmd ...string) string {
+	probeCmd := fmt.Sprintf("for i in `seq 1 %d`; do ", times)
+	probeCmd += strings.Join(cmd, " ")
+	probeCmd += "sleep 1; done"
+	return probeCmd
+}
+
+func assertLinesExist(lines sets.String, expect int, r io.Reader) error {
+	count := make(map[string]int)
+	unrecognized := sets.NewString()
+	scan := bufio.NewScanner(r)
+	for scan.Scan() {
+		line := scan.Text()
+		if lines.Has(line) {
+			count[line]++
+		} else {
+			unrecognized.Insert(line)
+		}
+	}
+	for k := range lines {
+		if count[k] != expect {
+			return fmt.Errorf("unexpected count %d/%d for %q: %v", count[k], expect, k, unrecognized)
+		}
+	}
+	if unrecognized.Len() > 0 {
+		return fmt.Errorf("unexpected matches from output: %v", unrecognized)
+	}
+	return nil
+}
+
+func validateDNSResults(f *e2e.Framework, pod *api.Pod, fileNames sets.String, expect int) {
+	By("submitting the pod to kubernetes")
+	podClient := f.Client.Pods(f.Namespace.Name)
+	defer func() {
+		By("deleting the pod")
+		defer GinkgoRecover()
+		podClient.Delete(pod.Name, api.NewDeleteOptions(0))
+	}()
+	if _, err := podClient.Create(pod); err != nil {
+		e2e.Failf("Failed to create %s pod: %v", pod.Name, err)
+	}
+
+	Expect(f.WaitForPodRunning(pod.Name)).To(BeNil())
+	Expect(wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		pod, err := podClient.Get(pod.Name)
+		if err != nil {
+			return false, err
+		}
+		switch pod.Status.Phase {
+		case api.PodSucceeded:
+			return true, nil
+		case api.PodFailed:
+			return false, fmt.Errorf("pod failed")
+		default:
+			return false, nil
+		}
+	})).To(BeNil())
+
+	By("retrieving the pod logs")
+	r, err := podClient.GetLogs(pod.Name, &api.PodLogOptions{Container: "querier"}).Stream()
+	if err != nil {
+		e2e.Failf("Failed to get pod logs %s: %v", pod.Name, err)
+	}
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		e2e.Failf("Failed to read pod logs %s: %v", pod.Name, err)
+	}
+
+	// Try to find results for each expected name.
+	By("looking for the results for each expected name from probiers")
+
+	if err := assertLinesExist(fileNames, expect, bytes.NewBuffer(out)); err != nil {
+		e2e.Logf("Got results from pod:\n%s", out)
+		e2e.Failf("Unexpected results: %v", err)
+	}
+
+	e2e.Logf("DNS probes using %s succeeded\n", pod.Name)
+}
+
+func createServiceSpec(serviceName string, isHeadless bool, selector map[string]string) *api.Service {
+	headlessService := &api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: serviceName,
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{
+				{Port: 80, Name: "http", Protocol: "TCP"},
+			},
+			Selector: selector,
+		},
+	}
+	if isHeadless {
+		headlessService.Spec.ClusterIP = "None"
+	}
+	return headlessService
+}
+
+func createEndpointSpec(name string) *api.Endpoints {
+	return &api.Endpoints{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Subsets: []api.EndpointSubset{
+			{
+				Addresses: []api.EndpointAddress{
+					{IP: "1.1.1.1"},
+					{IP: "1.1.1.2"},
+				},
+				NotReadyAddresses: []api.EndpointAddress{
+					{IP: "2.1.1.1"},
+					{IP: "2.1.1.2"},
+				},
+				Ports: []api.EndpointPort{
+					{Port: 80},
+				},
+			},
+		},
+	}
+}
+
+func ipsForEndpoints(ep *api.Endpoints) []string {
+	ips := sets.NewString()
+	for _, sub := range ep.Subsets {
+		for _, addr := range sub.Addresses {
+			ips.Insert(addr.IP)
+		}
+	}
+	return ips.List()
+}
+
+var _ = Describe("DNS", func() {
+	f := e2e.NewDefaultFramework("dns")
+
+	It("should answer endpoint and wildcard queries for the cluster [Conformance]", func() {
+		e2e.ClusterDNSVerifier(f)
+
+		if _, err := f.Client.Services(f.Namespace.Name).Create(createServiceSpec("headless", true, nil)); err != nil {
+			e2e.Failf("unable to create headless service: %v", err)
+		}
+		if _, err := f.Client.Endpoints(f.Namespace.Name).Create(createEndpointSpec("headless")); err != nil {
+			e2e.Failf("unable to create clusterip endpoints: %v", err)
+		}
+		if _, err := f.Client.Services(f.Namespace.Name).Create(createServiceSpec("clusterip", false, nil)); err != nil {
+			e2e.Failf("unable to create clusterip service: %v", err)
+		}
+		if _, err := f.Client.Endpoints(f.Namespace.Name).Create(createEndpointSpec("clusterip")); err != nil {
+			e2e.Failf("unable to create clusterip endpoints: %v", err)
+		}
+
+		ep, err := f.Client.Endpoints("default").Get("kubernetes")
+		if err != nil {
+			e2e.Failf("unable to find endpoints for kubernetes.default: %v", err)
+		}
+		kubeEndpoints := ipsForEndpoints(ep)
+
+		readyEndpoints := ipsForEndpoints(createEndpointSpec(""))
+
+		// All the names we need to be able to resolve.
+		expect := sets.NewString()
+		times := 10
+		cmd := repeatCommand(
+			times,
+			// the DNS pod should be able to resolve these names
+			digForNames([]string{
+				// answer wildcards on default service
+				"prefix.kubernetes.default",
+				"prefix.kubernetes.default.svc",
+				"prefix.kubernetes.default.svc.cluster.local",
+
+				// answer wildcards on cluster service
+				fmt.Sprintf("prefix.headless.%s", f.Namespace.Name),
+				fmt.Sprintf("prefix.clusterip.%s", f.Namespace.Name),
+			}, expect),
+
+			// the DNS pod should be able to look up endpoints for names and wildcards
+			digForARecords(map[string][]string{
+				"kubernetes.default.endpoints":                      kubeEndpoints,
+				"prefix.kubernetes.default.endpoints.cluster.local": kubeEndpoints,
+
+				fmt.Sprintf("headless.%s.svc", f.Namespace.Name):        readyEndpoints,
+				fmt.Sprintf("headless.%s.endpoints", f.Namespace.Name):  readyEndpoints,
+				fmt.Sprintf("clusterip.%s.endpoints", f.Namespace.Name): readyEndpoints,
+			}, expect),
+
+			// the DNS pod should respond to its own request
+			digForPod(f.Namespace.Name, expect),
+		)
+
+		By("Running these commands:" + cmd + "\n")
+
+		// Run a pod which probes DNS and exposes the results by HTTP.
+		By("creating a pod to probe DNS")
+		pod := createDNSPod(f.Namespace.Name, cmd)
+		validateDNSResults(f, pod, expect, times)
+	})
+})

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/deployments"
+	_ "github.com/openshift/origin/test/extended/dns"
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/jenkins"
 	_ "github.com/openshift/origin/test/extended/jobs"

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -134,7 +134,6 @@ readonly EXCLUDED_TESTS=(
   Monitoring              # Not installed, should be
   "Cluster level logging" # Not installed yet
   Kibana                  # Not installed
-  DNS                     # Can't depend on kube-dns
   Ubernetes               # Can't set zone labels today
   kube-ui                 # Not installed by default
   "^Kubernetes Dashboard"  # Not installed by default (also probbaly slow image pull)

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -227,7 +227,7 @@ func TestDNS(t *testing.T) {
 		},
 		{
 			dnsQuestionName:   "www.google.com.",
-			recursionExpected: false,
+			recursionExpected: true,
 		},
 	}
 	for i, tc := range tests {
@@ -236,7 +236,7 @@ func TestDNS(t *testing.T) {
 			qType = dns.TypeSRV
 		}
 		m1 := &dns.Msg{
-			MsgHdr:   dns.MsgHdr{Id: dns.Id(), RecursionDesired: false},
+			MsgHdr:   dns.MsgHdr{Id: dns.Id(), RecursionDesired: tc.recursionExpected},
 			Question: []dns.Question{{tc.dnsQuestionName, qType, dns.ClassINET}},
 		}
 		ch := make(chan struct{})


### PR DESCRIPTION
Our DNS implementation was not returning an etcd-alike error to indicate to SkyDNS that the name was not found (and prompt NXDOMAIN error status). This changes the error we return, enables the upstream DNS tests, and adds our own e2e test for wildcarding and endpoints within the pod. This will supercede our integration test (which may not be necessary anymore).

[test]

Fixes #8556