### PR TITLE
remove unused constant that has been migrated to bootstrappolicy

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -68,10 +68,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
-const (
-	unauthenticatedUsername = "system:anonymous"
-)
-
 // MasterConfig defines the required parameters for starting the OpenShift master
 type MasterConfig struct {
 	Options configapi.MasterConfig


### PR DESCRIPTION
This constant is available in https://github.com/openshift/origin/blob/master/pkg/cmd/server/bootstrappolicy/constants.go#L36 and there were no references