### PR TITLE
Bug 1333172 - differ between route hostname and navigation within the console

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -426,6 +426,10 @@ label.checkbox {
   font-size: 128px;
 }
 
+.icon-medium {
+  font-size: 17px;
+}
+
 .create-route-icon,
 .create-storage-icon {
   padding-top: 0;

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -103,7 +103,10 @@
                         <h2 ng-if="displayRouteByService[serviceId]" ng-init="otherRoutes = (routesByService[serviceId] | hashSize) - 1">
                           <span ng-if="(displayRouteByService[serviceId] | isWebRoute)">
                             <!-- "route" class is present for e2e tests to check -->
-                            <a href="{{displayRouteByService[serviceId] | routeWebURL}}" class="route" target="_blank">{{displayRouteByService[serviceId] | routeLabel}}</a>
+                            <a href="{{displayRouteByService[serviceId] | routeWebURL}}" class="route" target="_blank">
+                              <i class="pficon pficon-route icon-medium"></i>
+                              {{displayRouteByService[serviceId] | routeLabel}}
+                            </a>
                           </span>
                           <!-- "route" class is present for e2e test -->
                           <span ng-if="!(displayRouteByService[serviceId] | isWebRoute)" class="route">


### PR DESCRIPTION
Making difference between route hostname and navigation within the console more obvious, by prepending the `pficon-route` icon before the exposed route link.

Screen prepending the icon(which I like more then the appending one):
![screenshot-11](https://cloud.githubusercontent.com/assets/1668218/15177827/7ab873c4-1772-11e6-99cb-d5a70f6f6880.png)


Screen appending the icon:
![screenshot-12](https://cloud.githubusercontent.com/assets/1668218/15177840/8653a348-1772-11e6-9da3-067d72284e47.png)

Also I've created a standalone class for the icon `font-size` since by default it will take the size of `h2` style which is 19px and that seems to be too big for the icon:
http://imgur.com/Fj6J3TL

@jwforres I know we should open new PRs agianst openshift/origin-web-console, but since this is going to get backported to ose and online, which have the same layout as the openshift/origin, I'm opening the PR here. Have the PR for openshift/origin-web-console prepared, so if anything I will open it, just let me know.
PTAL