### PR TITLE
Enable AlwaysPullImages without messing with the admission chain

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
@@ -34,10 +34,15 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 )
 
+// disable this plugin registration so we can steal the name with our own "disable-by-default" implementation downstream until we figure out how
+// make references to our configapilatest package here.  We want people to be able to enable this plugin without having to change the admission chain.
 func init() {
-	admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
-		return NewAlwaysPullImages(), nil
-	})
+	// avoid conflicting in import lines
+	if false {
+		admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+			return NewAlwaysPullImages(), nil
+		})
+	}
 }
 
 // alwaysPullImages is an implementation of admission.Interface.

--- a/pkg/cmd/server/api/latest/helpers.go
+++ b/pkg/cmd/server/api/latest/helpers.go
@@ -137,3 +137,21 @@ func captureSurroundingJSONForError(prefix string, data []byte, err error) error
 	}
 	return err
 }
+
+// IsAdmissionPluginActivated returns true if the admission plugin is activated using configapi.AdmissionPluginActivation
+// otherwise it returns a defautl value
+func IsAdmissionPluginActivated(reader io.Reader, defaultValue bool) (bool, error) {
+	obj, err := ReadYAML(reader)
+	if err != nil {
+		return false, err
+	}
+	if obj == nil {
+		return defaultValue, nil
+	}
+	_, ok := obj.(*configapi.AdmissionPluginActivation)
+	if !ok {
+		return false, fmt.Errorf("unexpected config object: %#v", obj)
+	}
+
+	return true, nil
+}

--- a/pkg/cmd/server/api/register.go
+++ b/pkg/cmd/server/api/register.go
@@ -53,8 +53,12 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&OpenIDIdentityProvider{},
 
 		&LDAPSyncConfig{},
+
+		&AdmissionPluginActivation{},
 	)
 }
+
+func (obj *AdmissionPluginActivation) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 
 func (obj *LDAPSyncConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -1193,3 +1193,14 @@ type ServiceServingCert struct {
 	// If this value is nil, then certs are not signed automatically.
 	Signer *CertInfo
 }
+
+// AdmissionPluginActivation can be used to enable to disable various admission plugins.
+// When this type is present as the `configuration` object in and `pluginConfig` and *if* the admission plugin supports it,
+// this will cause an off by default admission plugin to be enabled
+type AdmissionPluginActivation struct {
+	unversioned.TypeMeta
+
+	// TODO, we may want to make it possible to turn off an on by default admission plugin
+	//	Disable turns off an admission plugin that is enabled by default.
+	// Disable bool
+}

--- a/pkg/cmd/server/api/v1/register.go
+++ b/pkg/cmd/server/api/v1/register.go
@@ -36,8 +36,12 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&OpenIDIdentityProvider{},
 
 		&LDAPSyncConfig{},
+
+		&AdmissionPluginActivation{},
 	)
 }
+
+func (obj *AdmissionPluginActivation) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 
 func (obj *LDAPSyncConfig) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -26,6 +26,14 @@ func (AdmissionConfig) SwaggerDoc() map[string]string {
 	return map_AdmissionConfig
 }
 
+var map_AdmissionPluginActivation = map[string]string{
+	"": "AdmissionPluginActivation can be used to enable to disable various admission plugins. When this type is present as the `configuration` object in and `pluginConfig` and *if* the admission plugin supports it, this will cause an off by default admission plugin to be enabled",
+}
+
+func (AdmissionPluginActivation) SwaggerDoc() map[string]string {
+	return map_AdmissionPluginActivation
+}
+
 var map_AdmissionPluginConfig = map[string]string{
 	"":              "AdmissionPluginConfig holds the necessary configuration options for admission plugins",
 	"location":      "Location is the path to a configuration file that contains the plugin's configuration",

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -1199,3 +1199,14 @@ type ServiceServingCert struct {
 	// If this value is nil, then certs are not signed automatically.
 	Signer *CertInfo `json:"signer"`
 }
+
+// AdmissionPluginActivation can be used to enable to disable various admission plugins.
+// When this type is present as the `configuration` object in and `pluginConfig` and *if* the admission plugin supports it,
+// this will cause an off by default admission plugin to be enabled
+type AdmissionPluginActivation struct {
+	unversioned.TypeMeta `json:",inline"`
+
+	// TODO, we may want to make it possible to turn off an on by default admission plugin
+	//	Disable turns off an admission plugin that is enabled by default.
+	// Disable bool
+}

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -47,7 +47,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "ResourceQuota", "SCCExecRestrictions"}
+var AdmissionPlugins = []string{"RunOnceDuration", lifecycle.PluginName, "PodNodeConstraints", "OriginPodNodeEnvironment", overrideapi.PluginName, serviceadmit.ExternalIPPluginName, "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "BuildDefaults", "BuildOverrides", "AlwaysPullImages", "ResourceQuota", "SCCExecRestrictions"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/openshift/origin/pkg/build/admission/defaults"
 	_ "github.com/openshift/origin/pkg/build/admission/overrides"
 	_ "github.com/openshift/origin/pkg/build/admission/strategyrestrictions"
+	_ "github.com/openshift/origin/pkg/image/admission/alwayspullimages"
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"

--- a/pkg/image/admission/alwayspullimages/admission.go
+++ b/pkg/image/admission/alwayspullimages/admission.go
@@ -1,0 +1,27 @@
+package alwayspullimages
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/admission"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
+
+	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+)
+
+func init() {
+	admission.RegisterPlugin("AlwaysPullImages", func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+		activated, err := configlatest.IsAdmissionPluginActivated(config, false)
+		if err != nil {
+			return nil, err
+		}
+		if !activated {
+			glog.Infof("Admission plugin %q is not enabled so it will be off.", "AlwaysPullImages")
+			return nil, nil
+		}
+		return alwayspullimages.NewAlwaysPullImages(), nil
+	})
+}

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -291,3 +291,80 @@ func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
 		t.Errorf("Error: %v", err)
 	}
 }
+
+func TestAlwaysPullImagesOn(t *testing.T) {
+	testutil.RequireEtcd(t)
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("error creating config: %v", err)
+	}
+	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		"AlwaysPullImages": {
+			Configuration: &configapi.AdmissionPluginActivation{},
+		},
+	}
+	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("error starting server: %v", err)
+	}
+	kubeClient, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting client: %v", err)
+	}
+
+	if err := testserver.WaitForPodCreationServiceAccounts(kubeClient, "default"); err != nil {
+		t.Fatalf("error getting client config: %v", err)
+	}
+
+	testPod := &kapi.Pod{}
+	testPod.GenerateName = "test"
+	testPod.Spec.Containers = []kapi.Container{
+		{
+			Name:            "container",
+			Image:           "openshift/origin-pod:notlatest",
+			ImagePullPolicy: kapi.PullNever,
+		},
+	}
+
+	actualPod, err := kubeClient.Pods("default").Create(testPod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actualPod.Spec.Containers[0].ImagePullPolicy != kapi.PullAlways {
+		t.Errorf("expected %v, got %v", kapi.PullAlways, actualPod.Spec.Containers[0].ImagePullPolicy)
+	}
+}
+
+func TestAlwaysPullImagesOff(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, kubeConfigFile, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("error starting server: %v", err)
+	}
+	kubeClient, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting client: %v", err)
+	}
+
+	if err := testserver.WaitForPodCreationServiceAccounts(kubeClient, "default"); err != nil {
+		t.Fatalf("error getting client config: %v", err)
+	}
+
+	testPod := &kapi.Pod{}
+	testPod.GenerateName = "test"
+	testPod.Spec.Containers = []kapi.Container{
+		{
+			Name:            "container",
+			Image:           "openshift/origin-pod:notlatest",
+			ImagePullPolicy: kapi.PullNever,
+		},
+	}
+
+	actualPod, err := kubeClient.Pods("default").Create(testPod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actualPod.Spec.Containers[0].ImagePullPolicy != kapi.PullNever {
+		t.Errorf("expected %v, got %v", kapi.PullNever, actualPod.Spec.Containers[0].ImagePullPolicy)
+	}
+}


### PR DESCRIPTION
This lets you enable the AlwaysPullImages admission plugin without changing the entire chain.

@csrwng ptal
@stenwt I think you were the one asking about this?