### PR TITLE
Fix go vet errors

### DIFF
--- a/pkg/cmd/util/net.go
+++ b/pkg/cmd/util/net.go
@@ -66,7 +66,7 @@ func ListenAndServeTLS(srv *http.Server, network string, certFile, keyFile strin
 	}
 	config := &tls.Config{}
 	if srv.TLSConfig != nil {
-		*config = *srv.TLSConfig
+		config = srv.TLSConfig
 	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}

--- a/pkg/config/cmd/cmd.go
+++ b/pkg/config/cmd/cmd.go
@@ -65,7 +65,7 @@ func (b *Bulk) Run(list *kapi.List, namespace string) []error {
 		}
 		obj, err := b.Op(info, namespace, item)
 		if err != nil && b.Retry != nil {
-			if obj := b.Retry(info, err); obj != nil {
+			if obj = b.Retry(info, err); obj != nil {
 				obj, err = b.Op(info, namespace, obj)
 			}
 		}

--- a/pkg/deploy/reaper/reaper_test.go
+++ b/pkg/deploy/reaper/reaper_test.go
@@ -177,7 +177,7 @@ func TestStop(t *testing.T) {
 			t.Errorf("%s: expected an error", test.testName)
 		}
 		if len(test.oc.Actions()) != len(test.expected) {
-			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, test.oc.Actions, test.expected)
+			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, test.oc.Actions(), test.expected)
 		}
 		for j, actualAction := range test.oc.Actions() {
 			if !reflect.DeepEqual(actualAction, test.expected[j]) {

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -35,7 +35,7 @@ func getClientConfig(path string) (*restclient.Config, error) {
 		return nil, fmt.Errorf("Credentials %q error: %v", path, err)
 	}
 
-	if err := restclient.LoadTLSFiles(config); err != nil {
+	if err = restclient.LoadTLSFiles(config); err != nil {
 		return nil, fmt.Errorf("Unable to load certificate info using credentials from %q: %v", path, err)
 	}
 

--- a/pkg/quota/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/runtime"
 
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
@@ -125,7 +124,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 	tests := []struct {
 		name               string
 		config             *api.ClusterResourceOverrideConfig
-		object             runtime.Object
+		pod                *kapi.Pod
 		expectedMemRequest resource.Quantity
 		expectedCpuLimit   resource.Quantity
 		expectedCpuRequest resource.Quantity
@@ -134,7 +133,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "ignore pods that have no memory limit specified",
 			config:             testConfig(100, 50, 50),
-			object:             testBestEffortPod(),
+			pod:                testBestEffortPod(),
 			expectedMemRequest: resource.MustParse("0"),
 			expectedCpuLimit:   resource.MustParse("0"),
 			expectedCpuRequest: resource.MustParse("0"),
@@ -143,7 +142,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "test floor for memory and cpu",
 			config:             testConfig(100, 50, 50),
-			object:             testPod("1Mi", "0", "0", "0"),
+			pod:                testPod("1Mi", "0", "0", "0"),
 			expectedMemRequest: resource.MustParse("1Mi"),
 			expectedCpuLimit:   resource.MustParse("1m"),
 			expectedCpuRequest: resource.MustParse("1m"),
@@ -152,7 +151,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "nil config",
 			config:             nil,
-			object:             testPod("1", "1", "1", "1"),
+			pod:                testPod("1", "1", "1", "1"),
 			expectedMemRequest: resource.MustParse("1"),
 			expectedCpuLimit:   resource.MustParse("1"),
 			expectedCpuRequest: resource.MustParse("1"),
@@ -161,7 +160,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "all values are adjusted",
 			config:             testConfig(100, 50, 50),
-			object:             testPod("1Gi", "0", "2000m", "0"),
+			pod:                testPod("1Gi", "0", "2000m", "0"),
 			expectedMemRequest: resource.MustParse("512Mi"),
 			expectedCpuLimit:   resource.MustParse("1"),
 			expectedCpuRequest: resource.MustParse("500m"),
@@ -170,7 +169,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "just requests are adjusted",
 			config:             testConfig(0, 50, 50),
-			object:             testPod("10Mi", "0", "50m", "0"),
+			pod:                testPod("10Mi", "0", "50m", "0"),
 			expectedMemRequest: resource.MustParse("5Mi"),
 			expectedCpuLimit:   resource.MustParse("50m"),
 			expectedCpuRequest: resource.MustParse("25m"),
@@ -179,7 +178,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "project annotation disables overrides",
 			config:             testConfig(0, 50, 50),
-			object:             testPod("10Mi", "0", "50m", "0"),
+			pod:                testPod("10Mi", "0", "50m", "0"),
 			expectedMemRequest: resource.MustParse("0"),
 			expectedCpuLimit:   resource.MustParse("50m"),
 			expectedCpuRequest: resource.MustParse("0"),
@@ -188,7 +187,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "large values don't overflow",
 			config:             testConfig(100, 50, 50),
-			object:             testPod("1Ti", "0", "0", "0"),
+			pod:                testPod("1Ti", "0", "0", "0"),
 			expectedMemRequest: resource.MustParse("512Gi"),
 			expectedCpuLimit:   resource.MustParse("1024"),
 			expectedCpuRequest: resource.MustParse("512"),
@@ -197,7 +196,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "little values mess things up",
 			config:             testConfig(500, 10, 10),
-			object:             testPod("1.024Mi", "0", "0", "0"),
+			pod:                testPod("1.024Mi", "0", "0", "0"),
 			expectedMemRequest: resource.MustParse("1Mi"),
 			expectedCpuLimit:   resource.MustParse("5m"),
 			expectedCpuRequest: resource.MustParse("1m"),
@@ -206,7 +205,7 @@ func TestLimitRequestAdmission(t *testing.T) {
 		{
 			name:               "test fractional memory requests round up",
 			config:             testConfig(500, 10, 60),
-			object:             testPod("512Mi", "0", "0", "0"),
+			pod:                testPod("512Mi", "0", "0", "0"),
 			expectedMemRequest: resource.MustParse("307Mi"),
 			expectedCpuLimit:   resource.MustParse("2.5"),
 			expectedCpuRequest: resource.MustParse("250m"),
@@ -221,16 +220,12 @@ func TestLimitRequestAdmission(t *testing.T) {
 			continue
 		}
 		c.(*clusterResourceOverridePlugin).SetProjectCache(fakeProjectCache(test.namespace))
-		attrs := admission.NewAttributesRecord(test.object, unversioned.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
-		if err := c.Admit(attrs); err != nil {
-			t.Errorf("%s: admission controller should not return error", test.name)
-		}
-		// if it's a pod, test that the resources are as expected
-		pod, ok := test.object.(*kapi.Pod)
-		if !ok {
+		attrs := admission.NewAttributesRecord(test.pod, unversioned.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
+		if err = c.Admit(attrs); err != nil {
+			t.Errorf("%s: admission controller returned error: %v", test.name, err)
 			continue
 		}
-		resources := pod.Spec.Containers[0].Resources // only test one container
+		resources := test.pod.Spec.Containers[0].Resources // only test one container
 		if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
 			t.Errorf("%s: memory requests do not match; %s should be %s", test.name, actual, test.expectedMemRequest)
 		}

--- a/pkg/quota/image/usage.go
+++ b/pkg/quota/image/usage.go
@@ -2,8 +2,9 @@ package image
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
@@ -192,7 +193,7 @@ func (c *GenericImageStreamUsageComputer) processImageStreamImages(
 
 			cacheInternalRegistryName(img.DockerImageReference)
 
-			if err := handler(tag, history.Items[i].DockerImageReference, img); err != nil {
+			if err = handler(tag, history.Items[i].DockerImageReference, img); err != nil {
 				return err
 			}
 		}
@@ -269,7 +270,7 @@ func (c *GenericImageStreamUsageComputer) processImageStreamSpecImages(
 
 		cacheInternalRegistryName(img.DockerImageReference)
 
-		if err := handler(tag, img.DockerImageReference, img); err != nil {
+		if err = handler(tag, img.DockerImageReference, img); err != nil {
 			return err
 		}
 	}

--- a/pkg/quota/util/sharedcontextevaluator.go
+++ b/pkg/quota/util/sharedcontextevaluator.go
@@ -86,7 +86,7 @@ func (sce *SharedContextEvaluator) UsageStats(options quota.UsageStatsOptions) (
 	}
 	list, err := sce.ListFuncByNamespace(options.Namespace, kapi.ListOptions{})
 	if err != nil {
-		return result, fmt.Errorf("%s: Failed to list %v: %v", sce.Name, sce.GroupKind, err)
+		return result, fmt.Errorf("%s: Failed to list %v: %v", sce.Name, sce.GroupKind(), err)
 	}
 	_, err = meta.Accessor(list)
 	if err != nil {


### PR DESCRIPTION
This fixes several issues pointed out by running `go vet` (`hack/verify-govet.sh`).