### PR TITLE
default to letting oauth clients request all scopes from users

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -22044,10 +22044,6 @@
        "$ref": "v1.ScopeRestriction"
       },
       "description": "ScopeRestrictions describes which scopes this client can request.  Each requested scope is checked against each restriction.  If any restriction matches, then the scope is allowed. If no restriction matches, then the scope is denied."
-     },
-     "allowAnyScope": {
-      "type": "boolean",
-      "description": "AllowAnyScope indicates that the client is allowed to request a token unconstrained by scopes. If this is true, then ScopeRestrictions is ignored."
      }
     }
    },

--- a/pkg/auth/server/grant/grant_test.go
+++ b/pkg/auth/server/grant/grant_test.go
@@ -36,8 +36,8 @@ func badAuth(err error) *testAuth {
 	return &testAuth{Success: false, User: nil, Err: err}
 }
 
-func goodClientRegistry(clientID string, redirectURIs []string, literalScopes []string, unrestrictedScopes bool) *test.ClientRegistry {
-	client := &oapi.OAuthClient{ObjectMeta: kapi.ObjectMeta{Name: clientID}, Secret: "mysecret", RedirectURIs: redirectURIs, AllowAnyScope: unrestrictedScopes}
+func goodClientRegistry(clientID string, redirectURIs []string, literalScopes []string) *test.ClientRegistry {
+	client := &oapi.OAuthClient{ObjectMeta: kapi.ObjectMeta{Name: clientID}, Secret: "mysecret", RedirectURIs: redirectURIs}
 	client.Name = clientID
 	if len(literalScopes) > 0 {
 		client.ScopeRestrictions = []oapi.ScopeRestriction{{ExactValues: literalScopes}}
@@ -83,7 +83,7 @@ func TestGrant(t *testing.T) {
 		"display form": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   emptyAuthRegistry(),
 			Path:           "/grant?client_id=myclient&scopes=myscope1%20myscope2&redirect_uri=/myredirect&then=/authorize",
 
@@ -137,7 +137,7 @@ func TestGrant(t *testing.T) {
 		"error when POST fails CSRF": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   emptyAuthRegistry(),
 			Path:           "/grant",
 			PostValues: url.Values{
@@ -185,7 +185,7 @@ func TestGrant(t *testing.T) {
 		"successful create grant with redirect": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   emptyAuthRegistry(),
 			Path:           "/grant",
 			PostValues: url.Values{
@@ -205,7 +205,7 @@ func TestGrant(t *testing.T) {
 		"successful create grant without redirect": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   emptyAuthRegistry(),
 			Path:           "/grant",
 			PostValues: url.Values{
@@ -227,7 +227,7 @@ func TestGrant(t *testing.T) {
 		"successful update grant with identical scopes": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   existingAuthRegistry([]string{"myscope2", "myscope1"}),
 			Path:           "/grant",
 			PostValues: url.Values{
@@ -247,7 +247,7 @@ func TestGrant(t *testing.T) {
 		"successful update grant with additional scopes": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"newscope1", "existingscope1", "existingscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"newscope1", "existingscope1", "existingscope2"}),
 			AuthRegistry:   existingAuthRegistry([]string{"existingscope2", "existingscope1"}),
 			Path:           "/grant",
 			PostValues: url.Values{
@@ -267,7 +267,7 @@ func TestGrant(t *testing.T) {
 		"successful reject grant": {
 			CSRF:           &csrf.FakeCSRF{Token: "test"},
 			Auth:           goodAuth("username"),
-			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}, false),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
 			AuthRegistry:   existingAuthRegistry([]string{"existingscope2", "existingscope1"}),
 			Path:           "/grant",
 			PostValues: url.Values{

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -272,7 +272,7 @@ func getAPIGroupSet(rule authorizationapi.PolicyRule) sets.String {
 }
 
 func ValidateScopeRestrictions(client *oauthapi.OAuthClient, scopes ...string) error {
-	if client.AllowAnyScope {
+	if len(client.ScopeRestrictions) == 0 {
 		return nil
 	}
 	if len(scopes) == 0 {
@@ -292,7 +292,7 @@ func ValidateScopeRestrictions(client *oauthapi.OAuthClient, scopes ...string) e
 func validateScopeRestrictions(client *oauthapi.OAuthClient, scope string) error {
 	errs := []error{}
 
-	if client.AllowAnyScope {
+	if len(client.ScopeRestrictions) == 0 {
 		return nil
 	}
 

--- a/pkg/authorization/authorizer/scope/validate_test.go
+++ b/pkg/authorization/authorizer/scope/validate_test.go
@@ -18,35 +18,17 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "unrestricted allows any",
 			scopes: []string{"one"},
-			client: &oauthapi.OAuthClient{AllowAnyScope: true},
+			client: &oauthapi.OAuthClient{},
 		},
 		{
 			name:   "unrestricted allows empty",
 			scopes: []string{""},
-			client: &oauthapi.OAuthClient{AllowAnyScope: true},
+			client: &oauthapi.OAuthClient{},
 		},
 		{
 			name:   "unrestricted allows none",
 			scopes: []string{},
-			client: &oauthapi.OAuthClient{AllowAnyScope: true},
-		},
-		{
-			name:           "no restrictions denies any",
-			scopes:         []string{"one"},
-			client:         &oauthapi.OAuthClient{},
-			expectedErrors: []string{`one did not match any scope restriction`},
-		},
-		{
-			name:           "no restrictions denies empty",
-			scopes:         []string{""},
-			client:         &oauthapi.OAuthClient{},
-			expectedErrors: []string{`did not match any scope restriction`},
-		},
-		{
-			name:           "no restrictions denies none",
-			scopes:         []string{},
-			client:         &oauthapi.OAuthClient{},
-			expectedErrors: []string{`may not request unscoped tokens`},
+			client: &oauthapi.OAuthClient{},
 		},
 		{
 			name:   "simple literal",

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -243,8 +243,6 @@ func ensureOAuthClient(client oauthapi.OAuthClient, clientRegistry clientregistr
 		if len(existing.Secret) == 0 {
 			existing.Secret = client.Secret
 		}
-		// Ensure the correct scope setting
-		existing.AllowAnyScope = client.AllowAnyScope
 
 		// Preserve redirects for clients other than the CLI client
 		// The CLI client doesn't care about the redirect URL, just the token or error fragment
@@ -273,7 +271,6 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			Secret:                uuid.New(),
 			RespondWithChallenges: false,
 			RedirectURIs:          assetPublicAddresses,
-			AllowAnyScope:         true,
 		}
 		if err := ensureOAuthClient(webConsoleClient, clientRegistry, true); err != nil {
 			return err
@@ -286,7 +283,6 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			Secret:                uuid.New(),
 			RespondWithChallenges: false,
 			RedirectURIs:          []string{masterPublicAddr + path.Join(OpenShiftOAuthAPIPrefix, tokenrequest.DisplayTokenEndpoint)},
-			AllowAnyScope:         true,
 		}
 		if err := ensureOAuthClient(browserClient, clientRegistry, true); err != nil {
 			return err
@@ -299,7 +295,6 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			Secret:                uuid.New(),
 			RespondWithChallenges: true,
 			RedirectURIs:          []string{masterPublicAddr + path.Join(OpenShiftOAuthAPIPrefix, tokenrequest.ImplicitTokenEndpoint)},
-			AllowAnyScope:         true,
 		}
 		if err := ensureOAuthClient(cliClient, clientRegistry, false); err != nil {
 			return err

--- a/pkg/oauth/api/deep_copy_generated.go
+++ b/pkg/oauth/api/deep_copy_generated.go
@@ -163,7 +163,6 @@ func DeepCopy_api_OAuthClient(in OAuthClient, out *OAuthClient, c *conversion.Cl
 	} else {
 		out.ScopeRestrictions = nil
 	}
-	out.AllowAnyScope = in.AllowAnyScope
 	return nil
 }
 

--- a/pkg/oauth/api/types.go
+++ b/pkg/oauth/api/types.go
@@ -78,10 +78,6 @@ type OAuthClient struct {
 	// is checked against each restriction.  If any restriction matches, then the scope is allowed.
 	// If no restriction matches, then the scope is denied.
 	ScopeRestrictions []ScopeRestriction
-
-	// AllowAnyScope indicates that the client is allowed to request a token unconstrained by scopes.
-	// If this is true, then ScopeRestrictions is ignored.
-	AllowAnyScope bool
 }
 
 // ScopeRestriction describe one restriction on scopes.  Exactly one option must be non-nil.

--- a/pkg/oauth/api/v1/conversion_generated.go
+++ b/pkg/oauth/api/v1/conversion_generated.go
@@ -360,7 +360,6 @@ func autoConvert_v1_OAuthClient_To_api_OAuthClient(in *OAuthClient, out *oauth_a
 	} else {
 		out.ScopeRestrictions = nil
 	}
-	out.AllowAnyScope = in.AllowAnyScope
 	return nil
 }
 
@@ -399,7 +398,6 @@ func autoConvert_api_OAuthClient_To_v1_OAuthClient(in *oauth_api.OAuthClient, ou
 	} else {
 		out.ScopeRestrictions = nil
 	}
-	out.AllowAnyScope = in.AllowAnyScope
 	return nil
 }
 

--- a/pkg/oauth/api/v1/deep_copy_generated.go
+++ b/pkg/oauth/api/v1/deep_copy_generated.go
@@ -164,7 +164,6 @@ func DeepCopy_v1_OAuthClient(in OAuthClient, out *OAuthClient, c *conversion.Clo
 	} else {
 		out.ScopeRestrictions = nil
 	}
-	out.AllowAnyScope = in.AllowAnyScope
 	return nil
 }
 

--- a/pkg/oauth/api/v1/swagger_doc.go
+++ b/pkg/oauth/api/v1/swagger_doc.go
@@ -76,7 +76,6 @@ var map_OAuthClient = map[string]string{
 	"respondWithChallenges": "RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects",
 	"redirectURIs":          "RedirectURIs is the valid redirection URIs associated with a client",
 	"scopeRestrictions":     "ScopeRestrictions describes which scopes this client can request.  Each requested scope is checked against each restriction.  If any restriction matches, then the scope is allowed. If no restriction matches, then the scope is denied.",
-	"allowAnyScope":         "AllowAnyScope indicates that the client is allowed to request a token unconstrained by scopes. If this is true, then ScopeRestrictions is ignored.",
 }
 
 func (OAuthClient) SwaggerDoc() map[string]string {

--- a/pkg/oauth/api/v1/types.go
+++ b/pkg/oauth/api/v1/types.go
@@ -84,10 +84,6 @@ type OAuthClient struct {
 	// is checked against each restriction.  If any restriction matches, then the scope is allowed.
 	// If no restriction matches, then the scope is denied.
 	ScopeRestrictions []ScopeRestriction `json:"scopeRestrictions,omitempty"`
-
-	// AllowAnyScope indicates that the client is allowed to request a token unconstrained by scopes.
-	// If this is true, then ScopeRestrictions is ignored.
-	AllowAnyScope bool `json:"allowAnyScope,omitempty"`
 }
 
 // ScopeRestriction describe one restriction on scopes.  Exactly one option must be non-nil.

--- a/pkg/oauth/api/v1beta3/types.go
+++ b/pkg/oauth/api/v1beta3/types.go
@@ -78,10 +78,6 @@ type OAuthClient struct {
 	// is checked against each restriction.  If any restriction matches, then the scope is allowed.
 	// If no restriction matches, then the scope is denied.
 	ScopeRestrictions []ScopeRestriction `json:"scopeRestrictions,omitempty"`
-
-	// AllowAnyScope indicates that the client is allowed to request a token unconstrained by scopes.
-	// If this is true, then ScopeRestrictions is ignored.
-	AllowAnyScope bool `json:"allowAnyScope,omitempty"`
 }
 
 // ScopeRestriction describe one restriction on scopes.  Exactly one option must be non-nil.

--- a/pkg/oauth/api/validation/validation.go
+++ b/pkg/oauth/api/validation/validation.go
@@ -90,13 +90,6 @@ func ValidateClient(client *api.OAuthClient) field.ErrorList {
 		}
 	}
 
-	if client.AllowAnyScope && len(client.ScopeRestrictions) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("scopeRestrictions"), client.ScopeRestrictions, "invalid when allowAnyScope is allowed"))
-	}
-	if !client.AllowAnyScope && len(client.ScopeRestrictions) == 0 {
-		allErrs = append(allErrs, field.Required(field.NewPath("scopeRestrictions"), "required when allowAnyScope is false"))
-	}
-
 	for i, restriction := range client.ScopeRestrictions {
 		allErrs = append(allErrs, ValidateScopeRestriction(restriction, field.NewPath("scopeRestrictions").Index(i))...)
 	}

--- a/pkg/oauth/api/validation/validation_test.go
+++ b/pkg/oauth/api/validation/validation_test.go
@@ -173,8 +173,7 @@ func TestValidateClientAuthorization(t *testing.T) {
 
 func TestValidateClient(t *testing.T) {
 	errs := ValidateClient(&oapi.OAuthClient{
-		ObjectMeta:    api.ObjectMeta{Name: "client-name"},
-		AllowAnyScope: true,
+		ObjectMeta: api.ObjectMeta{Name: "client-name"},
 	})
 	if len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
@@ -186,30 +185,14 @@ func TestValidateClient(t *testing.T) {
 		F      string
 	}{
 		"zero-length name": {
-			Client: oapi.OAuthClient{AllowAnyScope: true},
+			Client: oapi.OAuthClient{},
 			T:      field.ErrorTypeRequired,
 			F:      "metadata.name",
 		},
 		"disallowed namespace": {
-			Client: oapi.OAuthClient{ObjectMeta: api.ObjectMeta{Name: "name", Namespace: "foo"}, AllowAnyScope: true},
+			Client: oapi.OAuthClient{ObjectMeta: api.ObjectMeta{Name: "name", Namespace: "foo"}},
 			T:      field.ErrorTypeForbidden,
 			F:      "metadata.namespace",
-		},
-		"some scope note": {
-			Client: oapi.OAuthClient{
-				ObjectMeta: api.ObjectMeta{Name: "client-name"},
-			},
-			T: field.ErrorTypeRequired,
-			F: "scopeRestrictions",
-		},
-		"not both scope notes": {
-			Client: oapi.OAuthClient{
-				ObjectMeta:        api.ObjectMeta{Name: "client-name"},
-				ScopeRestrictions: []oapi.ScopeRestriction{{ExactValues: []string{"a"}}},
-				AllowAnyScope:     true,
-			},
-			T: field.ErrorTypeInvalid,
-			F: "scopeRestrictions",
 		},
 		"literal must have value": {
 			Client: oapi.OAuthClient{
@@ -218,27 +201,6 @@ func TestValidateClient(t *testing.T) {
 			},
 			T: field.ErrorTypeInvalid,
 			F: "scopeRestrictions[0].literals[0]",
-		},
-		"must have some restriction": {
-			Client: oapi.OAuthClient{
-				ObjectMeta:        api.ObjectMeta{Name: "client-name"},
-				ScopeRestrictions: []oapi.ScopeRestriction{{}},
-			},
-			T: field.ErrorTypeInvalid,
-			F: "scopeRestrictions[0]",
-		},
-		"can't have both restrictions": {
-			Client: oapi.OAuthClient{
-				ObjectMeta: api.ObjectMeta{Name: "client-name"},
-				ScopeRestrictions: []oapi.ScopeRestriction{
-					{
-						ExactValues: []string{""},
-						ClusterRole: &oapi.ClusterRoleScopeRestriction{RoleNames: []string{"a"}, Namespaces: []string{"b"}},
-					},
-				},
-			},
-			T: field.ErrorTypeInvalid,
-			F: "scopeRestrictions[0]",
 		},
 		"must have role names": {
 			Client: oapi.OAuthClient{

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -53,7 +53,7 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 	t.Logf("proxy server is on %v\n", proxyServer.URL)
 
 	// need to prime clients so that we can get back a code.  the client must be valid
-	result := clusterAdminClient.RESTClient.Post().Resource("oAuthClients").Body(&oauthapi.OAuthClient{ObjectMeta: kapi.ObjectMeta{Name: "test"}, Secret: "secret", RedirectURIs: []string{clusterAdminClientConfig.Host}, AllowAnyScope: true}).Do()
+	result := clusterAdminClient.RESTClient.Post().Resource("oAuthClients").Body(&oauthapi.OAuthClient{ObjectMeta: kapi.ObjectMeta{Name: "test"}, Secret: "secret", RedirectURIs: []string{clusterAdminClientConfig.Host}}).Do()
 	checkErr(t, result.Error())
 
 	// our simple URL to get back a code.  We want to go through the front proxy

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -113,10 +113,9 @@ func TestOAuthStorage(t *testing.T) {
 	}))
 
 	clientRegistry.CreateClient(kapi.NewContext(), &api.OAuthClient{
-		ObjectMeta:    kapi.ObjectMeta{Name: "test"},
-		Secret:        "secret",
-		RedirectURIs:  []string{assertServer.URL + "/assert"},
-		AllowAnyScope: true,
+		ObjectMeta:   kapi.ObjectMeta{Name: "test"},
+		Secret:       "secret",
+		RedirectURIs: []string{assertServer.URL + "/assert"},
 	})
 	storedClient, err := storage.GetClient("test")
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/8913.

This sets the default for oauthclients to be "request any scope you want".  If we were designing from scratch, I don't think we'd choose to define an API that defaults dangerous, but this is the only way I can think of to maintain backwards compatibility until we get a v2.

Without scopes before, there was no "safe" setting to have.

@openshift/api-review 