### PR TITLE
Enforce overview scaling rules for deployments without a service

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -236,7 +236,7 @@
                       deployment-config-id="deploymentConfigId"
                       deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
                       deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[''][deploymentConfigId]"
-                      scalable="true"
+                      scalable="isScalable(deployment, deploymentConfigId)"
                       images-by-docker-reference="imagesByDockerReference"
                       builds="builds"
                       pods="podsByDeployment[deployment.metadata.name]">


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1326214

We were not checking if a deployment was scalable on the overview when it did not have a service. This adds the existing check we use elsewhere.

@jwforres @smarterclayton 