### PR TITLE
Update for split-out openshift-sdn proxy plugin

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -874,32 +874,32 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/cmd/admin/network",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/exec",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ipcmd",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/netutils",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ovs",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins/osdn",
 			"Comment": "v0.1-418-gfccee21",
-			"Rev": "c709df994a5bbecfa80fae62c20131cd25337b79"
+			"Rev": "0fbae3c75c6802a5f5d7fe48d562856443457f6a"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/api/types.go
@@ -14,5 +14,5 @@ type OsdnPlugin interface {
 
 type FilteringEndpointsConfigHandler interface {
 	pconfig.EndpointsConfigHandler
-	SetBaseEndpointsHandler(base pconfig.EndpointsConfigHandler)
+	Start(baseHandler pconfig.EndpointsConfigHandler) error
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/factory/factory.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/factory/factory.go
@@ -12,8 +12,17 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 )
 
-// Call by higher layers to create the plugin instance
-func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+// Call by higher layers to create the plugin SDN master instance
+func NewMasterPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client) (api.OsdnPlugin, error) {
+	return newPlugin(pluginType, osClient, kClient, "", "")
+}
+
+// Call by higher layers to create the plugin SDN node instance
+func NewNodePlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, error) {
+	return newPlugin(pluginType, osClient, kClient, hostname, selfIP)
+}
+
+func newPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, error) {
 	switch strings.ToLower(pluginType) {
 	case ovs.SingleTenantPluginName:
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)
@@ -21,5 +30,15 @@ func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Cl
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), true, hostname, selfIP)
 	}
 
-	return nil, nil, nil
+	return nil, nil
+}
+
+// Call by higher layers to create the proxy plugin instance; only used by nodes
+func NewProxyPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client) (api.FilteringEndpointsConfigHandler, error) {
+	switch strings.ToLower(pluginType) {
+	case ovs.MultiTenantPluginName:
+		return ovs.CreateProxyPlugin(osdn.NewRegistry(osClient, kClient))
+	}
+
+	return nil, nil
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
@@ -34,19 +34,15 @@ type ovsPlugin struct {
 	multitenant bool
 }
 
-func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, selfIP string) (api.OsdnPlugin, error) {
 	plugin := &ovsPlugin{multitenant: multitenant}
 
 	err := plugin.BaseInit(registry, plugin, multitenant, hostname, selfIP)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if multitenant {
-		return plugin, registry, err
-	} else {
-		return plugin, nil, err
-	}
+	return plugin, err
 }
 
 func (plugin *ovsPlugin) PluginStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/proxy.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/proxy.go
@@ -1,0 +1,158 @@
+package ovs
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/openshift-sdn/plugins/osdn"
+	"github.com/openshift/openshift-sdn/plugins/osdn/api"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	pconfig "k8s.io/kubernetes/pkg/proxy/config"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type ovsProxyPlugin struct {
+	registry  *osdn.Registry
+	podsByIP  map[string]*kapi.Pod
+	podsMutex sync.Mutex
+
+	baseEndpointsHandler pconfig.EndpointsConfigHandler
+}
+
+func CreateProxyPlugin(registry *osdn.Registry) (api.FilteringEndpointsConfigHandler, error) {
+	return &ovsProxyPlugin{
+		registry: registry,
+		podsByIP: make(map[string]*kapi.Pod),
+	}, nil
+}
+
+func (proxy *ovsProxyPlugin) Start(baseHandler pconfig.EndpointsConfigHandler) error {
+	glog.Infof("Starting multitenant SDN proxy endpoint filter")
+
+	proxy.baseEndpointsHandler = baseHandler
+
+	// Populate pod info map synchronously so that kube proxy can filter endpoints to support isolation
+	pods, err := proxy.registry.GetAllPods()
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods {
+		proxy.trackPod(&pod)
+	}
+
+	go utilwait.Forever(proxy.watchPods, 0)
+
+	return nil
+}
+
+func (proxy *ovsProxyPlugin) watchPods() {
+	eventQueue := proxy.registry.RunEventQueue(osdn.Pods)
+
+	for {
+		eventType, obj, err := eventQueue.Pop()
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("EventQueue failed for pods: %v", err))
+			return
+		}
+		pod := obj.(*kapi.Pod)
+
+		switch eventType {
+		case watch.Added, watch.Modified:
+			proxy.trackPod(pod)
+		case watch.Deleted:
+			proxy.unTrackPod(pod)
+		}
+	}
+}
+
+func (proxy *ovsProxyPlugin) getTrackedPod(ip string) (*kapi.Pod, bool) {
+	proxy.podsMutex.Lock()
+	defer proxy.podsMutex.Unlock()
+
+	pod, ok := proxy.podsByIP[ip]
+	return pod, ok
+}
+
+func (proxy *ovsProxyPlugin) trackPod(pod *kapi.Pod) {
+	if pod.Status.PodIP == "" {
+		return
+	}
+
+	proxy.podsMutex.Lock()
+	defer proxy.podsMutex.Unlock()
+	podInfo, ok := proxy.podsByIP[pod.Status.PodIP]
+
+	if pod.Status.Phase == kapi.PodPending || pod.Status.Phase == kapi.PodRunning {
+		// When a pod hits one of the states where the IP is in use then
+		// we need to add it to our IP -> namespace tracker.  There _should_ be no
+		// other entries for the IP if we caught all of the right messages, so warn
+		// if we see one, but clobber it anyway since the IPAM
+		// should ensure that each IP is uniquely assigned to a pod (when running)
+		if ok && podInfo.UID != pod.UID {
+			glog.Warningf("IP '%s' was marked as used by namespace '%s' (pod '%s')... updating to namespace '%s' (pod '%s')",
+				pod.Status.PodIP, podInfo.Namespace, podInfo.UID, pod.ObjectMeta.Namespace, pod.UID)
+		}
+
+		proxy.podsByIP[pod.Status.PodIP] = pod
+	} else if ok && podInfo.UID == pod.UID {
+		// If the UIDs match, then this pod is moving to a state that indicates it is not running
+		// so we need to remove it from the cache
+		delete(proxy.podsByIP, pod.Status.PodIP)
+	}
+}
+
+func (proxy *ovsProxyPlugin) unTrackPod(pod *kapi.Pod) {
+	proxy.podsMutex.Lock()
+	defer proxy.podsMutex.Unlock()
+
+	// Only delete if the pod ID is the one we are tracking (in case there is a failed or complete
+	// pod lying around that gets deleted while there is a running pod with the same IP)
+	if podInfo, ok := proxy.podsByIP[pod.Status.PodIP]; ok && podInfo.UID == pod.UID {
+		delete(proxy.podsByIP, pod.Status.PodIP)
+	}
+}
+
+func (proxy *ovsProxyPlugin) OnEndpointsUpdate(allEndpoints []kapi.Endpoints) {
+	clusterNetwork, _, serviceNetwork, err := proxy.registry.GetNetworkInfo()
+	if err != nil {
+		glog.Warningf("Error fetching cluster network: %v", err)
+		return
+	}
+
+	filteredEndpoints := make([]kapi.Endpoints, 0, len(allEndpoints))
+
+EndpointLoop:
+	for _, ep := range allEndpoints {
+		ns := ep.ObjectMeta.Namespace
+		for _, ss := range ep.Subsets {
+			for _, addr := range ss.Addresses {
+				IP := net.ParseIP(addr.IP)
+				if serviceNetwork.Contains(IP) {
+					glog.Warningf("Service '%s' in namespace '%s' has an Endpoint inside the service network (%s)", ep.ObjectMeta.Name, ns, addr.IP)
+					continue EndpointLoop
+				}
+				if clusterNetwork.Contains(IP) {
+					podInfo, ok := proxy.getTrackedPod(addr.IP)
+					if !ok {
+						glog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to non-existent pod (%s)", ep.ObjectMeta.Name, ns, addr.IP)
+						continue EndpointLoop
+					}
+					if podInfo.ObjectMeta.Namespace != ns {
+						glog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to pod %s in namespace '%s'", ep.ObjectMeta.Name, ns, addr.IP, podInfo.ObjectMeta.Namespace)
+						continue EndpointLoop
+					}
+				}
+			}
+		}
+		filteredEndpoints = append(filteredEndpoints, ep)
+	}
+
+	proxy.baseEndpointsHandler.OnEndpointsUpdate(filteredEndpoints)
+}

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -392,12 +392,13 @@ func (c *NodeConfig) RunProxy() {
 
 	endpointsConfig := pconfig.NewEndpointsConfig()
 	// customized handling registration that inserts a filter if needed
-	if c.FilteringEndpointsHandler == nil {
-		endpointsConfig.RegisterHandler(endpointsHandler)
-	} else {
-		c.FilteringEndpointsHandler.SetBaseEndpointsHandler(endpointsHandler)
-		endpointsConfig.RegisterHandler(c.FilteringEndpointsHandler)
+	if c.FilteringEndpointsHandler != nil {
+		if err := c.FilteringEndpointsHandler.Start(endpointsHandler); err != nil {
+			glog.Fatalf("error: node proxy plugin startup failed: %v", err)
+		}
+		endpointsHandler = c.FilteringEndpointsHandler
 	}
+	endpointsConfig.RegisterHandler(endpointsHandler)
 
 	pconfig.NewSourceAPI(
 		c.Client,

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -358,7 +358,7 @@ func (c *MasterConfig) RunDeploymentImageChangeTriggerController() {
 // RunSDNController runs openshift-sdn if the said network plugin is provided
 func (c *MasterConfig) RunSDNController() {
 	oClient, kClient := c.SDNControllerClients()
-	controller, _, err := factory.NewPlugin(c.Options.NetworkConfig.NetworkPluginName, oClient, kClient, "", "")
+	controller, err := factory.NewMasterPlugin(c.Options.NetworkConfig.NetworkPluginName, oClient, kClient)
 	if err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)
 	}

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -151,14 +151,7 @@ func ValidateRuntime(config *configapi.NodeConfig, components *utilflags.Compone
 	}
 
 	switch strings.ToLower(config.NetworkConfig.NetworkPluginName) {
-	case ovs.MultiTenantPluginName:
-		if actual.Has(ComponentKubelet) && !actual.Has(ComponentPlugins) {
-			return fmt.Errorf("the multi-tenant SDN plugin must be run in the same process as the kubelet")
-		}
-		if actual.Has(ComponentProxy) && !actual.Has(ComponentPlugins) {
-			return fmt.Errorf("the multi-tenant SDN plugin requires the proxy and plugins components be enabled in the same process")
-		}
-	case ovs.SingleTenantPluginName:
+	case ovs.SingleTenantPluginName, ovs.MultiTenantPluginName:
 		if actual.Has(ComponentKubelet) && !actual.Has(ComponentPlugins) {
 			return fmt.Errorf("the SDN plugin must be run in the same process as the kubelet")
 		}

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -87,7 +87,7 @@ func NewCommandStartNetwork(basename string, out io.Writer) (*cobra.Command, *No
 	cmd := &cobra.Command{
 		Use:   "network",
 		Short: "Launch node network",
-		Long:  fmt.Sprintf(nodeLong, basename),
+		Long:  fmt.Sprintf(networkLong, basename),
 		Run:   options.Run,
 	}
 
@@ -310,7 +310,6 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 	if components.Enabled(ComponentKubelet) {
 		config.RunKubelet()
 	}
-	// SDN plugins get the opportunity to filter service rules, so they start first
 	if components.Enabled(ComponentPlugins) {
 		config.RunPlugin()
 	}


### PR DESCRIPTION
See https://github.com/openshift/openshift-sdn/pull/300 for the openshift-sdn side.

Still not entirely standalone but it should be a lot easier now.  This assumes the proxy will also take a --network-plugin argument (or something like that) which the proxy plugin code now interprets.