### PR TITLE
Separate build strategy permissions into distinct roles

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -63,6 +63,10 @@ const (
 	RegistryViewerRoleName = "registry-viewer"
 	RegistryEditorRoleName = "registry-editor"
 
+	BuildStrategyDockerRoleName = "system:build-strategy-docker"
+	BuildStrategyCustomRoleName = "system:build-strategy-custom"
+	BuildStrategySourceRoleName = "system:build-strategy-source"
+
 	ImageAuditorRoleName      = "system:image-auditor"
 	ImagePullerRoleName       = "system:image-puller"
 	ImagePusherRoleName       = "system:image-pusher"
@@ -113,6 +117,10 @@ const (
 	RegistryAdminRoleBindingName     = RegistryAdminRoleName + "s"
 	RegistryViewerRoleBindingName    = RegistryViewerRoleName + "s"
 	RegistryEditorRoleBindingName    = RegistryEditorRoleName + "s"
+
+	BuildStrategyDockerRoleBindingName = BuildStrategyDockerRoleName + "-binding"
+	BuildStrategyCustomRoleBindingName = BuildStrategyCustomRoleName + "-binding"
+	BuildStrategySourceRoleBindingName = BuildStrategySourceRoleName + "-binding"
 
 	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "s"
 )

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -111,6 +111,43 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: BuildStrategyDockerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.DockerBuildResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: BuildStrategyCustomRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.CustomBuildResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: BuildStrategySourceRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.SourceBuildResource),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: AdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
@@ -132,9 +169,6 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 						authorizationapi.OpenshiftExposedGroupName,
 						authorizationapi.PermissionGrantingGroupName,
 						"projects",
-						authorizationapi.DockerBuildResource,
-						authorizationapi.SourceBuildResource,
-						authorizationapi.CustomBuildResource,
 						"deploymentconfigs/scale",
 						"imagestreams/secrets",
 					),
@@ -196,9 +230,6 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
 					Resources: sets.NewString(
 						authorizationapi.OpenshiftExposedGroupName,
-						authorizationapi.DockerBuildResource,
-						authorizationapi.SourceBuildResource,
-						authorizationapi.CustomBuildResource,
 						"deploymentconfigs/scale",
 						"imagestreams/secrets",
 					),
@@ -941,6 +972,25 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup},
 				{Kind: authorizationapi.SystemGroupKind, Name: UnauthenticatedGroup},
 			},
+		},
+
+		// Allow all build strategies by default.
+		// Cluster admins can remove these role bindings, and the reconcile-cluster-role-bindings command
+		// run during an upgrade won't re-add the "system:authenticated" group
+		{
+			ObjectMeta: kapi.ObjectMeta{Name: BuildStrategyDockerRoleBindingName},
+			RoleRef:    kapi.ObjectReference{Name: BuildStrategyDockerRoleName},
+			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{Name: BuildStrategyCustomRoleBindingName},
+			RoleRef:    kapi.ObjectReference{Name: BuildStrategyCustomRoleName},
+			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{Name: BuildStrategySourceRoleBindingName},
+			RoleRef:    kapi.ObjectReference{Name: BuildStrategySourceRoleName},
+			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
 		},
 	}
 }

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -210,5 +210,44 @@ items:
   - kind: SystemGroup
     name: system:unauthenticated
   userNames: null
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:build-strategy-docker-binding
+  roleRef:
+    name: system:build-strategy-docker
+  subjects:
+  - kind: SystemGroup
+    name: system:authenticated
+  userNames: null
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:build-strategy-custom-binding
+  roleRef:
+    name: system:build-strategy-custom
+  subjects:
+  - kind: SystemGroup
+    name: system:authenticated
+  userNames: null
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:build-strategy-source-binding
+  roleRef:
+    name: system:build-strategy-source
+  subjects:
+  - kind: SystemGroup
+    name: system:authenticated
+  userNames: null
 kind: List
 metadata: {}

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -162,6 +162,45 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: system:build-strategy-docker
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/docker
+    verbs:
+    - create
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:build-strategy-custom
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/custom
+    verbs:
+    - create
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:build-strategy-source
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/source
+    verbs:
+    - create
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: admin
   rules:
   - apiGroups:
@@ -203,10 +242,7 @@ items:
     - buildlogs
     - builds
     - builds/clone
-    - builds/custom
-    - builds/docker
     - builds/log
-    - builds/source
     - deploymentconfigrollbacks
     - deploymentconfigs
     - deploymentconfigs/log
@@ -383,10 +419,7 @@ items:
     - buildlogs
     - builds
     - builds/clone
-    - builds/custom
-    - builds/docker
     - builds/log
-    - builds/source
     - deploymentconfigrollbacks
     - deploymentconfigs
     - deploymentconfigs/log


### PR DESCRIPTION
Resolves https://github.com/openshift/origin/issues/8526 by making build strategy permissions individually grantable/revocable.