### PR TITLE
Web console: don't validate limit against request default

### DIFF
--- a/assets/app/views/_edit-request-limit.html
+++ b/assets/app/views/_edit-request-limit.html
@@ -33,7 +33,7 @@
       default-value="limits.defaultLimit"
       limit-range-min="limits.min"
       limit-range-max="limits.max"
-      request="requestCalculated ? undefined : resources.requests[type] || limits.defaultRequest"
+      request="requestCalculated ? undefined : resources.requests[type]"
       max-limit-request-ratio="limits.maxLimitRequestRatio"
       ng-if="!hideLimit">
   </compute-resource>


### PR DESCRIPTION
If a limit is set, the request will default to the limit value. Therefore, it's shouldn't be a validation failure if limit is set to something smaller than the default request in the limit range.

https://bugzilla.redhat.com/show_bug.cgi?id=1329044

Validation against limit range default:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/14747767/1a000530-0884-11e6-93a3-67fa269be212.png)

Validation against user-entered value:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/14747787/2d2f48e6-0884-11e6-8891-433c19ccdfd1.png)

@jwforres @derekwaynecarr 