### PR TITLE
[test] end-to-end-docker test: Bind DNS only to API_HOST address

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -88,7 +88,7 @@ sudo docker run -d --name="origin" \
 	--privileged --net=host --pid=host \
 	-v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
 	-v "${VOLUME_DIR}:${VOLUME_DIR}" -v "${VOLUME_DIR}/etcd":/var/lib/origin/openshift.local.etcd:rw \
-	"openshift/origin:${TAG}" start --loglevel=4 --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}"
+	"openshift/origin:${TAG}" start --dns="tcp://${API_HOST}":53 --loglevel=4 --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}"
 
 
 # the CA is in the container, log in as a different cluster admin to run the test

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -144,6 +144,7 @@ function start_os_server {
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
 	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start \
+	 --dns="tcp://${API_HOST}:53" \
 	 --master-config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --node-config=${NODE_CONFIG_DIR}/node-config.yaml \
 	 --loglevel=4 --logspec='*importer=5' \
@@ -197,6 +198,7 @@ function start_os_master {
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
 	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master \
+	 --dns="tcp://${API_HOST}:53" \
 	 --config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --loglevel=4 --logspec='*importer=5' \
 	&>"${LOG_DIR}/openshift.log" &


### PR DESCRIPTION
These tests fail on many developer systems because the default
configuration attempts to bind port 53 on all interfaces. This means
that systems running libvirt or dnsmasq for local caching will fail
and be unable to run the tests. With this patch, we restrict the DNS
to bind only to the public address of the API_HOST.

Addresses https://github.com/openshift/origin/issues/8034

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>