### PR TITLE
add default resource requests to router creation

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -14,6 +14,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -666,6 +667,12 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			ReadinessProbe:  readinessProbe,
 			ImagePullPolicy: kapi.PullIfNotPresent,
 			VolumeMounts:    mounts,
+			Resources: kapi.ResourceRequirements{
+				Requests: kapi.ResourceList{
+					kapi.ResourceCPU:    resource.MustParse("100m"),
+					kapi.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Add the ability to specify resource quotas on a router when it is
created using the "oadm router" command. When creating a router
without requests or limits oadm returns a warning that it is not
recommended to run a router without resource quotas.

if the limits or requests are not not passed the the router is still
built but a warning is returned that it is not advised to run a router
without requests and limits in a production environment

Also adds the flags help text to oadm help router

addresses: https://github.com/openshift/origin/issues/8328