### PR TITLE
BZ 1332787 Cannot create resources defined in List through From File option on create page

### DIFF
--- a/assets/app/scripts/directives/fromFile.js
+++ b/assets/app/scripts/directives/fromFile.js
@@ -140,7 +140,8 @@ angular.module("openshiftConsole")
             };
             return false;
           }
-          if (!item.metadata.name) {
+          // Validate if resource has 'name' field in its 'metadata', but it's not a List
+          if (!item.metadata.name && !item.kind.endsWith("List")) {
             $scope.error = {
               message: "Resource name is missing in metadata field."
             };


### PR DESCRIPTION
Since List doesnt have a 'name' field in its metadata, its not necessary to validate it.

@spadgett PTAL