### PR TITLE
dockerbuild: stop container before committing it

### DIFF
--- a/pkg/util/docker/dockerfile/builder/client.go
+++ b/pkg/util/docker/dockerfile/builder/client.go
@@ -175,6 +175,13 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 		}
 	}
 
+	if mustStart {
+		glog.V(4).Infof("Stopping container %s ...", e.Container.ID)
+		if err := e.Client.StopContainer(e.Container.ID, 0); err != nil {
+			return err
+		}
+	}
+
 	config := b.Config()
 	var repository, tag string
 	if len(e.Tag) > 0 {


### PR DESCRIPTION
The problem:
Images built with the new dockerbuild command get the wrong permisisons (0700 instead of 0755) in the /run/secrets (or /var/run/secrets) directory when running on non-RedHat docker hosts. This breaks loading secrets in containers created from those images. 

The fix:
I found that this happens only when the container is committed while still running. If I the container is stopped before committing, the permissions for that directory come out right.