### PR TITLE
cluster up: test bootstrap asset locations

### DIFF
--- a/pkg/bootstrap/docker/up_test.go
+++ b/pkg/bootstrap/docker/up_test.go
@@ -1,0 +1,24 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/bootstrap"
+)
+
+// TestBootstrapFiles ensures that the files that are used for
+// Bootstrapping a cluster are available.
+func TestBootstrapFiles(t *testing.T) {
+	templateMaps := []map[string]string{
+		imageStreamLocations,
+		templateLocations,
+	}
+	for _, templateMap := range templateMaps {
+		for _, location := range templateMap {
+			_, err := bootstrap.Asset(location)
+			if err != nil {
+				t.Errorf("Error getting asset at: %s", location)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds unit tests to ensure we can access bindata asset locations.