### PR TITLE
add scoped impersonation

### DIFF
--- a/pkg/auth/api/types.go
+++ b/pkg/auth/api/types.go
@@ -13,6 +13,9 @@ const (
 	// This is useful when the immutable providerUserName is different than the login used to authenticate
 	// If present, this extra value is used as the preferred username
 	IdentityPreferredUsernameKey = "preferred_username"
+
+	ImpersonateUserHeader      = "Impersonate-User"
+	ImpersonateUserScopeHeader = "Impersonate-User-Scope"
 )
 
 // UserIdentityInfo contains information about an identity.  Identities are distinct from users.  An authentication server of

--- a/pkg/cmd/server/origin/handlers_test.go
+++ b/pkg/cmd/server/origin/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
@@ -222,7 +223,7 @@ func TestImpersonationFilter(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			continue
 		}
-		req.Header.Add("Impersonate-User", tc.impersonationString)
+		req.Header.Add(authenticationapi.ImpersonateUserHeader, tc.impersonationString)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -9,10 +9,13 @@ import (
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -90,5 +93,49 @@ func TestScopedTokens(t *testing.T) {
 	impersonatedUser, err := impersonatingClient.Users().Get("~")
 	if !kapierrors.IsForbidden(err) {
 		t.Fatalf("missing error: %v got user %#v", err, impersonatedUser)
+	}
+}
+
+func TestScopedImpersonation(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	projectName := "hammer-project"
+	userName := "harold"
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = clusterAdminClient.Get().
+		SetHeader(authenticationapi.ImpersonateUserHeader, "harold").
+		SetHeader(authenticationapi.ImpersonateUserScopeHeader, "user:info").
+		Namespace(projectName).Resource("builds").Name("name").Do().Into(&buildapi.Build{})
+	if !kapierrors.IsForbidden(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	user := &userapi.User{}
+	err = clusterAdminClient.Get().
+		SetHeader(authenticationapi.ImpersonateUserHeader, "harold").
+		SetHeader(authenticationapi.ImpersonateUserScopeHeader, "user:info").
+		Resource("users").Name("~").Do().Into(user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.Name != "harold" {
+		t.Fatalf("expected %v, got %v", "harold", user.Name)
 	}
 }


### PR DESCRIPTION
For https://trello.com/c/CqdFNLkd/697-3-auth-scopes-scoped-acting-as

This allows someone to act as a user and limit themselves to the scopes provided on the token.  This is useful for cases where our API talks back to itself and wants to switch to an impersonation model.  Doing this would prevent a token from accidentally being escalated.

@sgallagher ptal