### PR TITLE
Tolerate partial successes on reconciling cluter role bindings

### DIFF
--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -87,7 +87,7 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out, errout io.Wr
 			Message: "Upgrade and repair system policy:",
 			Commands: []*cobra.Command{
 				NewCmdReconcileClusterRoles(ReconcileClusterRolesRecommendedName, fullName+" "+ReconcileClusterRolesRecommendedName, f, out, errout),
-				NewCmdReconcileClusterRoleBindings(ReconcileClusterRoleBindingsRecommendedName, fullName+" "+ReconcileClusterRoleBindingsRecommendedName, f, out),
+				NewCmdReconcileClusterRoleBindings(ReconcileClusterRoleBindingsRecommendedName, fullName+" "+ReconcileClusterRoleBindingsRecommendedName, f, out, errout),
 				NewCmdReconcileSCC(ReconcileSCCRecommendedName, fullName+" "+ReconcileSCCRecommendedName, f, out),
 			},
 		},

--- a/pkg/diagnostics/cluster/rolebindings.go
+++ b/pkg/diagnostics/cluster/rolebindings.go
@@ -56,7 +56,11 @@ func (d *ClusterRoleBindings) Check() types.DiagnosticResult {
 	}
 
 	changedClusterRoleBindings, err := reconcileOptions.ChangedClusterRoleBindings()
-	if err != nil {
+	if policycmd.IsClusterRoleBindingLookupError(err) {
+		// we got a partial match, so we log the error that stopped us from getting a full match
+		// but continue to interpret the partial results that we did get
+		r.Warn("CRBD1008", err, fmt.Sprintf("Error finding ClusterRoleBindings: %v", err))
+	} else if err != nil {
 		r.Error("CRBD1000", err, fmt.Sprintf("Error inspecting ClusterRoleBindings: %v", err))
 		return r
 	}


### PR DESCRIPTION
When a specific set of cluster roles are identified in the reconciliation process, it is possible for the client to only be able to return a partial reconciliation. In this case, it is correct to warn the user but apply the partial results.

fixes https://github.com/openshift/origin/issues/8066

/cc @liggitt @deads2k 