### PR TITLE
Allow a user to specify --as-user or --as-root=false

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -2902,6 +2902,7 @@ _oc_debug()
     flags_completion=()
 
     flags+=("--as-root")
+    flags+=("--as-user=")
     flags+=("--container=")
     two_word_flags+=("-c")
     flags+=("--filename=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -6488,6 +6488,7 @@ _openshift_cli_debug()
     flags_completion=()
 
     flags+=("--as-root")
+    flags+=("--as-user=")
     flags+=("--container=")
     two_word_flags+=("-c")
     flags+=("--filename=")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1035,6 +1035,9 @@ Launch a new instance of a pod for debugging
   # Debug a currently running deployment
   oc debug dc/test
 
+  # Test running a deployment as a non-root user
+  oc debug dc/test --as-user=1000000
+
   # Debug a specific failing container by running the env command in the 'second' container
   oc debug dc/test -c second -- /bin/env
 

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -24,6 +24,8 @@ os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config -o yaml" '\- /bin/sh'
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --keep-annotations -o yaml" 'annotations:'
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --as-root -o yaml" 'runAsUser: 0'
+os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --as-root=false -o yaml" 'runAsNonRoot: true'
+os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --as-user=1 -o yaml" 'runAsUser: 1'
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --keep-liveness --keep-readiness -o yaml" ''
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" '\- /bin/env'
 os::cmd::expect_success_and_text "oc debug -t dc/test-deployment-config -o yaml" 'stdinOnce'


### PR DESCRIPTION
Gives a user the ability to easily verify their image works as an
arbitrary user (with nothing else changed).

@deads2k