### PR TITLE
Import from repository doesn't panic

### DIFF
--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -173,7 +173,7 @@ func importImages(ctx gocontext.Context, retriever RepositoryRetriever, isi *api
 			}
 			for _, index := range tags[j] {
 				if tag.Err != nil {
-					setImageImportStatus(isi, index, tag.Err)
+					setImageImportStatus(isi, index, tag.Name, tag.Err)
 					continue
 				}
 				copied := *tag.Image
@@ -194,7 +194,7 @@ func importImages(ctx gocontext.Context, retriever RepositoryRetriever, isi *api
 			}
 			for _, index := range ids[j] {
 				if digest.Err != nil {
-					setImageImportStatus(isi, index, digest.Err)
+					setImageImportStatus(isi, index, "", digest.Err)
 					continue
 				}
 				image := &isi.Status.Images[index]
@@ -267,6 +267,7 @@ func importFromRepository(ctx gocontext.Context, retriever RepositoryRetriever, 
 	status.Status.Status = unversioned.StatusSuccess
 	status.Images = make([]api.ImageImportStatus, len(repo.Tags))
 	for i, tag := range repo.Tags {
+		status.Images[i].Tag = tag.Name
 		if tag.Err != nil {
 			failures++
 			status.Images[i].Status = imageImportStatus(tag.Err, "", "repository")
@@ -277,7 +278,6 @@ func importFromRepository(ctx gocontext.Context, retriever RepositoryRetriever, 
 		copied := *tag.Image
 		ref.Tag, ref.ID = tag.Name, copied.Name
 		copied.DockerImageReference = ref.MostSpecific().Exact()
-		status.Images[i].Tag = tag.Name
 		status.Images[i].Image = &copied
 	}
 	if failures > 0 {
@@ -598,7 +598,8 @@ func imageImportStatus(err error, kind, position string) unversioned.Status {
 	}
 }
 
-func setImageImportStatus(images *api.ImageStreamImport, i int, err error) {
+func setImageImportStatus(images *api.ImageStreamImport, i int, tag string, err error) {
+	images.Status.Images[i].Tag = tag
 	images.Status.Images[i].Status = imageImportStatus(err, "", "")
 }
 

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -149,6 +149,12 @@ func TestImport(t *testing.T) {
 				if status := isi.Status.Images[3].Status; status.Status != "" {
 					t.Errorf("unexpected status: %#v", isi.Status.Images[3].Status)
 				}
+				expectedTags := []string{"latest", "", "", ""}
+				for i, image := range isi.Status.Images {
+					if image.Tag != expectedTags[i] {
+						t.Errorf("unexpected tag of status %d (%s != %s)", i, image.Tag, expectedTags[i])
+					}
+				}
 			},
 		},
 		{
@@ -186,6 +192,7 @@ func TestImport(t *testing.T) {
 				if len(isi.Status.Images) != 2 {
 					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
 				}
+				expectedTags := []string{"", "tag"}
 				for i, image := range isi.Status.Images {
 					if image.Status.Status != unversioned.StatusSuccess {
 						t.Errorf("unexpected status %d: %#v", i, image.Status)
@@ -197,6 +204,9 @@ func TestImport(t *testing.T) {
 					// the most specific reference is returned
 					if image.Image.DockerImageReference != "test@sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238" {
 						t.Errorf("unexpected ref %d: %#v", i, image.Image.DockerImageReference)
+					}
+					if image.Tag != expectedTags[i] {
+						t.Errorf("unexpected tag of status %d (%s != %s)", i, image.Tag, expectedTags[i])
 					}
 				}
 			},
@@ -222,9 +232,13 @@ func TestImport(t *testing.T) {
 				if len(isi.Status.Repository.Images) != 5 {
 					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
 				}
+				expectedTags := []string{"3", "v2", "v1", "3.1", "abc"}
 				for i, image := range isi.Status.Repository.Images {
 					if image.Status.Status != unversioned.StatusFailure || image.Status.Message != "Internal error occurred: no such tag" {
 						t.Errorf("unexpected status %d: %#v", i, isi.Status.Repository.Images)
+					}
+					if image.Tag != expectedTags[i] {
+						t.Errorf("unexpected tag of status %d (%s != %s)", i, image.Tag, expectedTags[i])
 					}
 				}
 			},


### PR DESCRIPTION
- Check the import status before a use of image object.
- Also to set tag names on import status objects in order to produce
  nice output (containing tag names that failed to import).

Resolves #8593

cc @smarterclayton, @legionus