### PR TITLE
Builds: allow users to specify a timeout in seconds for git check

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -17874,6 +17874,10 @@
      "httpsProxy": {
       "type": "string",
       "description": "httpsProxy is a proxy used to reach the git repository over https"
+     },
+     "urlCheckTimeoutSeconds": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -658,6 +658,13 @@ func DeepCopy_api_GitBuildSource(in GitBuildSource, out *GitBuildSource, c *conv
 	} else {
 		out.HTTPSProxy = nil
 	}
+	if in.URLCheckTimeoutSeconds != nil {
+		in, out := in.URLCheckTimeoutSeconds, &out.URLCheckTimeoutSeconds
+		*out = new(int)
+		**out = *in
+	} else {
+		out.URLCheckTimeoutSeconds = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -328,6 +328,9 @@ type GitBuildSource struct {
 
 	// HTTPSProxy is a proxy used to reach the git repository over https
 	HTTPSProxy *string
+
+	// URLCheckTimeoutSeconds is the timeout in seconds to use when checking connectivity to the git server
+	URLCheckTimeoutSeconds *int
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -1555,6 +1555,13 @@ func autoConvert_v1_GitBuildSource_To_api_GitBuildSource(in *GitBuildSource, out
 	} else {
 		out.HTTPSProxy = nil
 	}
+	if in.URLCheckTimeoutSeconds != nil {
+		in, out := &in.URLCheckTimeoutSeconds, &out.URLCheckTimeoutSeconds
+		*out = new(int)
+		**out = **in
+	} else {
+		out.URLCheckTimeoutSeconds = nil
+	}
 	return nil
 }
 
@@ -1581,6 +1588,13 @@ func autoConvert_api_GitBuildSource_To_v1_GitBuildSource(in *build_api.GitBuildS
 		**out = **in
 	} else {
 		out.HTTPSProxy = nil
+	}
+	if in.URLCheckTimeoutSeconds != nil {
+		in, out := &in.URLCheckTimeoutSeconds, &out.URLCheckTimeoutSeconds
+		*out = new(int)
+		**out = **in
+	} else {
+		out.URLCheckTimeoutSeconds = nil
 	}
 	return nil
 }

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -661,6 +661,13 @@ func DeepCopy_v1_GitBuildSource(in GitBuildSource, out *GitBuildSource, c *conve
 	} else {
 		out.HTTPSProxy = nil
 	}
+	if in.URLCheckTimeoutSeconds != nil {
+		in, out := in.URLCheckTimeoutSeconds, &out.URLCheckTimeoutSeconds
+		*out = new(int)
+		**out = *in
+	} else {
+		out.URLCheckTimeoutSeconds = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -268,11 +268,12 @@ func (GenericWebHookEvent) SwaggerDoc() map[string]string {
 }
 
 var map_GitBuildSource = map[string]string{
-	"":           "GitBuildSource defines the parameters of a Git SCM",
-	"uri":        "uri points to the source that will be built. The structure of the source will depend on the type of build to run",
-	"ref":        "ref is the branch/tag/ref to build.",
-	"httpProxy":  "httpProxy is a proxy used to reach the git repository over http",
-	"httpsProxy": "httpsProxy is a proxy used to reach the git repository over https",
+	"":                       "GitBuildSource defines the parameters of a Git SCM",
+	"uri":                    "uri points to the source that will be built. The structure of the source will depend on the type of build to run",
+	"ref":                    "ref is the branch/tag/ref to build.",
+	"httpProxy":              "httpProxy is a proxy used to reach the git repository over http",
+	"httpsProxy":             "httpsProxy is a proxy used to reach the git repository over https",
+	"urlCheckTimeoutSeconds": "urlCheckTimeoutSeconds is the timeout in seconds to use when checking connectivity to the git server",
 }
 
 func (GitBuildSource) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -283,6 +283,9 @@ type GitBuildSource struct {
 
 	// httpsProxy is a proxy used to reach the git repository over https
 	HTTPSProxy *string `json:"httpsProxy,omitempty"`
+
+	// urlCheckTimeoutSeconds is the timeout in seconds to use when checking connectivity to the git server
+	URLCheckTimeoutSeconds *int `json:"urlCheckTimeoutSeconds,omitempty"`
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -48,7 +48,7 @@ func NewDockerBuilder(dockerClient DockerClient, buildsClient client.BuildInterf
 		build:        build,
 		gitClient:    gitClient,
 		tar:          tar.New(),
-		urlTimeout:   urlCheckTimeout,
+		urlTimeout:   getURLCheckTimeout(build),
 		client:       buildsClient,
 		cgLimits:     cgLimits,
 	}

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -116,7 +116,7 @@ func (s *S2IBuilder) Build() error {
 	download := &downloader{
 		s:       s,
 		in:      os.Stdin,
-		timeout: urlCheckTimeout,
+		timeout: getURLCheckTimeout(s.build),
 
 		dir:        srcDir,
 		contextDir: contextDir,


### PR DESCRIPTION
Exposes the git timeout in seconds as a field in the GitSource structure

fixes https://github.com/openshift/origin/issues/8772
