### PR TITLE
Bug 1329138: stop emitting events on update conflicts

### DIFF
--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -127,6 +127,10 @@ func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy, pod *kap
 		} else {
 			errs = append(errs, validateCustomParams(strategy.CustomParams, fldPath.Child("customParams"))...)
 		}
+	case "":
+		errs = append(errs, field.Required(fldPath.Child("type"), "strategy type is required"))
+	default:
+		errs = append(errs, field.Invalid(fldPath.Child("type"), strategy.Type, "unsupported strategy type, use \"Custom\" instead and specify your own strategy"))
 	}
 
 	if strategy.Labels != nil {

--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -45,8 +45,8 @@ func TestHandle_createPodOk(t *testing.T) {
 				return pod, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return expectedContainer, nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return expectedContainer
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -132,7 +132,7 @@ func TestHandle_makeContainerFail(t *testing.T) {
 
 	controller := &DeploymentController{
 		decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
-			return deployutil.DecodeDeploymentConfig(deployment, kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
+			return nil, fmt.Errorf("invalid serialized object reference")
 		},
 		deploymentClient: &deploymentClientImpl{
 			updateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
@@ -149,8 +149,8 @@ func TestHandle_makeContainerFail(t *testing.T) {
 				return nil, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return nil, fmt.Errorf("couldn't make container")
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -192,8 +192,8 @@ func TestHandle_createPodFail(t *testing.T) {
 				return nil, fmt.Errorf("Failed to create pod %s", pod.Name)
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -241,8 +241,8 @@ func TestHandle_deployerPodAlreadyExists(t *testing.T) {
 				return nil, kerrors.NewAlreadyExists(kapi.Resource("Pod"), pod.Name)
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -291,8 +291,8 @@ func TestHandle_unrelatedPodAlreadyExists(t *testing.T) {
 				return nil, kerrors.NewAlreadyExists(kapi.Resource("Pod"), pod.Name)
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -338,9 +338,9 @@ func TestHandle_noop(t *testing.T) {
 				return &kapi.Pod{}, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -392,9 +392,9 @@ func TestHandle_failedTest(t *testing.T) {
 				return nil, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -452,9 +452,9 @@ func TestHandle_cleanupPodOk(t *testing.T) {
 				return pods, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -513,9 +513,9 @@ func TestHandle_cleanupPodOkTest(t *testing.T) {
 				return pods, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -570,9 +570,9 @@ func TestHandle_cleanupPodNoop(t *testing.T) {
 				return []kapi.Pod{}, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -613,9 +613,9 @@ func TestHandle_cleanupPodFail(t *testing.T) {
 				return []kapi.Pod{{}}, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
 			t.Fatalf("unexpected call to make container")
-			return nil, nil
+			return nil
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -653,8 +653,8 @@ func TestHandle_cancelNew(t *testing.T) {
 				return []kapi.Pod{}, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -704,8 +704,8 @@ func TestHandle_cancelNewWithDeployers(t *testing.T) {
 				return []kapi.Pod{*relatedPod(deployment)}, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -756,8 +756,8 @@ func TestHandle_cancelPendingRunning(t *testing.T) {
 				return pods, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -810,8 +810,8 @@ func TestHandle_deployerPodDisappeared(t *testing.T) {
 				return nil, kerrors.NewNotFound(kapi.Resource("Pod"), name)
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 		recorder: &record.FakeRecorder{},
 	}
@@ -857,8 +857,8 @@ func TestDeployerCustomLabelsAndAnnotations(t *testing.T) {
 				return pod, nil
 			},
 		},
-		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
-			return okContainer(), nil
+		makeContainer: func(strategy *deployapi.DeploymentStrategy) *kapi.Container {
+			return okContainer()
 		},
 	}
 

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -132,15 +132,14 @@ func IsImageChangeControllerChange(newDc, oldDc deployapi.DeploymentConfig) bool
 // if the controller doesn't contain an encoded config.
 func DecodeDeploymentConfig(controller *api.ReplicationController, decoder runtime.Decoder) (*deployapi.DeploymentConfig, error) {
 	encodedConfig := []byte(EncodedDeploymentConfigFor(controller))
-	if decoded, err := runtime.Decode(decoder, encodedConfig); err == nil {
+	decoded, err := runtime.Decode(decoder, encodedConfig)
+	if err == nil {
 		if config, ok := decoded.(*deployapi.DeploymentConfig); ok {
 			return config, nil
-		} else {
-			return nil, fmt.Errorf("decoded DeploymentConfig from controller is not a DeploymentConfig: %v", err)
 		}
-	} else {
-		return nil, fmt.Errorf("failed to decode DeploymentConfig from controller: %v", err)
+		return nil, fmt.Errorf("decoded object from controller is not a DeploymentConfig")
 	}
+	return nil, fmt.Errorf("failed to decode DeploymentConfig from controller: %v", err)
 }
 
 // EncodeDeploymentConfig encodes config as a string using codec.


### PR DESCRIPTION
Update conflicts for deployments are pretty common since they are
handled by three different controllers (kube: rc manager, origin:
deployer pod controller, deployment controller) and their events
stay attached on deploymentconfigs which may confuse users ("My
deployment is running but I have this event over there talking about
an update conflict"). This commit makes it so those events will be
superseded by successful updates.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1329138
Closes https://github.com/openshift/origin/issues/8630

@ironcladlou @smarterclayton 