### PR TITLE
Change the context being used when Stat-ing remote registry

### DIFF
--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -90,7 +90,7 @@ func (r *pullthroughBlobStore) proxyStat(ctx context.Context, retriever importer
 		return distribution.Descriptor{}, err
 	}
 	pullthroughBlobStore := repo.Blobs(ctx)
-	desc, err := pullthroughBlobStore.Stat(r.repo.ctx, dgst)
+	desc, err := pullthroughBlobStore.Stat(ctx, dgst)
 	if err != nil {
 		if err != distribution.ErrBlobUnknown {
 			context.GetLogger(r.repo.ctx).Errorf("Error getting pullthroughBlobStore for image %q: %v", ref.Exact(), err)


### PR DESCRIPTION
This is another try to address #8399.

My latest chase revealed this error (split into lines for readability):
```
Error getting pullthroughBlobStore for image \"docker.io/library/mysql:latest\": 
unauthorized: authentication required" 
go.version=go1.6 
http.request.host="172.30.25.55:5000" 
http.request.id=5cc013f5-2662-496a-9cb5-6fce187f711b 
http.request.method=HEAD 
http.request.remoteaddr="172.18.15.86:42495" 
http.request.uri="/v2/cache/mysql/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4" 
http.request.useragent="docker/1.9.1 go/go1.4.2 kernel/3.10.0-229.7.2.el7.x86_64 os/linux arch/amd64" 
instance.id=be1a0e30-a5ce-41bd-8e98-682ed6469885 vars.digest="sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4" vars.name="cache/mysql" 
```

after talking to @miminar he suggested changing the context used in Stat. @smarterclayton wdyt?
@pweil- fyi