### PR TITLE
Update deployment logs and surge on recreate

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/rolling_updater.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/rolling_updater.go
@@ -83,6 +83,10 @@ type RollingUpdaterConfig struct {
 	// further, ensuring that total number of pods running at any time during
 	// the update is atmost 130% of desired pods.
 	MaxSurge intstr.IntOrString
+	// OnProgress is invoked if set during each scale cycle, to allow the caller to perform additional logic or
+	// abort the scale. If an error is returned the cleanup method will not be invoked. The percentage value
+	// is a synthetic "progress" calculation that represents the approximate percentage completion.
+	OnProgress func(oldRc, newRc *api.ReplicationController, percentage int) error
 }
 
 // RollingUpdaterCleanupPolicy is a cleanup action to take after the
@@ -216,6 +220,26 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 	fmt.Fprintf(out, "Scaling up %s from %d to %d, scaling down %s from %d to 0 (keep %d pods available, don't exceed %d pods)\n",
 		newRc.Name, newRc.Spec.Replicas, desired, oldRc.Name, oldRc.Spec.Replicas, minAvailable, desired+maxSurge)
 
+	// give a caller incremental notification and allow them to exit early
+	goal := desired - newRc.Spec.Replicas
+	if goal < 0 {
+		goal = -goal
+	}
+	progress := func(complete bool) error {
+		if config.OnProgress == nil {
+			return nil
+		}
+		progress := desired - newRc.Spec.Replicas
+		if progress < 0 {
+			progress = -progress
+		}
+		percentage := 100
+		if !complete && goal > 0 {
+			percentage = (goal - progress) * 100 / goal
+		}
+		return config.OnProgress(oldRc, newRc, percentage)
+	}
+
 	// Scale newRc and oldRc until newRc has the desired number of replicas and
 	// oldRc has 0 replicas.
 	progressDeadline := time.Now().UnixNano() + config.Timeout.Nanoseconds()
@@ -231,6 +255,11 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 		}
 		newRc = scaledRc
 
+		// notify the caller if necessary
+		if err := progress(false); err != nil {
+			return err
+		}
+
 		// Wait between scaling operations for things to settle.
 		time.Sleep(config.UpdatePeriod)
 
@@ -241,6 +270,11 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 		}
 		oldRc = scaledRc
 
+		// notify the caller if necessary
+		if err := progress(false); err != nil {
+			return err
+		}
+
 		// If we are making progress, continue to advance the progress deadline.
 		// Otherwise, time out with an error.
 		progressMade := (newRc.Spec.Replicas != newReplicas) || (oldRc.Spec.Replicas != oldReplicas)
@@ -249,6 +283,11 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 		} else if time.Now().UnixNano() > progressDeadline {
 			return fmt.Errorf("timed out waiting for any update progress to be made")
 		}
+	}
+
+	// notify the caller if necessary
+	if err := progress(true); err != nil {
+		return err
 	}
 
 	// Housekeeping and cleanup policy execution.

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -15788,6 +15788,7 @@ _openshift_infra_deploy()
 
     flags+=("--deployment=")
     flags+=("--namespace=")
+    flags+=("--until=")
     flags+=("--google-json-key=")
     flags+=("--log-flush-frequency=")
 

--- a/pkg/cmd/infra/deployer/deployer_test.go
+++ b/pkg/cmd/infra/deployer/deployer_test.go
@@ -1,6 +1,7 @@
 package deployer
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"testing"
@@ -135,6 +136,8 @@ func TestDeployer_deployScenarios(t *testing.T) {
 		scaler := &scalertest.FakeScaler{}
 
 		deployer := &Deployer{
+			out:    &bytes.Buffer{},
+			errOut: &bytes.Buffer{},
 			strategyFor: func(config *deployapi.DeploymentConfig) (strategy.DeploymentStrategy, error) {
 				return &testStrategy{
 					deployFunc: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int) error {

--- a/pkg/deploy/api/deep_copy_generated.go
+++ b/pkg/deploy/api/deep_copy_generated.go
@@ -270,15 +270,6 @@ func DeepCopy_api_DeploymentLogOptions(in DeploymentLogOptions, out *DeploymentL
 
 func DeepCopy_api_DeploymentStrategy(in DeploymentStrategy, out *DeploymentStrategy, c *conversion.Cloner) error {
 	out.Type = in.Type
-	if in.CustomParams != nil {
-		in, out := in.CustomParams, &out.CustomParams
-		*out = new(CustomDeploymentStrategyParams)
-		if err := DeepCopy_api_CustomDeploymentStrategyParams(*in, *out, c); err != nil {
-			return err
-		}
-	} else {
-		out.CustomParams = nil
-	}
 	if in.RecreateParams != nil {
 		in, out := in.RecreateParams, &out.RecreateParams
 		*out = new(RecreateDeploymentStrategyParams)
@@ -296,6 +287,15 @@ func DeepCopy_api_DeploymentStrategy(in DeploymentStrategy, out *DeploymentStrat
 		}
 	} else {
 		out.RollingParams = nil
+	}
+	if in.CustomParams != nil {
+		in, out := in.CustomParams, &out.CustomParams
+		*out = new(CustomDeploymentStrategyParams)
+		if err := DeepCopy_api_CustomDeploymentStrategyParams(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
 	}
 	if err := api.DeepCopy_api_ResourceRequirements(in.Resources, &out.Resources, c); err != nil {
 		return err

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -29,12 +29,15 @@ type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
 	Type DeploymentStrategyType
 
-	// CustomParams are the input to the Custom deployment strategy.
-	CustomParams *CustomDeploymentStrategyParams
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams
 	// RollingParams are the input to the Rolling deployment strategy.
 	RollingParams *RollingDeploymentStrategyParams
+
+	// CustomParams are the input to the Custom deployment strategy, and may also
+	// be specified for the Recreate and Rolling strategies to customize the execution
+	// process that runs the deployment.
+	CustomParams *CustomDeploymentStrategyParams
 
 	// Resources contains resource requirements to execute the deployment
 	Resources kapi.ResourceRequirements
@@ -50,7 +53,7 @@ type DeploymentStrategyType string
 const (
 	// DeploymentStrategyTypeRecreate is a simple strategy suitable as a default.
 	DeploymentStrategyTypeRecreate DeploymentStrategyType = "Recreate"
-	// DeploymentStrategyTypeCustom is a user defined strategy.
+	// DeploymentStrategyTypeCustom is a user defined strategy. It is optional to set.
 	DeploymentStrategyTypeCustom DeploymentStrategyType = "Custom"
 	// DeploymentStrategyTypeRolling uses the Kubernetes RollingUpdater.
 	DeploymentStrategyTypeRolling DeploymentStrategyType = "Rolling"

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -199,6 +199,10 @@ const (
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
 	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
+	// DeploymentIgnorePodAnnotation is an annotation on a deployment config that will bypass creating
+	// a deployment pod with the deployment. The caller is responsible for setting the deployment
+	// status and running the deployment process.
+	DeploymentIgnorePodAnnotation = "deploy.openshift.io/deployer-pod.ignore"
 	// DeploymentPodTypeLabel is a label with which contains a type of deployment pod.
 	DeploymentPodTypeLabel = "openshift.io/deployer-pod.type"
 	// DeployerPodForDeploymentLabel is a label which groups pods related to a

--- a/pkg/deploy/api/v1/conversion_generated.go
+++ b/pkg/deploy/api/v1/conversion_generated.go
@@ -759,15 +759,6 @@ func autoConvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *deploy_api.
 		defaulting.(func(*deploy_api.DeploymentStrategy))(in)
 	}
 	out.Type = DeploymentStrategyType(in.Type)
-	if in.CustomParams != nil {
-		in, out := &in.CustomParams, &out.CustomParams
-		*out = new(CustomDeploymentStrategyParams)
-		if err := Convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CustomParams = nil
-	}
 	if in.RecreateParams != nil {
 		in, out := &in.RecreateParams, &out.RecreateParams
 		*out = new(RecreateDeploymentStrategyParams)
@@ -785,6 +776,15 @@ func autoConvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *deploy_api.
 		}
 	} else {
 		out.RollingParams = nil
+	}
+	if in.CustomParams != nil {
+		in, out := &in.CustomParams, &out.CustomParams
+		*out = new(CustomDeploymentStrategyParams)
+		if err := Convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
 	}
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -240,7 +240,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			field.ErrorTypeRequired,
 			"spec.strategy.customParams",
 		},
-		"missing spec.strategy.customParams.image": {
+		"invalid spec.strategy.customParams.environment": {
 			api.DeploymentConfig{
 				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
 				Spec: api.DeploymentConfigSpec{
@@ -248,14 +248,18 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 					Triggers: manualTrigger(),
 					Selector: test.OkSelector(),
 					Strategy: api.DeploymentStrategy{
-						Type:         api.DeploymentStrategyTypeCustom,
-						CustomParams: &api.CustomDeploymentStrategyParams{},
+						Type: api.DeploymentStrategyTypeCustom,
+						CustomParams: &api.CustomDeploymentStrategyParams{
+							Environment: []kapi.EnvVar{
+								{Name: "A=B"},
+							},
+						},
 					},
 					Template: test.OkPodTemplate(),
 				},
 			},
-			field.ErrorTypeRequired,
-			"spec.strategy.customParams.image",
+			field.ErrorTypeInvalid,
+			"spec.strategy.customParams.environment[0].name",
 		},
 		"missing spec.strategy.recreateParams.pre.failurePolicy": {
 			api.DeploymentConfig{

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -103,6 +103,11 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 			// Don't try and re-create the deployer pod.
 			break
 		}
+
+		if _, ok := deployment.Annotations[deployapi.DeploymentIgnorePodAnnotation]; ok {
+			return nil
+		}
+
 		// Generate a deployer pod spec.
 		podTemplate, err := c.makeDeployerPod(deployment)
 		if err != nil {

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -245,6 +245,8 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 				},
 			},
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
+			DNSPolicy:             deployment.Spec.Template.Spec.DNSPolicy,
+			ImagePullSecrets:      deployment.Spec.Template.Spec.ImagePullSecrets,
 			// Setting the node selector on the deployer pod so that it is created
 			// on the same set of nodes as the pods.
 			NodeSelector:       deployment.Spec.Template.Spec.NodeSelector,

--- a/pkg/deploy/strategy/interfaces.go
+++ b/pkg/deploy/strategy/interfaces.go
@@ -1,6 +1,9 @@
 package strategy
 
 import (
+	"strconv"
+	"strings"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
@@ -22,4 +25,45 @@ type DeploymentStrategy interface {
 type UpdateAcceptor interface {
 	// Accept returns nil if the controller is okay, otherwise returns an error.
 	Accept(*kapi.ReplicationController) error
+}
+
+type errConditionReached struct {
+	msg string
+}
+
+func NewConditionReachedErr(msg string) error {
+	return &errConditionReached{msg: msg}
+}
+
+func (e *errConditionReached) Error() string {
+	return e.msg
+}
+
+func IsConditionReached(err error) bool {
+	value, ok := err.(*errConditionReached)
+	return ok && value != nil
+}
+
+func PercentageBetween(until string, min, max int) bool {
+	if !strings.HasSuffix(until, "%") {
+		return false
+	}
+	until = until[:len(until)-1]
+	i, err := strconv.Atoi(until)
+	if err != nil {
+		return false
+	}
+	return i >= min && i <= max
+}
+
+func Percentage(until string) (int, bool) {
+	if !strings.HasSuffix(until, "%") {
+		return 0, false
+	}
+	until = until[:len(until)-1]
+	i, err := strconv.Atoi(until)
+	if err != nil {
+		return 0, false
+	}
+	return i, true
 }

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -165,6 +165,9 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 }
 
 func (s *RecreateDeploymentStrategy) scaleAndWait(deployment *kapi.ReplicationController, replicas int, retry *kubectl.RetryParams, wait *kubectl.RetryParams) (*kapi.ReplicationController, error) {
+	if replicas == deployment.Spec.Replicas && replicas == deployment.Status.Replicas {
+		return deployment, nil
+	}
 	if err := s.scaler.Scale(deployment.Namespace, deployment.Name, uint(replicas), &kubectl.ScalePrecondition{Size: -1, ResourceVersion: ""}, retry, wait); err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -47,7 +47,7 @@ func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
 		decoder: kapi.Codecs.UniversalDecoder(),
 	}
 
-	err := executor.executeExecNewPod(hook, deployment, "hook")
+	err := executor.executeExecNewPod(hook, deployment, "hook", "test")
 
 	if err == nil {
 		t.Fatalf("expected an error")
@@ -80,20 +80,20 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 				return func() *kapi.Pod { return createdPod }
 			},
 		},
-		podLogDestination: podLogs,
+		out: podLogs,
 		podLogStream: func(namespace, name string, opts *kapi.PodLogOptions) (io.ReadCloser, error) {
 			return ioutil.NopCloser(strings.NewReader("test")), nil
 		},
 		decoder: kapi.Codecs.UniversalDecoder(),
 	}
 
-	err := executor.executeExecNewPod(hook, deployment, "hook")
+	err := executor.executeExecNewPod(hook, deployment, "hook", "test")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if e, a := "test", podLogs.String(); e != a {
+	if e, a := "--> test: Running hook pod ...\ntest--> test: Success\n", podLogs.String(); e != a {
 		t.Fatalf("expected pod logs to be %q, got %q", e, a)
 	}
 
@@ -132,14 +132,14 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 				return func() *kapi.Pod { return createdPod }
 			},
 		},
-		podLogDestination: ioutil.Discard,
+		out: ioutil.Discard,
 		podLogStream: func(namespace, name string, opts *kapi.PodLogOptions) (io.ReadCloser, error) {
 			return nil, fmt.Errorf("can't access logs")
 		},
 		decoder: kapi.Codecs.UniversalDecoder(),
 	}
 
-	err := executor.executeExecNewPod(hook, deployment, "hook")
+	err := executor.executeExecNewPod(hook, deployment, "hook", "test")
 
 	if err == nil {
 		t.Fatalf("expected an error, got none")
@@ -516,6 +516,7 @@ func TestAcceptNewlyObservedReadyPods_scenarios(t *testing.T) {
 		deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
 		deployment.Spec.Replicas = 1
 
+		acceptor.out = &bytes.Buffer{}
 		err := acceptor.Accept(deployment)
 
 		if s.accepted {

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -229,6 +229,9 @@ func MakeDeployment(config *deployapi.DeploymentConfig, codec runtime.Codec) (*a
 			},
 		},
 	}
+	if value, ok := config.Annotations[deployapi.DeploymentIgnorePodAnnotation]; ok {
+		deployment.Annotations[deployapi.DeploymentIgnorePodAnnotation] = value
+	}
 
 	return deployment, nil
 }

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -141,8 +141,8 @@ var _ = g.Describe("deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
 			o.Expect(out).To(o.ContainSubstring("deployment-test-1 to 2"))
-			o.Expect(out).To(o.ContainSubstring("Pre hook finished"))
-			o.Expect(out).To(o.ContainSubstring("Deployment deployment-test-1 successfully made active"))
+			o.Expect(out).To(o.ContainSubstring("--> pre: Success"))
+			o.Expect(out).To(o.ContainSubstring("--> Success"))
 
 			g.By("verifying the deployment is marked complete and scaled to zero")
 			o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
@@ -177,7 +177,9 @@ var _ = g.Describe("deploymentconfigs", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
 				o.Expect(out).To(o.ContainSubstring(fmt.Sprintf("deployment-test-%d up to 1", i+2)))
-				o.Expect(out).To(o.ContainSubstring("Pre hook finished"))
+				o.Expect(out).To(o.ContainSubstring("--> pre: Success"))
+				o.Expect(out).To(o.ContainSubstring("test pre hook executed"))
+				o.Expect(out).To(o.ContainSubstring("--> Success"))
 
 				g.By("verifying the deployment is marked complete and scaled to zero")
 				o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())

--- a/test/extended/fixtures/custom-deployment.yaml
+++ b/test/extended/fixtures/custom-deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
-  name: deployment-test
+  name: custom-deployment
 spec:
   replicas: 2
   selector:
-    name: deployment-test
+    name: custom-deployment
   strategy:
     type: Rolling
     rollingParams:
@@ -16,10 +16,20 @@ spec:
           command:
           - /bin/echo
           - test pre hook executed
+    customParams:
+      command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        openshift-deploy --until=50%
+        echo Halfway
+        openshift-deploy
+        echo Finished
   template:
     metadata:
       labels:
-        name: deployment-test
+        name: custom-deployment
     spec:
       terminationGracePeriodSeconds: 0
       containers:
@@ -29,6 +39,5 @@ spec:
         command:
         - /bin/sleep
         - "100"
-  test: true
   triggers:
   - type: ConfigChange

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -328,7 +328,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 				},
 			},
 		},
-		"test",
+		"test", "test",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -366,7 +366,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 				},
 			},
 		},
-		"test",
+		"test", "test",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -398,7 +398,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 				},
 			},
 		},
-		"test",
+		"test", "test",
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Don't use glog in deployment output, also surge on recreate.  Make deployment truly reentrant, with the `--until=[start|pre|mid|0%|50%|100%]` condition to gate how far to go:

    $ openshift-deploy --until=pre
    --> pre: Running hook pod ...
    my hook pod ran
    --> pre: Success
    --> pre hook completed
    $ openshift-deploy --until=50%
    --> pre: Hook pod already succeeded
    --> Scaling deployment-2 from 0 to 5
        Scaling deployment-2 up to 3
        Scaling deployment-1 down to 2
    --> Reached 50% (currently 60%)
    $ sleep 5
    $ curl http://myservice:8080/metrics
    user metrics ok
    $ openshift-deploy
    --> pre: Hook pod already succeeded
    --> Scaling deployment-2 from 3 to 5
        Scaling deployment-2 up to 5
        Scaling deployment-1 down to 0
    --> Success

Will allow custom deployments to be scriptable.