### PR TITLE
support project watch resourceversion=0

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -196,7 +196,7 @@ func (ac *AuthorizationCache) RemoveWatcher(watcher CacheWatcher) {
 				// if we're not the last element, shift
 				copy(ac.watchers[i:], ac.watchers[i+1:])
 			}
-			ac.watchers = ac.watchers[:lastIndex-1]
+			ac.watchers = ac.watchers[:lastIndex]
 			break
 		}
 	}

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -27,7 +27,7 @@ func newTestWatcher(user string, groups []string, namespaces ...*kapi.Namespace)
 	projectCache.Run()
 	fakeAuthCache := &fakeAuthCache{}
 
-	return NewUserProjectWatcher(user, groups, projectCache, fakeAuthCache), fakeAuthCache
+	return NewUserProjectWatcher(user, groups, projectCache, fakeAuthCache, false), fakeAuthCache
 }
 
 type fakeAuthCache struct {

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -116,17 +116,12 @@ func TestAddModifyDeleteEventsByUser(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 
+	// the object didn't change, we shouldn't observe it
 	watcher.GroupMembershipChanged("ns-01", sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{}, sets.String{}, sets.String{})
 	select {
 	case event := <-watcher.ResultChan():
-		if event.Type != watch.Modified {
-			t.Errorf("expected Modified, got %v", event)
-		}
-		if event.Object.(*projectapi.Project).Name != "ns-01" {
-			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
-		}
+		t.Fatalf("unexpected event %v", event)
 	case <-time.After(3 * time.Second):
-		t.Fatalf("timeout")
 	}
 
 	watcher.GroupMembershipChanged("ns-01", sets.NewString("alice"), sets.String{}, sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{})
@@ -160,17 +155,12 @@ func TestAddModifyDeleteEventsByGroup(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 
+	// the object didn't change, we shouldn't observe it
 	watcher.GroupMembershipChanged("ns-01", sets.String{}, sets.NewString("group-one"), sets.String{}, sets.String{}, sets.String{}, sets.String{})
 	select {
 	case event := <-watcher.ResultChan():
-		if event.Type != watch.Modified {
-			t.Errorf("expected Modified, got %v", event)
-		}
-		if event.Object.(*projectapi.Project).Name != "ns-01" {
-			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
-		}
+		t.Fatalf("unexpected event %v", event)
 	case <-time.After(3 * time.Second):
-		t.Fatalf("timeout")
 	}
 
 	watcher.GroupMembershipChanged("ns-01", sets.String{}, sets.NewString("group-two"), sets.String{}, sets.NewString("group-one"), sets.String{}, sets.String{})

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -88,7 +88,10 @@ func (s *REST) Watch(ctx kapi.Context, options *kapi.ListOptions) (watch.Interfa
 	if !exists {
 		return nil, fmt.Errorf("no user")
 	}
-	watcher := projectauth.NewUserProjectWatcher(userInfo.GetName(), userInfo.GetGroups(), s.projectCache, s.authCache)
+
+	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
+
+	watcher := projectauth.NewUserProjectWatcher(userInfo.GetName(), userInfo.GetGroups(), s.projectCache, s.authCache, includeAllExistingProjects)
 	s.authCache.AddWatcher(watcher)
 
 	go watcher.Watch()

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -194,42 +194,6 @@ func TestProjectWatch(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 
-	select {
-	case event := <-w.ResultChan():
-		if event.Type != watch.Modified {
-			t.Errorf("expected Modified, got %v", event)
-		}
-		project := event.Object.(*projectapi.Project)
-		if project.Name != "ns-01" {
-			t.Fatalf("expected %v, got %#v", "ns-01", project)
-		}
-		project.Annotations[projectapi.ProjectDisplayName] = "whatever"
-		_, err := bobClient.Projects().Update(project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-	case <-time.After(3 * time.Second):
-		t.Fatalf("timeout")
-	}
-
-	select {
-	case event := <-w.ResultChan():
-		if event.Type != watch.Modified {
-			t.Errorf("expected Modified, got %v", event)
-		}
-		project := event.Object.(*projectapi.Project)
-		if project.Name != "ns-01" {
-			t.Errorf("expected %v, got %#v", "ns-01", project)
-		}
-		if project.Annotations[projectapi.ProjectDisplayName] != "whatever" {
-			t.Errorf("expected %v, got %#v", "whatever", project)
-		}
-
-	case <-time.After(3 * time.Second):
-		t.Fatalf("timeout")
-	}
-
 	joeClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-02", "joe")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -277,4 +277,34 @@ func TestProjectWatch(t *testing.T) {
 		}
 	}
 
+	// test the "start from beginning watch"
+	beginningWatch, err := bobClient.Projects().Watch(kapi.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case event := <-beginningWatch.ResultChan():
+		if event.Type != watch.Added {
+			t.Errorf("expected added, got %v", event)
+		}
+		project := event.Object.(*projectapi.Project)
+		if project.Name != "ns-01" {
+			t.Fatalf("expected %v, got %#v", "ns-01", project)
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	fromNowWatch, err := bobClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case event := <-fromNowWatch.ResultChan():
+		t.Fatalf("unexpected event %v", event)
+
+	case <-time.After(3 * time.Second):
+	}
+
 }


### PR DESCRIPTION
Passing `resourceVersion=0` now gives you a full list of all your projects.

Also stops sending repeat modified events for projects we've already seen.  I haven't stopped the re-evaluation in the project cache itself, only the emission of those events.  Something in there is still recalculating more than we'd like.

@openshift/api-review I think we've agreed on the API change already
@kargakis you've reviewed this area before. Up for another?