### PR TITLE
remove admission plugins from chain

### DIFF
--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -27,6 +29,10 @@ func init() {
 		pluginConfig, err := readConfig(config)
 		if err != nil {
 			return nil, err
+		}
+		if pluginConfig == nil {
+			glog.Infof("Admission plugin %q is not configured so it will be disabled.", "ProjectRequestLimit")
+			return nil, nil
 		}
 		return NewProjectRequestLimit(pluginConfig)
 	})

--- a/pkg/quota/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission_test.go
@@ -86,10 +86,12 @@ func TestConfigReader(t *testing.T) {
 			name:          "choke on out-of-bounds ratio",
 			config:        bytes.NewReader([]byte(invalidConfig)),
 			expectInvalid: true,
+			expectErr:     true,
 		}, {
 			name:          "complain about no settings",
 			config:        bytes.NewReader([]byte(invalidConfig2)),
 			expectInvalid: true,
+			expectErr:     true,
 		},
 	}
 	for _, test := range tests {
@@ -213,15 +215,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		var reader io.Reader
-		if test.config != nil { // we would get nil with the plugin un-configured
-			config, err := configapilatest.WriteYAML(test.config)
-			if err != nil {
-				t.Fatalf("unexpected: %v", err)
-			}
-			reader = bytes.NewReader(config)
-		}
-		c, err := newClusterResourceOverride(fake.NewSimpleClientset(), reader)
+		c, err := newClusterResourceOverride(fake.NewSimpleClientset(), test.config)
 		if err != nil {
 			t.Errorf("%s: config de/serialize failed: %v", test.name, err)
 			continue

--- a/pkg/quota/admission/runonceduration/admission.go
+++ b/pkg/quota/admission/runonceduration/admission.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -23,6 +25,10 @@ func init() {
 		pluginConfig, err := readConfig(config)
 		if err != nil {
 			return nil, err
+		}
+		if pluginConfig == nil {
+			glog.Infof("Admission plugin %q is not configured so it will be disabled.", "RunOnceDuration")
+			return nil, nil
 		}
 		return NewRunOnceDuration(pluginConfig), nil
 	})

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/golang/glog"
+
 	admission "k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
@@ -26,6 +28,10 @@ func init() {
 		pluginConfig, err := readConfig(config)
 		if err != nil {
 			return nil, err
+		}
+		if pluginConfig == nil {
+			glog.Infof("Admission plugin %q is not configured so it will be disabled.", "PodNodeConstraints")
+			return nil, nil
 		}
 		return NewPodNodeConstraints(pluginConfig), nil
 	})


### PR DESCRIPTION
Proper fix for handling nil config for admission plugins.  This fails because of this: https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/plugins.go#L107 and I don't want to refactor something that core to the product right now.

@smarterclayton @sosiouxme 