### PR TITLE
Increase deployment test fixture timeout

### DIFF
--- a/test/integration/fixtures/test-deployment-config.yaml
+++ b/test/integration/fixtures/test-deployment-config.yaml
@@ -9,7 +9,7 @@ spec:
   strategy:
     type: Recreate
     recreateParams:
-      timeoutSeconds: 10
+      timeoutSeconds: 20
       post:
         failurePolicy: Ignore
         tagImages:


### PR DESCRIPTION
Recent test runs indicate that the pod in this deployment fixture may be
coming up right at the edge of its 10 second timeout. Increase the
timeout to try and prevent flakes.

Timeout flake observed in https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_origin_integration/415.

Deployer pod logs:

```
I0427 14:16:30.917560       1 lifecycle.go:445] Waiting 10 seconds for pods owned by deployment "test/test-deployment-config-1" to become ready (checking every 1 seconds; 0 pods previously accepted)
F0427 14:16:40.926117       1 deployer.go:70] update acceptor rejected test/test-deployment-config-1: pods for deployment "test/test-deployment-config-1" took longer than 10 seconds to become ready
```

The deployer's waiting on pod `test-deployment-config-1-vlj5a` (container `f0234f96712e877d440d3e2261d86c5f17933a3078468463d2235daf4d25713a`) with the following status:

```
"state":{"running":{"startedAt":"2016-04-27T14:16:40Z"}},"lastState":{},"ready":true,"restartCount":0
```

The `running` time and the deployer timeout are extremely close together, and the running time could actually be later (we're lacking the time precision in the status to know for sure).