### PR TITLE
allow who-can to reference resource names

### DIFF
--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -16,6 +16,7 @@ os::test::junit::declare_suite_start "cmd/policy"
 os::cmd::expect_success_and_text 'oc whoami --as deads' "deads"
 
 os::cmd::expect_success 'oadm policy add-cluster-role-to-user sudoer wheel'
+os::cmd::try_until_text 'oc policy who-can impersonate systemusers system:admin' "wheel"
 os::cmd::expect_success 'oc login -u wheel -p pw'
 os::cmd::expect_success_and_text 'oc whoami' "wheel"
 os::cmd::expect_failure 'oc whoami --as deads'


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/8897

It was a negotiation that failed on a 403.  We should probably make that easier to read too.

@kargakis