### PR TITLE
eliminate need for SA token as client secret annotation

### DIFF
--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	OAuthClientSecretAnnotation            = "serviceaccounts.openshift.io/oauth-client-secret"
 	OAuthRedirectURISecretAnnotationPrefix = "serviceaccounts.openshift.io/oauth-redirecturi."
 	OAuthWantChallengesAnnotationPrefix    = "serviceaccounts.openshift.io/oauth-want-challenges"
 )
@@ -59,7 +58,7 @@ func (a *saOAuthClientAdapter) GetClient(ctx kapi.Context, name string) (*oautha
 		return nil, err
 	}
 	if len(tokens) == 0 {
-		return nil, fmt.Errorf("%v has no tokens allowed as oauth client secrets; set %v=true on a token secret", name, OAuthClientSecretAnnotation)
+		return nil, fmt.Errorf("%v has no tokens", name)
 	}
 
 	saWantsChallenges, _ := strconv.ParseBool(sa.Annotations[OAuthWantChallengesAnnotationPrefix])
@@ -97,10 +96,6 @@ func (a *saOAuthClientAdapter) getServiceAccountTokens(sa *kapi.ServiceAccount) 
 	tokens := []string{}
 	for i := range allSecrets.Items {
 		secret := allSecrets.Items[i]
-		if intendedAsClientSecret, _ := strconv.ParseBool(secret.Annotations[OAuthClientSecretAnnotation]); !intendedAsClientSecret {
-			continue
-		}
-
 		if serviceaccount.IsServiceAccountToken(&secret, sa) {
 			tokens = append(tokens, string(secret.Data[kapi.ServiceAccountTokenKey]))
 		}

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
@@ -62,36 +62,7 @@ func TestGetClient(t *testing.T) {
 						Annotations: map[string]string{OAuthRedirectURISecretAnnotationPrefix + "one": "anywhere"},
 					},
 				}),
-			expectedErr: `system:serviceaccount:ns-01:default has no tokens allowed as oauth client secrets; set serviceaccounts.openshift.io/oauth-client-secret=true on a token secret`,
-			expectedActions: []ktestclient.Action{
-				ktestclient.NewGetAction("serviceaccounts", "ns-01", "default"),
-				ktestclient.NewListAction("secrets", "ns-01", kapi.ListOptions{}),
-			},
-		},
-		{
-			name:       "sa no tokens two",
-			clientName: "system:serviceaccount:ns-01:default",
-			kubeClient: ktestclient.NewSimpleFake(
-				&kapi.ServiceAccount{
-					ObjectMeta: kapi.ObjectMeta{
-						Namespace:   "ns-01",
-						Name:        "default",
-						Annotations: map[string]string{OAuthRedirectURISecretAnnotationPrefix + "one": "anywhere"},
-					},
-				},
-				&kapi.Secret{
-					ObjectMeta: kapi.ObjectMeta{
-						Namespace: "ns-01",
-						Name:      "default",
-						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
-						},
-					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
-				}),
-			expectedErr: `system:serviceaccount:ns-01:default has no tokens allowed as oauth client secrets; set serviceaccounts.openshift.io/oauth-client-secret=true on a token secret`,
+			expectedErr: `system:serviceaccount:ns-01:default has no tokens`,
 			expectedActions: []ktestclient.Action{
 				ktestclient.NewGetAction("serviceaccounts", "ns-01", "default"),
 				ktestclient.NewListAction("secrets", "ns-01", kapi.ListOptions{}),
@@ -114,9 +85,8 @@ func TestGetClient(t *testing.T) {
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							OAuthClientSecretAnnotation: "true",
-							kapi.ServiceAccountNameKey:  "default",
-							kapi.ServiceAccountUIDKey:   "any",
+							kapi.ServiceAccountNameKey: "default",
+							kapi.ServiceAccountUIDKey:  "any",
 						},
 					},
 					Type: kapi.SecretTypeServiceAccountToken,

--- a/test/integration/sa_oauthclient_test.go
+++ b/test/integration/sa_oauthclient_test.go
@@ -108,19 +108,11 @@ func TestSAAsOAuthClient(t *testing.T) {
 		for i := range allSecrets.Items {
 			secret := allSecrets.Items[i]
 			if serviceaccount.IsServiceAccountToken(&secret, defaultSA) {
-				secret.Annotations[saoauth.OAuthClientSecretAnnotation] = "true"
-				if _, err := clusterAdminKubeClient.Secrets(projectName).Update(&secret); err != nil {
-					t.Logf("unexpected err: %v", err)
-					return false, nil
-				}
 				oauthSecret = &secret
-				break
+				return true, nil
 			}
 		}
 
-		if oauthSecret != nil {
-			return true, nil
-		}
 		return false, nil
 	})
 	if err != nil {


### PR DESCRIPTION
Eliminates the need to annotation a token to use it as an oauth client secret.

@liggitt convinced me that this is ok since I'd need to have control over the SA's redirect urls to abuse my SA token.

[test]