### PR TITLE
[DO NOT MERGE] Updated spdysteream logger, forced flake in e2e

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/spdystream/utils.go
+++ b/Godeps/_workspace/src/github.com/docker/spdystream/utils.go
@@ -1,16 +1,12 @@
 package spdystream
 
 import (
-	"log"
-	"os"
+	"fmt"
+
+	"github.com/golang/glog"
 )
 
-var (
-	DEBUG = os.Getenv("DEBUG")
-)
-
-func debugMessage(fmt string, args ...interface{}) {
-	if DEBUG != "" {
-		log.Printf(fmt, args...)
-	}
+func debugMessage(fmtDirective string, args ...interface{}) {
+	fmt.Printf(fmtDirective+"\n", args...)
+	glog.V(1).Infof(fmtDirective+"\n", args...)
 }

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ endif
 # Example:
 #   make test
 test: check
-	$(MAKE) test-tools test-integration test-assets -o build
+	# $(MAKE) test-tools test-integration test-assets -o build
 	$(MAKE) test-end-to-end -o build
 .PHONY: test
 

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -86,7 +86,8 @@ echo "[INFO] Using images:							${USE_IMAGES}"
 echo "[INFO] Starting OpenShift containerized server"
 oc cluster up --server-loglevel=4 --version="${TAG}" \
         --host-data-dir="${VOLUME_DIR}/etcd" \
-        --host-volumes-dir="${VOLUME_DIR}"
+        --host-volumes-dir="${VOLUME_DIR}" \
+        --env 'DEBUG=true'
 
 IMAGE_WORKING_DIR=/var/lib/origin
 docker cp origin:${IMAGE_WORKING_DIR}/openshift.local.config ${BASETMPDIR}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -167,11 +167,17 @@ os::cmd::expect_success 'oc whoami'
 
 echo "[INFO] Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
-oc run cli-with-token --attach --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 > ${LOG_DIR}/cli-with-token.log 2>&1
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-os::cmd::expect_success 'oc delete pod cli-with-token'
-oc run cli-with-token-2 --attach --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=4 > ${LOG_DIR}/cli-with-token2.log 2>&1
+# oc run cli-with-token --attach --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 > ${LOG_DIR}/cli-with-token.log 2>&1
+# os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+# os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+# os::cmd::expect_success 'oc delete pod cli-with-token'
+i=1
+while true; do
+  echo "=============== ATTEMPT $i AT $(date) ===============" && (( i+=1 ))
+  DEBUG=1 oc run cli-with-token-2 --attach --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=1 2>&1 | tee ${LOG_DIR}/cli-with-token2.log
+  os::cmd::expect_success 'oc delete pod cli-with-token-2'
+  os::cmd::try_until_failure 'oc get pod cli-with-token-2'
+done
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
 os::cmd::expect_success 'oc delete pod cli-with-token-2'
 oc run kubectl-with-token --attach --image=openshift/origin:${TAG} --restart=Never --command -- kubectl get pods --loglevel=4 > ${LOG_DIR}/kubectl-with-token.log 2>&1


### PR DESCRIPTION
The spdystream logger was being clobbered by k8s custom
logging solutions, so in order to see the output we had
to simply put it into `fmt.Printf`.

In order to force the e2e `oc run --attach` flake to
manifest in every Jenkins test job, it is placed in a
while loop.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>