### PR TITLE
add impersonate-group

### DIFF
--- a/pkg/auth/api/types.go
+++ b/pkg/auth/api/types.go
@@ -15,6 +15,7 @@ const (
 	IdentityPreferredUsernameKey = "preferred_username"
 
 	ImpersonateUserHeader      = "Impersonate-User"
+	ImpersonateGroupHeader     = "Impersonate-Group"
 	ImpersonateUserScopeHeader = "Impersonate-User-Scope"
 )
 

--- a/pkg/cmd/server/origin/audit.go
+++ b/pkg/cmd/server/origin/audit.go
@@ -1,6 +1,7 @@
 package origin
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/golang/glog"
@@ -45,14 +46,27 @@ func (c *MasterConfig) auditHandler(handler http.Handler) http.Handler {
 		if len(asuser) == 0 {
 			asuser = "<self>"
 		}
+		requestedGroups := req.Header[authenticationapi.ImpersonateGroupHeader]
+		asgroups := "<lookup>"
+		if len(requestedGroups) == 0 {
+			asgroups = ""
+			first := true
+			for _, group := range requestedGroups {
+				if !first {
+					asgroups = asgroups + ","
+				}
+				asgroups = asgroups + fmt.Sprintf("%q", group)
+				first = false
+			}
+		}
 		namespace := kapi.NamespaceValue(ctx)
 		if len(namespace) == 0 {
 			namespace = "<none>"
 		}
 		id := uuid.NewRandom().String()
 
-		glog.Infof("AUDIT: id=%q ip=%q method=%q user=%q as=%q namespace=%q uri=%q",
-			id, net.GetClientIP(req), req.Method, user.GetName(), asuser, namespace, req.URL)
+		glog.Infof("AUDIT: id=%q ip=%q method=%q user=%q as=%q asgroups=%q namespace=%q uri=%q",
+			id, net.GetClientIP(req), req.Method, user.GetName(), asuser, asgroups, namespace, req.URL)
 		handler.ServeHTTP(&auditResponseWriter{w, id}, req)
 	})
 }


### PR DESCRIPTION
Adds the ability to specify groups on an impersonation request.  This allows clean impersonation on requests through a loopback to our API.  This is needed to enable the jenkins template to be created using user credentials in an admission plugin.

`Impersonate-Group`

@openshift/api-review 