### PR TITLE
dind: stop attempting to cache images during build

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -104,9 +104,7 @@ function check-selinux() {
   fi
 }
 
-IMAGE_REGISTRY="${OPENSHIFT_TEST_IMAGE_REGISTRY:-}"
-IMAGE_TAG="${OPENSHIFT_TEST_IMAGE_TAG:-}"
-DIND_IMAGE="${IMAGE_REGISTRY}openshift/dind${IMAGE_TAG}"
+DIND_IMAGE="openshift/dind"
 BUILD_IMAGES="${OPENSHIFT_DIND_BUILD_IMAGES:-1}"
 
 function build-image() {
@@ -123,14 +121,7 @@ function build-images() {
   # separation of image build from cluster creation.
   if [[ "${BUILD_IMAGES}" = "1" ]]; then
     echo "Building container images"
-    if [[ -n "${IMAGE_REGISTRY}" ]]; then
-      # Failure to cache is assumed to not be worth failing the build.
-      ${DOCKER_CMD} pull "${DIND_IMAGE}" || true
-    fi
     build-image "${ORIGIN_ROOT}/images/dind" "${DIND_IMAGE}"
-    if [[ -n "${IMAGE_REGISTRY}" ]]; then
-      ${DOCKER_CMD} push "${DIND_IMAGE}" || true
-    fi
   fi
 }
 


### PR DESCRIPTION
Under the assumption that a pulled image would populate the docker build
cache, dind was previously capable of pulling a cached image in the
interests of minimizing the time to build the dind image.  Since that
assumption was incorrect, this change removes that capability.

cc: @openshift/networking 