### PR TITLE
Disable sticky sessions for tcp routes based on env value.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -239,7 +239,7 @@ backend be_tcp_{{$cfgIdx}}
 {{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
   option tcplog
 {{ end }}
-  balance source
+  balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source" }}
   hash-type consistent
   timeout check 5000ms
                 {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}


### PR DESCRIPTION
To use a different tcp balancing scheme, use: 
oc env dc/router ROUTER_TCP_BALANCE_SCHEME=leastconn

*Edited* Usage to reflect current usage.
