### PR TITLE
Additional web console updates for JenkinsPipeline strategy

### DIFF
--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -31,7 +31,8 @@ angular.module('openshiftConsole')
         "displayName":              ["openshift.io/display-name"],
         "description":              ["openshift.io/description"],
         "buildNumber":              ["openshift.io/build.number"],
-        "buildPod":                 ["openshift.io/build.pod-name"]
+        "buildPod":                 ["openshift.io/build.pod-name"],
+        "jenkinsLogURL":            ["openshift.io/jenkins-log-url"]
       };
       return annotationMap[annotationKey] || null;
     };
@@ -810,6 +811,32 @@ angular.module('openshiftConsole')
         default:
           return null;
       }
+    };
+  })
+  .filter('isJenkinsPipelineStrategy', function() {
+    return function(/* build or build config */ resource) {
+      return _.get(resource, 'spec.strategy.type') === 'JenkinsPipeline';
+    };
+  })
+  .filter('jenkinsLogURL', function(annotationFilter) {
+    return function(build) {
+      return annotationFilter(build, 'jenkinsLogURL');
+    };
+  })
+  .filter('buildLogURL', function(isJenkinsPipelineStrategyFilter,
+                                  jenkinsLogURLFilter,
+                                  navigateResourceURLFilter) {
+    return function(build) {
+      if (isJenkinsPipelineStrategyFilter(build)) {
+        return jenkinsLogURLFilter(build);
+      }
+
+      var navURL = navigateResourceURLFilter(build);
+      if (!navURL) {
+        return null;
+      }
+
+      return new URI(navURL).addSearch('tab', 'logs').toString();
     };
   })
   .filter('humanizeKind', function (startCaseFilter) {

--- a/assets/app/scripts/services/builds.js
+++ b/assets/app/scripts/services/builds.js
@@ -70,15 +70,18 @@ angular.module("openshiftConsole")
       DataService.create("builds/clone", buildName, req, context).then(
         function(build) { //success
             $scope.alerts = $scope.alerts || {};
-            $scope.alerts["rebuild"] =
-            {
+            var logLink = $filter('buildLogURL')(build);
+            var alert = {
               type: "success",
-              message: "Build " + buildName + " is being rebuilt as " + build.metadata.name + ".",
-              links: [{
-                href: $filter('navigateResourceURL')(build) + "?tab=logs",
-                label: "View Log"
-              }]
+              message: "Build " + buildName + " is being rebuilt as " + build.metadata.name + "."
             };
+            if (logLink) {
+              alert.links = [{
+                href: logLink,
+                label: "View Log"
+              }];
+            }
+            $scope.alerts["rebuild"] = alert;
         },
         function(result) { //failure
           $scope.alerts = $scope.alerts || {};

--- a/assets/app/views/_triggers.html
+++ b/assets/app/views/_triggers.html
@@ -30,12 +30,8 @@
             </span>
           </span>
         </span>
-        <a
-          ng-if="!!['New', 'Pending'].indexOf(build.status.phase)"
-          ng-href="{{build | navigateResourceURL}}?tab=logs">
-          View Log
-        </a>
-        <span class="action-divider" ng-show="!!['New', 'Pending'].indexOf(build.status.phase) && !(build | isIncompleteBuild)">|</span>
+        <a ng-if="!!['New', 'Pending'].indexOf(build.status.phase) && (build | buildLogURL)" ng-href="{{build | buildLogURL}}">View Log</a>
+        <span class="action-divider" ng-show="!!['New', 'Pending'].indexOf(build.status.phase) && (build | buildLogURL) && !(build | isIncompleteBuild)">|</span>
         <a ng-hide="build | isIncompleteBuild" href="" ng-click="hideBuild(build)">Dismiss</a>
       </div>
     </div>

--- a/assets/app/views/browse/_build-details.html
+++ b/assets/app/views/browse/_build-details.html
@@ -7,12 +7,16 @@
         <dd>
           <status-icon status="build.status.phase"></status-icon>
           {{build.status.phase}}
+          <span ng-if="build | jenkinsLogURL">
+            <span class="text-muted">&ndash;</span>
+            <a ng-href="{{build | jenkinsLogURL}}">View Log</a>
+          </span>
         </dd>
         <dt>Started:</dt>
         <dd>
           <span ng-if="build.status.startTimestamp">
             <relative-timestamp timestamp="build.status.startTimestamp"></relative-timestamp>
-            <span>- {{build.status.startTimestamp | date : 'short'}}</span>
+            <span><span class="text-muted">&ndash;</span> {{build.status.startTimestamp | date : 'short'}}</span>
           </span>
           <span ng-if="!build.status.startTimestamp"><em>not started</em></span>
         </dd>
@@ -34,9 +38,9 @@
       <h3>Configuration <span class="small" ng-if="buildConfigName">created from <a href="{{buildConfigName | navigateResourceURL : 'BuildConfig' : build.metadata.namespace}}">{{buildConfigName}}</a></span></h3>
       <dl class="dl-horizontal left">
         <dt>Build strategy:</dt>
-        <dd>{{build.spec.strategy.type}}</dd>
-        <dt>Builder image:</dt>
-        <dd class="truncate">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}<span ng-if="!(build | buildStrategy).from"><em>none</em></span></dd>
+        <dd>{{build.spec.strategy.type | startCase}}</dd>
+        <dt ng-if-start="(build | buildStrategy).from">Builder image:</dt>
+        <dd ng-if-end class="truncate">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}<span ng-if="!(build | buildStrategy).from"><em>none</em></span></dd>
         <dt>Source type:</dt>
         <dd>{{build.spec.source.type}}</dd>
         <dt ng-if-start="build.spec.source.git.uri">Source repo:</dt>
@@ -49,6 +53,27 @@
         <dd ng-if-end>{{build.spec.output.to | imageObjectRef : build.metadata.namespace}}</dd>
         <dt ng-if-start="build.spec.output.pushSecret.name">Push secret:</dt>
         <dd ng-if-end>{{build.spec.output.pushSecret.name}}</dd>
+        <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
+          Jenkinsfile Path:
+        </dt>
+        <dd ng-if-end>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>
+        <dt ng-if-start="build.spec.strategy.jenkinsPipelineStrategy.jenkinsfile">
+          Jenkinsfile:
+        </dt>
+        <dd></dd>
+        <div ng-if-end ui-ace="{
+          mode: 'groovy',
+          theme: 'eclipse',
+          showGutter: false,
+          rendererOptions: {
+            fadeFoldWidgets: true,
+            highlightActiveLine: false,
+            showPrintMargin: false
+          },
+          advanced: {
+            highlightActiveLine: false
+          }
+        }" readonly ng-model="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfile" class="ace-bordered ace-inline ace-read-only mar-top-md"></div>
       </dl>
     </div>
   </div>

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -117,7 +117,7 @@
                             <span ng-switch-default>is {{latestBuild.status.phase | lowercase}}.</span>
                           </span>
                         </span>
-                        <a ng-href="{{latestBuild | navigateResourceURL}}?tab=logs">View Log</a>
+                        <a ng-href="{{build | buildLogURL}}" ng-if="build | buildLogURL">View Log</a>
                       </div>
                       <div class="latest-build-timestamp meta text-muted">
                         <span ng-if="!latestBuild.status.startTimestamp">
@@ -246,7 +246,7 @@
                                   <dt ng-if="buildConfig.spec.source.contextDir">Source context dir:</dt>
                                   <dd ng-if="buildConfig.spec.source.contextDir">{{buildConfig.spec.source.contextDir}}</dd>
                                 </div>
-                                <div ng-if="buildConfig.spec.strategy.type === 'JenkinsPipeline'">
+                                <div ng-if="buildConfig | isJenkinsPipelineStrategy">
                                   <div ng-if="buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath">
                                     <dt>Jenkinsfile Path:</dt>
                                     <dd>{{buildConfig.spec.strategy.jenkinsPipelineStrategy.jenkinsfilePath}}</dd>
@@ -356,7 +356,7 @@
                       <annotations annotations="buildConfig.metadata.annotations"></annotations>
                     </div>
                   </uib-tab>
-                  <uib-tab heading="Environment" active="selectedTab.environment" ng-if="buildConfig">
+                  <uib-tab heading="Environment" active="selectedTab.environment" ng-if="buildConfig && !(buildConfig | isJenkinsPipelineStrategy)">
                     <uib-tab-heading>Environment</uib-tab-heading>
                     <environment env-vars="(buildConfig | buildStrategy).env"></environment>
                     <em ng-if="!(buildConfig | buildStrategy).env">The build strategy had no environment variables defined.</em>

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -88,13 +88,13 @@
                       <ng-include src=" 'views/browse/_build-details.html' "></ng-include>
                     </uib-tab>
 
-                    <uib-tab heading="Environment" active="selectedTab.environment">
+                    <uib-tab heading="Environment" active="selectedTab.environment" ng-if="!(build | isJenkinsPipelineStrategy)">
                       <uib-tab-heading>Environment</uib-tab-heading>
                       <environment env-vars="(build | buildStrategy).env"></environment>
                       <em ng-if="!(build | buildStrategy).env">The build strategy had no environment variables defined.</em>
                     </uib-tab>
 
-                    <uib-tab active="selectedTab.logs">
+                    <uib-tab active="selectedTab.logs" ng-if="!(build | isJenkinsPipelineStrategy)">
                       <uib-tab-heading>Logs</uib-tab-heading>
                       <log-viewer
                         ng-if="selectedTab.logs"

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -44,8 +44,8 @@
                     <td data-title="Last Build"><em>No builds</em></td>
                     <td class="hidden-xs">&nbsp;</td>
                     <td class="hidden-xs">&nbsp;</td>
-                    <td data-title="Type">{{buildConfigs[buildConfigName].spec.strategy.type}}</td>
-                    <td data-title="Source">                        
+                    <td data-title="Type">{{buildConfigs[buildConfigName].spec.strategy.type | startCase}}</td>
+                    <td data-title="Source">
                       <span ng-if="buildConfigs[buildConfigName].spec.source.type == 'None'"><i>none</i></span>
                       <span ng-if="buildConfigs[buildConfigName].spec.source.type == 'Git'" ng-bind-html='buildConfigs[buildConfigName].spec.source.git.uri | githubLink : buildConfigs[buildConfigName].spec.source.git.ref : buildConfigs[buildConfigName].spec.source.contextDir | linky'></span></td>
                   </tr>
@@ -94,7 +94,7 @@
                       <relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp>
                       <span>- {{build.metadata.creationTimestamp | date : 'short'}}</span>
                     </td>
-                    <td data-title="Type">{{build.spec.strategy.type}}</td>
+                    <td data-title="Type">{{build.spec.strategy.type | startCase}}</td>
                     <td data-title="Source" class="word-break-all">
                       <span ng-if="build.spec.source">
                         <span ng-if="build.spec.source.type == 'None'">

--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -142,7 +142,7 @@
                             </div>
                           </div>
 
-                          <div ng-if="updatedBuildConfig.spec.strategy.type === 'JenkinsPipeline'">
+                          <div ng-if="updatedBuildConfig | isJenkinsPipelineStrategy">
                             <h3>Jenkins Pipeline Configuration</h3>
                             <div class="form-group">
                               <label for="jenkinsfile-type">Jenkinsfile Type</label>
@@ -507,7 +507,7 @@
 
 
                     <div class="col-lg-6">
-                      <div ng-if="updatedBuildConfig.spec.strategy.type !== 'JenkinsPipeline'" class="section">
+                      <div ng-if="!(updatedBuildConfig | isJenkinsPipelineStrategy)" class="section">
                         <h3>Environment Variables<span class="help action-inline">
                           <a href>
                           <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Environment variables are used to configure and pass information to running containers.  These environment variables will be available during your build and at runtime."></i>
@@ -562,7 +562,7 @@
                               </label>
                             </div>
 
-                            <div ng-if="updatedBuildConfig.spec.strategy.type !== 'JenkinsPipeline'" class="checkbox">
+                            <div ng-if="!(updatedBuildConfig | isJenkinsPipelineStrategy)" class="checkbox">
                               <label>
                                 <input type="checkbox" ng-model="triggers.present.imageChange" ng-disabled="builderOptions.pickedType === 'None'"/>
                                   Automatically build a new image when the builder image changes


### PR DESCRIPTION
* Environment is not used for JenkinsPipeline builds, so remove the tab from the UI.
* Logs currently are in Jenkins. Remove the Build Logs tab for now (until we can provide native support).
* Add links to the log in Jenkins where appropriate.
* Show the Jenkinsfile or Jenkinsfilepath on the browse build page.
* Consistently start case the strategy name.

@jwforres @bparees