### PR TITLE
Update atomic registry quickstart artifacts

### DIFF
--- a/examples/atomic-registry/Makefile
+++ b/examples/atomic-registry/Makefile
@@ -13,7 +13,8 @@ install:
 	sudo atomic run $(TEST_IMAGE) $(INSTALLHOST)
 
 test:
-	bash test.sh
+	bash test.sh 127.0.0.1
 
 clean:
-	sudo atomic uninstall --force $(TEST_IMAGE) ; sudo docker rm $(sudo docker ps -qa)
+	sudo atomic uninstall --force $(TEST_IMAGE)
+	sudo docker rm $(sudo docker ps -qa)

--- a/examples/atomic-registry/install.sh
+++ b/examples/atomic-registry/install.sh
@@ -11,7 +11,11 @@ INSTALL_HOST=${1:-`hostname`}
 echo "Installing using hostname ${INSTALL_HOST}"
 
 # write out configuration
-openshift start --write-config /etc/origin/ --etcd-dir /var/lib/origin/etcd --volume-dir /var/lib/origin/volumes --public-master ${INSTALL_HOST}
+openshift start --write-config /etc/origin/ \
+  --etcd-dir /var/lib/origin/etcd
+  --volume-dir /var/lib/origin/volumes
+  --public-master ${INSTALL_HOST}
+  --hostname ${INSTALL_HOST}
 
 echo "Copy files to host"
 
@@ -31,10 +35,10 @@ cat /etc/origin/master/master.server.crt /etc/origin/master/master.server.key > 
 set +x
 
 echo "Updating servicesNodePortRange to 443-32767..."
-sed -i 's/  servicesNodePortRange:.*$/  servicesNodePortRange: 443-32767/' /etc/origin/master/master-config.yaml
+sed -i 's/  servicesNodePortRange:.*$/  servicesNodePortRange: 80-32767/' /etc/origin/master/master-config.yaml
 echo "Updating login template"
 sed -i 's/  templates: null$/  templates:\n    login: site\/registry-login-template.html/' /etc/origin/master/master-config.yaml
 
 echo "Optionally edit configuration file /etc/origin/master/master-config.yaml,"
 echo "add certificates to /etc/origin/master,"
-echo "then run 'atomic run atomic-registry-quickstart'"
+echo "then run 'atomic run projectatomic/atomic-registry-quickstart'"

--- a/examples/atomic-registry/run.sh
+++ b/examples/atomic-registry/run.sh
@@ -71,7 +71,7 @@ $CMD oc new-app --template registry-console-template \
      -p OPENSHIFT_OAUTH_PROVIDER_URL=https://${INSTALL_HOST}:8443,COCKPIT_KUBE_URL=https://${INSTALL_HOST},REGISTRY_HOST=${INSTALL_HOST}:5000
 # we're hacking the service to use a node port to reduce deployment complexity
 $CMD oc patch service registry-console -p \
-     '{ "spec": { "type": "NodePort", "selector": {"name": "registry-console"}, "ports": [ {"nodePort": 443, "port": 9000, "targetPort": 9090}] }}'
+     '{ "spec": { "type": "NodePort", "selector": {"name": "registry-console"}, "ports": [ {"name": "https", "nodePort": 443, "port": 9000, "targetPort": 9090}, {"name": "http", "nodePort": 80, "port": 9000, "targetPort": 9090} ] }}'
 
 set +x
 echo "Updating default project configuration"

--- a/examples/atomic-registry/test.sh
+++ b/examples/atomic-registry/test.sh
@@ -5,6 +5,8 @@
 # run with "uninstall" argument to test tear down after test
 ###
 
+# $1 is optional hostname override
+
 set -o errexit
 set -o pipefail
 set -x
@@ -13,7 +15,7 @@ TEST_IMAGE=atomic-registry-quickstart
 
 # we're going to use this for testing
 # node ports aren't working with boxes default hostname localdomain.localhost
-LOCALHOST=127.0.0.1
+LOCALHOST=${1:-`hostname`}
 CMD="docker exec -it origin"
 
 USER=mary


### PR DESCRIPTION
Enable hostname override in test script
Patch registry console service to include port 80
Extend node port range down to port 80
Use --hostname arg when writing origin config