### PR TITLE
Ignore errors on debug when a template is returned

### DIFF
--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -218,8 +218,11 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 	}
 
 	template, err := f.ApproximatePodTemplateForObject(infos[0].Object)
-	if err != nil || template == nil {
+	if err != nil && template == nil {
 		return fmt.Errorf("cannot debug %s: %v", infos[0].Name, err)
+	}
+	if err != nil {
+		glog.V(4).Infof("Unable to get exact template, but continuing with fallback: %v", err)
 	}
 	pod := &kapi.Pod{
 		ObjectMeta: template.ObjectMeta,
@@ -229,7 +232,7 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 	o.Attach.Pod = pod
 
 	if len(o.Attach.ContainerName) == 0 && len(pod.Spec.Containers) > 0 {
-		glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)
+		glog.V(4).Infof("Defaulting container name to %s", pod.Spec.Containers[0].Name)
 		o.Attach.ContainerName = pod.Spec.Containers[0].Name
 	}
 

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -549,6 +549,16 @@ func (w *Factory) ApproximatePodTemplateForObject(object runtime.Object) (*api.P
 				Spec:       pod.Spec,
 			}, err
 		}
+		switch t := object.(type) {
+		case *api.ReplicationController:
+			return t.Spec.Template, err
+		case *extensions.ReplicaSet:
+			return &t.Spec.Template, err
+		case *extensions.DaemonSet:
+			return &t.Spec.Template, err
+		case *extensions.Job:
+			return &t.Spec.Template, err
+		}
 		return nil, err
 	}
 }


### PR DESCRIPTION
ApproximatePodTemplateForObject is allowed to return a fallback while
trying to find the most specific object.

Fixes #8828 [merge]