### PR TITLE
Separated export from declaration for environment variables

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -15,7 +15,8 @@ source "${OS_ROOT}/hack/util.sh"
 # Returns:
 #  - export USE_SUDO
 function os::util::environment::use_sudo() {
-    export USE_SUDO=true
+    USE_SUDO=true
+    export USE_SUDO
 }
 
 # os::util::environment::setup_time_vars sets up environment variables that describe durations of time
@@ -30,9 +31,12 @@ function os::util::environment::use_sudo() {
 #  - export TIME_SEC
 #  - export TIME_MIN
 function os::util::environment::setup_time_vars() {
-    export TIME_MS=1
-    export TIME_SEC="$(( 1000  * ${TIME_MS} ))"
-    export TIME_MIN="$(( 60 * ${TIME_SEC} ))"
+    TIME_MS=1
+    export TIME_MS
+    TIME_SEC="$(( 1000  * ${TIME_MS} ))"
+    export TIME_SEC
+    TIME_MIN="$(( 60 * ${TIME_SEC} ))"
+    export TIME_MIN
 }
 
 # os::util::environment::setup_all_server_vars sets up all environment variables necessary to configure and start an OpenShift server
@@ -106,7 +110,8 @@ function os::util::environment::setup_all_server_vars() {
 # Returns:
 #  - export PATH
 function os::util::environment::update_path_var() {
-    export PATH="${OS_ROOT}/_output/local/bin/$(os::util::host_platform):${PATH}"
+    PATH="${OS_ROOT}/_output/local/bin/$(os::util::host_platform):${PATH}"
+    export PATH
 }
 
 # os::util::environment::setup_misc_tmpdir_vars sets up temporary directory path variables
@@ -127,14 +132,20 @@ function os::util::environment::update_path_var() {
 function os::util::environment::setup_tmpdir_vars() {
     local sub_dir=$1
 
-    export BASETMPDIR="${TPMDIR:-/tmp}/openshift/${sub_dir}"
-    export LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
-    export VOLUME_DIR="${BASETMPDIR}/volumes"
-    export ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
+    BASETMPDIR="${TPMDIR:-/tmp}/openshift/${sub_dir}"
+    export BASETMPDIR
+    LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
+    export LOG_DIR
+    VOLUME_DIR="${BASETMPDIR}/volumes"
+    export VOLUME_DIR
+    ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
+    export ARTIFACT_DIR
 
     # change the location of $HOME so no one does anything naughty
-    export FAKE_HOME_DIR="${BASETMPDIR}/openshift.local.home"
-    export HOME="${FAKE_HOME_DIR}"
+    FAKE_HOME_DIR="${BASETMPDIR}/openshift.local.home"
+    export FAKE_HOME_DIR
+    HOME="${FAKE_HOME_DIR}"
+    export HOME
 
     mkdir -p  "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"
 }
@@ -154,10 +165,14 @@ function os::util::environment::setup_tmpdir_vars() {
 #  - export KUBELET_HOST
 #  - export KUBELET_PORT
 function os::util::environment::setup_kubelet_vars() {
-    export KUBELET_SCHEME="${KUBELET_SCHEME:-https}"
-    export KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip)}"
-    export KUBELET_HOST="${KUBELET_HOST:-${KUBELET_BIND_HOST}}"
-    export KUBELET_PORT="${KUBELET_PORT:-10250}"
+    KUBELET_SCHEME="${KUBELET_SCHEME:-https}"
+    export KUBELET_SCHEME
+    KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip)}"
+    export KUBELET_BIND_HOST
+    KUBELET_HOST="${KUBELET_HOST:-${KUBELET_BIND_HOST}}"
+    export KUBELET_HOST
+    KUBELET_PORT="${KUBELET_PORT:-10250}"
+    export KUBELET_PORT
 }
 
 # os::util::environment::setup_etcd_vars sets up environment variables necessary for interacting with etcd
@@ -175,11 +190,15 @@ function os::util::environment::setup_kubelet_vars() {
 #  - export ETCD_PEER_PORT
 #  - export ETCD_DATA_DIR
 function os::util::environment::setup_etcd_vars() {
-    export ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
-    export ETCD_PORT="${ETCD_PORT:-4001}"
-    export ETCD_PEER_PORT="${ETCD_PEER_PORT:-7001}"
+    ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
+    export ETCD_HOST
+    ETCD_PORT="${ETCD_PORT:-4001}"
+    export ETCD_PORT
+    ETCD_PEER_PORT="${ETCD_PEER_PORT:-7001}"
+    export ETCD_PEER_PORT
 
-    export ETCD_DATA_DIR="${BASETMPDIR}/etcd"
+    ETCD_DATA_DIR="${BASETMPDIR}/etcd"
+    export ETCD_DATA_DIR
 
     mkdir -p "${ETCD_DATA_DIR}"
 }
@@ -208,24 +227,36 @@ function os::util::environment::setup_etcd_vars() {
 #  - export MASTER_CONFIG_DIR
 #  - export NODE_CONFIG_DIR
 function os::util::environment::setup_server_vars() {
-    export API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip)}"
-    export API_HOST="${API_HOST:-${API_BIND_HOST}}"
-    export API_PORT="${API_PORT:-8443}"
-    export API_SCHEME="${API_SCHEME:-https}"
+    API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip)}"
+    export API_BIND_HOST
+    API_HOST="${API_HOST:-${API_BIND_HOST}}"
+    export API_HOST
+    API_PORT="${API_PORT:-8443}"
+    export API_PORT
+    API_SCHEME="${API_SCHEME:-https}"
+    export API_SCHEME
 
-    export MASTER_ADDR="${API_SCHEME}://${API_HOST}:${API_PORT}"
-    export PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
+    MASTER_ADDR="${API_SCHEME}://${API_HOST}:${API_PORT}"
+    export MASTER_ADDR
+    PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
+    export PUBLIC_MASTER_HOST
 
-    export SERVER_CONFIG_DIR="${BASETMPDIR}/openshift.local.config"
-    export MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
-    export NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${KUBELET_HOST}"
+    SERVER_CONFIG_DIR="${BASETMPDIR}/openshift.local.config"
+    export SERVER_CONFIG_DIR
+    MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
+    export MASTER_CONFIG_DIR
+    NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${KUBELET_HOST}"
+    export NODE_CONFIG_DIR
 
     mkdir -p "${SERVER_CONFIG_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}"
 
     if [[ "${API_SCHEME}" == "https" ]]; then
-        export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
-        export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
-        export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
+        CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
+        export CURL_CA_BUNDLE
+        CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
+        export CURL_CERT
+        CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
+        export CURL_KEY
     fi
 }
 
@@ -242,12 +273,16 @@ function os::util::environment::setup_server_vars() {
 function os::util::environment::setup_images_vars() {
     # Use either the latest release built images, or latest.
     if [[ -z "${USE_IMAGES-}" ]]; then
-        export TAG='latest'
-        export USE_IMAGES='openshift/origin-${component}:latest'
+        TAG='latest'
+        export TAG
+        USE_IMAGES='openshift/origin-${component}:latest'
+        export USE_IMAGES
 
         if [[ -e "${OS_ROOT}/_output/local/releases/.commit" ]]; then
-            export TAG="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
-            export USE_IMAGES="openshift/origin-\${component}:${TAG}"
+            TAG="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
+            export TAG
+            USE_IMAGES="openshift/origin-\${component}:${TAG}"
+            export USE_IMAGES
         fi
     fi
 }


### PR DESCRIPTION
When an export and a declaration is done in one line, the
return code from the export aliases that of the declaration
and this can lead to issues when the declaration fails, but
the overall script does not stop, as the return code of the
export and declare compound statement is 0.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@Miciah PTAL

@smarterclayton FYI for merge button
@soltysh FYI