### PR TITLE
Re-enable monopods on oc status

### DIFF
--- a/pkg/api/graph/graphview/dc_pipeline.go
+++ b/pkg/api/graph/graphview/dc_pipeline.go
@@ -63,10 +63,13 @@ func NewDeploymentConfigPipeline(g osgraph.Graph, dcNode *deploygraph.Deployment
 
 	dcPipeline.ActiveDeployment, dcPipeline.InactiveDeployments = deployedges.RelevantDeployments(g, dcNode)
 	for _, rc := range dcPipeline.InactiveDeployments {
-		covered.Insert(rc.ID())
+		_, covers := NewReplicationController(g, rc)
+		covered.Insert(covers.List()...)
 	}
+
 	if dcPipeline.ActiveDeployment != nil {
-		covered.Insert(dcPipeline.ActiveDeployment.ID())
+		_, covers := NewReplicationController(g, dcPipeline.ActiveDeployment)
+		covered.Insert(covers.List()...)
 	}
 
 	return dcPipeline, covered

--- a/pkg/api/graph/graphview/pod.go
+++ b/pkg/api/graph/graphview/pod.go
@@ -1,0 +1,39 @@
+package graphview
+
+import (
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+)
+
+type Pod struct {
+	Pod *kubegraph.PodNode
+}
+
+// AllPods returns all Pods and the set of covered NodeIDs
+func AllPods(g osgraph.Graph, excludeNodeIDs IntSet) ([]Pod, IntSet) {
+	covered := IntSet{}
+	pods := []Pod{}
+
+	for _, uncastNode := range g.NodesByKind(kubegraph.PodNodeKind) {
+		if excludeNodeIDs.Has(uncastNode.ID()) {
+			continue
+		}
+
+		pod, covers := NewPod(g, uncastNode.(*kubegraph.PodNode))
+		covered.Insert(covers.List()...)
+		pods = append(pods, pod)
+	}
+
+	return pods, covered
+}
+
+// NewPod returns the Pod and a set of all the NodeIDs covered by the Pod
+func NewPod(g osgraph.Graph, podNode *kubegraph.PodNode) (Pod, IntSet) {
+	covered := IntSet{}
+	covered.Insert(podNode.ID())
+
+	podView := Pod{}
+	podView.Pod = podNode
+
+	return podView, covered
+}

--- a/pkg/api/graph/graphview/service_group.go
+++ b/pkg/api/graph/graphview/service_group.go
@@ -97,6 +97,11 @@ func NewServiceGroup(g osgraph.Graph, serviceNode *kubegraph.ServiceNode) (Servi
 		service.ReplicationControllers = append(service.ReplicationControllers, rcView)
 	}
 
+	for _, fulfillingPod := range service.FulfillingPods {
+		_, podCovers := NewPod(g, fulfillingPod)
+		covered.Insert(podCovers.List()...)
+	}
+
 	return service, covered
 }
 

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -155,6 +155,9 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 	standaloneImages, coveredByImages := graphview.AllImagePipelinesFromBuildConfig(g, coveredNodes)
 	coveredNodes.Insert(coveredByImages.List()...)
 
+	standalonePods, coveredByPods := graphview.AllPods(g, coveredNodes)
+	coveredNodes.Insert(coveredByPods.List()...)
+
 	return tabbedString(func(out *tabwriter.Writer) error {
 		indent := "  "
 		if allNamespaces {
@@ -219,6 +222,15 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 		for _, standaloneRC := range standaloneRCs {
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeRCInServiceGroup(f, standaloneRC.RC)...)
+		}
+
+		monopods, err := filterBoringPods(standalonePods)
+		if err != nil {
+			return err
+		}
+		for _, monopod := range monopods {
+			fmt.Fprintln(out)
+			printLines(out, indent, 0, describeMonopod(f, monopod.Pod)...)
 		}
 
 		allMarkers := osgraph.Markers{}
@@ -501,6 +513,16 @@ func describeRCInServiceGroup(f formatter, rcNode *kubegraph.ReplicationControll
 }
 
 func describePodInServiceGroup(f formatter, podNode *kubegraph.PodNode) []string {
+	images := []string{}
+	for _, container := range podNode.Pod.Spec.Containers {
+		images = append(images, container.Image)
+	}
+
+	lines := []string{fmt.Sprintf("%s runs %s", f.ResourceName(podNode), strings.Join(images, ", "))}
+	return lines
+}
+
+func describeMonopod(f formatter, podNode *kubegraph.PodNode) []string {
 	images := []string{}
 	for _, container := range podNode.Pod.Spec.Containers {
 		images = append(images, container.Image)
@@ -1059,6 +1081,30 @@ func describeServicePorts(spec kapi.ServiceSpec) string {
 		}
 		return " ports " + strings.Join(pairs, ", ")
 	}
+}
+
+func filterBoringPods(pods []graphview.Pod) ([]graphview.Pod, error) {
+	monopods := []graphview.Pod{}
+
+	for _, pod := range pods {
+		actualPod, ok := pod.Pod.Object().(*kapi.Pod)
+		if !ok {
+			continue
+		}
+		meta, err := kapi.ObjectMetaFor(actualPod)
+		if err != nil {
+			return nil, err
+		}
+		_, isDeployerPod := meta.Labels[deployapi.DeployerPodForDeploymentLabel]
+		_, isBuilderPod := meta.Annotations[buildapi.BuildAnnotation]
+		isFinished := actualPod.Status.Phase == kapi.PodSucceeded || actualPod.Status.Phase == kapi.PodFailed
+		if isDeployerPod || isBuilderPod || isFinished {
+			continue
+		}
+		monopods = append(monopods, pod)
+	}
+
+	return monopods, nil
 }
 
 // GraphLoader is a stateful interface that provides methods for building the nodes of a graph

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -293,6 +293,20 @@ func TestProjectStatus(t *testing.T) {
 				`View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.`,
 			},
 		},
+		"monopod": {
+			Path: "../../../../test/fixtures/app-scenarios/k8s-lonely-pod.json",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example on server https://example.com:8443\n",
+				"pod/lonely-pod runs openshift/hello-openshift",
+				"You have no services, deployment configs, or build configs.",
+			},
+		},
 	}
 	oldTimeFn := timeNowFn
 	defer func() { timeNowFn = oldTimeFn }()

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -307,6 +307,20 @@ func TestProjectStatus(t *testing.T) {
 				"You have no services, deployment configs, or build configs.",
 			},
 		},
+		"deploys single pod": {
+			Path: "../../../../test/fixtures/simple-deployment.yaml",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example on server https://example.com:8443\n",
+				"dc/simple-deployment deploys docker.io/openshift/deployment-example:v1",
+				`View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.`,
+			},
+		},
 	}
 	oldTimeFn := timeNowFn
 	defer func() { timeNowFn = oldTimeFn }()

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -29,6 +29,9 @@ os::cmd::expect_success 'oc describe deploymentConfigs test-deployment-config'
 os::cmd::expect_success_and_text 'oc get dc -o name' 'deploymentconfig/test-deployment-config'
 os::cmd::try_until_success 'oc get rc/test-deployment-config-1'
 os::cmd::expect_success_and_text 'oc describe dc test-deployment-config' 'deploymentconfig=test-deployment-config'
+os::cmd::expect_success_and_text 'oc status' 'dc/test-deployment-config deploys docker.io/openshift/origin-pod:latest'
+os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
+os::cmd::try_until_text 'oc status' 'pod/hello-openshift runs openshift/hello-openshift'
 
 os::test::junit::declare_suite_start "cmd/deployments/env"
 # Patch a nil list

--- a/test/fixtures/simple-deployment.yaml
+++ b/test/fixtures/simple-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: simple-deployment
+spec:
+  replicas: 1
+  selector:
+    name: simple-deployment
+  strategy:
+    type: Rolling
+    rollingParams:
+  template:
+    metadata:
+      labels:
+        name: simple-deployment
+    spec:
+      containers:
+      - image: "docker.io/openshift/deployment-example:v1"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+  triggers:
+  - type: ConfigChange


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/8487

The deployment config pipeline must mark the pods it covers so that they are not displayed as monopods.

@smarterclayton @deads2k 

```
$ oc status
In project test4 on server https://192.168.2.200:8443

dc/deployment-simple deploys docker.io/openshift/deployment-example:v1 
  deployment #1 deployed about an hour ago - 2 pods

pod/hello-openshift runs openshift/hello-openshift

View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.

```