### PR TITLE
add what-can-i-do endpoint

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15686,6 +15686,102 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/selfsubjectrulesreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.SelfSubjectRulesReview",
+      "method": "POST",
+      "summary": "create a SelfSubjectRulesReview",
+      "nickname": "createNamespacedSelfSubjectRulesReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.SelfSubjectRulesReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.SelfSubjectRulesReview"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/selfsubjectrulesreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.SelfSubjectRulesReview",
+      "method": "POST",
+      "summary": "create a SelfSubjectRulesReview",
+      "nickname": "createNamespacedSelfSubjectRulesReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.SelfSubjectRulesReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.SelfSubjectRulesReview"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/namespaces/{namespace}/subjectaccessreviews",
     "description": "OpenShift REST API, version v1",
     "operations": [
@@ -22607,6 +22703,44 @@
      "lastTransitionTime": {
       "type": "string",
       "description": "RFC 3339 date and time when this condition last transitioned"
+     }
+    }
+   },
+   "v1.SelfSubjectRulesReview": {
+    "id": "v1.SelfSubjectRulesReview",
+    "description": "SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "status": {
+      "$ref": "v1.SubjectRulesReviewStatus",
+      "description": "Status is completed by the server to tell which permissions you have"
+     }
+    }
+   },
+   "v1.SubjectRulesReviewStatus": {
+    "id": "v1.SubjectRulesReviewStatus",
+    "description": "SubjectRulesReviewStatus is contains the result of a rules check",
+    "required": [
+     "rules"
+    ],
+    "properties": {
+     "rules": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.PolicyRule"
+      },
+      "description": "Rules is the list of rules (no particular sort) that are allowed for the subject"
+     },
+     "evaluationError": {
+      "type": "string",
+      "description": "EvaluationError can appear in combination with Rules.  It means some error happened during evaluation that may have prevented additional rules from being populated."
      }
     }
    },

--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -7216,6 +7216,46 @@ _oc_policy_who-can()
     must_have_one_noun=()
 }
 
+_oc_policy_what-can-i-do()
+{
+    last_command="oc_policy_what-can-i-do"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-version=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oc_policy_add-role-to-user()
 {
     last_command="oc_policy_add-role-to-user"
@@ -7469,6 +7509,7 @@ _oc_policy()
     last_command="oc_policy"
     commands=()
     commands+=("who-can")
+    commands+=("what-can-i-do")
     commands+=("add-role-to-user")
     commands+=("remove-role-from-user")
     commands+=("remove-user")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -10801,6 +10801,46 @@ _openshift_cli_policy_who-can()
     must_have_one_noun=()
 }
 
+_openshift_cli_policy_what-can-i-do()
+{
+    last_command="openshift_cli_policy_what-can-i-do"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--api-version=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_cli_policy_add-role-to-user()
 {
     last_command="openshift_cli_policy_add-role-to-user"
@@ -11054,6 +11094,7 @@ _openshift_cli_policy()
     last_command="openshift_cli_policy"
     commands=()
     commands+=("who-can")
+    commands+=("what-can-i-do")
     commands+=("add-role-to-user")
     commands+=("remove-role-from-user")
     commands+=("remove-user")

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -632,6 +632,18 @@ func deepCopy_api_RoleList(in api.RoleList, out *api.RoleList, c *conversion.Clo
 	return nil
 }
 
+func deepCopy_api_SelfSubjectRulesReview(in api.SelfSubjectRulesReview, out *api.SelfSubjectRulesReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(unversioned.TypeMeta)
+	}
+	if err := deepCopy_api_SubjectRulesReviewStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_api_SubjectAccessReview(in api.SubjectAccessReview, out *api.SubjectAccessReview, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -666,6 +678,21 @@ func deepCopy_api_SubjectAccessReviewResponse(in api.SubjectAccessReviewResponse
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	return nil
+}
+
+func deepCopy_api_SubjectRulesReviewStatus(in api.SubjectRulesReviewStatus, out *api.SubjectRulesReviewStatus, c *conversion.Cloner) error {
+	if in.Rules != nil {
+		out.Rules = make([]api.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := deepCopy_api_PolicyRule(in.Rules[i], &out.Rules[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 
@@ -3316,8 +3343,10 @@ func init() {
 		deepCopy_api_RoleBinding,
 		deepCopy_api_RoleBindingList,
 		deepCopy_api_RoleList,
+		deepCopy_api_SelfSubjectRulesReview,
 		deepCopy_api_SubjectAccessReview,
 		deepCopy_api_SubjectAccessReviewResponse,
+		deepCopy_api_SubjectRulesReviewStatus,
 		deepCopy_api_BinaryBuildRequestOptions,
 		deepCopy_api_BinaryBuildSource,
 		deepCopy_api_Build,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -457,6 +457,20 @@ func Convert_api_RoleList_To_v1_RoleList(in *authorizationapi.RoleList, out *aut
 	return autoConvert_api_RoleList_To_v1_RoleList(in, out, s)
 }
 
+func autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in *authorizationapi.SelfSubjectRulesReview, out *authorizationapiv1.SelfSubjectRulesReview, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.SelfSubjectRulesReview))(in)
+	}
+	if err := Convert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in *authorizationapi.SelfSubjectRulesReview, out *authorizationapiv1.SelfSubjectRulesReview, s conversion.Scope) error {
+	return autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in, out, s)
+}
+
 func autoConvert_api_SubjectAccessReview_To_v1_SubjectAccessReview(in *authorizationapi.SubjectAccessReview, out *authorizationapiv1.SubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReview))(in)
@@ -479,6 +493,28 @@ func autoConvert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewRespon
 
 func Convert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *authorizationapiv1.SubjectAccessReviewResponse, s conversion.Scope) error {
 	return autoConvert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(in, out, s)
+}
+
+func autoConvert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(in *authorizationapi.SubjectRulesReviewStatus, out *authorizationapiv1.SubjectRulesReviewStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.SubjectRulesReviewStatus))(in)
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapiv1.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := authorizationapiv1.Convert_api_PolicyRule_To_v1_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
+	return nil
+}
+
+func Convert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(in *authorizationapi.SubjectRulesReviewStatus, out *authorizationapiv1.SubjectRulesReviewStatus, s conversion.Scope) error {
+	return autoConvert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(in, out, s)
 }
 
 func autoConvert_v1_ClusterPolicy_To_api_ClusterPolicy(in *authorizationapiv1.ClusterPolicy, out *authorizationapi.ClusterPolicy, s conversion.Scope) error {
@@ -910,6 +946,20 @@ func Convert_v1_RoleList_To_api_RoleList(in *authorizationapiv1.RoleList, out *a
 	return autoConvert_v1_RoleList_To_api_RoleList(in, out, s)
 }
 
+func autoConvert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in *authorizationapiv1.SelfSubjectRulesReview, out *authorizationapi.SelfSubjectRulesReview, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapiv1.SelfSubjectRulesReview))(in)
+	}
+	if err := Convert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in *authorizationapiv1.SelfSubjectRulesReview, out *authorizationapi.SelfSubjectRulesReview, s conversion.Scope) error {
+	return autoConvert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in, out, s)
+}
+
 func autoConvert_v1_SubjectAccessReview_To_api_SubjectAccessReview(in *authorizationapiv1.SubjectAccessReview, out *authorizationapi.SubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapiv1.SubjectAccessReview))(in)
@@ -932,6 +982,28 @@ func autoConvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewRespon
 
 func Convert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse(in *authorizationapiv1.SubjectAccessReviewResponse, out *authorizationapi.SubjectAccessReviewResponse, s conversion.Scope) error {
 	return autoConvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse(in, out, s)
+}
+
+func autoConvert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in *authorizationapiv1.SubjectRulesReviewStatus, out *authorizationapi.SubjectRulesReviewStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapiv1.SubjectRulesReviewStatus))(in)
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := authorizationapiv1.Convert_v1_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
+	return nil
+}
+
+func Convert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in *authorizationapiv1.SubjectRulesReviewStatus, out *authorizationapi.SubjectRulesReviewStatus, s conversion.Scope) error {
+	return autoConvert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in, out, s)
 }
 
 func autoConvert_api_BinaryBuildRequestOptions_To_v1_BinaryBuildRequestOptions(in *buildapi.BinaryBuildRequestOptions, out *v1.BinaryBuildRequestOptions, s conversion.Scope) error {
@@ -9097,11 +9169,13 @@ func init() {
 		autoConvert_api_SecretSpec_To_v1_SecretSpec,
 		autoConvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
 		autoConvert_api_SecurityContext_To_v1_SecurityContext,
+		autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview,
 		autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy,
 		autoConvert_api_SourceControlUser_To_v1_SourceControlUser,
 		autoConvert_api_SourceRevision_To_v1_SourceRevision,
 		autoConvert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse,
 		autoConvert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
+		autoConvert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus,
 		autoConvert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		autoConvert_api_TLSConfig_To_v1_TLSConfig,
 		autoConvert_api_TagEventCondition_To_v1_TagEventCondition,
@@ -9277,11 +9351,13 @@ func init() {
 		autoConvert_v1_SecretSpec_To_api_SecretSpec,
 		autoConvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
 		autoConvert_v1_SecurityContext_To_api_SecurityContext,
+		autoConvert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview,
 		autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy,
 		autoConvert_v1_SourceControlUser_To_api_SourceControlUser,
 		autoConvert_v1_SourceRevision_To_api_SourceRevision,
 		autoConvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse,
 		autoConvert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
+		autoConvert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus,
 		autoConvert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		autoConvert_v1_TLSConfig_To_api_TLSConfig,
 		autoConvert_v1_TagEventCondition_To_api_TagEventCondition,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -656,6 +656,18 @@ func deepCopy_v1_RoleList(in v1.RoleList, out *v1.RoleList, c *conversion.Cloner
 	return nil
 }
 
+func deepCopy_v1_SelfSubjectRulesReview(in v1.SelfSubjectRulesReview, out *v1.SelfSubjectRulesReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(unversioned.TypeMeta)
+	}
+	if err := deepCopy_v1_SubjectRulesReviewStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1_SubjectAccessReview(in v1.SubjectAccessReview, out *v1.SubjectAccessReview, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -686,6 +698,21 @@ func deepCopy_v1_SubjectAccessReviewResponse(in v1.SubjectAccessReviewResponse, 
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	return nil
+}
+
+func deepCopy_v1_SubjectRulesReviewStatus(in v1.SubjectRulesReviewStatus, out *v1.SubjectRulesReviewStatus, c *conversion.Cloner) error {
+	if in.Rules != nil {
+		out.Rules = make([]v1.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := deepCopy_v1_PolicyRule(in.Rules[i], &out.Rules[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 
@@ -3205,8 +3232,10 @@ func init() {
 		deepCopy_v1_RoleBinding,
 		deepCopy_v1_RoleBindingList,
 		deepCopy_v1_RoleList,
+		deepCopy_v1_SelfSubjectRulesReview,
 		deepCopy_v1_SubjectAccessReview,
 		deepCopy_v1_SubjectAccessReviewResponse,
+		deepCopy_v1_SubjectRulesReviewStatus,
 		deepCopy_v1_BinaryBuildRequestOptions,
 		deepCopy_v1_BinaryBuildSource,
 		deepCopy_v1_Build,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -460,6 +460,20 @@ func Convert_api_RoleList_To_v1beta3_RoleList(in *authorizationapi.RoleList, out
 	return autoConvert_api_RoleList_To_v1beta3_RoleList(in, out, s)
 }
 
+func autoConvert_api_SelfSubjectRulesReview_To_v1beta3_SelfSubjectRulesReview(in *authorizationapi.SelfSubjectRulesReview, out *authorizationapiv1beta3.SelfSubjectRulesReview, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.SelfSubjectRulesReview))(in)
+	}
+	if err := Convert_api_SubjectRulesReviewStatus_To_v1beta3_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_api_SelfSubjectRulesReview_To_v1beta3_SelfSubjectRulesReview(in *authorizationapi.SelfSubjectRulesReview, out *authorizationapiv1beta3.SelfSubjectRulesReview, s conversion.Scope) error {
+	return autoConvert_api_SelfSubjectRulesReview_To_v1beta3_SelfSubjectRulesReview(in, out, s)
+}
+
 func autoConvert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview(in *authorizationapi.SubjectAccessReview, out *authorizationapiv1beta3.SubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReview))(in)
@@ -482,6 +496,28 @@ func autoConvert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewR
 
 func Convert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *authorizationapiv1beta3.SubjectAccessReviewResponse, s conversion.Scope) error {
 	return autoConvert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse(in, out, s)
+}
+
+func autoConvert_api_SubjectRulesReviewStatus_To_v1beta3_SubjectRulesReviewStatus(in *authorizationapi.SubjectRulesReviewStatus, out *authorizationapiv1beta3.SubjectRulesReviewStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.SubjectRulesReviewStatus))(in)
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapiv1beta3.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := authorizationapiv1beta3.Convert_api_PolicyRule_To_v1beta3_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
+	return nil
+}
+
+func Convert_api_SubjectRulesReviewStatus_To_v1beta3_SubjectRulesReviewStatus(in *authorizationapi.SubjectRulesReviewStatus, out *authorizationapiv1beta3.SubjectRulesReviewStatus, s conversion.Scope) error {
+	return autoConvert_api_SubjectRulesReviewStatus_To_v1beta3_SubjectRulesReviewStatus(in, out, s)
 }
 
 func autoConvert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *authorizationapiv1beta3.ClusterPolicy, out *authorizationapi.ClusterPolicy, s conversion.Scope) error {
@@ -918,6 +954,20 @@ func Convert_v1beta3_RoleList_To_api_RoleList(in *authorizationapiv1beta3.RoleLi
 	return autoConvert_v1beta3_RoleList_To_api_RoleList(in, out, s)
 }
 
+func autoConvert_v1beta3_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in *authorizationapiv1beta3.SelfSubjectRulesReview, out *authorizationapi.SelfSubjectRulesReview, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapiv1beta3.SelfSubjectRulesReview))(in)
+	}
+	if err := Convert_v1beta3_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1beta3_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in *authorizationapiv1beta3.SelfSubjectRulesReview, out *authorizationapi.SelfSubjectRulesReview, s conversion.Scope) error {
+	return autoConvert_v1beta3_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in, out, s)
+}
+
 func autoConvert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview(in *authorizationapiv1beta3.SubjectAccessReview, out *authorizationapi.SubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapiv1beta3.SubjectAccessReview))(in)
@@ -940,6 +990,28 @@ func autoConvert_v1beta3_SubjectAccessReviewResponse_To_api_SubjectAccessReviewR
 
 func Convert_v1beta3_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse(in *authorizationapiv1beta3.SubjectAccessReviewResponse, out *authorizationapi.SubjectAccessReviewResponse, s conversion.Scope) error {
 	return autoConvert_v1beta3_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse(in, out, s)
+}
+
+func autoConvert_v1beta3_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in *authorizationapiv1beta3.SubjectRulesReviewStatus, out *authorizationapi.SubjectRulesReviewStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapiv1beta3.SubjectRulesReviewStatus))(in)
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := authorizationapiv1beta3.Convert_v1beta3_PolicyRule_To_api_PolicyRule(&in.Rules[i], &out.Rules[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
+	return nil
+}
+
+func Convert_v1beta3_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in *authorizationapiv1beta3.SubjectRulesReviewStatus, out *authorizationapi.SubjectRulesReviewStatus, s conversion.Scope) error {
+	return autoConvert_v1beta3_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(in, out, s)
 }
 
 func autoConvert_api_BinaryBuildRequestOptions_To_v1beta3_BinaryBuildRequestOptions(in *buildapi.BinaryBuildRequestOptions, out *v1beta3.BinaryBuildRequestOptions, s conversion.Scope) error {
@@ -6880,11 +6952,13 @@ func init() {
 		autoConvert_api_SecretBuildSource_To_v1beta3_SecretBuildSource,
 		autoConvert_api_SecretSpec_To_v1beta3_SecretSpec,
 		autoConvert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource,
+		autoConvert_api_SelfSubjectRulesReview_To_v1beta3_SelfSubjectRulesReview,
 		autoConvert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy,
 		autoConvert_api_SourceControlUser_To_v1beta3_SourceControlUser,
 		autoConvert_api_SourceRevision_To_v1beta3_SourceRevision,
 		autoConvert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse,
 		autoConvert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
+		autoConvert_api_SubjectRulesReviewStatus_To_v1beta3_SubjectRulesReviewStatus,
 		autoConvert_api_TCPSocketAction_To_v1beta3_TCPSocketAction,
 		autoConvert_api_TLSConfig_To_v1beta3_TLSConfig,
 		autoConvert_api_TagImageHook_To_v1beta3_TagImageHook,
@@ -7023,11 +7097,13 @@ func init() {
 		autoConvert_v1beta3_SecretBuildSource_To_api_SecretBuildSource,
 		autoConvert_v1beta3_SecretSpec_To_api_SecretSpec,
 		autoConvert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource,
+		autoConvert_v1beta3_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview,
 		autoConvert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy,
 		autoConvert_v1beta3_SourceControlUser_To_api_SourceControlUser,
 		autoConvert_v1beta3_SourceRevision_To_api_SourceRevision,
 		autoConvert_v1beta3_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse,
 		autoConvert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
+		autoConvert_v1beta3_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus,
 		autoConvert_v1beta3_TCPSocketAction_To_api_TCPSocketAction,
 		autoConvert_v1beta3_TLSConfig_To_api_TLSConfig,
 		autoConvert_v1beta3_TagImageHook_To_api_TagImageHook,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -664,6 +664,18 @@ func deepCopy_v1beta3_RoleList(in v1beta3.RoleList, out *v1beta3.RoleList, c *co
 	return nil
 }
 
+func deepCopy_v1beta3_SelfSubjectRulesReview(in v1beta3.SelfSubjectRulesReview, out *v1beta3.SelfSubjectRulesReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(unversioned.TypeMeta)
+	}
+	if err := deepCopy_v1beta3_SubjectRulesReviewStatus(in.Status, &out.Status, c); err != nil {
+		return err
+	}
+	return nil
+}
+
 func deepCopy_v1beta3_SubjectAccessReview(in v1beta3.SubjectAccessReview, out *v1beta3.SubjectAccessReview, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -694,6 +706,21 @@ func deepCopy_v1beta3_SubjectAccessReviewResponse(in v1beta3.SubjectAccessReview
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	return nil
+}
+
+func deepCopy_v1beta3_SubjectRulesReviewStatus(in v1beta3.SubjectRulesReviewStatus, out *v1beta3.SubjectRulesReviewStatus, c *conversion.Cloner) error {
+	if in.Rules != nil {
+		out.Rules = make([]v1beta3.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := deepCopy_v1beta3_PolicyRule(in.Rules[i], &out.Rules[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 
@@ -3008,8 +3035,10 @@ func init() {
 		deepCopy_v1beta3_RoleBinding,
 		deepCopy_v1beta3_RoleBindingList,
 		deepCopy_v1beta3_RoleList,
+		deepCopy_v1beta3_SelfSubjectRulesReview,
 		deepCopy_v1beta3_SubjectAccessReview,
 		deepCopy_v1beta3_SubjectAccessReviewResponse,
+		deepCopy_v1beta3_SubjectRulesReviewStatus,
 		deepCopy_v1beta3_BinaryBuildRequestOptions,
 		deepCopy_v1beta3_BinaryBuildSource,
 		deepCopy_v1beta3_Build,

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -36,6 +36,7 @@ func init() {
 }
 
 func registerAll() {
+	Validator.MustRegister(&authorizationapi.SelfSubjectRulesReview{}, authorizationvalidation.ValidateSelfSubjectRulesReview, nil)
 	Validator.MustRegister(&authorizationapi.SubjectAccessReview{}, authorizationvalidation.ValidateSubjectAccessReview, nil)
 	Validator.MustRegister(&authorizationapi.ResourceAccessReview{}, authorizationvalidation.ValidateResourceAccessReview, nil)
 	Validator.MustRegister(&authorizationapi.LocalSubjectAccessReview{}, authorizationvalidation.ValidateLocalSubjectAccessReview, nil)

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -37,6 +37,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&RoleBindingList{},
 		&RoleList{},
 
+		&SelfSubjectRulesReview{},
 		&ResourceAccessReview{},
 		&SubjectAccessReview{},
 		&LocalResourceAccessReview{},
@@ -72,6 +73,7 @@ func (obj *LocalSubjectAccessReview) GetObjectKind() unversioned.ObjectKind     
 func (obj *LocalResourceAccessReview) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *SubjectAccessReview) GetObjectKind() unversioned.ObjectKind           { return &obj.TypeMeta }
 func (obj *ResourceAccessReview) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *SelfSubjectRulesReview) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
 
 func (obj *RoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *RoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -92,7 +92,8 @@ var (
 		PermissionGrantingGroupName: {"roles", "rolebindings", "resourceaccessreviews" /* cluster scoped*/, "subjectaccessreviews" /* cluster scoped*/, "localresourceaccessreviews", "localsubjectaccessreviews"},
 		OpenshiftExposedGroupName:   {BuildGroupName, ImageGroupName, DeploymentGroupName, TemplateGroupName, "routes"},
 		OpenshiftAllGroupName: {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects",
-			"clusterroles", "clusterrolebindings", "clusterpolicies", "clusterpolicybindings", "images" /* cluster scoped*/, "projectrequests", "builds/details", "imagestreams/secrets"},
+			"clusterroles", "clusterrolebindings", "clusterpolicies", "clusterpolicybindings", "images" /* cluster scoped*/, "projectrequests", "builds/details", "imagestreams/secrets",
+			"selfsubjectrulesreviews"},
 		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status"},
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
@@ -197,6 +198,23 @@ type PolicyBinding struct {
 	PolicyRef kapi.ObjectReference
 	// RoleBindings holds all the RoleBindings held by this PolicyBinding, mapped by RoleBinding.Name
 	RoleBindings map[string]*RoleBinding
+}
+
+// SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace
+type SelfSubjectRulesReview struct {
+	unversioned.TypeMeta
+
+	// Status is completed by the server to tell which permissions you have
+	Status SubjectRulesReviewStatus
+}
+
+// SubjectRulesReviewStatus is contains the result of a rules check
+type SubjectRulesReviewStatus struct {
+	// Rules is the list of rules (no particular sort) that are allowed for the subject
+	Rules []PolicyRule
+	// EvaluationError can appear in combination with Rules.  It means some error happened during evaluation
+	// that may have prevented additional rules from being populated.
+	EvaluationError string
 }
 
 // ResourceAccessReviewResponse describes who can perform the action

--- a/pkg/authorization/api/v1/register.go
+++ b/pkg/authorization/api/v1/register.go
@@ -28,6 +28,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&RoleBindingList{},
 		&RoleList{},
 
+		&SelfSubjectRulesReview{},
 		&ResourceAccessReview{},
 		&SubjectAccessReview{},
 		&LocalResourceAccessReview{},
@@ -63,6 +64,7 @@ func (obj *LocalSubjectAccessReview) GetObjectKind() unversioned.ObjectKind     
 func (obj *LocalResourceAccessReview) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *SubjectAccessReview) GetObjectKind() unversioned.ObjectKind           { return &obj.TypeMeta }
 func (obj *ResourceAccessReview) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *SelfSubjectRulesReview) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
 
 func (obj *RoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *RoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/v1/swagger_doc.go
+++ b/pkg/authorization/api/v1/swagger_doc.go
@@ -291,6 +291,15 @@ func (RoleList) SwaggerDoc() map[string]string {
 	return map_RoleList
 }
 
+var map_SelfSubjectRulesReview = map[string]string{
+	"":       "SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace",
+	"status": "Status is completed by the server to tell which permissions you have",
+}
+
+func (SelfSubjectRulesReview) SwaggerDoc() map[string]string {
+	return map_SelfSubjectRulesReview
+}
+
 var map_SubjectAccessReview = map[string]string{
 	"":       "SubjectAccessReview is an object for requesting information about whether a user or group can perform an action",
 	"user":   "User is optional. If both User and Groups are empty, the current authenticated user is used.",
@@ -310,4 +319,14 @@ var map_SubjectAccessReviewResponse = map[string]string{
 
 func (SubjectAccessReviewResponse) SwaggerDoc() map[string]string {
 	return map_SubjectAccessReviewResponse
+}
+
+var map_SubjectRulesReviewStatus = map[string]string{
+	"":                "SubjectRulesReviewStatus is contains the result of a rules check",
+	"rules":           "Rules is the list of rules (no particular sort) that are allowed for the subject",
+	"evaluationError": "EvaluationError can appear in combination with Rules.  It means some error happened during evaluation that may have prevented additional rules from being populated.",
+}
+
+func (SubjectRulesReviewStatus) SwaggerDoc() map[string]string {
+	return map_SubjectRulesReviewStatus
 }

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -116,6 +116,23 @@ type NamedRoleBinding struct {
 	RoleBinding RoleBinding `json:"roleBinding"`
 }
 
+// SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace
+type SelfSubjectRulesReview struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Status is completed by the server to tell which permissions you have
+	Status SubjectRulesReviewStatus `json:"status,omitempty"`
+}
+
+// SubjectRulesReviewStatus is contains the result of a rules check
+type SubjectRulesReviewStatus struct {
+	// Rules is the list of rules (no particular sort) that are allowed for the subject
+	Rules []PolicyRule `json:"rules"`
+	// EvaluationError can appear in combination with Rules.  It means some error happened during evaluation
+	// that may have prevented additional rules from being populated.
+	EvaluationError string `json:"evaluationError,omitempty"`
+}
+
 // ResourceAccessReviewResponse describes who can perform the action
 type ResourceAccessReviewResponse struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -28,6 +28,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&RoleBindingList{},
 		&RoleList{},
 
+		&SelfSubjectRulesReview{},
 		&ResourceAccessReview{},
 		&SubjectAccessReview{},
 		&LocalResourceAccessReview{},
@@ -63,6 +64,7 @@ func (obj *LocalSubjectAccessReview) GetObjectKind() unversioned.ObjectKind     
 func (obj *LocalResourceAccessReview) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *SubjectAccessReview) GetObjectKind() unversioned.ObjectKind           { return &obj.TypeMeta }
 func (obj *ResourceAccessReview) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *SelfSubjectRulesReview) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
 
 func (obj *RoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *RoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -109,6 +109,23 @@ type NamedRoleBinding struct {
 	RoleBinding RoleBinding `json:"roleBinding"`
 }
 
+// SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace
+type SelfSubjectRulesReview struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// Status is completed by the server to tell which permissions you have
+	Status SubjectRulesReviewStatus `json:"status,omitempty"`
+}
+
+// SubjectRulesReviewStatus is contains the result of a rules check
+type SubjectRulesReviewStatus struct {
+	// Rules is the list of rules (no particular sort) that are allowed for the subject
+	Rules []PolicyRule `json:"rules"`
+	// EvaluationError can appear in combination with Rules.  It means some error happened during evaluation
+	// that may have prevented additional rules from being populated.
+	EvaluationError string `json:"evaluationError,omitempty"`
+}
+
 // ResourceAccessReviewResponse describes who can perform the action
 type ResourceAccessReviewResponse struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -13,6 +13,10 @@ import (
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
+func ValidateSelfSubjectRulesReview(review *authorizationapi.SelfSubjectRulesReview) field.ErrorList {
+	return field.ErrorList{}
+}
+
 func ValidateSubjectAccessReview(review *authorizationapi.SubjectAccessReview) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/authorization/registry/selfsubjectrulesreview/storage.go
+++ b/pkg/authorization/registry/selfsubjectrulesreview/storage.go
@@ -1,0 +1,39 @@
+package selfsubjectrulesreview
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+)
+
+type REST struct {
+	ruleResolver rulevalidation.AuthorizationRuleResolver
+}
+
+func NewREST(ruleResolver rulevalidation.AuthorizationRuleResolver) *REST {
+	return &REST{ruleResolver: ruleResolver}
+}
+
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.SelfSubjectRulesReview{}
+}
+
+// Create registers a given new ResourceAccessReview instance to r.registry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	// the input object has no valuable input, so don't bother checking it.false
+	policyRules, err := r.ruleResolver.GetEffectivePolicyRules(ctx)
+
+	ret := &authorizationapi.SelfSubjectRulesReview{
+		Status: authorizationapi.SubjectRulesReviewStatus{
+			Rules: policyRules,
+		},
+	}
+
+	if err != nil {
+		ret.Status.EvaluationError = err.Error()
+	}
+
+	return ret, nil
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,6 +44,7 @@ type Interface interface {
 	ResourceAccessReviews
 	SubjectAccessReviews
 	LocalSubjectAccessReviewsNamespacer
+	SelfSubjectRulesReviewsNamespacer
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
 	OAuthAccessTokensInterface
@@ -220,6 +221,10 @@ func (c *Client) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessR
 // SubjectAccessReviews provides a REST client for SubjectAccessReviews
 func (c *Client) SubjectAccessReviews() SubjectAccessReviewInterface {
 	return newSubjectAccessReviews(c)
+}
+
+func (c *Client) SelfSubjectRulesReviews(namespace string) SelfSubjectRulesReviewInterface {
+	return newSelfSubjectRulesReviews(c, namespace)
 }
 
 // OAuthAccessTokens provides a REST client for OAuthAccessTokens

--- a/pkg/client/selfsubjectrulesreviews.go
+++ b/pkg/client/selfsubjectrulesreviews.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type SelfSubjectRulesReviewsNamespacer interface {
+	SelfSubjectRulesReviews(namespace string) SelfSubjectRulesReviewInterface
+}
+
+type SelfSubjectRulesReviewInterface interface {
+	Create(*authorizationapi.SelfSubjectRulesReview) (*authorizationapi.SelfSubjectRulesReview, error)
+}
+
+type selfSubjectRulesReviews struct {
+	r  *Client
+	ns string
+}
+
+func newSelfSubjectRulesReviews(c *Client, namespace string) *selfSubjectRulesReviews {
+	return &selfSubjectRulesReviews{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+func (c *selfSubjectRulesReviews) Create(selfSubjectRulesReview *authorizationapi.SelfSubjectRulesReview) (result *authorizationapi.SelfSubjectRulesReview, err error) {
+	result = &authorizationapi.SelfSubjectRulesReview{}
+	err = c.r.Post().Namespace(c.ns).Resource("selfSubjectRulesReviews").Body(selfSubjectRulesReview).Do().Into(result)
+
+	return
+}

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -256,6 +256,10 @@ func (c *Fake) PolicyBindings(namespace string) client.PolicyBindingInterface {
 	return &FakePolicyBindings{Fake: c, Namespace: namespace}
 }
 
+func (c *Fake) SelfSubjectRulesReviews(namespace string) client.SelfSubjectRulesReviewInterface {
+	return &FakeSelfSubjectRulesReviews{Fake: c, Namespace: namespace}
+}
+
 // LocalResourceAccessReviews provides a fake REST client for ResourceAccessReviews
 func (c *Fake) LocalResourceAccessReviews(namespace string) client.LocalResourceAccessReviewInterface {
 	return &FakeLocalResourceAccessReviews{Fake: c}

--- a/pkg/client/testclient/fake_selfsubjectrulesreview.go
+++ b/pkg/client/testclient/fake_selfsubjectrulesreview.go
@@ -1,0 +1,20 @@
+package testclient
+
+import (
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeSelfSubjectRulesReviews struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeSelfSubjectRulesReviews) Create(inObj *authorizationapi.SelfSubjectRulesReview) (*authorizationapi.SelfSubjectRulesReview, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewCreateAction("selfsubjectrulesreviews", c.Namespace, inObj), &authorizationapi.SelfSubjectRulesReview{})
+	if cast, ok := obj.(*authorizationapi.SelfSubjectRulesReview); ok {
+		return cast, err
+	}
+	return nil, err
+}

--- a/pkg/cmd/admin/policy/whatcanido.go
+++ b/pkg/cmd/admin/policy/whatcanido.go
@@ -1,0 +1,90 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const WhatCanIDoRecommendedName = "what-can-i-do"
+
+type whatCanIDoOptions struct {
+	namespace string
+	client    client.SelfSubjectRulesReviewsNamespacer
+
+	out io.Writer
+}
+
+// NewCmdWhatCanIDo implements the OpenShift cli who-can command
+func NewCmdWhatCanIDo(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &whatCanIDoOptions{out: out}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "List what I can do in this namespace",
+		Long:  "List what I can do in this namespace",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.complete(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			kcmdutil.CheckErr(options.run())
+		},
+	}
+
+	return cmd
+}
+
+const (
+	tabwriterMinWidth = 10
+	tabwriterWidth    = 4
+	tabwriterPadding  = 3
+	tabwriterPadChar  = ' '
+	tabwriterFlags    = 0
+)
+
+func (o *whatCanIDoOptions) complete(f *clientcmd.Factory, args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+
+	var err error
+	o.client, _, err = f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.namespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *whatCanIDoOptions) run() error {
+	whatCanIDo, err := o.client.SelfSubjectRulesReviews(o.namespace).Create(&authorizationapi.SelfSubjectRulesReview{})
+	if err != nil {
+		return err
+	}
+
+	writer := tabwriter.NewWriter(o.out, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
+	fmt.Fprint(writer, describe.PolicyRuleHeadings+"\n")
+	for _, rule := range whatCanIDo.Status.Rules {
+		describe.DescribePolicyRule(writer, rule, "")
+
+	}
+	writer.Flush()
+
+	return nil
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -1101,9 +1101,9 @@ func DescribePolicy(policy *authorizationapi.Policy) (string, error) {
 		// using .List() here because I always want the sorted order that it provides
 		for _, key := range sets.StringKeySet(policy.Roles).List() {
 			role := policy.Roles[key]
-			fmt.Fprint(out, key+"\t"+policyRuleHeadings+"\n")
+			fmt.Fprint(out, key+"\t"+PolicyRuleHeadings+"\n")
 			for _, rule := range role.Rules {
-				describePolicyRule(out, rule, "\t")
+				DescribePolicyRule(out, rule, "\t")
 			}
 		}
 
@@ -1111,9 +1111,9 @@ func DescribePolicy(policy *authorizationapi.Policy) (string, error) {
 	})
 }
 
-const policyRuleHeadings = "Verbs\tNon-Resource URLs\tExtension\tResource Names\tAPI Groups\tResources"
+const PolicyRuleHeadings = "Verbs\tNon-Resource URLs\tExtension\tResource Names\tAPI Groups\tResources"
 
-func describePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule, indent string) {
+func DescribePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule, indent string) {
 	extensionString := ""
 	if rule.AttributeRestrictions != nil {
 		extensionString = fmt.Sprintf("%#v", rule.AttributeRestrictions)
@@ -1155,9 +1155,9 @@ func DescribeRole(role *authorizationapi.Role) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, role.ObjectMeta)
 
-		fmt.Fprint(out, policyRuleHeadings+"\n")
+		fmt.Fprint(out, PolicyRuleHeadings+"\n")
 		for _, rule := range role.Rules {
-			describePolicyRule(out, rule, "")
+			DescribePolicyRule(out, rule, "")
 
 		}
 
@@ -1248,9 +1248,9 @@ func DescribeRoleBinding(roleBinding *authorizationapi.RoleBinding, role *author
 			formatString(out, "Policy Rules", fmt.Sprintf("error: %v", err))
 
 		case role != nil:
-			fmt.Fprint(out, policyRuleHeadings+"\n")
+			fmt.Fprint(out, PolicyRuleHeadings+"\n")
 			for _, rule := range role.Rules {
-				describePolicyRule(out, rule, "")
+				DescribePolicyRule(out, rule, "")
 			}
 
 		default:

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -67,6 +67,7 @@ var DescriberCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalSubjectAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalResourceAccessReview{}),
+	reflect.TypeOf(&authorizationapi.SelfSubjectRulesReview{}),
 }
 
 // MissingDescriberCoverageExceptions is the list of types that were missing describer methods when I started

--- a/pkg/cmd/cli/describe/printer_test.go
+++ b/pkg/cmd/cli/describe/printer_test.go
@@ -39,6 +39,7 @@ var PrinterCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalSubjectAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalResourceAccessReview{}),
+	reflect.TypeOf(&authorizationapi.SelfSubjectRulesReview{}),
 	reflect.TypeOf(&buildapi.BuildLog{}),
 	reflect.TypeOf(&buildapi.BinaryBuildRequestOptions{}),
 	reflect.TypeOf(&buildapi.BuildRequest{}),

--- a/pkg/cmd/cli/policy/policy.go
+++ b/pkg/cmd/cli/policy/policy.go
@@ -22,6 +22,7 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	}
 
 	cmds.AddCommand(adminpolicy.NewCmdWhoCan(adminpolicy.WhoCanRecommendedName, fullName+" "+adminpolicy.WhoCanRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdWhatCanIDo(adminpolicy.WhatCanIDoRecommendedName, fullName+" "+adminpolicy.WhatCanIDoRecommendedName, f, out))
 
 	cmds.AddCommand(adminpolicy.NewCmdAddRoleToUser(adminpolicy.AddRoleToUserRecommendedName, fullName+" "+adminpolicy.AddRoleToUserRecommendedName, f, out))
 	cmds.AddCommand(adminpolicy.NewCmdRemoveRoleFromUser(adminpolicy.RemoveRoleFromUserRecommendedName, fullName+" "+adminpolicy.RemoveRoleFromUserRecommendedName, f, out))

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -336,6 +336,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{Verbs: sets.NewString("list", "get"), Resources: sets.NewString("clusterroles")},
 				{Verbs: sets.NewString("list", "watch"), Resources: sets.NewString("projects")},
 				{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("create"), Resources: sets.NewString("selfsubjectrulesreviews")},
 			},
 		},
 		{

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -101,6 +101,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
 	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
+	"github.com/openshift/origin/pkg/authorization/registry/selfsubjectrulesreview"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -389,6 +390,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	identityRegistry := identityregistry.NewRegistry(identityStorage)
 	userIdentityMappingStorage := useridentitymapping.NewREST(userRegistry, identityRegistry)
 
+	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver)
+
 	policyStorage := policyetcd.NewStorage(c.EtcdHelper)
 	policyRegistry := policyregistry.NewRegistry(policyStorage)
 	policyBindingStorage := policybindingetcd.NewStorage(c.EtcdHelper)
@@ -528,6 +531,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"subjectAccessReviews":       subjectAccessReviewStorage,
 		"localSubjectAccessReviews":  localSubjectAccessReviewStorage,
 		"localResourceAccessReviews": localResourceAccessReviewStorage,
+		"selfSubjectRulesReviews":    selfSubjectRulesReviewStorage,
 
 		"policies":       policyStorage,
 		"policyBindings": policyBindingStorage,

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -81,6 +81,9 @@ os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/jenkinsp
 os::cmd::expect_success 'oadm policy reconcile-cluster-role-bindings --confirm'
 
 
+os::cmd::expect_success_and_text 'oc policy what-can-i-do' 'get update.*imagestreams/layers'
+
+
 # adjust the cluster-admin role to check defaulting and coverage checks
 # this is done here instead of an integration test because we need to make sure the actual yaml serializations work
 workingdir=$(mktemp -d)

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -105,6 +105,7 @@ items:
     - routes
     - routes/status
     - securitycontextconstraints
+    - selfsubjectrulesreviews
     - serviceaccounts
     - services
     - subjectaccessreviews
@@ -710,6 +711,12 @@ items:
     resources:
     - localsubjectaccessreviews
     - subjectaccessreviews
+    verbs:
+    - create
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - selfsubjectrulesreviews
     verbs:
     - create
 - apiVersion: v1


### PR DESCRIPTION
Let's argue about names.  This as a REST endpoint and a command (`oc policy what-can-i-do`) that gives back a list of all the policy rules that a given user has in namespace.  I need a good name for the resource and kind.

I want one endpoint for determining it about yourself (with scopes properly applied) and one for determining it about someone else.  Having two endpoints makes it easier to write policy rules without introspection.

Things that are missing:
 - [ ] the "someone else" endpoint - willl make issue.
 - [x] normalization of the rules to neatly bundle by resource tuples, collapsing for identical verbs and names - turns out our rules don't look too bad as-is.
 - [x] tests
 - [ ] respect for scopes (scopes haven't merged yet) - can't reasonably do without scopes having merged

@jwforres @spadgett you both asked for this.  I don't intend to associate the list in any particular way.
@openshift/api-review `PertinentPermissions` and `PersonalPertinentPermissions`?