### PR TITLE
Update atomic registry quickstart artifacts

### DIFF
--- a/examples/atomic-registry/Dockerfile
+++ b/examples/atomic-registry/Dockerfile
@@ -13,7 +13,7 @@ LABEL name="projectatomic/atomic-registry-quickstart" \
       url="https://projectatomic.io/registry" \
       summary="Quickstart image for Atomic Registry" \
       description="This is a quickstart image to install Atomic Registry on a single host. It is an open source enterprise registry solution based on the Origin project featuring single sign-on (SSO) user experience, a robust web interface and advanced role-based access control (RBAC)." \
-      INSTALL='docker run -it --rm \
+      INSTALL='docker run -i --rm \
                 --privileged --net=host \
                 -v /var/run:/var/run:rw \
                 -v /sys:/sys \
@@ -25,7 +25,7 @@ LABEL name="projectatomic/atomic-registry-quickstart" \
                 -e KUBECONFIG=/etc/origin/master/admin.kubeconfig \
                 --entrypoint /container/bin/install.sh \
                 $IMAGE' \
-      RUN='docker run -it --rm --privileged \
+      RUN='docker run -i --rm --privileged \
                 --net=host \
                 -v /:/host \
                 -v /var/lib/docker:/var/lib/docker:rw \
@@ -34,7 +34,7 @@ LABEL name="projectatomic/atomic-registry-quickstart" \
                 -e KUBECONFIG=/etc/origin/master/admin.kubeconfig \
                 --entrypoint /container/bin/run.sh \
                 $IMAGE' \
-      UNINSTALL='docker run -it --rm --privileged \
+      UNINSTALL='docker run -i --rm --privileged \
                 -v /:/host \
                 --entrypoint /container/bin/uninstall.sh \
                 $IMAGE'

--- a/examples/atomic-registry/install.sh
+++ b/examples/atomic-registry/install.sh
@@ -12,9 +12,9 @@ echo "Installing using hostname ${INSTALL_HOST}"
 
 # write out configuration
 openshift start --write-config /etc/origin/ \
-  --etcd-dir /var/lib/origin/etcd
-  --volume-dir /var/lib/origin/volumes
-  --public-master ${INSTALL_HOST}
+  --etcd-dir /var/lib/origin/etcd \
+  --volume-dir /var/lib/origin/volumes \
+  --public-master ${INSTALL_HOST} \
   --hostname ${INSTALL_HOST}
 
 echo "Copy files to host"
@@ -33,11 +33,11 @@ cp /container/etc/origin/registry-login-template.html /host/etc/origin/master/si
 cat /etc/origin/master/master.server.crt /etc/origin/master/master.server.key > /etc/origin/registry/master.server.cert
 
 set +x
-
-echo "Updating servicesNodePortRange to 443-32767..."
-sed -i 's/  servicesNodePortRange:.*$/  servicesNodePortRange: 80-32767/' /etc/origin/master/master-config.yaml
+PORT_RANGE="80-32767"
+echo "Updating servicesNodePortRange to ${PORT_RANGE}..."
+sed -i "s/  servicesNodePortRange:.*$/  servicesNodePortRange: ${PORT_RANGE}/" /etc/origin/master/master-config.yaml
 echo "Updating login template"
-sed -i 's/  templates: null$/  templates:\n    login: site\/registry-login-template.html/' /etc/origin/master/master-config.yaml
+sed -i "s/  templates: null$/  templates:\n    login: site\/registry-login-template.html/" /etc/origin/master/master-config.yaml
 
 echo "Optionally edit configuration file /etc/origin/master/master-config.yaml,"
 echo "add certificates to /etc/origin/master,"

--- a/examples/atomic-registry/registry-console-template.yaml
+++ b/examples/atomic-registry/registry-console-template.yaml
@@ -85,6 +85,25 @@ objects:
                 -
                   name: REGISTRY_HOST
                   value: "${REGISTRY_HOST}"
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ping
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 5
   -
     kind: Service
     apiVersion: v1
@@ -122,6 +141,7 @@ objects:
       name: "${OPENSHIFT_OAUTH_CLIENT_ID}"
       respondWithChallenges: false
     secret: "${OPENSHIFT_OAUTH_CLIENT_SECRET}"
+    allowAnyScope: true
     redirectURIs:
       -
         "${COCKPIT_KUBE_URL}"

--- a/examples/atomic-registry/run.sh
+++ b/examples/atomic-registry/run.sh
@@ -34,7 +34,7 @@ INSTALL_HOST=${1:-`hostname`}
 
 echo "Running using hostname ${INSTALL_HOST}"
 
-chroot /host sudo docker run -d --name "origin" \
+chroot /host docker run -d --name "origin" \
         --privileged --pid=host --net=host \
         -e KUBECONFIG=/etc/origin/master/admin.kubeconfig \
         -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys -v /var/lib/docker:/var/lib/docker:rw \
@@ -47,7 +47,7 @@ chroot /host sudo docker run -d --name "origin" \
 echo "Waiting for services to come up..."
 wait_for_url "https://${INSTALL_HOST}:8443/api"
 
-CMD="chroot /host docker exec -it origin"
+CMD="chroot /host docker exec -i origin"
 echo "Starting registry services..."
 
 set -x

--- a/examples/atomic-registry/test.sh
+++ b/examples/atomic-registry/test.sh
@@ -16,7 +16,7 @@ TEST_IMAGE=atomic-registry-quickstart
 # we're going to use this for testing
 # node ports aren't working with boxes default hostname localdomain.localhost
 LOCALHOST=${1:-`hostname`}
-CMD="docker exec -it origin"
+CMD="docker exec -i origin"
 
 USER=mary
 PROJ=mary-project

--- a/examples/atomic-registry/uninstall.sh
+++ b/examples/atomic-registry/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CMD="chroot /host docker exec -it origin"
+CMD="chroot /host docker exec -i origin"
 
 # let's make sure we're logged in as admin/default
 $CMD oc login -u system:admin


### PR DESCRIPTION
- Enable hostname override in test script
- Patch registry console service to include port 80
- Extend node port range down to port 80
- Use --hostname arg when writing origin config
- Remove tty for unattended install / automated testing
- Fix oauthclient in console template
- Add readiness/liveliness checks in console template
- Misc bugfixes