### PR TITLE
create jenkins template from admission so we can use user powers

### DIFF
--- a/pkg/auth/client/impersonate.go
+++ b/pkg/auth/client/impersonate.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type impersonatingRoundTripper struct {
+	user     user.Info
+	delegate http.RoundTripper
+}
+
+// NewImpersonatingRoundTripper will add headers to impersonate a user, including user, groups, and scopes
+func NewImpersonatingRoundTripper(user user.Info, delegate http.RoundTripper) http.RoundTripper {
+	return &impersonatingRoundTripper{user, delegate}
+}
+
+func (rt *impersonatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = cloneRequest(req)
+	req.Header.Del(authenticationapi.ImpersonateUserHeader)
+	req.Header.Del(authenticationapi.ImpersonateGroupHeader)
+	req.Header.Del(authenticationapi.ImpersonateUserScopeHeader)
+
+	req.Header.Set(authenticationapi.ImpersonateUserHeader, rt.user.GetName())
+	for _, group := range rt.user.GetGroups() {
+		req.Header.Add(authenticationapi.ImpersonateGroupHeader, group)
+	}
+	for _, scope := range rt.user.GetExtra()[authorizationapi.ScopesKey] {
+		req.Header.Add(authenticationapi.ImpersonateUserScopeHeader, scope)
+	}
+	return rt.delegate.RoundTrip(req)
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	return r2
+}

--- a/pkg/build/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission.go
@@ -1,0 +1,156 @@
+package jenkinsbootstrapper
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	authenticationclient "github.com/openshift/origin/pkg/auth/client"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	jenkinscontroller "github.com/openshift/origin/pkg/build/controller/jenkins"
+	"github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/config/cmd"
+)
+
+func init() {
+	admission.RegisterPlugin("JenkinsBootstrapper", func(c clientset.Interface, config io.Reader) (admission.Interface, error) {
+		return NewJenkingsBootstrapper(c.Core()), nil
+	})
+}
+
+type jenkingsBootstrapper struct {
+	*admission.Handler
+
+	privilegedRESTClientConfig restclient.Config
+	serviceClient              coreclient.ServicesGetter
+	openshiftClient            client.Interface
+
+	jenkinsConfig configapi.JenkinsPipelineConfig
+}
+
+// NewJenkingsBootstrapper returns an admission plugin that will create required jenkins resources as the user if they are needed.
+func NewJenkingsBootstrapper(serviceClient coreclient.ServicesGetter) admission.Interface {
+	return &jenkingsBootstrapper{
+		Handler:       admission.NewHandler(admission.Create),
+		serviceClient: serviceClient,
+	}
+}
+
+func (a *jenkingsBootstrapper) Admit(attributes admission.Attributes) error {
+	if a.jenkinsConfig.Enabled != nil && !*a.jenkinsConfig.Enabled {
+		return nil
+	}
+	if len(attributes.GetSubresource()) != 0 {
+		return nil
+	}
+	if attributes.GetResource().GroupResource() != buildapi.Resource("buildconfigs") && attributes.GetResource().GroupResource() != buildapi.Resource("builds") {
+		return nil
+	}
+	if !needsJenkinsTemplate(attributes.GetObject()) {
+		return nil
+	}
+
+	namespace := attributes.GetNamespace()
+
+	svcName := a.jenkinsConfig.ServiceName
+	if len(svcName) == 0 {
+		return nil
+	}
+
+	// TODO pull this from a cache.
+	if _, err := a.serviceClient.Services(namespace).Get(svcName); !kapierrors.IsNotFound(err) {
+		// if it isn't a "not found" error, return the error.  Either its nil and there's nothing to do or something went really wrong
+		return err
+	}
+
+	glog.V(3).Infof("Adding new jenkins service %q to the project %q", svcName, namespace)
+	jenkinsTemplate := jenkinscontroller.NewPipelineTemplate(namespace, a.jenkinsConfig, a.openshiftClient)
+	objects, errs := jenkinsTemplate.Process()
+	if len(errs) > 0 {
+		return kutilerrors.NewAggregate(errs)
+	}
+	if !jenkinsTemplate.HasJenkinsService(objects) {
+		return fmt.Errorf("template %s/%s does not contain required service %q", a.jenkinsConfig.TemplateNamespace, a.jenkinsConfig.TemplateName, a.jenkinsConfig.ServiceName)
+	}
+
+	impersonatingConfig := a.privilegedRESTClientConfig
+	oldWrapTransport := impersonatingConfig.WrapTransport
+	impersonatingConfig.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		return authenticationclient.NewImpersonatingRoundTripper(attributes.GetUserInfo(), oldWrapTransport(rt))
+	}
+
+	var bulkErr error
+
+	bulk := &cmd.Bulk{
+		Mapper: &resource.Mapper{
+			RESTMapper:  registered.RESTMapper(),
+			ObjectTyper: kapi.Scheme,
+			ClientMapper: resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+				if latest.OriginKind(mapping.GroupVersionKind) {
+					return client.New(&impersonatingConfig)
+				}
+				return kclient.New(&impersonatingConfig)
+			}),
+		},
+		Op: cmd.Create,
+		After: func(info *resource.Info, err error) bool {
+			if kapierrors.IsAlreadyExists(err) {
+				return false
+			}
+			if err != nil {
+				bulkErr = err
+				return true
+			}
+			return false
+		},
+	}
+	// we're intercepting the error we care about using After
+	bulk.Run(objects, namespace)
+	if bulkErr != nil {
+		return bulkErr
+	}
+
+	glog.V(1).Infof("Jenkins Pipeline service %q created", svcName)
+
+	return nil
+
+}
+
+func needsJenkinsTemplate(obj runtime.Object) bool {
+	switch t := obj.(type) {
+	case *buildapi.Build:
+		return t.Spec.Strategy.JenkinsPipelineStrategy != nil
+	case *buildapi.BuildConfig:
+		return t.Spec.Strategy.JenkinsPipelineStrategy != nil
+	default:
+		return false
+	}
+}
+
+func (a *jenkingsBootstrapper) SetJenkinsPipelineConfig(jenkinsConfig configapi.JenkinsPipelineConfig) {
+	a.jenkinsConfig = jenkinsConfig
+}
+
+func (a *jenkingsBootstrapper) SetRESTClientConfig(restClientConfig restclient.Config) {
+	a.privilegedRESTClientConfig = restClientConfig
+}
+
+func (a *jenkingsBootstrapper) SetOpenshiftClient(oclient client.Interface) {
+	a.openshiftClient = oclient
+}

--- a/pkg/build/admission/jenkinsbootstrapper/admission_test.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission_test.go
@@ -1,0 +1,149 @@
+package jenkinsbootstrapper
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client/testclient"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func TestAdmission(t *testing.T) {
+	enableBuild := &buildapi.Build{Spec: buildapi.BuildSpec{CommonSpec: buildapi.CommonSpec{Strategy: buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}}}}
+	testCases := []struct {
+		name           string
+		objects        []runtime.Object
+		jenkinsEnabled *bool
+
+		attributes  admission.Attributes
+		expectedErr string
+
+		validateClients func(kubeClient *fake.Clientset, originClient *testclient.Fake) string
+	}{
+		{
+			name:            "disabled",
+			attributes:      admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			jenkinsEnabled:  boolptr(false),
+			validateClients: noAction,
+		},
+		{
+			name:            "not a jenkins build",
+			attributes:      admission.NewAttributesRecord(&buildapi.Build{Spec: buildapi.BuildSpec{CommonSpec: buildapi.CommonSpec{Strategy: buildapi.BuildStrategy{}}}}, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			validateClients: noAction,
+		},
+		{
+			name:            "not a build kind",
+			attributes:      admission.NewAttributesRecord(&kapi.Service{}, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			validateClients: noAction,
+		},
+		{
+			name:            "not a build resource",
+			attributes:      admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("notbuilds"), "", admission.Create, &user.DefaultInfo{}),
+			validateClients: noAction,
+		},
+		{
+			name:            "subresource",
+			attributes:      admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "subresource", admission.Create, &user.DefaultInfo{}),
+			validateClients: noAction,
+		},
+		{
+			name:       "service present",
+			attributes: admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			objects: []runtime.Object{
+				&kapi.Service{ObjectMeta: kapi.ObjectMeta{Namespace: "namespace", Name: "jenkins"}},
+			},
+			validateClients: func(kubeClient *fake.Clientset, originClient *testclient.Fake) string {
+				if len(kubeClient.Actions()) == 1 && kubeClient.Actions()[0].Matches("get", "services") {
+					return ""
+				}
+				return fmt.Sprintf("missing get service in: %v", kubeClient.Actions())
+			},
+		},
+		{
+			name:       "works on true",
+			attributes: admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			objects: []runtime.Object{
+				&kapi.Service{ObjectMeta: kapi.ObjectMeta{Namespace: "namespace", Name: "jenkins"}},
+			},
+			jenkinsEnabled: boolptr(true),
+			validateClients: func(kubeClient *fake.Clientset, originClient *testclient.Fake) string {
+				if len(kubeClient.Actions()) == 1 && kubeClient.Actions()[0].Matches("get", "services") {
+					return ""
+				}
+				return fmt.Sprintf("missing get service in: %v", kubeClient.Actions())
+			},
+		},
+		{
+			name:       "service missing",
+			attributes: admission.NewAttributesRecord(enableBuild, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			objects:    []runtime.Object{},
+			validateClients: func(kubeClient *fake.Clientset, originClient *testclient.Fake) string {
+				if len(kubeClient.Actions()) == 0 {
+					return fmt.Sprintf("missing get service in: %v", kubeClient.Actions())
+				}
+				if !kubeClient.Actions()[0].Matches("get", "services") {
+					return fmt.Sprintf("missing get service in: %v", kubeClient.Actions())
+				}
+				if len(originClient.Actions()) == 0 {
+					return fmt.Sprintf("missing get template in: %v", originClient.Actions())
+				}
+				if !originClient.Actions()[0].Matches("get", "templates") {
+					return fmt.Sprintf("missing get template in: %v", originClient.Actions())
+				}
+				return ""
+			},
+			expectedErr: "Jenkins pipeline template / not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		kubeClient := fake.NewSimpleClientset(tc.objects...)
+		originClient := testclient.NewSimpleFake(tc.objects...)
+
+		admission := NewJenkingsBootstrapper(kubeClient.Core()).(*jenkingsBootstrapper)
+		admission.openshiftClient = originClient
+		admission.jenkinsConfig = configapi.JenkinsPipelineConfig{
+			Enabled:     tc.jenkinsEnabled,
+			ServiceName: "jenkins",
+		}
+
+		err := admission.Admit(tc.attributes)
+		switch {
+		case len(tc.expectedErr) == 0 && err == nil:
+		case len(tc.expectedErr) == 0 && err != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		case len(tc.expectedErr) != 0 && err == nil:
+			t.Errorf("%s: missing error: %v", tc.name, tc.expectedErr)
+		case len(tc.expectedErr) != 0 && err != nil && !strings.Contains(err.Error(), tc.expectedErr):
+			t.Errorf("%s: missing error: expected %v, got %v", tc.name, tc.expectedErr, err)
+		}
+
+		if tc.validateClients != nil {
+			if err := tc.validateClients(kubeClient, originClient); len(err) != 0 {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			}
+		}
+	}
+}
+func noAction(kubeClient *fake.Clientset, originClient *testclient.Fake) string {
+	if len(kubeClient.Actions()) != 0 {
+		return fmt.Sprintf("unexpected actions: %v", kubeClient.Actions())
+	}
+	if len(originClient.Actions()) != 0 {
+		return fmt.Sprintf("unexpected actions: %v", originClient.Actions())
+	}
+	return ""
+}
+
+func boolptr(in bool) *bool {
+	return &in
+}

--- a/pkg/build/controller/config_controller.go
+++ b/pkg/build/controller/config_controller.go
@@ -7,16 +7,11 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/record"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildclient "github.com/openshift/origin/pkg/build/client"
-	"github.com/openshift/origin/pkg/build/controller/jenkins"
 	buildgenerator "github.com/openshift/origin/pkg/build/generator"
-	"github.com/openshift/origin/pkg/client"
-	osclient "github.com/openshift/origin/pkg/client"
-	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
 // ConfigControllerFatalError represents a fatal error while generating a build.
@@ -40,64 +35,12 @@ func IsFatal(err error) bool {
 type BuildConfigController struct {
 	BuildConfigInstantiator buildclient.BuildConfigInstantiator
 
-	KubeClient kclient.Interface
-	Client     osclient.Interface
-
-	JenkinsConfig serverapi.JenkinsPipelineConfig
-
 	// recorder is used to record events.
 	Recorder record.EventRecorder
 }
 
 func (c *BuildConfigController) HandleBuildConfig(bc *buildapi.BuildConfig) error {
 	glog.V(4).Infof("Handling BuildConfig %s/%s", bc.Namespace, bc.Name)
-
-	if strategy := bc.Spec.Strategy.JenkinsPipelineStrategy; strategy != nil {
-		svcName := c.JenkinsConfig.ServiceName
-		if len(svcName) == 0 {
-			return fmt.Errorf("the Jenkins Pipeline ServiceName must be set in master configuration")
-		}
-
-		glog.V(4).Infof("Detected Jenkins pipeline strategy in %s/%s build configuration", bc.Namespace, bc.Name)
-		if _, err := c.KubeClient.Services(bc.Namespace).Get(svcName); err == nil {
-			glog.V(4).Infof("The Jenkins Pipeline service %q already exists in project %q", svcName, bc.Namespace)
-			return nil
-		}
-
-		if b := c.JenkinsConfig.Enabled; b == nil || !*b {
-			glog.V(4).Infof("Provisioning Jenkins Pipeline from a template is disabled in master configuration")
-			return nil
-		}
-
-		glog.V(3).Infof("Adding new Jenkins service %q to the project %q", svcName, bc.Namespace)
-		kc, ok := c.KubeClient.(*kclient.Client)
-		if !ok {
-			return fmt.Errorf("unable to get kubernetes client from %v", c.KubeClient)
-		}
-		oc, ok := c.Client.(*client.Client)
-		if !ok {
-			return fmt.Errorf("unable to get openshift client from %v", c.KubeClient)
-		}
-
-		jenkinsTemplate := jenkins.NewPipelineTemplate(bc.Namespace, c.JenkinsConfig, kc, oc)
-		objects, errs := jenkinsTemplate.Process()
-		if len(errs) > 0 {
-			for _, err := range errs {
-				c.Recorder.Eventf(bc, kapi.EventTypeWarning, "Failed", "Processing %s/%s error: %v", c.JenkinsConfig.TemplateNamespace, c.JenkinsConfig.TemplateName, err)
-			}
-			return fmt.Errorf("processing Jenkins pipeline template failed")
-		}
-
-		if errs := jenkinsTemplate.Instantiate(objects); len(errs) > 0 {
-			for _, err := range errs {
-				c.Recorder.Eventf(bc, kapi.EventTypeWarning, "Failed", "Instantiating %s/%s error: %v", c.JenkinsConfig.TemplateNamespace, c.JenkinsConfig.TemplateName, err)
-			}
-			return fmt.Errorf("instantiating Jenkins pipeline template failed")
-		}
-
-		c.Recorder.Eventf(bc, kapi.EventTypeNormal, "Started", "Jenkins Pipeline service %q created", svcName)
-		return nil
-	}
 
 	hasChangeTrigger := false
 	for _, trigger := range bc.Spec.Triggers {

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -25,7 +25,6 @@ import (
 	strategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	osclient "github.com/openshift/origin/pkg/client"
-	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
 	controller "github.com/openshift/origin/pkg/controller"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	errors "github.com/openshift/origin/pkg/util/errors"
@@ -314,7 +313,6 @@ type BuildConfigControllerFactory struct {
 	Client                  osclient.Interface
 	KubeClient              kclient.Interface
 	BuildConfigInstantiator buildclient.BuildConfigInstantiator
-	JenkinsConfig           serverapi.JenkinsPipelineConfig
 	// Stop may be set to allow controllers created by this factory to be terminated.
 	Stop <-chan struct{}
 }
@@ -329,9 +327,6 @@ func (factory *BuildConfigControllerFactory) Create() controller.RunnableControl
 
 	bcController := &buildcontroller.BuildConfigController{
 		BuildConfigInstantiator: factory.BuildConfigInstantiator,
-		KubeClient:              factory.KubeClient,
-		Client:                  factory.Client,
-		JenkinsConfig:           factory.JenkinsConfig,
 		Recorder:                eventBroadcaster.NewRecorder(kapi.EventSource{Component: "build-config-controller"}),
 	}
 

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -2,18 +2,22 @@ package admission
 
 import (
 	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/quota"
 
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/project/cache"
 )
 
 type PluginInitializer struct {
-	OpenshiftClient     client.Interface
-	ProjectCache        *cache.ProjectCache
-	OriginQuotaRegistry quota.Registry
-	Authorizer          authorizer.Authorizer
+	OpenshiftClient       client.Interface
+	ProjectCache          *cache.ProjectCache
+	OriginQuotaRegistry   quota.Registry
+	Authorizer            authorizer.Authorizer
+	JenkinsPipelineConfig configapi.JenkinsPipelineConfig
+	RESTClientConfig      restclient.Config
 }
 
 // Initialize will check the initialization interfaces implemented by each plugin
@@ -31,6 +35,12 @@ func (i *PluginInitializer) Initialize(plugins []admission.Interface) {
 		}
 		if wantsAuthorizer, ok := plugin.(WantsAuthorizer); ok {
 			wantsAuthorizer.SetAuthorizer(i.Authorizer)
+		}
+		if wantsJenkinsPipelineConfig, ok := plugin.(WantsJenkinsPipelineConfig); ok {
+			wantsJenkinsPipelineConfig.SetJenkinsPipelineConfig(i.JenkinsPipelineConfig)
+		}
+		if wantsRESTClientConfig, ok := plugin.(WantsRESTClientConfig); ok {
+			wantsRESTClientConfig.SetRESTClientConfig(i.RESTClientConfig)
 		}
 	}
 }

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -1,10 +1,12 @@
 package admission
 
 import (
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/quota"
 
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/project/cache"
 )
 
@@ -35,4 +37,15 @@ type Validator interface {
 // need access to the Authorizer interface
 type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
+}
+
+// WantsJenkinsPipelineConfig gives access to the JenkinsPipelineConfig.  This is a historical oddity.
+// It's likely that what we really wanted was this as an admission plugin config
+type WantsJenkinsPipelineConfig interface {
+	SetJenkinsPipelineConfig(jenkinsConfig configapi.JenkinsPipelineConfig)
+}
+
+// WantsRESTClientConfig gives access to a RESTClientConfig.  It's useful for doing unusual things with transports.
+type WantsRESTClientConfig interface {
+	SetRESTClientConfig(restclient.Config)
 }

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -191,7 +191,15 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{"ProjectRequestLimit", "OriginNamespaceLifecycle", "PodNodeConstraints", "BuildByStrategy", imageadmission.PluginName, quotaadmission.PluginName}
+	admissionControlPluginNames := []string{
+		"ProjectRequestLimit",
+		"OriginNamespaceLifecycle",
+		"PodNodeConstraints",
+		"JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		quotaadmission.PluginName,
+	}
 	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
 		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
 	}
@@ -206,10 +214,12 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	authorizer := newAuthorizer(ruleResolver, policyClient, options.ProjectConfig.ProjectRequestMessage)
 
 	pluginInitializer := oadmission.PluginInitializer{
-		OpenshiftClient:     privilegedLoopbackOpenShiftClient,
-		ProjectCache:        projectCache,
-		OriginQuotaRegistry: quotaRegistry,
-		Authorizer:          authorizer,
+		OpenshiftClient:       privilegedLoopbackOpenShiftClient,
+		ProjectCache:          projectCache,
+		OriginQuotaRegistry:   quotaRegistry,
+		Authorizer:            authorizer,
+		JenkinsPipelineConfig: options.JenkinsPipelineConfig,
+		RESTClientConfig:      *privilegedLoopbackClientConfig,
 	}
 
 	plugins := []admission.Interface{}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -296,7 +296,6 @@ func (c *MasterConfig) RunBuildConfigChangeController() {
 		Client:                  bcClient,
 		KubeClient:              kClient,
 		BuildConfigInstantiator: bcInstantiator,
-		JenkinsConfig:           c.Options.JenkinsPipelineConfig,
 	}
 	factory.Create().Run()
 }

--- a/pkg/cmd/server/start/admission.go
+++ b/pkg/cmd/server/start/admission.go
@@ -8,6 +8,7 @@ import (
 
 	// Admission control plug-ins used by OpenShift
 	_ "github.com/openshift/origin/pkg/build/admission/defaults"
+	_ "github.com/openshift/origin/pkg/build/admission/jenkinsbootstrapper"
 	_ "github.com/openshift/origin/pkg/build/admission/overrides"
 	_ "github.com/openshift/origin/pkg/build/admission/strategyrestrictions"
 	_ "github.com/openshift/origin/pkg/image/admission"

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -28,6 +28,7 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"BuildDefaults",            // from origin, only needed for managing builds, not kubernetes resources
 	"BuildOverrides",           // from origin, only needed for managing builds, not kubernetes resources
 	imageadmission.PluginName,  // from origin, used for limiting image sizes, not kubernetes resources
+	"JenkinsBootstrapper",      // from origin, only needed for managing builds, not kubernetes resources
 	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube
 	"ProjectRequestLimit",      // from origin, used for limiting project requests by user (online use case)
 	"RunOnceDuration",          // from origin, used for overriding the ActiveDeadlineSeconds for run-once pods

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -197,6 +197,18 @@ func setupBuildStrategyTest(t *testing.T, includeControllers bool) (clusterAdmin
 		t.Fatalf("Couldn't create ImageStreamMapping: %v", err)
 	}
 
+	template, err := testutil.GetTemplateFixture("../../examples/jenkins/jenkins-ephemeral-template.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	template.Name = "jenkins"
+	template.Namespace = "openshift"
+
+	_, err = clusterAdminClient.Templates("openshift").Create(template)
+	if err != nil {
+		t.Fatalf("Couldn't create jenkins template: %v", err)
+	}
+
 	return
 }
 


### PR DESCRIPTION
Still needs unit tests.

@smarterclayton per our conversation, this remove the build controller user escalation and replaces it with an admission plugin that intercepts an attempt to create a jenkins build or buildconfig and instantiates the template.

Problems found while doing this:
 - [x] templates create the service first, preventing retry
 - [x] template continued after failures making retries impossible if the service was eventually created.
 - [ ] master-config fails by default because a template isn't present.

@bparees are you the reviewer?