### PR TITLE
allow project request limits on system users and service accounts

### DIFF
--- a/pkg/project/admission/requestlimit/api/types.go
+++ b/pkg/project/admission/requestlimit/api/types.go
@@ -10,6 +10,15 @@ import (
 type ProjectRequestLimitConfig struct {
 	unversioned.TypeMeta
 	Limits []ProjectLimitBySelector
+
+	// MaxProjectsForSystemUsers controls how many projects a certificate user may have.  Certificate
+	// users do not have any labels associated with them for more fine grained control
+	MaxProjectsForSystemUsers *int
+
+	// MaxProjectsForServiceAccounts controls how many projects a service account may have.  Service
+	// accounts can't create projects by default, but if they are allowed to create projects, you cannot
+	// trust any labels placed on them since project editors can manipulate those labels
+	MaxProjectsForServiceAccounts *int
 }
 
 // ProjectLimitBySelector specifies the maximum number of projects allowed for a given user label selector

--- a/pkg/project/admission/requestlimit/api/v1/swagger_doc.go
+++ b/pkg/project/admission/requestlimit/api/v1/swagger_doc.go
@@ -16,8 +16,10 @@ func (ProjectLimitBySelector) SwaggerDoc() map[string]string {
 }
 
 var map_ProjectRequestLimitConfig = map[string]string{
-	"":       "ProjectRequestLimitConfig is the configuration for the project request limit plug-in It contains an ordered list of limits based on user label selectors. Selectors will be checked in order and the first one that applies will be used as the limit.",
-	"limits": "Limits are the project request limits",
+	"":                              "ProjectRequestLimitConfig is the configuration for the project request limit plug-in It contains an ordered list of limits based on user label selectors. Selectors will be checked in order and the first one that applies will be used as the limit.",
+	"limits":                        "Limits are the project request limits",
+	"maxProjectsForSystemUsers":     "MaxProjectsForSystemUsers controls how many projects a certificate user may have.  Certificate users do not have any labels associated with them for more fine grained control",
+	"maxProjectsForServiceAccounts": "MaxProjectsForServiceAccounts controls how many projects a service account may have.  Service accounts can't create projects by default, but if they are allowed to create projects, you cannot trust any labels placed on them since project editors can manipulate those labels",
 }
 
 func (ProjectRequestLimitConfig) SwaggerDoc() map[string]string {

--- a/pkg/project/admission/requestlimit/api/v1/types.go
+++ b/pkg/project/admission/requestlimit/api/v1/types.go
@@ -12,6 +12,15 @@ type ProjectRequestLimitConfig struct {
 
 	// Limits are the project request limits
 	Limits []ProjectLimitBySelector `json:"limits",description:"project request limits"`
+
+	// MaxProjectsForSystemUsers controls how many projects a certificate user may have.  Certificate
+	// users do not have any labels associated with them for more fine grained control
+	MaxProjectsForSystemUsers *int `json:"maxProjectsForSystemUsers"`
+
+	// MaxProjectsForServiceAccounts controls how many projects a service account may have.  Service
+	// accounts can't create projects by default, but if they are allowed to create projects, you cannot
+	// trust any labels placed on them since project editors can manipulate those labels
+	MaxProjectsForServiceAccounts *int `json:"maxProjectsForServiceAccounts"`
 }
 
 // ProjectLimitBySelector specifies the maximum number of projects allowed for a given user label selector

--- a/pkg/project/admission/requestlimit/api/validation/validation.go
+++ b/pkg/project/admission/requestlimit/api/validation/validation.go
@@ -12,6 +12,12 @@ func ValidateProjectRequestLimitConfig(config *api.ProjectRequestLimitConfig) fi
 	for i, projectLimit := range config.Limits {
 		allErrs = append(allErrs, ValidateProjectLimitBySelector(projectLimit, field.NewPath("limits").Index(i))...)
 	}
+	if config.MaxProjectsForSystemUsers != nil && *config.MaxProjectsForSystemUsers < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("maxProjectsForSystemUsers"), *config.MaxProjectsForSystemUsers, "cannot be a negative number"))
+	}
+	if config.MaxProjectsForServiceAccounts != nil && *config.MaxProjectsForServiceAccounts < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("maxProjectsForServiceAccounts"), *config.MaxProjectsForServiceAccounts, "cannot be a negative number"))
+	}
 	return allErrs
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1333049

Adds the ability to limit the number of projects that a cert user can have and prevents the forbidden error.

@csrwng ptal
@stenwt @a13m  fyi