### PR TITLE
Prevent concurrent deployer pod creation

### DIFF
--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -659,7 +659,7 @@ func TestHandle_cancelNew(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if e, a := deployapi.DeploymentStatusFailed, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusPending, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected deployment status %s, got %s", e, a)
 	}
 }
@@ -706,7 +706,7 @@ func TestHandle_cancelNewWithDeployers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if e, a := deployapi.DeploymentStatusFailed, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusPending, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected deployment status %s, got %s", e, a)
 	}
 	if !updatedDeployer {


### PR DESCRIPTION
When cancelling deployer pods while the deployment is still in a New
phase, transition the deployment to a non-terminal phase so that the
other controllers don't think the deployment is complete/failed before
the deployer pods for the cancelled deployment have actually terminated.

For https://github.com/openshift/origin/issues/8403