### PR TITLE
make new project wait for rolebinding cache before returning

### DIFF
--- a/pkg/authorization/cache/readonlycache.go
+++ b/pkg/authorization/cache/readonlycache.go
@@ -15,6 +15,11 @@ import (
 
 // ReadOnlyCache exposes administrative methods for the readOnlyAuthorizationCache
 type ReadOnlyCache interface {
+	client.PoliciesReadOnlyNamespacer
+	client.PolicyBindingsReadOnlyNamespacer
+	client.ClusterPoliciesReadOnlyInterface
+	client.ClusterPolicyBindingsReadOnlyInterface
+
 	Run()
 	RunUntil(bindingStopChannel, policyStopChannel <-chan struct{})
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -472,7 +472,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		glog.Errorf("Error parsing project request template value: %v", err)
 		// we can continue on, the storage that gets created will be valid, it simply won't work properly.  There's no reason to kill the master
 	}
-	projectRequestStorage := projectrequeststorage.NewREST(c.Options.ProjectConfig.ProjectRequestMessage, namespace, templateName, c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient)
+	projectRequestStorage := projectrequeststorage.NewREST(c.Options.ProjectConfig.ProjectRequestMessage, namespace, templateName, c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient, c.PolicyCache)
 
 	bcClient := c.BuildConfigWebHookClient()
 	buildConfigWebHooks := buildconfigregistry.NewWebHookREST(

--- a/pkg/project/registry/projectrequest/delegated/delegated_test.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated_test.go
@@ -1,6 +1,87 @@
 package delegated
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
 
-func TestDelegated(t *testing.T) {
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationclient "github.com/openshift/origin/pkg/authorization/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+)
+
+func TestDelegatedWait(t *testing.T) {
+	cache := &testReadOnlyPolicyBinding{}
+	storage := &REST{policyBindings: cache}
+
+	cache.binding = &authorizationapi.PolicyBinding{}
+	cache.binding.RoleBindings = map[string]*authorizationapi.RoleBinding{}
+	cache.binding.RoleBindings["anything"] = nil
+
+	callReturnedCh := testWait(storage)
+
+	select {
+	case <-callReturnedCh:
+		t.Errorf("too fast, should have blocked")
+	case <-time.After(1 * time.Second):
+	}
+
+	func() {
+		cache.lock.Lock()
+		defer cache.lock.Unlock()
+		cache.binding.RoleBindings[bootstrappolicy.AdminRoleName] = nil
+	}()
+
+	select {
+	case <-callReturnedCh:
+	case <-time.After(1 * time.Second):
+		t.Errorf("too slow, should have returned")
+	}
+}
+
+func testWait(storage *REST) chan struct{} {
+	ret := make(chan struct{})
+
+	go func() {
+		storage.waitForRoleBinding("foo", bootstrappolicy.AdminRoleName)
+		close(ret)
+	}()
+
+	return ret
+}
+
+type testReadOnlyPolicyBinding struct {
+	binding *authorizationapi.PolicyBinding
+	lock    sync.Mutex
+}
+
+func (t *testReadOnlyPolicyBinding) ReadOnlyPolicyBindings(namespace string) authorizationclient.ReadOnlyPolicyBindingInterface {
+	return t
+}
+
+// ReadOnlyPolicyBindingInterface exposes methods on PolicyBindings resources
+func (t *testReadOnlyPolicyBinding) List(options *kapi.ListOptions) (*authorizationapi.PolicyBindingList, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	ret := &authorizationapi.PolicyBindingList{}
+	if t.binding != nil {
+		returning := authorizationapi.PolicyBinding{}
+		returning.RoleBindings = map[string]*authorizationapi.RoleBinding{}
+		for k, v := range t.binding.RoleBindings {
+			returning.RoleBindings[k] = v
+		}
+
+		ret.Items = []authorizationapi.PolicyBinding{returning}
+	}
+
+	return ret, nil
+}
+
+func (t *testReadOnlyPolicyBinding) Get(name string) (*authorizationapi.PolicyBinding, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.binding, nil
 }

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -42,17 +42,17 @@ func DefaultTemplate() *templateapi.Template {
 	}
 	templateContents = append(templateContents, project)
 
+	serviceAccountRoleBindings := bootstrappolicy.GetBootstrapServiceAccountProjectRoleBindings(ns)
+	for i := range serviceAccountRoleBindings {
+		templateContents = append(templateContents, &serviceAccountRoleBindings[i])
+	}
+
 	binding := &authorizationapi.RoleBinding{}
 	binding.Name = bootstrappolicy.AdminRoleName
 	binding.Namespace = ns
 	binding.Subjects = []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "${" + ProjectAdminUserParam + "}"}}
 	binding.RoleRef.Name = bootstrappolicy.AdminRoleName
 	templateContents = append(templateContents, binding)
-
-	serviceAccountRoleBindings := bootstrappolicy.GetBootstrapServiceAccountProjectRoleBindings(ns)
-	for i := range serviceAccountRoleBindings {
-		templateContents = append(templateContents, &serviceAccountRoleBindings[i])
-	}
 
 	if err := templateapi.AddObjectsToTemplate(ret, templateContents, latest.Version); err != nil {
 		// this should never happen because we're tightly controlling what goes in.


### PR DESCRIPTION
Updates the project request endpoint to wait for a rolebinding cache update before returning.

@soltysh @smarterclayton