### PR TITLE
Add 'MissingSecret' reason for pending builds

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -259,6 +259,11 @@ const (
 	// StatusReasonExceededRetryTimeout is an error condition when the build has
 	// not completed and retrying the build times out.
 	StatusReasonExceededRetryTimeout = "ExceededRetryTimeout"
+
+	// StatusReasonMissingPushSecret indicates that the build is missing required
+	// secret for pushing the output image.
+	// The build will stay in the pending state until the secret is created, or the build times out.
+	StatusReasonMissingPushSecret = "MissingPushSecret"
 )
 
 // BuildSource is the input used for the build.

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -197,6 +197,7 @@ func (factory *BuildPodControllerFactory) Create() controller.RunnableController
 	buildPodController := &buildcontroller.BuildPodController{
 		BuildStore:   factory.buildStore,
 		BuildUpdater: factory.BuildUpdater,
+		SecretClient: factory.KubeClient,
 		PodManager:   client,
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/6781

When you have a build configuration and you pushing to a private repository in external registry and you set the push secret but the push secret does not exists, we should set the reason for the build to be in the pending state.

This PR will add 'MissingSecret' reason for such build. This will be displayed next to 'Pending'.