### PR TITLE
Fixing test flake for docker builds

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -6,6 +6,12 @@
 #
 FROM centos:centos7
 
+# Until nss-3.21.0-9.el7_2 and openssl-libs-1.0.1e-51.el7_2.5.x86_64 is
+# released in the base image we need to manually update this to workaround an
+# issue where some of the mirrors are using a certificate
+RUN yum update -y nss openssl-libs && \
+    yum clean all
+
 RUN INSTALL_PKGS="which git tar wget hostname sysvinit-tools util-linux bsdtar epel-release \
       socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof" && \
     yum install -y $INSTALL_PKGS && \


### PR DESCRIPTION
The problem appears to be triggered by a small number of epel mirrors.  In the
past this sort of problem has been solved by upgrading nss.  I updated nss
inside the centos7 container and still saw the problem.  Only when I updated
openssl-libs did the problem seem to disappear.

Below you can see the error message:
---------------------------

One of the configured repositories failed (Unknown),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Disable the repository, so yum won't use it by default. Yum will then
        just ignore the repository until you permanently enable it again or use
        --enablerepo for temporary usage:

            yum-config-manager --disable <repoid>

     4. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true

Cannot retrieve metalink for repository: epel/x86_64. Please verify its path and try again