### PR TITLE
cluster up: config copy - mount only host dir to copy files from

### DIFF
--- a/pkg/bootstrap/docker/host/host.go
+++ b/pkg/bootstrap/docker/host/host.go
@@ -81,7 +81,7 @@ func catHostFile(hostFile string) string {
 func (h *HostHelper) CopyFromHost(sourceDir, destDir string) error {
 	container, err := h.runner().
 		Image(h.image).
-		Bind("/:/rootfs:ro").
+		Bind(fmt.Sprintf("%[1]s:%[1]s:ro", sourceDir)).
 		Create()
 	if err != nil {
 		return err
@@ -100,10 +100,9 @@ func (h *HostHelper) CopyFromHost(sourceDir, destDir string) error {
 		}
 		errors.LogError(os.Remove(localTarFile.Name()))
 	}()
-	hostPath := path.Join("/rootfs", sourceDir) + "/."
-	glog.V(4).Infof("Downloading from host path %s to local tar file: %s", hostPath, localTarFile.Name())
+	glog.V(4).Infof("Downloading from host path %s to local tar file: %s", sourceDir, localTarFile.Name())
 	err = h.client.DownloadFromContainer(container, docker.DownloadFromContainerOptions{
-		Path:         hostPath,
+		Path:         sourceDir,
 		OutputStream: localTarFile,
 	})
 	if err != nil {

--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -340,7 +340,7 @@ func (h *Helper) copyConfig(hostDir string) (string, error) {
 		}
 		return "", err
 	}
-	return tempDir, nil
+	return filepath.Join(tempDir, filepath.Base(hostDir)), nil
 }
 
 func (h *Helper) updateConfig(configDir, hostDir, serverIP string) error {

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -436,7 +436,7 @@ func (c *ClientStartConfig) CheckAvailablePorts(out io.Writer) error {
 		err = c.OpenShiftHelper().TestPorts(openshift.PortsWithAlternateDNS)
 		if err == nil {
 			c.DNSPort = openshift.AlternateDNSPort
-			fmt.Fprintf(out, "WARNING: Binding DNS on port %d instead of 53, which may be not be resolvable from all clients.", openshift.AlternateDNSPort)
+			fmt.Fprintf(out, "WARNING: Binding DNS on port %d instead of 53, which may be not be resolvable from all clients.\n", openshift.AlternateDNSPort)
 			return nil
 		}
 	}


### PR DESCRIPTION
Instead of mounting the host root, only mounts the host directory where files need to be copied from.