### PR TITLE
Use "font-awesome" bower dependency instead of "fontawesome" to lock versions

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -212,7 +212,8 @@ module.exports = function (grunt) {
           'bower_components/messenger/build/css/messenger-theme-block.css',
           'bower_components/messenger/build/css/messenger-theme-air.css',
           'bower_components/messenger/build/css/messenger-theme-ice.css',
-          'bower_components/messenger/build/js/messenger-theme-future.js'
+          'bower_components/messenger/build/js/messenger-theme-future.js',
+          'bower_components/fontawesome/css/font-awesome.css'
         ]
       }
     },

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -36,17 +36,16 @@
     "yamljs": "0.1.5",
     "clipboard": "1.5.8",
     "pathseg": "1.0.2",
-    "fontawesome": "4.6.1",
     "ansi_up": "1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",
-    "angular-scenario": "1.3.8"
+    "angular-scenario": "1.3.8",
+    "font-awesome": "4.6.1"
   },
   "appPath": "app",
   "resolutions": {
-    "lodash": "3.10.1",
-    "fontawesome": "4.6.1"
+    "lodash": "3.10.1"
   },
   "overrides": {
     "angular-patternfly": {


### PR DESCRIPTION
Use "font-awesome" rather than "fontawesome" to match k8s-container-terminal and lock to a version.

@jwforres @smarterclayton 