### PR TITLE
Make the trigger controllers cooperate instead of race

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -19457,7 +19457,7 @@
     "properties": {
      "automatic": {
       "type": "boolean",
-      "description": "Automatic means that the detection of a new tag value should result in a new deployment."
+      "description": "Automatic means that the detection of a new tag value should result in an image update inside the pod template. Deployment configs that haven't been deployed yet will always have their images updated. Deployment configs that have been deployed at least once, will have their images updated only if this is set to true."
      },
      "containerNames": {
       "type": "array",

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -9,6 +9,22 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
+const (
+	ImageStreamName      = "test-image-stream"
+	ImageID              = "00000000000000000000000000000001"
+	DockerImageReference = "registry:5000/openshift/test-image-stream@sha256:00000000000000000000000000000001"
+)
+
+func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
+	return &deployapi.DeploymentConfig{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "config",
+		},
+		Spec:   OkDeploymentConfigSpec(),
+		Status: OkDeploymentConfigStatus(version),
+	}
+}
+
 func OkDeploymentConfigSpec() deployapi.DeploymentConfigSpec {
 	return deployapi.DeploymentConfigSpec{
 		Replicas: 1,
@@ -17,6 +33,7 @@ func OkDeploymentConfigSpec() deployapi.DeploymentConfigSpec {
 		Template: OkPodTemplate(),
 		Triggers: []deployapi.DeploymentTriggerPolicy{
 			OkImageChangeTrigger(),
+			OkConfigChangeTrigger(),
 		},
 	}
 }
@@ -33,7 +50,7 @@ func OkImageChangeDetails() *deployapi.DeploymentDetails {
 			Type: deployapi.DeploymentTriggerOnImageChange,
 			ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
 				From: kapi.ObjectReference{
-					Name: imageapi.JoinImageStreamTag("test-image-stream", imageapi.DefaultImageTag),
+					Name: imageapi.JoinImageStreamTag(ImageStreamName, imageapi.DefaultImageTag),
 					Kind: "ImageStreamTag",
 				}}}}}
 }
@@ -158,19 +175,9 @@ func OkImageChangeTrigger() deployapi.DeploymentTriggerPolicy {
 			},
 			From: kapi.ObjectReference{
 				Kind: "ImageStreamTag",
-				Name: imageapi.JoinImageStreamTag("test-image-stream", imageapi.DefaultImageTag),
+				Name: imageapi.JoinImageStreamTag(ImageStreamName, imageapi.DefaultImageTag),
 			},
 		},
-	}
-}
-
-func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: "config",
-		},
-		Spec:   OkDeploymentConfigSpec(),
-		Status: OkDeploymentConfigStatus(version),
 	}
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -355,7 +355,10 @@ const (
 
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
-	// Automatic means that the detection of a new tag value should result in a new deployment.
+	// Automatic means that the detection of a new tag value should result in an image update
+	// inside the pod template. Deployment configs that haven't been deployed yet will always
+	// have their images updated. Deployment configs that have been deployed at least once, will
+	// have their images updated only if this is set to true.
 	Automatic bool
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string

--- a/pkg/deploy/api/v1/defaults.go
+++ b/pkg/deploy/api/v1/defaults.go
@@ -94,9 +94,14 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				}
 			}
 		},
-		func(obj *DeploymentTriggerImageChangeParams) {
-			if len(obj.From.Kind) == 0 {
-				obj.From.Kind = "ImageStreamTag"
+		func(obj *DeploymentConfig) {
+			for _, t := range obj.Spec.Triggers {
+				if t.ImageChangeParams != nil {
+					t.ImageChangeParams.From.Kind = "ImageStreamTag"
+					if len(t.ImageChangeParams.From.Name) > 0 && len(t.ImageChangeParams.From.Namespace) == 0 {
+						t.ImageChangeParams.From.Namespace = obj.Namespace
+					}
+				}
 			}
 		},
 	)

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -156,7 +156,7 @@ func (DeploymentStrategy) SwaggerDoc() map[string]string {
 
 var map_DeploymentTriggerImageChangeParams = map[string]string{
 	"":                   "DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.",
-	"automatic":          "Automatic means that the detection of a new tag value should result in a new deployment.",
+	"automatic":          "Automatic means that the detection of a new tag value should result in an image update inside the pod template. Deployment configs that haven't been deployed yet will always have their images updated. Deployment configs that have been deployed at least once, will have their images updated only if this is set to true.",
 	"containerNames":     "ContainerNames is used to restrict tag updates to the specified set of container names in a pod.",
 	"from":               "From is a reference to an image stream tag to watch for changes. From.Name is the only required subfield - if From.Namespace is blank, the namespace of the current deployment trigger will be used.",
 	"lastTriggeredImage": "LastTriggeredImage is the last image to be triggered.",

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -310,7 +310,10 @@ const (
 
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
-	// Automatic means that the detection of a new tag value should result in a new deployment.
+	// Automatic means that the detection of a new tag value should result in an image update
+	// inside the pod template. Deployment configs that haven't been deployed yet will always
+	// have their images updated. Deployment configs that have been deployed at least once, will
+	// have their images updated only if this is set to true.
 	Automatic bool `json:"automatic,omitempty"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty"`

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -324,7 +324,10 @@ const (
 
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
-	// Automatic means that the detection of a new tag value should result in a new deployment.
+	// Automatic means that the detection of a new tag value should result in an image update
+	// inside the pod template. Deployment configs that haven't been deployed yet will always
+	// have their images updated. Deployment configs that have been deployed at least once, will
+	// have their images updated only if this is set to true.
 	Automatic bool `json:"automatic,omitempty"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty"`

--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	osclient "github.com/openshift/origin/pkg/client"
@@ -41,19 +40,41 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 		return nil
 	}
 
+	// Try to decode this deployment config from the encoded annotation found in
+	// its latest deployment.
+	decoded, err := c.decodeFromLatest(config)
+	if err != nil {
+		return err
+	}
+
+	// If this is the initial deployment, then wait for any images that need to be resolved, otherwise
+	// automatically start a new deployment.
 	if config.Status.LatestVersion == 0 {
-		_, _, abort, err := c.generateDeployment(config)
-		if err != nil {
-			if kerrors.IsConflict(err) {
-				return fatalError(fmt.Sprintf("deployment config %q updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
-			}
-			glog.V(4).Infof("Couldn't create initial deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
+		canTrigger, causes := canTrigger(config, decoded)
+		if !canTrigger {
+			// If we cannot trigger then we need to wait for the image change controller.
+			glog.V(5).Infof("Ignoring deployment config %q; template image needs to be resolved by the image change controller", deployutil.LabelForDeploymentConfig(config))
 			return nil
 		}
-		if !abort {
-			glog.V(4).Infof("Created initial deployment for deployment config %q", deployutil.LabelForDeploymentConfig(config))
-		}
+		return c.updateStatus(config, causes)
+	}
+
+	// If this is not the initial deployment, check if there is any template difference between
+	// this and the decoded deploymentconfig.
+	if kapi.Semantic.DeepEqual(config.Spec.Template, decoded.Spec.Template) {
 		return nil
+	}
+
+	_, causes := canTrigger(config, decoded)
+	return c.updateStatus(config, causes)
+}
+
+// decodeFromLatest will try to return the decoded version of the current deploymentconfig found
+// in the annotations of its latest deployment. If there is no previous deploymentconfig (ie.
+// latestVersion == 0), the returned deploymentconfig will be the same.
+func (c *DeploymentConfigChangeController) decodeFromLatest(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
+	if config.Status.LatestVersion == 0 {
+		return config, nil
 	}
 
 	latestDeploymentName := deployutil.LatestDeploymentNameForConfig(config)
@@ -62,73 +83,81 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 		// If there's no deployment for the latest config, we have no basis of
 		// comparison. It's the responsibility of the deployment config controller
 		// to make the deployment for the config, so return early.
-		if kerrors.IsNotFound(err) {
-			glog.V(5).Infof("Ignoring change for deployment config %q; no existing deployment found", deployutil.LabelForDeploymentConfig(config))
-			return nil
-		}
-		return fmt.Errorf("couldn't retrieve deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
+		return nil, fmt.Errorf("couldn't retrieve deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 
-	deployedConfig, err := c.decodeConfig(deployment)
-	if err != nil {
-		return fatalError(fmt.Sprintf("error decoding deployment config from deployment %q for deployment config %s: %v", deployutil.LabelForDeployment(deployment), deployutil.LabelForDeploymentConfig(config), err))
-	}
-
-	// Detect template diffs, and return early if there aren't any changes.
-	if kapi.Semantic.DeepEqual(config.Spec.Template, deployedConfig.Spec.Template) {
-		glog.V(5).Infof("Ignoring deployment config change for %q (latestVersion=%d); same as deployment %q", deployutil.LabelForDeploymentConfig(config), config.Status.LatestVersion, deployutil.LabelForDeployment(deployment))
-		return nil
-	}
-
-	// There was a template diff, so generate a new config version.
-	fromVersion, toVersion, abort, err := c.generateDeployment(config)
-	if err != nil {
-		if kerrors.IsConflict(err) {
-			return fatalError(fmt.Sprintf("deployment config %q updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
-		}
-		return fmt.Errorf("couldn't generate deployment for deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
-	}
-	if !abort {
-		glog.V(4).Infof("Updated deployment config %q from version %d to %d for existing deployment %s", deployutil.LabelForDeploymentConfig(config), fromVersion, toVersion, deployutil.LabelForDeployment(deployment))
-	}
-	return nil
+	return c.decodeConfig(deployment)
 }
 
-func (c *DeploymentConfigChangeController) generateDeployment(config *deployapi.DeploymentConfig) (int, int, bool, error) {
-	newConfig, err := c.client.DeploymentConfigs(config.Namespace).Generate(config.Name)
-	if err != nil {
-		return -1, -1, false, err
+// canTrigger is used by the config change controller to determine if the provided config can
+// trigger its initial deployment. The only requirement is set for image change trigger (ICT)
+// deployments - all of the ICTs need to have LastTriggedImage set which means that the image
+// change controller did its job. The second return argument helps in separating between config
+// change and image change causes.
+func canTrigger(config, decoded *deployapi.DeploymentConfig) (bool, []deployapi.DeploymentCause) {
+	ictCount, resolved := 0, 0
+	var causes []deployapi.DeploymentCause
+
+	for _, t := range config.Spec.Triggers {
+		if t.Type != deployapi.DeploymentTriggerOnImageChange {
+			continue
+		}
+		ictCount++
+
+		// If this is the inital deployment then we need to wait for the image change controller
+		// to resolve the image inside the pod template.
+		lastTriggered := t.ImageChangeParams.LastTriggeredImage
+		if len(lastTriggered) == 0 {
+			continue
+		}
+		resolved++
+
+		// We need stronger checks in order to validate that this template
+		// change is an image change. Look at the deserialized config's
+		// triggers and compare with the present trigger.
+		if !triggeredByDifferentImage(*t.ImageChangeParams, *decoded) {
+			continue
+		}
+
+		causes = append(causes, deployapi.DeploymentCause{
+			Type: deployapi.DeploymentTriggerOnImageChange,
+			ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
+				From: kapi.ObjectReference{
+					Name:      t.ImageChangeParams.From.Name,
+					Namespace: t.ImageChangeParams.From.Namespace,
+					Kind:      "ImageStreamTag",
+				},
+			},
+		})
 	}
 
-	// The generator returns a cause only when there is an image change. If the configchange
-	// controller detects an image change, it should just quit, otherwise it is racing with
-	// the imagechange controller.
-	if newConfig.Status.LatestVersion != config.Status.LatestVersion &&
-		deployutil.CauseFromAutomaticImageChange(newConfig) {
-		return -1, -1, true, nil
+	if len(causes) == 0 {
+		causes = []deployapi.DeploymentCause{{Type: deployapi.DeploymentTriggerOnConfigChange}}
 	}
 
-	if newConfig.Status.LatestVersion == config.Status.LatestVersion {
-		newConfig.Status.LatestVersion++
-	}
+	return ictCount == resolved, causes
+}
 
-	// set the trigger details for the new deployment config
-	causes := []deployapi.DeploymentCause{
-		{
-			Type: deployapi.DeploymentTriggerOnConfigChange,
-		},
-	}
-	newConfig.Status.Details = &deployapi.DeploymentDetails{
-		Causes: causes,
-	}
+func triggeredByDifferentImage(ictParams deployapi.DeploymentTriggerImageChangeParams, previous deployapi.DeploymentConfig) bool {
+	for _, t := range previous.Spec.Triggers {
+		if t.Type != deployapi.DeploymentTriggerOnImageChange {
+			continue
+		}
 
-	// This update is atomic. If it fails because a newer resource was already persisted, that's
-	// okay - we can just ignore the update for the old resource and any changes to the more
-	// current config will be captured in future events.
-	updatedConfig, err := c.client.DeploymentConfigs(config.Namespace).UpdateStatus(newConfig)
-	if err != nil {
-		return config.Status.LatestVersion, newConfig.Status.LatestVersion, false, err
-	}
+		if t.ImageChangeParams.From.Name != ictParams.From.Name &&
+			t.ImageChangeParams.From.Namespace != ictParams.From.Namespace {
+			continue
+		}
 
-	return config.Status.LatestVersion, updatedConfig.Status.LatestVersion, false, nil
+		return t.ImageChangeParams.LastTriggeredImage != ictParams.LastTriggeredImage
+	}
+	return false
+}
+
+func (c *DeploymentConfigChangeController) updateStatus(config *deployapi.DeploymentConfig, causes []deployapi.DeploymentCause) error {
+	config.Status.LatestVersion++
+	config.Status.Details = new(deployapi.DeploymentDetails)
+	config.Status.Details.Causes = causes
+	_, err := c.client.DeploymentConfigs(config.Namespace).UpdateStatus(config)
+	return err
 }

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -5,37 +5,42 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-// ImageChangeController increments the version of a DeploymentConfig which has an image
+// ImageChangeController increments the version of a deployment config which has an image
 // change trigger when a tag update to a triggered ImageStream is detected.
 //
 // Use the ImageChangeControllerFactory to create this controller.
 type ImageChangeController struct {
-	deploymentConfigClient deploymentConfigClient
+	listDeploymentConfigs func() ([]*deployapi.DeploymentConfig, error)
+	client                client.Interface
 }
 
 // fatalError is an error which can't be retried.
 type fatalError string
 
 func (e fatalError) Error() string {
-	return fmt.Sprintf("fatal error handling ImageStream: %s", string(e))
+	return fmt.Sprintf("fatal error handling image stream: %s", string(e))
 }
 
-// Handle processes image change triggers associated with imageRepo.
-func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
-	configs, err := c.deploymentConfigClient.listDeploymentConfigs()
+// Handle processes image change triggers associated with imagestream.
+func (c *ImageChangeController) Handle(stream *imageapi.ImageStream) error {
+	configs, err := c.listDeploymentConfigs()
 	if err != nil {
-		return fmt.Errorf("couldn't get list of DeploymentConfig while handling ImageStream %s: %v", labelForRepo(imageRepo), err)
+		return fmt.Errorf("couldn't get list of deployment configs while handling image stream %q: %v", imageapi.LabelForStream(stream), err)
 	}
 
 	// Find any configs which should be updated based on the new image state
-	configsToUpdate := map[string]*deployapi.DeploymentConfig{}
+	configsToUpdate := []*deployapi.DeploymentConfig{}
 	for _, config := range configs {
-		glog.V(4).Infof("Detecting changed images for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Detecting image changes for deployment config %q", deployutil.LabelForDeploymentConfig(config))
+		hasImageChange := false
 
 		for _, trigger := range config.Spec.Triggers {
 			params := trigger.ImageChangeParams
@@ -45,119 +50,72 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 				continue
 			}
 
-			// Check if the image repo matches the trigger
-			if !triggerMatchesImage(config, params, imageRepo) {
+			// Check if the image stream matches the trigger
+			if !triggerMatchesImage(config, params, stream) {
 				continue
 			}
 
 			_, tag, ok := imageapi.SplitImageStreamTag(params.From.Name)
 			if !ok {
-				return fmt.Errorf("invalid ImageStreamTag: %s", params.From.Name)
+				glog.Warningf("Invalid image stream tag %q in %q", params.From.Name, deployutil.LabelForDeploymentConfig(config))
+				continue
 			}
 
 			// Find the latest tag event for the trigger tag
-			latestEvent := imageapi.LatestTaggedImage(imageRepo, tag)
+			latestEvent := imageapi.LatestTaggedImage(stream, tag)
 			if latestEvent == nil {
-				glog.V(5).Infof("Couldn't find latest tag event for tag %s in ImageStream %s", tag, labelForRepo(imageRepo))
+				glog.V(5).Infof("Couldn't find latest tag event for tag %q in image stream %q", tag, imageapi.LabelForStream(stream))
 				continue
 			}
 
 			// Ensure a change occurred
-			if len(latestEvent.DockerImageReference) > 0 &&
-				latestEvent.DockerImageReference != params.LastTriggeredImage {
-				// Mark the config for regeneration
-				configsToUpdate[config.Name] = config
+			if len(latestEvent.DockerImageReference) == 0 || latestEvent.DockerImageReference == params.LastTriggeredImage {
+				glog.V(4).Infof("No image changes for deployment config %q were detected", deployutil.LabelForDeploymentConfig(config))
+				continue
 			}
+
+			names := sets.NewString(params.ContainerNames...)
+			for i := range config.Spec.Template.Spec.Containers {
+				container := &config.Spec.Template.Spec.Containers[i]
+				if !names.Has(container.Name) {
+					continue
+				}
+				// Update the image
+				container.Image = latestEvent.DockerImageReference
+				// Log the last triggered image ID
+				params.LastTriggeredImage = latestEvent.DockerImageReference
+				hasImageChange = true
+			}
+		}
+
+		if hasImageChange {
+			configsToUpdate = append(configsToUpdate, config)
 		}
 	}
 
 	// Attempt to regenerate all configs which may contain image updates
 	anyFailed := false
 	for _, config := range configsToUpdate {
-		err := c.regenerate(config)
-		if err != nil {
+		if _, err := c.client.DeploymentConfigs(config.Namespace).Update(config); err != nil {
 			anyFailed = true
-			glog.V(2).Infof("Couldn't regenerate DeploymentConfig %s: %s", deployutil.LabelForDeploymentConfig(config), err)
-			continue
+			glog.V(2).Infof("Couldn't update deployment config %q: %v", deployutil.LabelForDeploymentConfig(config), err)
 		}
 	}
 
 	if anyFailed {
-		return fatalError(fmt.Sprintf("couldn't update some DeploymentConfig for trigger on ImageStream %s", labelForRepo(imageRepo)))
+		return fatalError(fmt.Sprintf("couldn't update some deployment configs for trigger on image stream %q", imageapi.LabelForStream(stream)))
 	}
 
-	glog.V(5).Infof("Updated all DeploymentConfigs for trigger on ImageStream %s", labelForRepo(imageRepo))
+	glog.V(5).Infof("Updated all deployment configs for trigger on image stream %q", imageapi.LabelForStream(stream))
 	return nil
 }
 
-// triggerMatchesImages decides whether a given trigger for config matches the provided image repo.
-// When matching:
-// - The trigger From field is preferred over the deprecated RepositoryName field.
-// - The namespace of the trigger is preferred over the config's namespace.
-func triggerMatchesImage(config *deployapi.DeploymentConfig, params *deployapi.DeploymentTriggerImageChangeParams, repo *imageapi.ImageStream) bool {
-	if len(params.From.Name) > 0 {
-		namespace := params.From.Namespace
-		if len(namespace) == 0 {
-			namespace = config.Namespace
-		}
-		name, _, ok := imageapi.SplitImageStreamTag(params.From.Name)
-		return repo.Namespace == namespace && repo.Name == name && ok
+// triggerMatchesImages decides whether a given trigger for config matches the provided image stream.
+func triggerMatchesImage(config *deployapi.DeploymentConfig, params *deployapi.DeploymentTriggerImageChangeParams, stream *imageapi.ImageStream) bool {
+	namespace := params.From.Namespace
+	if len(namespace) == 0 {
+		namespace = config.Namespace
 	}
-	return false
-}
-
-// regenerate calls the generator to get a new config. If the newly generated
-// config's version is newer, update the old config to be the new config.
-// Otherwise do nothing.
-func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) error {
-	// Get a regenerated config which includes the new image repo references
-	newConfig, err := c.deploymentConfigClient.generateDeploymentConfig(config.Namespace, config.Name)
-	if err != nil {
-		return fmt.Errorf("error generating new version of DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
-	}
-
-	// No update occurred
-	if config.Status.LatestVersion == newConfig.Status.LatestVersion {
-		glog.V(5).Infof("No version difference for generated DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
-		return nil
-	}
-
-	// Persist the new config
-	_, err = c.deploymentConfigClient.updateDeploymentConfig(newConfig.Namespace, newConfig)
-	if err != nil {
-		return err
-	}
-
-	glog.V(4).Infof("Regenerated DeploymentConfig %s for image updates", deployutil.LabelForDeploymentConfig(config))
-	return nil
-}
-
-func labelForRepo(imageRepo *imageapi.ImageStream) string {
-	return fmt.Sprintf("%s/%s", imageRepo.Namespace, imageRepo.Name)
-}
-
-// deploymentConfigClient abstracts access to DeploymentConfigs.
-type deploymentConfigClient interface {
-	listDeploymentConfigs() ([]*deployapi.DeploymentConfig, error)
-	updateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-	generateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
-}
-
-// deploymentConfigClientImpl is a pluggable deploymentConfigClient.
-type deploymentConfigClientImpl struct {
-	listDeploymentConfigsFunc    func() ([]*deployapi.DeploymentConfig, error)
-	generateDeploymentConfigFunc func(namespace, name string) (*deployapi.DeploymentConfig, error)
-	updateDeploymentConfigFunc   func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-}
-
-func (i *deploymentConfigClientImpl) listDeploymentConfigs() ([]*deployapi.DeploymentConfig, error) {
-	return i.listDeploymentConfigsFunc()
-}
-
-func (i *deploymentConfigClientImpl) generateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error) {
-	return i.generateDeploymentConfigFunc(namespace, name)
-}
-
-func (i *deploymentConfigClientImpl) updateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-	return i.updateDeploymentConfigFunc(namespace, config)
+	name, _, ok := imageapi.SplitImageStreamTag(params.From.Name)
+	return stream.Namespace == namespace && stream.Name == name && ok
 }

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -46,7 +46,15 @@ func (c *ImageChangeController) Handle(stream *imageapi.ImageStream) error {
 			params := trigger.ImageChangeParams
 
 			// Only automatic image change triggers should fire
-			if trigger.Type != deployapi.DeploymentTriggerOnImageChange || !params.Automatic {
+			if trigger.Type != deployapi.DeploymentTriggerOnImageChange {
+				continue
+			}
+
+			// All initial deployments (latestVersion == 0) should have their images resolved in order
+			// to be able to work and not try to pull non-existent images from DockerHub.
+			// Deployments with automatic set to false that have been deployed at least once (latestVersion > 0)
+			// shouldn't have their images updated.
+			if !params.Automatic && config.Status.LatestVersion != 0 {
 				continue
 			}
 

--- a/pkg/deploy/controller/imagechange/factory.go
+++ b/pkg/deploy/controller/imagechange/factory.go
@@ -48,22 +48,15 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 	cache.NewReflector(deploymentConfigLW, &deployapi.DeploymentConfig{}, store, 2*time.Minute).Run()
 
 	changeController := &ImageChangeController{
-		deploymentConfigClient: &deploymentConfigClientImpl{
-			listDeploymentConfigsFunc: func() ([]*deployapi.DeploymentConfig, error) {
-				configs := []*deployapi.DeploymentConfig{}
-				objs := store.List()
-				for _, obj := range objs {
-					configs = append(configs, obj.(*deployapi.DeploymentConfig))
-				}
-				return configs, nil
-			},
-			generateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				return factory.Client.DeploymentConfigs(namespace).Generate(name)
-			},
-			updateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-				return factory.Client.DeploymentConfigs(namespace).Update(config)
-			},
+		listDeploymentConfigs: func() ([]*deployapi.DeploymentConfig, error) {
+			configs := []*deployapi.DeploymentConfig{}
+			objs := store.List()
+			for _, obj := range objs {
+				configs = append(configs, obj.(*deployapi.DeploymentConfig))
+			}
+			return configs, nil
 		},
+		client: factory.Client,
 	}
 
 	return &controller.RetryController{

--- a/pkg/deploy/registry/deployconfig/strategy.go
+++ b/pkg/deploy/registry/deployconfig/strategy.go
@@ -54,20 +54,8 @@ func (strategy) PrepareForUpdate(obj, old runtime.Object) {
 	newVersion := newDc.Status.LatestVersion
 	oldVersion := oldDc.Status.LatestVersion
 
-	// Check for imagechange controller change
-	isImageControllerChange := deployutil.IsImageChangeControllerChange(*newDc, *oldDc)
-
 	// Persist status
-	newStatus := newDc.Status
 	newDc.Status = oldDc.Status
-
-	// If this update comes from the imagechange controller, tolerate status detail updates.
-	// TODO: Make the config change controller detect this change and update latestVersion.
-	// Then the main controller should detect there is a change coming from the image change
-	// controller and update status details accordingly.
-	if isImageControllerChange {
-		newDc.Status.Details = newStatus.Details
-	}
 
 	// oc deploy --latest from new clients
 	if newVersion == oldVersion && deployutil.IsInstantiated(newDc) {

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -103,29 +102,6 @@ func HasChangeTrigger(config *deployapi.DeploymentConfig) bool {
 		}
 	}
 	return false
-}
-
-// CauseFromAutomaticImageChange inspects any existing deployment config cause and
-// validates if it comes from the image change controller.
-func CauseFromAutomaticImageChange(config *deployapi.DeploymentConfig) bool {
-	if config.Status.Details != nil && len(config.Status.Details.Causes) > 0 {
-		for _, trigger := range config.Spec.Triggers {
-			if trigger.Type == deployapi.DeploymentTriggerOnImageChange &&
-				trigger.ImageChangeParams.Automatic &&
-				config.Status.Details.Causes[0].Type == deployapi.DeploymentTriggerOnImageChange &&
-				reflect.DeepEqual(trigger.ImageChangeParams.From, config.Status.Details.Causes[0].ImageTrigger.From) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// IsImageChangeControllerChange detects if there is an image change between two dcs.
-// Used by the update hook.
-func IsImageChangeControllerChange(newDc, oldDc deployapi.DeploymentConfig) bool {
-	return CauseFromAutomaticImageChange(&newDc) && !CauseFromAutomaticImageChange(&oldDc) &&
-		newDc.Status.LatestVersion != oldDc.Status.LatestVersion
 }
 
 // DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -843,3 +843,7 @@ func SetContainerImageEntrypointAnnotation(annotations map[string]string, contai
 	s, _ := json.Marshal(cmd)
 	annotations[key] = string(s)
 }
+
+func LabelForStream(stream *ImageStream) string {
+	return fmt.Sprintf("%s/%s", stream.Namespace, stream.Name)
+}

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -8,6 +8,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -29,6 +30,7 @@ func TestDeployScale(t *testing.T) {
 	checkErr(t, err)
 
 	config := deploytest.OkDeploymentConfig(0)
+	config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{}
 	config.Spec.Replicas = 1
 
 	dc, err := osClient.DeploymentConfigs(namespace).Create(config)


### PR DESCRIPTION
The plan here is to remove the generator from the trigger controllers and make the image change controller update only the spec of the deploymentConfig, deferring to the config change controller for incrementing latestVersion.

FIxes https://github.com/openshift/origin/issues/8937
Fixes https://github.com/openshift/origin/issues/8696
Fixes https://github.com/openshift/origin/issues/6934

Trello card: https://trello.com/c/XRA3RF5W/714-5-remove-shared-dependency-from-trigger-controllers

@ironcladlou @smarterclayton @deads2k @liggitt @pweil- @mfojtik 