### PR TITLE
haproxy Cookie id leaks information about software

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -217,9 +217,9 @@ backend be_edge_http_{{$cfgIdx}}
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   {{ if (eq $cfg.TLSTermination "") }}
-    cookie OPENSHIFT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly
+    cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
   {{ else }}
-    cookie OPENSHIFT_EDGE_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure
+    cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
   {{ end }}
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
                 {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
@@ -243,7 +243,7 @@ backend be_secure_{{$cfgIdx}}
   option redispatch
   balance leastconn
   timeout check 5000ms
-  cookie OPENSHIFT_REENCRYPT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure
+  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
                 {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}}
                 {{ end }}

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -1,6 +1,7 @@
 package templaterouter
 
 import (
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -449,6 +450,9 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string)
 			}
 		}
 	}
+
+	key := fmt.Sprintf("%s %s", config.TLSTermination, backendKey)
+	config.RoutingKeyName = fmt.Sprintf("%x", md5.Sum([]byte(key)))
 
 	//create or replace
 	frontend.ServiceAliasConfigs[backendKey] = config

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -37,6 +37,8 @@ type ServiceAliasConfig struct {
 	// insecure connections to an edge-terminated route:
 	//   none (or disable), allow or redirect
 	InsecureEdgeTerminationPolicy routeapi.InsecureEdgeTerminationPolicyType
+	// Hash of the route name - used to obscure cookieId
+	RoutingKeyName string
 }
 
 type ServiceAliasConfigStatus string

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1035,6 +1035,12 @@ func getRoute(routerUrl string, hostName string, protocol string, headers map[st
 			return "", fmt.Errorf("GET of %s returned: %d", url, resp.StatusCode)
 		}
 		respBody, err := ioutil.ReadAll(resp.Body)
+		cookies := resp.Cookies()
+		for _, cookie := range cookies {
+			if len(cookie.Name) != 32 || len(cookie.Value) != 32 {
+				return "", fmt.Errorf("GET of %s returned bad cookie %s=%s", url, cookie.Name, cookie.Value)
+			}
+		}
 		return string(respBody), err
 
 	case "ws", "wss":


### PR DESCRIPTION
Resolves: bz1318796
haproxy now uses environment variables, set in the deploymentconfigs
to set the cookie prefix and sufix. When the environment variables are
not set, the original cookie name is generated which prevents breaking
software that relies on the structure of the cookie name.

There are three environment variables to set the prefix on the three
distince cookies that can be generated. When a prefix is set the
"project_routename" is hashed to obfuscate it. The suffix environment
variable sets the suffix.
COOKIE_PREFIX_MAIN       default "OPENSHIFT_"
COOKIE_PREFIX_EDGE       default "OPENSHIFT_EDGE_"
COOKIE_PREFIX_REENCRYPT  default "OPENSHIFT_REENCRYPT_"
COOKIE_SUFFIX            default "_SERVERID"

Signed-off-by: Phil Cameron <pcameron@redhat.com>