### PR TITLE
blacklist the ThirdPartyResource kind from other resources page

### DIFF
--- a/assets/app/scripts/constants.js
+++ b/assets/app/scripts/constants.js
@@ -36,6 +36,9 @@ window.OPENSHIFT_CONSTANTS = {
       "Binding",
       "Ingress",
       "ReplicaSet",
+
+      // These are kinds that end users are not allowed to List by default
+      "ThirdPartyResource",
    
       // These are things like SARs that aren't actually persisted resources
       "LocalResourceAccessReview",
@@ -43,6 +46,6 @@ window.OPENSHIFT_CONSTANTS = {
       "ResourceAccessReview",
       "SubjectAccessReview",
       "ReplicationControllerDummy",
-      "DeploymentConfigRollback"    
+      "DeploymentConfigRollback"
   ]
 };

--- a/assets/app/scripts/controllers/otherResources.js
+++ b/assets/app/scripts/controllers/otherResources.js
@@ -86,7 +86,10 @@ angular.module('openshiftConsole')
       });   
     }
     $scope.loadKind = loadKind;
-    $scope.$watch("kindSelector.selected", loadKind);
+    $scope.$watch("kindSelector.selected", function() {
+      $scope.alerts = {};
+      loadKind();
+    });
     
     var humanizeKind = $filter("humanizeKind");
     $scope.matchKind = function(kind, search) {     


### PR DESCRIPTION
also clears any alerts when switching between different kinds because it seemed weird that they persisted