### PR TITLE
platformmanagement_public_704: Added basic auditing capabilities

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http.go
@@ -153,8 +153,14 @@ func GetClientIP(req *http.Request) net.IP {
 	}
 
 	// Fallback to Remote Address in request, which will give the correct client IP when there is no proxy.
-	ip := net.ParseIP(req.RemoteAddr)
-	return ip
+	// Remote Address in Go's HTTP server is in the form host:port so we need to split that first.
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err == nil {
+		return net.ParseIP(host)
+	}
+
+	// Fallback if Remote Address was just IP.
+	return net.ParseIP(req.RemoteAddr)
 }
 
 var defaultProxyFuncPointer = fmt.Sprintf("%p", http.ProxyFromEnvironment)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/net/http_test.go
@@ -76,7 +76,8 @@ func TestGetClientIP(t *testing.T) {
 		},
 		{
 			Request: http.Request{
-				RemoteAddr: ipString,
+				// RemoteAddr is in the form host:port
+				RemoteAddr: ipString + ":1234",
 			},
 			ExpectedIP: ip,
 		},
@@ -90,6 +91,7 @@ func TestGetClientIP(t *testing.T) {
 				Header: map[string][]string{
 					"X-Forwarded-For": {invalidIPString},
 				},
+				// RemoteAddr is in the form host:port
 				RemoteAddr: ipString,
 			},
 			ExpectedIP: ip,
@@ -98,7 +100,7 @@ func TestGetClientIP(t *testing.T) {
 
 	for i, test := range testCases {
 		if a, e := GetClientIP(&test.Request), test.ExpectedIP; reflect.DeepEqual(e, a) != true {
-			t.Fatalf("test case %d failed. expected: %v, actual: %v", i+1, e, a)
+			t.Fatalf("test case %d failed. expected: %v, actual: %v", i, e, a)
 		}
 	}
 }

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -294,6 +294,16 @@ type MasterConfig struct {
 	// JenkinsPipelineConfig holds information about the default Jenkins template
 	// used for JenkinsPipeline build strategy.
 	JenkinsPipelineConfig JenkinsPipelineConfig
+
+	// AuditConfig holds information related to auditing capabilities.
+	AuditConfig AuditConfig
+}
+
+// AuditConfig holds configuration for the audit capabilities
+type AuditConfig struct {
+	// If this flag is set, audit log will be printed in the logs.
+	// The logs contains, method, user and a requested URL.
+	Enabled bool
 }
 
 // JenkinsPipelineConfig holds configuration for the Jenkins pipeline strategy

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -73,6 +73,15 @@ func (AssetExtensionsConfig) SwaggerDoc() map[string]string {
 	return map_AssetExtensionsConfig
 }
 
+var map_AuditConfig = map[string]string{
+	"":        "AuditConfig holds configuration for the audit capabilities",
+	"enabled": "If this flag is set, basic audit log will be printed in the logs. The logs contains, method, user and a requested URL.",
+}
+
+func (AuditConfig) SwaggerDoc() map[string]string {
+	return map_AuditConfig
+}
+
 var map_AugmentedActiveDirectoryConfig = map[string]string{
 	"":                          "AugmentedActiveDirectoryConfig holds the necessary configuration options to define how an LDAP group sync interacts with an LDAP server using the augmented Active Directory schema",
 	"usersQuery":                "AllUsersQuery holds the template for an LDAP query that returns user entries.",
@@ -433,6 +442,7 @@ var map_MasterConfig = map[string]string{
 	"networkConfig":          "NetworkConfig to be passed to the compiled in network plugin",
 	"volumeConfig":           "MasterVolumeConfig contains options for configuring volume plugins in the master node.",
 	"jenkinsPipelineConfig":  "JenkinsPipelineConfig holds information about the default Jenkins template used for JenkinsPipeline build strategy.",
+	"auditConfig":            "AuditConfig holds information related to auditing capabilities.",
 }
 
 func (MasterConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -235,6 +235,16 @@ type MasterConfig struct {
 	// JenkinsPipelineConfig holds information about the default Jenkins template
 	// used for JenkinsPipeline build strategy.
 	JenkinsPipelineConfig JenkinsPipelineConfig `json:"jenkinsPipelineConfig"`
+
+	// AuditConfig holds information related to auditing capabilities.
+	AuditConfig AuditConfig `json:"auditConfig"`
+}
+
+// AuditConfig holds configuration for the audit capabilities
+type AuditConfig struct {
+	// If this flag is set, basic audit log will be printed in the logs.
+	// The logs contains, method, user and a requested URL.
+	Enabled bool `json:"enabled"`
 }
 
 // JenkinsPipelineConfig holds configuration for the Jenkins pipeline strategy

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -102,6 +102,8 @@ assetConfig:
     maxRequestsInFlight: 0
     namedCertificates: null
     requestTimeoutSeconds: 0
+auditConfig:
+  enabled: false
 controllerConfig:
   serviceServingCert:
     signer: null

--- a/pkg/cmd/server/origin/audit.go
+++ b/pkg/cmd/server/origin/audit.go
@@ -1,0 +1,58 @@
+package origin
+
+import (
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/pborman/uuid"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/net"
+
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+)
+
+type auditResponseWriter struct {
+	http.ResponseWriter
+	id string
+}
+
+func (a *auditResponseWriter) WriteHeader(code int) {
+	glog.Infof("AUDIT: id=%q response=\"%d\"", a.id, code)
+	a.ResponseWriter.WriteHeader(code)
+}
+
+// auditHandler is responsible for logging audit information for all the
+// request coming to server. Each audit log contains two entries:
+// 1. the request line containing:
+//    - unique id allowing to match the response line (see 2)
+//    - source ip of the request
+//    - HTTP method being invoked
+//    - original user invoking the operation
+//    - impersonated user for the operation
+//    - namespace of the request or <none>
+//    - uri is the full URI as requested
+// 2. the response line containing the unique id from 1 and response code
+func (c *MasterConfig) auditHandler(handler http.Handler) http.Handler {
+	if !c.Options.AuditConfig.Enabled {
+		return handler
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, _ := c.RequestContextMapper.Get(req)
+		user, _ := kapi.UserFrom(ctx)
+		asuser := req.Header.Get(authenticationapi.ImpersonateUserHeader)
+		if len(asuser) == 0 {
+			asuser = "<self>"
+		}
+		namespace := kapi.NamespaceValue(ctx)
+		if len(namespace) == 0 {
+			namespace = "<none>"
+		}
+		id := uuid.NewRandom().String()
+
+		glog.Infof("AUDIT: id=%q ip=%q method=%q user=%q as=%q namespace=%q uri=%q",
+			id, net.GetClientIP(req), req.Method, user.GetName(), asuser, namespace, req.URL)
+		handler.ServeHTTP(&auditResponseWriter{w, id}, req)
+	})
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -164,6 +164,8 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 	handler := c.versionSkewFilter(safe)
 	handler = c.authorizationFilter(handler)
 	handler = c.impersonationFilter(handler)
+	// audit handler must comes before the impersonationFilter to read the original user
+	handler = c.auditHandler(handler)
 	handler = authenticationHandlerFilter(handler, c.Authenticator, c.getRequestContextMapper())
 	handler = namespacingFilter(handler, c.getRequestContextMapper())
 	handler = cacheControlFilter(handler, "no-store") // protected endpoints should not be cached


### PR DESCRIPTION
This implements basic audit capabilities as described in [this trello](https://trello.com/c/A2ALCoaZ).
The only thing is there's no log from the response, I'd have to do it completely differently to get it.
Sample log looks like this:
```
I0510 09:55:56.405651   17618 audit.go:21] GET - test-admin@openshift - /oapi/v1/namespaces/openshift/imagestreams/python
```
and is enabled with following config option:
```
auditConfig:
  basicAuditEnabled: true
```
@openshift/api-review for api changes
@pweil- @danmcp ptal
@mpbarrett fyi
