### PR TITLE
add ROUTER_SLOWLORIS_TIMEOUT enviroment variable to default HAProxy image

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -39,6 +39,7 @@ defaults
   option httplog
   log global
 {{ end }}
+  timeout http-request {{env "ROUTER_SLOWLORIS_TIMEOUT" "10s" }}
   timeout connect 5s
   timeout client 30s
   timeout server 30s


### PR DESCRIPTION
Using the HAProxy router to impliement basic DDOS protection. When the
enviroment variable ROUTER_SLOWLORIS_TIMEOUT is set it limits the amount
of time a client has to send their whole HTTP request or HAProxy will
shut down the connection

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1328037