### PR TITLE
Default role reconciliation to additive-only

### DIFF
--- a/pkg/cmd/admin/policy/reconcile_clusterroles.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterroles.go
@@ -60,7 +60,10 @@ You can see which cluster role have recommended changed by choosing an output ty
 
 // NewCmdReconcileClusterRoles implements the OpenShift cli reconcile-cluster-roles command
 func NewCmdReconcileClusterRoles(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	o := &ReconcileClusterRolesOptions{Out: out}
+	o := &ReconcileClusterRolesOptions{
+		Out:   out,
+		Union: true,
+	}
 
 	cmd := &cobra.Command{
 		Use:     name + " [ClusterRoleName]...",

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -185,7 +185,7 @@ os::cmd::expect_success 'oadm policy reconcile-cluster-roles --additive-only --c
 os::cmd::expect_success_and_text 'oc get clusterroles/basic-user -o json' 'custom-label'
 os::cmd::expect_success_and_text 'oc get clusterroles/basic-user -o json' 'custom-annotation'
 os::cmd::expect_success_and_text 'oc get clusterroles/basic-user -o json' 'groups'
-os::cmd::expect_success 'oadm policy reconcile-cluster-roles --confirm'
+os::cmd::expect_success 'oadm policy reconcile-cluster-roles --additive-only=false --confirm'
 os::cmd::expect_success_and_not_text 'oc get clusterroles/basic-user -o yaml' 'groups'
 echo "admin-reconcile-cluster-roles: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1328822 by changing the CLI default behavior to leave existing permissions alone. `oadm policy reconcile-cluster-roles --additive-only=false` can still be used to tighten permissions to the current defaults.