### PR TITLE
Show newlines and links in template descriptions

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -648,6 +648,10 @@ label.checkbox {
   margin-left: 3px;
 }
 
+.resource-description {
+  .word-break();
+  .pre-wrap();
+}
 
 // Misc
 // TODO: pull out into _partials where it makes sense

--- a/assets/app/styles/_mixins.less
+++ b/assets/app/styles/_mixins.less
@@ -59,6 +59,12 @@
      min-width: 0;          // firefox (1)
 }
 
+// Sequences of whitespace are preserved. Lines are broken at newline
+// characters, at <br>, and as necessary to fill line boxes.
+.pre-wrap {
+  white-space: pre-wrap;
+}
+
 // Linear-gradient stripes
 .striped(@color: rgba(255,255,255,.15); @angle: 45deg) {
   background-image: -webkit-linear-gradient(@angle, @color 25%, transparent 25%, transparent 50%, @color 50%, @color 75%, transparent 75%, transparent);

--- a/assets/app/views/directives/osc-image-summary.html
+++ b/assets/app/views/directives/osc-image-summary.html
@@ -4,6 +4,6 @@
   <div ng-show="resource | annotation:'provider'">Provider: {{ resource | annotation:'provider' }}</div>
   <div ng-show="resource.metadata.namespace">Namespace: {{ resource.metadata.namespace }}</div>
 </div>
-<div class="description gutter-bottom">
-  <truncate-long-text content="resource | description" limit="256" use-word-boundary="true"></truncate-long-text>
+<div class="resource-description gutter-bottom"
+     ng-bind-html="resource | description | linky">
 </div>


### PR DESCRIPTION
Also don't truncate description as it might contain important information.

<img width="773" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/15071743/03dde2da-135c-11e6-957a-e7055fe51867.png">

Fixes #8718
https://bugzilla.redhat.com/show_bug.cgi?id=1333590

@jwforres PTAL
@bparees CC
