### PR TITLE
UPSTREAM: 25472: tolerate nil error in HandleError

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/runtime/runtime.go
@@ -67,6 +67,11 @@ var ErrorHandlers = []func(error){logError}
 // is preferable to logging the error - the default behavior is to log but the
 // errors may be sent to a remote server for analysis.
 func HandleError(err error) {
+	// this is sometimes called with a nil error.  We probably shouldn't fail and should do nothing instead
+	if err == nil {
+		return
+	}
+
 	for _, fn := range ErrorHandlers {
 		fn(err)
 	}


### PR DESCRIPTION
At least one call site here: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/node/nodecontroller.go#L362 doesn't always return an error. See https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/node/nodecontroller.go#L406-L413 .

I think its pretty reasonable to no-op on nil errors.