### PR TITLE
chroot docker to the rootfs inside our node container

### DIFF
--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -8,7 +8,7 @@ PartOf=docker.service
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node
 ExecStartPre=-/usr/bin/docker rm -f origin-node
-ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /usr/bin/docker:/usr/bin/docker:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
+ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always

--- a/images/node/scripts/docker
+++ b/images/node/scripts/docker
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+chroot /rootfs docker "${@}"

--- a/images/node/scripts/docker
+++ b/images/node/scripts/docker
@@ -1,3 +1,18 @@
 #!/bin/sh
 
+# We need to ensure that the version of docker we're running inside the
+# container matches that of the host. A newer version of docker client against
+# and older daemon is known not to work and older versions of the client
+# against newer versions of the daemon aren't widely tested. So therefore we
+# rely on running docker from the host's filesystem which we expect to be
+# mounted at /rootfs. Docker on the host can be upgraded without a corresponding
+# update to the node image and that update may add dependencies like libseccomp
+# that aren't available inside our node image. By chroot'ing to /rootfs we can
+# ensure that as long as the host has a valid install things will work.
+
+# NOTE: This means that anything inside the node container needs to call
+# `docker` or `/usr/local/bin/docker`. We're not replacing /usr/bin/docker
+# because most installs currently mount /usr/bin/docker from the host into that
+# path.
+
 chroot /rootfs docker "${@}"


### PR DESCRIPTION
Currently we mount /usr/bin/docker:/usr/bin/docker into the node container. When /usr/bin/docker-current was added we had to account for that. Now in docker-1.10 libseccomp is a dependency and we'd have to start mounting that in. We already mount /:/rootfs so we should just execute docker chroot /rootfs so that we don't have to keep chasing these dependencies.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1340324

Downsides to this approach, we assume everyone will call `docker` not `/usr/bin/docker` -- the sdn calls `docker` and is the impetus for this change. Also, if the invocations were expecting access to a path that doesn't exist in the chroot it'll fail, I know of none of those.

@eparis @runcom 