### PR TITLE
auto-create rolebinding with user creds for jenkins on first touch

### DIFF
--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -1,24 +1,41 @@
 package etcd
 
 import (
+	"fmt"
+
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	etcdgeneric "k8s.io/kubernetes/pkg/registry/generic/etcd"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
+	"k8s.io/kubernetes/pkg/util/sets"
 
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/registry/buildconfig"
+	oclient "github.com/openshift/origin/pkg/client"
+
+	// refactor to avoid wacky dependency
+	"github.com/openshift/origin/pkg/cmd/admin/policy"
 )
 
 type REST struct {
 	*etcdgeneric.Etcd
+
+	// TODO make this an index from namespace/username to roles
+	roleBindingClient oclient.RoleBindingsNamespacer
+
+	restClient *restclient.RESTClient
 }
 
 // NewStorage returns a RESTStorage object that will work against nodes.
-func NewREST(s storage.Interface) *REST {
+func NewREST(s storage.Interface, roleBindingClient oclient.RoleBindingsNamespacer, restClient *restclient.RESTClient) *REST {
 	prefix := "/buildconfigs"
 
 	store := &etcdgeneric.Etcd{
@@ -45,5 +62,132 @@ func NewREST(s storage.Interface) *REST {
 		Storage:             s,
 	}
 
-	return &REST{store}
+	return &REST{
+		Etcd:              store,
+		roleBindingClient: roleBindingClient,
+		restClient:        restClient,
+	}
+}
+
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	bc, ok := obj.(*api.BuildConfig)
+	if !ok {
+		return r.Etcd.Create(ctx, obj)
+	}
+	if bc.Spec.Strategy.JenkinsPipelineStrategy == nil {
+		return r.Etcd.Create(ctx, obj)
+	}
+	user, ok := kapi.UserFrom(ctx)
+	if !ok {
+		return r.Etcd.Create(ctx, obj)
+	}
+
+	// otherwise, find the jenkins SA specified (is that missing) and get roles it has in this namespace
+	roleBindings, err := r.roleBindingClient.RoleBindings(bc.Namespace).List(kapi.ListOptions{})
+	if err != nil {
+		return nil, kapierrors.NewInternalError(err)
+	}
+	foundEdit := false
+	for _, roleBinding := range roleBindings.Items {
+		if len(roleBinding.RoleRef.Namespace) != 0 || roleBinding.RoleRef.Name != "edit" {
+			continue
+		}
+		for _, subject := range roleBinding.Subjects {
+			if subject.Kind == "ServiceAccount" && subject.Name == "jenkins" && subject.Namespace == bc.Namespace {
+				foundEdit = true
+			}
+		}
+	}
+
+	// we didn't find the role we wanted, try to add that role
+	if !foundEdit {
+		addRole := &policy.RoleModificationOptions{
+			RoleName: "edit",
+			RoleBindingAccessor: &impersonatingRoleBindingAccessor{
+				user:              user,
+				bindingNamespace:  bc.Namespace,
+				roleBindingClient: r.roleBindingClient,
+				restClient:        r.restClient,
+			},
+			Subjects: []kapi.ObjectReference{{Kind: "ServiceAccount", Namespace: bc.Namespace, Name: "jenkins"}},
+		}
+
+		if err := addRole.AddRole(); err != nil {
+			if kapierrors.IsForbidden(err) {
+				return nil, kapierrors.NewInternalError(fmt.Errorf("need to bind jenkins to edit: `oc policy add-role-to-user edit -z jenkins`"))
+			}
+			return nil, kapierrors.NewInternalError(err)
+		}
+	}
+
+	return r.Etcd.Create(ctx, obj)
+}
+
+type impersonatingRoleBindingAccessor struct {
+	user             user.Info
+	bindingNamespace string
+
+	roleBindingClient oclient.RoleBindingsNamespacer
+
+	// TODO pretty this up
+	restClient *restclient.RESTClient
+}
+
+func (a impersonatingRoleBindingAccessor) GetExistingRoleBindingsForRole(roleNamespace, role string) ([]*authorizationapi.RoleBinding, error) {
+	existingBindings, err := a.roleBindingClient.RoleBindings(a.bindingNamespace).List(kapi.ListOptions{})
+	if err != nil && !kapierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	ret := make([]*authorizationapi.RoleBinding, 0)
+	// see if we can find an existing binding that points to the role in question.
+	for i := range existingBindings.Items {
+		currBinding := &existingBindings.Items[i]
+		if currBinding.RoleRef.Namespace == roleNamespace && currBinding.RoleRef.Name == role {
+			t := currBinding
+			ret = append(ret, t)
+		}
+	}
+
+	return ret, nil
+}
+
+func (a impersonatingRoleBindingAccessor) GetExistingRoleBindingNames() (*sets.String, error) {
+	roleBindings, err := a.roleBindingClient.RoleBindings(a.bindingNamespace).List(kapi.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &sets.String{}
+	for _, currBinding := range roleBindings.Items {
+		ret.Insert(currBinding.Name)
+	}
+
+	return ret, nil
+}
+
+func (a impersonatingRoleBindingAccessor) UpdateRoleBinding(binding *authorizationapi.RoleBinding) error {
+	request := a.restClient.Put()
+	request = request.SetHeader(authenticationapi.ImpersonateUserHeader, a.user.GetName())
+	// TODO need Impersonate-User-Groups
+	for _, scope := range a.user.GetExtra()[authorizationapi.ScopesKey] {
+		request = request.SetHeader(authenticationapi.ImpersonateUserScopeHeader, scope)
+	}
+
+	_, err := request.Namespace(a.bindingNamespace).Resource("roleBindings").Name(binding.Name).Body(binding).Do().Get()
+	return err
+}
+
+func (a impersonatingRoleBindingAccessor) CreateRoleBinding(binding *authorizationapi.RoleBinding) error {
+	binding.Namespace = a.bindingNamespace
+
+	request := a.restClient.Post()
+	request = request.SetHeader(authenticationapi.ImpersonateUserHeader, a.user.GetName())
+	// TODO need Impersonate-User-Groups
+	for _, scope := range a.user.GetExtra()[authorizationapi.ScopesKey] {
+		request = request.SetHeader(authenticationapi.ImpersonateUserScopeHeader, scope)
+	}
+
+	_, err := request.Namespace(a.bindingNamespace).Resource("roleBindings").Body(binding).Do().Get()
+	return err
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -375,7 +375,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	buildStorage, buildDetailsStorage := buildetcd.NewREST(c.EtcdHelper)
 	buildRegistry := buildregistry.NewRegistry(buildStorage)
 
-	buildConfigStorage := buildconfigetcd.NewREST(c.EtcdHelper)
+	buildConfigStorage := buildconfigetcd.NewREST(c.EtcdHelper, c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackOpenShiftClient.RESTClient)
 	buildConfigRegistry := buildconfigregistry.NewRegistry(buildConfigStorage)
 
 	deployConfigStorage, deployConfigStatusStorage, deployConfigScaleStorage := deployconfigetcd.NewREST(c.EtcdHelper, c.DeploymentConfigScaleClient())


### PR DESCRIPTION
Small pull demonstrating how to create the rolebinding on first touch.  It needs some tests and a minor refactor to avoid a cli dependency.

@bparees @gabemontero @liggitt @smarterclayton 

```bash
oc login -u deads -p asdf
oc new-project another
oc policy add-role-to-user edit liggitt
oc login -u liggitt -p asdf

oc create -f ../jenkins.json
Error from server: error when creating "../jenkins.json": Internal error occurred: need to bind jenkins to edit: `oc policy add-user-to-role edit -z jenkins`

oc login -u deads -p asdf
oc create -f ../jenkins.json
buildconfig "sample-pipeline" created

oc delete bc --all

oc login -u liggitt -p asdf
oc create -f ../jenkins.json
buildconfig "sample-pipeline" created
```