### PR TITLE
Update egress-router package dependencies

### DIFF
--- a/images/router/egress/Dockerfile
+++ b/images/router/egress/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM openshift/origin-base
 
-RUN yum install -y iproute && \
+RUN yum install -y iproute iputils && \
     yum clean all
 
 ADD egress-router.sh /bin/egress-router.sh


### PR DESCRIPTION
iputils (which contains arping) is included in the centos:centos7 image that our origin-base is based on, but it's not in the RHEL-based OSE base image. So require it explicitly just to be sure.

cc @tdawson since you'll need to pull this fix into dist-git
