### PR TITLE
added cleanup policy for deployments

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -21542,6 +21542,11 @@
       "format": "int32",
       "description": "Replicas is the number of desired replicas."
      },
+     "revisionHistoryLimit": {
+      "type": "integer",
+      "format": "int32",
+      "description": "RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks. This field is a pointer to allow for differentiation between an explicit zero and not specified."
+     },
      "test": {
       "type": "boolean",
       "description": "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action."

--- a/hack/test-kube-e2e.sh
+++ b/hack/test-kube-e2e.sh
@@ -26,7 +26,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ORIGIN_ROOT=$(
+OS_ROOT=$(
   unset CDPATH
   origin_root=$(dirname "${BASH_SOURCE}")/..
   cd "${origin_root}"
@@ -40,7 +40,7 @@ if [ -z "${KUBE_ROOT}" ]; then
   exit 1
 fi
 
-CONF_ROOT="${OS_CONF_ROOT:-${ORIGIN_ROOT}}"
+CONF_ROOT="${OS_CONF_ROOT:-${OS_ROOT}}"
 CONF_PATH="${CONF_ROOT}/openshift.local.config"
 KUBECONFIG="${CONF_PATH}/master/admin.kubeconfig"
 

--- a/pkg/deploy/api/deep_copy_generated.go
+++ b/pkg/deploy/api/deep_copy_generated.go
@@ -170,6 +170,13 @@ func DeepCopy_api_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentC
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	if in.RevisionHistoryLimit != nil {
+		in, out := in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int)
+		**out = *in
+	} else {
+		out.RevisionHistoryLimit = nil
+	}
 	out.Test = in.Test
 	out.Paused = in.Paused
 	if in.Selector != nil {

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -305,6 +305,10 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int32
 
+	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
+	// This field is a pointer to allow for differentiation between an explicit zero and not specified.
+	RevisionHistoryLimit *int
+
 	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
 	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.

--- a/pkg/deploy/api/v1/conversion_generated.go
+++ b/pkg/deploy/api/v1/conversion_generated.go
@@ -331,6 +331,7 @@ func autoConvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *Deploym
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
 	out.Test = in.Test
 	out.Paused = in.Paused
 	out.Selector = in.Selector
@@ -366,6 +367,7 @@ func autoConvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deploy_
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
 	out.Test = in.Test
 	out.Paused = in.Paused
 	out.Selector = in.Selector

--- a/pkg/deploy/api/v1/deep_copy_generated.go
+++ b/pkg/deploy/api/v1/deep_copy_generated.go
@@ -169,6 +169,13 @@ func DeepCopy_v1_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentCo
 		out.Triggers = nil
 	}
 	out.Replicas = in.Replicas
+	if in.RevisionHistoryLimit != nil {
+		in, out := in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int)
+		**out = *in
+	} else {
+		out.RevisionHistoryLimit = nil
+	}
 	out.Test = in.Test
 	out.Paused = in.Paused
 	if in.Selector != nil {

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -82,14 +82,15 @@ func (DeploymentConfigRollbackSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentConfigSpec = map[string]string{
-	"":         "DeploymentConfigSpec represents the desired state of the deployment.",
-	"strategy": "Strategy describes how a deployment is executed.",
-	"triggers": "Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers are defined, a new deployment can only occur as a result of an explicit client update to the DeploymentConfig with a new LatestVersion.",
-	"replicas": "Replicas is the number of desired replicas.",
-	"test":     "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.",
-	"paused":   "Paused indicates that the deployment config is paused resulting in no new deployments on template changes or changes in the template caused by other triggers.",
-	"selector": "Selector is a label query over pods that should match the Replicas count.",
-	"template": "Template is the object that describes the pod that will be created if insufficient replicas are detected.",
+	"":                     "DeploymentConfigSpec represents the desired state of the deployment.",
+	"strategy":             "Strategy describes how a deployment is executed.",
+	"triggers":             "Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers are defined, a new deployment can only occur as a result of an explicit client update to the DeploymentConfig with a new LatestVersion.",
+	"replicas":             "Replicas is the number of desired replicas.",
+	"revisionHistoryLimit": "RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks. This field is a pointer to allow for differentiation between an explicit zero and not specified.",
+	"test":                 "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.",
+	"paused":               "Paused indicates that the deployment config is paused resulting in no new deployments on template changes or changes in the template caused by other triggers.",
+	"selector":             "Selector is a label query over pods that should match the Replicas count.",
+	"template":             "Template is the object that describes the pod that will be created if insufficient replicas are detected.",
 }
 
 func (DeploymentConfigSpec) SwaggerDoc() map[string]string {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -265,6 +265,10 @@ type DeploymentConfigSpec struct {
 	// Replicas is the number of desired replicas.
 	Replicas int32 `json:"replicas"`
 
+	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
+	// This field is a pointer to allow for differentiation between an explicit zero and not specified.
+	RevisionHistoryLimit *int `json:"revisionHistoryLimit,omitempty"`
+
 	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
 	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -10,6 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	unversionedvalidation "k8s.io/kubernetes/pkg/api/unversioned/validation"
 	"k8s.io/kubernetes/pkg/api/validation"
+	kapivalidation "k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	kvalidation "k8s.io/kubernetes/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/util/validation/field"
@@ -37,7 +38,11 @@ func ValidateDeploymentConfigSpec(spec deployapi.DeploymentConfigSpec) field.Err
 	if spec.Template != nil {
 		podSpec = &spec.Template.Spec
 	}
+
 	allErrs = append(allErrs, validateDeploymentStrategy(&spec.Strategy, podSpec, specPath.Child("strategy"))...)
+	if spec.RevisionHistoryLimit != nil {
+		allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(*spec.RevisionHistoryLimit), specPath.Child("revisionHistoryLimit"))...)
+	}
 	if spec.Template == nil {
 		allErrs = append(allErrs, field.Required(specPath.Child("template"), ""))
 	} else {

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -8,12 +8,13 @@ import (
 	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/errors"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 
@@ -142,11 +143,17 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		if !deployutil.IsTerminatedDeployment(latestDeployment) {
 			return c.updateStatus(config, existingDeployments)
 		}
+
 		return c.reconcileDeployments(existingDeployments, config)
 	}
 	// If the config is paused we shouldn't create new deployments for it.
-	// TODO: Make sure cleanup policy will work for paused configs.
 	if config.Spec.Paused {
+		// in order for revision history limit cleanup to work for paused
+		// deployments, we need to trigger it here
+		if err := c.cleanupOldDeployments(existingDeployments, config); err != nil {
+			c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCleanupFailed", "Couldn't clean up deployments: %v", err)
+		}
+
 		return c.updateStatus(config, existingDeployments)
 	}
 	// No deployments are running and the latest deployment doesn't exist, so
@@ -159,13 +166,20 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 	if err != nil {
 		// If the deployment was already created, just move on. The cache could be
 		// stale, or another process could have already handled this update.
-		if errors.IsAlreadyExists(err) {
+		if kapierrors.IsAlreadyExists(err) {
 			return c.updateStatus(config, existingDeployments)
 		}
 		c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCreationFailed", "Couldn't deploy version %d: %s", config.Status.LatestVersion, err)
 		return fmt.Errorf("couldn't create deployment for deployment config %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 	c.recorder.Eventf(config, kapi.EventTypeNormal, "DeploymentCreated", "Created new deployment %q for version %d", created.Name, config.Status.LatestVersion)
+
+	// As we've just created a new deployment, we need to make sure to clean
+	// up old deployments if we have reached our deployment history quota
+	existingDeployments = append(existingDeployments, *created)
+	if err := c.cleanupOldDeployments(existingDeployments, config); err != nil {
+		c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCleanupFailed", "Couldn't clean up deployments: %v", err)
+	}
 
 	return c.updateStatus(config, existingDeployments)
 }
@@ -306,6 +320,12 @@ func (c *DeploymentConfigController) reconcileDeployments(existingDeployments []
 		updatedDeployments = append(updatedDeployments, toAppend)
 	}
 
+	// As the deployment configuration has changed, we need to make sure to clean
+	// up old deployments if we have now reached our deployment history quota
+	if err := c.cleanupOldDeployments(existingDeployments, config); err != nil {
+		c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCleanupFailed", "Couldn't clean up deployments: %v", err)
+	}
+
 	return c.updateStatus(config, updatedDeployments)
 }
 
@@ -385,4 +405,36 @@ func (c *DeploymentConfigController) handleErr(err error, key interface{}) {
 
 	utilruntime.HandleError(err)
 	c.queue.Forget(key)
+}
+
+// cleanupOldDeployments deletes old replication controller deployments if their quota has been reached
+func (c *DeploymentConfigController) cleanupOldDeployments(existingDeployments []kapi.ReplicationController, deploymentConfig *deployapi.DeploymentConfig) error {
+	if deploymentConfig.Spec.RevisionHistoryLimit == nil {
+		// there is no past deplyoment quota set
+		return nil
+	}
+
+	prunableDeployments := deployutil.DeploymentsForCleanup(deploymentConfig, existingDeployments)
+	if len(prunableDeployments) <= *deploymentConfig.Spec.RevisionHistoryLimit {
+		// the past deployment quota has not been exceeded
+		return nil
+	}
+
+	deletionErrors := []error{}
+	for i := 0; i < (len(prunableDeployments) - *deploymentConfig.Spec.RevisionHistoryLimit); i++ {
+		deployment := prunableDeployments[i]
+		if deployment.Spec.Replicas != 0 {
+			// we do not want to clobber active older deployments, but we *do* want them to count
+			// against the quota so that they will be pruned when they're scaled down
+			continue
+		}
+
+		err := c.rn.ReplicationControllers(deployment.Namespace).Delete(deployment.Name)
+		if err != nil && !kapierrors.IsNotFound(err) {
+			glog.V(2).Infof("Failed deleting old Replication Controller %q for Deployment Config %q: %v", deployment.Name, deploymentConfig.Name, err)
+			deletionErrors = append(deletionErrors, err)
+		}
+	}
+
+	return kutilerrors.NewAggregate(deletionErrors)
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -35,7 +35,14 @@ func LatestDeploymentInfo(config *deployapi.DeploymentConfig, deployments []api.
 // ActiveDeployment returns the latest complete deployment, or nil if there is
 // no such deployment. The active deployment is not always the same as the
 // latest deployment.
-func ActiveDeployment(config *deployapi.DeploymentConfig, deployments []api.ReplicationController) *api.ReplicationController {
+func ActiveDeployment(config *deployapi.DeploymentConfig, input []api.ReplicationController) *api.ReplicationController {
+	// we need to create our own copy of the input slice so that our sort here
+	// doesn't change the caller's slice
+	var deployments []api.ReplicationController
+	for _, deployment := range input {
+		deployments = append(deployments, deployment)
+	}
+
 	sort.Sort(ByLatestVersionDesc(deployments))
 	var activeDeployment *api.ReplicationController
 	for _, deployment := range deployments {
@@ -388,6 +395,37 @@ func int32AnnotationFor(obj runtime.Object, key string) (int32, bool) {
 		return 0, false
 	}
 	return int32(i), true
+}
+
+// DeploymentsForCleanup determines which deployments for a configuration are relevant for the
+// revision history limit quota
+func DeploymentsForCleanup(configuration *deployapi.DeploymentConfig, deployments []api.ReplicationController) []api.ReplicationController {
+	// if the past deployment quota has been exceeded, we need to prune the oldest deployments
+	// until we are not exceeding the quota any longer, so we sort oldest first
+	sort.Sort(ByLatestVersionAsc(deployments))
+
+	relevantDeployments := []api.ReplicationController{}
+	activeDeployment := ActiveDeployment(configuration, deployments)
+	if activeDeployment == nil {
+		// if cleanup policy is set but no successful deployments have happened, there will be
+		// no active deployment. We can consider all of the deployments in this case except for
+		// the latest one
+		for _, deployment := range deployments {
+			if DeploymentVersionFor(&deployment) != configuration.Status.LatestVersion {
+				relevantDeployments = append(relevantDeployments, deployment)
+			}
+		}
+	} else {
+		// if there is an active deployment, we need to filter out any deployments that we don't
+		// care about, namely the active deployment and any newer deployments
+		for _, deployment := range deployments {
+			if &deployment != activeDeployment || DeploymentVersionFor(&deployment) < DeploymentVersionFor(activeDeployment) {
+				relevantDeployments = append(relevantDeployments, deployment)
+			}
+		}
+	}
+
+	return relevantDeployments
 }
 
 // ByLatestVersionAsc sorts deployments by LatestVersion ascending.

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -288,3 +288,7 @@ func createFixture(oc *exutil.CLI, fixture string) (string, string, error) {
 	}
 	return resource, parts[1], nil
 }
+
+func checkDeploymentConfigHasSynced(dc *deployapi.DeploymentConfig, _ []kapi.ReplicationController, _ []kapi.Pod) (bool, error) {
+	return deployutil.HasSynced(dc), nil
+}

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -34,8 +34,7 @@ function os::test::extended::setup {
   if [[ -z $(os::build::find-binary openshift) ]]; then
     hack/build-go.sh
   fi
-
-  source "${OS_ROOT}/hack/lib/util/environment.sh"
+  
   os::util::environment::setup_time_vars
 
   # ensure proper relative directories are set

--- a/test/extended/testdata/deployment-history-limit.yaml
+++ b/test/extended/testdata/deployment-history-limit.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: history-limit
+spec:
+  replicas: 1
+  selector:
+    name: history-limit
+  strategy:
+    type: Rolling
+    rollingParams:
+      pre:
+        failurePolicy: Abort
+        execNewPod:
+          containerName: myapp
+          command:
+          - /bin/echo
+          - test pre hook executed
+  template:
+    metadata:
+      labels:
+        name: history-limit
+    spec:
+      containers:
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        command:
+        - /bin/sleep
+        - "100"
+  triggers:
+  - type: ConfigChange
+  revisionHistoryLimit: 3


### PR DESCRIPTION
This PR adds past deployment cleanup to the `DeploymentController` which ensures that we don't have too many replication controllers lying around after deployment configurations evolve.

fixes https://github.com/openshift/origin/issues/6731
/cc https://bugzilla.redhat.com/show_bug.cgi?id=1312433
Part of https://trello.com/c/Mljldox7/643-5-deployments-downstream-support-for-upstream-features

@kargakis @deads2k PTAL