### PR TITLE
Allow new-app params to be templatized

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -47,6 +47,13 @@ func (s NameSuggestions) SuggestName() (string, bool) {
 	return "", false
 }
 
+// IsParameterizableValue returns true if the value contains standard replacement
+// syntax, to preserve the value for use inside of the generated output. Passing
+// parameters into output is only valid if the output is used inside of a template.
+func IsParameterizableValue(s string) bool {
+	return strings.Contains(s, "${") || strings.Contains(s, "$(")
+}
+
 // Generated is a list of runtime objects
 type Generated struct {
 	Items []runtime.Object

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -244,7 +244,7 @@ func (c *AppConfig) AddArguments(args []string) []string {
 }
 
 func validateEnforcedName(name string) error {
-	if ok, _ := validation.ValidateServiceName(name, false); !ok {
+	if ok, _ := validation.ValidateServiceName(name, false); !ok && !app.IsParameterizableValue(name) {
 		return fmt.Errorf("invalid name: %s. Must be an a lower case alphanumeric (a-z, and 0-9) string with a maximum length of 24 characters, where the first character is a letter (a-z), and the '-' character is allowed anywhere except the first or last character.", name)
 	}
 	return nil

--- a/pkg/generate/app/uniquenamegenerator.go
+++ b/pkg/generate/app/uniquenamegenerator.go
@@ -57,18 +57,21 @@ func (ung *uniqueNameGenerator) ensureValidName(name string) (string, error) {
 		return "", fmt.Errorf("invalid name: %s", name)
 	}
 
-	// Make all names lowercase
-	name = strings.ToLower(name)
+	if !IsParameterizableValue(name) {
 
-	// Remove everything except [-0-9a-z]
-	name = invalidNameCharactersRegexp.ReplaceAllString(name, "")
+		// Make all names lowercase
+		name = strings.ToLower(name)
 
-	// Remove leading hyphen(s) that may be introduced by the previous step
-	name = strings.TrimLeft(name, "-")
+		// Remove everything except [-0-9a-z]
+		name = invalidNameCharactersRegexp.ReplaceAllString(name, "")
 
-	if len(name) > kvalidation.DNS1123SubdomainMaxLength {
-		glog.V(4).Infof("Trimming %s to maximum allowable length (%d)\n", name, kvalidation.DNS1123SubdomainMaxLength)
-		name = name[:kvalidation.DNS1123SubdomainMaxLength]
+		// Remove leading hyphen(s) that may be introduced by the previous step
+		name = strings.TrimLeft(name, "-")
+
+		if len(name) > kvalidation.DNS1123SubdomainMaxLength {
+			glog.V(4).Infof("Trimming %s to maximum allowable length (%d)\n", name, kvalidation.DNS1123SubdomainMaxLength)
+			name = name[:kvalidation.DNS1123SubdomainMaxLength]
+		}
 	}
 
 	count, existing := names[name]


### PR DESCRIPTION
Callers can pass templates to name and have it persisted throughout the
output:

    oc new-app php --name='${NAME}' -o yaml

generates output where '${NAME}' is passed down into each component.

[test]