### PR TITLE
add user:list-projects scope

### DIFF
--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -52,6 +52,11 @@ func TestUserEvaluator(t *testing.T) {
 			scopes:   []string{UserIndicator + UserInfo, UserIndicator + UserAccessCheck},
 			numRules: 3,
 		},
+		{
+			name:     "list-projects",
+			scopes:   []string{UserIndicator + UserListProject},
+			numRules: 2,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -26,6 +26,11 @@ whoamitoken=$(oc process -f ${OS_ROOT}/test/fixtures/authentication/scoped-token
 os::cmd::expect_success_and_text 'oc get user/~ --token="${whoamitoken}"' "${username}"
 os::cmd::expect_failure_and_text 'oc get pods --token="${whoamitoken}" -n cmd-authentication' 'prevent this action; User "scoped-user" cannot list pods in project "cmd-authentication"'
 
+listprojecttoken=$(oc process -f ${OS_ROOT}/test/fixtures/authentication/scoped-token-template.yaml TOKEN_PREFIX=listproject SCOPE=user:list-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')
+os::cmd::expect_success_and_text 'oc get projects --token="${listprojecttoken}"' 'cmd-authentication'
+os::cmd::expect_failure_and_text 'oc get user/~ --token="${listprojecttoken}"' 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
+os::cmd::expect_failure_and_text 'oc get pods --token="${listprojecttoken}" -n cmd-authentication' 'prevent this action; User "scoped-user" cannot list pods in project "cmd-authentication"'
+
 adminnonescalatingpowerstoken=$(oc process -f ${OS_ROOT}/test/fixtures/authentication/scoped-token-template.yaml TOKEN_PREFIX=admin SCOPE=role:admin:* USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')
 os::cmd::expect_failure_and_text 'oc get user/~ --token="${adminnonescalatingpowerstoken}"' 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
 os::cmd::expect_failure_and_text 'oc get secrets --token="${adminnonescalatingpowerstoken}" -n cmd-authentication' 'prevent this action; User "scoped-user" cannot list secrets in project "cmd-authentication"'


### PR DESCRIPTION
needed for https://github.com/openshift/origin-aggregated-logging/pull/139#issuecomment-220058074

This adds `user:list-projects` as a curated scope to allow seeing which projects are user has visibility into.  There's no clean role that does this and use-case of "I need to see which  projects a user can see" seems reasonably strong.

@openshift/api-review for the new scope
@ewolinetz fyi