### PR TITLE
When building oc from build-*-images, use found path

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -18,10 +18,14 @@ os::log::install_errexit
 # Go to the top of the tree.
 cd "${OS_ROOT}"
 
-"${OS_ROOT}/hack/build-go.sh" cmd/oc
-oc="$(os::build::find-binary oc)"
+oc="$(os::build::find-binary oc ${OS_ROOT})"
+if [[ -z "${oc}" ]]; then
+  "${OS_ROOT}/hack/build-go.sh" cmd/oc
+  oc="$(os::build::find-binary oc ${OS_ROOT})"
+fi
+
 function build() {
-  oc ex dockerbuild $2 $1
+  "${oc}" ex dockerbuild $2 $1
 }
 
 # Build the images

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -55,10 +55,14 @@ else
   os::build::extract_tar "${OS_IMAGE_RELEASE_TAR}" "${imagedir}"
 fi
 
-"${OS_ROOT}/hack/build-go.sh" cmd/oc
-oc="$(os::build::find-binary oc)"
+oc="$(os::build::find-binary oc ${OS_ROOT})"
+if [[ -z "${oc}" ]]; then
+  "${OS_ROOT}/hack/build-go.sh" cmd/oc
+  oc="$(os::build::find-binary oc ${OS_ROOT})"
+fi
+
 function build() {
-  oc ex dockerbuild $2 $1
+  "${oc}" ex dockerbuild $2 $1
 }
 
 # Create link to file if the FS supports hardlinks, otherwise copy the file


### PR DESCRIPTION
Don't assume PATH contains oc - oversight when merged.

@brenton addresses https://github.com/openshift/origin/pull/7823#issuecomment-217935958

[test]