### PR TITLE
Add extended network tests for default namespace non-isolation

### DIFF
--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -33,6 +33,32 @@ var _ = Describe("[networking] network isolation", func() {
 		skipIfMultiTenant()
 		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
 	})
+
+	// The test framework doesn't allow us to easily make use of the actual "default"
+	// namespace, so we test default namespace behavior by changing either f1's or
+	// f2's NetNamespace to have VNID 0 instead. But this only works under the
+	// multi-tenant plugin since the single-tenant one doesn't create NetNamespaces at
+	// all (and so there's not really any point in even running these tests anyway).
+	Specify("multi-tenant plugins should allow communication from default to non-default namespace on the same node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f2.Namespace)
+		Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow communication from default to non-default namespace on a different node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f2.Namespace)
+		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow communication from non-default to default namespace on the same node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f1.Namespace)
+		Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow communication from non-default to default namespace on a different node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f1.Namespace)
+		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+	})
 })
 
 func checkPodIsolation(f1, f2 *e2e.Framework, numNodes int) error {

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -41,6 +41,27 @@ var _ = Describe("[networking] services", func() {
 		err := checkServiceConnectivity(f1, f2, 2)
 		Expect(err).To(HaveOccurred())
 	})
+
+	Specify("multi-tenant plugins should allow connections to services in the default namespace from a pod in another namespaces on the same node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f1.Namespace)
+		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow connections to services in the default namespace from a pod in another namespace on a different node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f1.Namespace)
+		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow connections from pods in the default namespace to a service in another namespaces on the same node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f2.Namespace)
+		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+	})
+	Specify("multi-tenant plugins should allow connections from pods in the default namespace to a service in another namespaces on a different node", func() {
+		skipIfSingleTenant()
+		makeNamespaceGlobal(f2.Namespace)
+		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+	})
 })
 
 func checkServiceConnectivity(serverFramework, clientFramework *e2e.Framework, numNodes int) error {

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"time"
 
+	testexutil "github.com/openshift/origin/test/extended/util"
+	testutil "github.com/openshift/origin/test/util"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -154,6 +157,16 @@ func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, 
 
 func pluginIsolatesNamespaces() bool {
 	return os.Getenv("OPENSHIFT_NETWORK_ISOLATION") == "true"
+}
+
+func makeNamespaceGlobal(ns *api.Namespace) {
+	client, err := testutil.GetClusterAdminClient(testexutil.KubeConfigPath())
+	expectNoError(err)
+	netns, err := client.NetNamespaces().Get(ns.Name)
+	expectNoError(err)
+	netns.NetID = 0
+	_, err = client.NetNamespaces().Update(netns)
+	expectNoError(err)
 }
 
 func skipIfSingleTenant() {


### PR DESCRIPTION
@marun PTAL
(and @pravisankar FYI since the "makeGlobalNamespace()" function will need to change when you change how netnamespaces work...)