### PR TITLE
web console: defensive blocks in valuesIn and valuesNotIn filters

### DIFF
--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -254,6 +254,9 @@ angular.module('openshiftConsole')
    */
   .filter("valuesIn", function(){
     return function(entries, keys){
+      if (!keys) {
+        return {};
+      }
       var readonly = keys.split(",");
       var result = {};
       angular.forEach(entries, function(value, key){
@@ -273,6 +276,9 @@ angular.module('openshiftConsole')
    */
   .filter("valuesNotIn", function(){
     return function(entries, keys){
+      if (!keys) {
+        return entries;
+      }
       var readonly = keys.split(",");
       var result = {};
       angular.forEach(entries, function(value, key){
@@ -369,7 +375,7 @@ angular.module('openshiftConsole')
       catch (e) {
         // it wasn't valid json
         return null;
-      }      
+      }
     };
   })
   .filter('prettifyJSON', function(parseJSONFilter) {
@@ -422,7 +428,7 @@ angular.module('openshiftConsole')
     return function(value, format) {
       if (!value) {
         return value;
-      }  
+      }
       var accessModes = [];
       angular.forEach(value, function(item) {
         var accessModeString;
@@ -470,7 +476,7 @@ angular.module('openshiftConsole')
         if (lastSpace !== -1) {
           truncated = truncated.substring(0, lastSpace);
         }
-      }      
+      }
 
       return truncated;
     };


### PR DESCRIPTION
Originally in [this PR](https://github.com/jwforres/origin/pull/44/files) from @spadgett, will affect @rhamilto's work on the osc-key-values directive for env vars.
@jwforres