### PR TITLE
Improve parsing of semantic version for git tag

### DIFF
--- a/pkg/cmd/util/variable/variable.go
+++ b/pkg/cmd/util/variable/variable.go
@@ -64,10 +64,7 @@ func Versions(key string) (string, bool) {
 		}
 		return s, true
 	case "version":
-		s := OverrideVersion.GitVersion
-		if strings.HasSuffix(s, "-dirty") {
-			s = strings.TrimSuffix(s, "-dirty")
-		}
+		s := OverrideVersion.LastSemanticVersion()
 		return s, true
 	default:
 		return "", false


### PR DESCRIPTION
Handles v1.2.0-rc1-5-g3549834 correctly

Unblock local dev [merge]

Fixes #8609