### PR TITLE
add istag to oc debug

### DIFF
--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -25,6 +25,7 @@ import (
 
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/generate/app"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -531,17 +532,18 @@ func (o *DebugOptions) transformPodForDebug(annotations map[string]string) (*kap
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
-		pod.Labels[debugPodLabelName] = pod.Name
 	} else {
-		pod.Labels = map[string]string{debugPodLabelName: pod.Name}
+		pod.Labels = map[string]string{}
 	}
 	// always clear the NodeName
 	pod.Spec.NodeName = o.NodeName
 
 	pod.ResourceVersion = ""
 	pod.Spec.RestartPolicy = kapi.RestartPolicyNever
-	// TODO: shorten segments, make incrementing?
-	pod.Name = fmt.Sprintf("%s-debug", pod.Name)
+
+	// shorten segments to handle long names and names with bad characters
+	pod.Name, _ = app.NewUniqueNameGenerator(fmt.Sprintf("%s-debug", pod.Name)).Generate(nil)
+
 	pod.Status = kapi.PodStatus{}
 	pod.UID = ""
 	pod.CreationTimestamp = unversioned.Time{}

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -38,5 +38,10 @@ os::cmd::expect_success_and_text "oc debug -f examples/hello-openshift/hello-pod
 os::cmd::expect_success_and_not_text "oc debug -f examples/hello-openshift/hello-pod.json -o yaml -- /bin/env" 'stdin'
 os::cmd::expect_success_and_not_text "oc debug -f examples/hello-openshift/hello-pod.json -o yaml -- /bin/env" 'tty'
 # TODO: write a test that emulates a TTY to verify the correct defaulting of what the pod is created
+
+os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
+os::cmd::expect_success_and_text "oc debug istag/wildfly:latest -o yaml" 'image: openshift/wildfly-100-centos7'
+
 echo "debug: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Let's me `oc debug istag/name` so I can mess around with my image before I've created any pods or dcs.

@stevekuznetsov 
@smarterclayton for concept approval.  Turns out I like debug.