### PR TITLE
remove unused describe user function

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -89,21 +89,6 @@ type BuildDescriber struct {
 	kubeClient kclient.Interface
 }
 
-// DescribeUser formats the description of a user
-func (d *BuildDescriber) DescribeUser(out *tabwriter.Writer, label string, u buildapi.SourceControlUser) {
-	if len(u.Name) > 0 && len(u.Email) > 0 {
-		formatString(out, label, fmt.Sprintf("%s <%s>", u.Name, u.Email))
-		return
-	}
-	if len(u.Name) > 0 {
-		formatString(out, label, u.Name)
-		return
-	}
-	if len(u.Email) > 0 {
-		formatString(out, label, u.Email)
-	}
-}
-
 // Describe returns the description of a build
 func (d *BuildDescriber) Describe(namespace, name string) (string, error) {
 	c := d.osClient.Builds(namespace)


### PR DESCRIPTION
i think this is a left over from this PR:
https://github.com/openshift/origin/pull/8293/files#diff-677cd147da9da054b24bb9a600046af9L267

can we remove this now, since i can not find a use for it anywhere?

@php-coder  @bparees PTAL