### PR TITLE
default the volume type

### DIFF
--- a/pkg/cmd/cli/cmd/set/volume.go
+++ b/pkg/cmd/cli/cmd/set/volume.go
@@ -237,11 +237,22 @@ func (v *VolumeOptions) Validate(args []string) error {
 
 func (a *AddVolumeOptions) Validate(isAddOp bool) error {
 	if isAddOp {
+		if len(a.MountPath) == 0 {
+			return errors.New("must provide --mount-path for --add operation")
+		}
+
 		if len(a.Type) == 0 && (len(a.ClaimName) > 0 || len(a.ClaimSize) > 0) {
 			a.Type = "persistentvolumeclaim"
 			a.TypeChanged = true
 		}
-
+		if len(a.Type) == 0 && (len(a.SecretName) > 0) {
+			a.Type = "secret"
+			a.TypeChanged = true
+		}
+		if len(a.Type) == 0 && (len(a.Path) > 0) {
+			a.Type = "hostpath"
+			a.TypeChanged = true
+		}
 		if len(a.Type) == 0 {
 			a.Type = "emptydir"
 		}

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -28,12 +28,13 @@ os::cmd::expect_success_and_text 'oc volume dc/test-deployment-config --list' 'v
 os::cmd::expect_success 'oc volume dc/test-deployment-config --add --name=vol0 -m /opt5'
 os::cmd::expect_success 'oc set volume dc/test-deployment-config --add --name=vol2 --type=emptydir -m /opt'
 os::cmd::expect_failure_and_text "oc set volume dc/test-deployment-config --add --name=vol1 --type=secret --secret-name='\$ecret' -m /data" 'overwrite to replace'
+os::cmd::expect_success "oc set volume dc/test-deployment-config --add --name=vol10 --secret-name='my-secret' -m /data-2"
 os::cmd::expect_success 'oc set volume dc/test-deployment-config --add --name=vol1 --type=emptyDir -m /data --overwrite'
 os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --add -m /opt' "'/opt' already exists"
 os::cmd::expect_success_and_text "oc set volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby' --overwrite" 'does not have any containers'
 os::cmd::expect_success "oc set volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby*' --overwrite"
 os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --list --name=vol2' 'mounted at /etc'
-os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --add --name=vol3 -o yaml' 'name: vol3'
+os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --add --name=vol3 -m=/anywhere -o yaml' 'name: vol3'
 os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --list --name=vol3' 'volume "vol3" not found'
 os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --remove' 'confirm for removing more than one volume'
 os::cmd::expect_success 'oc set volume dc/test-deployment-config --remove --name=vol2'


### PR DESCRIPTION
If I type `oc set volumes dc/my-nginx --add --secret-name=nginx-ssl-key`, the type should be secret.  I shouldn't have to say it.

@fabianofranz 