### PR TITLE
Reconcile configs when their deployments are terminated

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -248,6 +248,9 @@ const (
 	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
 	// The annotation value does not matter and its mere presence indicates instantiation.
 	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
+	// DeploymentTerminatedAnnotation is used by the deployer pod controller in order to trigger
+	// deploymentconfig reconcilation after a deployment for the config terminates.
+	DeploymentTerminatedAnnotation = "openshift.io/deployment.terminated"
 	// PostHookPodSuffix is the suffix added to all pre hook pods
 	PreHookPodSuffix = "hook-pre"
 	// PostHookPodSuffix is the suffix added to all mid hook pods


### PR DESCRIPTION
Using a shared cache can obsolete this commit since we can identify in the
update resource handler of the controller that the deployment was marked
as complete/failed and requeue the deployment config without the need to
annotate it. For now trigger a dc reconcilation on complete deployments too.

Needed for https://github.com/openshift/origin/pull/8691

Deployment finishes -> deployer pod controller annotates the dc -> dc reconciled by the deploymentconfig controller -> cleaned up

@stevekuznetsov @ironcladlou @mfojtik @smarterclayton 

I will factor this out once we have caches