### PR TITLE
make an SA an oauthclient

### DIFF
--- a/Godeps/_workspace/src/github.com/RangelReale/osin/access.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/access.go
@@ -510,7 +510,7 @@ func getClient(auth *BasicAuth, storage Storage, w *Response) Client {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if client.GetSecret() != auth.Password {
+	if !client.ValidateSecret(auth.Password) {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/client.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/client.go
@@ -5,8 +5,8 @@ type Client interface {
 	// Client id
 	GetId() string
 
-	// Client secret
-	GetSecret() string
+	// check a client secret
+	ValidateSecret(secret string) bool
 
 	// Base client uri
 	GetRedirectUri() string
@@ -31,17 +31,14 @@ func (d *DefaultClient) GetSecret() string {
 	return d.Secret
 }
 
+func (d *DefaultClient) ValidateSecret(secret string) bool {
+	return d.Secret == secret
+}
+
 func (d *DefaultClient) GetRedirectUri() string {
 	return d.RedirectUri
 }
 
 func (d *DefaultClient) GetUserData() interface{} {
 	return d.UserData
-}
-
-func (d *DefaultClient) CopyFrom(client Client) {
-	d.Id = client.GetId()
-	d.Secret = client.GetSecret()
-	d.RedirectUri = client.GetRedirectUri()
-	d.UserData = client.GetUserData()
 }

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -22027,6 +22027,13 @@
       "type": "string",
       "description": "Secret is the unique secret associated with a client"
      },
+     "additionalSecrets": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation and for service account token validation"
+     },
      "respondWithChallenges": {
       "type": "boolean",
       "description": "RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects"

--- a/pkg/auth/api/types.go
+++ b/pkg/auth/api/types.go
@@ -40,7 +40,7 @@ type UserIdentityMapper interface {
 
 type Client interface {
 	GetId() string
-	GetSecret() string
+	ValidateSecret(secret string) bool
 	GetRedirectUri() string
 	GetUserData() interface{}
 }

--- a/pkg/auth/oauth/handlers/default_auth_handler_test.go
+++ b/pkg/auth/oauth/handlers/default_auth_handler_test.go
@@ -19,8 +19,8 @@ func (w *testClient) GetId() string {
 	return w.client.Name
 }
 
-func (w *testClient) GetSecret() string {
-	return w.client.Secret
+func (w *testClient) ValidateSecret(in string) bool {
+	return w.client.Secret == in
 }
 
 func (w *testClient) GetRedirectUri() string {
@@ -229,8 +229,8 @@ func (w *badTestClient) GetId() string {
 	return w.client.Name
 }
 
-func (w *badTestClient) GetSecret() string {
-	return w.client.Secret
+func (w *badTestClient) ValidateSecret(in string) bool {
+	return in == w.client.Secret
 }
 
 func (w *badTestClient) GetRedirectUri() string {

--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -66,11 +66,11 @@ type Grant struct {
 	auth           authenticator.Request
 	csrf           csrf.CSRF
 	render         FormRenderer
-	clientregistry oauthclient.Registry
+	clientregistry oauthclient.Getter
 	authregistry   oauthclientauthorization.Registry
 }
 
-func NewGrant(csrf csrf.CSRF, auth authenticator.Request, render FormRenderer, clientregistry oauthclient.Registry, authregistry oauthclientauthorization.Registry) *Grant {
+func NewGrant(csrf csrf.CSRF, auth authenticator.Request, render FormRenderer, clientregistry oauthclient.Getter, authregistry oauthclientauthorization.Registry) *Grant {
 	return &Grant{
 		auth:           auth,
 		csrf:           csrf,

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -889,6 +889,10 @@ type OpenIDClaims struct {
 type GrantConfig struct {
 	// Method: allow, deny, prompt
 	Method GrantHandlerType
+
+	// ServiceAccountMethod is used for determining client authorization for service account oauth client.
+	// It must be either: deny, prompt
+	ServiceAccountMethod GrantHandlerType
 }
 
 type GrantHandlerType string
@@ -903,6 +907,7 @@ const (
 )
 
 var ValidGrantHandlerTypes = sets.NewString(string(GrantHandlerAuto), string(GrantHandlerPrompt), string(GrantHandlerDeny))
+var ValidServiceAccountGrantHandlerTypes = sets.NewString(string(GrantHandlerPrompt), string(GrantHandlerDeny))
 
 type EtcdConfig struct {
 	// ServingInfo describes how to start serving the etcd master

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -164,6 +164,11 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				obj.MappingMethod = "claim"
 			}
 		},
+		func(obj *GrantConfig) {
+			if len(obj.ServiceAccountMethod) == 0 {
+				obj.ServiceAccountMethod = "prompt"
+			}
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -221,8 +221,9 @@ func (GoogleIdentityProvider) SwaggerDoc() map[string]string {
 }
 
 var map_GrantConfig = map[string]string{
-	"":       "GrantConfig holds the necessary configuration options for grant handlers",
-	"method": "Method: allow, deny, prompt",
+	"":                     "GrantConfig holds the necessary configuration options for grant handlers",
+	"method":               "Method: allow, deny, prompt",
+	"serviceAccountMethod": "ServiceAccountMethod is used for determining client authorization for service account oauth client. It must be either: deny, prompt",
 }
 
 func (GrantConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -887,6 +887,10 @@ type OpenIDClaims struct {
 type GrantConfig struct {
 	// Method: allow, deny, prompt
 	Method GrantHandlerType `json:"method"`
+
+	// ServiceAccountMethod is used for determining client authorization for service account oauth client.
+	// It must be either: deny, prompt
+	ServiceAccountMethod GrantHandlerType `json:"serviceAccountMethod"`
 }
 
 type GrantHandlerType string

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -203,6 +203,7 @@ oauthConfig:
   assetPublicURL: ""
   grantConfig:
     method: ""
+    serviceAccountMethod: ""
   identityProviders:
   - challenge: false
     login: false

--- a/pkg/cmd/server/api/validation/oauth.go
+++ b/pkg/cmd/server/api/validation/oauth.go
@@ -387,7 +387,10 @@ func validateGrantConfig(config api.GrantConfig, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	if !api.ValidGrantHandlerTypes.Has(string(config.Method)) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("method"), config.Method, fmt.Sprintf("must be one of: %v", api.ValidGrantHandlerTypes.List())))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("method"), config.Method, api.ValidGrantHandlerTypes.List()))
+	}
+	if !api.ValidServiceAccountGrantHandlerTypes.Has(string(config.ServiceAccountMethod)) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("serviceAccountMethod"), config.ServiceAccountMethod, api.ValidServiceAccountGrantHandlerTypes.List()))
 	}
 
 	return allErrs

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pborman/uuid"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/storage"
 
 	"github.com/openshift/origin/pkg/auth/server/session"
@@ -26,6 +27,9 @@ type AuthConfig struct {
 	// AssetPublicAddresses contains valid redirectURI prefixes to direct browsers to the web console
 	AssetPublicAddresses []string
 
+	// KubeClient is kubeclient with enough permission for the auth API
+	KubeClient kclient.Interface
+
 	// EtcdHelper provides storage capabilities
 	EtcdHelper storage.Interface
 
@@ -42,7 +46,7 @@ type AuthConfig struct {
 	HandlerWrapper handlerWrapper
 }
 
-func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
+func BuildAuthConfig(options configapi.MasterConfig, kubeClient kclient.Interface) (*AuthConfig, error) {
 	etcdClient, err := etcd.MakeNewEtcdClient(options.EtcdClientInfo)
 	if err != nil {
 		return nil, err
@@ -96,6 +100,8 @@ func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
 
 	ret := &AuthConfig{
 		Options: *options.OAuthConfig,
+
+		KubeClient: kubeClient,
 
 		AssetPublicAddresses: assetPublicURLs,
 		EtcdHelper:           etcdHelper,

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -75,6 +75,7 @@ import (
 	hostsubnetetcd "github.com/openshift/origin/pkg/sdn/registry/hostsubnet/etcd"
 	netnamespaceetcd "github.com/openshift/origin/pkg/sdn/registry/netnamespace/etcd"
 	"github.com/openshift/origin/pkg/service"
+	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
 	templateregistry "github.com/openshift/origin/pkg/template/registry"
 	templateetcd "github.com/openshift/origin/pkg/template/registry/etcd"
 	groupetcd "github.com/openshift/origin/pkg/user/registry/group/etcd"
@@ -493,6 +494,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 	clientStorage := clientetcd.NewREST(c.EtcdHelper)
 	clientRegistry := clientregistry.NewRegistry(clientStorage)
+	combinedOAuthClientGetter := saoauth.NewServiceAccountOAuthClientGetter(c.KubeClient(), c.KubeClient(), clientRegistry)
 
 	storage := map[string]rest.Storage{
 		"images":               imageStorage,
@@ -529,10 +531,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"identities":           identityStorage,
 		"userIdentityMappings": userIdentityMappingStorage,
 
-		"oAuthAuthorizeTokens":      authorizetokenetcd.NewREST(c.EtcdHelper, clientRegistry),
-		"oAuthAccessTokens":         accesstokenetcd.NewREST(c.EtcdHelper, clientRegistry),
+		"oAuthAuthorizeTokens":      authorizetokenetcd.NewREST(c.EtcdHelper, combinedOAuthClientGetter),
+		"oAuthAccessTokens":         accesstokenetcd.NewREST(c.EtcdHelper, combinedOAuthClientGetter),
 		"oAuthClients":              clientStorage,
-		"oAuthClientAuthorizations": clientauthetcd.NewREST(c.EtcdHelper, clientRegistry),
+		"oAuthClientAuthorizations": clientauthetcd.NewREST(c.EtcdHelper, combinedOAuthClientGetter),
 
 		"resourceAccessReviews":      resourceAccessReviewStorage,
 		"subjectAccessReviews":       subjectAccessReviewStorage,

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -445,7 +445,7 @@ func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 	unprotectedInstallers := []origin.APIInstaller{}
 
 	if oc.Options.OAuthConfig != nil {
-		authConfig, err := origin.BuildAuthConfig(oc.Options)
+		authConfig, err := origin.BuildAuthConfig(oc.Options, oc.KubeClient())
 		if err != nil {
 			return err
 		}

--- a/pkg/oauth/api/deep_copy_generated.go
+++ b/pkg/oauth/api/deep_copy_generated.go
@@ -144,6 +144,13 @@ func DeepCopy_api_OAuthClient(in OAuthClient, out *OAuthClient, c *conversion.Cl
 		return err
 	}
 	out.Secret = in.Secret
+	if in.AdditionalSecrets != nil {
+		in, out := in.AdditionalSecrets, &out.AdditionalSecrets
+		*out = make([]string, len(in))
+		copy(*out, in)
+	} else {
+		out.AdditionalSecrets = nil
+	}
 	out.RespondWithChallenges = in.RespondWithChallenges
 	if in.RedirectURIs != nil {
 		in, out := in.RedirectURIs, &out.RedirectURIs

--- a/pkg/oauth/api/types.go
+++ b/pkg/oauth/api/types.go
@@ -68,6 +68,10 @@ type OAuthClient struct {
 	// Secret is the unique secret associated with a client
 	Secret string
 
+	// AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation
+	// and for service account token validation
+	AdditionalSecrets []string
+
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
 	RespondWithChallenges bool
 

--- a/pkg/oauth/api/v1/conversion_generated.go
+++ b/pkg/oauth/api/v1/conversion_generated.go
@@ -341,6 +341,13 @@ func autoConvert_v1_OAuthClient_To_api_OAuthClient(in *OAuthClient, out *oauth_a
 		return err
 	}
 	out.Secret = in.Secret
+	if in.AdditionalSecrets != nil {
+		in, out := &in.AdditionalSecrets, &out.AdditionalSecrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	} else {
+		out.AdditionalSecrets = nil
+	}
 	out.RespondWithChallenges = in.RespondWithChallenges
 	if in.RedirectURIs != nil {
 		in, out := &in.RedirectURIs, &out.RedirectURIs
@@ -380,6 +387,13 @@ func autoConvert_api_OAuthClient_To_v1_OAuthClient(in *oauth_api.OAuthClient, ou
 		return err
 	}
 	out.Secret = in.Secret
+	if in.AdditionalSecrets != nil {
+		in, out := &in.AdditionalSecrets, &out.AdditionalSecrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	} else {
+		out.AdditionalSecrets = nil
+	}
 	out.RespondWithChallenges = in.RespondWithChallenges
 	if in.RedirectURIs != nil {
 		in, out := &in.RedirectURIs, &out.RedirectURIs

--- a/pkg/oauth/api/v1/deep_copy_generated.go
+++ b/pkg/oauth/api/v1/deep_copy_generated.go
@@ -145,6 +145,13 @@ func DeepCopy_v1_OAuthClient(in OAuthClient, out *OAuthClient, c *conversion.Clo
 		return err
 	}
 	out.Secret = in.Secret
+	if in.AdditionalSecrets != nil {
+		in, out := in.AdditionalSecrets, &out.AdditionalSecrets
+		*out = make([]string, len(in))
+		copy(*out, in)
+	} else {
+		out.AdditionalSecrets = nil
+	}
 	out.RespondWithChallenges = in.RespondWithChallenges
 	if in.RedirectURIs != nil {
 		in, out := in.RedirectURIs, &out.RedirectURIs

--- a/pkg/oauth/api/v1/swagger_doc.go
+++ b/pkg/oauth/api/v1/swagger_doc.go
@@ -73,6 +73,7 @@ var map_OAuthClient = map[string]string{
 	"":                      "OAuthClient describes an OAuth client",
 	"metadata":              "Standard object's metadata.",
 	"secret":                "Secret is the unique secret associated with a client",
+	"additionalSecrets":     "AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation and for service account token validation",
 	"respondWithChallenges": "RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects",
 	"redirectURIs":          "RedirectURIs is the valid redirection URIs associated with a client",
 	"scopeRestrictions":     "ScopeRestrictions describes which scopes this client can request.  Each requested scope is checked against each restriction.  If any restriction matches, then the scope is allowed. If no restriction matches, then the scope is denied.",

--- a/pkg/oauth/api/v1/types.go
+++ b/pkg/oauth/api/v1/types.go
@@ -74,6 +74,10 @@ type OAuthClient struct {
 	// Secret is the unique secret associated with a client
 	Secret string `json:"secret,omitempty"`
 
+	// AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation
+	// and for service account token validation
+	AdditionalSecrets []string `json:"additionalSecrets,omitempty"`
+
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
 	RespondWithChallenges bool `json:"respondWithChallenges,omitempty"`
 

--- a/pkg/oauth/api/v1beta3/types.go
+++ b/pkg/oauth/api/v1beta3/types.go
@@ -68,6 +68,10 @@ type OAuthClient struct {
 	// Secret is the unique secret associated with a client
 	Secret string `json:"secret,omitempty"`
 
+	// AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation
+	// and for service account token validation
+	AdditionalSecrets []string `json:"additionalSecrets,omitempty"`
+
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
 	RespondWithChallenges bool `json:"respondWithChallenges,omitempty"`
 

--- a/pkg/oauth/server/osinserver/registrystorage/storage.go
+++ b/pkg/oauth/server/osinserver/registrystorage/storage.go
@@ -50,8 +50,18 @@ func (w *clientWrapper) GetId() string {
 	return w.id
 }
 
-func (w *clientWrapper) GetSecret() string {
-	return w.client.Secret
+func (w *clientWrapper) ValidateSecret(secret string) bool {
+	if w.client.Secret == secret {
+		return true
+	}
+
+	for _, additionalSecret := range w.client.AdditionalSecrets {
+		if additionalSecret == secret {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (w *clientWrapper) GetRedirectUri() string {

--- a/pkg/oauth/server/osinserver/registrystorage/storage.go
+++ b/pkg/oauth/server/osinserver/registrystorage/storage.go
@@ -28,11 +28,11 @@ type UserConversion interface {
 type storage struct {
 	accesstoken    oauthaccesstoken.Registry
 	authorizetoken oauthauthorizetoken.Registry
-	client         oauthclient.Registry
+	client         oauthclient.Getter
 	user           UserConversion
 }
 
-func New(access oauthaccesstoken.Registry, authorize oauthauthorizetoken.Registry, client oauthclient.Registry, user UserConversion) osin.Storage {
+func New(access oauthaccesstoken.Registry, authorize oauthauthorizetoken.Registry, client oauthclient.Getter, user UserConversion) osin.Storage {
 	return &storage{
 		accesstoken:    access,
 		authorizetoken: authorize,

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
@@ -1,0 +1,109 @@
+package oauthclient
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
+)
+
+const (
+	OAuthClientSecretAnnotation            = "serviceaccounts.openshift.io/oauth-client-secret"
+	OAuthRedirectURISecretAnnotationPrefix = "serviceaccounts.openshift.io/oauth-redirecturi."
+	OAuthWantChallengesAnnotationPrefix    = "serviceaccounts.openshift.io/oauth-want-challenges"
+)
+
+type saOAuthClientAdapter struct {
+	saClient     kclient.ServiceAccountsNamespacer
+	secretClient kclient.SecretsNamespacer
+
+	delegate oauthclient.Getter
+}
+
+var _ oauthclient.Getter = &saOAuthClientAdapter{}
+
+func NewServiceAccountOAuthClientGetter(saClient kclient.ServiceAccountsNamespacer, secretClient kclient.SecretsNamespacer, delegate oauthclient.Getter) oauthclient.Getter {
+	return &saOAuthClientAdapter{saClient: saClient, secretClient: secretClient, delegate: delegate}
+}
+
+func (a *saOAuthClientAdapter) GetClient(ctx kapi.Context, name string) (*oauthapi.OAuthClient, error) {
+	saNamespace, saName, err := serviceaccount.SplitUsername(name)
+	if err != nil {
+		return a.delegate.GetClient(ctx, name)
+	}
+
+	sa, err := a.saClient.ServiceAccounts(saNamespace).Get(saName)
+	if err != nil {
+		return nil, err
+	}
+
+	redirectURIs := []string{}
+	for key, value := range sa.Annotations {
+		if strings.HasPrefix(key, OAuthRedirectURISecretAnnotationPrefix) {
+			redirectURIs = append(redirectURIs, value)
+		}
+	}
+	if len(redirectURIs) == 0 {
+		return nil, fmt.Errorf("%v has no redirectURIs; set %v<some-value>=<redirect>", name, OAuthRedirectURISecretAnnotationPrefix)
+	}
+
+	tokens, err := a.getServiceAccountTokens(sa)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("%v has no tokens allowed as oauth client secrets; set %v=true on a token secret", name, OAuthClientSecretAnnotation)
+	}
+
+	saWantsChallenges, _ := strconv.ParseBool(sa.Annotations[OAuthWantChallengesAnnotationPrefix])
+
+	saClient := &oauthapi.OAuthClient{
+		ObjectMeta:            kapi.ObjectMeta{Name: name},
+		ScopeRestrictions:     getScopeRestrictionsFor(saNamespace, saName),
+		AdditionalSecrets:     tokens,
+		RespondWithChallenges: saWantsChallenges,
+
+		// TODO update this to allow https redirection to any
+		// 1. service IP (useless in general)
+		// 2. service DNS (useless in general)
+		// 3. route DNS (useful)
+		// 4. loopback? (useful, but maybe a bit weird)
+		RedirectURIs: redirectURIs,
+	}
+	return saClient, nil
+}
+
+func getScopeRestrictionsFor(namespace, name string) []oauthapi.ScopeRestriction {
+	return []oauthapi.ScopeRestriction{
+		{ExactValues: []string{scopeauthorizer.UserIndicator + scopeauthorizer.UserInfo, scopeauthorizer.UserIndicator + scopeauthorizer.UserAccessCheck}},
+		{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{RoleNames: []string{"*"}, Namespaces: []string{namespace}, AllowEscalation: true}},
+	}
+}
+
+// getServiceAccountTokens returns all ServiceAccountToken secrets for the given ServiceAccount
+func (a *saOAuthClientAdapter) getServiceAccountTokens(sa *kapi.ServiceAccount) ([]string, error) {
+	allSecrets, err := a.secretClient.Secrets(sa.Namespace).List(kapi.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := []string{}
+	for i := range allSecrets.Items {
+		secret := allSecrets.Items[i]
+		if intendedAsClientSecret, _ := strconv.ParseBool(secret.Annotations[OAuthClientSecretAnnotation]); !intendedAsClientSecret {
+			continue
+		}
+
+		if serviceaccount.IsServiceAccountToken(&secret, sa) {
+			tokens = append(tokens, string(secret.Data[kapi.ServiceAccountTokenKey]))
+		}
+	}
+	return tokens, nil
+}

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
@@ -1,0 +1,176 @@
+package oauthclient
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/types"
+
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+)
+
+func TestGetClient(t *testing.T) {
+	testCases := []struct {
+		name       string
+		clientName string
+		kubeClient *ktestclient.Fake
+
+		expectedDelegation bool
+		expectedErr        string
+		expectedClient     *oauthapi.OAuthClient
+		expectedActions    []ktestclient.Action
+	}{
+		{
+			name:               "delegate",
+			clientName:         "not:serviceaccount",
+			kubeClient:         ktestclient.NewSimpleFake(),
+			expectedDelegation: true,
+			expectedActions:    []ktestclient.Action{},
+		},
+		{
+			name:            "missing sa",
+			clientName:      "system:serviceaccount:ns-01:missing-sa",
+			kubeClient:      ktestclient.NewSimpleFake(),
+			expectedErr:     `ServiceAccount "missing-sa" not found`,
+			expectedActions: []ktestclient.Action{ktestclient.NewGetAction("serviceaccounts", "ns-01", "missing-sa")},
+		},
+		{
+			name:       "sa no redirects",
+			clientName: "system:serviceaccount:ns-01:default",
+			kubeClient: ktestclient.NewSimpleFake(
+				&kapi.ServiceAccount{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace:   "ns-01",
+						Name:        "default",
+						Annotations: map[string]string{},
+					},
+				}),
+			expectedErr:     `system:serviceaccount:ns-01:default has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>`,
+			expectedActions: []ktestclient.Action{ktestclient.NewGetAction("serviceaccounts", "ns-01", "default")},
+		},
+		{
+			name:       "sa no tokens",
+			clientName: "system:serviceaccount:ns-01:default",
+			kubeClient: ktestclient.NewSimpleFake(
+				&kapi.ServiceAccount{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace:   "ns-01",
+						Name:        "default",
+						Annotations: map[string]string{OAuthRedirectURISecretAnnotationPrefix + "one": "anywhere"},
+					},
+				}),
+			expectedErr: `system:serviceaccount:ns-01:default has no tokens allowed as oauth client secrets; set serviceaccounts.openshift.io/oauth-client-secret=true on a token secret`,
+			expectedActions: []ktestclient.Action{
+				ktestclient.NewGetAction("serviceaccounts", "ns-01", "default"),
+				ktestclient.NewListAction("secrets", "ns-01", kapi.ListOptions{}),
+			},
+		},
+		{
+			name:       "sa no tokens two",
+			clientName: "system:serviceaccount:ns-01:default",
+			kubeClient: ktestclient.NewSimpleFake(
+				&kapi.ServiceAccount{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace:   "ns-01",
+						Name:        "default",
+						Annotations: map[string]string{OAuthRedirectURISecretAnnotationPrefix + "one": "anywhere"},
+					},
+				},
+				&kapi.Secret{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "ns-01",
+						Name:      "default",
+						Annotations: map[string]string{
+							kapi.ServiceAccountNameKey: "default",
+							kapi.ServiceAccountUIDKey:  "any",
+						},
+					},
+					Type: kapi.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+				}),
+			expectedErr: `system:serviceaccount:ns-01:default has no tokens allowed as oauth client secrets; set serviceaccounts.openshift.io/oauth-client-secret=true on a token secret`,
+			expectedActions: []ktestclient.Action{
+				ktestclient.NewGetAction("serviceaccounts", "ns-01", "default"),
+				ktestclient.NewListAction("secrets", "ns-01", kapi.ListOptions{}),
+			},
+		},
+		{
+			name:       "good SA",
+			clientName: "system:serviceaccount:ns-01:default",
+			kubeClient: ktestclient.NewSimpleFake(
+				&kapi.ServiceAccount{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace:   "ns-01",
+						Name:        "default",
+						UID:         types.UID("any"),
+						Annotations: map[string]string{OAuthRedirectURISecretAnnotationPrefix + "one": "anywhere"},
+					},
+				},
+				&kapi.Secret{
+					ObjectMeta: kapi.ObjectMeta{
+						Namespace: "ns-01",
+						Name:      "default",
+						Annotations: map[string]string{
+							OAuthClientSecretAnnotation: "true",
+							kapi.ServiceAccountNameKey:  "default",
+							kapi.ServiceAccountUIDKey:   "any",
+						},
+					},
+					Type: kapi.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+				}),
+			expectedClient: &oauthapi.OAuthClient{
+				ObjectMeta:        kapi.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
+				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
+				AdditionalSecrets: []string{"foo"},
+				RedirectURIs:      []string{"anywhere"},
+			},
+			expectedActions: []ktestclient.Action{
+				ktestclient.NewGetAction("serviceaccounts", "ns-01", "default"),
+				ktestclient.NewListAction("secrets", "ns-01", kapi.ListOptions{}),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		delegate := &fakeDelegate{}
+		getter := NewServiceAccountOAuthClientGetter(tc.kubeClient, tc.kubeClient, delegate)
+		client, err := getter.GetClient(kapi.NewContext(), tc.clientName)
+		switch {
+		case len(tc.expectedErr) == 0 && err == nil:
+		case len(tc.expectedErr) == 0 && err != nil,
+			len(tc.expectedErr) > 0 && err == nil,
+			len(tc.expectedErr) > 0 && err != nil && !strings.Contains(err.Error(), tc.expectedErr):
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedErr, err)
+			continue
+		}
+
+		if tc.expectedDelegation != delegate.called {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedDelegation, delegate.called)
+			continue
+		}
+
+		if !kapi.Semantic.DeepEqual(tc.expectedClient, client) {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedClient, client)
+			continue
+		}
+
+		if !reflect.DeepEqual(tc.expectedActions, tc.kubeClient.Actions()) {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedActions, tc.kubeClient.Actions())
+			continue
+		}
+	}
+
+}
+
+type fakeDelegate struct {
+	called bool
+}
+
+func (d *fakeDelegate) GetClient(ctx kapi.Context, name string) (*oauthapi.OAuthClient, error) {
+	d.called = true
+	return nil, nil
+}

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -122,7 +122,10 @@ func TestOAuthStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if storedClient.GetSecret() != "secret" {
+	if !storedClient.ValidateSecret("secret") {
+		t.Fatalf("unexpected stored client: %#v", storedClient)
+	}
+	if storedClient.ValidateSecret("secret2") {
 		t.Fatalf("unexpected stored client: %#v", storedClient)
 	}
 

--- a/test/integration/sa_oauthclient_test.go
+++ b/test/integration/sa_oauthclient_test.go
@@ -1,0 +1,224 @@
+// +build integration
+
+package integration
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"testing"
+	"time"
+
+	"github.com/RangelReale/osincli"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/oauth/scope"
+	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestSAAsOAuthClient(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authorizationCodes := make(chan string, 1)
+	authorizationErrors := make(chan string, 1)
+	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Logf("fake pod server got %v", req.URL)
+
+		if code := req.URL.Query().Get("code"); len(code) > 0 {
+			authorizationCodes <- code
+		}
+		if err := req.URL.Query().Get("error"); len(err) > 0 {
+			authorizationErrors <- err
+		}
+	}))
+	defer oauthServer.Close()
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	projectName := "hammer-project"
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := testserver.WaitForServiceAccounts(clusterAdminKubeClient, projectName, []string{"default"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// get the SA ready with redirect URIs and secret annotations
+	defaultSA, err := clusterAdminKubeClient.ServiceAccounts(projectName).Get("default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defaultSA.Annotations == nil {
+		defaultSA.Annotations = map[string]string{}
+	}
+	defaultSA.Annotations[saoauth.OAuthRedirectURISecretAnnotationPrefix+"one"] = oauthServer.URL
+	defaultSA.Annotations[saoauth.OAuthWantChallengesAnnotationPrefix] = "true"
+	defaultSA, err = clusterAdminKubeClient.ServiceAccounts(projectName).Update(defaultSA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	allSecrets, err := clusterAdminKubeClient.Secrets(projectName).List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var oauthSecret *kapi.Secret
+	for i := range allSecrets.Items {
+		secret := allSecrets.Items[i]
+		if serviceaccount.IsServiceAccountToken(&secret, defaultSA) {
+			secret.Annotations[saoauth.OAuthClientSecretAnnotation] = "true"
+			if _, err := clusterAdminKubeClient.Secrets(projectName).Update(&secret); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			oauthSecret = &secret
+			break
+		}
+	}
+
+	oauthClientConfig := &osincli.ClientConfig{
+		ClientId:     serviceaccount.MakeUsername(defaultSA.Namespace, defaultSA.Name),
+		ClientSecret: string(oauthSecret.Data[kapi.ServiceAccountTokenKey]),
+		AuthorizeUrl: clusterAdminClientConfig.Host + "/oauth/authorize",
+		TokenUrl:     clusterAdminClientConfig.Host + "/oauth/token",
+		RedirectUrl:  oauthServer.URL,
+		Scope:        scope.Join([]string{"user:info", "role:edit:" + projectName}),
+		SendClientSecretInParams: true,
+	}
+	runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, authorizationCodes, authorizationErrors, false, true)
+
+	oauthClientConfig = &osincli.ClientConfig{
+		ClientId:     serviceaccount.MakeUsername(defaultSA.Namespace, defaultSA.Name),
+		ClientSecret: string(oauthSecret.Data[kapi.ServiceAccountTokenKey]),
+		AuthorizeUrl: clusterAdminClientConfig.Host + "/oauth/authorize",
+		TokenUrl:     clusterAdminClientConfig.Host + "/oauth/token",
+		RedirectUrl:  oauthServer.URL,
+		Scope:        scope.Join([]string{"user:info", "role:edit:other-ns"}),
+		SendClientSecretInParams: true,
+	}
+	runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, authorizationCodes, authorizationErrors, true, false)
+
+	oauthClientConfig = &osincli.ClientConfig{
+		ClientId:     serviceaccount.MakeUsername(defaultSA.Namespace, defaultSA.Name),
+		ClientSecret: string(oauthSecret.Data[kapi.ServiceAccountTokenKey]),
+		AuthorizeUrl: clusterAdminClientConfig.Host + "/oauth/authorize",
+		TokenUrl:     clusterAdminClientConfig.Host + "/oauth/token",
+		RedirectUrl:  oauthServer.URL,
+		Scope:        scope.Join([]string{"user:info"}),
+		SendClientSecretInParams: true,
+	}
+	runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, authorizationCodes, authorizationErrors, false, false)
+
+}
+
+func runOAuthFlow(t *testing.T, clusterAdminClientConfig *restclient.Config, projectName string, oauthClientConfig *osincli.ClientConfig, authorizationCodes, authorizationErrors chan string, expectAuthCodeError, expectBuildSuccess bool) {
+	oauthRuntimeClient, err := osincli.NewClient(oauthClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	oauthRuntimeClient.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	directHTTPClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	// make sure we're prompted for a password
+	authorizeRequest := oauthRuntimeClient.NewAuthorizeRequest(osincli.CODE)
+	authorizeURL := authorizeRequest.GetAuthorizeUrlWithParams("opaque-scope")
+	authorizeHTTPRequest, err := http.NewRequest("GET", authorizeURL.String(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	authorizeHTTPRequest.Header.Add("X-CSRF-Token", "csrf-01")
+	authorizeResponse, err := directHTTPClient.Do(authorizeHTTPRequest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorizeResponse.StatusCode != http.StatusUnauthorized {
+		response, _ := httputil.DumpResponse(authorizeResponse, true)
+		t.Fatalf("didn't get an unauthorized:\n %v", string(response))
+	}
+
+	authenticatedAuthorizeHTTPRequest, err := http.NewRequest("GET", authorizeURL.String(), nil)
+	authenticatedAuthorizeHTTPRequest.Header.Add("X-CSRF-Token", "csrf-01")
+	authenticatedAuthorizeHTTPRequest.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("harold:any-pass")))
+	authentictedAuthorizeResponse, err := directHTTPClient.Do(authenticatedAuthorizeHTTPRequest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authorizationCode := ""
+	select {
+	case authorizationCode = <-authorizationCodes:
+		if expectAuthCodeError {
+			response, _ := httputil.DumpResponse(authentictedAuthorizeResponse, true)
+			t.Fatalf("got a code:\n %v", string(response))
+		}
+	case <-authorizationErrors:
+		if !expectAuthCodeError {
+			response, _ := httputil.DumpResponse(authentictedAuthorizeResponse, true)
+			t.Fatalf("unexpected error:\n %v", string(response))
+		}
+		return
+	case <-time.After(10 * time.Second):
+		response, _ := httputil.DumpResponse(authentictedAuthorizeResponse, true)
+		t.Fatalf("didn't get a code:\n %v", string(response))
+	}
+
+	accessRequest := oauthRuntimeClient.NewAccessRequest(osincli.AUTHORIZATION_CODE, &osincli.AuthorizeData{Code: authorizationCode})
+	accessData, err := accessRequest.GetToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	whoamiConfig := clientcmd.AnonymousClientConfig(clusterAdminClientConfig)
+	whoamiConfig.BearerToken = accessData.AccessToken
+	whoamiClient, err := client.New(&whoamiConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := whoamiClient.Builds(projectName).List(kapi.ListOptions{}); !kapierrors.IsForbidden(err) && !expectBuildSuccess {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	user, err := whoamiClient.Users().Get("~")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.Name != "harold" {
+		t.Fatalf("expected %v, got %v", "harold", user.Name)
+	}
+}


### PR DESCRIPTION
Still sorting out how to find the correct redirect URIs and figuring out how I can test it, but I'd like feedback on some API changes and the UPSTREAM patch I need to handle tokens.

Only some SA tokens are valid as client secrets, so users have to opt-in and they can still share SA tokens in general for other systems and purposes without exposing themselves to impersonation like this.