### PR TITLE
[RPMS] Improve default permissions

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -320,7 +320,7 @@ install -p -m 644 contrib/completions/bash/* %{buildroot}%{_sysconfdir}/bash_com
 %{_sysconfdir}/bash_completion.d/atomic-enterprise
 %{_sysconfdir}/bash_completion.d/oadm
 %{_sysconfdir}/bash_completion.d/openshift
-%defattr(0700,-,-)
+%defattr(-,root,root,0700)
 %dir %config(noreplace) %{_sysconfdir}/origin
 %ghost %dir %config(noreplace) %{_sysconfdir}/origin
 %ghost %config(noreplace) %{_sysconfdir}/origin/.config_managed
@@ -346,7 +346,7 @@ fi
 %files master
 %{_unitdir}/%{name}-master.service
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-master
-%defattr(0700,-,-)
+%defattr(-,root,root,0700)
 %config(noreplace) %{_sysconfdir}/origin/master
 %ghost %config(noreplace) %{_sysconfdir}/origin/admin.crt
 %ghost %config(noreplace) %{_sysconfdir}/origin/admin.key
@@ -401,7 +401,7 @@ fi
 %files node
 %{_unitdir}/%{name}-node.service
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-node
-%defattr(0700,-,-)
+%defattr(-,root,root,0700)
 %config(noreplace) %{_sysconfdir}/origin/node
 %ghost %config(noreplace) %{_sysconfdir}/origin/node/node-config.yaml
 %ghost %config(noreplace) %{_sysconfdir}/origin/.config_managed


### PR DESCRIPTION
Fixes `rpm -V origin-master origin-node` displaying errors because the files are owned by root rather than the user they were built with.