### PR TITLE
All image references should be using full semantic version

### DIFF
--- a/pkg/cmd/util/variable/variable.go
+++ b/pkg/cmd/util/variable/variable.go
@@ -65,8 +65,10 @@ func Versions(key string) (string, bool) {
 		return s, true
 	case "version":
 		s := OverrideVersion.GitVersion
-		seg := strings.SplitN(s, "-", 2)
-		return seg[0], true
+		if strings.HasSuffix(s, "-dirty") {
+			s = strings.TrimSuffix(s, "-dirty")
+		}
+		return s, true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
1.2.0-rc1 was being trimmed to 1.2.0, which is wrong. We still have to
trim -dirty.