### PR TITLE
Fix _atomic-registry_ example install step

### DIFF
--- a/examples/atomic-registry/Makefile
+++ b/examples/atomic-registry/Makefile
@@ -4,7 +4,7 @@ INSTALLHOST=127.0.0.1
 all: build install test
 
 build:
-	docker build -t atomic-registry-quickstart .
+	sudo docker build -t atomic-registry-quickstart .
 
 install:
 	sudo yum install -y atomic
@@ -13,7 +13,7 @@ install:
 	sudo atomic run $(TEST_IMAGE) $(INSTALLHOST)
 
 test:
-	bash test.sh 127.0.0.1
+	bash test.sh $INSTALLHOST
 
 clean:
 	sudo atomic uninstall --force $(TEST_IMAGE)


### PR DESCRIPTION
These changes are for the _atomic-registry_ example project:
- Added missing trailing "\" at the end of the lines.
- Use variable instead of 127.0.0.1 in make file.
- test.sh script should use the given parameter instead of hostname.
- Added _sudo_ to the build step.

Missing trailing "\" results in following error by `make install`:
```
...
Installing using hostname 127.0.0.1
Wrote master config to: /etc/origin/master/master-config.yaml
/container/bin/install.sh: line 16: --volume-dir: command not found
/container/bin/install.sh: line 17: --public-master: command not found
/container/bin/install.sh: line 18: --hostname: command not found
...
```