### PR TITLE
Support path routes with port number in Host header

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -63,6 +63,9 @@ frontend public
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
+  # Remove port from Host header
+  http-request replace-header Host (.*):.* \1
+
   # check if we need to redirect/force using https.
   acl secure_redirect base,map_beg(/var/lib/haproxy/conf/os_edge_http_redirect.map) -m found
   redirect scheme https if secure_redirect
@@ -118,6 +121,9 @@ frontend fe_sni
   bind 127.0.0.1:10444 ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt {{ $workingDir }}/certs accept-proxy
   mode http
 
+  # Remove port from Host header
+  http-request replace-header Host (.*):.* \1
+
   # check re-encrypt backends first - from most specific to general path.
   acl reencrypt base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map) -m found
 
@@ -151,6 +157,9 @@ frontend fe_no_sni
   # terminate ssl on edge
   bind 127.0.0.1:10443 ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
   mode http
+
+  # Remove port from Host header
+  http-request replace-header Host (.*):.* \1
 
   # check re-encrypt backends first - path or host based.
   acl reencrypt base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map) -m found

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -464,6 +464,10 @@ func TestRouterPathSpecificity(t *testing.T) {
 	if _, err := getRoute(routeAddress, "www.example.com", "http", nil, ""); err != ErrUnavailable {
 		t.Fatalf("unexpected response: %q", err)
 	}
+	//ensure you can curl path with port in Host header
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodPath); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
 
 	//create newer, conflicting path based route
 	endpointEvent = &watch.Event{
@@ -499,6 +503,9 @@ func TestRouterPathSpecificity(t *testing.T) {
 	if err := waitForRoute(routeTestAddress, "www.example.com", "http", nil, tr.HelloPodPath); err != nil {
 		t.Fatalf("unexpected response: %q", err)
 	}
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodPath); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
 
 	//create host based route
 	routeEvent = &watch.Event{
@@ -524,6 +531,9 @@ func TestRouterPathSpecificity(t *testing.T) {
 		t.Fatalf("unexpected response: %q", err)
 	}
 	if err := waitForRoute(routeAddress, "www.example.com", "http", nil, tr.HelloPod); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodPath); err != nil {
 		t.Fatalf("unexpected response: %q", err)
 	}
 
@@ -558,6 +568,9 @@ func TestRouterPathSpecificity(t *testing.T) {
 	if err := waitForRoute(routeAddress, "www.example.com", "http", nil, tr.HelloPod); err != nil {
 		t.Fatalf("unexpected response: %q", err)
 	}
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodPath); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
 
 	// create newer, conflicting host based route that is ignored
 	routeEvent = &watch.Event{
@@ -584,6 +597,9 @@ func TestRouterPathSpecificity(t *testing.T) {
 	if err := waitForRoute(routeAddress, "www.example.com", "http", nil, tr.HelloPod); err != nil {
 		t.Fatalf("unexpected response: %q", err)
 	}
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodPath); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
 
 	//create old, conflicting host based route which should take over the route
 	routeEvent = &watch.Event{
@@ -608,6 +624,9 @@ func TestRouterPathSpecificity(t *testing.T) {
 		t.Fatalf("unexpected response: %q", err)
 	}
 	if err := waitForRoute(routeAddress, "www.example.com", "http", nil, tr.HelloPodAlternate); err != nil {
+		t.Fatalf("unexpected response: %q", err)
+	}
+	if err := waitForRoute(routeTestAddress, "www.example.com:80", "http", nil, tr.HelloPodAlternate); err != nil {
 		t.Fatalf("unexpected response: %q", err)
 	}
 


### PR DESCRIPTION
~~This deals with #8471 by adding a duplicate entry to the map files that also includes the port, which will match values of `base` that result when a client includes the port number in the `Host` header.~~

This deals with #8471 by removing ports from the `Host` header send by clients.

Fixes #8471.