### PR TITLE
[POC] shared cluster quota

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/restclient/request.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/restclient/request.go
@@ -619,13 +619,13 @@ func (r Request) finalURLTemplate() string {
 }
 
 func (r *Request) tryThrottle() {
-	now := time.Now()
-	if r.throttle != nil {
-		r.throttle.Accept()
-	}
-	if latency := time.Since(now); latency > longThrottleLatency {
-		glog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
-	}
+	// now := time.Now()
+	// if r.throttle != nil {
+	// 	r.throttle.Accept()
+	// }
+	// if latency := time.Since(now); latency > longThrottleLatency {
+	// 	glog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
+	// }
 }
 
 // Watch attempts to begin watching the requested location.

--- a/pkg/authorization/admission/clusterquota/admission.go
+++ b/pkg/authorization/admission/clusterquota/admission.go
@@ -1,0 +1,116 @@
+package clusterquota
+
+import (
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/install"
+
+	oclient "github.com/openshift/origin/pkg/client"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+)
+
+func init() {
+	admission.RegisterPlugin("ClusterResourceQuota",
+		func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+			registry := install.NewRegistry(client)
+			return NewResourceQuota(client, registry, 5)
+		})
+}
+
+// quotaAdmission implements an admission controller that can enforce quota constraints
+type quotaAdmission struct {
+	*admission.Handler
+
+	evaluator *quotaEvaluator
+
+	startup            sync.Once
+	clusterQuotaClient oclient.Interface
+	registry           quota.Registry
+	numEvaluators      int
+}
+
+var _ = oadmission.WantsOpenshiftClient(&quotaAdmission{})
+
+type liveLookupEntry struct {
+	expiry time.Time
+	items  []*api.ResourceQuota
+}
+
+// NewResourceQuota configures an admission controller that can enforce quota constraints
+// using the provided registry.  The registry must have the capability to handle group/kinds that
+// are persisted by the server this admission controller is intercepting
+func NewResourceQuota(client clientset.Interface, registry quota.Registry, numEvaluators int) (admission.Interface, error) {
+	return &quotaAdmission{
+		Handler:       admission.NewHandler(admission.Create, admission.Update),
+		registry:      registry,
+		numEvaluators: numEvaluators,
+	}, nil
+}
+
+// Admit makes admission decisions while enforcing quota
+func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
+	q.startup.Do(func() {
+		evaluator, err := newQuotaEvaluator(q.clusterQuotaClient, q.registry)
+		if err != nil {
+			// TODO always fail somehow if this fails
+			panic(err)
+		}
+		evaluator.Run(q.numEvaluators)
+
+		q.evaluator = evaluator
+	})
+
+	// ignore all operations that correspond to sub-resource actions
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	// if we do not know how to evaluate use for this kind, just ignore
+	evaluators := q.evaluator.registry.Evaluators()
+	evaluator, found := evaluators[a.GetKind().GroupKind()]
+	if !found {
+		return nil
+	}
+
+	// for this kind, check if the operation could mutate any quota resources
+	// if no resources tracked by quota are impacted, then just return
+	op := a.GetOperation()
+	operationResources := evaluator.OperationResources(op)
+	if len(operationResources) == 0 {
+		return nil
+	}
+
+	return q.evaluator.evaluate(a)
+}
+
+// prettyPrint formats a resource list for usage in errors
+func prettyPrint(item api.ResourceList) string {
+	parts := []string{}
+	for key, value := range item {
+		constraint := string(key) + "=" + value.String()
+		parts = append(parts, constraint)
+	}
+	return strings.Join(parts, ",")
+}
+
+// hasUsageStats returns true if for each hard constraint there is a value for its current usage
+func hasUsageStats(resourceQuota *api.ResourceQuota) bool {
+	for resourceName := range resourceQuota.Status.Hard {
+		if _, found := resourceQuota.Status.Used[resourceName]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *quotaAdmission) SetOpenshiftClient(c oclient.Interface) {
+	a.clusterQuotaClient = c
+}

--- a/pkg/authorization/admission/clusterquota/controller.go
+++ b/pkg/authorization/admission/clusterquota/controller.go
@@ -1,0 +1,502 @@
+package clusterquota
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/quota"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+
+	quotaapi "github.com/openshift/origin/pkg/authorization/api"
+	oclient "github.com/openshift/origin/pkg/client"
+)
+
+type quotaEvaluator struct {
+	client oclient.Interface
+
+	// registry that knows how to measure usage for objects
+	registry quota.Registry
+
+	// TODO these are used together to bucket items by namespace and then batch them up for processing.
+	// The technique is valuable for rollup activities to avoid fanout and reduce resource contention.
+	// We could move this into a library if another component needed it.
+	// queue is indexed by namespace, so that we bundle up on a per-namespace basis
+	queue      *workqueue.Type
+	workLock   sync.Mutex
+	work       map[string][]*admissionWaiter
+	dirtyWork  map[string][]*admissionWaiter
+	inProgress sets.String
+
+	lockFactory LockFactory
+}
+
+type admissionWaiter struct {
+	attributes admission.Attributes
+	finished   chan struct{}
+	result     error
+}
+
+type defaultDeny struct{}
+
+func (defaultDeny) Error() string {
+	return "DEFAULT DENY"
+}
+
+func IsDefaultDeny(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(defaultDeny)
+	return ok
+}
+
+func newAdmissionWaiter(a admission.Attributes) *admissionWaiter {
+	return &admissionWaiter{
+		attributes: a,
+		finished:   make(chan struct{}),
+		result:     defaultDeny{},
+	}
+}
+
+// newQuotaEvaluator configures an admission controller that can enforce quota constraints
+// using the provided registry.  The registry must have the capability to handle group/kinds that
+// are persisted by the server this admission controller is intercepting
+func newQuotaEvaluator(client oclient.Interface, registry quota.Registry) (*quotaEvaluator, error) {
+	return &quotaEvaluator{
+		client:   client,
+		registry: registry,
+
+		queue:      workqueue.New(),
+		work:       map[string][]*admissionWaiter{},
+		dirtyWork:  map[string][]*admissionWaiter{},
+		inProgress: sets.String{},
+
+		lockFactory: NewDefaultLockFactory(),
+	}, nil
+}
+
+// Run begins watching and syncing.
+func (e *quotaEvaluator) Run(workers int) {
+	defer utilruntime.HandleCrash()
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(e.doWork, time.Second, make(chan struct{}))
+	}
+}
+
+func (e *quotaEvaluator) doWork() {
+	for {
+		func() {
+			ns, admissionAttributes := e.getWork()
+			defer e.completeWork(ns)
+			fmt.Printf("#### 1a %v\n", ns)
+			if len(admissionAttributes) == 0 {
+				fmt.Printf("#### 1b %v\n", ns)
+				return
+			}
+
+			e.checkAttributes(ns, admissionAttributes)
+		}()
+	}
+}
+
+// checkAttributes iterates evaluates all the waiting admissionAttributes.  It will always notify all waiters
+// before returning.  The default is to deny.
+func (e *quotaEvaluator) checkAttributes(ns string, admissionAttributes []*admissionWaiter) {
+	// notify all on exit
+	defer func() {
+		for _, admissionAttribute := range admissionAttributes {
+			close(admissionAttribute.finished)
+		}
+	}()
+
+	fmt.Printf("#### 2a %v\n", ns)
+	quotas, err := e.getQuotas(ns)
+	if err != nil {
+		fmt.Printf("#### 2b %v\n", ns)
+		for _, admissionAttribute := range admissionAttributes {
+			admissionAttribute.result = err
+		}
+		return
+	}
+	if len(quotas) == 0 {
+		fmt.Printf("#### 2c %v\n", ns)
+		for _, admissionAttribute := range admissionAttributes {
+			admissionAttribute.result = nil
+		}
+		return
+	}
+
+	// acquire the locks in alphabetical order because I'm too lazy to think of something clever
+	fmt.Printf("#### 2d %v\n", quotas)
+	sort.Sort(ByName(quotas))
+	for _, quota := range quotas {
+		lock := e.lockFactory.GetLock(quota.Name)
+		fmt.Printf("#### 2dA WAITING FOR LOCK%v\n", quotas)
+		lock.Lock()
+		fmt.Printf("#### 2dA GOT LOCK!!!!!! LOCK%v\n", quotas)
+		defer lock.Unlock()
+	}
+
+	fmt.Printf("#### 2e %v\n", quotas)
+	e.checkQuotas(quotas, admissionAttributes, 3)
+}
+
+type ByName []api.ResourceQuota
+
+func (v ByName) Len() int           { return len(v) }
+func (v ByName) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+func (v ByName) Less(i, j int) bool { return v[i].Name < v[j].Name }
+
+// checkQuotas checks the admission atttributes against the passed quotas.  If a quota applies, it will attempt to update it
+// AFTER it has checked all the admissionAttributes.  The method breaks down into phase like this:
+// 0. make a copy of the quotas to act as a "running" quota so we know what we need to update and can still compare against the
+//    originals
+// 1. check each admission attribute to see if it fits within *all* the quotas.  If it doesn't fit, mark the waiter as failed
+//    and the running quota don't change.  If it did fit, check to see if any quota was changed.  It there was no quota change
+//    mark the waiter as succeeded.  If some quota did change, update the running quotas
+// 2. If no running quota was changed, return now since no updates are needed.
+// 3. for each quota that has changed, attempt an update.  If all updates succeeded, update all unset waiters to success status and return.  If the some
+//    updates failed on conflict errors and we have retries left, re-get the failed quota from our cache for the latest version
+//    and recurse into this method with the subset.  It's safe for us to evaluate ONLY the subset, because the other quota
+//    documents for these waiters have already been evaluated.  Step 1, will mark all the ones that should already have succeeded.
+func (e *quotaEvaluator) checkQuotas(quotas []api.ResourceQuota, admissionAttributes []*admissionWaiter, remainingRetries int) {
+	// yet another copy to compare against originals to see if we actually have deltas
+	originalQuotas := make([]api.ResourceQuota, len(quotas), len(quotas))
+	copy(originalQuotas, quotas)
+
+	atLeastOneChanged := false
+	for i := range admissionAttributes {
+		admissionAttribute := admissionAttributes[i]
+		newQuotas, err := e.checkRequest(quotas, admissionAttribute.attributes)
+		if err != nil {
+			admissionAttribute.result = err
+			continue
+		}
+
+		// if the new quotas are the same as the old quotas, then this particular one doesn't issue any updates
+		// that means that no quota docs applied, so it can get a pass
+		atLeastOneChangeForThisWaiter := false
+		for j := range newQuotas {
+			if !quota.Equals(originalQuotas[j].Status.Used, newQuotas[j].Status.Used) {
+				atLeastOneChanged = true
+				atLeastOneChangeForThisWaiter = true
+				break
+			}
+		}
+
+		if !atLeastOneChangeForThisWaiter {
+			admissionAttribute.result = nil
+		}
+		quotas = newQuotas
+	}
+
+	// if none of the requests changed anything, there's no reason to issue an update, just fail them all now
+	if !atLeastOneChanged {
+		return
+	}
+
+	// now go through and try to issue updates.  Things get a little weird here:
+	// 1. check to see if the quota changed.  If not, skip.
+	// 2. if the quota changed and the update passes, be happy
+	// 3. if the quota changed and the update fails, add the original to a retry list
+	var updatedFailedQuotas []api.ResourceQuota
+	var lastErr error
+	for i := range quotas {
+		newQuota := quotas[i]
+		// if this quota didn't have its status changed, skip it
+		fmt.Printf("#### 4a\n")
+		if quota.Equals(originalQuotas[i].Status.Used, newQuota.Status.Used) {
+			fmt.Printf("#### 4b\n")
+			continue
+		}
+
+		clusterQuota := quotaapi.ClusterResourceQuota{}
+		clusterQuota.ObjectMeta = newQuota.ObjectMeta
+		clusterQuota.Status = newQuota.Status
+
+		fmt.Printf("#### 4c %#v\n", newQuota)
+		fmt.Printf("#### 4cA %#v\n", clusterQuota)
+		if _, err := e.client.ClusterResourceQuotas().UpdateStatus(&clusterQuota); err != nil {
+			fmt.Printf("#### 4d\n")
+			updatedFailedQuotas = append(updatedFailedQuotas, newQuota)
+			lastErr = err
+		}
+	}
+
+	if len(updatedFailedQuotas) == 0 {
+		// all the updates succeeded.  At this point, anything with the default deny error was just waiting to
+		// get a successful update, so we can mark and notify
+		for _, admissionAttribute := range admissionAttributes {
+			if IsDefaultDeny(admissionAttribute.result) {
+				admissionAttribute.result = nil
+			}
+		}
+		return
+	}
+
+	// at this point, errors are fatal.  Update all waiters without status to failed and return
+	if remainingRetries <= 0 {
+		for _, admissionAttribute := range admissionAttributes {
+			if IsDefaultDeny(admissionAttribute.result) {
+				admissionAttribute.result = lastErr
+			}
+		}
+		return
+	}
+
+	// this retry logic has the same bug that its possible to be checking against quota in a state that never actually exists where
+	// you've added a new documented, then updated an old one, your resource matches both and you're only checking one
+	// updates for these quota names failed.  Get the current quotas in the namespace, compare by name, check to see if the
+	// resource versions have changed.  If not, we're going to fall through an fail everything.  If they all have, then we can try again
+	newQuotas, err := e.getQuotas(quotas[0].Namespace)
+	if err != nil {
+		// this means that updates failed.  Anything with a default deny error has failed and we need to let them know
+		for _, admissionAttribute := range admissionAttributes {
+			if IsDefaultDeny(admissionAttribute.result) {
+				admissionAttribute.result = lastErr
+			}
+		}
+		return
+	}
+
+	// this logic goes through our cache to find the new version of all quotas that failed update.  If something has been removed
+	// it is skipped on this retry.  After all, you removed it.
+	quotasToCheck := []api.ResourceQuota{}
+	for _, newQuota := range newQuotas {
+		for _, oldQuota := range updatedFailedQuotas {
+			if newQuota.Name == oldQuota.Name {
+				quotasToCheck = append(quotasToCheck, newQuota)
+				break
+			}
+		}
+	}
+	e.checkQuotas(quotasToCheck, admissionAttributes, remainingRetries-1)
+}
+
+// checkRequest verifies that the request does not exceed any quota constraint. it returns back a copy of quotas not yet persisted
+// that capture what the usage would be if the request succeeded.  It return an error if the is insufficient quota to satisfy the request
+func (e *quotaEvaluator) checkRequest(quotas []api.ResourceQuota, a admission.Attributes) ([]api.ResourceQuota, error) {
+	fmt.Printf("#### 3a\n")
+	namespace := a.GetNamespace()
+	name := a.GetName()
+
+	evaluators := e.registry.Evaluators()
+	evaluator, found := evaluators[a.GetKind().GroupKind()]
+	fmt.Printf("#### 3b\n")
+	if !found {
+		fmt.Printf("#### 3c\n")
+		return quotas, nil
+	}
+
+	op := a.GetOperation()
+	operationResources := evaluator.OperationResources(op)
+	fmt.Printf("#### 3d\n")
+	if len(operationResources) == 0 {
+		fmt.Printf("#### 3e\n")
+		return quotas, nil
+	}
+
+	// find the set of quotas that are pertinent to this request
+	// reject if we match the quota, but usage is not calculated yet
+	// reject if the input object does not satisfy quota constraints
+	// if there are no pertinent quotas, we can just return
+	inputObject := a.GetObject()
+	fmt.Printf("#### 3f\n")
+	interestingQuotaIndexes := []int{}
+	for i := range quotas {
+		fmt.Printf("#### 3g\n")
+		resourceQuota := quotas[i]
+		match := evaluator.Matches(&resourceQuota, inputObject)
+		if !match {
+			fmt.Printf("#### 3h\n")
+			continue
+		}
+
+		hardResources := quota.ResourceNames(resourceQuota.Status.Hard)
+		evaluatorResources := evaluator.MatchesResources()
+		requiredResources := quota.Intersection(hardResources, evaluatorResources)
+		err := evaluator.Constraints(requiredResources, inputObject)
+		if err != nil {
+			fmt.Printf("#### 3i\n")
+			return nil, admission.NewForbidden(a, fmt.Errorf("Failed quota: %s: %v", resourceQuota.Name, err))
+		}
+		if !hasUsageStats(&resourceQuota) {
+			fmt.Printf("#### 3j\n")
+			return nil, admission.NewForbidden(a, fmt.Errorf("Status unknown for quota: %s", resourceQuota.Name))
+		}
+
+		interestingQuotaIndexes = append(interestingQuotaIndexes, i)
+	}
+	fmt.Printf("#### 3k\n")
+	if len(interestingQuotaIndexes) == 0 {
+		fmt.Printf("#### 3l\n")
+		return quotas, nil
+	}
+
+	// Usage of some resources cannot be counted in isolation. For example when
+	// the resource represents a number of unique references to external
+	// resource. In such a case an evaluator needs to process other objects in
+	// the same namespace which needs to be known.
+	if accessor, err := meta.Accessor(inputObject); namespace != "" && err == nil {
+		if accessor.GetNamespace() == "" {
+			accessor.SetNamespace(namespace)
+		}
+	}
+
+	// there is at least one quota that definitely matches our object
+	// as a result, we need to measure the usage of this object for quota
+	// on updates, we need to subtract the previous measured usage
+	// if usage shows no change, just return since it has no impact on quota
+	fmt.Printf("#### 3m\n")
+	deltaUsage := evaluator.Usage(inputObject)
+	if admission.Update == op {
+		prevItem, err := evaluator.Get(namespace, name)
+		if err != nil {
+			fmt.Printf("#### 3n\n")
+			return nil, admission.NewForbidden(a, fmt.Errorf("Unable to get previous: %v", err))
+		}
+		prevUsage := evaluator.Usage(prevItem)
+		deltaUsage = quota.Subtract(deltaUsage, prevUsage)
+	}
+	fmt.Printf("#### 3o\n")
+	if quota.IsZero(deltaUsage) {
+		fmt.Printf("#### 3p\n")
+		return quotas, nil
+	}
+
+	for _, index := range interestingQuotaIndexes {
+		resourceQuota := quotas[index]
+
+		hardResources := quota.ResourceNames(resourceQuota.Status.Hard)
+		requestedUsage := quota.Mask(deltaUsage, hardResources)
+		newUsage := quota.Add(resourceQuota.Status.Used, requestedUsage)
+		if allowed, exceeded := quota.LessThanOrEqual(newUsage, resourceQuota.Status.Hard); !allowed {
+			failedRequestedUsage := quota.Mask(requestedUsage, exceeded)
+			failedUsed := quota.Mask(resourceQuota.Status.Used, exceeded)
+			failedHard := quota.Mask(resourceQuota.Status.Hard, exceeded)
+			fmt.Printf("#### 3q\n")
+			return nil, admission.NewForbidden(a,
+				fmt.Errorf("Exceeded quota: %s, requested: %s, used: %s, limited: %s",
+					resourceQuota.Name,
+					prettyPrint(failedRequestedUsage),
+					prettyPrint(failedUsed),
+					prettyPrint(failedHard)))
+		}
+
+		// update to the new usage number
+		quotas[index].Status.Used = newUsage
+	}
+
+	fmt.Printf("#### 3r\n")
+	return quotas, nil
+}
+
+func (e *quotaEvaluator) evaluate(a admission.Attributes) error {
+	waiter := newAdmissionWaiter(a)
+
+	e.addWork(waiter)
+
+	// wait for completion or timeout
+	select {
+	case <-waiter.finished:
+	case <-time.After(10 * time.Second):
+		return fmt.Errorf("timeout")
+	}
+
+	return waiter.result
+}
+
+func (e *quotaEvaluator) addWork(a *admissionWaiter) {
+	e.workLock.Lock()
+	defer e.workLock.Unlock()
+
+	ns := a.attributes.GetNamespace()
+	// this Add can trigger a Get BEFORE the work is added to a list, but this is ok because the getWork routine
+	// waits the worklock before retrieving the work to do, so the writes in this method will be observed
+	e.queue.Add(ns)
+
+	if e.inProgress.Has(ns) {
+		e.dirtyWork[ns] = append(e.dirtyWork[ns], a)
+		return
+	}
+
+	e.work[ns] = append(e.work[ns], a)
+}
+
+func (e *quotaEvaluator) completeWork(ns string) {
+	e.workLock.Lock()
+	defer e.workLock.Unlock()
+
+	e.queue.Done(ns)
+	e.work[ns] = e.dirtyWork[ns]
+	delete(e.dirtyWork, ns)
+	e.inProgress.Delete(ns)
+}
+
+func (e *quotaEvaluator) getWork() (string, []*admissionWaiter) {
+	uncastNS, _ := e.queue.Get()
+	ns := uncastNS.(string)
+
+	e.workLock.Lock()
+	defer e.workLock.Unlock()
+	// at this point, we know we have a coherent view of e.work.  It is entirely possible
+	// that our workqueue has another item requeued to it, but we'll pick it up early.  This ok
+	// because the next time will go into our dirty list
+
+	work := e.work[ns]
+	delete(e.work, ns)
+	delete(e.dirtyWork, ns)
+
+	if len(work) != 0 {
+		e.inProgress.Insert(ns)
+		return ns, work
+	}
+
+	e.queue.Done(ns)
+	e.inProgress.Delete(ns)
+	return ns, []*admissionWaiter{}
+}
+
+func (e *quotaEvaluator) getQuotas(namespace string) ([]api.ResourceQuota, error) {
+	// trust me to do somethign clever here with a pre-computed cache ala project cache
+	liveList, err := e.client.ClusterResourceQuotas().List(api.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Error resolving quota.")
+	}
+
+	resourceQuotas := []api.ResourceQuota{}
+	for i := range liveList.Items {
+		// always make a copy.  We're going to muck around with this and we should never mutate the originals
+		clusterQuota := liveList.Items[i]
+		item := api.ResourceQuota{}
+		item.ObjectMeta = clusterQuota.ObjectMeta
+		item.Namespace = namespace
+		item.Spec = clusterQuota.Spec.Quota
+		item.Status = clusterQuota.Status
+
+		if len(item.Status.Hard) == 0 {
+			item.Status.Hard = item.Spec.Hard
+		}
+		if len(item.Status.Used) == 0 {
+			item.Status.Used = api.ResourceList{}
+			for name := range item.Spec.Hard {
+				item.Status.Used[name] = resource.MustParse("0")
+			}
+		}
+
+		resourceQuotas = append(resourceQuotas, item)
+	}
+
+	return resourceQuotas, nil
+}

--- a/pkg/authorization/admission/clusterquota/lockfactory.go
+++ b/pkg/authorization/admission/clusterquota/lockfactory.go
@@ -1,0 +1,40 @@
+package clusterquota
+
+import (
+	"sync"
+)
+
+type LockFactory interface {
+	GetLock(string) sync.Locker
+}
+
+type DefaultLockFactory struct {
+	lock sync.RWMutex
+
+	locks map[string]sync.Locker
+}
+
+func NewDefaultLockFactory() *DefaultLockFactory {
+	return &DefaultLockFactory{locks: map[string]sync.Locker{}}
+}
+
+func (f *DefaultLockFactory) GetLock(key string) sync.Locker {
+	lock, exists := f.getExistingLock(key)
+	if exists {
+		return lock
+	}
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	lock = &sync.Mutex{}
+	f.locks[key] = lock
+	return lock
+}
+
+func (f *DefaultLockFactory) getExistingLock(key string) (sync.Locker, bool) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	lock, exists := f.locks[key]
+	return lock, exists
+}

--- a/pkg/authorization/api/install/install.go
+++ b/pkg/authorization/api/install/install.go
@@ -92,7 +92,7 @@ func addVersionsToScheme(externalVersions ...unversioned.GroupVersion) {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	rootScoped := sets.NewString("ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding")
+	rootScoped := sets.NewString("ClusterResourceQuota", "ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding")
 	ignoredKinds := sets.NewString()
 	return kapi.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -53,8 +53,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+
+		&ClusterResourceQuota{},
+		&ClusterResourceQuotaList{},
 	)
 }
+
+func (obj *ClusterResourceQuotaList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+func (obj *ClusterResourceQuota) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 
 func (obj *ClusterRoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *ClusterRoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -118,6 +118,33 @@ func init() {
 		Difference(NormalizeResources(sets.NewString(GroupsToResources[KubeEscalatingViewableGroupName]...))).List()
 }
 
+// we care argue exact shape later.  Point is, it's easily convertible to and from resourcequota
+type ClusterResourceQuota struct {
+	unversioned.TypeMeta
+	kapi.ObjectMeta
+
+	// Spec defines the desired quota
+	Spec ClusterResourceQuotaSpec
+
+	// Status defines the actual enforced quota and its current usage
+	Status kapi.ResourceQuotaStatus
+}
+
+type ClusterResourceQuotaSpec struct {
+	Selector map[string]string
+	// Spec defines the desired quota
+	Quota kapi.ResourceQuotaSpec
+}
+
+type ClusterResourceQuotaList struct {
+	unversioned.TypeMeta
+	// Standard object's metadata.
+	unversioned.ListMeta
+
+	// Items is a list of roles
+	Items []ClusterResourceQuota
+}
+
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {

--- a/pkg/authorization/api/v1/register.go
+++ b/pkg/authorization/api/v1/register.go
@@ -44,8 +44,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+
+		&ClusterResourceQuota{},
+		&ClusterResourceQuotaList{},
 	)
 }
+
+func (obj *ClusterResourceQuotaList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+func (obj *ClusterResourceQuota) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 
 func (obj *ClusterRoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *ClusterRoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -6,6 +6,31 @@ import (
 	kruntime "k8s.io/kubernetes/pkg/runtime"
 )
 
+type ClusterResourceQuota struct {
+	unversioned.TypeMeta `json:",inline"`
+	kapi.ObjectMeta      `json:"metadata,omitempty"`
+
+	// Spec defines the desired quota
+	Spec ClusterResourceQuotaSpec `json:"spec,omitempty"`
+
+	// Status defines the actual enforced quota and its current usage
+	Status kapi.ResourceQuotaStatus `json:"status,omitempty"`
+}
+
+type ClusterResourceQuotaSpec struct {
+	Selector map[string]string `json:"selector,omitempty"`
+	// Spec defines the desired quota
+	Quota kapi.ResourceQuotaSpec `json:"quota,omitempty"`
+}
+
+type ClusterResourceQuotaList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of roles
+	Items []ClusterResourceQuota `json:",items"`
+}
+
 // Authorization is calculated against
 // 1. all deny RoleBinding PolicyRules in the master namespace - short circuit on match
 // 2. all allow RoleBinding PolicyRules in the master namespace - short circuit on match

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -44,8 +44,14 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+
+		&ClusterResourceQuota{},
+		&ClusterResourceQuotaList{},
 	)
 }
+
+func (obj *ClusterResourceQuotaList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
+func (obj *ClusterResourceQuota) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 
 func (obj *ClusterRoleList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *ClusterRoleBindingList) GetObjectKind() unversioned.ObjectKind   { return &obj.TypeMeta }

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -6,6 +6,31 @@ import (
 	kruntime "k8s.io/kubernetes/pkg/runtime"
 )
 
+type ClusterResourceQuota struct {
+	unversioned.TypeMeta `json:",inline"`
+	kapi.ObjectMeta      `json:"metadata,omitempty"`
+
+	// Spec defines the desired quota
+	Spec ClusterResourceQuotaSpec `json:"spec,omitempty"`
+
+	// Status defines the actual enforced quota and its current usage
+	Status kapi.ResourceQuotaStatus `json:"status,omitempty"`
+}
+
+type ClusterResourceQuotaSpec struct {
+	Selector map[string]string `json:"selector,omitempty"`
+	// Spec defines the desired quota
+	Quota kapi.ResourceQuotaSpec `json:"quota,omitempty"`
+}
+
+type ClusterResourceQuotaList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	// Items is a list of roles
+	Items []ClusterResourceQuota `json:",items"`
+}
+
 // Authorization is calculated against
 // 1. all deny RoleBinding PolicyRules in the master namespace - short circuit on match
 // 2. all allow RoleBinding PolicyRules in the master namespace - short circuit on match

--- a/pkg/authorization/registry/clusterquota/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterquota/etcd/etcd.go
@@ -1,0 +1,64 @@
+package etcd
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	etcdgeneric "k8s.io/kubernetes/pkg/registry/generic/etcd"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/clusterquota"
+)
+
+type REST struct {
+	*etcdgeneric.Etcd
+}
+
+// NewStorage returns a RESTStorage object that will work against Build objects.
+func NewREST(s storage.Interface) (*REST, *StatusREST) {
+	prefix := "/clusterresourcequotas"
+
+	store := &etcdgeneric.Etcd{
+		NewFunc:           func() runtime.Object { return &api.ClusterResourceQuota{} },
+		NewListFunc:       func() runtime.Object { return &api.ClusterResourceQuotaList{} },
+		QualifiedResource: api.Resource("clusterresourcequotas"),
+		KeyRootFunc: func(ctx kapi.Context) string {
+			return prefix
+		},
+		KeyFunc: func(ctx kapi.Context, id string) (string, error) {
+			return etcdgeneric.NoNamespaceKeyFunc(ctx, prefix, id)
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.ClusterResourceQuota).Name, nil
+		},
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return clusterquota.Matcher(label, field)
+		},
+		CreateStrategy: clusterquota.Strategy,
+		UpdateStrategy: clusterquota.Strategy,
+		DeleteStrategy: clusterquota.Strategy,
+		Storage:        s,
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = clusterquota.StatusStrategy
+
+	return &REST{store}, &StatusREST{store: &statusStore}
+}
+
+// StatusREST implements the REST endpoint for changing the status of a resourcequota.
+type StatusREST struct {
+	store *etcdgeneric.Etcd
+}
+
+func (r *StatusREST) New() runtime.Object {
+	return &api.ClusterResourceQuota{}
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
+}

--- a/pkg/authorization/registry/clusterquota/strategy.go
+++ b/pkg/authorization/registry/clusterquota/strategy.go
@@ -1,0 +1,110 @@
+package clusterquota
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+)
+
+// strategy implements behavior for nodes
+type strategy struct {
+	runtime.ObjectTyper
+}
+
+// Strategy is the default logic that applies when creating and updating Policy objects.
+var Strategy = strategy{kapi.Scheme}
+
+// NamespaceScoped is true for policies.
+func (strategy) NamespaceScoped() bool {
+	return false
+}
+
+// AllowCreateOnUpdate is false for policies.
+func (strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (strategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+func (strategy) GenerateName(base string) string {
+	return base
+}
+
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (strategy) PrepareForCreate(obj runtime.Object) {
+}
+
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+func (strategy) PrepareForUpdate(obj, old runtime.Object) {
+}
+
+// Canonicalize normalizes the object after validation.
+func (strategy) Canonicalize(obj runtime.Object) {
+}
+
+// Validate validates a new policy.
+func (strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
+	return nil
+}
+
+// ValidateUpdate is the default update validation for an end user.
+func (strategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) field.ErrorList {
+	return nil
+}
+
+// Matcher returns a generic matcher for a given label and field selector.
+func Matcher(label labels.Selector, field fields.Selector) generic.Matcher {
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			quota, ok := obj.(*api.ClusterResourceQuota)
+			if !ok {
+				return nil, nil, fmt.Errorf("not a ClusterResourceQuota")
+			}
+			return labels.Set(quota.ObjectMeta.Labels), nil, nil
+		},
+	}
+}
+
+type resourcequotaStatusStrategy struct {
+	strategy
+}
+
+var StatusStrategy = resourcequotaStatusStrategy{Strategy}
+
+func (resourcequotaStatusStrategy) PrepareForUpdate(obj, old runtime.Object) {
+	newResourcequota := obj.(*api.ClusterResourceQuota)
+	oldResourcequota := old.(*api.ClusterResourceQuota)
+	newResourcequota.Spec = oldResourcequota.Spec
+}
+
+func (resourcequotaStatusStrategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) field.ErrorList {
+	return nil
+}
+
+// MatchResourceQuota returns a generic matcher for a given label and field selector.
+func MatchResourceQuota(label labels.Selector, field fields.Selector) generic.Matcher {
+	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {
+		resourcequotaObj, ok := obj.(*api.ClusterResourceQuota)
+		if !ok {
+			return false, fmt.Errorf("not a resourcequota")
+		}
+		fields := ResourceQuotaToSelectableFields(resourcequotaObj)
+		return label.Matches(labels.Set(resourcequotaObj.Labels)) && field.Matches(fields), nil
+	})
+}
+
+// ResourceQuotaToSelectableFields returns a label set that represents the object
+func ResourceQuotaToSelectableFields(resourcequota *api.ClusterResourceQuota) labels.Set {
+	return labels.Set(generic.ObjectMetaFieldsSet(resourcequota.ObjectMeta, true))
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -51,6 +51,7 @@ type Interface interface {
 	PolicyBindingsNamespacer
 	RolesNamespacer
 	RoleBindingsNamespacer
+	ClusterResourceQuotasInterface
 	ClusterPoliciesInterface
 	ClusterPolicyBindingsInterface
 	ClusterRolesInterface
@@ -225,6 +226,10 @@ func (c *Client) SubjectAccessReviews() SubjectAccessReviewInterface {
 // OAuthAccessTokens provides a REST client for OAuthAccessTokens
 func (c *Client) OAuthAccessTokens() OAuthAccessTokenInterface {
 	return newOAuthAccessTokens(c)
+}
+
+func (c *Client) ClusterResourceQuotas() ClusterResourceQuotaInterface {
+	return newClusterResourceQuotas(c)
 }
 
 func (c *Client) ClusterPolicies() ClusterPolicyInterface {

--- a/pkg/client/clusterquota.go
+++ b/pkg/client/clusterquota.go
@@ -1,0 +1,78 @@
+package client
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+)
+
+type ClusterResourceQuotasInterface interface {
+	ClusterResourceQuotas() ClusterResourceQuotaInterface
+}
+
+type ClusterResourceQuotaInterface interface {
+	List(opts kapi.ListOptions) (*api.ClusterResourceQuotaList, error)
+	Get(name string) (*api.ClusterResourceQuota, error)
+	Create(clusterResourceQuota *api.ClusterResourceQuota) (*api.ClusterResourceQuota, error)
+	Update(clusterResourceQuota *api.ClusterResourceQuota) (*api.ClusterResourceQuota, error)
+	Delete(name string) error
+	Watch(opts kapi.ListOptions) (watch.Interface, error)
+	UpdateStatus(clusterResourceQuota *api.ClusterResourceQuota) (result *api.ClusterResourceQuota, err error)
+}
+
+type clusterResourceQuotas struct {
+	r *Client
+}
+
+func newClusterResourceQuotas(c *Client) *clusterResourceQuotas {
+	return &clusterResourceQuotas{
+		r: c,
+	}
+}
+
+func (c *clusterResourceQuotas) List(opts kapi.ListOptions) (result *api.ClusterResourceQuotaList, err error) {
+	result = &api.ClusterResourceQuotaList{}
+	err = c.r.Get().
+		Resource("clusterResourceQuotas").
+		VersionedParams(&opts, kapi.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+func (c *clusterResourceQuotas) Get(name string) (result *api.ClusterResourceQuota, err error) {
+	result = &api.ClusterResourceQuota{}
+	err = c.r.Get().Resource("clusterResourceQuotas").Name(name).Do().Into(result)
+	return
+}
+
+func (c *clusterResourceQuotas) Create(clusterResourceQuota *api.ClusterResourceQuota) (result *api.ClusterResourceQuota, err error) {
+	result = &api.ClusterResourceQuota{}
+	err = c.r.Post().Resource("clusterResourceQuotas").Body(clusterResourceQuota).Do().Into(result)
+	return
+}
+
+func (c *clusterResourceQuotas) Update(clusterResourceQuota *api.ClusterResourceQuota) (result *api.ClusterResourceQuota, err error) {
+	result = &api.ClusterResourceQuota{}
+	err = c.r.Put().Resource("clusterResourceQuotas").Name(clusterResourceQuota.Name).Body(clusterResourceQuota).Do().Into(result)
+	return
+}
+
+func (c *clusterResourceQuotas) Delete(name string) error {
+	return c.r.Delete().Resource("clusterResourceQuotas").Name(name).Do().Error()
+}
+
+func (c *clusterResourceQuotas) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Resource("clusterResourceQuotas").
+		VersionedParams(&opts, kapi.ParameterCodec).
+		Watch()
+}
+
+func (c *clusterResourceQuotas) UpdateStatus(clusterResourceQuota *api.ClusterResourceQuota) (result *api.ClusterResourceQuota, err error) {
+	result = &api.ClusterResourceQuota{}
+	err = c.r.Put().Resource("clusterResourceQuotas").Name(clusterResourceQuota.Name).SubResource("status").Body(clusterResourceQuota).Do().Into(result)
+	return
+}

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -310,3 +310,7 @@ func (c *Fake) ClusterRoles() client.ClusterRoleInterface {
 func (c *Fake) ClusterRoleBindings() client.ClusterRoleBindingInterface {
 	return &FakeClusterRoleBindings{Fake: c}
 }
+
+func (c *Fake) ClusterResourceQuotas() client.ClusterResourceQuotaInterface {
+	return &FakeClusterResourceQuotas{Fake: c}
+}

--- a/pkg/client/testclient/fake_clusterquota.go
+++ b/pkg/client/testclient/fake_clusterquota.go
@@ -1,0 +1,67 @@
+package testclient
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+)
+
+// FakeClusterResourceQuotas implements ClusterResourceQuotasInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeClusterResourceQuotas struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterResourceQuotas) Get(name string) (*api.ClusterResourceQuota, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootGetAction("clusterResourceQuotas", name), &api.ClusterResourceQuota{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ClusterResourceQuota), err
+}
+
+func (c *FakeClusterResourceQuotas) List(opts kapi.ListOptions) (*api.ClusterResourceQuotaList, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootListAction("clusterResourceQuotas", opts), &api.ClusterResourceQuotaList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ClusterResourceQuotaList), err
+}
+
+func (c *FakeClusterResourceQuotas) Create(inObj *api.ClusterResourceQuota) (*api.ClusterResourceQuota, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("clusterResourceQuotas", inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ClusterResourceQuota), err
+}
+
+func (c *FakeClusterResourceQuotas) Update(inObj *api.ClusterResourceQuota) (*api.ClusterResourceQuota, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootUpdateAction("clusterResourceQuotas", inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ClusterResourceQuota), err
+}
+
+func (c *FakeClusterResourceQuotas) Delete(name string) error {
+	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("clusterResourceQuotas", name), &api.ClusterResourceQuota{})
+	return err
+}
+
+func (c *FakeClusterResourceQuotas) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(ktestclient.NewRootWatchAction("clusterResourceQuotas", opts))
+}
+
+func (c *FakeClusterResourceQuotas) UpdateStatus(inObj *api.ClusterResourceQuota) (result *api.ClusterResourceQuota, err error) {
+	create := ktestclient.NewRootCreateAction("clusterResourceQuotas", inObj)
+	create.Subresource = "status"
+	obj, err := c.Fake.Invokes(create, inObj)
+	return obj.(*api.ClusterResourceQuota), err
+}

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -1,6 +1,7 @@
 package describe
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -60,6 +61,8 @@ var (
 	hostSubnetColumns     = []string{"NAME", "HOST", "HOST IP", "SUBNET"}
 	netNamespaceColumns   = []string{"NAME", "NETID"}
 	clusterNetworkColumns = []string{"NAME", "NETWORK", "HOST SUBNET LENGTH", "SERVICE NETWORK"}
+
+	resourceQuotaColumns = []string{"NAME", "AGE"}
 )
 
 // NewHumanReadablePrinter returns a new HumanReadablePrinter
@@ -130,7 +133,101 @@ func NewHumanReadablePrinter(noHeaders, withNamespace, wide bool, showAll bool, 
 	p.Handler(clusterNetworkColumns, printClusterNetwork)
 	p.Handler(clusterNetworkColumns, printClusterNetworkList)
 
+	p.Handler(resourceQuotaColumns, printResourceQuota)
+	p.Handler(resourceQuotaColumns, printResourceQuotaList)
+
 	return p
+}
+
+func printResourceQuota(resourceQuota *authorizationapi.ClusterResourceQuota, w io.Writer, options kctl.PrintOptions) error {
+	name := resourceQuota.Name
+	namespace := resourceQuota.Namespace
+
+	if options.WithNamespace {
+		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(
+		w, "%s\t%s",
+		name,
+		translateTimestamp(resourceQuota.CreationTimestamp),
+	); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(w, appendLabels(resourceQuota.Labels, options.ColumnLabels)); err != nil {
+		return err
+	}
+	_, err := fmt.Fprint(w, appendAllLabels(options.ShowLabels, resourceQuota.Labels))
+	return err
+}
+
+// Prints the ResourceQuotaList in a human-friendly format.
+func printResourceQuotaList(list *authorizationapi.ClusterResourceQuotaList, w io.Writer, options kctl.PrintOptions) error {
+	for i := range list.Items {
+		if err := printResourceQuota(&list.Items[i], w, options); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func shortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*364 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// translateTimestamp returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestamp(timestamp unversioned.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return shortHumanDuration(time.Now().Sub(timestamp.Time))
+}
+
+func appendLabels(itemLabels map[string]string, columnLabels []string) string {
+	var buffer bytes.Buffer
+
+	for _, cl := range columnLabels {
+		buffer.WriteString(fmt.Sprint("\t"))
+		if il, ok := itemLabels[cl]; ok {
+			buffer.WriteString(fmt.Sprint(il))
+		} else {
+			buffer.WriteString("<none>")
+		}
+	}
+
+	return buffer.String()
+}
+
+// Append all labels to a single column. We need this even when show-labels flag* is
+// false, since this adds newline delimiter to the end of each row.
+func appendAllLabels(showLabels bool, itemLabels map[string]string) string {
+	var buffer bytes.Buffer
+
+	if showLabels {
+		buffer.WriteString(fmt.Sprint("\t"))
+		buffer.WriteString(labels.FormatLabels(itemLabels))
+	}
+	buffer.WriteString("\n")
+
+	return buffer.String()
 }
 
 const templateDescriptionLen = 80

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -24,7 +24,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				obj.ServingInfo.RequestTimeoutSeconds = 60 * 60
 			}
 			if obj.ServingInfo.MaxRequestsInFlight == 0 {
-				obj.ServingInfo.MaxRequestsInFlight = 500
+				obj.ServingInfo.MaxRequestsInFlight = 5000
 			}
 			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
 				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -47,7 +47,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
+var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions", "ClusterResourceQuota"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -90,6 +90,7 @@ import (
 	clusterpolicystorage "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy/etcd"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	clusterpolicybindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding/etcd"
+	clusterquotastorage "github.com/openshift/origin/pkg/authorization/registry/clusterquota/etcd"
 	clusterrolestorage "github.com/openshift/origin/pkg/authorization/registry/clusterrole/proxy"
 	clusterrolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding/proxy"
 	"github.com/openshift/origin/pkg/authorization/registry/localresourceaccessreview"
@@ -485,6 +486,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		},
 	)
 
+	clusterQuota, clusterQuotaStatus := clusterquotastorage.NewREST(c.EtcdHelper)
+
 	storage := map[string]rest.Storage{
 		"images":               imageStorage,
 		"imageStreams/secrets": imageStreamSecretsStorage,
@@ -538,6 +541,9 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"clusterPolicyBindings": clusterPolicyBindingStorage,
 		"clusterRoleBindings":   clusterRoleBindingStorage,
 		"clusterRoles":          clusterRoleStorage,
+
+		"clusterResourceQuotas":        clusterQuota,
+		"clusterResourceQuotas/status": clusterQuotaStatus,
 	}
 
 	if configapi.IsBuildEnabled(&c.Options) {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -172,7 +172,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{"ProjectRequestLimit", "OriginNamespaceLifecycle", "PodNodeConstraints", "BuildByStrategy", "OriginResourceQuota"}
+	admissionControlPluginNames := []string{"ProjectRequestLimit", "OriginNamespaceLifecycle", "PodNodeConstraints", "BuildByStrategy", "OriginResourceQuota", "ClusterResourceQuota"}
 	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
 		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
 	}

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -3,6 +3,7 @@ package start
 import (
 
 	// Admission control plug-ins used by OpenShift
+	_ "github.com/openshift/origin/pkg/authorization/admission/clusterquota"
 	_ "github.com/openshift/origin/pkg/build/admission/defaults"
 	_ "github.com/openshift/origin/pkg/build/admission/overrides"
 	_ "github.com/openshift/origin/pkg/build/admission/strategyrestrictions"

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -1,0 +1,168 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const (
+	numProjects             = 100
+	podsPerProjectPerSecond = 20.0
+	testLength              = 30 * time.Second
+)
+
+func TestClusterQuota(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cq := &authorizationapi.ClusterResourceQuota{
+		ObjectMeta: kapi.ObjectMeta{Name: "overall"},
+		Spec: authorizationapi.ClusterResourceQuotaSpec{
+			Quota: kapi.ResourceQuotaSpec{
+				Hard: kapi.ResourceList{
+					kapi.ResourceConfigMaps: resource.MustParse("1000000"),
+				},
+			},
+		},
+	}
+	if _, err := clusterAdminClient.ClusterResourceQuotas().Create(cq); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	startCh := make(chan struct{})
+	stopCh := make(chan struct{})
+
+	for i := 0; i < numProjects; i++ {
+		projectName := fmt.Sprintf("project-%v", i)
+		if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if err := testserver.WaitForPodCreationServiceAccounts(clusterAdminKubeClient, projectName); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		go makeConfigMaps(clusterAdminKubeClient.ConfigMaps(projectName), podsPerProjectPerSecond, startCh, stopCh)
+		// go makeConfigMaps(clusterAdminKubeClient.ConfigMaps(projectName), podsPerProjectPerSecond, startCh, stopCh)
+		// go makeConfigMaps(clusterAdminKubeClient.ConfigMaps(projectName), podsPerProjectPerSecond, startCh, stopCh)
+		// go makeConfigMaps(clusterAdminKubeClient.ConfigMaps(projectName), podsPerProjectPerSecond, startCh, stopCh)
+	}
+
+	// this should make everyone start trying to create pods
+	close(startCh)
+	time.Sleep(testLength)
+	// this should make everyone stop trying to create pods
+	close(stopCh)
+
+	// let's see how many we got
+	podList, err := clusterAdminKubeClient.ConfigMaps(kapi.NamespaceAll).List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Errorf("Got %v pods in %v", len(podList.Items), testLength)
+
+	endingCq, _ := clusterAdminClient.ClusterResourceQuotas().Get(cq.Name)
+	t.Errorf("Ended with %#v", endingCq)
+}
+
+func makePods(podClient kclient.PodInterface, podsPerSecond float32, startCh, stopCh chan struct{}) {
+	<-startCh
+
+	testPod := &kapi.Pod{}
+	testPod.GenerateName = "test"
+	testPod.Spec.Containers = []kapi.Container{
+		{
+			Name:  "container",
+			Image: "openshift/origin-pod:latest",
+		},
+	}
+
+	startTime := time.Now()
+	numPods := 0
+	waitDuration := time.Duration(int64((1.2*1000)/podsPerSecond)) * time.Millisecond
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		duration := time.Now().Sub(startTime)
+		numberOfExpectedPods := float32(duration.Seconds()) * podsPerSecond
+
+		if numberOfExpectedPods <= float32(numPods) {
+			select {
+			case <-stopCh:
+				return
+			case <-time.After(waitDuration):
+				continue
+			}
+		}
+
+		if _, err := podClient.Create(testPod); err == nil {
+			numPods = numPods + 1
+		}
+	}
+}
+
+func makeConfigMaps(client kclient.ConfigMapsInterface, podsPerSecond float32, startCh, stopCh chan struct{}) {
+	<-startCh
+
+	configmap := &kapi.ConfigMap{}
+	configmap.GenerateName = "test"
+
+	startTime := time.Now()
+	numPods := 0
+	waitDuration := time.Duration(int64((1.2*1000)/podsPerSecond)) * time.Millisecond
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		duration := time.Now().Sub(startTime)
+		numberOfExpectedPods := float32(duration.Seconds()) * podsPerSecond
+
+		if numberOfExpectedPods <= float32(numPods) {
+			select {
+			case <-stopCh:
+				return
+			case <-time.After(waitDuration):
+				continue
+			}
+		}
+
+		if _, err := client.Create(configmap); err == nil {
+			numPods = numPods + 1
+		}
+	}
+}

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -43,6 +43,9 @@ func GetClusterAdminClient(adminKubeConfigFile string) (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// no rate limit
+	clientConfig.QPS = -1
+
 	osClient, err := client.New(clientConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@derekwaynecarr  before I go down the path of quota allocation, I want to make sure that your concerns about rolling quota up beyond the single project still exist. 

This is a working demonstration of quota across multiple projects.  I didn't build the precomputed label selecting cache, but I wouldn't expect that to be contentious.  If we're participating in project scoped quota, all other controller caches for replenishment will already exist and with a little re-swizzling I can reuse the quota evaluator.  The ordered lock acquisition to coordinate threads is a in a layer above most of the work and is demonstrated here.

```yaml
apiVersion: v1
kind: ClusterResourceQuota
metadata:
  name: quota
spec:
  quota:
      hard:
        persistentvolumeclaims: "10"
        pods: "10"
        replicationcontrollers: "20"
        resourcequotas: "10"
        secrets: "20"
        services: "5"
```

@pweil- @smarterclayton @danmcp 