### PR TITLE
cluster up: ensure you can login as administrator

### DIFF
--- a/pkg/bootstrap/docker/openshift/login.go
+++ b/pkg/bootstrap/docker/openshift/login.go
@@ -30,6 +30,9 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 	if err != nil {
 		return err
 	}
+	for k := range adminConfig.AuthInfos {
+		adminConfig.AuthInfos[k].LocationOfOrigin = ""
+	}
 	newConfig, err := config.MergeConfig(existingConfig, *adminConfig)
 	if err != nil {
 		return err

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -514,7 +514,9 @@ func (c *ClientStartConfig) ServerInfo(out io.Writer) error {
 		"    %s\n\n"+
 		"You are logged in as:\n"+
 		"    User:     %s\n"+
-		"    Password: %s\n\n",
+		"    Password: %s\n\n"+
+		"To login as administrator:\n"+
+		"    oc login -u system:admin\n\n",
 		c.OpenShiftHelper().Master(c.ServerIP),
 		initialUser,
 		initialPassword)


### PR DESCRIPTION
Fixes issue with admin user not getting saved to local config.
Prints info on how to become admin.