### PR TITLE
ab testing

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -206,18 +206,19 @@ backend openshift_default
             where to send the traffic but should run the be in tcp mode
         3. if the config is terminated at the
 */}}
-{{ range $id, $serviceUnit := .State }}
-        {{ range $cfgIdx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-            {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
-                {{ if (eq $cfg.TLSTermination "") }}
+{{ range $cfgIdx, $cfg := .State }}
+  {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
+    {{ if (eq $cfg.TLSTermination "") }}
+# Plain http backend
 backend be_http_{{$cfgIdx}}
-                {{ else }}
+    {{ else }}
+# Plain http backend but request is TLS, terminated at edge
 backend be_edge_http_{{$cfgIdx}}
-                {{ end }}
+    {{ end }}
   mode http
   option redispatch
   option forwardfor
-  balance leastconn
+  balance roundrobin
   timeout check 5000ms
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
@@ -226,15 +227,28 @@ backend be_edge_http_{{$cfgIdx}}
   {{ if (eq $cfg.TLSTermination "") }}
     cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
   {{ else }}
-    cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
+  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
   {{ end }}
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
-                {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash}}
-                {{ end }}
+    {{ range $svcUnitIdx, $serviceUnitName := $cfg.ServiceUnitNames }}
+      {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+          {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+            {{ with $weight := index $cfg.Annotations (print "weight." $serviceUnitName) }}
+	      {{ with $matchValue := (matchString "^[0-9]+$" $weight) }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash}} weight {{ $weight }}
+              {{ else }}
+                ## matchstring returned {{ $matchValue }}: weight for {{ $serviceUnitName }}is not a number?
+	      {{ end }}
+	    {{ else }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash }}
             {{ end }}
+          {{ end }}
+      {{ end }}
+    {{ end }}{{/* end iterate over services */}}
+  {{ end }}{{/* end if tls==edge/none */}}
 
-            {{ if eq $cfg.TLSTermination "passthrough" }}
+# Secure backend, pass through
+  {{ if eq $cfg.TLSTermination "passthrough" }}
 backend be_tcp_{{$cfgIdx}}
 {{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
   option tcplog
@@ -242,25 +256,32 @@ backend be_tcp_{{$cfgIdx}}
   balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source" }}
   hash-type consistent
   timeout check 5000ms
-                {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+    {{ range $svcUnitIdx, $serviceUnitName := $cfg.ServiceUnitNames }}
+      {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+        {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms
-                {{ end }}
-            {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}{{/* end iterate over services*/}}
+  {{ end }}{{/*end tls==passthrough*/}}
 
-            {{ if eq $cfg.TLSTermination "reencrypt" }}
+# Secure backend which requires re-encryption
+  {{ if eq $cfg.TLSTermination "reencrypt" }}
 backend be_secure_{{$cfgIdx}}
   mode http
   option redispatch
   balance leastconn
   timeout check 5000ms
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
-                {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+    {{ range $svcUnitIdx, $serviceUnitName := $cfg.ServiceUnitNames }}
+      {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+        {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}}
-                {{ end }}
-            {{ end  }}
-        {{ end  }}{{/* $serviceUnit.ServiceAliasConfigs*/}}
-{{ end }}{{/* $serviceUnit */}}
-
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}{{/* end tls==reencrypt */}}
+{{ end }}{{/* end loop over routes */}}
 {{ end }}{{/* end haproxy config template */}}
 
 {{/*--------------------------------- END OF HAPROXY CONFIG, BELOW ARE MAPPING FILES ------------------------*/}}
@@ -269,13 +290,11 @@ backend be_secure_{{$cfgIdx}}
                         by attaching a prefix (be_http_) by use_backend statements if acls are matched.
 */}}
 {{ define "/var/lib/haproxy/conf/os_http_be.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "")}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end http host map template */}}
 
 {{/*
@@ -283,13 +302,11 @@ backend be_secure_{{$cfgIdx}}
                             a tls only route on the unsecure port
 */}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_be.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "edge")}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end edge http host map template */}}
 
 {{/*
@@ -298,13 +315,11 @@ backend be_secure_{{$cfgIdx}}
     (http) if acls match for routes with insecure option set to expose.
 */}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_expose.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "Allow"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end edge insecure expose http host map template */}}
 
 {{/*
@@ -313,13 +328,11 @@ backend be_secure_{{$cfgIdx}}
     if acls match for routes that have the insecure option set to redirect.
 */}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_redirect.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "Redirect"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end edge insecure redirect http host map template */}}
 
 
@@ -328,13 +341,11 @@ backend be_secure_{{$cfgIdx}}
                         by attaching a prefix (be_tcp_ or be_secure_) by use_backend statements if acls are matched.
 */}}
 {{ define "/var/lib/haproxy/conf/os_tcp_be.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (eq $cfg.Path "") (and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "passthrough") (eq $cfg.TLSTermination "reencrypt"))) }}
 {{$cfg.Host}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end tcp host map template */}}
 
 {{/*
@@ -342,13 +353,11 @@ backend be_secure_{{$cfgIdx}}
     					through to the host_be.  Driven by the termination type of the ServiceAliasConfigs
 */}}
 {{ define "/var/lib/haproxy/conf/os_sni_passthrough.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "passthrough") }}
 {{$cfg.Host}} 1
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end sni passthrough map template */}}
 
 
@@ -357,11 +366,9 @@ backend be_secure_{{$cfgIdx}}
                     that does specific checks that avoid mitm attacks: http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-ssl
 */}}
 {{ define "/var/lib/haproxy/conf/os_reencrypt.map" }}
-{{   range $id, $serviceUnit := .State }}
-{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{     range $idx, $cfg := .State }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "reencrypt") }}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
-{{   end }}
 {{ end }}{{/* end reencrypt passthrough map template */}}

--- a/pkg/route/allocation/simple/plugin.go
+++ b/pkg/route/allocation/simple/plugin.go
@@ -38,7 +38,7 @@ func NewSimpleAllocationPlugin(suffix string) (*SimpleAllocationPlugin, error) {
 // the "global" router shard.
 // TODO: replace with per router allocation
 func (p *SimpleAllocationPlugin) Allocate(route *routeapi.Route) (*routeapi.RouterShard, error) {
-	glog.V(4).Infof("Allocating global shard *.%s to Route: %s", p.DNSSuffix, route.Spec.To.Name)
+	glog.V(4).Infof("Allocating global shard *.%s to Route: %s", p.DNSSuffix, route.Name)
 
 	return &routeapi.RouterShard{ShardName: "global", DNSSuffix: p.DNSSuffix}, nil
 }

--- a/pkg/route/api/deep_copy_generated.go
+++ b/pkg/route/api/deep_copy_generated.go
@@ -112,6 +112,17 @@ func DeepCopy_api_RouteSpec(in RouteSpec, out *RouteSpec, c *conversion.Cloner) 
 	if err := api.DeepCopy_api_ObjectReference(in.To, &out.To, c); err != nil {
 		return err
 	}
+	if in.AdditionalTos != nil {
+		in, out := in.AdditionalTos, &out.AdditionalTos
+		*out = make([]api.ObjectReference, len(in))
+		for i := range in {
+			if err := api.DeepCopy_api_ObjectReference(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalTos = nil
+	}
 	if in.Port != nil {
 		in, out := in.Port, &out.Port
 		*out = new(RoutePort)

--- a/pkg/route/api/defaults.go
+++ b/pkg/route/api/defaults.go
@@ -1,0 +1,20 @@
+
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/runtime"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func addDefaultingFuncs(scheme *runtime.Scheme) {
+	err := scheme.AddDefaultingFuncs(
+		func(obj *RouteSpec) {
+			if obj.AdditionalTos == nil {
+				obj.AdditionalTos = make([]kapi.ObjectReference, 0)
+			}
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/route/api/register.go
+++ b/pkg/route/api/register.go
@@ -23,6 +23,7 @@ func Resource(resource string) unversioned.GroupResource {
 func AddToScheme(scheme *runtime.Scheme) {
 	// Add the API to Scheme.
 	addKnownTypes(scheme)
+	addDefaultingFuncs(scheme)
 }
 
 // Adds the list of known types to api.Scheme.

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -25,9 +25,11 @@ type RouteSpec struct {
 	// Path that the router watches for, to route traffic for to the service. Optional
 	Path string
 
-	// An object the route points to. Only the Service kind is allowed, and it will
+	// Objects that the route points to. Only the Service kind is allowed, and it will
 	// be defaulted to Service.
 	To kapi.ObjectReference
+
+	AdditionalTos []kapi.ObjectReference
 
 	// If specified, the port to be used by the router. Most routers will use all
 	// endpoints exposed by the service by default - set this value to instruct routers

--- a/pkg/route/api/v1/conversion.go
+++ b/pkg/route/api/v1/conversion.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 
 	oapi "github.com/openshift/origin/pkg/api"
+	kapi "k8s.io/kubernetes/pkg/api/v1"
 	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
@@ -12,6 +13,9 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		func(obj *RouteSpec) {
 			if len(obj.To.Kind) == 0 {
 				obj.To.Kind = "Service"
+			}
+			if obj.AdditionalTos == nil {
+				obj.AdditionalTos = make([]kapi.ObjectReference, 0)
 			}
 		},
 		func(obj *TLSConfig) {

--- a/pkg/route/api/v1/conversion_generated.go
+++ b/pkg/route/api/v1/conversion_generated.go
@@ -277,6 +277,18 @@ func autoConvert_v1_RouteSpec_To_api_RouteSpec(in *RouteSpec, out *route_api.Rou
 	if err := s.Convert(&in.To, &out.To, 0); err != nil {
 		return err
 	}
+	if in.AdditionalTos != nil {
+		in, out := &in.AdditionalTos, &out.AdditionalTos
+		*out = make([]api.ObjectReference, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalTos = nil
+	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(route_api.RoutePort)
@@ -311,6 +323,18 @@ func autoConvert_api_RouteSpec_To_v1_RouteSpec(in *route_api.RouteSpec, out *Rou
 	// TODO: Inefficient conversion - can we improve it?
 	if err := s.Convert(&in.To, &out.To, 0); err != nil {
 		return err
+	}
+	if in.AdditionalTos != nil {
+		in, out := &in.AdditionalTos, &out.AdditionalTos
+		*out = make([]api_v1.ObjectReference, len(*in))
+		for i := range *in {
+			// TODO: Inefficient conversion - can we improve it?
+			if err := s.Convert(&(*in)[i], &(*out)[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalTos = nil
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port

--- a/pkg/route/api/v1/deep_copy_generated.go
+++ b/pkg/route/api/v1/deep_copy_generated.go
@@ -113,6 +113,17 @@ func DeepCopy_v1_RouteSpec(in RouteSpec, out *RouteSpec, c *conversion.Cloner) e
 	if err := api_v1.DeepCopy_v1_ObjectReference(in.To, &out.To, c); err != nil {
 		return err
 	}
+	if in.AdditionalTos != nil {
+		in, out := in.AdditionalTos, &out.AdditionalTos
+		*out = make([]api_v1.ObjectReference, len(in))
+		for i := range in {
+			if err := api_v1.DeepCopy_v1_ObjectReference(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.AdditionalTos = nil
+	}
 	if in.Port != nil {
 		in, out := in.Port, &out.Port
 		*out = new(RoutePort)

--- a/pkg/route/api/v1/types.go
+++ b/pkg/route/api/v1/types.go
@@ -43,6 +43,10 @@ type RouteSpec struct {
 	// be defaulted to Service.
 	To kapi.ObjectReference `json:"to"`
 
+	// AdditionalTos is an extension of the 'to' field. If more than one service needs to be
+	// pointed to, then use this field
+	AdditionalTos []kapi.ObjectReference `json:"additionalTos,omitempty"`
+
 	// If specified, the port to be used by the router. Most routers will use all
 	// endpoints exposed by the service by default - set this value to instruct routers
 	// which port to use.

--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -47,6 +47,18 @@ func ValidateRoute(route *routeapi.Route) field.ErrorList {
 		result = append(result, field.Invalid(specPath.Child("to", "kind"), route.Spec.To.Kind, "must reference a Service"))
 	}
 
+	if len(route.Spec.AdditionalTos) > 3 {
+		result = append(result, field.Required(specPath.Child("to"), "cannot specify more than 3 additional services"))
+	}
+	for _, svc := range route.Spec.AdditionalTos {
+		if len(svc.Name) == 0 {
+			result = append(result, field.Required(specPath.Child("to", "name"), ""))
+		}
+		if svc.Kind != "Service" {
+			result = append(result, field.Invalid(specPath.Child("to", "kind"), svc.Kind, "must reference a Service"))
+		}
+	}
+
 	if route.Spec.Port != nil {
 		switch target := route.Spec.Port.TargetPort; {
 		case target.Type == intstr.Int && target.IntVal == 0,

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -112,6 +112,14 @@ bGvtpjWA4r9WASIDPFsxk/cDEEEO6iPxgMOf5MdpQC2y2MU0rzF/Gg==
 	testDestinationCACertificate = testCACertificate
 )
 
+func createRouteSpecTo(name string, kind string) kapi.ObjectReference {
+	svc := kapi.ObjectReference{
+			Name: name,
+			Kind: kind,
+		}
+	return svc
+}
+
 // TestValidateRouteBad ensures not specifying a required field results in error and a fully specified
 // route passes successfully
 func TestValidateRoute(t *testing.T) {
@@ -128,10 +136,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "host",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 1,
@@ -144,10 +149,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "host",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 1,
@@ -160,10 +162,7 @@ func TestValidateRoute(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: api.RouteSpec{
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 0,
@@ -177,10 +176,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "**",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 1,
@@ -194,9 +190,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "host",
-					To: kapi.ObjectReference{
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 1,
@@ -210,9 +204,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "host",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-					},
+					To: createRouteSpecTo("serviceName", ""),
 				},
 			},
 			expectedErrors: 1,
@@ -226,10 +218,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 					Port: &api.RoutePort{
 						TargetPort: intstr.FromInt(0),
 					},
@@ -246,10 +235,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 					Port: &api.RoutePort{
 						TargetPort: intstr.FromString(""),
 					},
@@ -266,10 +252,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
 			expectedErrors: 0,
@@ -283,10 +266,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 					Path: "/test",
 				},
 			},
@@ -301,10 +281,7 @@ func TestValidateRoute(t *testing.T) {
 				},
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 					Path: "test",
 				},
 			},
@@ -320,10 +297,7 @@ func TestValidateRoute(t *testing.T) {
 				Spec: api.RouteSpec{
 					Host: "www.example.com",
 					Path: "/test",
-					To: kapi.ObjectReference{
-						Name: "serviceName",
-						Kind: "Service",
-					},
+					To: createRouteSpecTo("serviceName", "Service"),
 					TLS: &api.TLSConfig{
 						Termination: api.TLSTerminationPassthrough,
 					},

--- a/pkg/route/controller/allocation/controller.go
+++ b/pkg/route/controller/allocation/controller.go
@@ -17,7 +17,7 @@ type RouteAllocationController struct {
 func (c *RouteAllocationController) AllocateRouterShard(route *routeapi.Route) (*routeapi.RouterShard, error) {
 
 	glog.V(4).Infof("Allocating router shard for Route: %s [alias=%s]",
-		route.Spec.To.Name, route.Spec.Host)
+		route.Name, route.Spec.Host)
 
 	shard, err := c.Plugin.Allocate(route)
 
@@ -27,19 +27,19 @@ func (c *RouteAllocationController) AllocateRouterShard(route *routeapi.Route) (
 	}
 
 	glog.V(4).Infof("Route %s allocated to shard %s [suffix=%s]",
-		route.Spec.To.Name, shard.ShardName, shard.DNSSuffix)
+		route.Name, shard.ShardName, shard.DNSSuffix)
 
 	return shard, err
 }
 
 // GenerateHostname generates a host name for the given route and router shard combination.
 func (c *RouteAllocationController) GenerateHostname(route *routeapi.Route, shard *routeapi.RouterShard) string {
-	glog.V(4).Infof("Generating host name for Route: %s", route.Spec.To.Name)
+	glog.V(4).Infof("Generating host name for Route: %s", route.Name)
 
 	s := c.Plugin.GenerateHostname(route, shard)
 
 	glog.V(4).Infof("Route: %s, generated host name/alias=%s",
-		route.Spec.To.Name, s)
+		route.Name, s)
 
 	return s
 }

--- a/pkg/route/graph/edges.go
+++ b/pkg/route/graph/edges.go
@@ -24,6 +24,15 @@ func AddRouteEdges(g osgraph.MutableUniqueGraph, node *routegraph.RouteNode) {
 
 	serviceNode := kubegraph.FindOrCreateSyntheticServiceNode(g, syntheticService)
 	g.AddEdge(node, serviceNode, ExposedThroughRouteEdgeKind)
+
+	for _, svc := range node.Spec.AdditionalTos {
+		syntheticService := &kapi.Service{}
+		syntheticService.Namespace = node.Namespace
+		syntheticService.Name = svc.Name
+
+		serviceNode := kubegraph.FindOrCreateSyntheticServiceNode(g, syntheticService)
+		g.AddEdge(node, serviceNode, ExposedThroughRouteEdgeKind)
+	}
 }
 
 // AddAllRouteEdges adds service edges to all route nodes in the given graph

--- a/pkg/route/registry/route/strategy.go
+++ b/pkg/route/registry/route/strategy.go
@@ -46,6 +46,9 @@ func (s routeStrategy) PrepareForCreate(obj runtime.Object) {
 	// Limit to kind/name
 	// TODO: convert to LocalObjectReference
 	route.Spec.To = kapi.ObjectReference{Kind: route.Spec.To.Kind, Name: route.Spec.To.Name}
+	for i, _ := range route.Spec.AdditionalTos {
+		route.Spec.AdditionalTos[i] = kapi.ObjectReference{Kind: route.Spec.AdditionalTos[i].Kind, Name: route.Spec.AdditionalTos[i].Name}
+	}
 	if len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
 		// TODO: this does not belong here, and should be removed
 		shard, err := s.RouteAllocator.AllocateRouterShard(route)
@@ -69,6 +72,9 @@ func (routeStrategy) PrepareForUpdate(obj, old runtime.Object) {
 	// Limit to kind/name
 	// TODO: convert to LocalObjectReference
 	route.Spec.To = kapi.ObjectReference{Kind: route.Spec.To.Kind, Name: route.Spec.To.Name}
+	for i, _ := range route.Spec.AdditionalTos {
+		route.Spec.AdditionalTos[i] = kapi.ObjectReference{Kind: route.Spec.AdditionalTos[i].Kind, Name: route.Spec.AdditionalTos[i].Name}
+	}
 }
 
 func (routeStrategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -93,7 +93,6 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 		return nil
 	}
 
-	key := routeKey(route)
 	routeName := routeNameKey(route)
 
 	host := p.hostForRoute(route)
@@ -154,7 +153,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 			p.hostToRoute[host] = []*routeapi.Route{route}
 		}
 	} else {
-		glog.V(4).Infof("Route %s claims %s", key, host)
+		glog.V(4).Infof("Route %s claims %s", routeName, host)
 		p.hostToRoute[host] = []*routeapi.Route{route}
 	}
 
@@ -162,7 +161,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 	case watch.Added, watch.Modified:
 		if old, ok := p.routeToHost[routeName]; ok {
 			if old != host {
-				glog.V(4).Infof("Route %s changed from serving host %s to host %s", key, old, host)
+				glog.V(4).Infof("Route %s changed from serving host %s to host %s", routeName, old, host)
 				delete(p.hostToRoute, old)
 			}
 		}
@@ -170,7 +169,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 		return p.plugin.HandleRoute(eventType, route)
 
 	case watch.Deleted:
-		glog.V(4).Infof("Deleting routes for %s", key)
+		glog.V(4).Infof("Deleting routes for %s", routeName)
 		if old, ok := p.hostToRoute[host]; ok {
 			switch len(old) {
 			case 1, 0:
@@ -212,9 +211,14 @@ func (p *UniqueHost) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
-// routeKey returns the internal router key to use for the given Route.
-func routeKey(route *routeapi.Route) string {
-	return fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
+// routeKeys returns the internal router key to use for the given Route.
+func routeKeys(route *routeapi.Route) []string {
+	keys := make([]string, 0)
+	keys = append(keys, fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name))
+	for _, svc := range route.Spec.AdditionalTos {
+		keys = append(keys, fmt.Sprintf("%s/%s", route.Namespace, svc.Name))
+	}
+	return keys
 }
 
 // routeNameKey returns a unique name for a given route

--- a/pkg/router/f5/plugin.go
+++ b/pkg/router/f5/plugin.go
@@ -475,10 +475,10 @@ func (p *F5Plugin) HandleNamespaces(namespaces sets.String) error {
 func (p *F5Plugin) HandleRoute(eventType watch.EventType,
 	route *routeapi.Route) error {
 	glog.V(4).Infof("Processing route for service: %v (%v)",
-		route.Spec.To.Name, route)
+		route.Spec.To, route)
 
 	// Name of the pool in F5.
-	poolname := poolName(route.Namespace, route.Spec.To.Name)
+	poolname := poolName(route.Namespace, route.Name)
 
 	// Virtual hostname for policy rule in F5.
 	hostname := route.Spec.Host

--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -5,7 +5,7 @@ package templaterouter
 func newFakeTemplateRouter() *templateRouter {
 	fakeCertManager, _ := newSimpleCertificateManager(newFakeCertificateManagerConfig(), &fakeCertWriter{})
 	return &templateRouter{
-		state:       map[string]ServiceUnit{},
+		state:       map[string]ServiceAliasConfig{},
 		certManager: fakeCertManager,
 	}
 }

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -90,6 +90,7 @@ func NewTemplatePlugin(cfg TemplatePluginConfig) (*TemplatePlugin, error) {
 	globalFuncs := template.FuncMap{
 		"endpointsForAlias": endpointsForAlias,
 		"env":               env,
+		"matchString":       matchString,
 	}
 	masterTemplate, err := template.New("config").Funcs(globalFuncs).ParseFiles(cfg.TemplatePath)
 	if err != nil {
@@ -159,26 +160,35 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 //   determines which component needs to be recalculated (which template) and then does so
 //   on demand.
 func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.Route) error {
-	key := routeKey(route)
+	serviceKeys := routeKeys(route)
 
 	host := route.Spec.Host
 
 	switch eventType {
 	case watch.Added, watch.Modified:
-		if _, ok := p.Router.FindServiceUnit(key); !ok {
-			glog.V(4).Infof("Creating new frontend for key: %v", key)
-			p.Router.CreateServiceUnit(key)
+		// Delete the route first, because modify is to be treated as delete+add
+		for _, key := range serviceKeys {
+			p.Router.RemoveRoute(key, route)
 		}
+		// Now add it back again
+		for _, key := range serviceKeys {
+			if _, ok := p.Router.FindServiceUnit(key); !ok {
+				glog.V(4).Infof("Creating new frontend for key: %v", key)
+				p.Router.CreateServiceUnit(key)
+			}
 
-		glog.V(4).Infof("Modifying routes for %s", key)
-		commit := p.Router.AddRoute(key, route, host)
-		if commit {
-			p.Router.Commit()
+			glog.V(4).Infof("Modifying routes for %s", key)
+			commit := p.Router.AddRoute(key, route, host)
+			if commit {
+				p.Router.Commit()
+			}
 		}
 	case watch.Deleted:
-		glog.V(4).Infof("Deleting routes for %s", key)
-		p.Router.RemoveRoute(key, route)
-		p.Router.Commit()
+		for _, key := range serviceKeys {
+			glog.V(4).Infof("Deleting routes for %s", key)
+			p.Router.RemoveRoute(key, route)
+			p.Router.Commit()
+		}
 	}
 	return nil
 }
@@ -191,9 +201,15 @@ func (p *TemplatePlugin) HandleNamespaces(namespaces sets.String) error {
 	return nil
 }
 
-// routeKey returns the internal router key to use for the given Route.
-func routeKey(route *routeapi.Route) string {
-	return fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
+// routeKeys returns the internal router keys to use for the given Route.
+// A route can have several services that it can point to, now
+func routeKeys(route *routeapi.Route) []string {
+	keys := make([]string, 0)
+	keys = append(keys, fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name))
+	for _, svc := range route.Spec.AdditionalTos {
+		keys = append(keys, fmt.Sprintf("%s/%s", route.Namespace, svc.Name))
+	}
+	return keys
 }
 
 // endpointsKey returns the internal router key to use for the given Endpoints.

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"text/template"
@@ -47,7 +48,8 @@ type templateRouter struct {
 	templates        map[string]*template.Template
 	reloadScriptPath string
 	reloadInterval   time.Duration
-	state            map[string]ServiceUnit
+	state            map[string]ServiceAliasConfig
+	serviceUnits	 map[string]ServiceUnit
 	certManager      certificateManager
 	// defaultCertificate is a concatenated certificate(s), their keys, and their CAs that should be used by the underlying
 	// implementation as the default certificate if no certificate is resolved by the normal matching mechanisms.  This is
@@ -99,7 +101,9 @@ type templateData struct {
 	// the directory that files will be written to, defaults to /var/lib/containers/router
 	WorkingDir string
 	// the routes
-	State map[string]ServiceUnit
+	State map[string](ServiceAliasConfig)
+	// the service lookup
+	ServiceUnits map[string]ServiceUnit
 	// full path and file name to the default certificate
 	DefaultCertificate string
 	// peers
@@ -136,7 +140,8 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		templates:              cfg.templates,
 		reloadScriptPath:       cfg.reloadScriptPath,
 		reloadInterval:         cfg.reloadInterval,
-		state:                  make(map[string]ServiceUnit),
+		state:                  make(map[string]ServiceAliasConfig),
+		serviceUnits:           make(map[string]ServiceUnit),
 		certManager:            certManager,
 		defaultCertificate:     cfg.defaultCertificate,
 		defaultCertificatePath: cfg.defaultCertificatePath,
@@ -169,6 +174,17 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 	glog.V(4).Infof("Committing state")
 	router.Commit()
 	return router, nil
+}
+
+func matchString(pattern, s string) bool {
+	glog.V(4).Infof("Matchstring called with %s and %s", pattern, s)
+	status, err := regexp.MatchString(pattern, s)
+	if err == nil {
+		glog.V(4).Infof("Matchstring returning status: %v", status)
+		return status
+	}
+	fmt.Errorf("Error with regex pattern in call to matchString: %v", err)
+	return false
 }
 
 func endpointsForAlias(alias ServiceAliasConfig, svc ServiceUnit) []Endpoint {
@@ -204,7 +220,7 @@ func (r *templateRouter) readState() error {
 	data, err := ioutil.ReadFile(filepath.Join(r.dir, routeFile))
 	// TODO: rework
 	if err != nil {
-		r.state = make(map[string]ServiceUnit)
+		r.state = make(map[string]ServiceAliasConfig)
 		return nil
 	}
 
@@ -256,14 +272,12 @@ func (r *templateRouter) writeState() error {
 // writeConfig writes the config to disk
 func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
-	for _, serviceUnit := range r.state {
-		for k, cfg := range serviceUnit.ServiceAliasConfigs {
-			if err := r.writeCertificates(&cfg); err != nil {
-				return fmt.Errorf("error writing certificates for %s: %v", serviceUnit.Name, err)
-			}
-			cfg.Status = ServiceAliasConfigStatusSaved
-			serviceUnit.ServiceAliasConfigs[k] = cfg
+	for k, cfg := range r.state {
+		if err := r.writeCertificates(&cfg); err != nil {
+			return fmt.Errorf("error writing certificates for %s", k, err)
 		}
+		cfg.Status = ServiceAliasConfigStatusSaved
+		r.state[k] = cfg
 	}
 
 	for path, template := range r.templates {
@@ -275,6 +289,7 @@ func (r *templateRouter) writeConfig() error {
 		data := templateData{
 			WorkingDir:         r.dir,
 			State:              r.state,
+			ServiceUnits:	    r.serviceUnits,
 			DefaultCertificate: r.defaultCertificatePath,
 			PeerEndpoints:      r.peerEndpoints,
 			StatsUser:          r.statsUser,
@@ -317,7 +332,7 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	defer r.lock.Unlock()
 
 	if len(namespaces) == 0 {
-		r.state = make(map[string]ServiceUnit)
+		r.state = make(map[string]ServiceAliasConfig)
 	}
 	for k := range r.state {
 		// TODO: the id of a service unit should be defined inside this class, not passed in from the outside
@@ -334,20 +349,19 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 func (r *templateRouter) CreateServiceUnit(id string) {
 	service := ServiceUnit{
 		Name:                id,
-		ServiceAliasConfigs: make(map[string]ServiceAliasConfig),
 		EndpointTable:       []Endpoint{},
 	}
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.state[id] = service
+	r.serviceUnits[id] = service
 }
 
 // findMatchingServiceUnit finds the service with the given id - internal
 // lockless form, caller needs to ensure lock acquisition [and release].
 func (r *templateRouter) findMatchingServiceUnit(id string) (ServiceUnit, bool) {
-	v, ok := r.state[id]
+	v, ok := r.serviceUnits[id]
 	return v, ok
 }
 
@@ -364,16 +378,12 @@ func (r *templateRouter) DeleteServiceUnit(id string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	svcUnit, ok := r.findMatchingServiceUnit(id)
+	_, ok := r.findMatchingServiceUnit(id)
 	if !ok {
 		return
 	}
 
-	for _, cfg := range svcUnit.ServiceAliasConfigs {
-		r.cleanUpServiceAliasConfig(&cfg)
-	}
-
-	delete(r.state, id)
+	delete(r.serviceUnits, id)
 }
 
 // DeleteEndpoints deletes the endpoints for the service with the given id.
@@ -388,7 +398,7 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 
 	service.EndpointTable = []Endpoint{}
 
-	r.state[id] = service
+	r.serviceUnits[id] = service
 
 	// TODO: this is not safe (assuming that the subset of elements we are watching includes the peer endpoints)
 	// should be a DNS lookup for endpoints of our service name.
@@ -413,61 +423,67 @@ func (r *templateRouter) routeKey(route *routeapi.Route) string {
 	return fmt.Sprintf("%s_%s", route.Namespace, route.Name)
 }
 
-// AddRoute adds a route for the given id
+// AddRoute adds a route for the given service id
 func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string) bool {
 	backendKey := r.routeKey(route)
 
-	config := ServiceAliasConfig{
-		Host: host,
-		Path: route.Spec.Path,
-	}
+	config, ok := r.state[backendKey]
 
-	if route.Spec.Port != nil {
-		config.PreferPort = route.Spec.Port.TargetPort.String()
-	}
-
-	tls := route.Spec.TLS
-	if tls != nil && len(tls.Termination) > 0 {
-		config.TLSTermination = tls.Termination
-
-		if tls.Termination == routeapi.TLSTerminationEdge {
-			config.InsecureEdgeTerminationPolicy = tls.InsecureEdgeTerminationPolicy
+	if !ok {
+		config = ServiceAliasConfig{
+			Host: host,
+			Path: route.Spec.Path,
+			Annotations: route.Annotations,
+			ServiceUnitNames: make(map[string]string),
 		}
 
-		if tls.Termination != routeapi.TLSTerminationPassthrough {
-			if config.Certificates == nil {
-				config.Certificates = make(map[string]Certificate)
+		if route.Spec.Port != nil {
+			config.PreferPort = route.Spec.Port.TargetPort.String()
+		}
+
+		tls := route.Spec.TLS
+		if tls != nil && len(tls.Termination) > 0 {
+			config.TLSTermination = tls.Termination
+
+			if tls.Termination == routeapi.TLSTerminationEdge {
+				config.InsecureEdgeTerminationPolicy = tls.InsecureEdgeTerminationPolicy
 			}
 
-			if len(tls.Certificate) > 0 {
-				certKey := generateCertKey(&config)
-				cert := Certificate{
-					ID:         backendKey,
-					Contents:   tls.Certificate,
-					PrivateKey: tls.Key,
+			if tls.Termination != routeapi.TLSTerminationPassthrough {
+				if config.Certificates == nil {
+					config.Certificates = make(map[string]Certificate)
 				}
 
-				config.Certificates[certKey] = cert
-			}
+				if len(tls.Certificate) > 0 {
+					certKey := generateCertKey(&config)
+					cert := Certificate{
+						ID:         backendKey,
+						Contents:   tls.Certificate,
+						PrivateKey: tls.Key,
+					}
 
-			if len(tls.CACertificate) > 0 {
-				caCertKey := generateCACertKey(&config)
-				caCert := Certificate{
-					ID:       backendKey,
-					Contents: tls.CACertificate,
+					config.Certificates[certKey] = cert
 				}
 
-				config.Certificates[caCertKey] = caCert
-			}
+				if len(tls.CACertificate) > 0 {
+					caCertKey := generateCACertKey(&config)
+					caCert := Certificate{
+						ID:       backendKey,
+						Contents: tls.CACertificate,
+					}
 
-			if len(tls.DestinationCACertificate) > 0 {
-				destCertKey := generateDestCertKey(&config)
-				destCert := Certificate{
-					ID:       backendKey,
-					Contents: tls.DestinationCACertificate,
+					config.Certificates[caCertKey] = caCert
 				}
 
-				config.Certificates[destCertKey] = destCert
+				if len(tls.DestinationCACertificate) > 0 {
+					destCertKey := generateDestCertKey(&config)
+					destCert := Certificate{
+						ID:       backendKey,
+						Contents: tls.DestinationCACertificate,
+					}
+
+					config.Certificates[destCertKey] = destCert
+				}
 			}
 		}
 	}
@@ -481,29 +497,11 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string)
 	frontend, _ := r.findMatchingServiceUnit(id)
 
 	//create or replace
-	frontend.ServiceAliasConfigs[backendKey] = config
-	r.state[id] = frontend
-	r.cleanUpdates(id, backendKey)
+	config.ServiceUnitNames[frontend.Name] = frontend.Name
+	r.state[backendKey] = config
+	r.serviceUnits[id] = frontend
+	//r.cleanUpdates(id, backendKey)
 	return true
-}
-
-// cleanUpdates ensures the route is only under a single service key.  Backends are keyed
-// by route namespace and name.  Frontends are keyed by service namespace name.  This accounts
-// for times when someone updates the service name on a route which leaves the existing old service
-// in state.
-// TODO: remove this when we refactor the model to use existing objects and integrate this into
-// the api somehow.
-func (r *templateRouter) cleanUpdates(frontendKey string, backendKey string) {
-	for k, v := range r.state {
-		if k == frontendKey {
-			continue
-		}
-		for routeKey := range v.ServiceAliasConfigs {
-			if routeKey == backendKey {
-				delete(v.ServiceAliasConfigs, backendKey)
-			}
-		}
-	}
 }
 
 // RemoveRoute removes the given route for the given id.
@@ -511,18 +509,23 @@ func (r *templateRouter) RemoveRoute(id string, route *routeapi.Route) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	serviceUnit, ok := r.state[id]
+	_, ok := r.serviceUnits[id]
 	if !ok {
 		return
 	}
 
 	routeKey := r.routeKey(route)
-	serviceAliasConfig, ok := serviceUnit.ServiceAliasConfigs[routeKey]
+	serviceAliasConfig, ok := r.state[routeKey]
 	if !ok {
 		return
 	}
+	delete(serviceAliasConfig.ServiceUnitNames, id)
+
 	r.cleanUpServiceAliasConfig(&serviceAliasConfig)
-	delete(r.state[id].ServiceAliasConfigs, routeKey)
+
+	if len(serviceAliasConfig.ServiceUnitNames) == 0 {
+		delete(r.state, routeKey)
+	}
 }
 
 // AddEndpoints adds new Endpoints for the given id.
@@ -538,7 +541,7 @@ func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
 	}
 
 	frontend.EndpointTable = endpoints
-	r.state[id] = frontend
+	r.serviceUnits[id] = frontend
 
 	if id == r.peerEndpointsKey {
 		r.peerEndpoints = frontend.EndpointTable

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -13,8 +13,6 @@ type ServiceUnit struct {
 	// EndpointTable are endpoints that back the service, this translates into a final backend
 	// implementation for routers.
 	EndpointTable []Endpoint
-	// ServiceAliasConfigs is a collection of unique routes that support this service, keyed by host + path
-	ServiceAliasConfigs map[string]ServiceAliasConfig
 }
 
 // ServiceAliasConfig is a route for a service.  Uniquely identified by host + path.
@@ -37,8 +35,15 @@ type ServiceAliasConfig struct {
 	// insecure connections to an edge-terminated route:
 	//   none (or disable), allow or redirect
 	InsecureEdgeTerminationPolicy routeapi.InsecureEdgeTerminationPolicyType
+
 	// Hash of the route name - used to obscure cookieId
 	RoutingKeyName string
+
+	// Annotations attached to this route
+	Annotations map[string]string
+
+	// ServiceUnitNames is a collection of services that support this route, keyed by service name
+	ServiceUnitNames map[string]string
 }
 
 type ServiceAliasConfigStatus string


### PR DESCRIPTION
Refer to #8854 

This is a revision PR fixing comments pointed out in the other PR. One thing that has been kept as-is: the weights are still treated as annotations. Strict type-checking can be enforced though through a 'matchstring' function provided in the template. That makes the weights as good as an internal 'integer' field.

Primary fix is that 'To' field remains as is in both v1/latest. AdditionalTos is a new field added (limit to 3).

@smarterclayton @eparis @liggitt @knobunc 