### PR TITLE
Truncate labels of builds generated from a BuildConfig

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -420,8 +420,8 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 	if build.Labels == nil {
 		build.Labels = make(map[string]string)
 	}
-	build.Labels[buildapi.BuildConfigLabelDeprecated] = bcCopy.Name
-	build.Labels[buildapi.BuildConfigLabel] = bcCopy.Name
+	build.Labels[buildapi.BuildConfigLabelDeprecated] = buildapi.LabelValue(bcCopy.Name)
+	build.Labels[buildapi.BuildConfigLabel] = buildapi.LabelValue(bcCopy.Name)
 	build.Labels[buildapi.BuildRunPolicyLabel] = string(bc.Spec.RunPolicy)
 
 	builderSecrets, err := g.FetchServiceAccountSecrets(bc.Namespace, serviceAccount)

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/api/validation"
 	mocks "github.com/openshift/origin/pkg/build/generator/test"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -680,6 +681,18 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 	}
 	if build.Annotations[buildapi.BuildNumberAnnotation] != "13" {
 		t.Errorf("Build number annotation value %s does not match expected value 13", build.Annotations[buildapi.BuildNumberAnnotation])
+	}
+
+	// Test long name
+	bc.Name = strings.Repeat("a", 100)
+	build, err = generator.generateBuildFromConfig(kapi.NewContext(), bc, revision, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	build.Namespace = "test-namespace"
+	errors := validation.ValidateBuild(build)
+	if len(errors) > 0 {
+		t.Fatalf("Unexpected validation errors %v", errors)
 	}
 }
 

--- a/pkg/build/generator/test/mocks.go
+++ b/pkg/build/generator/test/mocks.go
@@ -111,7 +111,7 @@ func MockOutput() buildapi.BuildOutput {
 	return buildapi.BuildOutput{
 		To: &kapi.ObjectReference{
 			Kind: "DockerImage",
-			Name: "http://localhost:5000/test/image-tag",
+			Name: "localhost:5000/test/image-tag",
 		},
 	}
 }


### PR DESCRIPTION
Follow-up to #8864
Updates unit test to validate build generated from a BuildConfig with a long name.