### PR TITLE
Increase default web console line limit to 5000

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -258,7 +258,7 @@ angular.module('openshiftConsole')
 
               var options = angular.extend({
                 follow: true,
-                tailLines: 1000,
+                tailLines: 5000,
                 limitBytes: 10 * 1024 * 1024 // Limit log size to 10 MiB
               }, $scope.options);
 

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -23,7 +23,7 @@
 
 <div ng-if="largeLog" class="alert alert-info log-size-warning">
   <span class="pficon pficon-info" aria-hidden="true"></span>
-  Only the previous {{options.tailLines || 1000}} log lines and new log
+  Only the previous {{options.tailLines || 5000}} log lines and new log
   messages will be displayed because of the large log size.
 </div>
 


### PR DESCRIPTION
Many build logs can exceed the previous default  web console 1000 line limit, particularly those that install dependencies (npm, Maven). Increase the limit to 5000.

@jwforres @sspeiche 