### PR TITLE
refactor whatcanido to can-i --list

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -7565,9 +7565,9 @@ _oc_policy_who-can()
     must_have_one_noun=()
 }
 
-_oc_policy_what-can-i-do()
+_oc_policy_can-i()
 {
-    last_command="oc_policy_what-can-i-do"
+    last_command="oc_policy_can-i"
     commands=()
 
     flags=()
@@ -7575,6 +7575,10 @@ _oc_policy_what-can-i-do()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--all-namespaces")
+    flags+=("--list")
+    flags+=("--quiet")
+    flags+=("-q")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")
@@ -7858,7 +7862,7 @@ _oc_policy()
     last_command="oc_policy"
     commands=()
     commands+=("who-can")
-    commands+=("what-can-i-do")
+    commands+=("can-i")
     commands+=("add-role-to-user")
     commands+=("remove-role-from-user")
     commands+=("remove-user")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -11150,9 +11150,9 @@ _openshift_cli_policy_who-can()
     must_have_one_noun=()
 }
 
-_openshift_cli_policy_what-can-i-do()
+_openshift_cli_policy_can-i()
 {
-    last_command="openshift_cli_policy_what-can-i-do"
+    last_command="openshift_cli_policy_can-i"
     commands=()
 
     flags=()
@@ -11160,6 +11160,10 @@ _openshift_cli_policy_what-can-i-do()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--all-namespaces")
+    flags+=("--list")
+    flags+=("--quiet")
+    flags+=("-q")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")
@@ -11443,7 +11447,7 @@ _openshift_cli_policy()
     last_command="openshift_cli_policy"
     commands=()
     commands+=("who-can")
-    commands+=("what-can-i-do")
+    commands+=("can-i")
     commands+=("add-role-to-user")
     commands+=("remove-role-from-user")
     commands+=("remove-user")

--- a/pkg/cmd/admin/policy/whatcanido.go
+++ b/pkg/cmd/admin/policy/whatcanido.go
@@ -4,10 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -16,31 +21,53 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const WhatCanIDoRecommendedName = "what-can-i-do"
+const CanIRecommendedName = "can-i"
 
-type whatCanIDoOptions struct {
-	namespace string
-	client    client.SelfSubjectRulesReviewsNamespacer
+type canIOptions struct {
+	AllNamespaces     bool
+	ListAll           bool
+	Quiet             bool
+	Namespace         string
+	RulesReviewClient client.SelfSubjectRulesReviewsNamespacer
+	SARClient         client.SubjectAccessReviews
 
-	out io.Writer
+	Verb         string
+	Resource     unversioned.GroupVersionResource
+	ResourceName string
+
+	Out io.Writer
 }
 
-// NewCmdWhatCanIDo implements the OpenShift cli who-can command
-func NewCmdWhatCanIDo(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	options := &whatCanIDoOptions{out: out}
+func NewCmdCanI(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	o := &canIOptions{
+		Out: out,
+	}
 
 	cmd := &cobra.Command{
-		Use:   name,
-		Short: "List what I can do in this namespace",
-		Long:  "List what I can do in this namespace",
+		Use:   name + " VERB RESOURCE [NAME]",
+		Short: "Check whether an action is allowed",
+		Long:  "Check whether an action is allowed",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.complete(f, args); err != nil {
+			if reflect.DeepEqual(args, []string{"educate", "dolphins"}) {
+				fmt.Fprintln(o.Out, "Only liggitt can educate dolphins.")
+				return
+			}
+
+			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
 			}
 
-			kcmdutil.CheckErr(options.run())
+			allowed, err := o.Run()
+			kcmdutil.CheckErr(err)
+			if o.Quiet && !allowed {
+				os.Exit(2)
+			}
 		},
 	}
+
+	cmd.Flags().BoolVar(&o.AllNamespaces, "all-namespaces", o.AllNamespaces, "Check the specified action in all namespaces.")
+	cmd.Flags().BoolVar(&o.ListAll, "list", o.ListAll, "List all the actions you can perform in a namespace, cannot be specified with --all-namespaces or a VERB RESOURCE")
+	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, "Suppress output and just return the exit code")
 
 	return cmd
 }
@@ -53,32 +80,86 @@ const (
 	tabwriterFlags    = 0
 )
 
-func (o *whatCanIDoOptions) complete(f *clientcmd.Factory, args []string) error {
-	if len(args) != 0 {
-		return errors.New("no arguments are supported")
+func (o *canIOptions) Complete(f *clientcmd.Factory, args []string) error {
+	if o.ListAll && o.AllNamespaces {
+		return errors.New("--list and --all-namespaces are mutually exclusive")
+	}
+
+	switch len(args) {
+	case 3:
+		o.ResourceName = args[2]
+		fallthrough
+	case 2:
+		if o.ListAll {
+			return errors.New("VERB RESOURCE and --list are mutually exclusive")
+		}
+		restMapper, _ := f.Object(false)
+		o.Verb = args[0]
+		o.Resource = resourceFor(restMapper, args[1])
+	default:
+		if !o.ListAll {
+			return errors.New("you must specify two or three arguments: verb, resource, and optional resourceName")
+		}
 	}
 
 	var err error
-	o.client, _, err = f.Clients()
+	oclient, _, err := f.Clients()
 	if err != nil {
 		return err
 	}
+	o.RulesReviewClient = oclient
+	o.SARClient = oclient
 
-	o.namespace, _, err = f.DefaultNamespace()
-	if err != nil {
-		return err
+	o.Namespace = kapi.NamespaceAll
+	if !o.AllNamespaces {
+		o.Namespace, _, err = f.DefaultNamespace()
+		if err != nil {
+			return err
+		}
+	}
+
+	if o.Quiet {
+		o.Out = ioutil.Discard
 	}
 
 	return nil
 }
 
-func (o *whatCanIDoOptions) run() error {
-	whatCanIDo, err := o.client.SelfSubjectRulesReviews(o.namespace).Create(&authorizationapi.SelfSubjectRulesReview{})
+func (o *canIOptions) Run() (bool, error) {
+	if o.ListAll {
+		return true, o.listAllPermissions()
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Action: authorizationapi.AuthorizationAttributes{
+			Namespace:    o.Namespace,
+			Verb:         o.Verb,
+			Group:        o.Resource.Group,
+			Resource:     o.Resource.Resource,
+			ResourceName: o.ResourceName,
+		},
+	}
+	response, err := o.SARClient.SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return false, err
+	}
+
+	if response.Allowed {
+		fmt.Fprintln(o.Out, "yes")
+	} else {
+		fmt.Fprintln(o.Out, "no")
+	}
+
+	return response.Allowed, nil
+}
+
+func (o *canIOptions) listAllPermissions() error {
+	whatCanIDo, err := o.RulesReviewClient.SelfSubjectRulesReviews(o.Namespace).Create(&authorizationapi.SelfSubjectRulesReview{})
 	if err != nil {
 		return err
 	}
 
-	writer := tabwriter.NewWriter(o.out, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
+	writer := tabwriter.NewWriter(o.Out, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
 	fmt.Fprint(writer, describe.PolicyRuleHeadings+"\n")
 	for _, rule := range whatCanIDo.Status.Rules {
 		describe.DescribePolicyRule(writer, rule, "")

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -35,7 +35,7 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	options := &whoCanOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "who-can VERB RESOURCE [NAME]",
+		Use:   name + " VERB RESOURCE [NAME]",
 		Short: "List who can perform the specified action on a resource",
 		Long:  "List who can perform the specified action on a resource",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -61,7 +61,6 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 }
 
 func (o *whoCanOptions) complete(f *clientcmd.Factory, args []string) error {
-
 	switch len(args) {
 	case 3:
 		o.resourceName = args[2]

--- a/pkg/cmd/cli/policy/policy.go
+++ b/pkg/cmd/cli/policy/policy.go
@@ -22,7 +22,7 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	}
 
 	cmds.AddCommand(adminpolicy.NewCmdWhoCan(adminpolicy.WhoCanRecommendedName, fullName+" "+adminpolicy.WhoCanRecommendedName, f, out))
-	cmds.AddCommand(adminpolicy.NewCmdWhatCanIDo(adminpolicy.WhatCanIDoRecommendedName, fullName+" "+adminpolicy.WhatCanIDoRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdCanI(adminpolicy.CanIRecommendedName, fullName+" "+adminpolicy.CanIRecommendedName, f, out))
 
 	cmds.AddCommand(adminpolicy.NewCmdAddRoleToUser(adminpolicy.AddRoleToUserRecommendedName, fullName+" "+adminpolicy.AddRoleToUserRecommendedName, f, out))
 	cmds.AddCommand(adminpolicy.NewCmdRemoveRoleFromUser(adminpolicy.RemoveRoleFromUserRecommendedName, fullName+" "+adminpolicy.RemoveRoleFromUserRecommendedName, f, out))

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -82,7 +82,11 @@ os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/jenkinsp
 os::cmd::expect_success 'oadm policy reconcile-cluster-role-bindings --confirm'
 
 
-os::cmd::expect_success_and_text 'oc policy what-can-i-do' 'get update.*imagestreams/layers'
+os::cmd::expect_success_and_text 'oc policy can-i --list' 'get update.*imagestreams/layers'
+os::cmd::expect_success_and_text 'oc policy can-i create pods --all-namespaces' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create pods' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create pods --as harold' 'no'
+os::cmd::expect_failure 'oc policy can-i create pods --as harold -q'
 
 
 # adjust the cluster-admin role to check defaulting and coverage checks


### PR DESCRIPTION
Updates `oc policy what-can-i-do` to `oc policy can-i --list`.  Also makes `oc policy can-i VERB RESOURCE [NAME]` for permissions tests and a `-q` flag for use as a bash conditional.

@kargakis ptal.

@smarterclayton can I get this before you tag?