### PR TITLE
Allow network test runner to accept kubeconfig

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -337,6 +337,10 @@ openshift.local.config) can be supplied instead:
 
         $ OPENSHIFT_CONFIG_ROOT=[cluster config root] test/extended/networking.sh
 
+It's also possible to supply the path to a kubeconfig file:
+
+        $ OPENSHIFT_TEST_KUBECONFIG=./admin.kubeconfig test/extended/networking.sh
+
 See the script's inline documentation for further details.
 
 ==== Running Kubernetes e2e tests


### PR DESCRIPTION
Previously the networking extended test runner required that the root
of a config tree be specified to target an arbitrary cluster.  This
change adds support for the configuration file to be specified via
OPENSHIFT_TEST_KUBECONFIG.  KUBECONFIG is not used due to jenkins
having this set in the slave environment to an invalid value.

cc: @openshift/networking 