### PR TITLE
return error on args passed to no-args oc cmd

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -308,6 +308,9 @@ os::cmd::expect_success_and_text 'oc whoami -t' '.'
 os::cmd::expect_success_and_text 'oc whoami -c' '.'
 os::cmd::expect_failure_and_text 'oc whoami -c -t test_arg' 'no arguments'
 
+# test status cmd with no arguments
+os::cmd::expect_failure_and_text "oc status test_arg" "no arguments"
+
 # test config files from the --config flag
 os::cmd::expect_success "oc get services --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'"
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -269,6 +269,8 @@ os::cmd::expect_failure_and_text "oc login https://server1 https://server2.com" 
 os::cmd::expect_success "oc login ${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything --api-version=v1"
 os::cmd::expect_success_and_text "cat ${HOME}/.kube/config" "v1"
 os::cmd::expect_success 'oc logout'
+# fails after receiving extraneous arguments with logout cmd
+os::cmd::expect_failure_and_text "oc logout test_arg" "no arguments"
 # logs in skipping certificate check
 os::cmd::expect_success "oc login ${KUBERNETES_MASTER} --insecure-skip-tls-verify -u test-user -p anything"
 # logs in by an existing and valid token

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -304,6 +304,7 @@ os::cmd::expect_success_and_text 'oc whoami' 'test-user'
 os::cmd::expect_success_and_text "oc whoami --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'system:admin'
 os::cmd::expect_success_and_text 'oc whoami -t' '.'
 os::cmd::expect_success_and_text 'oc whoami -c' '.'
+os::cmd::expect_failure_and_text 'oc whoami -c -t test_arg' 'no arguments'
 
 # test config files from the --config flag
 os::cmd::expect_success "oc get services --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'"

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -95,7 +95,7 @@ func (o *LogoutOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, arg
 
 func (o LogoutOptions) Validate(args []string) error {
 	if len(args) > 0 {
-		return errors.New("No arguments are allowed")
+		return fmt.Errorf("no arguments should be provided")
 	}
 
 	if o.StartingKubeConfig == nil {

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -87,7 +87,7 @@ func NewCmdStatus(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 // Complete completes the options for the Openshift cli status command.
 func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
-		return kcmdutil.UsageError(cmd, "no arguments should be provided")
+		return fmt.Errorf("no arguments should be provided")
 	}
 
 	o.logsCommandName = fmt.Sprintf("%s logs", cmd.Parent().CommandPath())

--- a/pkg/cmd/cli/cmd/whoami.go
+++ b/pkg/cmd/cli/cmd/whoami.go
@@ -59,7 +59,7 @@ func (o WhoAmIOptions) WhoAmI() (*userapi.User, error) {
 
 func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string, o *WhoAmIOptions) error {
 	if len(args) > 0 {
-		return kcmdutil.UsageError(cmd, "%s", "no arguments should be provided")
+		return fmt.Errorf("no arguments should be provided")
 	}
 	if kcmdutil.GetFlagBool(cmd, "token") {
 		cfg, err := f.OpenShiftClientConfig.ClientConfig()

--- a/pkg/cmd/cli/cmd/whoami.go
+++ b/pkg/cmd/cli/cmd/whoami.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	// "errors"
 	"fmt"
 	"io"
 

--- a/pkg/cmd/cli/cmd/whoami.go
+++ b/pkg/cmd/cli/cmd/whoami.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	// "errors"
 	"fmt"
 	"io"
 
@@ -57,6 +58,9 @@ func (o WhoAmIOptions) WhoAmI() (*userapi.User, error) {
 }
 
 func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string, o *WhoAmIOptions) error {
+	if len(args) > 0 {
+		return kcmdutil.UsageError(cmd, "%s", "no arguments should be provided")
+	}
 	if kcmdutil.GetFlagBool(cmd, "token") {
 		cfg, err := f.OpenShiftClientConfig.ClientConfig()
 		if err != nil {


### PR DESCRIPTION
Returns 
```
error: no arguments should be provided
See 'oc whoami -h' for help and examples.
```

when the `oc whoami` command is run with arguments.

All commands have been checked to make sure they return an error if args are passed when they don't take any. All `origin` commands are fine. There are a few others that do not fail, but are part of the k8s dep

fixes #4021 