### PR TITLE
Switch gitserver to use openshift/origin-base

### DIFF
--- a/examples/gitserver/Dockerfile
+++ b/examples/gitserver/Dockerfile
@@ -3,8 +3,9 @@
 #
 # The standard name for this image is openshift/origin-gitserver
 #
-FROM openshift/origin
+FROM openshift/origin-base
 
+COPY bin/oc /usr/bin/oc
 COPY bin/gitserver /usr/bin/gitserver
 COPY hooks/ /var/lib/git-hooks/
 COPY gitconfig /var/lib/gitconfig/.gitconfig

--- a/examples/gitserver/README.md
+++ b/examples/gitserver/README.md
@@ -14,6 +14,9 @@ repository's source.
 
 The Dockerfile built by this example is published as openshift/origin-gitserver
 
+Persistent and ephemeral templates are provided. For OpenShift Online you need to use
+the persistent one.
+
 Quick Start
 -----------
 
@@ -21,7 +24,7 @@ Prerequisites:
 
 * You have an OpenShift v3 server running
 * You are logged in and have access to a project
-* You have the `gitserver.yaml` from this directory
+* You have the `gitserver-ephemeral.yaml` or `gitserver-persistent.yaml` from this directory
 * You can create externally accessible routes on your server
 
 ### Deploy the Git Server
@@ -29,7 +32,13 @@ Prerequisites:
 1. Create the Git Server
 
     ```sh
-    $ oc create -f gitserver.yaml
+    $ oc create -f gitserver-ephemeral.yaml
+    ```
+
+    OR 
+
+    ```sh
+    $ oc create -f gitserver-persistent.yaml
     ```
 
 2. Grant `edit` access to the `git` service account

--- a/examples/gitserver/gitserver-ephemeral.yaml
+++ b/examples/gitserver/gitserver-ephemeral.yaml
@@ -26,6 +26,10 @@ items:
           image: openshift/origin-gitserver:latest
           ports:
           - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /_/healthz
+              port: 8080
 
           env:
           # Each environment variable matching GIT_INITIAL_CLONE_* will

--- a/examples/gitserver/gitserver-persistent.yaml
+++ b/examples/gitserver/gitserver-persistent.yaml
@@ -1,0 +1,211 @@
+apiVersion: v1
+kind: List
+items:
+
+# The git server is deployed as a singleton pod and uses a very small amount
+# of resources. It can host or transiently serve Git repositories, as well
+# as automatically integrate with builds in a namespace.
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: git
+    labels:
+      app: git
+  spec:
+    replicas: 1 # the git server is not HA and should not be scaled past 1
+    selector:
+      run-container: git
+    template:
+      metadata:
+        labels:
+          run-container: git
+      spec:
+        serviceAccountName: git
+        containers:
+        - name: git
+          image: openshift/origin-gitserver:latest
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /_/healthz
+              port: 8080
+
+          env:
+          # Each environment variable matching GIT_INITIAL_CLONE_* will
+          # be cloned when the process starts; failures will be logged.
+          # <name> must be [A-Z0-9_\-\.], the cloned directory name will
+          # be lowercased. If the name is invalid the pod will halt. If
+          # the repository already exists on disk, it will be updated
+          # from the remote.
+          #
+          #- name: GIT_INITIAL_CLONE_1
+          #  value:  <url>[;<name>]
+
+
+          # The namespace of the pod is required for implicit config
+          # (passing '-' to AUTOLINK_KUBECONFIG or REQUIRE_SERVER_AUTH)
+          # and can also be used to target a specific namespace.
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+          # The URL that builds must use to access the Git repositories
+          # stored in this app.
+          # TOOD: support HTTPS
+          - name: PUBLIC_URL
+            value: http://git.$(POD_NAMESPACE).svc.cluster.local:8080
+          # If INTERNAL_URL is specified, then it's used to point
+          # BuildConfigs to the internal service address of the git
+          # server
+          - name: INTERNAL_URL
+            value: http://git:8080
+
+          # The directory to store Git repositories in. If not backed
+          # by a persistent volume, repositories will be lost when
+          # deployments occur. Use INITIAL_GIT_CLONE and AUTOLINK_*
+          # to remove the need to use a persistent volume.
+          - name: GIT_HOME
+            value: /var/lib/git
+
+          # The directory to use as the default hook directory for any
+          # cloned or autolinked directories.
+          - name: HOOK_PATH
+            value: /var/lib/git-hooks
+
+          # If 'true' new-app will be invoked on push for repositories
+          # for which a matching BuildConfig is not found.
+          - name: GENERATE_ARTIFACTS
+            value: "true"
+
+          # The script to use for custom language detection on a
+          # repository. See hooks/detect-language for an example.
+          # To use new-app's default detection, leave this variable
+          # blank.
+          - name: DETECTION_SCRIPT
+          # value: detect-language
+
+          # Authentication and authorization
+
+          # If 'true', clients may push to the server with git push.
+          - name: ALLOW_GIT_PUSH
+            value: "true"
+          # If 'true', clients may set hooks via the API. However, unless
+          # the Git home is backed by a persistent volume, any deployment
+          # will result in the hooks being lost.
+          - name: ALLOW_GIT_HOOKS
+            value: "true"
+          # If 'true', clients can create new git repositories on demand
+          # by pushing. If the data on disk is not backed by a persistent
+          # volume, the Git repo will be deleted if the deployment is
+          # updated.
+          - name: ALLOW_LAZY_CREATE
+            value: "true"
+          # If 'true', clients can pull without being authenticated.
+          - name: ALLOW_ANON_GIT_PULL
+            value: "true"
+
+          # Provides the path to a kubeconfig file in the image that
+          # should be used to authorize against the server. The value
+          # '-' will use the pod's service account.
+          # May not be used in combination with REQUIRE_GIT_AUTH
+          - name: REQUIRE_SERVER_AUTH
+            value: "-"
+          # The namespace to check authorization against when
+          # REQUIRE_SERVICE_AUTH is used. Users must have 'get' on
+          # 'pods' to pull and 'create' on 'pods' to push.
+          - name: AUTH_NAMESPACE
+            value: $(POD_NAMESPACE)
+          # Require BASIC authentication with a username and password
+          # to push or pull.
+          # May not be used in combination with REQUIRE_SERVER_AUTH
+          - name: REQUIRE_GIT_AUTH
+          # value: <username>:<password>
+
+          # Autolinking:
+          #
+          # The git server can automatically clone Git repositories
+          # associated with a build config and replace the URL with
+          # a link to the repo on PUBLIC_URL. The default post-receive
+          # hook on the cloned repo will then trigger a build. You
+          # may customize the hook with AUTOLINK_HOOK (path to hook).
+          # To autolink, the account the pod runs under must have 'edit'
+          # on the AUTOLINK_NAMESPACE:
+          #
+          #    oc policy add-role-to-user -z git edit
+          #
+          # Links are checked every time the pod starts.
+
+          # The location to read auth configuration from for autolinking.
+          # If '-', use the service account token to link. The account
+          # represented by this config must have the edit role on the
+          # namespace.
+          - name: AUTOLINK_KUBECONFIG
+            value: "-"
+
+          # The namespace to autolink
+          - name: AUTOLINK_NAMESPACE
+            value: $(POD_NAMESPACE)
+
+          # The path to a script in the image to use as the default
+          # post-receive hook - only set during link, so has no effect
+          # on cloned repositories. See the "hooks" directory in the
+          # image for examples.
+          - name: AUTOLINK_HOOK
+
+          volumeMounts:
+          - mountPath: /var/lib/git
+            name: git-data
+        volumes:
+        - name: git-data
+          persistentVolumeClaim:
+            claimName: git
+    triggers:
+    - type: ConfigChange
+
+# The git server service is required for DNS resolution
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: git
+    labels:
+      app: git
+  spec:
+    ports:
+    - port: 8080
+      targetPort: 8080
+    selector:
+      run-container: git
+
+# The service account for the git server must be granted the view role to
+# automatically start builds, edit role to create objects and autolink
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: git
+    labels:
+      app: git
+
+# Default route for git service
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: git
+    name: git
+  spec:
+    to:
+      name: git
+
+# Persistent volume claim
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: git
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1G

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -84,6 +84,7 @@ ln_or_cp "${imagedir}/pod"             images/pod/bin
 ln_or_cp "${imagedir}/hello-openshift" examples/hello-openshift/bin
 ln_or_cp "${imagedir}/deployment"      examples/deployment/bin
 ln_or_cp "${imagedir}/gitserver"       examples/gitserver/bin
+ln_or_cp "${imagedir}/oc"              examples/gitserver/bin
 ln_or_cp "${imagedir}/dockerregistry"  images/dockerregistry/bin
 
 # Copy SDN scripts into images/node
@@ -113,11 +114,11 @@ image openshift/origin-haproxy-router        images/router/haproxy
 image openshift/origin-keepalived-ipfailover images/ipfailover/keepalived
 image openshift/origin-docker-registry       images/dockerregistry
 image openshift/origin-egress-router         images/router/egress
+image openshift/origin-gitserver             examples/gitserver
 # images that depend on openshift/origin
 image openshift/origin-deployer              images/deployer
 image openshift/origin-recycler              images/recycler
 image openshift/origin-docker-builder        images/builder/docker/docker-builder
-image openshift/origin-gitserver             examples/gitserver
 image openshift/origin-sti-builder           images/builder/docker/sti-builder
 image openshift/origin-f5-router             images/router/f5
 image openshift/node                         images/node


### PR DESCRIPTION
Switches gitserver to use openshift/origin-base as its FROM image instead of openshift/origin. This prevents having 2 volume directives in the image, when only one is needed.

Also updated documentation to explain how to create a PVC for the git server so that it can work online.

Fixes BZ 1336318