### PR TITLE
update registry config, deprecated storage cache setting

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -5,7 +5,7 @@ http:
   addr: :5000
 storage:
   cache:
-    layerinfo: inmemory
+    blobdescriptor: inmemory
   filesystem:
     rootdirectory: /registry
   delete:


### PR DESCRIPTION
Per [upstream documentation note](https://docs.docker.com/registry/configuration/#cache), "layerinfo has been deprecated, in favor or blobdescriptor".

Upstream commit: https://github.com/docker/distribution/commit/593bbccdb5820a6afb1e8e17931a5210ebf0cf6a

Old:
```
storage:
  cache:
    layerinfo: inmemory
```

New:
```
storage:
  cache:
    blobdescriptor: inmemory
```
