### PR TITLE
Reverting mountPath validation for add 

### DIFF
--- a/pkg/cmd/cli/cmd/set/volume.go
+++ b/pkg/cmd/cli/cmd/set/volume.go
@@ -237,10 +237,6 @@ func (v *VolumeOptions) Validate(args []string) error {
 
 func (a *AddVolumeOptions) Validate(isAddOp bool) error {
 	if isAddOp {
-		if len(a.MountPath) == 0 {
-			return errors.New("must provide --mount-path for --add operation")
-		}
-
 		if len(a.Type) == 0 && (len(a.ClaimName) > 0 || len(a.ClaimSize) > 0) {
 			a.Type = "persistentvolumeclaim"
 			a.TypeChanged = true

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -34,7 +34,7 @@ os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --add 
 os::cmd::expect_success_and_text "oc set volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby' --overwrite" 'does not have any containers'
 os::cmd::expect_success "oc set volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby*' --overwrite"
 os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --list --name=vol2' 'mounted at /etc'
-os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --add --name=vol3 -m=/anywhere -o yaml' 'name: vol3'
+os::cmd::expect_success_and_text 'oc set volume dc/test-deployment-config --add --name=vol3 -o yaml' 'name: vol3'
 os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --list --name=vol3' 'volume "vol3" not found'
 os::cmd::expect_failure_and_text 'oc set volume dc/test-deployment-config --remove' 'confirm for removing more than one volume'
 os::cmd::expect_success 'oc set volume dc/test-deployment-config --remove --name=vol2'
@@ -55,4 +55,3 @@ os::cmd::expect_success 'oc set volumes dc/test-deployment-config --list'
 os::cmd::expect_success 'oc delete dc/test-deployment-config'
 echo "volumes: ok"
 os::test::junit::declare_suite_end
-


### PR DESCRIPTION
This is to allow overwriting volume without specifying mountPath

@deads2k 