### PR TITLE
return status errors from build clone API

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -220,7 +220,7 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 	}
 
 	if buildutil.IsPaused(bc) {
-		return nil, &GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", bc.Namespace, bc.Name)}
+		return nil, errors.NewInternalError(&GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", bc.Namespace, bc.Name)})
 	}
 
 	if err := g.checkLastVersion(bc, request.LastVersion); err != nil {
@@ -330,7 +330,7 @@ func (g *BuildGenerator) Clone(ctx kapi.Context, request *buildapi.BuildRequest)
 		}
 
 		if buildutil.IsPaused(buildConfig) {
-			return nil, &GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", buildConfig.Namespace, buildConfig.Name)}
+			return nil, errors.NewInternalError(&GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", buildConfig.Namespace, buildConfig.Name)})
 		}
 	}
 


### PR DESCRIPTION
The API should always return status errors.

@bparees @csrwng ptal.