### PR TITLE
Add scope validation in api

### DIFF
--- a/pkg/oauth/api/validation/validation.go
+++ b/pkg/oauth/api/validation/validation.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/validation/field"
 
 	oapi "github.com/openshift/origin/pkg/api"
+	authorizerscopes "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	"github.com/openshift/origin/pkg/oauth/api"
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
@@ -53,6 +54,7 @@ func ValidateAccessToken(accessToken *api.OAuthAccessToken) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&accessToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(accessToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(accessToken.UserName, field.NewPath("userName"))...)
+	allErrs = append(allErrs, ValidateScopes(accessToken.Scopes, field.NewPath("scopes"))...)
 
 	if len(accessToken.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("userUID"), ""))
@@ -68,6 +70,7 @@ func ValidateAuthorizeToken(authorizeToken *api.OAuthAuthorizeToken) field.Error
 	allErrs := validation.ValidateObjectMeta(&authorizeToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(authorizeToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(authorizeToken.UserName, field.NewPath("userName"))...)
+	allErrs = append(allErrs, ValidateScopes(authorizeToken.Scopes, field.NewPath("scopes"))...)
 
 	if len(authorizeToken.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("userUID"), ""))
@@ -132,6 +135,7 @@ func ValidateClientAuthorization(clientAuthorization *api.OAuthClientAuthorizati
 
 	allErrs = append(allErrs, ValidateClientNameField(clientAuthorization.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(clientAuthorization.UserName, field.NewPath("userName"))...)
+	allErrs = append(allErrs, ValidateScopes(clientAuthorization.Scopes, field.NewPath("scopes"))...)
 
 	if len(clientAuthorization.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("useruid"), ""))
@@ -174,4 +178,46 @@ func ValidateUserNameField(value string, fldPath *field.Path) field.ErrorList {
 		return field.ErrorList{field.Invalid(fldPath, value, msg)}
 	}
 	return field.ErrorList{}
+}
+
+func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, scope := range scopes {
+		illegalCharacter := false
+		// https://tools.ietf.org/html/rfc6749#section-3.3 (full list of allowed chars is %x21 / %x23-5B / %x5D-7E)
+		// for those without an ascii table, that's `!`, `#-[`, `]-~` inclusive.
+		for _, ch := range scope {
+			switch {
+			case ch == rune("!"[0]):
+			case ch >= rune("#"[0]) && ch <= rune("]"[0]):
+			case ch >= rune("]"[0]) && ch <= rune("~"[0]):
+			default:
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, fmt.Sprintf("%v not allowed", ch)))
+				illegalCharacter = true
+			}
+		}
+		if illegalCharacter {
+			continue
+		}
+
+		found := false
+		for _, evaluator := range authorizerscopes.ScopeEvaluators {
+			if !evaluator.Handles(scope) {
+				continue
+			}
+
+			found = true
+			if err := evaluator.Validate(scope); err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, err.Error()))
+				break
+			}
+		}
+
+		if !found {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, "no scope handler found"))
+		}
+	}
+
+	return allErrs
 }

--- a/pkg/oauth/api/validation/validation_test.go
+++ b/pkg/oauth/api/validation/validation_test.go
@@ -131,6 +131,28 @@ func TestValidateClientAuthorization(t *testing.T) {
 			T: field.ErrorTypeForbidden,
 			F: "metadata.namespace",
 		},
+		"no scope handler": {
+			A: oapi.OAuthClientAuthorization{
+				ObjectMeta: api.ObjectMeta{Name: "myusername:myclientname"},
+				ClientName: "myclientname",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"invalid"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
+		"bad scope": {
+			A: oapi.OAuthClientAuthorization{
+				ObjectMeta: api.ObjectMeta{Name: "myusername:myclientname"},
+				ClientName: "myclientname",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"user:dne"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
 	}
 	for k, v := range errorCases {
 		errs := ValidateClientAuthorization(&v.A)
@@ -225,6 +247,28 @@ func TestValidateAccessTokens(t *testing.T) {
 			T: field.ErrorTypeForbidden,
 			F: "metadata.namespace",
 		},
+		"no scope handler": {
+			Token: oapi.OAuthAccessToken{
+				ObjectMeta: api.ObjectMeta{Name: "accessTokenNameWithMinimumLength"},
+				ClientName: "myclient",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"invalid"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
+		"bad scope": {
+			Token: oapi.OAuthAccessToken{
+				ObjectMeta: api.ObjectMeta{Name: "accessTokenNameWithMinimumLength"},
+				ClientName: "myclient",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"user:dne"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
 	}
 	for k, v := range errorCases {
 		errs := ValidateAccessToken(&v.Token)
@@ -249,6 +293,7 @@ func TestValidateAuthorizeTokens(t *testing.T) {
 		ClientName: "myclient",
 		UserName:   "myusername",
 		UserUID:    "myuseruid",
+		Scopes:     []string{`user:info`},
 	})
 	if len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
@@ -304,6 +349,39 @@ func TestValidateAuthorizeTokens(t *testing.T) {
 			},
 			T: field.ErrorTypeForbidden,
 			F: "metadata.namespace",
+		},
+		"no scope handler": {
+			Token: oapi.OAuthAuthorizeToken{
+				ObjectMeta: api.ObjectMeta{Name: "authorizeTokenNameWithMinimumLength"},
+				ClientName: "myclient",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"invalid"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
+		"bad scope": {
+			Token: oapi.OAuthAuthorizeToken{
+				ObjectMeta: api.ObjectMeta{Name: "authorizeTokenNameWithMinimumLength"},
+				ClientName: "myclient",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{"user:dne"},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
+		},
+		"illegal character": {
+			Token: oapi.OAuthAuthorizeToken{
+				ObjectMeta: api.ObjectMeta{Name: "authorizeTokenNameWithMinimumLength"},
+				ClientName: "myclient",
+				UserName:   "myusername",
+				UserUID:    "myuseruid",
+				Scopes:     []string{`role:asdf":foo`},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "scopes[0]",
 		},
 	}
 	for k, v := range errorCases {


### PR DESCRIPTION
Adds validation to the access token, authorize token, and client authorization types to ensure that we only set scope values that we can interpret.

@sgallagher ptal at the last commit.