### PR TITLE
Improve oc cancel-build command

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -861,6 +861,7 @@ _oc_cancel-build()
 
     flags+=("--dump-logs")
     flags+=("--restart")
+    flags+=("--state=")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -4446,6 +4446,7 @@ _openshift_cli_cancel-build()
 
     flags+=("--dump-logs")
     flags+=("--restart")
+    flags+=("--state=")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -627,20 +627,26 @@ Autoscale a deployment config or replication controller
 
 
 == oc cancel-build
-Cancel a pending or running build
+Cancel running, pending, or new builds
 
 ====
 
 [options="nowrap"]
 ----
   # Cancel the build with the given name
-  $ oc cancel-build 1da32cvq
+  $ oc cancel-build ruby-build-2
 
   # Cancel the named build and print the build logs
-  $ oc cancel-build 1da32cvq --dump-logs
+  $ oc cancel-build ruby-build-2 --dump-logs
 
   # Cancel the named build and create a new one with the same parameters
-  $ oc cancel-build 1da32cvq --restart
+  $ oc cancel-build ruby-build-2 --restart
+
+  # Cancel multiple builds
+  $ oc cancel-build ruby-build-1 ruby-build-2 ruby-build-3
+
+  # Cancel all builds created from 'ruby-build' build configuration that are in 'new' state
+  $ oc cancel-build bc/ruby-build --state=new
 ----
 ====
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -105,7 +105,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdRollback(fullName, f, out),
 				cmd.NewCmdNewBuild(fullName, f, in, out),
 				cmd.NewCmdStartBuild(fullName, f, in, out),
-				cmd.NewCmdCancelBuild(fullName, f, out),
+				cmd.NewCmdCancelBuild(fullName, f, in, out),
 				cmd.NewCmdImportImage(fullName, f, out),
 				cmd.NewCmdTag(fullName, f, out),
 			},

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -128,6 +128,7 @@ os::cmd::expect_success 'oc delete all -l build=docker'
 echo "buildConfig: ok"
 os::test::junit::declare_suite_end
 
+
 os::test::junit::declare_suite_start "cmd/builds/start-build"
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-buildcli.json'
 # a build for which there is not an upstream tag in the corresponding imagerepo, so
@@ -140,14 +141,26 @@ echo "start-build: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/builds/cancel-build"
-os::cmd::expect_success_and_text "oc cancel-build ${started} --dump-logs --restart" "Restarted build ${started}."
+os::cmd::expect_success_and_text "oc cancel-build ${started} --dump-logs --restart" "restarted build \"${started}\""
 os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -'
 os::cmd::try_until_success 'oc get build/ruby-sample-build-1'
 # Uses type/name resource syntax to cancel the build and check for proper message
-os::cmd::expect_success_and_text 'oc cancel-build build/ruby-sample-build-1' 'Build ruby-sample-build-1 was cancelled.'
+os::cmd::expect_success_and_text 'oc cancel-build build/ruby-sample-build-1' 'build "ruby-sample-build-1" cancelled'
 # Make sure canceling already cancelled build returns proper message
-os::cmd::try_until_text 'oc cancel-build build/ruby-sample-build-1' 'A cancellation event was already triggered for the build ruby-sample-build-1.'
+os::cmd::expect_success 'oc cancel-build build/ruby-sample-build-1'
+# Cancel all builds from a build configuration
+os::cmd::expect_success "oc start-build bc/ruby-sample-build"
+os::cmd::expect_success "oc start-build bc/ruby-sample-build"
+lastbuild=$(oc start-build bc/ruby-sample-build)
+os::cmd::expect_success_and_text 'oc cancel-build bc/ruby-sample-build', "build \"${lastbuild}\" cancelled"
+os::cmd::expect_success_and_text "oc get builds ${lastbuild} -o template --template '{{.status.phase}}'", 'Cancelled'
+builds=$(oc get builds -o template --template '{{range .items}}{{ .status.phase }} {{end}}')
+for state in $builds; do
+  os::cmd::expect_success "[ \"${state}\" == \"Cancelled\" ]"
+done
+# Running this command again when all builds are cancelled should be no-op.
+os::cmd::expect_success 'oc cancel-build bc/ruby-sample-build'
 os::cmd::expect_success 'oc delete all --all'
 echo "cancel-build: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
This is rework of the `oc cancel-build` command, following the 'options' style @smarterclayton introduced for start-build and other commands already.

It also adds more functions and control over cancelling builds, following this PR: https://github.com/openshift/origin/pull/8453

More specifically:

* You can now cancel multiple builds: 

`oc cancel-build ruby-build-1 ruby-build-2 ...`

* You can now cancel all (new, pending, running) builds created from build config: 

`oc cancel-build bc/ruby-build`

* And you can also select what builds you want to cancel: 

`oc cancel-build bc/ruby-build --state=new`

The last example is basically a command that will cleanup the build queue, allowing the next created build to be first executed (@bparees).

@smarterclayton PTAL.