### PR TITLE
Fix jshint warnings

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -183,7 +183,7 @@ angular.module("openshiftConsole")
 
         initAndValidate($scope);
 
-        var ifResourcesDontExist = function(apiObjects, namespace, scope){
+        var ifResourcesDontExist = function(apiObjects, namespace){
           var result = $q.defer();
           var successResults = [];
           var failureResults = [];
@@ -195,9 +195,10 @@ angular.module("openshiftConsole")
                 //means some resources exist with the given nanme
                 result.reject(successResults);
               }
-              else
+              else {
                 //means no resources exist with the given nanme
                 result.resolve(apiObjects);
+              }
             }
           }
 
@@ -301,7 +302,7 @@ angular.module("openshiftConsole")
           var resourceMap = ApplicationGenerator.generate($scope);
           //init tasks
           var resources = [];
-          angular.forEach(resourceMap, function(value, key){
+          angular.forEach(resourceMap, function(value){
             if(value !== null){
               Logger.debug("Generated resource definition:", value);
               resources.push(value);

--- a/assets/app/scripts/controllers/create/nextSteps.js
+++ b/assets/app/scripts/controllers/create/nextSteps.js
@@ -86,7 +86,7 @@ angular.module("openshiftConsole")
             }
           });
           return erroredTasks;
-        };
+        }
         $scope.erroredTasks = erroredTasks;
 
         function pendingTasks(tasks) {
@@ -97,7 +97,7 @@ angular.module("openshiftConsole")
             }
           });
           return pendingTasks;
-        };
+        }
         $scope.pendingTasks = pendingTasks;
 
         $scope.goBack = function() {

--- a/assets/app/scripts/controllers/edit/buildConfig.js
+++ b/assets/app/scripts/controllers/edit/buildConfig.js
@@ -810,7 +810,7 @@ angular.module('openshiftConsole')
 
     $scope.getSourceMap = function(sourceMap, sources) {
       if (sources.type === "None") {
-        return sourceMap
+        return sourceMap;
       }
       sourceMap.none = false;
       angular.forEach(sources, function(value, key) {

--- a/assets/app/scripts/controllers/modals/confirmReplaceModal.js
+++ b/assets/app/scripts/controllers/modals/confirmReplaceModal.js
@@ -8,7 +8,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('ConfirmReplaceModalController', function ($scope, $uibModalInstance, AlertMessageService) {
+  .controller('ConfirmReplaceModalController', function ($scope, $uibModalInstance) {
     $scope.replace = function() {
       $uibModalInstance.close('replace');
     };

--- a/assets/app/scripts/controllers/util/error.js
+++ b/assets/app/scripts/controllers/util/error.js
@@ -11,8 +11,6 @@ angular.module('openshiftConsole')
   .controller('ErrorController', function ($scope, $window) {
     var params = URI(window.location.href).query(true);
     var error = params.error;
-    var error_description = params.error_description;
-    var error_uri = params.error_uri;
 
     switch(error) {
       case 'access_denied':


### PR DESCRIPTION
Fix the following jshint warnings:

```
assets❯ jshint app/scripts
app/scripts/controllers/create/createFromImage.js: line 200, col 17, Expected '{' and instead saw 'result'.
app/scripts/controllers/create/createFromImage.js: line 186, col 68, 'scope' is defined but never used.
app/scripts/controllers/create/createFromImage.js: line 304, col 56, 'key' is defined but never used.

app/scripts/controllers/create/nextSteps.js: line 89, col 10, Unnecessary semicolon.
app/scripts/controllers/create/nextSteps.js: line 100, col 10, Unnecessary semicolon.

app/scripts/controllers/edit/buildConfig.js: line 813, col 25, Missing semicolon.

app/scripts/controllers/modals/confirmReplaceModal.js: line 11, col 85, 'AlertMessageService' is defined but never used.

app/scripts/controllers/util/error.js: line 14, col 9, 'error_description' is defined but never used.
app/scripts/controllers/util/error.js: line 15, col 9, 'error_uri' is defined but never used.
```

@jwforres PTAL