### PR TITLE
Show/edit run policy for a BuildConfig

### DIFF
--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -49,10 +49,10 @@ angular.module('openshiftConsole')
     };
 
     var updateCanBuild = function() {
-      if (!$scope.buildConfig || !$scope.buildConfigBuildsInProgress) {
+      if (!$scope.buildConfig) {
         $scope.canBuild = false;
       } else {
-        $scope.canBuild = BuildsService.canBuild($scope.buildConfig, $scope.buildConfigBuildsInProgress);
+        $scope.canBuild = BuildsService.canBuild($scope.buildConfig);
       }
     };
 
@@ -128,20 +128,6 @@ angular.module('openshiftConsole')
           if (build) {
             buildConfigName = build.metadata.labels.buildconfig;
             buildName = build.metadata.name;
-          }
-
-          if (!action) {
-            // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
-            $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.builds);
-          } else if (action === 'ADDED'){
-            // When new build id instantiated/cloned associate him to his buildConfig and add him into buildConfigBuildsInProgress structure.
-            $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
-            $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-          } else if (action === 'MODIFIED'){
-            // After the build ends remove him from the buildConfigBuildsInProgress structure.
-            if (!$filter('isIncompleteBuild')(build)){
-              delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-            }
           }
 
           updateCanBuild();

--- a/assets/app/scripts/controllers/buildConfig.js
+++ b/assets/app/scripts/controllers/buildConfig.js
@@ -37,15 +37,6 @@ angular.module('openshiftConsole')
     };
 
     var orderByDate = $filter('orderObjectsByDate');
-
-    var updateCanBuild = function() {
-      if (!$scope.buildConfig || !$scope.buildConfigBuildsInProgress) {
-        $scope.canBuild = false;
-      } else {
-        $scope.canBuild = BuildsService.canBuild($scope.buildConfig, $scope.buildConfigBuildsInProgress);
-      }
-    };
-
     var watches = [];
 
     ProjectsService
@@ -59,7 +50,6 @@ angular.module('openshiftConsole')
             $scope.loaded = true;
             $scope.buildConfig = buildConfig;
             $scope.paused = BuildsService.isPaused($scope.buildConfig);
-            updateCanBuild();
 
             if ($scope.buildConfig.spec.source.images) {
               $scope.imageSources = $scope.buildConfig.spec.source.images;
@@ -79,64 +69,7 @@ angular.module('openshiftConsole')
               }
               $scope.buildConfig = buildConfig;
               $scope.paused = BuildsService.isPaused($scope.buildConfig);
-              updateCanBuild();
             }));
-
-
-            watches.push(DataService.watch("builds", context, function(builds, action, build) {
-              $scope.emptyMessage = "No builds to show";
-              // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
-              // to only load the buildconfig's builds, but this requires some DataService changes
-              if (!action) {
-                $scope.unfilteredBuilds = builds.by("metadata.name");
-
-                // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
-                $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.unfilteredBuilds);
-              } else if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
-                var buildName = build.metadata.name;
-                var buildConfigName = $routeParams.buildconfig;
-                switch (action) {
-                  case 'ADDED':
-                  case 'MODIFIED':
-                    $scope.unfilteredBuilds[buildName] = build;
-                    // After the build ends remove him from the buildConfigBuildsInProgress structure.
-                    if ($filter('isIncompleteBuild')(build)){
-                      $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
-                      $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-                    } else if ($scope.buildConfigBuildsInProgress[buildConfigName]) {
-                      delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-                    }
-                    break;
-                  case 'DELETED':
-                    delete $scope.unfilteredBuilds[buildName];
-                    if ($scope.buildConfigBuildsInProgress[buildConfigName]){
-                      delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-                    }
-                    break;
-                }
-              }
-
-              $scope.builds = LabelFilter.getLabelSelector().select($scope.unfilteredBuilds);
-              updateCanBuild();
-              updateFilterWarning();
-              LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
-              LabelFilter.setLabelSuggestions($scope.labelSuggestions);
-
-              // Sort now to avoid sorting on every digest loop.
-              $scope.orderedBuilds = orderByDate($scope.builds, true);
-              $scope.latestBuild = $scope.orderedBuilds.length ? $scope.orderedBuilds[0] : null;
-            },
-            // params object for filtering
-            {
-              // http is passed to underlying $http calls
-              http: {
-                params: {
-                  labelSelector: 'buildconfig='+$scope.buildConfigName
-                }
-              }
-            }));
-
-
           },
           // failure
           function(e) {
@@ -149,8 +82,41 @@ angular.module('openshiftConsole')
           }
         );
 
+      watches.push(DataService.watch("builds", context, function(builds, action, build) {
+        $scope.emptyMessage = "No builds to show";
+        if (!action) {
+          $scope.unfilteredBuilds = builds.by("metadata.name");
+        } else if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
+          var buildName = build.metadata.name;
+          switch (action) {
+            case 'ADDED':
+            case 'MODIFIED':
+              $scope.unfilteredBuilds[buildName] = build;
+              break;
+            case 'DELETED':
+              delete $scope.unfilteredBuilds[buildName];
+              break;
+          }
+        }
 
+        $scope.builds = LabelFilter.getLabelSelector().select($scope.unfilteredBuilds);
+        updateFilterWarning();
+        LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
+        LabelFilter.setLabelSuggestions($scope.labelSuggestions);
 
+        // Sort now to avoid sorting on every digest loop.
+        $scope.orderedBuilds = orderByDate($scope.builds, true);
+        $scope.latestBuild = $scope.orderedBuilds.length ? $scope.orderedBuilds[0] : null;
+      },
+      // params object for filtering
+      {
+        // http is passed to underlying $http calls
+        http: {
+          params: {
+            labelSelector: 'buildconfig='+$scope.buildConfigName
+          }
+        }
+      }));
 
         function updateFilterWarning() {
           if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.builds) && !$.isEmptyObject($scope.unfilteredBuilds)) {
@@ -175,17 +141,7 @@ angular.module('openshiftConsole')
         });
 
         $scope.startBuild = function() {
-          if ($scope.canBuild) {
-            BuildsService.startBuild($scope.buildConfig.metadata.name, context, $scope);
-          }
-        };
-
-        $scope.cancelBuild = function(build, buildConfigName) {
-          BuildsService.cancelBuild(build, buildConfigName, context, $scope);
-        };
-
-        $scope.cloneBuild = function(buildName) {
-          BuildsService.cloneBuild(buildName, context, $scope);
+          BuildsService.startBuild($scope.buildConfig.metadata.name, context, $scope);
         };
 
         $scope.$on('$destroy', function(){

--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -47,19 +47,6 @@ angular.module('openshiftConsole')
             buildConfigName = build.metadata.labels.buildconfig;
             buildName = build.metadata.name;
           }
-          if (!action) {
-            // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
-            $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.builds);
-          } else if (action === 'ADDED'){
-            // When new build id instantiated/cloned associate him to his buildConfig and add him into buildConfigBuildsInProgress structure.
-            $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
-            $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-          } else if (action === 'MODIFIED'){
-            // After the build ends remove him from the buildConfigBuildsInProgress structure.
-            if (!$filter('isIncompleteBuild')(build) && $scope.buildConfigBuildsInProgress[buildConfigName]){
-              delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-            }
-          }
 
           // Scroll to anchor on first load if location has a hash.
           if (!action && $location.hash()) {

--- a/assets/app/scripts/controllers/edit/buildConfig.js
+++ b/assets/app/scripts/controllers/edit/buildConfig.js
@@ -107,6 +107,11 @@ angular.module('openshiftConsole')
       builderImageChangeTrigger: {},
       imageChangeTriggers: []
     };
+    $scope.runPolicyTypes = [
+      "Serial",
+      "Parallel",
+      "SerialLatestOnly"
+    ];
     $scope.availableProjects = [];
 
     AlertMessageService.getAlerts().forEach(function(alert) {

--- a/assets/app/scripts/services/builds.js
+++ b/assets/app/scripts/services/builds.js
@@ -95,33 +95,16 @@ angular.module("openshiftConsole")
       );
     };
 
-    BuildsService.prototype.associateRunningBuildToBuildConfig = function(builds) {
-      var buildConfigBuildsInProgress = {};
-      angular.forEach(builds, function(build, buildName) {
-        if ($filter('isIncompleteBuild')(build)) {
-          var buildConfigName = build.metadata.labels.buildconfig;
-          buildConfigBuildsInProgress[buildConfigName] = buildConfigBuildsInProgress[buildConfigName] || {};
-          buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-        }
-      });
-      return buildConfigBuildsInProgress;
-    };
-
     BuildsService.prototype.isPaused = function(buildConfig) {
       return $filter('annotation')(buildConfig, "openshift.io/build-config.paused") === 'true';
     };
 
-    BuildsService.prototype.canBuild = function(buildConfig, buildConfigBuildsInProgressMap) {
+    BuildsService.prototype.canBuild = function(buildConfig) {
       if (!buildConfig) {
         return false;
       }
 
       if (buildConfig.metadata.deletionTimestamp) {
-        return false;
-      }
-
-      if (buildConfigBuildsInProgressMap &&
-          $filter('hashSize')(buildConfigBuildsInProgressMap[buildConfig.metadata.name]) > 0) {
         return false;
       }
 

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -20,8 +20,7 @@
                 <!-- Primary Actions -->
                 <button
                     class="btn btn-default hidden-xs"
-                    ng-click="startBuild()"
-                    ng-disabled="!canBuild">
+                    ng-click="startBuild()">
                   Start Build
                 </button>
 
@@ -34,11 +33,9 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
-                  <li class="visible-xs-inline" ng-class="{ disabled: !canBuild }">
+                  <li class="visible-xs-inline">
                     <a href=""
                       role="button"
-                      ng-attr-aria-disabled="{{canBuild ? undefined : 'true'}}"
-                      ng-class="{ 'disabled-link': !canBuild }"
                       ng-click="startBuild()">Start Build</a>
                   </li>
                   <li>
@@ -299,6 +296,20 @@
                               <div ng-if="buildConfig.spec.output.to">
                                 <dt>Output to:</dt>
                                 <dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>
+                              </div>
+                              <div class="run-policy">
+                                <dt>Run Policy:</dt>
+                                <dd>
+                                  {{buildConfig.spec.runPolicy | sentenceCase}}
+                                  <span class="help action-inline">
+                                    <a href ng-switch="buildConfig.spec.runPolicy">
+                                      <i ng-switch-when="Serial" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered."></i>
+                                      <i ng-switch-when="Parallel" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed."></i>
+                                      <i ng-switch-when="SerialLatestOnly" class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled."></i>
+                                      <i ng-switch-default class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="Builds triggered from this Build Configuration will run using the {{buildConfig.spec.runPolicy | sentenceCase}} policy."></i>
+                                    </a>
+                                  </span>
+                                </dd>
                               </div>
                             </dl>
                           </div>

--- a/assets/app/views/edit/build-config.html
+++ b/assets/app/views/edit/build-config.html
@@ -578,6 +578,28 @@
                           </div>
                         </dl>
                       </div>
+                      <div class="section">
+                        <h3>Run Policy
+                          <span class="help action-inline">
+                            <a href>
+                              <i class="pficon pficon-help" data-toggle="tooltip" aria-hidden="true" data-original-title="The build run policy describes the order in which the builds created from the build configuration should run."></i>
+                            </a>
+                          </span>
+                        </h3>
+                        <div class="form-group">
+                          <select
+                            class="form-control"
+                            ng-model="updatedBuildConfig.spec.runPolicy"
+                            ng-options="type as (type | sentenceCase) for type in runPolicyTypes">
+                          </select>
+                        </div>
+                        <div ng-switch="updatedBuildConfig.spec.runPolicy">
+                          <div ng-switch-when="Serial">Builds triggered from this Build Configuration will run one at the time, in the order they have been triggered.</div>
+                          <div ng-switch-when="Parallel">Builds triggered from this Build Configuration will run all at the same time. The order in which they will finish is not guranteed.</div>
+                          <div ng-switch-when="SerialLatestOnly">Builds triggered from this Build Configuration will run one at the time. When a currently running build completes, the next build that will run is the latest build created. Other queued builds will be cancelled.</div>
+                          <div ng-switch-default>Builds triggered from this Build Configuration will run using the {{updatedBuildConfig.spec.runPolicy | sentenceCase}} policy.</div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                   <div class="buttons gutter-top-bottom">


### PR DESCRIPTION
Based on https://trello.com/c/qVzqRo0t/654
Things we want:
- show/edit buildConfigs `runPolicy` 
- get rid of disabling `Start Build` and `Rebuild` buttons (based on https://github.com/openshift/origin/issues/8510)

Things we might want:
- bulk actions on BCs - start-build
- bulk actions on Builds - rebuild, cancel-build

Preview of showing BS's runPolicy:
![screenshot-34](https://cloud.githubusercontent.com/assets/1668218/14984206/d6cf281a-1141-11e6-98a5-65ddde535aec.png)
![screenshot-35](https://cloud.githubusercontent.com/assets/1668218/14984196/c6190d4c-1141-11e6-9898-0d0eea2af252.png)


And here are couple of drafts for the BC's edit page. In here I've created a separate section, since it wouldnt make sense to have the `runPolicy` in any of the other section(source config., image config.,) :
1. dropdown with a description under
![screenshot-31](https://cloud.githubusercontent.com/assets/1668218/14984261/0c8fd9f4-1142-11e6-9536-e4695b31d07b.png)
2. dropdown with a italic description under
![screenshot-30](https://cloud.githubusercontent.com/assets/1668218/14984286/2ea537d2-1142-11e6-9339-78d6b70ef483.png)
3. radio buttons with tooltip for description
![screenshot-33](https://cloud.githubusercontent.com/assets/1668218/14984297/3b28a0b6-1142-11e6-8342-290ace000efe.png)


Drafts 1 and 2 contain tooltip next to the section header that says `The build run policy describes the order in which the builds created from the build configuration should run`. Draft 3 wont have the scetion header tooltip just a tooltip to each radio button, explaining the given runPolicy type.

Also I've haven't done any effort to show the `runPolicy` type for the build show page, since the type is a part of the build labels and those we are already listing, so I think thats enough.

@jwforres @spadgett PTAL. We also need to align on whether we want to have the bulk actions I've described at the top. I think they could come really handy, mainly the bulk cancellation of builds.
Thoughts ?  

