### PR TITLE
hack/util: wait for registry readiness

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -641,7 +641,9 @@ function install_registry {
 }
 
 function wait_for_registry {
-	wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 --template="{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=${ADMIN_KUBECONFIG} || echo "0")" != "0" ]]' $((5*TIME_MIN))
+	wait_for_command "oc get endpoints docker-registry --template='{{ len .subsets }}' --config='${ADMIN_KUBECONFIG}' | grep -q '[1-9][0-9]*'" $((5*TIME_MIN))
+	local readyjs='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+	wait_for_command "oc get pod -l deploymentconfig=docker-registry -o jsonpath='$readyjs' --config='${ADMIN_KUBECONFIG}' | grep -qi true" $TIME_MIN
 }
 
 


### PR DESCRIPTION
Waiting just for registry's endpoints isn't sufficient. It takes few
more seconds for the registry to become ready. Let's wait until ready
before launching tests.

The race occured for example in [job#200](https://ci.openshift.redhat.com/jenkins/job/test_pr_origin_extended/200/) (#8195).

The `wait_for_registry` now generates following log:

    [INFO] Waiting for command to finish: '[[ "$(oc get endpoints docker-registry --output-version=v1 --template='{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}' --config=/tmp/openshift/test-extended/core/openshift.local.config/master/admin.kubeconfig || echo 0)" != "0" ]]'...
    [INFO] Success running command: '[[ "$(oc get endpoints docker-registry --output-version=v1 --template='{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}' --config=/tmp/openshift/test-extended/core/openshift.local.config/master/admin.kubeconfig || echo 0)" != "0" ]]' after 12 seconds
    [INFO] Waiting for command to finish: 'oc get pod -l deploymentconfig=docker-registry --output-version=v1 --template='{{ range .items }}{{ range .status.conditions }}{{ if eq .type "Ready" }}{{ .status }}{{ end }}{{ end }}{{ end }}' --config=/tmp/openshift/test-extended/core/openshift.local.config/master/admin.kubeconfig | grep -qi '^True$''...
    [INFO] Success running command: 'oc get pod -l deploymentconfig=docker-registry --output-version=v1 --template='{{ range .items }}{{ range .status.conditions }}{{ if eq .type "Ready" }}{{ .status }}{{ end }}{{ end }}{{ end }}' --config=/tmp/openshift/test-extended/core/openshift.local.config/master/admin.kubeconfig | grep -qi '^True$'' after 7 seconds