### PR TITLE
Improve hack/verify-*.sh scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5.3
-  - 1.6
+  - 1.5.4
+  - 1.6.2
 
 install:
   - export PATH=$GOPATH/bin:./_tools/etcd/bin:$PATH

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/common.sh"
 
-GO_VERSION=($(go version))
-echo "Detected go version: $(go version)"
+echo $(go version)
 
 go get github.com/tools/godep
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 
-# GoFmt apparently is changing @ head...
-
 set -o errexit
 set -o nounset
 set -o pipefail
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') && -z "${FORCE_VERIFY-}"  ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping gofmt." >&2
-  exit 0
-fi
+echo $(go version)
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 set -o errexit
+set -o nounset
 set -o pipefail
+
+echo $(go version)
 
 if ! which golint &>/dev/null; then
   echo "Unable to detect 'golint' package"
@@ -9,15 +12,7 @@ if ! which golint &>/dev/null; then
   exit 1
 fi
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') && -z "${FORCE_VERIFY-}"  ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping golint."
-  exit 0
-fi
-
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"
@@ -46,7 +41,7 @@ else
 fi
 
 if [[ -n "${bad_files}" ]]; then
-  echo "golint detected following problems:"
+  echo "!!! golint detected the following problems:"
   echo "${bad_files}"
   exit 1
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -7,70 +7,13 @@ set -o pipefail
 echo $(go version)
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/common.sh"
-source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"
 
-os::build::setup_env
-
-FAILURE=false
-test_dirs=$(find_files | cut -d '/' -f 1-2 | sort -u)
-for test_dir in $test_dirs
-do
-  if ! go tool vet -shadow=false $test_dir
-  then
-    FAILURE=true
-  fi
-done
-
-# For the sake of slowly white-listing `shadow` checks, we need to keep track of which
-# directories we're searching through. The following are all of the directories we care about:
-# all top-level directories except for 'pkg', and all second-level subdirectories of 'pkg'.
-ALL_DIRS=$(find_files | grep -Eo "\./([^/]+|pkg/[^/]+)" | sort -u)
-
-DIR_BLACKLIST='./hack
-./pkg/api
-./pkg/authorization
-./pkg/build
-./pkg/client
-./pkg/cmd
-./pkg/deploy
-./pkg/diagnostics
-./pkg/dockerregistry
-./pkg/generate
-./pkg/gitserver
-./pkg/image
-./pkg/oauth
-./pkg/project
-./pkg/router
-./pkg/security
-./pkg/serviceaccounts
-./pkg/template
-./pkg/user
-./pkg/util
-./test
-./third_party
-./tools'
-
-for test_dir in $ALL_DIRS
-do
-  # use `grep` failure to determine that a directory is not in the blacklist
-  if ! echo "${DIR_BLACKLIST}" | grep -q "${test_dir}"; then
-    if ! go tool vet -shadow -shadowstrict $test_dir
-    then
-      FAILURE=true
-    fi
-  fi
-done
-
-# We don't want to exit on the first failure of go vet, so just keep track of
-# whether a failure occurred or not.
-if $FAILURE
-then
-  echo "FAILURE: go vet failed!"
-  exit 1
-else
+if go vet ./...; then
   echo "SUCCESS: go vet succeded!"
   exit 0
+else
+  echo "FAILURE: go vet failed!"
+  exit 1
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 
+set -o errexit
 set -o nounset
 set -o pipefail
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.[4-5]') && -z "${FORCE_VERIFY-}" ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping go vet."
-  exit 0
-fi
+echo $(go version)
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"
-mkdir -p _output/govet
 
 os::build::setup_env
 
@@ -23,8 +18,7 @@ FAILURE=false
 test_dirs=$(find_files | cut -d '/' -f 1-2 | sort -u)
 for test_dir in $test_dirs
 do
-  go tool vet -shadow=false $test_dir
-  if [ "$?" -ne 0 ]
+  if ! go tool vet -shadow=false $test_dir
   then
     FAILURE=true
   fi
@@ -63,8 +57,7 @@ for test_dir in $ALL_DIRS
 do
   # use `grep` failure to determine that a directory is not in the blacklist
   if ! echo "${DIR_BLACKLIST}" | grep -q "${test_dir}"; then
-    go tool vet -shadow -shadowstrict $test_dir
-    if [ "$?" -ne "0" ]
+    if ! go tool vet -shadow -shadowstrict $test_dir
     then
       FAILURE=true
     fi


### PR DESCRIPTION
Summary:
- Set common shell options in script headers.
- Simplify hack/install-tools.sh.
- Do not check Go version (verify-*.sh should be run no matter the Go
  version?!).
- Do not create directory _output/govet (not used?!).
- Fix early termination of hack/verify-govet.sh.
- Use only default `go vet` checks (do not use -shadow).

Also:
- Bump minor versions of Go 1.5 and 1.6 (as per #8717), not including Go 1.4 to the list because it requires installing `golang.org/x/tools/cmd/vet` which was deleted (the `vet` tool comes as part of the Go distribution in newer versions).