### PR TITLE
allow cni as a valid network plugin too

### DIFF
--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -190,7 +190,8 @@ os::provision::get-network-plugin() {
   local default_plugin="${subnet_plugin}"
 
   if [[ "${plugin}" != "${subnet_plugin}" &&
-          "${plugin}" != "${multitenant_plugin}" ]]; then
+          "${plugin}" != "${multitenant_plugin}" &&
+          "${plugin}" != "${cni}" ]]; then
     # Disable output when being called from the dind management script
     # since it may be doing something other than launching a cluster.
     if [[ "${dind_management_script}" = "false" ]]; then

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -191,7 +191,7 @@ os::provision::get-network-plugin() {
 
   if [[ "${plugin}" != "${subnet_plugin}" &&
           "${plugin}" != "${multitenant_plugin}" &&
-          "${plugin}" != "${cni}" ]]; then
+          "${plugin}" != "cni" ]]; then
     # Disable output when being called from the dind management script
     # since it may be doing something other than launching a cluster.
     if [[ "${dind_management_script}" = "false" ]]; then


### PR DESCRIPTION
Vagrant setup fails if network plugin is 'cni'. This change allows us to experiment with other solutions that support cni.
@marun @openshift/networking 