### PR TITLE
Fix for issue 8578 involving non-breaking strings.

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -231,16 +231,6 @@
   }
 }
 
-.events-table {
-  .pficon {
-    vertical-align: middle;
-  }
-  .severity-icon-td {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
 .build-config-summary {
   .latest-build-status {
     margin-right: 5px;
@@ -728,10 +718,6 @@ select:invalid {
   // Bootstrap mixin
   // Note: If truncating within a flex container then the parent needs a width
   .text-overflow();
-}
-
-.word-break {
-  .word-break();
 }
 
 .nowrap {

--- a/assets/app/styles/_mixins.less
+++ b/assets/app/styles/_mixins.less
@@ -38,11 +38,25 @@
   font-family: Menlo, Monaco, "Liberation Mono", Consolas, monospace;
 }
 
+// word-break and word-break-all test cases http://codepen.io/sg00dwin/pen/WwKMmP
 
-.word-break() {
- -ms-word-break: break-all; // ms
-     word-wrap: break-word;
-  overflow-wrap: break-word; // new name as per the CSS3 spec
+.word-break-all {
+  // USAGE: Breaks long non-breaking strings if within a table not set to table-layout: fixed, fieldset or a flex container only eg <div style="display:flex"><div class="word-break-all">...
+  // Guarantees the string will wrap. word-break: break-all; is used by firefox and IE to break in the usage cases.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=587438, https://bugzilla.mozilla.org/show_bug.cgi?id=1136818
+    word-break: break-all;  // firefox, IE
+    word-break: break-word; // non-standard for webkit
+ overflow-wrap: break-word; // new name as per the CSS3 spec
+}
+
+.word-break {
+  // USAGE: Breaks long non-breaking strings within a div or a flexed item that is within a flex container eg <div style="display:flex"><div style="flex:1" class="word-break">...
+  // An unbreakable "word" may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.
+  // (1) https://bugzilla.mozilla.org/show_bug.cgi?id=1136818#c2
+     word-wrap: break-word; // firefox, IE
+    word-break: break-word; // non-standard for webkit
+ overflow-wrap: break-word; // new name as per the CSS3 spec
+     min-width: 0;          // firefox (1)
 }
 
 // Linear-gradient stripes

--- a/assets/app/styles/_tables.less
+++ b/assets/app/styles/_tables.less
@@ -36,13 +36,6 @@
       border-top-width: 1px;
     }
   }
-  tr {
-    @media (min-width: @screen-md-min) {
-      td.event-time {
-        white-space: nowrap;
-      }
-    }
-  }
 }
 
 .table-borderless>tbody>tr>th,
@@ -146,4 +139,25 @@
   border-left: 1px solid @table-border-color;
   border-right: 1px solid @table-border-color;
   background-color: #f9f9f9;
+}
+
+// table for events
+.events-table {
+  table-layout: fixed;
+  th:nth-child(1) {width:90px;} // time
+  th:nth-child(2) {width:190px;} // name
+  th:nth-child(3) {width:160px;} // kind
+  th:nth-child(4) {width:10px;padding:0;} // icon
+  th:nth-child(5) {width:150px;} // reason
+  th:last-child   {width:100%;} // message; ensures it gets remaining width
+  td:nth-child(2),td:last-child {
+    .word-break;
+  }
+  .pficon {
+    vertical-align: middle;
+  }
+  .severity-icon-td {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -24,7 +24,7 @@
         <div>
           <span class="pficon pficon-image" aria-hidden="true"></span>
         </div>
-        <div flex>
+        <div flex class="word-break">
           <span class="pod-template-key">Image:</span>
           <span ng-if="!imagesByDockerReference[container.image]">{{container.image | imageStreamName}}</span>
           <span ng-if="imagesByDockerReference[container.image]">
@@ -41,7 +41,7 @@
           <div>
             <span class="fa fa-refresh" aria-hidden="true"></span>
           </div>
-          <div flex>
+          <div flex class="word-break">
             <span class="pod-template-key">Build:</span>
             <span ng-if="build.metadata.labels.buildconfig">
               <a ng-href="{{build.metadata.labels.buildconfig | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}">{{build.metadata.labels.buildconfig}}</a>,
@@ -86,7 +86,7 @@
         <div>
           <span data-icon="" aria-hidden="true" style="font-size:16px;line-height:normal"></span>
         </div>
-        <div flex>
+        <div flex class="word-break">
           <span class="pod-template-key">Ports:</span>
           <span ng-repeat="port in container.ports | orderBy: 'containerPort'">
             <span class="nowrap">{{port.containerPort}}/{{port.protocol}}<span ng-if="port.name">&thinsp;({{port.name}})</span><span ng-if="port.hostPort">&thinsp;<span class="port-icon">&#8594;</span>&thinsp;{{port.hostPort}}</span></span><span ng-if="!$last">, </span>
@@ -98,10 +98,10 @@
         <div>
           <span aria-hidden="true" class="fa fa-database"></span>
         </div>
-        <div flex>
+        <div flex class="word-break">
           <span class="pod-template-key">Mount:</span>
           <span>
-            {{mount.name}}&#8201;&#8594;&#8201;<span class="word-break">{{mount.mountPath}}</span>
+            {{mount.name}}&#8201;&#8594;&#8201;<span>{{mount.mountPath}}</span>
           </span>
         </div>
       </div>

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -95,12 +95,12 @@
                       <span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>
                     </td>
                     <td data-title="Type">{{build.spec.strategy.type}}</td>
-                    <td data-title="Source">
+                    <td data-title="Source" class="word-break-all">
                       <span ng-if="build.spec.source">
                         <span ng-if="build.spec.source.type == 'None'">
                           <i>none</i>
                         </span>
-                        <span ng-if="build.spec.source.type == 'Git'" ng-bind-html='build.spec.source.git.uri | githubLink : build.spec.source.git.ref : build.spec.source.contextDir | linky' class="word-break"></span>
+                        <span ng-if="build.spec.source.type == 'Git'" ng-bind-html='build.spec.source.git.uri | githubLink : build.spec.source.git.ref : build.spec.source.contextDir | linky'></span>
                       </span>
                     </td>
                   </tr>

--- a/assets/app/views/directives/events.html
+++ b/assets/app/views/directives/events.html
@@ -27,31 +27,26 @@
         <th ng-if="!resourceKind || !resourceName" class="hidden-sm hidden-md">
           <span class="visible-lg-inline">Kind</span>
         </th>
-        <th class="hidden-xs hidden-sm hidden-md sr-only">Severity</th>
+        <th class="hidden-xs hidden-sm hidden-md"><span class="sr-only">Severity</span></th>
         <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
         <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
       </tr>
     </thead>
     <tbody ng-if="(filteredEvents | hashSize) === 0">
       <tr>
-        <td>
+        <td colspan="6">
           <span ng-if="(unfilteredEvents | hashSize) === 0"><em>No events to show.</em></span>
           <span ng-if="(unfilteredEvents | hashSize) > 0">
             All events hidden by filter.
             <a href="" ng-click="filter.text = ''" role="button">Clear filter</a>
           </span>
         </td>
-        <td ng-if="!resourceKind || !resourceName" class="hidden-xs">&nbsp;</td>
-        <td ng-if="!resourceKind || !resourceName" class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-        <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-        <td class="hidden-xs hidden-sm hidden-md">&nbsp;</td>
-        <td class="hidden-xs">&nbsp;</td>
       </tr>
     </tbody>
     <tbody ng-repeat="event in filteredEvents">
       <tr>
         <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
-        <td ng-if="!resourceKind || !resourceName" data-title="Name" class="event-time">
+        <td ng-if="!resourceKind || !resourceName" data-title="Name">
           <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">{{event.involvedObject.kind | humanizeKind : true}}</div>
           {{event.involvedObject.name}}
         </td>
@@ -63,7 +58,7 @@
         <td class="hidden-sm hidden-md" data-title="Reason">
           {{event.reason | sentenceCase}}&nbsp;<span class="visible-xs-inline pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span>
         </td>
-        <td data-title="Message" class="word-break">
+        <td data-title="Message">
           <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
             {{event.reason | sentenceCase}}&nbsp;
             <span class="pficon pficon-warning-triangle-o" ng-show="event.type === 'Warning'" aria-hidden="true" data-toggle="tooltip" data-original-title="Warning"></span>


### PR DESCRIPTION
Creation of two mixins for breaking strings within certain markup contexts.


``` 
// Looks to break the string at acceptable break points in certain cases, 
// otherwise it will be broken at an arbitrary point.
// include min-width: 0 which is needed for firefox
.word-break() 

// Guarantees the string will break in all cases, by using word-break: break-all; 
// which is used by firefox and IE
.word-break-all()
```

Fixes https://github.com/openshift/origin/issues/8578

@spadgett @rhamilto @benjaminapetersen 