### PR TITLE
Add grant_type=password support to GitLab/OpenID identity providers

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -45,7 +45,7 @@
 		},
 		{
 			"ImportPath": "github.com/RangelReale/osincli",
-			"Rev": "23618ea0fc3faa3f43954ce8ff48e31f5c784212"
+			"Rev": "05659f31e8b694f522f44226839a66bd8b7c08cc"
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",

--- a/Godeps/_workspace/src/github.com/RangelReale/osincli/access_test.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osincli/access_test.go
@@ -1,0 +1,69 @@
+package osincli
+
+import "testing"
+
+func TestGetTokenUrl(t *testing.T) {
+	clientConfig := ClientConfig{
+		ClientId:     "myclient",
+		ClientSecret: "mysecret",
+		TokenUrl:     "https://example.com/token",
+		AuthorizeUrl: "https://example.com/authorize",
+		RedirectUrl:  "/",
+		Scope:        "scope1 scope2",
+	}
+
+	testcases := map[string]struct {
+		Type   AccessRequestType
+		Data   AuthorizeData
+		Params map[string]string
+
+		URL string
+	}{
+		"client credentials": {
+			Type: CLIENT_CREDENTIALS,
+			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			URL:  "https://example.com/token?grant_type=client_credentials&scope=scope1+scope2",
+		},
+		"client credentials with custom params": {
+			Type:   CLIENT_CREDENTIALS,
+			Data:   AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			Params: map[string]string{"scope": "customscope"},
+			URL:    "https://example.com/token?grant_type=client_credentials&scope=customscope",
+		},
+		"code grant": {
+			Type: AUTHORIZATION_CODE,
+			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			URL:  "https://example.com/token?code=mycode&grant_type=authorization_code&redirect_uri=%2F",
+		},
+		"refresh grant": {
+			Type: REFRESH_TOKEN,
+			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			URL:  "https://example.com/token?grant_type=refresh_token&refresh_token=mycode",
+		},
+		"password grant": {
+			Type: PASSWORD,
+			Data: AuthorizeData{State: "mystate", Code: "mycode", Username: "myusername", Password: "mypassword"},
+			URL:  "https://example.com/token?grant_type=password&password=mypassword&scope=scope1+scope2&username=myusername",
+		},
+		"password grant with custom params": {
+			Type:   PASSWORD,
+			Data:   AuthorizeData{},
+			Params: map[string]string{"username": "customuser", "password": "custompw", "scope": "customscope"},
+			URL:    "https://example.com/token?grant_type=password&password=custompw&scope=customscope&username=customuser",
+		},
+	}
+
+	client, err := NewClient(&clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, tc := range testcases {
+		req := client.NewAccessRequest(tc.Type, &tc.Data)
+		req.CustomParameters = tc.Params
+		url := req.GetTokenUrl().String()
+		if url != tc.URL {
+			t.Errorf("%s: Expected\n%s\ngot\n%s", k, tc.URL, url)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/RangelReale/osincli/authorize.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osincli/authorize.go
@@ -24,6 +24,10 @@ type AuthorizeRequest struct {
 type AuthorizeData struct {
 	Code  string
 	State string
+
+	// Resource Owner Password Credentials
+	Username string
+	Password string
 }
 
 // Creates a new authorize request

--- a/Godeps/_workspace/src/github.com/RangelReale/osincli/util.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osincli/util.go
@@ -61,10 +61,6 @@ func downloadData(method string, u *url.URL, auth *BasicAuth, transport http.Rou
 	// must close body
 	defer presp.Body.Close()
 
-	if presp.StatusCode != 200 {
-		return errors.New(fmt.Sprintf("Invalid status code (%d): %s", presp.StatusCode, presp.Status))
-	}
-
 	// decode JSON and detect OAuth error
 	jdec := json.NewDecoder(presp.Body)
 	if err = jdec.Decode(&output); err == nil {
@@ -73,5 +69,11 @@ func downloadData(method string, u *url.URL, auth *BasicAuth, transport http.Rou
 				fmt.Sprintf("%v", output["error_uri"]), fmt.Sprintf("%v", output["state"]))
 		}
 	}
+
+	// If no OAuth error was detected, make sure we don't return success in an error case
+	if err == nil && presp.StatusCode != 200 {
+		return errors.New(fmt.Sprintf("Invalid status code (%d): %s", presp.StatusCode, presp.Status))
+	}
+
 	return err
 }

--- a/pkg/cmd/server/api/validation/oauth.go
+++ b/pkg/cmd/server/api/validation/oauth.go
@@ -180,13 +180,13 @@ func ValidateIdentityProvider(identityProvider api.IdentityProvider, fldPath *fi
 			validationResults.Append(ValidateKeystoneIdentityProvider(provider, identityProvider, providerPath))
 
 		case (*api.GitHubIdentityProvider):
-			validationResults.AddErrors(ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, identityProvider.UseAsChallenger, fldPath)...)
+			validationResults.AddErrors(ValidateGitHubIdentityProvider(provider, identityProvider.UseAsChallenger, fldPath)...)
 
 		case (*api.GitLabIdentityProvider):
-			validationResults.AddErrors(ValidateGitLabIdentityProvider(provider, identityProvider.UseAsChallenger, fldPath)...)
+			validationResults.AddErrors(ValidateGitLabIdentityProvider(provider, fldPath)...)
 
 		case (*api.GoogleIdentityProvider):
-			validationResults.AddErrors(ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, identityProvider.UseAsChallenger, fldPath)...)
+			validationResults.AddErrors(ValidateGoogleIdentityProvider(provider, identityProvider.UseAsChallenger, fldPath)...)
 
 		case (*api.OpenIDIdentityProvider):
 			validationResults.AddErrors(ValidateOpenIDIdentityProvider(provider, identityProvider, fldPath)...)
@@ -288,7 +288,7 @@ func ValidateRequestHeaderIdentityProvider(provider *api.RequestHeaderIdentityPr
 	return validationResults
 }
 
-func ValidateOAuthIdentityProvider(clientID string, clientSecret api.StringSource, challenge bool, fieldPath *field.Path) field.ErrorList {
+func ValidateOAuthIdentityProvider(clientID string, clientSecret api.StringSource, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(clientID) == 0 {
@@ -304,17 +304,38 @@ func ValidateOAuthIdentityProvider(clientID string, clientSecret api.StringSourc
 			allErrs = append(allErrs, field.Required(fieldPath.Child("provider", "clientSecret"), ""))
 		}
 	}
+
+	return allErrs
+}
+
+func ValidateGitHubIdentityProvider(provider *api.GitHubIdentityProvider, challenge bool, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, fieldPath)...)
+
 	if challenge {
-		allErrs = append(allErrs, field.Invalid(fieldPath.Child("challenge"), challenge, "OAuth/OpenID providers cannot be used for challenges"))
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("challenge"), challenge, "A GitHub identity provider cannot be used for challenges"))
 	}
 
 	return allErrs
 }
 
-func ValidateGitLabIdentityProvider(provider *api.GitLabIdentityProvider, challenge bool, fieldPath *field.Path) field.ErrorList {
+func ValidateGoogleIdentityProvider(provider *api.GoogleIdentityProvider, challenge bool, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, challenge, fieldPath)...)
+	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, fieldPath)...)
+
+	if challenge {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("challenge"), challenge, "A Google identity provider cannot be used for challenges"))
+	}
+
+	return allErrs
+}
+
+func ValidateGitLabIdentityProvider(provider *api.GitLabIdentityProvider, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, fieldPath)...)
 
 	_, urlErrs := ValidateSecureURL(provider.URL, fieldPath.Child("provider", "url"))
 	allErrs = append(allErrs, urlErrs...)
@@ -329,7 +350,7 @@ func ValidateGitLabIdentityProvider(provider *api.GitLabIdentityProvider, challe
 func ValidateOpenIDIdentityProvider(provider *api.OpenIDIdentityProvider, identityProvider api.IdentityProvider, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, identityProvider.UseAsChallenger, fieldPath)...)
+	allErrs = append(allErrs, ValidateOAuthIdentityProvider(provider.ClientID, provider.ClientSecret, fieldPath)...)
 
 	// Communication with the Authorization Endpoint MUST utilize TLS
 	// http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -1,0 +1,242 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/client/restclient"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+// TestOAuthOIDC checks CLI password login against an OIDC provider
+func TestOAuthOIDC(t *testing.T) {
+
+	tokenCalled := false
+	userinfoCalled := false
+	expectedTokenPost := url.Values{
+		"grant_type":    []string{"password"},
+		"client_id":     []string{"myclient"},
+		"client_secret": []string{"mysecret"},
+		"username":      []string{"mylogin"},
+		"password":      []string{"mypassword"},
+		"scope":         []string{"openid scope1 scope2"},
+	}
+
+	// id_token made at https://jwt.io/
+	// {
+	// 	"sub": "mysub",
+	// 	"name": "John Doe",
+	// 	"myidclaim": "myid",
+	// 	"myemailclaim":"myemail",
+	// }
+	tokenResponse := `{
+		"token_type":   "bearer",
+		"access_token": "12345",
+		"id_token":     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJteXN1YiIsIm5hbWUiOiJKb2huIERvZSIsIm15aWRjbGFpbSI6Im15aWQiLCJteWVtYWlsY2xhaW0iOiJteWVtYWlsIn0.yMx2ZQw8Su641H_kO8ec_tFaysrFEc9uFUFm4ZbLGHw"
+	}`
+
+	// Additional claims in userInfo (sub claim must match)
+	userinfoResponse := `{
+		"sub": "mysub",
+	 	"mynameclaim":"myname",
+	 	"myusernameclaim":"myusername"
+	}`
+
+	// Write cert we're going to use to verify OIDC server requests
+	caFile, err := ioutil.TempFile("", "test.crt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(caFile.Name())
+	if err := ioutil.WriteFile(caFile.Name(), oidcLocalhostCert, os.FileMode(0600)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Get master config
+	testutil.RequireEtcd(t)
+
+	masterOptions, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Set up a dummy OIDC server
+	oidcServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.String() {
+		case "/token":
+			if r.Method != "POST" {
+				t.Fatalf("Expected POST to /token, got %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("Error parsing form POSTed to /token: %v", err)
+			}
+			if !reflect.DeepEqual(r.PostForm, expectedTokenPost) {
+				t.Fatalf("Expected\n%#v\ngot\n%#v", expectedTokenPost, r.PostForm)
+			}
+
+			w.Write([]byte(tokenResponse))
+			tokenCalled = true
+
+		case "/userinfo":
+			if r.Header.Get("Authorization") != "Bearer 12345" {
+				t.Fatalf("Expected authorization header, got %#v", r.Header)
+			}
+			w.Write([]byte(userinfoResponse))
+			userinfoCalled = true
+
+		default:
+			t.Fatalf("Unexpected OIDC request: %v", r.URL.String())
+		}
+	}))
+	cert, err := tls.X509KeyPair(oidcLocalhostCert, oidcLocalhostKey)
+	oidcServer.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	oidcServer.StartTLS()
+	defer oidcServer.Close()
+
+	masterOptions.OAuthConfig.IdentityProviders[0] = configapi.IdentityProvider{
+		Name:            "oidc",
+		UseAsChallenger: true,
+		UseAsLogin:      true,
+		MappingMethod:   "claim",
+		Provider: &configapi.OpenIDIdentityProvider{
+			CA:           caFile.Name(),
+			ClientID:     "myclient",
+			ClientSecret: configapi.StringSource{StringSourceSpec: configapi.StringSourceSpec{Value: "mysecret"}},
+			ExtraScopes:  []string{"scope1", "scope2"},
+			URLs: configapi.OpenIDURLs{
+				Authorize: oidcServer.URL + "/authorize",
+				Token:     oidcServer.URL + "/token",
+				UserInfo:  oidcServer.URL + "/userinfo",
+			},
+			Claims: configapi.OpenIDClaims{
+				ID:                []string{"myidclaim"},
+				Email:             []string{"myemailclaim"},
+				Name:              []string{"mynameclaim"},
+				PreferredUsername: []string{"myusernameclaim"},
+			},
+		},
+	}
+
+	// Start server
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Get the master CA data for the login command
+	masterCAFile := clientConfig.CAFile
+	if masterCAFile == "" {
+		// Write master ca data
+		tmpFile, err := ioutil.TempFile("", "ca.crt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(tmpFile.Name())
+		if err := ioutil.WriteFile(tmpFile.Name(), clientConfig.CAData, os.FileMode(0600)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		masterCAFile = tmpFile.Name()
+	}
+
+	// Attempt a login using a redirecting auth proxy
+	loginOutput := &bytes.Buffer{}
+	loginOptions := &cmd.LoginOptions{
+		Server:             clientConfig.Host,
+		CAFile:             masterCAFile,
+		StartingKubeConfig: &clientcmdapi.Config{},
+		Reader:             bytes.NewBufferString("mylogin\nmypassword\n"),
+		Out:                loginOutput,
+	}
+	if err := loginOptions.GatherInfo(); err != nil {
+		t.Fatalf("Error logging in: %v\n%v", err, loginOutput.String())
+	}
+	if loginOptions.Username != "myusername" {
+		t.Fatalf("Unexpected user after authentication: %#v", loginOptions)
+	}
+	if len(loginOptions.Config.BearerToken) == 0 {
+		t.Fatalf("Expected token after authentication: %#v", loginOptions.Config)
+	}
+
+	// Ex
+	userConfig := &restclient.Config{
+		Host: clientConfig.Host,
+		TLSClientConfig: restclient.TLSClientConfig{
+			CAFile: clientConfig.CAFile,
+			CAData: clientConfig.CAData,
+		},
+		BearerToken: loginOptions.Config.BearerToken,
+	}
+	userClient, err := client.New(userConfig)
+	userWhoamiOptions := cmd.WhoAmIOptions{UserInterface: userClient.Users(), Out: ioutil.Discard}
+	retrievedUser, err := userWhoamiOptions.WhoAmI()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if retrievedUser.Name != "myusername" {
+		t.Errorf("expected username %v, got %v", "myusername", retrievedUser.Name)
+	}
+	if retrievedUser.FullName != "myname" {
+		t.Errorf("expected display name %v, got %v", "myname", retrievedUser.FullName)
+	}
+	if !reflect.DeepEqual([]string{"oidc:myid"}, retrievedUser.Identities) {
+		t.Errorf("expected only oidc:myid identity, got %v", retrievedUser.Identities)
+	}
+}
+
+// oidcLocalhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at Jan 29 16:00:00 2084 GMT.
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var oidcLocalhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`)
+
+// oidcLocalhostKey is the private key for oidcLocalhostCert.
+var oidcLocalhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9
+SjY1bIw4iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZB
+l2+XsDulrKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQAB
+AoGAGRzwwir7XvBOAy5tM/uV6e+Zf6anZzus1s1Y1ClbjbE6HXbnWWF/wbZGOpet
+3Zm4vD6MXc7jpTLryzTQIvVdfQbRc6+MUVeLKwZatTXtdZrhu+Jk7hx0nTPy8Jcb
+uJqFk541aEw+mMogY/xEcfbWd6IOkp+4xqjlFLBEDytgbIECQQDvH/E6nk+hgN4H
+qzzVtxxr397vWrjrIgPbJpQvBsafG7b0dA4AFjwVbFLmQcj2PprIMmPcQrooz8vp
+jy4SHEg1AkEA/v13/5M47K9vCxmb8QeD/asydfsgS5TeuNi8DoUBEmiSJwma7FXY
+fFUtxuvL7XvjwjN5B30pNEbc6Iuyt7y4MQJBAIt21su4b3sjXNueLKH85Q+phy2U
+fQtuUE9txblTu14q3N7gHRZB4ZMhFYyDy8CKrN2cPg/Fvyt0Xlp/DoCzjA0CQQDU
+y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
+qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
+f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
+-----END RSA PRIVATE KEY-----`)


### PR DESCRIPTION
GitLab and some OIDC providers support resource owner password grants, which lets us authenticate from the CLI using those providers

Allows setting `challenge: true` for OIDC and GitLab providers