### PR TITLE
Speed up extended network tests a bit by skipping sooner

### DIFF
--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -36,6 +36,13 @@ DEFAULT_SKIP_LIST=(
 
   # DNS inside container fails in CI but works locally
   "should provide Internet connection for containers"
+
+  # Skip tests that require GCE or AWS. (They'll skip themselves if we run them, but
+  # only after several seconds of setup.)
+  "should be able to up and down services"
+  "should work after restarting kube-proxy"
+  "should work after restarting apiserver"
+  "should be able to change the type and ports of a service"
 )
 
 CLUSTER_CMD="${OS_ROOT}/hack/dind-cluster.sh"

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -9,55 +9,54 @@ import (
 )
 
 var _ = Describe("[networking] network isolation", func() {
-	f1 := e2e.NewDefaultFramework("net-isolation1")
-	f2 := e2e.NewDefaultFramework("net-isolation2")
+	InSingleTenantContext(func() {
+		f1 := e2e.NewDefaultFramework("net-isolation1")
+		f2 := e2e.NewDefaultFramework("net-isolation2")
 
-	Specify("multi-tenant plugins should prevent communication between pods in different namespaces on the same node", func() {
-		skipIfSingleTenant()
-		err := checkPodIsolation(f1, f2, 1)
-		Expect(err).To(HaveOccurred())
-	})
+		It("should allow communication between pods in different namespaces on the same node", func() {
+			Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
+		})
 
-	Specify("multi-tenant plugins should prevent communication between pods in different namespaces on different nodes", func() {
-		skipIfSingleTenant()
-		err := checkPodIsolation(f1, f2, 2)
-		Expect(err).To(HaveOccurred())
+		It("should allow communication between pods in different namespaces on different nodes", func() {
+			Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+		})
 	})
 
-	Specify("single-tenant plugins should allow communication between pods in different namespaces on the same node", func() {
-		skipIfMultiTenant()
-		Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
-	})
+	InMultiTenantContext(func() {
+		f1 := e2e.NewDefaultFramework("net-isolation1")
+		f2 := e2e.NewDefaultFramework("net-isolation2")
 
-	Specify("single-tenant plugins should allow communication between pods in different namespaces on different nodes", func() {
-		skipIfMultiTenant()
-		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
-	})
+		It("should prevent communication between pods in different namespaces on the same node", func() {
+			err := checkPodIsolation(f1, f2, 1)
+			Expect(err).To(HaveOccurred())
+		})
 
-	// The test framework doesn't allow us to easily make use of the actual "default"
-	// namespace, so we test default namespace behavior by changing either f1's or
-	// f2's NetNamespace to have VNID 0 instead. But this only works under the
-	// multi-tenant plugin since the single-tenant one doesn't create NetNamespaces at
-	// all (and so there's not really any point in even running these tests anyway).
-	Specify("multi-tenant plugins should allow communication from default to non-default namespace on the same node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f2.Namespace)
-		Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow communication from default to non-default namespace on a different node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f2.Namespace)
-		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow communication from non-default to default namespace on the same node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f1.Namespace)
-		Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow communication from non-default to default namespace on a different node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f1.Namespace)
-		Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+		It("should prevent communication between pods in different namespaces on different nodes", func() {
+			err := checkPodIsolation(f1, f2, 2)
+			Expect(err).To(HaveOccurred())
+		})
+
+		// The test framework doesn't allow us to easily make use of the actual "default"
+		// namespace, so we test default namespace behavior by changing either f1's or
+		// f2's NetNamespace to have VNID 0 instead. But this only works under the
+		// multi-tenant plugin since the single-tenant one doesn't create NetNamespaces at
+		// all (and so there's not really any point in even running these tests anyway).
+		It("should allow communication from default to non-default namespace on the same node", func() {
+			makeNamespaceGlobal(f2.Namespace)
+			Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
+		})
+		It("should allow communication from default to non-default namespace on a different node", func() {
+			makeNamespaceGlobal(f2.Namespace)
+			Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+		})
+		It("should allow communication from non-default to default namespace on the same node", func() {
+			makeNamespaceGlobal(f1.Namespace)
+			Expect(checkPodIsolation(f1, f2, 1)).To(Succeed())
+		})
+		It("should allow communication from non-default to default namespace on a different node", func() {
+			makeNamespaceGlobal(f1.Namespace)
+			Expect(checkPodIsolation(f1, f2, 2)).To(Succeed())
+		})
 	})
 })
 

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -9,58 +9,61 @@ import (
 )
 
 var _ = Describe("[networking] services", func() {
-	f1 := e2e.NewDefaultFramework("net-services2")
-	f2 := e2e.NewDefaultFramework("net-services2")
+	Context("basic functionality", func() {
+		f1 := e2e.NewDefaultFramework("net-services1")
 
-	It("should allow connections to another pod on the same node via a service IP", func() {
-		Expect(checkServiceConnectivity(f1, f1, 1)).To(Succeed())
-	})
+		It("should allow connections to another pod on the same node via a service IP", func() {
+			Expect(checkServiceConnectivity(f1, f1, 1)).To(Succeed())
+		})
 
-	It("should allow connections to another pod on a different node via a service IP", func() {
-		Expect(checkServiceConnectivity(f1, f1, 2)).To(Succeed())
-	})
-
-	Specify("single-tenant plugins should allow connections to pods in different namespaces on the same node via service IPs", func() {
-		skipIfMultiTenant()
-		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+		It("should allow connections to another pod on a different node via a service IP", func() {
+			Expect(checkServiceConnectivity(f1, f1, 2)).To(Succeed())
+		})
 	})
 
-	Specify("single-tenant plugins should allow connections to pods in different namespaces on different nodes via service IPs", func() {
-		skipIfMultiTenant()
-		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+	InSingleTenantContext(func() {
+		f1 := e2e.NewDefaultFramework("net-services1")
+		f2 := e2e.NewDefaultFramework("net-services2")
+
+		It("should allow connections to pods in different namespaces on the same node via service IPs", func() {
+			Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+		})
+
+		It("should allow connections to pods in different namespaces on different nodes via service IPs", func() {
+			Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+		})
 	})
 
-	Specify("multi-tenant plugins should prevent connections to pods in different namespaces on the same node via service IPs", func() {
-		skipIfSingleTenant()
-		err := checkServiceConnectivity(f1, f2, 1)
-		Expect(err).To(HaveOccurred())
-	})
+	InMultiTenantContext(func() {
+		f1 := e2e.NewDefaultFramework("net-services1")
+		f2 := e2e.NewDefaultFramework("net-services2")
 
-	Specify("multi-tenant plugins should prevent connections to pods in different namespaces on different nodes via service IPs", func() {
-		skipIfSingleTenant()
-		err := checkServiceConnectivity(f1, f2, 2)
-		Expect(err).To(HaveOccurred())
-	})
+		It("should prevent connections to pods in different namespaces on the same node via service IPs", func() {
+			err := checkServiceConnectivity(f1, f2, 1)
+			Expect(err).To(HaveOccurred())
+		})
 
-	Specify("multi-tenant plugins should allow connections to services in the default namespace from a pod in another namespaces on the same node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f1.Namespace)
-		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow connections to services in the default namespace from a pod in another namespace on a different node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f1.Namespace)
-		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow connections from pods in the default namespace to a service in another namespaces on the same node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f2.Namespace)
-		Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
-	})
-	Specify("multi-tenant plugins should allow connections from pods in the default namespace to a service in another namespaces on a different node", func() {
-		skipIfSingleTenant()
-		makeNamespaceGlobal(f2.Namespace)
-		Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+		It("should prevent connections to pods in different namespaces on different nodes via service IPs", func() {
+			err := checkServiceConnectivity(f1, f2, 2)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should allow connections to services in the default namespace from a pod in another namespace on the same node", func() {
+			makeNamespaceGlobal(f1.Namespace)
+			Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+		})
+		It("should allow connections to services in the default namespace from a pod in another namespace on a different node", func() {
+			makeNamespaceGlobal(f1.Namespace)
+			Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+		})
+		It("should allow connections from pods in the default namespace to a service in another namespace on the same node", func() {
+			makeNamespaceGlobal(f2.Namespace)
+			Expect(checkServiceConnectivity(f1, f2, 1)).To(Succeed())
+		})
+		It("should allow connections from pods in the default namespace to a service in another namespace on a different node", func() {
+			makeNamespaceGlobal(f2.Namespace)
+			Expect(checkServiceConnectivity(f1, f2, 2)).To(Succeed())
+		})
 	})
 })
 

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -169,14 +169,26 @@ func makeNamespaceGlobal(ns *api.Namespace) {
 	expectNoError(err)
 }
 
-func skipIfSingleTenant() {
-	if !pluginIsolatesNamespaces() {
-		e2e.Skipf("Not a multi-tenant plugin.")
-	}
+func InSingleTenantContext(body func()) {
+	Context("when using a single-tenant plugin", func() {
+		BeforeEach(func() {
+			if pluginIsolatesNamespaces() {
+				e2e.Skipf("Not a single-tenant plugin.")
+			}
+		})
+
+		body()
+	})
 }
 
-func skipIfMultiTenant() {
-	if pluginIsolatesNamespaces() {
-		e2e.Skipf("Not a single-tenant plugin.")
-	}
+func InMultiTenantContext(body func()) {
+	Context("when using a multi-tenant plugin", func() {
+		BeforeEach(func() {
+			if !pluginIsolatesNamespaces() {
+				e2e.Skipf("Not a multi-tenant plugin.")
+			}
+		})
+
+		body()
+	})
 }


### PR DESCRIPTION
We spend too much time doing setup on tests that we're going to skip... This cuts the time for a dind-cluster extended-networking check from 27m to 22m for me.

@marun?
