### PR TITLE
UPSTREAM: 23435: Fixed mounting with containerized kubelet

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -34,6 +34,7 @@ type Interface interface {
 	// consistent.
 	List() ([]MountPoint, error)
 	// IsLikelyNotMountPoint determines if a directory is a mountpoint.
+	// It should return ErrNotExist when the directory does not exist.
 	IsLikelyNotMountPoint(file string) (bool, error)
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
@@ -170,6 +170,12 @@ func (n *NsenterMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 		return true, err
 	}
 
+	// Check the directory exists
+	if _, err = os.Stat(file); os.IsNotExist(err) {
+		glog.V(5).Infof("findmnt: directory %s does not exist", file)
+		return true, err
+	}
+
 	args := []string{"--mount=/rootfs/proc/1/ns/mnt", "--", n.absHostPath("findmnt"), "-o", "target", "--noheadings", "--target", file}
 	glog.V(5).Infof("findmnt command: %v %v", nsenterPath, args)
 


### PR DESCRIPTION
NsenterMounter.IsLikelyNotMountPoint() should return ErrNotExist when the checked directory does not exists - the regular mounted does this and some volume plugins depend on this behavior.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1313210