### PR TITLE
Deleting buildconfig with wildcard results in wrong output, not related to action being taken

### DIFF
--- a/pkg/build/reaper/reaper_test.go
+++ b/pkg/build/reaper/reaper_test.go
@@ -149,23 +149,10 @@ func TestStop(t *testing.T) {
 			},
 			err: false,
 		},
-		"no config, some builds": {
-			oc: newBuildListFake(makeBuildList(2)),
+		"no config, no or some builds": {
+			oc: testclient.NewSimpleFake(notFound(), makeBuildList(2)),
 			expected: []ktestclient.Action{
 				ktestclient.NewGetAction("buildconfigs", "default", configName),
-				ktestclient.NewListAction("builds", "default", kapi.ListOptions{LabelSelector: buildutil.BuildConfigSelector(configName)}),
-				ktestclient.NewDeleteAction("builds", "default", "build-1"),
-				ktestclient.NewListAction("builds", "default", kapi.ListOptions{LabelSelector: buildutil.BuildConfigSelectorDeprecated(configName)}),
-				ktestclient.NewDeleteAction("builds", "default", "build-2"),
-			},
-			err: false,
-		},
-		"no config, no builds": {
-			oc: testclient.NewSimpleFake(notFound()),
-			expected: []ktestclient.Action{
-				ktestclient.NewGetAction("buildconfigs", "default", configName),
-				ktestclient.NewListAction("builds", "default", kapi.ListOptions{LabelSelector: buildutil.BuildConfigSelector(configName)}),
-				ktestclient.NewListAction("builds", "default", kapi.ListOptions{LabelSelector: buildutil.BuildConfigSelectorDeprecated(configName)}),
 			},
 			err: true,
 		},


### PR DESCRIPTION
Performing ```oc delete bc ruby*``` command with an existing ruby helloworld sample application, results in message ```buildconfig "ruby*" deleted``` eventhough buildconfig is not deleted. It is because it is associated with build deletion, resulting in wrong message,

If builds need to be removed, ```oc delete builds ruby*``` will remove all the related builds. Deletion of buildconfig should only be depend on itself rather that builds also. Following are the sequence of commands to reproduce it.
```
[vagrant@localhost ~]$ oc get bc
NAME                TYPE      FROM      LATEST
ruby-sample-build   Source    Git       1
[vagrant@localhost ~]$ oc get builds
NAME                  TYPE      FROM      STATUS                         STARTED   DURATION
ruby-sample-build-1   Source    Git       New (InvalidOutputReference)             
[vagrant@localhost ~]$ oc delete bc ruby*
buildconfig "ruby*" deleted
[vagrant@localhost ~]$ 
[vagrant@localhost ~]$ 
[vagrant@localhost ~]$ oc get bc
NAME                TYPE      FROM      LATEST
ruby-sample-build   Source    Git       1
[vagrant@localhost ~]$ oc get builds
[vagrant@localhost ~]$ 

```