### PR TITLE
gitserver: allow specifying build strategy

### DIFF
--- a/examples/gitserver/README.md
+++ b/examples/gitserver/README.md
@@ -221,3 +221,25 @@ metadata:
 **NOTE**: A build will be started for the BuildConfig matching the name of the repository and for any BuildConfig 
 that has an annotation pointing to the source repository. If there is a BuildConfig that has a matching name but
 has an annotation pointing to a different repository, a build will not be invoked for it.
+
+Build Strategy
+--------------
+
+When automatically starting a build, the git server will create a Docker type build if a Dockerfile is present
+in the repository. Otherwise, it will attempt a source type build. To force the git server to always use one
+strategy, set the BUILD_STRATEGY environment variable.
+
+Setting the BUILD_STRATEGY to `docker` will force new builds to be created with the Docker strategy:
+
+```sh
+oc set env dc/git BUILD_STRATEGY=docker
+```
+
+For OpenShift online which does not allow Docker type builds, you will need to set the strategy to `source` 
+if your repository contains a `Dockerfile`:
+
+```sh
+oc set env dc/git BUILD_STRATEGY=source
+```
+
+Valid values for BUILD_STRATEGY are "" (empty string), `source`, and `docker`.

--- a/examples/gitserver/gitserver-ephemeral.yaml
+++ b/examples/gitserver/gitserver-ephemeral.yaml
@@ -79,6 +79,13 @@ items:
           - name: GENERATE_ARTIFACTS
             value: "true"
 
+          # The strategy to use when creating build artifacts from a repository. 
+          # With the default empty value, a Docker build  will be generated if 
+          # a Dockerfile is present in the repository. Otherwise, a source build 
+          # will be created. Valid values are: "", docker, source
+          - name: BUILD_STRATEGY
+            value: ""
+
           # The script to use for custom language detection on a
           # repository. See hooks/detect-language for an example.
           # To use new-app's default detection, leave this variable

--- a/examples/gitserver/gitserver-persistent.yaml
+++ b/examples/gitserver/gitserver-persistent.yaml
@@ -79,6 +79,13 @@ items:
           - name: GENERATE_ARTIFACTS
             value: "true"
 
+          # The strategy to use when creating build artifacts from a repository. 
+          # With the default empty value, a Docker build  will be generated if 
+          # a Dockerfile is present in the repository. Otherwise, a source build 
+          # will be created. Valid values are: "", docker, source
+          - name: BUILD_STRATEGY
+            value: ""
+
           # The script to use for custom language detection on a
           # repository. See hooks/detect-language for an example.
           # To use new-app's default detection, leave this variable

--- a/examples/gitserver/hooks/post-receive
+++ b/examples/gitserver/hooks/post-receive
@@ -16,18 +16,24 @@ function detect {
   local repoURL="$1"
   local repoName="$2"
   local detectionScript=${DETECTION_SCRIPT:-}
+  local buildStrategy=${BUILD_STRATEGY:-}
+  local strategyArg=""
+  if [[ -n "$buildStrategy" ]]; then 
+    strategyArg="--strategy=${buildStrategy}"
+  fi
+
   # The purpose of using a custom detection script is that users can customize the 
   # 'detect-language' script to return the image that's appropriate for their needs. 
   # It is possible to just have new-app do code detection. In that case, just set
   # the DETECTION_SCRIPT variable to an empty string.
   if [[ -z $detectionScript ]]; then
-    oc new-app "${repoURL}"
+    oc new-app "${repoURL}" $strategyArg
   else
     if ! lang=$($(dirname $0)/${detectionScript}); then
       return
     fi
     echo "detect: found language ${lang} for ${repoName}"
-    oc new-app "${lang}~${repoURL}"
+    oc new-app "${lang}~${repoURL}" $strategyArg
   fi
   # TODO: when a command to set a secret is available,
   # set an optional secret on the resulting build configuration


### PR DESCRIPTION
Adds environment variable to git server yaml to allow you to specify the strategy to use when invoking new-app. 

Fixes BZ 1336318