### PR TITLE
Add possibility to add bind options to haproxy

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -65,7 +65,7 @@ listen stats :1936
 {{ end }}
 
 frontend public
-  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
+  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} {{env "ROUTER_SERVICE_HTTP_PORT_BIND_OPTIONS" ""}}
   mode http
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
@@ -93,7 +93,7 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
-  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}
+  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} {{env "ROUTER_SERVICE_HTTPS_PORT_BIND_OPTIONS" ""}}
   tcp-request  inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
 


### PR DESCRIPTION
Sometimes the haproxy/default router runs behind other loadbalance like AWS ELB
AWS ELB have the option to setup the proxy protocol on there elb.

http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html

This PR adds not the possibility to add 'accept-proxy' to the bind line.
http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.1-accept-proxy
