### PR TITLE
[POC] label based policy

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/attributes.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/attributes.go
@@ -23,17 +23,17 @@ import (
 )
 
 type attributesRecord struct {
-	kind        unversioned.GroupKind
+	kind        unversioned.GroupVersionKind
 	namespace   string
 	name        string
-	resource    unversioned.GroupResource
+	resource    unversioned.GroupVersionResource
 	subresource string
 	operation   Operation
 	object      runtime.Object
 	userInfo    user.Info
 }
 
-func NewAttributesRecord(object runtime.Object, kind unversioned.GroupKind, namespace, name string, resource unversioned.GroupResource, subresource string, operation Operation, userInfo user.Info) Attributes {
+func NewAttributesRecord(object runtime.Object, kind unversioned.GroupVersionKind, namespace, name string, resource unversioned.GroupVersionResource, subresource string, operation Operation, userInfo user.Info) Attributes {
 	return &attributesRecord{
 		kind:        kind,
 		namespace:   namespace,
@@ -46,7 +46,7 @@ func NewAttributesRecord(object runtime.Object, kind unversioned.GroupKind, name
 	}
 }
 
-func (record *attributesRecord) GetKind() unversioned.GroupKind {
+func (record *attributesRecord) GetKind() unversioned.GroupVersionKind {
 	return record.kind
 }
 
@@ -58,7 +58,7 @@ func (record *attributesRecord) GetName() string {
 	return record.name
 }
 
-func (record *attributesRecord) GetResource() unversioned.GroupResource {
+func (record *attributesRecord) GetResource() unversioned.GroupVersionResource {
 	return record.resource
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/chain_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/chain_test.go
@@ -100,7 +100,7 @@ func TestAdmit(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := test.chain.Admit(NewAttributesRecord(nil, unversioned.GroupKind{}, "", "", unversioned.GroupResource{}, "", test.operation, nil))
+		err := test.chain.Admit(NewAttributesRecord(nil, unversioned.GroupVersionKind{}, "", "", unversioned.GroupVersionResource{}, "", test.operation, nil))
 		accepted := (err == nil)
 		if accepted != test.accept {
 			t.Errorf("%s: unexpected result of admit call: %v\n", test.name, accepted)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/errors.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/errors.go
@@ -25,7 +25,7 @@ import (
 
 func extractResourceName(a Attributes) (name string, resource unversioned.GroupResource, err error) {
 	name = "Unknown"
-	resource = a.GetResource()
+	resource = a.GetResource().GroupResource()
 	obj := a.GetObject()
 	if obj != nil {
 		objectMeta, err := api.ObjectMetaFor(obj)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/interfaces.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/admission/interfaces.go
@@ -32,7 +32,7 @@ type Attributes interface {
 	// GetNamespace is the namespace associated with the request (if any)
 	GetNamespace() string
 	// GetResource is the name of the resource being requested.  This is not the kind.  For example: pods
-	GetResource() unversioned.GroupResource
+	GetResource() unversioned.GroupVersionResource
 	// GetSubresource is the name of the subresource being requested.  This is a different resource, scoped to the parent resource, but it may have a different kind.
 	// For instance, /pods has the resource "pods" and the kind "Pod", while /pods/foo/status has the resource "pods", the sub resource "status", and the kind "Pod"
 	// (because status operates on pods). The binding resource for a pod though may be /pods/foo/binding, which has resource "pods", subresource "binding", and kind "Binding".
@@ -42,7 +42,7 @@ type Attributes interface {
 	// GetObject is the object from the incoming request prior to default values being applied
 	GetObject() runtime.Object
 	// GetKind is the type of object being manipulated.  For example: Pod
-	GetKind() unversioned.GroupKind
+	GetKind() unversioned.GroupVersionKind
 	// GetUserInfo is information about the requesting user
 	GetUserInfo() user.Info
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/resthandler.go
@@ -197,7 +197,7 @@ func ConnectResource(connecter rest.Connecter, scope RequestScope, admit admissi
 			}
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(connectRequest, scope.Kind.GroupKind(), namespace, name, scope.Resource.GroupResource(), scope.Subresource, admission.Connect, userInfo))
+			err = admit.Admit(admission.NewAttributesRecord(connectRequest, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Connect, userInfo))
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -388,7 +388,7 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 		if admit != nil && admit.Handles(admission.Create) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind.GroupKind(), namespace, name, scope.Resource.GroupResource(), scope.Subresource, admission.Create, userInfo))
+			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Create, userInfo))
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -491,7 +491,7 @@ func PatchResource(r rest.Patcher, scope RequestScope, typer runtime.ObjectTyper
 		updateAdmit := func(updatedObject runtime.Object) error {
 			if admit != nil && admit.Handles(admission.Update) {
 				userInfo, _ := api.UserFrom(ctx)
-				return admit.Admit(admission.NewAttributesRecord(updatedObject, scope.Kind.GroupKind(), namespace, name, scope.Resource.GroupResource(), scope.Subresource, admission.Update, userInfo))
+				return admit.Admit(admission.NewAttributesRecord(updatedObject, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
 			}
 
 			return nil
@@ -667,7 +667,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 		if admit != nil && admit.Handles(admission.Update) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind.GroupKind(), namespace, name, scope.Resource.GroupResource(), scope.Subresource, admission.Update, userInfo))
+			err = admit.Admit(admission.NewAttributesRecord(obj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -750,7 +750,7 @@ func DeleteResource(r rest.GracefulDeleter, checkBody bool, scope RequestScope, 
 		if admit != nil && admit.Handles(admission.Delete) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind.GroupKind(), namespace, name, scope.Resource.GroupResource(), scope.Subresource, admission.Delete, userInfo))
+			err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Delete, userInfo))
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return
@@ -811,7 +811,7 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope RequestSco
 		if admit != nil && admit.Handles(admission.Delete) {
 			userInfo, _ := api.UserFrom(ctx)
 
-			err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind.GroupKind(), namespace, "", scope.Resource.GroupResource(), scope.Subresource, admission.Delete, userInfo))
+			err = admit.Admit(admission.NewAttributesRecord(nil, scope.Kind, namespace, "", scope.Resource, scope.Subresource, admission.Delete, userInfo))
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)
 				return

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
@@ -48,7 +48,7 @@ type alwaysPullImages struct {
 
 func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
 	// Ignore all calls to subresources or resources other than pods.
-	if len(attributes.GetSubresource()) != 0 || attributes.GetResource() != api.Resource("pods") {
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 	pod, ok := attributes.GetObject().(*api.Pod)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission_test.go
@@ -40,7 +40,7 @@ func TestAdmission(t *testing.T) {
 			},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -97,7 +97,7 @@ func TestOtherResources(t *testing.T) {
 	for _, tc := range tests {
 		handler := &alwaysPullImages{}
 
-		err := handler.Admit(admission.NewAttributesRecord(tc.object, api.Kind(tc.kind), namespace, name, api.Resource(tc.resource), tc.subresource, admission.Create, nil))
+		err := handler.Admit(admission.NewAttributesRecord(tc.object, api.Kind(tc.kind).WithVersion("version"), namespace, name, api.Resource(tc.resource).WithVersion("version"), tc.subresource, admission.Create, nil))
 
 		if tc.expectError {
 			if err == nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/deny/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/deny/admission_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAdmission(t *testing.T) {
 	handler := NewAlwaysDeny()
-	err := handler.Admit(admission.NewAttributesRecord(nil, api.Kind("kind"), "namespace", "name", api.Resource("resource"), "subresource", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(nil, api.Kind("kind").WithVersion("version"), "namespace", "name", api.Resource("resource").WithVersion("version"), "subresource", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error returned from admission handler")
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission_test.go
@@ -103,7 +103,7 @@ func testAdmission(t *testing.T, pod *api.Pod, handler *denyExec, shouldAccept b
 	// pods/exec
 	{
 		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/exec"}
-		err := handler.Admit(admission.NewAttributesRecord(req, api.Kind("Pod"), "test", "name", api.Resource("pods"), "exec", admission.Connect, nil))
+		err := handler.Admit(admission.NewAttributesRecord(req, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "exec", admission.Connect, nil))
 		if shouldAccept && err != nil {
 			t.Errorf("Unexpected error returned from admission handler: %v", err)
 		}
@@ -115,7 +115,7 @@ func testAdmission(t *testing.T, pod *api.Pod, handler *denyExec, shouldAccept b
 	// pods/attach
 	{
 		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/attach"}
-		err := handler.Admit(admission.NewAttributesRecord(req, api.Kind("Pod"), "test", "name", api.Resource("pods"), "attach", admission.Connect, nil))
+		err := handler.Admit(admission.NewAttributesRecord(req, api.Kind("Pod").WithVersion("version"), "test", "name", api.Resource("pods").WithVersion("version"), "attach", admission.Connect, nil))
 		if shouldAccept && err != nil {
 			t.Errorf("Unexpected error returned from admission handler: %v", err)
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/initialresources/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/initialresources/admission.go
@@ -74,7 +74,7 @@ func newInitialResources(source dataSource, percentile int64, nsOnly bool) admis
 
 func (ir initialResources) Admit(a admission.Attributes) (err error) {
 	// Ignore all calls to subresources or resources other than pods.
-	if a.GetSubresource() != "" || a.GetResource() != api.Resource("pods") {
+	if a.GetSubresource() != "" || a.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 	pod, ok := a.GetObject().(*api.Pod)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/initialresources/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/initialresources/admission_test.go
@@ -107,7 +107,7 @@ func expectNoAnnotation(t *testing.T, pod *api.Pod) {
 func admit(t *testing.T, ir admission.Interface, pods []*api.Pod) {
 	for i := range pods {
 		p := pods[i]
-		if err := ir.Admit(admission.NewAttributesRecord(p, api.Kind("Pod"), "test", p.ObjectMeta.Name, api.Resource("pods"), "", admission.Create, nil)); err != nil {
+		if err := ir.Admit(admission.NewAttributesRecord(p, api.Kind("Pod").WithVersion("version"), "test", p.ObjectMeta.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil)); err != nil {
 			t.Error(err)
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
@@ -75,7 +75,7 @@ func (l *limitRanger) Admit(a admission.Attributes) (err error) {
 	}
 
 	// ignore all calls that do not deal with pod resources since that is all this supports now.
-	if a.GetKind() != api.Kind("Pod") {
+	if a.GetKind().GroupKind() != api.Kind("Pod") {
 		return nil
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission_test.go
@@ -445,12 +445,12 @@ func TestLimitRangerIgnoresSubresource(t *testing.T) {
 	testPod := validPod("testPod", 1, api.ResourceRequirements{})
 
 	indexer.Add(&limitRange)
-	err := handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "", admission.Update, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "status", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}
@@ -479,12 +479,12 @@ func TestLimitRangerCacheMisses(t *testing.T) {
 	// add to the lru cache
 	liveLookupCache.Add(limitRange.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(30 * time.Second)), items: []*api.LimitRange{&limitRange}})
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "status", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}
@@ -509,12 +509,12 @@ func TestLimitRangerCacheAndLRUMisses(t *testing.T) {
 
 	testPod := validPod("testPod", 1, api.ResourceRequirements{})
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "status", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}
@@ -542,12 +542,12 @@ func TestLimitRangerCacheAndLRUExpiredMisses(t *testing.T) {
 	// add to the lru cache
 	liveLookupCache.Add(limitRange.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(-30 * time.Second)), items: []*api.LimitRange{}})
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an error since the pod did not specify resource limits in its update call")
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod"), limitRange.Namespace, "testPod", api.Resource("pods"), "status", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&testPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "testPod", api.Resource("pods").WithVersion("version"), "status", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -48,7 +48,7 @@ func (p *provision) Admit(a admission.Attributes) (err error) {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
-	if len(a.GetNamespace()) == 0 || a.GetKind() == api.Kind("Namespace") {
+	if len(a.GetNamespace()) == 0 || a.GetKind().GroupKind() == api.Kind("Namespace") {
 		return nil
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -43,7 +43,7 @@ func TestAdmission(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -75,7 +75,7 @@ func TestAdmissionNamespaceExists(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -96,7 +96,7 @@ func TestIgnoreAdmission(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Update, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}
@@ -125,7 +125,7 @@ func TestAdmissionNamespaceExistsUnknownToHandler(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler")
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/exists/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/exists/admission.go
@@ -49,7 +49,7 @@ func (e *exists) Admit(a admission.Attributes) (err error) {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
-	if len(a.GetNamespace()) == 0 || a.GetKind() == api.Kind("Namespace") {
+	if len(a.GetNamespace()) == 0 || a.GetKind().GroupKind() == api.Kind("Namespace") {
 		return nil
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -51,14 +51,14 @@ type lifecycle struct {
 
 func (l *lifecycle) Admit(a admission.Attributes) (err error) {
 	// prevent deletion of immortal namespaces
-	if a.GetOperation() == admission.Delete && a.GetKind() == api.Kind("Namespace") && l.immortalNamespaces.Has(a.GetName()) {
-		return errors.NewForbidden(a.GetResource(), a.GetName(), fmt.Errorf("this namespace may not be deleted"))
+	if a.GetOperation() == admission.Delete && a.GetKind().GroupKind() == api.Kind("Namespace") && l.immortalNamespaces.Has(a.GetName()) {
+		return errors.NewForbidden(a.GetResource().GroupResource(), a.GetName(), fmt.Errorf("this namespace may not be deleted"))
 	}
 
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
 	// if we're here, then the API server has found a route, which means that if we have a non-empty namespace
 	// its a namespaced resource.
-	if len(a.GetNamespace()) == 0 || a.GetKind() == api.Kind("Namespace") {
+	if len(a.GetNamespace()) == 0 || a.GetKind().GroupKind() == api.Kind("Namespace") {
 		// if a namespace is deleted, we want to prevent all further creates into it
 		// while it is undergoing termination.  to reduce incidences where the cache
 		// is slow to update, we forcefully remove the namespace from our local cache.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -78,7 +78,7 @@ func TestAdmission(t *testing.T) {
 			Containers: []api.Container{{Name: "ctr", Image: "image"}},
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
@@ -90,47 +90,47 @@ func TestAdmission(t *testing.T) {
 	store.Add(namespaceObj)
 
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
 	}
 
 	// verify update operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod"), pod.Namespace, pod.Name, api.Resource("pods"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete of namespace default can never proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Namespace"), "", api.NamespaceDefault, api.Resource("namespaces"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Namespace").WithVersion("version"), "", api.NamespaceDefault, api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
 	if err == nil {
 		t.Errorf("Expected an error that this namespace can never be deleted")
 	}
 
 	// verify delete of namespace other than default can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Namespace"), "", "other", api.Resource("namespaces"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Namespace").WithVersion("version"), "", "other", api.Resource("namespaces").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error %v", err)
 	}
 
 	// verify create/update/delete of object in non-existent namespace throws error
-	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod"), badPod.Namespace, badPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod").WithVersion("version"), badPod.Namespace, badPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an aerror that objects cannot be created in non-existant namespaces", err)
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod"), badPod.Namespace, badPod.Name, api.Resource("pods"), "", admission.Update, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod").WithVersion("version"), badPod.Namespace, badPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
 	if err == nil {
 		t.Errorf("Expected an aerror that objects cannot be updated in non-existant namespaces", err)
 	}
 
-	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod"), badPod.Namespace, badPod.Name, api.Resource("pods"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&badPod, api.Kind("Pod").WithVersion("version"), badPod.Namespace, badPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err == nil {
 		t.Errorf("Expected an aerror that objects cannot be deleted in non-existant namespaces", err)
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -59,7 +59,7 @@ func NewPersistentVolumeLabel() *persistentVolumeLabel {
 }
 
 func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
-	if a.GetResource() != api.Resource("persistentvolumes") {
+	if a.GetResource().GroupResource() != api.Resource("persistentvolumes") {
 		return nil
 	}
 	obj := a.GetObject()

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -87,20 +87,20 @@ func TestAdmission(t *testing.T) {
 	}
 
 	// Non-cloud PVs are ignored
-	err := handler.Admit(admission.NewAttributesRecord(&ignoredPV, api.Kind("PersistentVolume"), ignoredPV.Namespace, ignoredPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(&ignoredPV, api.Kind("PersistentVolume").WithVersion("version"), ignoredPV.Namespace, ignoredPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler (on ignored pv): %v", err)
 	}
 
 	// We only add labels on creation
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler (when deleting aws pv):  %v", err)
 	}
 
 	// Errors from the cloudprovider block creation of the volume
 	pvHandler.ebsVolumes = mockVolumeFailure(fmt.Errorf("invalid volume"))
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected error when aws pv info fails")
 	}
@@ -108,7 +108,7 @@ func TestAdmission(t *testing.T) {
 	// Don't add labels if the cloudprovider doesn't return any
 	labels := make(map[string]string)
 	pvHandler.ebsVolumes = mockVolumeLabels(labels)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}
@@ -118,7 +118,7 @@ func TestAdmission(t *testing.T) {
 
 	// Don't panic if the cloudprovider returns nil, nil
 	pvHandler.ebsVolumes = mockVolumeFailure(nil)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when cloud provider returns empty labels")
 	}
@@ -128,7 +128,7 @@ func TestAdmission(t *testing.T) {
 	labels["a"] = "1"
 	labels["b"] = "2"
 	pvHandler.ebsVolumes = mockVolumeLabels(labels)
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}
@@ -140,7 +140,7 @@ func TestAdmission(t *testing.T) {
 	awsPV.ObjectMeta.Labels = make(map[string]string)
 	awsPV.ObjectMeta.Labels["a"] = "not1"
 	awsPV.ObjectMeta.Labels["c"] = "3"
-	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(&awsPV, api.Kind("PersistentVolume").WithVersion("version"), awsPV.Namespace, awsPV.Name, api.Resource("persistentvolumes").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Expected no error when creating aws pv")
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
@@ -104,7 +104,7 @@ func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
 
 	// if we do not know how to evaluate use for this kind, just ignore
 	evaluators := q.registry.Evaluators()
-	evaluator, found := evaluators[a.GetKind()]
+	evaluator, found := evaluators[a.GetKind().GroupKind()]
 	if !found {
 		return nil
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
@@ -80,7 +80,7 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 		t.Errorf("Unexpected error %v", err)
 	}
 	namespace := "default"
-	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod"), namespace, "name", api.Resource("pods"), "", admission.Delete, nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, api.Kind("Pod").WithVersion("version"), namespace, "name", api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {
 		t.Errorf("ResourceQuota should admit all deletes: %v", err)
 	}
@@ -109,11 +109,11 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 	}
 	handler.indexer.Add(resourceQuota)
 	newPod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod exceeded allowed quota")
 	}
-	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "subresource", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "subresource", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error because the action went to a subresource: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 	}
 	handler.indexer.Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 	}
 	handler.indexer.Add(resourceQuota)
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error exceeding quota")
 	}
@@ -255,7 +255,7 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	}
 	handler.indexer.Add(resourceQuota)
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
 		t.Errorf("Expected an error because the pod does not specify a memory limit")
 	}
@@ -298,7 +298,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
 	// Add to the lru cache so we do not do a live client lookup
 	liveLookupCache.Add(newPod.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(30 * time.Second)), items: []*api.ResourceQuota{}})
-	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err = handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Did not expect an error because the pod is in a different namespace than the quota")
 	}
@@ -359,7 +359,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
 	activeDeadlineSeconds := int64(30)
 	newPod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -454,7 +454,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 
 	// create a pod that is best effort because it does not make a request for anything
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	}
 	handler.indexer.Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), newPod.Namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -635,7 +635,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 	// unset the namespace
 	newPod.ObjectMeta.Namespace = ""
 
-	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod"), namespace, newPod.Name, api.Resource("pods"), "", admission.Create, nil))
+	err := handler.Admit(admission.NewAttributesRecord(newPod, api.Kind("Pod").WithVersion("version"), namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -49,7 +49,7 @@ func NewSecurityContextDeny(client clientset.Interface) admission.Interface {
 
 // Admit will deny any pod that defines SELinuxOptions or RunAsUser.
 func (p *plugin) Admit(a admission.Attributes) (err error) {
-	if a.GetResource() != api.Resource("pods") {
+	if a.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 
@@ -59,28 +59,28 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 	}
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SupplementalGroups != nil {
-		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
+		return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
 	}
 	if pod.Spec.SecurityContext != nil {
 		if pod.Spec.SecurityContext.SELinuxOptions != nil {
-			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
+			return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
 		}
 		if pod.Spec.SecurityContext.RunAsUser != nil {
-			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
+			return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
 		}
 	}
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil {
-		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.FSGroup is forbidden"))
+		return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("SecurityContext.FSGroup is forbidden"))
 	}
 
 	for _, v := range pod.Spec.Containers {
 		if v.SecurityContext != nil {
 			if v.SecurityContext.SELinuxOptions != nil {
-				return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SELinuxOptions is forbidden"))
+				return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("SecurityContext.SELinuxOptions is forbidden"))
 			}
 			if v.SecurityContext.RunAsUser != nil {
-				return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.RunAsUser is forbidden"))
+				return apierrors.NewForbidden(a.GetResource().GroupResource(), pod.Name, fmt.Errorf("SecurityContext.RunAsUser is forbidden"))
 			}
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
@@ -82,7 +82,7 @@ func TestAdmission(t *testing.T) {
 		pod.Spec.SecurityContext = tc.podSc
 		pod.Spec.Containers[0].SecurityContext = tc.sc
 
-		err := handler.Admit(admission.NewAttributesRecord(pod, api.Kind("Pod"), "foo", "name", api.Resource("pods"), "", "ignored", nil))
+		err := handler.Admit(admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 		if err != nil && !tc.expectError {
 			t.Errorf("%v: unexpected error: %v", tc.name, err)
 		} else if err == nil && tc.expectError {
@@ -126,7 +126,7 @@ func TestPodSecurityContextAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		pod.Spec.SecurityContext = &test.securityContext
-		err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod"), "foo", "name", api.Resource("pods"), "", "ignored", nil))
+		err := handler.Admit(admission.NewAttributesRecord(&pod, api.Kind("Pod").WithVersion("version"), "foo", "name", api.Resource("pods").WithVersion("version"), "", "ignored", nil))
 
 		if test.errorExpected && err == nil {
 			t.Errorf("Expected error for security context %+v but did not get an error", test.securityContext)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
@@ -149,7 +149,7 @@ func (s *serviceAccount) Stop() {
 }
 
 func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
-	if a.GetResource() != api.Resource("pods") {
+	if a.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 	obj := a.GetObject()

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -31,7 +31,7 @@ import (
 func TestIgnoresNonCreate(t *testing.T) {
 	pod := &api.Pod{}
 	for _, op := range []admission.Operation{admission.Update, admission.Delete, admission.Connect} {
-		attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", op, nil)
+		attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", op, nil)
 		handler := admission.NewChainHandler(NewServiceAccount(nil))
 		err := handler.Admit(attrs)
 		if err != nil {
@@ -42,7 +42,7 @@ func TestIgnoresNonCreate(t *testing.T) {
 
 func TestIgnoresNonPodResource(t *testing.T) {
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), "myns", "myname", api.Resource("CustomResource"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("CustomResource").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non-pod resource allowed, got err: %v", err)
@@ -50,7 +50,7 @@ func TestIgnoresNonPodResource(t *testing.T) {
 }
 
 func TestIgnoresNilObject(t *testing.T) {
-	attrs := admission.NewAttributesRecord(nil, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(nil, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected nil object allowed allowed, got err: %v", err)
@@ -59,7 +59,7 @@ func TestIgnoresNilObject(t *testing.T) {
 
 func TestIgnoresNonPodObject(t *testing.T) {
 	obj := &api.Namespace{}
-	attrs := admission.NewAttributesRecord(obj, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(obj, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected non pod object allowed, got err: %v", err)
@@ -79,7 +79,7 @@ func TestIgnoresMirrorPod(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err != nil {
 		t.Errorf("Expected mirror pod without service account or secrets allowed, got err: %v", err)
@@ -97,7 +97,7 @@ func TestRejectsMirrorPodWithServiceAccount(t *testing.T) {
 			ServiceAccountName: "default",
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a service account")
@@ -117,7 +117,7 @@ func TestRejectsMirrorPodWithSecretVolumes(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), "myns", "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), "myns", "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := NewServiceAccount(nil).Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected a mirror pod to be prevented from referencing a secret volume")
@@ -140,7 +140,7 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 	})
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -166,7 +166,7 @@ func TestAssignsDefaultServiceAccountAndRejectsMissingAPIToken(t *testing.T) {
 	})
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected admission error for missing API token")
@@ -188,7 +188,7 @@ func TestFetchesUncachedServiceAccount(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -207,7 +207,7 @@ func TestDeniesInvalidServiceAccount(t *testing.T) {
 	admit := NewServiceAccount(client)
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected error for missing service account, got none")
@@ -270,7 +270,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -349,7 +349,7 @@ func TestRespectsExistingMount(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -393,7 +393,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod1, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod1, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	if err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 			},
 		},
 	}
-	attrs = admission.NewAttributesRecord(pod2, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs = admission.NewAttributesRecord(pod2, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	if err := admit.Admit(attrs); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod1, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod1, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	if err := admit.Admit(attrs); err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
 	}
@@ -469,7 +469,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 			},
 		},
 	}
-	attrs = admission.NewAttributesRecord(pod2, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs = admission.NewAttributesRecord(pod2, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	if err := admit.Admit(attrs); err == nil || !strings.Contains(err.Error(), "with envVar") {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestAllowUnreferencedSecretVolumesForPermissiveSAs(t *testing.T) {
 			},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
@@ -528,7 +528,7 @@ func TestAllowsReferencedImagePullSecrets(t *testing.T) {
 			ImagePullSecrets: []api.LocalObjectReference{{Name: "foo"}},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -555,7 +555,7 @@ func TestRejectsUnreferencedImagePullSecrets(t *testing.T) {
 			ImagePullSecrets: []api.LocalObjectReference{{Name: "foo"}},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err == nil {
 		t.Errorf("Expected rejection for using a secret the service account does not reference")
@@ -586,7 +586,7 @@ func TestDoNotAddImagePullSecrets(t *testing.T) {
 			ImagePullSecrets: []api.LocalObjectReference{{Name: "foo"}},
 		},
 	}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -618,7 +618,7 @@ func TestAddImagePullSecrets(t *testing.T) {
 	admit.serviceAccounts.Add(sa)
 
 	pod := &api.Pod{}
-	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod"), ns, "myname", api.Resource("pods"), "", admission.Create, nil)
+	attrs := admission.NewAttributesRecord(pod, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 	err := admit.Admit(attrs)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -480,6 +480,14 @@ func deepCopy_api_PolicyRule(in api.PolicyRule, out *api.PolicyRule, c *conversi
 	} else {
 		out.NonResourceURLs = nil
 	}
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -481,7 +481,7 @@ func TestSpecificKind(t *testing.T) {
 	kapi.Scheme.Log(t)
 	defer kapi.Scheme.Log(nil)
 
-	kind := "DeploymentConfig"
+	kind := "Role"
 	item, err := kapi.Scheme.New(osapi.SchemeGroupVersion.WithKind(kind))
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -341,6 +341,14 @@ func autoConvert_api_PolicyRule_To_v1_PolicyRule(in *authorizationapi.PolicyRule
 	// in.Resources has no peer in out
 	// in.ResourceNames has no peer in out
 	// in.NonResourceURLs has no peer in out
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 
@@ -792,6 +800,14 @@ func autoConvert_v1_PolicyRule_To_api_PolicyRule(in *authorizationapiv1.PolicyRu
 	// in.Resources has no peer in out
 	// in.ResourceNames has no peer in out
 	// in.NonResourceURLsSlice has no peer in out
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -496,6 +496,14 @@ func deepCopy_v1_PolicyRule(in v1.PolicyRule, out *v1.PolicyRule, c *conversion.
 	} else {
 		out.NonResourceURLsSlice = nil
 	}
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -344,6 +344,14 @@ func autoConvert_api_PolicyRule_To_v1beta3_PolicyRule(in *authorizationapi.Polic
 	// in.Resources has no peer in out
 	// in.ResourceNames has no peer in out
 	// in.NonResourceURLs has no peer in out
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 
@@ -800,6 +808,14 @@ func autoConvert_v1beta3_PolicyRule_To_api_PolicyRule(in *authorizationapiv1beta
 	// in.Resources has no peer in out
 	// in.ResourceNames has no peer in out
 	// in.NonResourceURLsSlice has no peer in out
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -504,6 +504,14 @@ func deepCopy_v1beta3_PolicyRule(in v1beta3.PolicyRule, out *v1beta3.PolicyRule,
 	} else {
 		out.NonResourceURLsSlice = nil
 	}
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
 	return nil
 }
 

--- a/pkg/authorization/admission/authorizedlabels/admission.go
+++ b/pkg/authorization/admission/authorizedlabels/admission.go
@@ -1,0 +1,145 @@
+package authorizedlabels
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+)
+
+func init() {
+	admission.RegisterPlugin("LabelAuthorization", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		return &labelEnforcer{
+			Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
+		}, nil
+	})
+}
+
+type labelEnforcer struct {
+	*admission.Handler
+	ruleResolver rulevalidation.AuthorizationRuleResolver
+
+	// TODO replace this with shared caches after we get SharedIndexInformers from upstream
+	clientConfig restclient.Config
+}
+
+// ensure that the required Openshift admission interfaces are implemented
+var _ = oadmission.WantsAuthorizationRuleResolver(&labelEnforcer{})
+var _ = oadmission.WantsClientConfig(&labelEnforcer{})
+var _ = oadmission.Validator(&labelEnforcer{})
+
+// Admit ensures that only a configured number of projects can be requested by a particular user.
+func (o *labelEnforcer) Admit(a admission.Attributes) (err error) {
+	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), a.GetNamespace()), a.GetUserInfo())
+
+	rules, err := o.ruleResolver.GetEffectivePolicyRules(ctx)
+	if err != nil {
+		return err
+	}
+	filteredRules := []authorizationapi.PolicyRule{}
+
+	authAttributes := authorizer.DefaultAuthorizationAttributes{
+		Verb:         strings.ToLower(string(a.GetOperation())),
+		APIGroup:     a.GetResource().Group,
+		Resource:     a.GetResource().Resource,
+		ResourceName: a.GetName(),
+	}
+
+	// means delete collection
+	if a.GetOperation() == admission.Delete && len(a.GetName()) == 0 {
+		return nil
+	}
+
+	// filter the rules to only get rules with a selector, with a matching verb, with a matching group resource tuple
+	for _, rule := range rules {
+		matches, err := authAttributes.RuleMatches(rule)
+		if err != nil {
+			return err
+		}
+		if !matches {
+			continue
+		}
+		if len(rule.Selector) == 0 {
+			// if we match the rule, but have no selector, then this request should succeed
+			return nil
+		}
+
+		filteredRules = append(filteredRules, rule)
+	}
+
+	// without any rules to apply, this succeeds
+	if len(filteredRules) == 0 {
+		return nil
+	}
+
+	var objectLabels map[string]string
+	if a.GetOperation() == admission.Create {
+		// when we do a create we have the object we're interested in right here
+		var err error
+		objectLabels, err = meta.NewAccessor().Labels(a.GetObject())
+		if err != nil {
+			return err
+		}
+
+	} else {
+		// otherwise, we need to get the current object.  Without a rewrite of upstream admission
+		// this is the best we can get.
+		config := o.clientConfig
+		gv := a.GetResource().GroupVersion()
+		config.GroupVersion = &gv
+		client, err := restclient.RESTClientFor(&config)
+		if err != nil {
+			return err
+		}
+
+		// TODO use generic client here
+		originalObject := &kapi.ResourceQuota{}
+		if err := client.Get().Namespace(a.GetNamespace()).Resource(a.GetResource().Resource).Name(a.GetName()).Do().Into(originalObject); err != nil {
+			return err
+		}
+		objectLabels, err = meta.NewAccessor().Labels(originalObject)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, rule := range filteredRules {
+		selector := labels.Set(rule.Selector).AsSelector()
+		if selector.Matches(labels.Set(objectLabels)) {
+			return nil
+		}
+	}
+
+	return admission.NewForbidden(a, fmt.Errorf("%v does not match %v", objectLabels, filteredRules))
+}
+
+func (o *labelEnforcer) SetAuthorizationRuleResolver(ruleResolver rulevalidation.AuthorizationRuleResolver) {
+	o.ruleResolver = ruleResolver
+}
+func (o *labelEnforcer) SetClientConfig(clientConfig restclient.Config) {
+	o.clientConfig = clientConfig
+	o.clientConfig.APIPath = "api"
+	o.clientConfig.Codec = kapi.Codecs.LegacyCodec(kapiv1.SchemeGroupVersion)
+}
+
+func (o *labelEnforcer) Validate() error {
+	if o.ruleResolver == nil {
+		return fmt.Errorf("ruleResolver is required")
+	}
+	if o.clientConfig.Codec == nil {
+		return fmt.Errorf("clientConfig.Codec is required")
+	}
+	return nil
+}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -103,7 +103,7 @@ var (
 	}
 
 	// VerbsAllowingSelector is the list of special verbs that we know we can integrate with in admission to enforce label based policy
-	VerbsAllowingSelector = sets.NewString("create", "update", "delete")
+	VerbsAllowingSelector = sets.NewString("create", "update", "patch", "delete")
 )
 
 func init() {

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -101,6 +101,9 @@ var (
 
 		NonEscalatingResourcesGroupName: {OpenshiftNonEscalatingViewableGroupName, KubeNonEscalatingViewableGroupName},
 	}
+
+	// VerbsAllowingSelector is the list of special verbs that we know we can integrate with in admission to enforce label based policy
+	VerbsAllowingSelector = sets.NewString("create", "update", "delete")
 )
 
 func init() {
@@ -131,6 +134,9 @@ type PolicyRule struct {
 	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// If an action is not a resource API request, then the URL is split on '/' and is checked against the NonResourceURLs to look for a match.
 	NonResourceURLs sets.String
+
+	// Selector is a label query over to apply to the resource.  It is ONLY valid for create,update, and delete verbs.
+	Selector map[string]string
 }
 
 // IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -138,6 +138,7 @@ func convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRu
 		out.AttributeRestrictions = in.AttributeRestrictions.Object
 	}
 
+	out.Selector = in.Selector
 	out.APIGroups = in.APIGroups
 
 	out.Resources = sets.String{}
@@ -159,6 +160,7 @@ func convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRu
 	}
 
 	out.APIGroups = in.APIGroups
+	out.Selector = in.Selector
 
 	out.Resources = []string{}
 	out.Resources = append(out.Resources, in.Resources.List()...)

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -32,6 +32,9 @@ type PolicyRule struct {
 	// NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.
 	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
+
+	// Selector is a label query over to apply to the resource.  It is ONLY valid for create,update, and delete verbs.
+	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed

--- a/pkg/authorization/api/v1beta3/conversion.go
+++ b/pkg/authorization/api/v1beta3/conversion.go
@@ -138,6 +138,7 @@ func convert_v1beta3_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.Pol
 		out.AttributeRestrictions = in.AttributeRestrictions.Object
 	}
 
+	out.Selector = in.Selector
 	out.APIGroups = in.APIGroups
 
 	out.Resources = sets.String{}
@@ -159,6 +160,7 @@ func convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *Pol
 		return err
 	}
 
+	out.Selector = in.Selector
 	out.APIGroups = in.APIGroups
 
 	out.Resources = []string{}

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -35,6 +35,9 @@ type PolicyRule struct {
 	// NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.
 	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
+
+	// Selector is a label query over to apply to the resource.  It is ONLY valid for create,update, and delete verbs.
+	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed

--- a/pkg/authorization/api/validation/validation_test.go
+++ b/pkg/authorization/api/validation/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -369,6 +370,19 @@ func TestValidateRole(t *testing.T) {
 			},
 			T: field.ErrorTypeRequired,
 			F: "metadata.name",
+		},
+		"selector with bad verbs": {
+			A: authorizationapi.Role{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: kapi.NamespaceDefault},
+				Rules: []authorizationapi.PolicyRule{
+					{
+						Verbs:    sets.NewString("create", "update", "list"),
+						Selector: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "rules[0].selector",
 		},
 	}
 	for k, v := range errorCases {

--- a/pkg/authorization/authorizer/personal_subjectaccessreview.go
+++ b/pkg/authorization/authorizer/personal_subjectaccessreview.go
@@ -2,7 +2,6 @@ package authorizer
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -24,7 +23,8 @@ func IsPersonalAccessReview(a AuthorizationAttributes) (bool, error) {
 		return isPersonalAccessReviewFromLocalSAR(extendedAttributes), nil
 
 	default:
-		return false, fmt.Errorf("unexpected request attributes for checking personal access review: %v", extendedAttributes)
+		// I don't think we really care about erroring here.  It's just not a self-SAR
+		return false, nil
 
 	}
 }

--- a/pkg/build/admission/buildpodutil.go
+++ b/pkg/build/admission/buildpodutil.go
@@ -14,7 +14,7 @@ import (
 
 // IsBuildPod returns true if a pod is a pod generated for a Build
 func IsBuildPod(a admission.Attributes) bool {
-	if a.GetResource() != kapi.Resource("pods") {
+	if a.GetResource().GroupResource() != kapi.Resource("pods") {
 		return false
 	}
 	if len(a.GetSubresource()) != 0 {

--- a/pkg/build/admission/strategyrestrictions/admission.go
+++ b/pkg/build/admission/strategyrestrictions/admission.go
@@ -44,12 +44,12 @@ var (
 )
 
 func (a *buildByStrategy) Admit(attr admission.Attributes) error {
-	if resource := attr.GetResource(); resource != buildsResource && resource != buildConfigsResource {
+	if resource := attr.GetResource().GroupResource(); resource != buildsResource && resource != buildConfigsResource {
 		return nil
 	}
 	// Explicitly exclude the builds/details subresource because it's only
 	// updating commit info and cannot change build type.
-	if attr.GetResource() == buildsResource && attr.GetSubresource() == "details" {
+	if attr.GetResource().GroupResource() == buildsResource && attr.GetSubresource() == "details" {
 		return nil
 	}
 	switch obj := attr.GetObject().(type) {
@@ -136,7 +136,7 @@ func (a *buildByStrategy) checkBuildConfigAuthorization(buildConfig *buildapi.Bu
 }
 
 func (a *buildByStrategy) checkBuildRequestAuthorization(req *buildapi.BuildRequest, attr admission.Attributes) error {
-	switch attr.GetResource() {
+	switch attr.GetResource().GroupResource() {
 	case buildsResource:
 		build, err := a.client.Builds(attr.GetNamespace()).Get(req.Name)
 		if err != nil {

--- a/pkg/build/admission/strategyrestrictions/admission_test.go
+++ b/pkg/build/admission/strategyrestrictions/admission_test.go
@@ -147,7 +147,7 @@ func TestBuildAdmission(t *testing.T) {
 			client := fakeClient(test.expectedResource, test.reviewResponse, test.responseObject)
 			c := NewBuildByStrategy()
 			c.(oadmission.WantsOpenshiftClient).SetOpenshiftClient(client)
-			attrs := admission.NewAttributesRecord(test.object, test.kind, "default", "name", test.resource, test.subResource, op, fakeUser())
+			attrs := admission.NewAttributesRecord(test.object, test.kind.WithVersion("version"), "default", "name", test.resource.WithVersion("version"), test.subResource, op, fakeUser())
 			err := c.Admit(attrs)
 			if err != nil && test.expectAccept {
 				t.Errorf("%s: unexpected error: %v", test.name, err)

--- a/pkg/build/admission/testutil/pod.go
+++ b/pkg/build/admission/testutil/pod.go
@@ -72,10 +72,10 @@ func (p *TestPod) GetBuild(t *testing.T) *buildapi.Build {
 
 func (p *TestPod) ToAttributes() admission.Attributes {
 	return admission.NewAttributesRecord((*kapi.Pod)(p),
-		kapi.Kind("Pod"),
+		kapi.Kind("Pod").WithVersion("version"),
 		"default",
 		"TestPod",
-		kapi.Resource("pods"),
+		kapi.Resource("pods").WithVersion("version"),
 		"",
 		admission.Create,
 		nil)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -130,7 +130,7 @@ func (bs *SourceBuildStrategy) canRunAsRoot(build *buildapi.Build) bool {
 		},
 	}
 	userInfo := serviceaccount.UserInfo(build.Namespace, build.Spec.ServiceAccount, "")
-	attrs := admission.NewAttributesRecord(pod, kapi.Kind("Pod"), pod.Namespace, pod.Name, kapi.Resource("pods"), "", admission.Create, userInfo)
+	attrs := admission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion(""), pod.Namespace, pod.Name, kapi.Resource("pods").WithVersion(""), "", admission.Create, userInfo)
 	err := bs.AdmissionControl.Admit(attrs)
 	if err != nil {
 		glog.V(2).Infof("Admit for root user returned error: %v", err)

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -2,8 +2,10 @@ package admission
 
 import (
 	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/client/restclient"
 
 	"github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/project/cache"
 )
@@ -12,6 +14,8 @@ type PluginInitializer struct {
 	OpenshiftClient client.Interface
 	ProjectCache    *cache.ProjectCache
 	Authorizer      authorizer.Authorizer
+	RuleResolver    rulevalidation.AuthorizationRuleResolver
+	ClientConfig    restclient.Config
 }
 
 // Initialize will check the initialization interfaces implemented by each plugin
@@ -26,6 +30,12 @@ func (i *PluginInitializer) Initialize(plugins []admission.Interface) {
 		}
 		if wantsAuthorizer, ok := plugin.(WantsAuthorizer); ok {
 			wantsAuthorizer.SetAuthorizer(i.Authorizer)
+		}
+		if wantsAuthorizationRuleResolver, ok := plugin.(WantsAuthorizationRuleResolver); ok {
+			wantsAuthorizationRuleResolver.SetAuthorizationRuleResolver(i.RuleResolver)
+		}
+		if wantsClientConfig, ok := plugin.(WantsClientConfig); ok {
+			wantsClientConfig.SetClientConfig(i.ClientConfig)
 		}
 	}
 }

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -1,7 +1,10 @@
 package admission
 
 import (
+	"k8s.io/kubernetes/pkg/client/restclient"
+
 	"github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/project/cache"
 )
@@ -28,4 +31,12 @@ type Validator interface {
 // need access to the Authorizer interface
 type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
+}
+
+type WantsAuthorizationRuleResolver interface {
+	SetAuthorizationRuleResolver(rulevalidation.AuthorizationRuleResolver)
+}
+
+type WantsClientConfig interface {
+	SetClientConfig(restclient.Config)
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -163,6 +163,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					),
 				},
 				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("create", "update", "patch", "delete"),
+					Resources: sets.NewString("resourcequotas"),
+					Selector:  map[string]string{"foo": "bar"},
+				},
+				{
 					APIGroups: []string{api.GroupName},
 					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
 					Resources: sets.NewString(

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -47,7 +47,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
+var AdmissionPlugins = []string{"LabelAuthorization", "RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -3,6 +3,7 @@ package start
 import (
 
 	// Admission control plug-ins used by OpenShift
+	_ "github.com/openshift/origin/pkg/authorization/admission/authorizedlabels"
 	_ "github.com/openshift/origin/pkg/build/admission/defaults"
 	_ "github.com/openshift/origin/pkg/build/admission/overrides"
 	_ "github.com/openshift/origin/pkg/build/admission/strategyrestrictions"

--- a/pkg/project/admission/lifecycle/admission.go
+++ b/pkg/project/admission/lifecycle/admission.go
@@ -59,7 +59,7 @@ func (e *lifecycle) Admit(a admission.Attributes) (err error) {
 	if err != nil {
 		return err
 	}
-	mapping, err := groupMeta.RESTMapper.RESTMapping(a.GetKind())
+	mapping, err := groupMeta.RESTMapper.RESTMapping(a.GetKind().GroupKind())
 	if err != nil {
 		glog.V(4).Infof("Ignoring life-cycle enforcement for resource %v; no associated default version and kind could be found.", a.GetResource())
 		return nil
@@ -93,7 +93,7 @@ func (e *lifecycle) Admit(a admission.Attributes) (err error) {
 	}
 
 	if namespace.Status.Phase == kapi.NamespaceTerminating && !e.creatableResources.Has(strings.ToLower(a.GetResource().Resource)) {
-		return apierrors.NewForbidden(a.GetResource(), name, fmt.Errorf("Namespace %s is terminating", a.GetNamespace()))
+		return apierrors.NewForbidden(a.GetResource().GroupResource(), name, fmt.Errorf("Namespace %s is terminating", a.GetNamespace()))
 	}
 
 	// in case of concurrency issues, we will retry this logic
@@ -152,5 +152,5 @@ var (
 )
 
 func isSubjectAccessReview(a admission.Attributes) bool {
-	return a.GetKind() == sar || a.GetKind() == lsar
+	return a.GetKind().GroupKind() == sar || a.GetKind().GroupKind() == lsar
 }

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -35,7 +35,7 @@ func TestIgnoreThatWhichCannotBeKnown(t *testing.T) {
 	handler := &lifecycle{}
 	unknown := &UnknownObject{}
 
-	err := handler.Admit(admission.NewAttributesRecord(unknown, kapi.Kind("kind"), "namespace", "name", kapi.Resource("resource"), "subresource", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(unknown, kapi.Kind("kind").WithVersion("version"), "namespace", "name", kapi.Resource("resource").WithVersion("version"), "subresource", "CREATE", nil))
 	if err != nil {
 		t.Errorf("Admission control should not error if it finds an object it knows nothing about %v", err)
 	}
@@ -76,7 +76,7 @@ func TestAdmissionExists(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build"), "namespace", "name", kapi.Resource("builds"), "", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build").WithVersion("version"), "namespace", "name", kapi.Resource("builds").WithVersion("version"), "", "CREATE", nil))
 	if err == nil {
 		t.Errorf("Expected an error because namespace does not exist")
 	}
@@ -124,7 +124,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build"), build.Namespace, "name", kapi.Resource("builds"), "", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build").WithVersion("version"), build.Namespace, "name", kapi.Resource("builds").WithVersion("version"), "", "CREATE", nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
@@ -134,19 +134,19 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store.Add(namespaceObj)
 
 	// verify create operations in the namespace cause an error
-	err = handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build"), build.Namespace, "name", kapi.Resource("builds"), "", "CREATE", nil))
+	err = handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build").WithVersion("version"), build.Namespace, "name", kapi.Resource("builds").WithVersion("version"), "", "CREATE", nil))
 	if err == nil {
 		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
 	}
 
 	// verify update operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build"), build.Namespace, "name", kapi.Resource("builds"), "", "UPDATE", nil))
+	err = handler.Admit(admission.NewAttributesRecord(build, kapi.Kind("Build").WithVersion("version"), build.Namespace, "name", kapi.Resource("builds").WithVersion("version"), "", "UPDATE", nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
 
 	// verify delete operations in the namespace can proceed
-	err = handler.Admit(admission.NewAttributesRecord(nil, kapi.Kind("Build"), build.Namespace, "name", kapi.Resource("builds"), "", "DELETE", nil))
+	err = handler.Admit(admission.NewAttributesRecord(nil, kapi.Kind("Build").WithVersion("version"), build.Namespace, "name", kapi.Resource("builds").WithVersion("version"), "", "DELETE", nil))
 	if err != nil {
 		t.Errorf("Unexpected error returned from admission handler: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestSAR(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		err := handler.Admit(admission.NewAttributesRecord(nil, kapi.Kind(v.kind), "foo", "name", kapi.Resource(v.resource), "", "CREATE", nil))
+		err := handler.Admit(admission.NewAttributesRecord(nil, kapi.Kind(v.kind).WithVersion("version"), "foo", "name", kapi.Resource(v.resource).WithVersion("version"), "", "CREATE", nil))
 		if err != nil {
 			t.Errorf("Unexpected error for %s returned from admission handler: %v", k, err)
 		}

--- a/pkg/project/admission/nodeenv/admission.go
+++ b/pkg/project/admission/nodeenv/admission.go
@@ -32,7 +32,7 @@ var _ = oadmission.Validator(&podNodeEnvironment{})
 
 // Admit enforces that pod and its project node label selectors matches at least a node in the cluster.
 func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {
-	resource := a.GetResource()
+	resource := a.GetResource().GroupResource()
 	if resource != kapi.Resource("pods") {
 		return nil
 	}

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -113,7 +113,7 @@ func TestPodAdmission(t *testing.T) {
 		}
 		pod.Spec = kapi.PodSpec{NodeSelector: test.podNodeSelector}
 
-		err := handler.Admit(admission.NewAttributesRecord(pod, kapi.Kind("Pod"), "namespace", project.ObjectMeta.Name, kapi.Resource("pods"), "", admission.Create, nil))
+		err := handler.Admit(admission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion("version"), "namespace", project.ObjectMeta.Name, kapi.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 		if test.admit && err != nil {
 			t.Errorf("Test: %s, expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {

--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -68,7 +68,7 @@ func (o *projectRequestLimit) Admit(a admission.Attributes) (err error) {
 	if o.config == nil {
 		return nil
 	}
-	if a.GetResource() != projectapi.Resource("projectrequests") {
+	if a.GetResource().GroupResource() != projectapi.Resource("projectrequests") {
 		return nil
 	}
 	if _, isProjectRequest := a.GetObject().(*projectapi.ProjectRequest); !isProjectRequest {

--- a/pkg/project/admission/requestlimit/admission_test.go
+++ b/pkg/project/admission/requestlimit/admission_test.go
@@ -281,10 +281,10 @@ func TestAdmit(t *testing.T) {
 		}
 		err = reqLimit.Admit(admission.NewAttributesRecord(
 			&projectapi.ProjectRequest{},
-			projectapi.Kind("ProjectRequest"),
+			projectapi.Kind("ProjectRequest").WithVersion("version"),
 			"foo",
 			"name",
-			projectapi.Resource("projectrequests"),
+			projectapi.Resource("projectrequests").WithVersion("version"),
 			"",
 			"CREATE",
 			&user.DefaultInfo{Name: tc.user}))

--- a/pkg/quota/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission.go
@@ -124,7 +124,7 @@ func (a *clusterResourceOverridePlugin) Validate() error {
 // TODO this will need to update when we have pod requests/limits
 func (a *clusterResourceOverridePlugin) Admit(attr admission.Attributes) error {
 	glog.V(6).Infof("%s admission controller is invoked", api.PluginName)
-	if a.config == nil || attr.GetResource() != kapi.Resource("pods") || attr.GetSubresource() != "" {
+	if a.config == nil || attr.GetResource().GroupResource() != kapi.Resource("pods") || attr.GetSubresource() != "" {
 		return nil // not applicable
 	}
 	pod, ok := attr.GetObject().(*kapi.Pod)

--- a/pkg/quota/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission_test.go
@@ -227,7 +227,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 			continue
 		}
 		c.(*clusterResourceOverridePlugin).SetProjectCache(fakeProjectCache(test.namespace))
-		attrs := admission.NewAttributesRecord(test.object, unversioned.GroupKind{}, test.namespace.Name, "name", kapi.Resource("pods"), "", admission.Create, fakeUser())
+		attrs := admission.NewAttributesRecord(test.object, unversioned.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
 		if err := c.Admit(attrs); err != nil {
 			t.Errorf("%s: admission controller should not return error", test.name)
 		}

--- a/pkg/quota/admission/runonceduration/admission.go
+++ b/pkg/quota/admission/runonceduration/admission.go
@@ -67,7 +67,7 @@ var _ = oadmission.Validator(&runOnceDuration{})
 func (a *runOnceDuration) Admit(attributes admission.Attributes) error {
 	switch {
 	case a.config == nil,
-		attributes.GetResource() != kapi.Resource("pods"),
+		attributes.GetResource().GroupResource() != kapi.Resource("pods"),
 		len(attributes.GetSubresource()) > 0:
 		return nil
 	}

--- a/pkg/quota/admission/runonceduration/admission_test.go
+++ b/pkg/quota/admission/runonceduration/admission_test.go
@@ -137,7 +137,7 @@ func TestRunOnceDurationAdmit(t *testing.T) {
 		runOnceDuration := NewRunOnceDuration(tc.config)
 		runOnceDuration.(oadmission.WantsProjectCache).SetProjectCache(testCache(tc.projectAnnotations))
 		pod := tc.pod
-		attrs := admission.NewAttributesRecord(pod, kapi.Kind("Pod"), "default", "test", kapi.Resource("pods"), "", admission.Create, nil)
+		attrs := admission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion("version"), "default", "test", kapi.Resource("pods").WithVersion("version"), "", admission.Create, nil)
 		err := runOnceDuration.Admit(attrs)
 		if err != nil {
 			t.Errorf("%s: unexpected admission error: %v", tc.name, err)

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -112,7 +112,7 @@ func (o *podNodeConstraints) Admit(attr admission.Attributes) error {
 		attr.GetSubresource() != "":
 		return nil
 	}
-	shouldCheck, err := shouldCheckResource(attr.GetResource(), attr.GetKind())
+	shouldCheck, err := shouldCheckResource(attr.GetResource().GroupResource(), attr.GetKind().GroupKind())
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (o *podNodeConstraints) Admit(attr admission.Attributes) error {
 		return nil
 	}
 	// Only check Create operation on pods
-	if attr.GetResource() == kapi.Resource("pods") && attr.GetOperation() != admission.Create {
+	if attr.GetResource().GroupResource() == kapi.Resource("pods") && attr.GetOperation() != admission.Create {
 		return nil
 	}
 	ps, err := o.getPodSpec(attr)
@@ -199,7 +199,7 @@ func (o *podNodeConstraints) checkPodsBindAccess(attr admission.Attributes) (boo
 		Resource: "pods/binding",
 		APIGroup: kapi.GroupName,
 	}
-	if attr.GetResource() == kapi.Resource("pods") {
+	if attr.GetResource().GroupResource() == kapi.Resource("pods") {
 		authzAttr.ResourceName = attr.GetName()
 	}
 	allow, _, err := o.authorizer.Authorize(ctx, authzAttr)

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -111,7 +111,7 @@ func TestPodNodeConstraints(t *testing.T) {
 			checkAdmitError(t, err, expectedError, errPrefix)
 			continue
 		}
-		attrs := admission.NewAttributesRecord(tc.resource, kapi.Kind("Pod"), ns, "test", kapi.Resource("pods"), "", admission.Create, tc.userinfo)
+		attrs := admission.NewAttributesRecord(tc.resource, kapi.Kind("Pod").WithVersion("version"), ns, "test", kapi.Resource("pods").WithVersion("version"), "", admission.Create, tc.userinfo)
 		if tc.expectedErrorMsg != "" {
 			expectedError = admission.NewForbidden(attrs, fmt.Errorf(tc.expectedErrorMsg))
 		}
@@ -131,7 +131,7 @@ func TestPodNodeConstraintsPodUpdate(t *testing.T) {
 		checkAdmitError(t, err, expectedError, errPrefix)
 		return
 	}
-	attrs := admission.NewAttributesRecord(nodeNamePod(), kapi.Kind("Pod"), ns, "test", kapi.Resource("pods"), "", admission.Update, serviceaccount.UserInfo("", "", ""))
+	attrs := admission.NewAttributesRecord(nodeNamePod(), kapi.Kind("Pod").WithVersion("version"), ns, "test", kapi.Resource("pods").WithVersion("version"), "", admission.Update, serviceaccount.UserInfo("", "", ""))
 	err = prc.Admit(attrs)
 	checkAdmitError(t, err, expectedError, errPrefix)
 }
@@ -147,7 +147,7 @@ func TestPodNodeConstraintsNonHandledResources(t *testing.T) {
 		checkAdmitError(t, err, expectedError, errPrefix)
 		return
 	}
-	attrs := admission.NewAttributesRecord(resourceQuota(), kapi.Kind("ResourceQuota"), ns, "test", kapi.Resource("resourcequotas"), "", admission.Create, serviceaccount.UserInfo("", "", ""))
+	attrs := admission.NewAttributesRecord(resourceQuota(), kapi.Kind("ResourceQuota").WithVersion("version"), ns, "test", kapi.Resource("resourcequotas").WithVersion("version"), "", admission.Create, serviceaccount.UserInfo("", "", ""))
 	err = prc.Admit(attrs)
 	checkAdmitError(t, err, expectedError, errPrefix)
 }
@@ -253,7 +253,7 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 						checkAdmitError(t, err, expectedError, errPrefix)
 						continue
 					}
-					attrs := admission.NewAttributesRecord(tr.resource(tp.nodeselector), tr.kind, ns, "test", tr.groupresource, "", top.operation, tc.userinfo)
+					attrs := admission.NewAttributesRecord(tr.resource(tp.nodeselector), tr.kind.WithVersion("version"), ns, "test", tr.groupresource.WithVersion("version"), "", top.operation, tc.userinfo)
 					if tp.expectedErrorMsg != "" {
 						expectedError = admission.NewForbidden(attrs, fmt.Errorf(tp.expectedErrorMsg))
 					}

--- a/pkg/security/admission/admission.go
+++ b/pkg/security/admission/admission.go
@@ -95,7 +95,7 @@ func (a *constraint) Stop() {
 //     with the validated SCC.  If we don't find any reject the pod and give all errors from the
 //     failed attempts.
 func (c *constraint) Admit(a kadmission.Attributes) error {
-	if a.GetResource() != kapi.Resource("pods") {
+	if a.GetResource().GroupResource() != kapi.Resource("pods") {
 		return nil
 	}
 

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -133,7 +133,7 @@ func testSCCAdmit(testCaseName string, sccs []*kapi.SecurityContextConstraints, 
 
 	plugin := NewTestAdmission(store, tc)
 
-	attrs := kadmission.NewAttributesRecord(pod, kapi.Kind("Pod"), "namespace", "", kapi.Resource("pods"), "", kadmission.Create, &user.DefaultInfo{})
+	attrs := kadmission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion("version"), "namespace", "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 	err := plugin.Admit(attrs)
 
 	if shouldPass && err != nil {
@@ -374,7 +374,7 @@ func TestAdmit(t *testing.T) {
 	}
 
 	for k, v := range testCases {
-		attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod"), "namespace", "", kapi.Resource("pods"), "", kadmission.Create, &user.DefaultInfo{})
+		attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod").WithVersion("version"), "namespace", "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 		err := p.Admit(attrs)
 
 		if v.shouldAdmit && err != nil {
@@ -448,7 +448,7 @@ func TestAdmit(t *testing.T) {
 
 	for k, v := range testCases {
 		if !v.shouldAdmit {
-			attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod"), "namespace", "", kapi.Resource("pods"), "", kadmission.Create, &user.DefaultInfo{})
+			attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod").WithVersion("version"), "namespace", "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 			err := p.Admit(attrs)
 			if err != nil {
 				t.Errorf("Expected %s to pass with escalated scc but got error %v", k, err)
@@ -823,7 +823,7 @@ func TestCreateProvidersFromConstraints(t *testing.T) {
 		scc := v.scc()
 
 		// create the providers, this method only needs the namespace
-		attributes := kadmission.NewAttributesRecord(nil, kapi.Kind("Pod"), v.namespace.Name, "", kapi.Resource("pods"), "", kadmission.Create, nil)
+		attributes := kadmission.NewAttributesRecord(nil, kapi.Kind("Pod").WithVersion("version"), v.namespace.Name, "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, nil)
 		_, errs := admit.createProvidersFromConstraints(attributes.GetNamespace(), []*kapi.SecurityContextConstraints{scc})
 
 		if !reflect.DeepEqual(scc, v.scc()) {
@@ -1465,7 +1465,7 @@ func TestAdmitWithPrioritizedSCC(t *testing.T) {
 // testSCCAdmission is a helper to admit the pod and ensure it was validated against the expected
 // SCC.
 func testSCCAdmission(pod *kapi.Pod, plugin kadmission.Interface, expectedSCC string, t *testing.T) {
-	attrs := kadmission.NewAttributesRecord(pod, kapi.Kind("Pod"), "namespace", "", kapi.Resource("pods"), "", kadmission.Create, &user.DefaultInfo{})
+	attrs := kadmission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion("version"), "namespace", "", kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 	err := plugin.Admit(attrs)
 	if err != nil {
 		t.Errorf("error admitting pod: %v", err)

--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -28,7 +28,7 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 	if a.GetOperation() != admission.Connect {
 		return nil
 	}
-	if a.GetResource() != kapi.Resource("pods") {
+	if a.GetResource().GroupResource() != kapi.Resource("pods") {
 		return nil
 	}
 	if a.GetSubresource() != "attach" && a.GetSubresource() != "exec" {
@@ -42,7 +42,7 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 
 	// TODO, if we want to actually limit who can use which service account, then we'll need to add logic here to make sure that
 	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
-	createAttributes := admission.NewAttributesRecord(pod, kapi.Kind("Pod"), a.GetNamespace(), a.GetName(), a.GetResource(), a.GetSubresource(), admission.Create, a.GetUserInfo())
+	createAttributes := admission.NewAttributesRecord(pod, kapi.Kind("Pod").WithVersion(""), a.GetNamespace(), a.GetName(), a.GetResource(), a.GetSubresource(), admission.Create, a.GetUserInfo())
 	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
 		return admission.NewForbidden(a, err)
 	}

--- a/pkg/security/admission/scc_exec_test.go
+++ b/pkg/security/admission/scc_exec_test.go
@@ -90,7 +90,7 @@ func TestExecAdmit(t *testing.T) {
 		// create the admission plugin
 		p := NewSCCExecRestrictions(tc)
 
-		attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod"), "namespace", "pod-name", kapi.Resource(v.resource), v.subresource, v.operation, &user.DefaultInfo{})
+		attrs := kadmission.NewAttributesRecord(v.pod, kapi.Kind("Pod").WithVersion("version"), "namespace", "pod-name", kapi.Resource(v.resource).WithVersion("version"), v.subresource, v.operation, &user.DefaultInfo{})
 		err := p.Admit(attrs)
 
 		if v.shouldAdmit && err != nil {

--- a/pkg/service/admission/externalip_admission.go
+++ b/pkg/service/admission/externalip_admission.go
@@ -74,7 +74,7 @@ func (s networkSlice) Contains(ip net.IP) bool {
 
 // Admit determines if the service should be admitted based on the configured network CIDR.
 func (r *externalIPRanger) Admit(a kadmission.Attributes) error {
-	if a.GetResource() != kapi.Resource("services") {
+	if a.GetResource().GroupResource() != kapi.Resource("services") {
 		return nil
 	}
 
@@ -104,7 +104,7 @@ func (r *externalIPRanger) Admit(a kadmission.Attributes) error {
 		}
 	}
 	if len(errs) > 0 {
-		return apierrs.NewInvalid(a.GetKind(), a.GetName(), errs)
+		return apierrs.NewInvalid(a.GetKind().GroupKind(), a.GetName(), errs)
 	}
 	return nil
 }

--- a/pkg/service/admission/externalip_admission_test.go
+++ b/pkg/service/admission/externalip_admission_test.go
@@ -161,7 +161,7 @@ func TestAdmission(t *testing.T) {
 		svc.Spec.ExternalIPs = test.externalIPs
 		handler := NewExternalIPRanger(test.rejects, test.admits)
 
-		err := handler.Admit(admission.NewAttributesRecord(svc, kapi.Kind("Service"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services"), "", test.op, nil))
+		err := handler.Admit(admission.NewAttributesRecord(svc, kapi.Kind("Service").WithVersion("version"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services").WithVersion("version"), "", test.op, nil))
 		if test.admit && err != nil {
 			t.Errorf("%s: expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {


### PR DESCRIPTION
This allows a rule to be conditional on a label selector.  This would allow a project admin to create whatever resourcequota he wanted as long as it had the label `"for": "admin"` or some such.  That would allow a cluster-admin to have trumping powers for resourcequota, while allowing a project admin to easily (relatively) manage his own quota.

The only blocker right now: lack of a truly generic client.  We could say "only some resources" and constrain ourselves to all the known resource groups.

I think this would make the label based quota much easier to code and manage.

@smarterclayton @pweil- @liggitt 
@derekwaynecarr since the main purpose is quota management.
