### PR TITLE
remove resource groups and divide by API group

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -94,6 +94,13 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 				j.Subjects[i].FieldPath = ""
 			}
 		},
+		func(j *authorizationapi.PolicyRule, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			// if no groups are found, then we assume "".  This matches defaulting
+			if len(j.APIGroups) == 0 {
+				j.APIGroups = []string{""}
+			}
+		},
 		func(j *authorizationapi.ClusterRoleBinding, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
 			for i := range j.Subjects {

--- a/pkg/authorization/api/v1/defaults.go
+++ b/pkg/authorization/api/v1/defaults.go
@@ -21,6 +21,11 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 			if kapi.Semantic.Equalities.DeepEqual(oldAllowAllPolicyRule, *obj) && obj.APIGroups == nil {
 				obj.APIGroups = []string{internal.APIGroupAll}
 			}
+
+			// if no groups are found, then we assume ""
+			if len(obj.Resources) > 0 && len(obj.APIGroups) == 0 {
+				obj.APIGroups = []string{""}
+			}
 		},
 	)
 	if err != nil {

--- a/pkg/authorization/authorizer/attributes.go
+++ b/pkg/authorization/authorizer/attributes.go
@@ -70,11 +70,6 @@ func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.Policy
 }
 
 func (a DefaultAuthorizationAttributes) apiGroupMatches(allowedGroups []string) bool {
-	// if no APIGroups are specified, then the default APIGroup of "" is assumed.
-	if len(allowedGroups) == 0 && len(a.GetAPIGroup()) == 0 {
-		return true
-	}
-
 	// allowedGroups is expected to be small, so I don't feel bad about this.
 	for _, allowedGroup := range allowedGroups {
 		if allowedGroup == authorizationapi.APIGroupAll {

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -15,6 +15,8 @@ import (
 	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+
+	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 type authorizeTest struct {
@@ -646,6 +648,7 @@ func newAdzePolicies() []authorizationapi.Policy {
 					},
 					Rules: append(make([]authorizationapi.PolicyRule, 0),
 						authorizationapi.PolicyRule{
+							APIGroups: []string{""},
 							Verbs:     sets.NewString("watch", "list", "get"),
 							Resources: sets.NewString("buildConfigs"),
 						}),

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -539,11 +539,13 @@ func newInvalidExtensionPolicies() []authorizationapi.Policy {
 					},
 					Rules: []authorizationapi.PolicyRule{
 						{
+							APIGroups:             []string{""},
 							Verbs:                 sets.NewString("watch", "list", "get"),
 							Resources:             sets.NewString("buildConfigs"),
 							AttributeRestrictions: &authorizationapi.Role{},
 						},
 						{
+							APIGroups: []string{""},
 							Verbs:     sets.NewString("update"),
 							Resources: sets.NewString("buildConfigs"),
 						},

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -13,6 +13,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
@@ -124,11 +125,11 @@ func (userEvaluator) ResolveRules(scope, namespace string, clusterPolicyGetter r
 		}, nil
 	case UserIndicator + UserAccessCheck:
 		return []authorizationapi.PolicyRule{
-			{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+			{Verbs: sets.NewString("create"), APIGroups: []string{authorizationapi.GroupName}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 		}, nil
 	case UserIndicator + UserListProject:
 		return []authorizationapi.PolicyRule{
-			{Verbs: sets.NewString("list"), Resources: sets.NewString("projects")},
+			{Verbs: sets.NewString("list"), APIGroups: []string{projectapi.GroupName}, Resources: sets.NewString("projects")},
 		}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized scope: %v", scope)

--- a/pkg/cmd/server/bootstrappolicy/old_policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/old_policy_test.go
@@ -1,0 +1,901 @@
+package bootstrappolicy_test
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/autoscaling"
+	"k8s.io/kubernetes/pkg/apis/batch"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+func TestClusterRoles(t *testing.T) {
+	currentRoles := bootstrappolicy.GetBootstrapClusterRoles()
+	oldRoles := oldGetBootstrapClusterRoles()
+
+	// old roles don't have the SAs appended, so run through them.  The SAs haven't been converted yet
+	for i := range oldRoles {
+		oldRole := oldRoles[i]
+		newRole := currentRoles[i]
+
+		if oldRole.Name != newRole.Name {
+			t.Fatalf("%v vs %v", oldRole.Name, newRole.Name)
+		}
+
+		// @liggitt don't whine about a temporary test fataling
+		if covers, missing := rulevalidation.Covers(oldRole.Rules, newRole.Rules); !covers {
+			t.Fatalf("%v/%v: %#v", oldRole.Name, newRole.Name, missing)
+		}
+		if covers, missing := rulevalidation.Covers(newRole.Rules, oldRole.Rules); !covers {
+			t.Fatalf("%v/%v: %#v", oldRole.Name, newRole.Name, missing)
+		}
+	}
+}
+
+func oldGetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Role {
+	roles := []authorizationapi.Role{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      bootstrappolicy.OpenshiftSharedResourceViewRoleName,
+				Namespace: openshiftNamespace,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "list"),
+					Resources: sets.NewString("templates", authorizationapi.ImageGroupName),
+				},
+				{
+					// so anyone can pull from openshift/* image streams
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+			},
+		},
+	}
+
+	// we don't want to expose the resourcegroups externally because it makes it very difficult for customers to learn from
+	// our default roles and hard for them to reason about what power they are granting their users
+	for i := range roles {
+		for j := range roles[i].Rules {
+			roles[i].Rules[j].Resources = authorizationapi.NormalizeResources(roles[i].Rules[j].Resources)
+		}
+	}
+
+	return roles
+
+}
+
+func oldGetBootstrapClusterRoles() []authorizationapi.ClusterRole {
+	roles := []authorizationapi.ClusterRole{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ClusterAdminRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{authorizationapi.APIGroupAll},
+					Verbs:     sets.NewString(authorizationapi.VerbAll),
+					Resources: sets.NewString(authorizationapi.ResourceAll),
+				},
+				{
+					Verbs:           sets.NewString(authorizationapi.VerbAll),
+					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.SudoerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups:     []string{kapi.GroupName},
+					Verbs:         sets.NewString("impersonate"),
+					Resources:     sets.NewString(authorizationapi.SystemUserResource),
+					ResourceNames: sets.NewString(bootstrappolicy.SystemAdminUsername),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ClusterReaderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString(authorizationapi.NonEscalatingResourcesGroupName),
+				},
+				{
+					APIGroups: []string{autoscaling.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("horizontalpodautoscalers"),
+				},
+				{
+					APIGroups: []string{batch.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("jobs"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+				},
+				{ // permissions to check access.  These creates are non-mutating
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString("resourceaccessreviews", "subjectaccessreviews"),
+				},
+				// Allow read access to node metrics
+				{
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
+				},
+				// Allow read access to stats
+				// Node stats requests are submitted as POSTs.  These creates are non-mutating
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString(authorizationapi.NodeStatsResource),
+				},
+				{
+					Verbs:           sets.NewString("get"),
+					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.BuildStrategyDockerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.DockerBuildResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.BuildStrategyCustomRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.CustomBuildResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.BuildStrategySourceRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.SourceBuildResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.BuildStrategyJenkinsPipelineRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString(authorizationapi.JenkinsPipelineBuildResource),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.AdminRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString(
+						authorizationapi.KubeExposedGroupName,
+						"secrets",
+						"pods/attach", "pods/proxy", "pods/exec", "pods/portforward",
+						"services/proxy",
+						"replicationcontrollers/scale",
+					),
+				},
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("impersonate"),
+					Resources: sets.NewString("serviceaccounts"),
+				},
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString(
+						authorizationapi.OpenshiftExposedGroupName,
+						authorizationapi.PermissionGrantingGroupName,
+						"projects",
+						"deploymentconfigs/scale",
+						"imagestreams/secrets",
+					),
+				},
+				{
+					APIGroups: []string{autoscaling.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("horizontalpodautoscalers"),
+				},
+				{
+					APIGroups: []string{batch.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("jobs"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets"),
+				},
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName),
+				},
+				{
+					APIGroups: []string{imageapi.GroupName},
+					Verbs:     sets.NewString("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+				// an admin can run routers that write back conditions to the route
+				{
+					APIGroups: []string{routeapi.GroupName},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("routes/status"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.EditRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString(
+						authorizationapi.KubeExposedGroupName,
+						"secrets",
+						"pods/attach", "pods/proxy", "pods/exec", "pods/portforward",
+						"services/proxy",
+						"replicationcontrollers/scale",
+					),
+				},
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("impersonate"),
+					Resources: sets.NewString("serviceaccounts"),
+				},
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString(
+						authorizationapi.OpenshiftExposedGroupName,
+						"deploymentconfigs/scale",
+						"imagestreams/secrets",
+					),
+				},
+				{
+					APIGroups: []string{autoscaling.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("horizontalpodautoscalers"),
+				},
+				{
+					APIGroups: []string{batch.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("jobs"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
+					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets"),
+				},
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString(authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
+				},
+				{
+					APIGroups: []string{imageapi.GroupName},
+					Verbs:     sets.NewString("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ViewRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{api.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
+				},
+				{
+					APIGroups: []string{autoscaling.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("horizontalpodautoscalers"),
+				},
+				{
+					APIGroups: []string{batch.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("jobs"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.BasicUserRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{Verbs: sets.NewString("get"), Resources: sets.NewString("users"), ResourceNames: sets.NewString("~")},
+				{Verbs: sets.NewString("list"), Resources: sets.NewString("projectrequests")},
+				{Verbs: sets.NewString("list", "get"), Resources: sets.NewString("clusterroles")},
+				{Verbs: sets.NewString("list", "watch"), Resources: sets.NewString("projects")},
+				{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("create"), Resources: sets.NewString("selfsubjectrulesreviews")},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.SelfProvisionerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{Verbs: sets.NewString("create"), Resources: sets.NewString("projectrequests")},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.StatusCheckerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs: sets.NewString("get"),
+					NonResourceURLs: sets.NewString(
+						// Health
+						"/healthz", "/healthz/*",
+					),
+				},
+				authorizationapi.DiscoveryRule,
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ImageAuditorRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{imageapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch", "patch", "update"),
+					Resources: sets.NewString("images"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ImagePullerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs: sets.NewString("get"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+			},
+		},
+		{
+			// This role looks like a duplicate of ImageBuilderRole, but the ImageBuilder role is specifically for our builder service accounts
+			// if we found another permission needed by them, we'd add it there so the intent is different if you used the ImageBuilderRole
+			// you could end up accidentally granting more permissions than you intended.  This is intended to only grant enough powers to
+			// push an image to our registry
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ImagePusherRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs: sets.NewString("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ImageBuilderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs: sets.NewString("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+				{
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("builds/details"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.ImagePrunerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("delete"),
+					Resources: sets.NewString("images"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list"),
+					Resources: sets.NewString("images", "imagestreams", "pods", "replicationcontrollers", "buildconfigs", "builds", "deploymentconfigs"),
+				},
+				{
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("imagestreams/status"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.DeployerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					// replicationControllerGetter
+					Verbs:     sets.NewString("get", "list"),
+					Resources: sets.NewString("replicationcontrollers"),
+				},
+				{
+					// RecreateDeploymentStrategy.replicationControllerClient
+					// RollingDeploymentStrategy.updaterClient
+					Verbs:     sets.NewString("get", "update"),
+					Resources: sets.NewString("replicationcontrollers"),
+				},
+				{
+					// RecreateDeploymentStrategy.hookExecutor
+					// RollingDeploymentStrategy.hookExecutor
+					Verbs:     sets.NewString("get", "list", "watch", "create"),
+					Resources: sets.NewString("pods"),
+				},
+				{
+					// RecreateDeploymentStrategy.hookExecutor
+					// RollingDeploymentStrategy.hookExecutor
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("pods/log"),
+				},
+				{
+					// Deployer.After.TagImages
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("imagestreamtags"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.MasterRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{authorizationapi.APIGroupAll},
+					Verbs:     sets.NewString(authorizationapi.VerbAll),
+					Resources: sets.NewString(authorizationapi.ResourceAll),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.OAuthTokenDeleterRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("delete"),
+					Resources: sets.NewString("oauthaccesstokens", "oauthauthorizetokens"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.RouterRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("list", "watch"),
+					Resources: sets.NewString("routes", "endpoints"),
+				},
+				// routers write back conditions to the route
+				{
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("routes/status"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.RegistryRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "delete"),
+					Resources: sets.NewString("images"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("imagestreamimages", "imagestreamtags", "imagestreams", "imagestreams/secrets"),
+				},
+				{
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("imagestreams"),
+				},
+				{
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString("imagestreammappings"),
+				},
+				{
+					Verbs:     sets.NewString("list"),
+					Resources: sets.NewString("resourcequotas"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.NodeProxierRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					// Used to build serviceLister
+					Verbs:     sets.NewString("list", "watch"),
+					Resources: sets.NewString("services", "endpoints"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.NodeAdminRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// Allow read-only access to the API objects
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
+				// Allow all API calls to the nodes
+				{
+					Verbs:     sets.NewString("proxy"),
+					Resources: sets.NewString("nodes"),
+				},
+				{
+					Verbs:     sets.NewString(authorizationapi.VerbAll),
+					Resources: sets.NewString("nodes/proxy", authorizationapi.NodeMetricsResource, authorizationapi.NodeStatsResource, authorizationapi.NodeLogResource),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.NodeReaderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// Allow read-only access to the API objects
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
+				// Allow read access to node metrics
+				{
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
+				},
+				// Allow read access to stats
+				// Node stats requests are submitted as POSTs.  These creates are non-mutating
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString(authorizationapi.NodeStatsResource),
+				},
+				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.NodeRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					// Needed to check API access.  These creates are non-mutating
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"),
+				},
+				{
+					// Needed to build serviceLister, to populate env vars for services
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("services"),
+				},
+				{
+					// Nodes can register themselves
+					// TODO: restrict to creating a node with the same name they announce
+					Verbs:     sets.NewString("create", "get", "list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
+				{
+					// TODO: restrict to the bound node once supported
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("nodes/status"),
+				},
+
+				{
+					// TODO: restrict to the bound node as creator once supported
+					Verbs:     sets.NewString("create", "update", "patch"),
+					Resources: sets.NewString("events"),
+				},
+
+				{
+					// TODO: restrict to pods scheduled on the bound node once supported
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("pods"),
+				},
+				{
+					// TODO: remove once mirror pods are removed
+					// TODO: restrict deletion to mirror pods created by the bound node once supported
+					// Needed for the node to create/delete mirror pods
+					Verbs:     sets.NewString("get", "create", "delete"),
+					Resources: sets.NewString("pods"),
+				},
+				{
+					// TODO: restrict to pods scheduled on the bound node once supported
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("pods/status"),
+				},
+
+				{
+					// TODO: restrict to secrets and configmaps used by pods scheduled on bound node once supported
+					// Needed for imagepullsecrets, rbd/ceph and secret volumes, and secrets in envs
+					// Needed for configmap volume and envs
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("secrets", "configmaps"),
+				},
+				{
+					// TODO: restrict to claims/volumes used by pods scheduled on bound node once supported
+					// Needed for persistent volumes
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("persistentvolumeclaims", "persistentvolumes"),
+				},
+				{
+					// TODO: restrict to namespaces of pods scheduled on bound node once supported
+					// TODO: change glusterfs to use DNS lookup so this isn't needed?
+					// Needed for glusterfs volumes
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("endpoints"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.SDNReaderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("hostsubnets"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("netnamespaces"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("clusternetworks"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("namespaces"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.SDNManagerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "list", "watch", "create", "delete"),
+					Resources: sets.NewString("hostsubnets"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch", "create", "delete"),
+					Resources: sets.NewString("netnamespaces"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString("clusternetworks"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.WebHooksRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString("buildconfigs/webhooks"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.DiscoveryRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.DiscoveryRule,
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.RegistryAdminRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags"),
+				},
+				{
+					Verbs:     sets.NewString("get", "update"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+				{
+					Verbs:     sets.NewString("create"),
+					APIGroups: []string{authorizationapi.GroupName},
+					Resources: sets.NewString("localresourceaccessreviews", "localsubjectaccessreviews", "resourceaccessreviews", "subjectaccessreviews"),
+				},
+				{
+					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
+					APIGroups: []string{authorizationapi.GroupName},
+					Resources: sets.NewString("rolebindings", "roles"),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					APIGroups: []string{authorizationapi.GroupName},
+					Resources: sets.NewString("policies", "policybindings"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{kapi.GroupName},
+					Resources: sets.NewString("namespaces"),
+				},
+				{
+					Verbs:     sets.NewString("get", "delete"),
+					APIGroups: []string{projectapi.GroupName},
+					Resources: sets.NewString("projects"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.RegistryEditorRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags"),
+				},
+				{
+					Verbs:     sets.NewString("get", "update"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{kapi.GroupName},
+					Resources: sets.NewString("namespaces"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{projectapi.GroupName},
+					Resources: sets.NewString("projects"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: bootstrappolicy.RegistryViewerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreamtags"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{imageapi.GroupName},
+					Resources: sets.NewString("imagestreams/layers"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{kapi.GroupName},
+					Resources: sets.NewString("namespaces"),
+				},
+				{
+					Verbs:     sets.NewString("get"),
+					APIGroups: []string{projectapi.GroupName},
+					Resources: sets.NewString("projects"),
+				},
+			},
+		},
+	}
+
+	// we don't want to expose the resourcegroups externally because it makes it very difficult for customers to learn from
+	// our default roles and hard for them to reason about what power they are granting their users
+	for i := range roles {
+		for j := range roles[i].Rules {
+			roles[i].Rules[j].Resources = authorizationapi.NormalizeResources(roles[i].Rules[j].Resources)
+		}
+	}
+
+	versionedRoles := []authorizationapiv1.ClusterRole{}
+	for i := range roles {
+		newRole := &authorizationapiv1.ClusterRole{}
+		kapi.Scheme.Convert(&roles[i], newRole)
+		versionedRoles = append(versionedRoles, *newRole)
+	}
+
+	roundtrippedRoles := []authorizationapi.ClusterRole{}
+	for i := range versionedRoles {
+		newRole := &authorizationapi.ClusterRole{}
+		kapi.Scheme.Convert(&versionedRoles[i], newRole)
+		roundtrippedRoles = append(roundtrippedRoles, *newRole)
+	}
+
+	return roundtrippedRoles
+}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -9,12 +9,37 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	routeapi "github.com/openshift/origin/pkg/route/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+var (
+	readWrite = []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+	read      = []string{"get", "list", "watch"}
+
+	kapiGroup        = kapi.GroupName
+	autoscalingGroup = autoscaling.GroupName
+	batchGroup       = batch.GroupName
+	extensionsGroup  = extensions.GroupName
+	authzGroup       = authorizationapi.GroupName
+	buildGroup       = buildapi.GroupName
+	deployGroup      = deployapi.GroupName
+	imageGroup       = imageapi.GroupName
+	projectGroup     = projectapi.GroupName
+	routeGroup       = routeapi.GroupName
+	templateGroup    = templateapi.GroupName
+	userGroup        = userapi.GroupName
+	oauthGroup       = oauthapi.GroupName
+	sdnGroup         = sdnapi.GroupName
 )
 
 func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Role {
@@ -51,17 +76,17 @@ func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Ro
 }
 
 func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
+
+	// four resource can be a single line
+	// up to ten-ish resources per line otherwise
+
 	roles := []authorizationapi.ClusterRole{
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name: ClusterAdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{authorizationapi.APIGroupAll},
-					Verbs:     sets.NewString(authorizationapi.VerbAll),
-					Resources: sets.NewString(authorizationapi.ResourceAll),
-				},
+				authorizationapi.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
 				{
 					Verbs:           sets.NewString(authorizationapi.VerbAll),
 					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
@@ -73,12 +98,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: SudoerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups:     []string{kapi.GroupName},
-					Verbs:         sets.NewString("impersonate"),
-					Resources:     sets.NewString(authorizationapi.SystemUserResource),
-					ResourceNames: sets.NewString(SystemAdminUsername),
-				},
+				authorizationapi.NewRule("impersonate").Groups(kapiGroup).Resources(authorizationapi.SystemUserResource).Names(SystemAdminUsername).RuleOrDie(),
 			},
 		},
 		{
@@ -87,39 +107,22 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     sets.NewString("get", "list", "watch"),
+					APIGroups: []string{""},
+					Verbs:     sets.NewString(read...),
 					Resources: sets.NewString(authorizationapi.NonEscalatingResourcesGroupName),
 				},
-				{
-					APIGroups: []string{autoscaling.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("horizontalpodautoscalers"),
-				},
-				{
-					APIGroups: []string{batch.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("jobs"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
-				},
-				{ // permissions to check access.  These creates are non-mutating
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString("resourceaccessreviews", "subjectaccessreviews"),
-				},
+				authorizationapi.NewRule(read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets", "jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+
+				// permissions to check access.  These creates are non-mutating
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("resourceaccessreviews", "subjectaccessreviews").RuleOrDie(),
 				// Allow read access to node metrics
-				{
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
-				},
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources(authorizationapi.NodeMetricsResource).RuleOrDie(),
 				// Allow read access to stats
 				// Node stats requests are submitted as POSTs.  These creates are non-mutating
-				{
-					Verbs:     sets.NewString("get", "create"),
-					Resources: sets.NewString(authorizationapi.NodeStatsResource),
-				},
+				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources(authorizationapi.NodeStatsResource).RuleOrDie(),
+
 				{
 					Verbs:           sets.NewString("get"),
 					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
@@ -131,11 +134,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: BuildStrategyDockerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString(authorizationapi.DockerBuildResource),
-				},
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources(authorizationapi.DockerBuildResource).RuleOrDie(),
 			},
 		},
 		{
@@ -143,11 +142,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: BuildStrategyCustomRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString(authorizationapi.CustomBuildResource),
-				},
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources(authorizationapi.CustomBuildResource).RuleOrDie(),
 			},
 		},
 		{
@@ -155,11 +150,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: BuildStrategySourceRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString(authorizationapi.SourceBuildResource),
-				},
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources(authorizationapi.SourceBuildResource).RuleOrDie(),
 			},
 		},
 		{
@@ -167,11 +158,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: BuildStrategyJenkinsPipelineRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString(authorizationapi.JenkinsPipelineBuildResource),
-				},
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources(authorizationapi.JenkinsPipelineBuildResource).RuleOrDie(),
 			},
 		},
 
@@ -180,70 +167,60 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: AdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{kapi.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(
-						authorizationapi.KubeExposedGroupName,
-						"secrets",
-						"pods/attach", "pods/proxy", "pods/exec", "pods/portforward",
-						"services/proxy",
-						"replicationcontrollers/scale",
-					),
-				},
-				{
-					APIGroups: []string{kapi.GroupName},
-					Verbs:     sets.NewString("impersonate"),
-					Resources: sets.NewString("serviceaccounts"),
-				},
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(
-						authorizationapi.OpenshiftExposedGroupName,
-						authorizationapi.PermissionGrantingGroupName,
-						"projects",
-						"deploymentconfigs/scale",
-						"imagestreams/secrets",
-					),
-				},
-				{
-					APIGroups: []string{autoscaling.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("horizontalpodautoscalers"),
-				},
-				{
-					APIGroups: []string{batch.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("jobs"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("daemonsets"),
-				},
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName),
-				},
-				{
-					APIGroups: []string{imageapi.GroupName},
-					Verbs:     sets.NewString("get", "update"),
-					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
-					Resources: sets.NewString("imagestreams/layers"),
-				},
+				authorizationapi.NewRule(readWrite...).Groups(kapiGroup).Resources("pods", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(kapiGroup).Resources("replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
+					"services", "services/proxy", "endpoints", "persistentvolumeclaims", "configmaps", "secrets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
+					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
+				authorizationapi.NewRule("impersonate").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("localresourceaccessreviews", "localsubjectaccessreviews").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(authzGroup).Resources("policies", "policybindings").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(deployGroup).Resources("deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(imageGroup).Resources("imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages", "imagestreams/secrets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreams/status").RuleOrDie(),
+				// push and pull images
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
+
+				authorizationapi.NewRule("get", "patch", "update", "delete").Groups(projectGroup).Resources("projects").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(routeGroup).Resources("routes").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(routeGroup).Resources("routes/status").RuleOrDie(),
 				// an admin can run routers that write back conditions to the route
-				{
-					APIGroups: []string{routeapi.GroupName},
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("routes/status"),
-				},
+				authorizationapi.NewRule("update").Groups(routeGroup).Resources("routes/status").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(templateGroup).Resources("templates", "templateconfigs", "processedtemplates").RuleOrDie(),
+
+				// backwards compatibility
+				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("buildlogs").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("resourceaccessreviews", "subjectaccessreviews").RuleOrDie(),
+
+				// rules that shouldn't exist, but are here for the covers check until we're convinced of consistency
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(deployGroup).Resources("deploymentconfigs/log").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "delete", "deletecollection", "patch", "update").Groups(authzGroup).Resources("localresourceaccessreviews", "localsubjectaccessreviews", "resourceaccessreviews", "subjectaccessreviews").RuleOrDie(),
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "delete", "deletecollection", "patch", "update").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiateBinary", "builds/clone").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "delete", "deletecollection", "patch", "update").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch").Groups(kapiGroup).Resources("nodes", "persistentvolumes", "minions", "securitycontextconstraints").RuleOrDie(),
+				authorizationapi.NewRule("list", "watch", "create", "deletecollection").Groups(projectGroup).Resources("projects").RuleOrDie(),
 			},
 		},
 		{
@@ -251,62 +228,52 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: EditRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{kapi.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(
-						authorizationapi.KubeExposedGroupName,
-						"secrets",
-						"pods/attach", "pods/proxy", "pods/exec", "pods/portforward",
-						"services/proxy",
-						"replicationcontrollers/scale",
-					),
-				},
-				{
-					APIGroups: []string{kapi.GroupName},
-					Verbs:     sets.NewString("impersonate"),
-					Resources: sets.NewString("serviceaccounts"),
-				},
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString(
-						authorizationapi.OpenshiftExposedGroupName,
-						"deploymentconfigs/scale",
-						"imagestreams/secrets",
-					),
-				},
-				{
-					APIGroups: []string{autoscaling.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("horizontalpodautoscalers"),
-				},
-				{
-					APIGroups: []string{batch.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("jobs"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"),
-					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("daemonsets"),
-				},
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString(authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
-				},
-				{
-					APIGroups: []string{imageapi.GroupName},
-					Verbs:     sets.NewString("get", "update"),
-					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
-					Resources: sets.NewString("imagestreams/layers"),
-				},
+				authorizationapi.NewRule(readWrite...).Groups(kapiGroup).Resources("pods", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(kapiGroup).Resources("replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
+					"services", "services/proxy", "endpoints", "persistentvolumeclaims", "configmaps", "secrets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
+					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
+				authorizationapi.NewRule("impersonate").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(deployGroup).Resources("deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(imageGroup).Resources("imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages", "imagestreams/secrets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreams/status").RuleOrDie(),
+				// push and pull images
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
+
+				authorizationapi.NewRule("get").Groups(projectGroup).Resources("projects").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(routeGroup).Resources("routes").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(routeGroup).Resources("routes/status").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(templateGroup).Resources("templates", "templateconfigs", "processedtemplates").RuleOrDie(),
+
+				// backwards compatibility
+				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("buildlogs").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
+
+				// rules that shouldn't exist, but are here for the covers check until we're convinced of consistency
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(deployGroup).Resources("deploymentconfigs/log").RuleOrDie(),
+				authorizationapi.NewRule("create", "delete", "deletecollection", "patch", "update").Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "delete", "deletecollection", "patch", "update").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiateBinary", "builds/clone").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "delete", "deletecollection", "patch", "update").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch").Groups(kapiGroup).Resources("nodes", "persistentvolumes", "minions", "securitycontextconstraints").RuleOrDie(),
+				authorizationapi.NewRule("list", "watch").Groups(projectGroup).Resources("projects").RuleOrDie(),
 			},
 		},
 		{
@@ -314,26 +281,47 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ViewRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{api.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
-				},
-				{
-					APIGroups: []string{autoscaling.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("horizontalpodautoscalers"),
-				},
-				{
-					APIGroups: []string{batch.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("jobs"),
-				},
-				{
-					APIGroups: []string{extensions.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("daemonsets", "jobs", "horizontalpodautoscalers"),
-				},
+				// TODO add "replicationcontrollers/scale" here
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("pods", "replicationcontrollers", "serviceaccounts",
+					"services", "endpoints", "persistentvolumeclaims", "configmaps").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
+					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreams/status").RuleOrDie(),
+				// TODO let them pull images?
+				// pull images
+				// authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(projectGroup).Resources("projects").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(routeGroup).Resources("routes").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(routeGroup).Resources("routes/status").RuleOrDie(),
+
+				authorizationapi.NewRule(read...).Groups(templateGroup).Resources("templates", "templateconfigs", "processedtemplates").RuleOrDie(),
+
+				// backwards compatibility
+				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("buildlogs").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
+
+				// rules that shouldn't exist, but are here for the covers check until we're convinced of consistency
+				authorizationapi.NewRule("get", "list", "watch").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiateBinary", "builds/clone").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch").Groups(kapiGroup).Resources("nodes", "persistentvolumes", "minions", "securitycontextconstraints").RuleOrDie(),
+				authorizationapi.NewRule("list", "watch").Groups(projectGroup).Resources("projects").RuleOrDie(),
 			},
 		},
 		{
@@ -341,12 +329,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: BasicUserRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{Verbs: sets.NewString("get"), Resources: sets.NewString("users"), ResourceNames: sets.NewString("~")},
-				{Verbs: sets.NewString("list"), Resources: sets.NewString("projectrequests")},
-				{Verbs: sets.NewString("list", "get"), Resources: sets.NewString("clusterroles")},
-				{Verbs: sets.NewString("list", "watch"), Resources: sets.NewString("projects")},
-				{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
-				{Verbs: sets.NewString("create"), Resources: sets.NewString("selfsubjectrulesreviews")},
+				authorizationapi.NewRule("get").Groups(userGroup).Resources("users").Names("~").RuleOrDie(),
+				authorizationapi.NewRule("list").Groups(projectGroup).Resources("projectrequests").RuleOrDie(),
+				authorizationapi.NewRule("get", "list").Groups(authzGroup).Resources("clusterroles").RuleOrDie(),
+				authorizationapi.NewRule("list", "watch").Groups(projectGroup).Resources("projects").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("selfsubjectrulesreviews").RuleOrDie(),
+				{Verbs: sets.NewString("create"), APIGroups: []string{authzGroup}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			},
 		},
 		{
@@ -354,7 +342,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: SelfProvisionerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{Verbs: sets.NewString("create"), Resources: sets.NewString("projectrequests")},
+				authorizationapi.NewRule("create").Groups(projectGroup).Resources("projectrequests").RuleOrDie(),
 			},
 		},
 		{
@@ -377,11 +365,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ImageAuditorRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{imageapi.GroupName},
-					Verbs:     sets.NewString("get", "list", "watch", "patch", "update"),
-					Resources: sets.NewString("images"),
-				},
+				authorizationapi.NewRule("get", "list", "watch", "patch", "update").Groups(imageGroup).Resources("images").RuleOrDie(),
 			},
 		},
 		{
@@ -389,11 +373,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ImagePullerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs: sets.NewString("get"),
-					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
-					Resources: sets.NewString("imagestreams/layers"),
-				},
+				// pull images
+				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
 			},
 		},
 		{
@@ -405,11 +386,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ImagePusherRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs: sets.NewString("get", "update"),
-					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
-					Resources: sets.NewString("imagestreams/layers"),
-				},
+				// push and pull images
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
 			},
 		},
 		{
@@ -417,15 +395,9 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ImageBuilderRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs: sets.NewString("get", "update"),
-					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
-					Resources: sets.NewString("imagestreams/layers"),
-				},
-				{
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("builds/details"),
-				},
+				// push and pull images
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+				authorizationapi.NewRule("update").Groups(buildGroup).Resources("builds/details").RuleOrDie(),
 			},
 		},
 		{
@@ -433,18 +405,13 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ImagePrunerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("delete"),
-					Resources: sets.NewString("images"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list"),
-					Resources: sets.NewString("images", "imagestreams", "pods", "replicationcontrollers", "buildconfigs", "builds", "deploymentconfigs"),
-				},
-				{
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("imagestreams/status"),
-				},
+				authorizationapi.NewRule("get", "list").Groups(kapiGroup).Resources("pods", "replicationcontrollers").RuleOrDie(),
+				authorizationapi.NewRule("get", "list").Groups(buildGroup).Resources("buildconfigs", "builds").RuleOrDie(),
+				authorizationapi.NewRule("get", "list").Groups(deployGroup).Resources("deploymentconfigs").RuleOrDie(),
+
+				authorizationapi.NewRule("delete").Groups(imageGroup).Resources("images").RuleOrDie(),
+				authorizationapi.NewRule("get", "list").Groups(imageGroup).Resources("images", "imagestreams").RuleOrDie(),
+				authorizationapi.NewRule("update").Groups(imageGroup).Resources("imagestreams/status").RuleOrDie(),
 			},
 		},
 		{
@@ -452,34 +419,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: DeployerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					// replicationControllerGetter
-					Verbs:     sets.NewString("get", "list"),
-					Resources: sets.NewString("replicationcontrollers"),
-				},
-				{
-					// RecreateDeploymentStrategy.replicationControllerClient
-					// RollingDeploymentStrategy.updaterClient
-					Verbs:     sets.NewString("get", "update"),
-					Resources: sets.NewString("replicationcontrollers"),
-				},
-				{
-					// RecreateDeploymentStrategy.hookExecutor
-					// RollingDeploymentStrategy.hookExecutor
-					Verbs:     sets.NewString("get", "list", "watch", "create"),
-					Resources: sets.NewString("pods"),
-				},
-				{
-					// RecreateDeploymentStrategy.hookExecutor
-					// RollingDeploymentStrategy.hookExecutor
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("pods/log"),
-				},
-				{
-					// Deployer.After.TagImages
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("imagestreamtags"),
-				},
+				authorizationapi.NewRule("get", "list", "update").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "watch", "create").Groups(kapiGroup).Resources("pods").RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
+
+				authorizationapi.NewRule("update").Groups(imageGroup).Resources("imagestreamtags").RuleOrDie(),
 			},
 		},
 		{
@@ -487,11 +431,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: MasterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					APIGroups: []string{authorizationapi.APIGroupAll},
-					Verbs:     sets.NewString(authorizationapi.VerbAll),
-					Resources: sets.NewString(authorizationapi.ResourceAll),
-				},
+				authorizationapi.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
 			},
 		},
 		{
@@ -499,10 +439,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: OAuthTokenDeleterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("delete"),
-					Resources: sets.NewString("oauthaccesstokens", "oauthauthorizetokens"),
-				},
+				authorizationapi.NewRule("delete").Groups(oauthGroup).Resources("oauthaccesstokens", "oauthauthorizetokens").RuleOrDie(),
 			},
 		},
 		{
@@ -510,15 +447,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RouterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("routes", "endpoints"),
-				},
-				// routers write back conditions to the route
-				{
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("routes/status"),
-				},
+				authorizationapi.NewRule("list", "watch").Groups(kapiGroup).Resources("endpoints").RuleOrDie(),
+
+				authorizationapi.NewRule("list", "watch").Groups(routeGroup).Resources("routes").RuleOrDie(),
+				authorizationapi.NewRule("update").Groups(routeGroup).Resources("routes/status").RuleOrDie(),
 			},
 		},
 		{
@@ -526,26 +458,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RegistryRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "delete"),
-					Resources: sets.NewString("images"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("imagestreamimages", "imagestreamtags", "imagestreams", "imagestreams/secrets"),
-				},
-				{
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("imagestreams"),
-				},
-				{
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString("imagestreammappings"),
-				},
-				{
-					Verbs:     sets.NewString("list"),
-					Resources: sets.NewString("resourcequotas"),
-				},
+				authorizationapi.NewRule("list").Groups(kapiGroup).Resources("resourcequotas").RuleOrDie(),
+
+				authorizationapi.NewRule("get", "delete").Groups(imageGroup).Resources("images").RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreamimages", "imagestreamtags", "imagestreams/secrets").RuleOrDie(),
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreammappings").RuleOrDie(),
 			},
 		},
 		{
@@ -553,11 +471,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: NodeProxierRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					// Used to build serviceLister
-					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("services", "endpoints"),
-				},
+				// Used to build serviceLister
+				authorizationapi.NewRule("list", "watch").Groups(kapiGroup).Resources("services", "endpoints").RuleOrDie(),
 			},
 		},
 		{
@@ -566,19 +481,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				// Allow read-only access to the API objects
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("nodes"),
-				},
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes").RuleOrDie(),
 				// Allow all API calls to the nodes
-				{
-					Verbs:     sets.NewString("proxy"),
-					Resources: sets.NewString("nodes"),
-				},
-				{
-					Verbs:     sets.NewString(authorizationapi.VerbAll),
-					Resources: sets.NewString("nodes/proxy", authorizationapi.NodeMetricsResource, authorizationapi.NodeStatsResource, authorizationapi.NodeLogResource),
-				},
+				authorizationapi.NewRule("proxy").Groups(kapiGroup).Resources("nodes").RuleOrDie(),
+				authorizationapi.NewRule("*").Groups(kapiGroup).Resources("nodes/proxy", authorizationapi.NodeMetricsResource, authorizationapi.NodeStatsResource, authorizationapi.NodeLogResource).RuleOrDie(),
 			},
 		},
 		{
@@ -587,21 +493,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				// Allow read-only access to the API objects
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("nodes"),
-				},
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes").RuleOrDie(),
 				// Allow read access to node metrics
-				{
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
-				},
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources(authorizationapi.NodeMetricsResource).RuleOrDie(),
 				// Allow read access to stats
 				// Node stats requests are submitted as POSTs.  These creates are non-mutating
-				{
-					Verbs:     sets.NewString("get", "create"),
-					Resources: sets.NewString(authorizationapi.NodeStatsResource),
-				},
+				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources(authorizationapi.NodeStatsResource).RuleOrDie(),
 				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
 			},
 		},
@@ -610,72 +507,40 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: NodeRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					// Needed to check API access.  These creates are non-mutating
-					Verbs:     sets.NewString("create"),
-					Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"),
-				},
-				{
-					// Needed to build serviceLister, to populate env vars for services
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("services"),
-				},
-				{
-					// Nodes can register themselves
-					// TODO: restrict to creating a node with the same name they announce
-					Verbs:     sets.NewString("create", "get", "list", "watch"),
-					Resources: sets.NewString("nodes"),
-				},
-				{
-					// TODO: restrict to the bound node once supported
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("nodes/status"),
-				},
+				// Needed to check API access.  These creates are non-mutating
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("subjectaccessreviews", "localsubjectaccessreviews").RuleOrDie(),
+				// Needed to build serviceLister, to populate env vars for services
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("services").RuleOrDie(),
+				// Nodes can register themselves
+				// TODO: restrict to creating a node with the same name they announce
+				authorizationapi.NewRule("create", "get", "list", "watch").Groups(kapiGroup).Resources("nodes").RuleOrDie(),
+				// TODO: restrict to the bound node once supported
+				authorizationapi.NewRule("update").Groups(kapiGroup).Resources("nodes/status").RuleOrDie(),
 
-				{
-					// TODO: restrict to the bound node as creator once supported
-					Verbs:     sets.NewString("create", "update", "patch"),
-					Resources: sets.NewString("events"),
-				},
+				// TODO: restrict to the bound node as creator once supported
+				authorizationapi.NewRule("create", "update", "patch").Groups(kapiGroup).Resources("events").RuleOrDie(),
 
-				{
-					// TODO: restrict to pods scheduled on the bound node once supported
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("pods"),
-				},
-				{
-					// TODO: remove once mirror pods are removed
-					// TODO: restrict deletion to mirror pods created by the bound node once supported
-					// Needed for the node to create/delete mirror pods
-					Verbs:     sets.NewString("get", "create", "delete"),
-					Resources: sets.NewString("pods"),
-				},
-				{
-					// TODO: restrict to pods scheduled on the bound node once supported
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("pods/status"),
-				},
+				// TODO: restrict to pods scheduled on the bound node once supported
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("pods").RuleOrDie(),
 
-				{
-					// TODO: restrict to secrets and configmaps used by pods scheduled on bound node once supported
-					// Needed for imagepullsecrets, rbd/ceph and secret volumes, and secrets in envs
-					// Needed for configmap volume and envs
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("secrets", "configmaps"),
-				},
-				{
-					// TODO: restrict to claims/volumes used by pods scheduled on bound node once supported
-					// Needed for persistent volumes
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("persistentvolumeclaims", "persistentvolumes"),
-				},
-				{
-					// TODO: restrict to namespaces of pods scheduled on bound node once supported
-					// TODO: change glusterfs to use DNS lookup so this isn't needed?
-					// Needed for glusterfs volumes
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("endpoints"),
-				},
+				// TODO: remove once mirror pods are removed
+				// TODO: restrict deletion to mirror pods created by the bound node once supported
+				// Needed for the node to create/delete mirror pods
+				authorizationapi.NewRule("get", "create", "delete").Groups(kapiGroup).Resources("pods").RuleOrDie(),
+				// TODO: restrict to pods scheduled on the bound node once supported
+				authorizationapi.NewRule("update").Groups(kapiGroup).Resources("pods/status").RuleOrDie(),
+
+				// TODO: restrict to secrets and configmaps used by pods scheduled on bound node once supported
+				// Needed for imagepullsecrets, rbd/ceph and secret volumes, and secrets in envs
+				// Needed for configmap volume and envs
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("secrets", "configmaps").RuleOrDie(),
+				// TODO: restrict to claims/volumes used by pods scheduled on bound node once supported
+				// Needed for persistent volumes
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("persistentvolumeclaims", "persistentvolumes").RuleOrDie(),
+				// TODO: restrict to namespaces of pods scheduled on bound node once supported
+				// TODO: change glusterfs to use DNS lookup so this isn't needed?
+				// Needed for glusterfs volumes
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("endpoints").RuleOrDie(),
 			},
 		},
 
@@ -684,26 +549,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: SDNReaderRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("hostsubnets"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("netnamespaces"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("nodes"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("clusternetworks"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("namespaces"),
-				},
+				authorizationapi.NewRule(read...).Groups(sdnGroup).Resources("hostsubnets", "netnamespaces").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes", "namespaces").RuleOrDie(),
+
+				authorizationapi.NewRule("get").Groups(sdnGroup).Resources("clusternetworks").RuleOrDie(),
 			},
 		},
 
@@ -712,22 +561,9 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: SDNManagerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "list", "watch", "create", "delete"),
-					Resources: sets.NewString("hostsubnets"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch", "create", "delete"),
-					Resources: sets.NewString("netnamespaces"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					Resources: sets.NewString("nodes"),
-				},
-				{
-					Verbs:     sets.NewString("get", "create"),
-					Resources: sets.NewString("clusternetworks"),
-				},
+				authorizationapi.NewRule("get", "list", "watch", "create", "delete").Groups(sdnGroup).Resources("hostsubnets", "netnamespaces").RuleOrDie(),
+				authorizationapi.NewRule("get", "create").Groups(sdnGroup).Resources("clusternetworks").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes").RuleOrDie(),
 			},
 		},
 
@@ -736,10 +572,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: WebHooksRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "create"),
-					Resources: sets.NewString("buildconfigs/webhooks"),
-				},
+				authorizationapi.NewRule("get", "create").Groups(buildGroup).Resources("buildconfigs/webhooks").RuleOrDie(),
 			},
 		},
 
@@ -757,41 +590,18 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RegistryAdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags"),
-				},
-				{
-					Verbs:     sets.NewString("get", "update"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreams/layers"),
-				},
-				{
-					Verbs:     sets.NewString("create"),
-					APIGroups: []string{authorizationapi.GroupName},
-					Resources: sets.NewString("localresourceaccessreviews", "localsubjectaccessreviews", "resourceaccessreviews", "subjectaccessreviews"),
-				},
-				{
-					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
-					APIGroups: []string{authorizationapi.GroupName},
-					Resources: sets.NewString("rolebindings", "roles"),
-				},
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					APIGroups: []string{authorizationapi.GroupName},
-					Resources: sets.NewString("policies", "policybindings"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{kapi.GroupName},
-					Resources: sets.NewString("namespaces"),
-				},
-				{
-					Verbs:     sets.NewString("get", "delete"),
-					APIGroups: []string{projectapi.GroupName},
-					Resources: sets.NewString("projects"),
-				},
+				authorizationapi.NewRule(readWrite...).Groups(imageGroup).Resources("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags").RuleOrDie(),
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+
+				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("rolebindings", "roles").RuleOrDie(),
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("localresourceaccessreviews", "localsubjectaccessreviews").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(authzGroup).Resources("policies", "policybindings").RuleOrDie(),
+
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
+				authorizationapi.NewRule("get", "delete").Groups(projectGroup).Resources("projects").RuleOrDie(),
+
+				// backwards compatibility
+				authorizationapi.NewRule("create").Groups(authzGroup).Resources("resourceaccessreviews", "subjectaccessreviews").RuleOrDie(),
 			},
 		},
 		{
@@ -799,26 +609,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RegistryEditorRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags"),
-				},
-				{
-					Verbs:     sets.NewString("get", "update"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreams/layers"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{kapi.GroupName},
-					Resources: sets.NewString("namespaces"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{projectapi.GroupName},
-					Resources: sets.NewString("projects"),
-				},
+				authorizationapi.NewRule(readWrite...).Groups(imageGroup).Resources("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags").RuleOrDie(),
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(projectGroup).Resources("projects").RuleOrDie(),
 			},
 		},
 		{
@@ -826,26 +621,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RegistryViewerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "list", "watch"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreamtags"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{imageapi.GroupName},
-					Resources: sets.NewString("imagestreams/layers"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{kapi.GroupName},
-					Resources: sets.NewString("namespaces"),
-				},
-				{
-					Verbs:     sets.NewString("get"),
-					APIGroups: []string{projectapi.GroupName},
-					Resources: sets.NewString("projects"),
-				},
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreamimages", "imagestreamimports", "imagestreammappings", "imagestreams", "imagestreamtags").RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(projectGroup).Resources("projects").RuleOrDie(),
 			},
 		},
 	}
@@ -859,23 +639,14 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		}
 	}
 
-	roles = append(roles, saRoles...)
-
-	// we don't want to expose the resourcegroups externally because it makes it very difficult for customers to learn from
-	// our default roles and hard for them to reason about what power they are granting their users
-	for i := range roles {
-		for j := range roles[i].Rules {
-			roles[i].Rules[j].Resources = authorizationapi.NormalizeResources(roles[i].Rules[j].Resources)
-		}
-	}
-
 	// TODO roundtrip roles to pick up defaulting for API groups.  Without this, the covers check in reconcile-cluster-roles will fail.
 	// we can remove this again once everything gets group qualified and we have unit tests enforcing that.  other pulls are in
 	// progress to do that.
+	// we only want to roundtrip the sa roles now.  We'll remove this once we convert the SA roles
 	versionedRoles := []authorizationapiv1.ClusterRole{}
-	for i := range roles {
+	for i := range saRoles {
 		newRole := &authorizationapiv1.ClusterRole{}
-		if err := kapi.Scheme.Convert(&roles[i], newRole); err != nil {
+		if err := kapi.Scheme.Convert(&saRoles[i], newRole); err != nil {
 			panic(err)
 		}
 		versionedRoles = append(versionedRoles, *newRole)
@@ -889,7 +660,17 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		roundtrippedRoles = append(roundtrippedRoles, *newRole)
 	}
 
-	return roundtrippedRoles
+	roles = append(roles, roundtrippedRoles...)
+
+	// we don't want to expose the resourcegroups externally because it makes it very difficult for customers to learn from
+	// our default roles and hard for them to reason about what power they are granting their users
+	for i := range roles {
+		for j := range roles[i].Rules {
+			roles[i].Rules[j].Resources = authorizationapi.NormalizeResources(roles[i].Rules[j].Resources)
+		}
+	}
+
+	return roles
 }
 
 func GetBootstrapOpenshiftRoleBindings(openshiftNamespace string) []authorizationapi.RoleBinding {

--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/diff"
 
 	"github.com/openshift/origin/pkg/api/v1"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 
 	// install all APIs
@@ -89,5 +91,53 @@ func testObjects(t *testing.T, list *api.List, fixtureFilename string) {
 			t.Logf("Diff between bootstrap data and fixture data in %s:\n-------------\n%s", filename, diff.StringDiff(string(yamlData), string(expectedYAML)))
 			t.Logf("If the change is expected, re-run with %s=true to update the fixtures", updateEnvVar)
 		}
+	}
+}
+
+// Some roles should always cover others
+func TestCovers(t *testing.T) {
+	allRoles := bootstrappolicy.GetBootstrapClusterRoles()
+	var admin *authorizationapi.ClusterRole
+	var editor *authorizationapi.ClusterRole
+	var viewer *authorizationapi.ClusterRole
+	var registryAdmin *authorizationapi.ClusterRole
+	var registryEditor *authorizationapi.ClusterRole
+	var registryViewer *authorizationapi.ClusterRole
+
+	for i := range allRoles {
+		role := allRoles[i]
+		switch role.Name {
+		case bootstrappolicy.AdminRoleName:
+			admin = &role
+		case bootstrappolicy.EditRoleName:
+			editor = &role
+		case bootstrappolicy.ViewRoleName:
+			viewer = &role
+		case bootstrappolicy.RegistryAdminRoleName:
+			registryAdmin = &role
+		case bootstrappolicy.RegistryEditorRoleName:
+			registryEditor = &role
+		case bootstrappolicy.RegistryViewerRoleName:
+			registryViewer = &role
+		}
+	}
+
+	if covers, _ := rulevalidation.Covers(admin.Rules, editor.Rules); !covers {
+		t.Errorf("failed to cover")
+	}
+	if covers, _ := rulevalidation.Covers(admin.Rules, editor.Rules); !covers {
+		t.Errorf("failed to cover")
+	}
+	if covers, _ := rulevalidation.Covers(admin.Rules, viewer.Rules); !covers {
+		t.Errorf("failed to cover")
+	}
+	if covers, _ := rulevalidation.Covers(admin.Rules, registryAdmin.Rules); !covers {
+		t.Errorf("failed to cover")
+	}
+	if covers, _ := rulevalidation.Covers(registryAdmin.Rules, registryEditor.Rules); !covers {
+		t.Errorf("failed to cover")
+	}
+	if covers, _ := rulevalidation.Covers(registryAdmin.Rules, registryViewer.Rules); !covers {
+		t.Errorf("failed to cover")
 	}
 }

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -240,15 +240,27 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
     - pods
     - pods/attach
     - pods/exec
-    - pods/log
     - pods/portforward
     - pods/proxy
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
     - replicationcontrollers
     - replicationcontrollers/scale
     - secrets
@@ -268,52 +280,27 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - serviceaccounts
+    - bindings
+    - events
+    - limitranges
+    - namespaces
+    - namespaces/status
+    - pods/log
+    - pods/status
+    - replicationcontrollers/status
+    - resourcequotas
+    - resourcequotas/status
     verbs:
-    - impersonate
+    - get
+    - list
+    - watch
   - apiGroups:
     - ""
     attributeRestrictions: null
     resources:
-    - buildconfigs
-    - buildconfigs/instantiate
-    - buildconfigs/instantiatebinary
-    - buildconfigs/webhooks
-    - buildlogs
-    - builds
-    - builds/clone
-    - builds/log
-    - deploymentconfigrollbacks
-    - deploymentconfigs
-    - deploymentconfigs/log
-    - deploymentconfigs/scale
-    - generatedeploymentconfigs
-    - imagestreamimages
-    - imagestreamimports
-    - imagestreammappings
-    - imagestreams
-    - imagestreams/secrets
-    - imagestreamtags
-    - localresourceaccessreviews
-    - localsubjectaccessreviews
-    - processedtemplates
-    - projects
-    - resourceaccessreviews
-    - rolebindings
-    - roles
-    - routes
-    - subjectaccessreviews
-    - templateconfigs
-    - templates
+    - serviceaccounts
     verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+    - impersonate
   - apiGroups:
     - autoscaling
     attributeRestrictions: null
@@ -371,33 +358,119 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - bindings
-    - configmaps
-    - deploymentconfigs/status
-    - endpoints
-    - events
-    - imagestreams/status
-    - limitranges
-    - minions
-    - namespaces
-    - namespaces/status
-    - nodes
-    - persistentvolumeclaims
-    - persistentvolumes
-    - pods
-    - pods/log
-    - pods/status
+    - rolebindings
+    - roles
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - localresourceaccessreviews
+    - localsubjectaccessreviews
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - policies
     - policybindings
-    - replicationcontrollers
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    - resourcequotausages
-    - routes/status
-    - securitycontextconstraints
-    - serviceaccounts
-    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigrollbacks
+    - deploymentconfigs
+    - deploymentconfigs/scale
+    - generatedeploymentconfigs
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/log
+    - deploymentconfigs/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimages
+    - imagestreammappings
+    - imagestreams
+    - imagestreams/secrets
+    - imagestreamtags
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreams/status
     verbs:
     - get
     - list
@@ -414,9 +487,195 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - imagestreamimports
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - delete
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - routes/status
     verbs:
     - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildlogs
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotausages
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourceaccessreviews
+    - subjectaccessreviews
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - localresourceaccessreviews
+    - localsubjectaccessreviews
+    - resourceaccessreviews
+    - subjectaccessreviews
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimports
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - minions
+    - nodes
+    - persistentvolumes
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - create
+    - deletecollection
+    - list
+    - watch
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -427,15 +686,27 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
     - pods
     - pods/attach
     - pods/exec
-    - pods/log
     - pods/portforward
     - pods/proxy
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
     - replicationcontrollers
     - replicationcontrollers/scale
     - secrets
@@ -455,45 +726,27 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - serviceaccounts
+    - bindings
+    - events
+    - limitranges
+    - namespaces
+    - namespaces/status
+    - pods/log
+    - pods/status
+    - replicationcontrollers/status
+    - resourcequotas
+    - resourcequotas/status
     verbs:
-    - impersonate
+    - get
+    - list
+    - watch
   - apiGroups:
     - ""
     attributeRestrictions: null
     resources:
-    - buildconfigs
-    - buildconfigs/instantiate
-    - buildconfigs/instantiatebinary
-    - buildconfigs/webhooks
-    - buildlogs
-    - builds
-    - builds/clone
-    - builds/log
-    - deploymentconfigrollbacks
-    - deploymentconfigs
-    - deploymentconfigs/log
-    - deploymentconfigs/scale
-    - generatedeploymentconfigs
-    - imagestreamimages
-    - imagestreamimports
-    - imagestreammappings
-    - imagestreams
-    - imagestreams/secrets
-    - imagestreamtags
-    - processedtemplates
-    - routes
-    - templateconfigs
-    - templates
+    - serviceaccounts
     verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+    - impersonate
   - apiGroups:
     - autoscaling
     attributeRestrictions: null
@@ -551,32 +804,86 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - bindings
-    - configmaps
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigrollbacks
+    - deploymentconfigs
+    - deploymentconfigs/scale
+    - generatedeploymentconfigs
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/log
     - deploymentconfigs/status
-    - endpoints
-    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimages
+    - imagestreammappings
+    - imagestreams
+    - imagestreams/secrets
+    - imagestreamtags
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - imagestreams/status
-    - limitranges
-    - minions
-    - namespaces
-    - namespaces/status
-    - nodes
-    - persistentvolumeclaims
-    - persistentvolumes
-    - pods
-    - pods/log
-    - pods/status
-    - projects
-    - replicationcontrollers
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    - resourcequotausages
-    - routes/status
-    - securitycontextconstraints
-    - serviceaccounts
-    - services
     verbs:
     - get
     - list
@@ -589,6 +896,163 @@ items:
     verbs:
     - get
     - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimports
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildlogs
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotausages
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/log
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimports
+    verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - minions
+    - nodes
+    - persistentvolumes
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - list
+    - watch
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -599,54 +1063,31 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - bindings
-    - buildconfigs
-    - buildconfigs/instantiate
-    - buildconfigs/instantiatebinary
-    - buildconfigs/webhooks
-    - buildlogs
-    - builds
-    - builds/clone
-    - builds/log
     - configmaps
-    - deploymentconfigrollbacks
-    - deploymentconfigs
-    - deploymentconfigs/log
-    - deploymentconfigs/scale
-    - deploymentconfigs/status
     - endpoints
+    - persistentvolumeclaims
+    - pods
+    - replicationcontrollers
+    - serviceaccounts
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - bindings
     - events
-    - generatedeploymentconfigs
-    - imagestreamimages
-    - imagestreamimports
-    - imagestreammappings
-    - imagestreams
-    - imagestreams/status
-    - imagestreamtags
     - limitranges
-    - minions
     - namespaces
     - namespaces/status
-    - nodes
-    - persistentvolumeclaims
-    - persistentvolumes
-    - pods
     - pods/log
     - pods/status
-    - processedtemplates
-    - projects
-    - replicationcontrollers
     - replicationcontrollers/status
     - resourcequotas
     - resourcequotas/status
-    - resourcequotausages
-    - routes
-    - routes/status
-    - securitycontextconstraints
-    - serviceaccounts
-    - services
-    - templateconfigs
-    - templates
     verbs:
     - get
     - list
@@ -673,11 +1114,178 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
-    - daemonsets
     - horizontalpodautoscalers
     - jobs
     verbs:
     - get
+    - list
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigrollbacks
+    - deploymentconfigs
+    - deploymentconfigs/scale
+    - generatedeploymentconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/log
+    - deploymentconfigs/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimages
+    - imagestreammappings
+    - imagestreams
+    - imagestreamtags
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreams/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templates
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildlogs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotausages
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    - buildconfigs/instantiatebinary
+    - builds/clone
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimports
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - minions
+    - nodes
+    - persistentvolumes
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
     - list
     - watch
 - apiVersion: v1
@@ -720,19 +1328,19 @@ items:
     - watch
   - apiGroups:
     - ""
+    attributeRestrictions: null
+    resources:
+    - selfsubjectrulesreviews
+    verbs:
+    - create
+  - apiGroups:
+    - ""
     attributeRestrictions:
       apiVersion: v1
       kind: IsPersonalSubjectAccessReview
     resources:
     - localsubjectaccessreviews
     - subjectaccessreviews
-    verbs:
-    - create
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - selfsubjectrulesreviews
     verbs:
     - create
 - apiVersion: v1
@@ -852,6 +1460,32 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - pods
+    - replicationcontrollers
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    - builds
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - images
     verbs:
     - delete
@@ -859,13 +1493,8 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - buildconfigs
-    - builds
-    - deploymentconfigs
     - images
     - imagestreams
-    - pods
-    - replicationcontrollers
     verbs:
     - get
     - list
@@ -890,13 +1519,6 @@ items:
     verbs:
     - get
     - list
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers
-    verbs:
-    - get
     - update
   - apiGroups:
     - ""
@@ -960,6 +1582,13 @@ items:
     attributeRestrictions: null
     resources:
     - endpoints
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - routes
     verbs:
     - list
@@ -981,6 +1610,13 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - resourcequotas
+    verbs:
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - images
     verbs:
     - delete
@@ -990,7 +1626,6 @@ items:
     attributeRestrictions: null
     resources:
     - imagestreamimages
-    - imagestreams
     - imagestreams/secrets
     - imagestreamtags
     verbs:
@@ -1001,6 +1636,7 @@ items:
     resources:
     - imagestreams
     verbs:
+    - get
     - update
   - apiGroups:
     - ""
@@ -1009,13 +1645,6 @@ items:
     - imagestreammappings
     verbs:
     - create
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - resourcequotas
-    verbs:
-    - list
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -1201,14 +1830,6 @@ items:
     attributeRestrictions: null
     resources:
     - hostsubnets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
     - netnamespaces
     verbs:
     - get
@@ -1218,6 +1839,7 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - namespaces
     - nodes
     verbs:
     - get
@@ -1230,15 +1852,6 @@ items:
     - clusternetworks
     verbs:
     - get
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - namespaces
-    verbs:
-    - get
-    - list
-    - watch
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -1250,16 +1863,6 @@ items:
     attributeRestrictions: null
     resources:
     - hostsubnets
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
     - netnamespaces
     verbs:
     - create
@@ -1271,19 +1874,19 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - clusternetworks
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - nodes
     verbs:
     - get
     - list
     - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - clusternetworks
-    verbs:
-    - create
-    - get
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -1356,16 +1959,6 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - localresourceaccessreviews
-    - localsubjectaccessreviews
-    - resourceaccessreviews
-    - subjectaccessreviews
-    verbs:
-    - create
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
     - rolebindings
     - roles
     verbs:
@@ -1377,6 +1970,14 @@ items:
     - patch
     - update
     - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - localresourceaccessreviews
+    - localsubjectaccessreviews
+    verbs:
+    - create
   - apiGroups:
     - ""
     attributeRestrictions: null
@@ -1402,6 +2003,14 @@ items:
     verbs:
     - delete
     - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourceaccessreviews
+    - subjectaccessreviews
+    verbs:
+    - create
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -41,7 +41,8 @@ items:
     creationTimestamp: null
     name: cluster-reader
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - bindings
@@ -147,20 +148,23 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - resourceaccessreviews
     - subjectaccessreviews
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/metrics
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/stats
@@ -363,7 +367,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - bindings
@@ -397,14 +402,16 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - routes/status
@@ -540,7 +547,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - bindings
@@ -573,7 +581,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers
@@ -586,7 +595,8 @@ items:
     creationTimestamp: null
     name: view
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - bindings
@@ -676,7 +686,8 @@ items:
     creationTimestamp: null
     name: basic-user
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resourceNames:
     - "~"
@@ -684,27 +695,31 @@ items:
     - users
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - projectrequests
     verbs:
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - clusterroles
     verbs:
     - get
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - projects
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions:
       apiVersion: v1
       kind: IsPersonalSubjectAccessReview
@@ -713,7 +728,8 @@ items:
     - subjectaccessreviews
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - selfsubjectrulesreviews
@@ -725,7 +741,8 @@ items:
     creationTimestamp: null
     name: self-provisioner
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - projectrequests
@@ -783,7 +800,8 @@ items:
     creationTimestamp: null
     name: system:image-puller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers
@@ -795,7 +813,8 @@ items:
     creationTimestamp: null
     name: system:image-pusher
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers
@@ -808,14 +827,16 @@ items:
     creationTimestamp: null
     name: system:image-builder
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - builds/details
@@ -827,13 +848,15 @@ items:
     creationTimestamp: null
     name: system:image-pruner
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - images
     verbs:
     - delete
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - buildconfigs
@@ -846,7 +869,8 @@ items:
     verbs:
     - get
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/status
@@ -858,21 +882,24 @@ items:
     creationTimestamp: null
     name: system:deployer
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - get
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -881,13 +908,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods/log
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreamtags
@@ -912,7 +941,8 @@ items:
     creationTimestamp: null
     name: system:oauth-token-deleter
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - oauthaccesstokens
@@ -925,7 +955,8 @@ items:
     creationTimestamp: null
     name: system:router
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - endpoints
@@ -933,7 +964,8 @@ items:
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - routes/status
@@ -945,14 +977,16 @@ items:
     creationTimestamp: null
     name: system:registry
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - images
     verbs:
     - delete
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreamimages
@@ -961,19 +995,22 @@ items:
     - imagestreamtags
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreammappings
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - resourcequotas
@@ -985,7 +1022,8 @@ items:
     creationTimestamp: null
     name: system:node-proxier
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - endpoints
@@ -999,7 +1037,8 @@ items:
     creationTimestamp: null
     name: system:node-admin
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1007,13 +1046,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
     verbs:
     - proxy
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/log
@@ -1028,7 +1069,8 @@ items:
     creationTimestamp: null
     name: system:node-reader
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1036,13 +1078,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/metrics
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/stats
@@ -1055,14 +1099,16 @@ items:
     creationTimestamp: null
     name: system:node
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - localsubjectaccessreviews
     - subjectaccessreviews
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - services
@@ -1070,7 +1116,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1079,13 +1126,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1093,7 +1142,8 @@ items:
     - create
     - patch
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1101,7 +1151,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1109,27 +1160,31 @@ items:
     - create
     - delete
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - configmaps
     - secrets
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     - persistentvolumes
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - endpoints
@@ -1141,7 +1196,8 @@ items:
     creationTimestamp: null
     name: system:sdn-reader
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - hostsubnets
@@ -1149,7 +1205,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - netnamespaces
@@ -1157,7 +1214,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1165,13 +1223,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - clusternetworks
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - namespaces
@@ -1185,7 +1245,8 @@ items:
     creationTimestamp: null
     name: system:sdn-manager
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - hostsubnets
@@ -1195,7 +1256,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - netnamespaces
@@ -1205,7 +1267,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1213,7 +1276,8 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - clusternetworks
@@ -1226,7 +1290,8 @@ items:
     creationTimestamp: null
     name: system:webhook
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - buildconfigs/webhooks
@@ -1430,7 +1495,8 @@ items:
     creationTimestamp: null
     name: system:build-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - builds
@@ -1438,13 +1504,15 @@ items:
     - get
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - builds
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - builds/custom
@@ -1453,13 +1521,15 @@ items:
     - builds/source
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams
     verbs:
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1468,7 +1538,8 @@ items:
     - delete
     - get
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1490,14 +1561,16 @@ items:
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - nodes
@@ -1511,7 +1584,8 @@ items:
     - daemonsets/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1525,7 +1599,8 @@ items:
     - pods/binding
     verbs:
     - create
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1539,21 +1614,24 @@ items:
     creationTimestamp: null
     name: system:deployment-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1563,7 +1641,8 @@ items:
     - get
     - list
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1625,14 +1704,16 @@ items:
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - deploymentconfigs/scale
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1640,13 +1721,15 @@ items:
     - create
     - patch
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - list
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resourceNames:
     - 'https:heapster:'
@@ -1677,21 +1760,24 @@ items:
     - jobs/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - create
     - delete
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1739,14 +1825,16 @@ items:
     creationTimestamp: null
     name: system:pv-binder-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
@@ -1755,27 +1843,31 @@ items:
     - delete
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims/status
@@ -1787,14 +1879,16 @@ items:
     creationTimestamp: null
     name: system:pv-provisioner-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
@@ -1803,27 +1897,31 @@ items:
     - delete
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims/status
@@ -1835,14 +1933,16 @@ items:
     creationTimestamp: null
     name: system:pv-recycler-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes
@@ -1851,40 +1951,46 @@ items:
     - delete
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumes/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - persistentvolumeclaims/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
@@ -1892,7 +1998,8 @@ items:
     - create
     - delete
     - get
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1906,41 +2013,47 @@ items:
     creationTimestamp: null
     name: system:replication-controller
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers
     verbs:
     - get
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - replicationcontrollers/status
     verbs:
     - update
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - pods
     verbs:
     - create
     - delete
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events
@@ -1984,7 +2097,8 @@ items:
     verbs:
     - list
     - watch
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events


### PR DESCRIPTION
@liggitt last commit only

There's a unit test that roundtrips the old roles and does a two way covers to ensure perfect fidelity. 

After this pull, we remove the unit test so that new permissions can be added and remove the "bad" rules that I noted in teh roles.

SAs are next.