### PR TITLE
let builders create new imagestreams for pushes

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -372,6 +372,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				// push and pull images
 				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
+				// allow auto-provisioning when pushing an image that doesn't have an imagestream yet
+				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreams").RuleOrDie(),
 				authorizationapi.NewRule("update").Groups(buildGroup).Resources("builds/details").RuleOrDie(),
 			},
 		},

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -338,6 +338,8 @@ os::cmd::try_until_text 'oc get events -n node-selector' 'pod-with-node-name.+No
 
 # Image pruning
 echo "[INFO] Validating image pruning"
+# builder service account should have the power to create new image streams: prune in this case
+os::cmd::expect_success "docker login -u e2e-user -p $(oc sa get-token builder -n cache) -e builder@openshift.com ${DOCKER_REGISTRY}"
 os::cmd::expect_success 'docker pull busybox'
 os::cmd::expect_success 'docker pull gcr.io/google_containers/pause'
 os::cmd::expect_success 'docker pull openshift/hello-openshift'

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1225,6 +1225,13 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - imagestreams
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - builds/details
     verbs:
     - update


### PR DESCRIPTION
Reminder to myself to add a test and make sure it works:

```
1. Login OpenShift and create a project;
 
2. Use the use token to docker login the docker-registry:
 
  docker login -u service-account-creds -p `oc whoami -t` -e any@example.com <integrated registry>
 
3. Pull Image and tag the image from ;
 
  docker pull busybox;
 
    docker tag busybox   <integrated registry>/projectname/imagestreamname:tag
 
4. Push the image to the OpenShift registry:
 
docker push <integrated registry>/projectname/imagestreamname:tag
 
 5. Pull the image in the OpenShift registry again:
 
  docker pull <integrated registry>/projectname/imagestreamname:tag
```

@pruan-rht I think its you.