### PR TITLE
Prevent escalating resource access by default

### DIFF
--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -140,43 +140,56 @@ func (clusterRoleEvaluator) Handles(scope string) bool {
 }
 
 func (e clusterRoleEvaluator) Validate(scope string) error {
-	_, _, err := e.getRoleNamespace(scope)
+	_, _, _, err := e.parseScope(scope)
 	return err
 }
 
-func (e clusterRoleEvaluator) getRoleNamespace(scope string) (string, string, error) {
+// parseScope parses the requested scope, determining the requested role name, namespace, and if
+// access to escalating objects is required.  It will return an error if it doesn't parse cleanly
+func (e clusterRoleEvaluator) parseScope(scope string) (string /*role name*/, string /*namespace*/, bool /*escalating*/, error) {
 	if !e.Handles(scope) {
-		return "", "", fmt.Errorf("bad format for scope %v", scope)
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
 	}
+	escalating := false
+	if strings.HasSuffix(scope, ":!") {
+		escalating = true
+		// clip that last segment before parsing the rest
+		scope = scope[:strings.LastIndex(scope, ":")]
+	}
+
 	tokens := strings.SplitN(scope, ":", 2)
 	if len(tokens) != 2 {
-		return "", "", fmt.Errorf("bad format for scope %v", scope)
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
 	}
 
 	// namespaces can't have colons, but roles can.  pick last.
 	lastColonIndex := strings.LastIndex(tokens[1], ":")
 	if lastColonIndex <= 0 || lastColonIndex == (len(tokens[1])-1) {
-		return "", "", fmt.Errorf("bad format for scope %v", scope)
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
 	}
 
-	return tokens[1][0:lastColonIndex], tokens[1][lastColonIndex+1:], nil
+	return tokens[1][0:lastColonIndex], tokens[1][lastColonIndex+1:], escalating, nil
 }
 
 func (e clusterRoleEvaluator) Describe(scope string) string {
-	roleName, scopeNamespace, err := e.getRoleNamespace(scope)
+	roleName, scopeNamespace, escalating, err := e.parseScope(scope)
 	if err != nil {
 		return err.Error()
 	}
-
-	if scopeNamespace == authorizationapi.ScopesAllNamespaces {
-		return roleName + " access in all projects"
+	escalatingPhrase := "including any escalating resources like secrets"
+	if !escalating {
+		escalatingPhrase = "excluding any escalating resources like secrets"
 	}
 
-	return roleName + " access in the " + scopeNamespace + " project"
+	if scopeNamespace == authorizationapi.ScopesAllNamespaces {
+		return roleName + " access in all projects, " + escalatingPhrase
+	}
+
+	return roleName + " access in the " + scopeNamespace + " project, " + escalatingPhrase
 }
 
 func (e clusterRoleEvaluator) ResolveRules(scope, namespace string, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) ([]authorizationapi.PolicyRule, error) {
-	roleName, scopeNamespace, err := e.getRoleNamespace(scope)
+	roleName, scopeNamespace, escalating, err := e.parseScope(scope)
 	if err != nil {
 		return nil, err
 	}
@@ -198,21 +211,25 @@ func (e clusterRoleEvaluator) ResolveRules(scope, namespace string, clusterPolic
 
 	rules := []authorizationapi.PolicyRule{}
 	for _, rule := range role.Rules {
+		if escalating {
+			rules = append(rules, rule)
+			continue
+		}
+
 		// rules with unbounded access shouldn't be allowed in scopes.
 		if rule.Verbs.Has(authorizationapi.VerbAll) || rule.Resources.Has(authorizationapi.ResourceAll) || getAPIGroupSet(rule).Has(authorizationapi.APIGroupAll) {
 			continue
 		}
-
 		// rules that allow escalating resource access should be cleaned.
 		safeRule := removeEscalatingResources(rule)
-
 		rules = append(rules, safeRule)
 	}
 
 	return rules, nil
 }
 
-// removeEscalatingResources has coarse logic for now.  It is possible to rewrite one rule into many for the finest grain control
+// removeEscalatingResources inspects a PolicyRule and removes any references to escalating resources.
+// It has coarse logic for now.  It is possible to rewrite one rule into many for the finest grain control
 // but removing the entire matching resource regardless of verb or secondary group is cheaper, easier, and errs on the side removing
 // too much, not too little
 func removeEscalatingResources(in authorizationapi.PolicyRule) authorizationapi.PolicyRule {

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -251,6 +251,17 @@ func TestEscalationProtection(t *testing.T) {
 			expectedRules: []authorizationapi.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{"", "and-foo"}, Resources: sets.NewString("pods")}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
+		{
+			name: "allow the escalation",
+			clusterRoles: []authorizationapi.ClusterRole{
+				{
+					ObjectMeta: kapi.ObjectMeta{Name: "admin"},
+					Rules:      []authorizationapi.PolicyRule{{APIGroups: []string{""}, Resources: sets.NewString("pods", "secrets")}},
+				},
+			},
+			expectedRules: []authorizationapi.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{""}, Resources: sets.NewString("pods", "secrets")}},
+			scopes:        []string{ClusterRoleIndicator + "admin:*:!"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This prevents scopes from having access to escalating resource by default, but also provides a means to request a role based scope that is escalating by adding `:!` to the end of the "normal" definition `role:<role name>:<effective namespace[:!]`.

@sgallagher ptal  I think this is the last bit required to unblock useful scopes.