### PR TITLE
add the service serving cert signer ca to SA token secret

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const ServiceServingCASecretKey = "service-ca.crt"
+
 // RemoveTokenBackoff is the recommended (empirical) retry interval for removing
 // a secret reference from a service account when the secret is deleted. It is
 // exported for use by custom secret controllers.
@@ -66,6 +68,9 @@ type TokensControllerOptions struct {
 	// MaxRetries controls the maximum number of times a particular key is retried before giving up
 	// If zero, a default max is used
 	MaxRetries int
+
+	// This CA will be added in the secrets of service accounts
+	ServiceServingCA []byte
 }
 
 // NewTokensController returns a new *TokensController.
@@ -76,9 +81,10 @@ func NewTokensController(cl clientset.Interface, options TokensControllerOptions
 	}
 
 	e := &TokensController{
-		client: cl,
-		token:  options.TokenGenerator,
-		rootCA: options.RootCA,
+		client:           cl,
+		token:            options.TokenGenerator,
+		rootCA:           options.RootCA,
+		serviceServingCA: options.ServiceServingCA,
 
 		syncServiceAccountQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		syncSecretQueue:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
@@ -134,7 +140,8 @@ type TokensController struct {
 	client clientset.Interface
 	token  serviceaccount.TokenGenerator
 
-	rootCA []byte
+	rootCA           []byte
+	serviceServingCA []byte
 
 	serviceAccounts cache.Store
 	secrets         cache.Indexer
@@ -417,6 +424,9 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *api.ServiceAcco
 	if e.rootCA != nil && len(e.rootCA) > 0 {
 		secret.Data[api.ServiceAccountRootCAKey] = e.rootCA
 	}
+	if e.serviceServingCA != nil && len(e.serviceServingCA) > 0 {
+		secret.Data[ServiceServingCASecretKey] = e.serviceServingCA
+	}
 
 	// Save the secret
 	createdToken, err := e.client.Core().Secrets(serviceAccount.Namespace).Create(secret)
@@ -451,22 +461,23 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *api.ServiceAcco
 	return false, nil
 }
 
-func (e *TokensController) secretUpdateNeeded(secret *api.Secret) (bool, bool, bool) {
+func (e *TokensController) secretUpdateNeeded(secret *api.Secret) (bool, bool, bool, bool) {
 	caData := secret.Data[api.ServiceAccountRootCAKey]
 	needsCA := len(e.rootCA) > 0 && bytes.Compare(caData, e.rootCA) != 0
+	needsServiceServingCA := len(e.serviceServingCA) > 0 && bytes.Compare(secret.Data[ServiceServingCASecretKey], e.serviceServingCA) != 0
 
 	needsNamespace := len(secret.Data[api.ServiceAccountNamespaceKey]) == 0
 
 	tokenData := secret.Data[api.ServiceAccountTokenKey]
 	needsToken := len(tokenData) == 0
 
-	return needsCA, needsNamespace, needsToken
+	return needsCA, needsServiceServingCA, needsNamespace, needsToken
 }
 
 // generateTokenIfNeeded populates the token data for the given Secret if not already set
 func (e *TokensController) generateTokenIfNeeded(serviceAccount *api.ServiceAccount, cachedSecret *api.Secret) ( /* retry */ bool, error) {
 	// Check the cached secret to see if changes are needed
-	if needsCA, needsNamespace, needsToken := e.secretUpdateNeeded(cachedSecret); !needsCA && !needsToken && !needsNamespace {
+	if needsCA, needsServiceServingCA, needsNamespace, needsToken := e.secretUpdateNeeded(cachedSecret); !needsCA && !needsServiceServingCA && !needsToken && !needsNamespace {
 		return false, nil
 	}
 
@@ -485,8 +496,8 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *api.ServiceAcco
 		return false, nil
 	}
 
-	needsCA, needsNamespace, needsToken := e.secretUpdateNeeded(liveSecret)
-	if !needsCA && !needsToken && !needsNamespace {
+	needsCA, needsServiceServingCA, needsNamespace, needsToken := e.secretUpdateNeeded(liveSecret)
+	if !needsCA && !needsServiceServingCA && !needsToken && !needsNamespace {
 		return false, nil
 	}
 
@@ -500,6 +511,9 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *api.ServiceAcco
 	// Set the CA
 	if needsCA {
 		liveSecret.Data[api.ServiceAccountRootCAKey] = e.rootCA
+	}
+	if needsServiceServingCA {
+		liveSecret.Data[ServiceServingCASecretKey] = e.serviceServingCA
 	}
 	// Set the namespace
 	if needsNamespace {

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -178,7 +178,9 @@ os::cmd::expect_success_and_not_text 'oc status' 'pod\/test-deployment-config-1-
 
 # break mac os
 service_ip=$(oc get service/nginx -o=jsonpath={.spec.clusterIP})
-os::cmd::try_until_success "curl --cacert ${MASTER_CONFIG_DIR}/service-signer.crt --resolve nginx.service-serving-cert-generation.svc:443:${service_ip} https://nginx.service-serving-cert-generation.svc:443"
+os::cmd::try_until_success 'oc run --restart=Never --generator=run-pod/v1 --image=centos centos -- bash -c "curl --cacert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt https://nginx.service-serving-cert-generation.svc:443"'
+os::cmd::try_until_text 'oc get pods/centos -o jsonpath={.status.phase}' "Succeeded"
+os::cmd::expect_success_and_text 'oc logs pods/centos' "Welcome to nginx"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Adds the service serving cert signer ca to the SA token secret so it gets automounted into every pod.

Doing this in the upstream controller makes sure that new secrets always have this *before* the pod starts and old secrets also get updated.

I did create bundle of the rootCA and the serviceSignerCA to mount.  The rootCA key is more closely guarded and if you compromise that, you can change the CA cert in the mountpoint, so you're effectively trusting it anyway.  

Updated the existing extended test for proof.  I owe a conformance test, but those appear to busted in jenkins at the moment.

@liggitt @smarterclayton 

