### PR TITLE
db-templates: mongodb ephemeral dc should automatically resolve

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -54,7 +54,7 @@
           {
             "type": "ImageChange",
             "imageChangeParams": {
-              "automatic": false,
+              "automatic": true,
               "containerNames": [
                 "mongodb"
               ],

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -1167,7 +1167,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
           {
             "type": "ImageChange",
             "imageChangeParams": {
-              "automatic": false,
+              "automatic": true,
               "containerNames": [
                 "mongodb"
               ],


### PR DESCRIPTION
@smarterclayton @php-coder @bparees 

Fixes https://github.com/openshift/origin/issues/8367

Got it working on https://github.com/openshift/origin/pull/8746 but I think there is no difference on master.