### PR TITLE
Update yaml.js to latest, official version

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -123,7 +123,7 @@
     <script src="bower_components/ace-builds/src-min-noconflict/theme-dreamweaver.js"></script>
     <script src="bower_components/ace-builds/src-min-noconflict/theme-eclipse.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
-    <script src="bower_components/yamljs/bin/yaml.js"></script>
+    <script src="bower_components/yamljs/dist/yaml.js"></script>
     <script src="bower_components/clipboard/dist/clipboard.js"></script>
     <script src="bower_components/pathseg/pathseg.js"></script>
     <script src="bower_components/ansi_up/ansi_up.js"></script>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -33,9 +33,9 @@
     "bootstrap-hover-dropdown": "2.1.3",
     "angular-ui-ace": "0.2.3",
     "ace-builds": "1.2.2",
-    "yamljs": "0.1.5",
+    "yamljs": "jeremyfa/yaml.js#0.2.7",
     "clipboard": "1.5.8",
-    "pathseg": "1.0.2",   
+    "pathseg": "1.0.2",
     "ansi_up": "1.3.0",
     "angular-extension-registry": "1.2.6",
     "ng-sortable": "1.3.4",
@@ -91,11 +91,6 @@
         "src-min-noconflict/mode-yaml.js",
         "src-min-noconflict/theme-dreamweaver.js",
         "src-min-noconflict/theme-eclipse.js"
-      ]
-    },
-    "yamljs": {
-      "main": [
-        "bin/yaml.js"
       ]
     }
   }


### PR DESCRIPTION
We were unknowingly picking up a yaml.js fork (klederson/yaml.js) that registered bower support rather than the official repository (jeremyfa/yaml.js). The fork is a very old version that doesn't parse some valid YAML.

Use the latest from jeremyfa/yaml.js.

@jwforres @jhadvig 