### PR TITLE
Bug 1333118 - Make for CLI tools a standalone help page

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -215,6 +215,7 @@
         <script src="scripts/controllers/modals/confirmReplaceModal.js"></script>
         <script src="scripts/controllers/modals/processTemplateModal.js"></script>
         <script src="scripts/controllers/about.js"></script>
+        <script src="scripts/controllers/commandLine.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteLink.js"></script>
         <script src="scripts/directives/editLink.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -269,6 +269,10 @@ angular
         templateUrl: 'views/about.html',
         controller: 'AboutController'
       })
+      .when('/commandLine', {
+        templateUrl: 'views/command-line.html',
+        controller: 'CommandLineController'
+      })
       .when('/oauth', {
         templateUrl: 'views/util/oauth.html',
         controller: 'OAuthController'

--- a/assets/app/scripts/controllers/about.js
+++ b/assets/app/scripts/controllers/about.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('AboutController', function ($scope, DataService, AuthService, Constants) {
+  .controller('AboutController', function ($scope, AuthService, Constants) {
     AuthService.withUser();
     
     $scope.version = {
@@ -16,8 +16,4 @@ angular.module('openshiftConsole')
         kubernetes: Constants.VERSION.kubernetes,
       },
     };
-    $scope.cliDownloadURL = Constants.CLI;
-    $scope.cliDownloadURLPresent = $scope.cliDownloadURL && !_.isEmpty($scope.cliDownloadURL);
-    $scope.loginBaseURL = DataService.openshiftAPIBaseUrl();
-    $scope.sessionToken = AuthService.UserStore().getToken();
   });

--- a/assets/app/scripts/controllers/commandLine.js
+++ b/assets/app/scripts/controllers/commandLine.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CommandLineController
+ * @description
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CommandLineController', function ($scope, DataService, AuthService, Constants) {
+    AuthService.withUser();
+
+    $scope.cliDownloadURL = Constants.CLI;
+    $scope.cliDownloadURLPresent = $scope.cliDownloadURL && !_.isEmpty($scope.cliDownloadURL);
+    $scope.loginBaseURL = DataService.openshiftAPIBaseUrl();
+    $scope.sessionToken = AuthService.UserStore().getToken();
+  });

--- a/assets/app/scripts/extensions/nav/dropdownMobile.js
+++ b/assets/app/scripts/extensions/nav/dropdownMobile.js
@@ -24,6 +24,15 @@ angular.module('openshiftConsole')
           ].join('')
         }, {
           type: 'dom',
+          node: [
+            '<li>',
+              '<a href="commandLine">',
+                '<span class="fa fa-terminal" aria-hidden="true"></span> Command Line Tools',
+              '</a>',
+            '</li>'
+          ].join('')
+        }, {
+          type: 'dom',
           node: _.template([
             '<li>',
               '<a href="logout">',

--- a/assets/app/scripts/extensions/nav/helpDropdown.js
+++ b/assets/app/scripts/extensions/nav/helpDropdown.js
@@ -14,6 +14,10 @@ angular.module('openshiftConsole')
           {
             type: 'dom',
             node: '<li><a href="about">About</a></li>'
+          },
+          {
+            type: 'dom',
+            node: '<li><a href="commandLine">Command Line Tools</a></li>'
           }
         ];
       });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -432,7 +432,8 @@ label.checkbox {
   text-align: right;
 }
 
-.about {
+.about,
+.command-line {
   .about-icon {
     img {
       width: 100%;

--- a/assets/app/views/about.html
+++ b/assets/app/views/about.html
@@ -29,35 +29,7 @@
                         <dd>{{version.master.kubernetes || 'unknown'}}</dd>
                       </dl>
 
-                      <h2 id="cli">Command Line Tools</h2>
-                      <p>
-                        With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.
-                        <span ng-if="cliDownloadURLPresent">
-                          You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation.
-                        </span>
-                        <span ng-if="!cliDownloadURLPresent">
-                          Refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.
-                        </span>
-                        <div ng-if="cliDownloadURLPresent">
-                          <label class="cli-download-label">Download <code>oc</code>:</label>
-                          <div ng-repeat="(key, value) in cliDownloadURL">
-                            <a href="{{value}}" class="cli-download-link">
-                              {{key}}
-                              <i class="fa fa-external-link"></i>
-                            </a>
-                          </div>
-                        </div>
-                      </p>
-                      <p>
-                        After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
-                        <div class="code prettyprint ng-binding" ng-if="sessionToken">
-                          oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="showSessionToken = !showSessionToken" ng-show="!showSessionToken">...click to show token...</a>
-                        </div>
-                        <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
-        oc login {{loginBaseURL}}
-        </pre>
-                      </p>
-                      <p>For other information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
+                      <p>For information about the command line tools, check the <a target="_blank" href="commandLine">CLI page</a>.</p>
                     </div>
                   </div>
                 </div>

--- a/assets/app/views/command-line.html
+++ b/assets/app/views/command-line.html
@@ -1,0 +1,60 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle">
+    <!-- Middle section -->
+    <div class="middle-section surface-shaded">
+      <div class="middle-container has-scroll">
+        <div class="middle-content">
+          <div class="container surface-shaded gutter-top">
+            <div class="row">
+              <div class="col-md-12">
+                <div class="command-line">
+                  <div class="row">
+                    <div class="col-md-2 about-icon gutter-top hidden-sm hidden-xs">
+                      <img src="images/openshift-logo.svg" />
+                    </div>
+                    <div class="col-md-9">
+                      <h1>OpenShift by Red Hat&reg;</h1>
+                      <h2 id="cli">Command Line Tools</h2>
+                      <p>
+                        With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal.
+                        <span ng-if="cliDownloadURLPresent">
+                          You can download the <code>oc</code> client tool using the links below. For more information about downloading and installing it, please refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation.
+                        </span>
+                        <span ng-if="!cliDownloadURLPresent">
+                          Refer to the <a href="{{'get_started_cli' | helpLink}}">Get Started with the CLI</a> documentation for instructions about downloading and installing the <code>oc</code> client tool.
+                        </span>
+                        <div ng-if="cliDownloadURLPresent">
+                          <label class="cli-download-label">Download <code>oc</code>:</label>
+                          <div ng-repeat="(key, value) in cliDownloadURL">
+                            <a href="{{value}}" class="cli-download-link">
+                              {{key}}
+                              <i class="fa fa-external-link"></i>
+                            </a>
+                          </div>
+                        </div>
+                      </p>
+                      <p>
+                        After downloading and installing it, you can start by logging in using<span ng-if="sessionToken"> this current session token</span>:
+                        <div class="code prettyprint ng-binding" ng-if="sessionToken">
+                          oc login {{loginBaseURL}} --token=<span ng-show="showSessionToken">{{sessionToken}}</span><a href="#" ng-click="showSessionToken = !showSessionToken" ng-show="!showSessionToken">...click to show token...</a>
+                        </div>
+                        <pre class="code prettyprint ng-binding" ng-if="!sessionToken">
+        oc login {{loginBaseURL}}
+        </pre>
+                      </p>
+                      <p>For other information about the command line tools, check the <a target="_blank" href="{{'cli' | helpLink}}">CLI Reference</a> and <a target="_blank" href="{{'basic_cli_operations' | helpLink}}">Basic CLI Operations</a>.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->


### PR DESCRIPTION
I've split the About page which contained also info about CLI tools into two separate pages `About` and `Command Line Tools`

About page:
![screenshot-13](https://cloud.githubusercontent.com/assets/1668218/15180229/928d94da-1780-11e6-9ffb-c712357f032a.png)

Command Line page with updated dropdown:
![screenshot-16](https://cloud.githubusercontent.com/assets/1668218/15180313/0f16c260-1781-11e6-950a-4beed679225b.png)

Mobile version of the dropdown:
![screenshot-15](https://cloud.githubusercontent.com/assets/1668218/15180243/a59a9f6e-1780-11e6-8c8e-6512c389d314.png)

Will add bindata after review :)