### PR TITLE
[WIP] update additional bower dependencies in web console

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -201,12 +201,9 @@ module.exports = function (grunt) {
         src: ['<%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//,
         exclude: [
-          'bower_components/uri.js/src/IPv6.js',
-          'bower_components/uri.js/src/SecondLevelDomains.js',
-          'bower_components/uri.js/src/punycode.js',
-          'bower_components/uri.js/src/URI.min.js',
-          'bower_components/uri.js/src/jquery.URI.min.js',
-          'bower_components/uri.js/src/URI.fragmentQuery.js',
+          
+          // bower registration error? we get 2x versions of uri.js/urijs
+          'bower_components/urijs/',
           'bower_components/messenger/build/css/messenger.css',
           'bower_components/messenger/build/css/messenger-theme-future.css',
           'bower_components/messenger/build/css/messenger-theme-block.css',

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -2,23 +2,23 @@
   "name": "assets",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.3.8",
+    "angular": "1.3.20",
     "json3": "3.3.2",
     "es5-shim": "3.1.1",
-    "angular-resource": "1.3.8",
-    "angular-cookies": "1.3.8",
-    "angular-sanitize": "1.3.8",
-    "angular-animate": "1.3.8",
-    "angular-touch": "1.3.8",
-    "angular-route": "1.3.8",
+    "angular-resource": "1.3.20",
+    "angular-cookies": "1.3.20",
+    "angular-sanitize": "1.3.20",
+    "angular-animate": "1.3.20",
+    "angular-touch": "1.3.20",
+    "angular-route": "1.3.20",
     "angular-bootstrap": "0.14.3",
     "angular-patternfly": "3.3.0",
-    "uri.js": "1.14.1",
+    "uri.js": "1.17.1",
     "moment": "2.10.6",
     "moment-timezone": "0.5.3",
     "patternfly": "3.3.0",
     "hawtio-core": "2.0.11",
-    "hawtio-core-navigation": "2.0.48",
+    "hawtio-core-navigation": "2.0.56",
     "hawtio-extension-service": "2.0.2",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
@@ -30,7 +30,7 @@
     "kubernetes-topology-graph": "0.0.23",
     "kubernetes-container-terminal": "0.0.11",
     "openshift-object-describer": "1.1.2",
-    "layout.attrs": "1.1.2",
+    "layout.attrs": "2.1.0",
     "bootstrap-hover-dropdown": "2.1.3",
     "angular-ui-ace": "0.2.3",
     "ace-builds": "1.2.2",
@@ -44,8 +44,8 @@
     "matchHeight": "0.6.0"
   },
   "devDependencies": {
-    "angular-mocks": "1.3.8",
-    "angular-scenario": "1.3.8",
+    "angular-mocks": "1.3.20",
+    "angular-scenario": "1.3.20",
     "font-awesome": "4.6.1"
   },
   "appPath": "app",
@@ -57,6 +57,11 @@
     "font-awesome": "4.6.1"
   },
   "overrides": {
+    "angular" : {
+      "dependencies" : {
+        "jquery": "2.1.4"
+      }
+    },
     "angular-patternfly": {
       "main": [
         "dist/styles/angular-patternfly.css",
@@ -92,6 +97,14 @@
         "src-min-noconflict/mode-yaml.js",
         "src-min-noconflict/theme-dreamweaver.js",
         "src-min-noconflict/theme-eclipse.js"
+      ]
+    },
+    "uri.js" : {
+      "main" : [
+        "src/URI.js",
+        "src/URITemplate.js",
+        "src/jquery.URI.js",
+        "src/URI.fragmentURI.js"
       ]
     }
   }


### PR DESCRIPTION
NOTE: currently branched off of [my other PR for npm & some bower](https://github.com/openshift/origin/pull/8670).  Will rebase on master once that PR is merged.

**previously updated**
- patternfly/bootstrap

**already latest**
- kubernetes-topology-graph
- kubernetes-container-terminal
- kubernetes-label-selector
- openshift-object-describer
- json3 - latest

**updated**
- bumps angular & angular modules upto 1.3.20
- bump uril.js to 1.17.1
- bumps layout.attrs to latest w/@sg00dwin's flexbox bugs fixes

**wont update**
- selectize.js - next 0.12.0 includes breaking changes
- sifter.js - only included as a selectize dependency, to pin to a specific version
- microplugin.js - only included as a selectize dependency, to pin to a specific version
- lodash.js - 3.10.1 is latest before going to 4.x.x (breaking changes)
- moment - close to latest, eonasdan-bootstrap-datetimepicker not compatible with newer version of moment, little wary of updating this repo 
- es5-shim - some breaking changes if updated, changelog is unclear 

By 'wont update' I mean for this PR, I'd suggest we consider doing them as individual PRs in future if we want to update them due to potential for breaking changes.

@jwforres @spadgett keeping rest of bower separate from the NPM changes
