### PR TITLE
Fix misspells reported by goreportcard.com

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -2036,7 +2036,7 @@
         "type": "string",
         "paramType": "query",
         "name": "sinceTime",
-        "description": "sinceTime is an RFC3339 timestamp from which to show logs. If this value preceeds the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
+        "description": "sinceTime is an RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
         "required": false,
         "allowMultiple": false
        },
@@ -5289,7 +5289,7 @@
         "type": "string",
         "paramType": "query",
         "name": "sinceTime",
-        "description": "An RFC3339 timestamp from which to show logs. If this value preceeds the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
+        "description": "An RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
         "required": false,
         "allowMultiple": false
        },
@@ -21644,7 +21644,7 @@
      },
      "tag": {
       "$ref": "v1.TagReference",
-      "description": "Tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occured to this image stream."
+      "description": "Tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream."
      },
      "generation": {
       "type": "integer",

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Convert_runtime_Object_To_runtime_RawExtension is conversion function that assumes that the runtime.Object you've embedded is in
-// the same GroupVersion that your containing type is in.  This is signficantly better than simply breaking.
+// the same GroupVersion that your containing type is in.  This is significantly better than simply breaking.
 // Given an ordered list of preferred external versions for a given encode or conversion call, the behavior of this function could be
 // made generic, predictable, and controllable.
 func Convert_runtime_Object_To_runtime_RawExtension(in runtime.Object, out *runtime.RawExtension, s conversion.Scope) error {

--- a/pkg/api/kubegraph/analysis/hpa.go
+++ b/pkg/api/kubegraph/analysis/hpa.go
@@ -100,7 +100,7 @@ func createMissingScaleRefMarker(hpaNode *kubenodes.HorizontalPodAutoscalerNode,
 // can assume that it will be handled before this step. Therefore, we are only concerned with finding HPAs that are trying to
 // scale the same resources.
 //
-// The algorithm that is used to implement this check is decribed as follows:
+// The algorithm that is used to implement this check is described as follows:
 //  - create a sub-graph containing only HPA nodes and other nodes that can be scaled, as well as any scaling edges or other
 //    edges used to connect between objects that can be scaled
 //  - for every resulting edge in the new sub-graph, create an edge in the reverse direction

--- a/pkg/auth/ldaputil/testclient/testclient.go
+++ b/pkg/auth/ldaputil/testclient/testclient.go
@@ -95,7 +95,7 @@ func (c *Fake) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSize ui
 	return c.SearchResponse, nil
 }
 
-// NewMatchingSearchErrorClient returns a new MatchingSeachError client sitting on top of the parent
+// NewMatchingSearchErrorClient returns a new MatchingSearchError client sitting on top of the parent
 // client. This client returns the given error when a search base DN matches the given base DN, and
 // defers to the parent otherwise.
 func NewMatchingSearchErrorClient(parent ldap.Client, baseDN string, returnErr error) ldap.Client {

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -250,7 +250,7 @@ func (m *VirtualStorage) ensurePolicyBindingToMaster(ctx kapi.Context, policyNam
 
 // getPolicyBindingForPolicy returns a PolicyBinding that points to the specified policyNamespace.  It will autocreate ONLY if policyNamespace equals the master namespace
 func (m *VirtualStorage) getPolicyBindingForPolicy(ctx kapi.Context, policyNamespace string, allowAutoProvision bool) (*authorizationapi.PolicyBinding, error) {
-	// we can autocreate a PolicyBinding object if the RoleBinding is for the master namespace OR if we've been explicity told to create the policying binding.
+	// we can autocreate a PolicyBinding object if the RoleBinding is for the master namespace OR if we've been explicitly told to create the policying binding.
 	// the latter happens during priming
 	if (policyNamespace == "") || allowAutoProvision {
 		return m.ensurePolicyBindingToMaster(ctx, policyNamespace, authorizationapi.GetPolicyBindingName(policyNamespace))

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -875,7 +875,7 @@ type BuildLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64
 	// An RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -105,7 +105,7 @@ var map_BuildLogOptions = map[string]string{
 	"follow":       "follow if true indicates that the build log should be streamed until the build terminates.",
 	"previous":     "previous returns previous build logs. Defaults to false.",
 	"sinceSeconds": "sinceSeconds is a relative time in seconds before the current time from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
-	"sinceTime":    "sinceTime is an RFC3339 timestamp from which to show logs. If this value preceeds the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
+	"sinceTime":    "sinceTime is an RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
 	"timestamps":   "timestamps, If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.",
 	"tailLines":    "tailLines, If set, is the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime",
 	"limitBytes":   "limitBytes, If set, is the number of bytes to read from the server before terminating the log output. This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.",

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -834,7 +834,7 @@ type BuildLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64 `json:"sinceSeconds,omitempty"`
 	// sinceTime is an RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -773,7 +773,7 @@ type BuildLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64 `json:"sinceSeconds,omitempty"`
 	// An RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -232,7 +232,7 @@ func (d *DockerBuilder) buildInfo() []dockerfile.KeyValue {
 // consume.
 func (d *DockerBuilder) buildLabels(dir string) []dockerfile.KeyValue {
 	labels := map[string]string{}
-	// TODO: allow source info to be overriden by build
+	// TODO: allow source info to be overridden by build
 	sourceInfo := &git.SourceInfo{}
 	if d.build.Spec.Source.Git != nil {
 		var errors []error

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -51,7 +51,7 @@ func readNetClsCGroup(reader io.Reader) string {
 }
 
 // getDockerNetworkMode determines whether the builder is running as a container
-// by examining /proc/self/cgroup. This contenxt is then passed to source-to-image.
+// by examining /proc/self/cgroup. This context is then passed to source-to-image.
 func getDockerNetworkMode() s2iapi.DockerNetworkMode {
 	file, err := os.Open("/proc/self/cgroup")
 	if err != nil {

--- a/pkg/build/graph/analysis/bc.go
+++ b/pkg/build/graph/analysis/bc.go
@@ -275,7 +275,7 @@ func getImageStreamImageSuggestion(imageID string, imageStream *imageapi.ImageSt
 		// this time based annotation is set by pkg/image/controller/controller.go whenever import/tag operations are performed; unless
 		// in the midst of an import/tag operation, it stays set and serves as a timestamp for when the last operation occurred;
 		// so we will check if the image stream has been updated "recently";
-		// in case it is a slow link to the remote repo, see if if the check annotation occured within the last 5 minutes; if so, consider that as potentially "in progress"
+		// in case it is a slow link to the remote repo, see if if the check annotation occurred within the last 5 minutes; if so, consider that as potentially "in progress"
 		compareTime := checkTime.Add(5 * time.Minute)
 		currentTime, _ := time.Parse(time.RFC3339, unversioned.Now().UTC().Format(time.RFC3339))
 		if compareTime.Before(currentTime) {

--- a/pkg/build/graph/helpers.go
+++ b/pkg/build/graph/helpers.go
@@ -10,7 +10,7 @@ import (
 	buildgraph "github.com/openshift/origin/pkg/build/graph/nodes"
 )
 
-// RelevantBuilds returns the lastSuccessful build, lastUnsuccesful build, and a list of active builds
+// RelevantBuilds returns the lastSuccessful build, lastUnsuccessful build, and a list of active builds
 func RelevantBuilds(g osgraph.Graph, bcNode *buildgraph.BuildConfigNode) (*buildgraph.BuildNode, *buildgraph.BuildNode, []*buildgraph.BuildNode) {
 	var (
 		lastSuccessfulBuild   *buildgraph.BuildNode

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
 )
 
-// DiscoveryClient implements the functions that dicovery server-supported API groups,
+// DiscoveryClient implements the functions that discovery server-supported API groups,
 // versions and resources.
 type DiscoveryClient struct {
 	*discovery.DiscoveryClient

--- a/pkg/cmd/admin/groups/sync/groupdetector/groupdetector.go
+++ b/pkg/cmd/admin/groups/sync/groupdetector/groupdetector.go
@@ -64,7 +64,7 @@ func (l *MemberBasedDetector) Exists(ldapGrouUID string) (bool, error) {
 // NewCompoundDetector returns an LDAPGroupDetector that subsumes some other LDAPGroupDetectors.
 // This detector checks all subordinate detectors in order to determine if a group exists. If any of
 // the subordinate detectors raise an error while being queried, the the search is abandoned and the
-// error returned. All detectors must successfully determine existance for the compound detector to
+// error returned. All detectors must successfully determine existence for the compound detector to
 // determine that the group exists.
 func NewCompoundDetector(locators ...interfaces.LDAPGroupDetector) interfaces.LDAPGroupDetector {
 	return &CompoundDetector{locators: locators}
@@ -73,7 +73,7 @@ func NewCompoundDetector(locators ...interfaces.LDAPGroupDetector) interfaces.LD
 // CompoundDetector is an LDAPGroupDetector that subsumes some other LDAPGroupDetectors.
 // This detector checks all subordinate detectors in order to determine if a group exists. If any of
 // the subordinate detectors raise an error while being queried, the the search is abandoned and the
-// error returned. All detectors must successfully determine existance for the compound detector to
+// error returned. All detectors must successfully determine existence for the compound detector to
 // determine that the group exists.
 type CompoundDetector struct {
 	locators []interfaces.LDAPGroupDetector

--- a/pkg/cmd/admin/groups/sync/syncerror/handler.go
+++ b/pkg/cmd/admin/groups/sync/syncerror/handler.go
@@ -65,7 +65,7 @@ func NewMemberLookupMemberNotFoundSuppressor(err io.Writer) Handler {
 	return &memberLookupMemberNotFoundSuppressor{err: err}
 }
 
-// memberLookupMemberNotFoundSuppressor supresses member lookup errors caused by a search returning no valid entries,
+// memberLookupMemberNotFoundSuppressor suppresses member lookup errors caused by a search returning no valid entries,
 // which can happen in two ways:
 //   - if the search is not by DN, an empty result list is returned
 //   - if the search is by DN, an error is returned from the LDAP server: no such object

--- a/pkg/cmd/cli/cmd/importimage_test.go
+++ b/pkg/cmd/cli/cmd/importimage_test.go
@@ -156,7 +156,7 @@ func TestCreateImageImport(t *testing.T) {
 			}},
 		},
 		{
-			// 7: insecure annotation should be overriden by the flag
+			// 7: insecure annotation should be overridden by the flag
 			name: "testis",
 			stream: &imageapi.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{

--- a/pkg/cmd/infra/gitserver/gitserver.go
+++ b/pkg/cmd/infra/gitserver/gitserver.go
@@ -64,7 +64,7 @@ func NewCommandGitServer(name string) *cobra.Command {
 }
 
 func RunGitServer() error {
-	config, err := gitserver.NewEnviromentConfig()
+	config, err := gitserver.NewEnvironmentConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -1191,12 +1191,12 @@ type AdmissionConfig struct {
 // ControllerConfig holds configuration values for controllers
 type ControllerConfig struct {
 	// ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for
-	// pods fullfilling a service to serve with.
+	// pods fulfilling a service to serve with.
 	ServiceServingCert ServiceServingCert
 }
 
 // ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for
-// pods fullfilling a service to serve with.
+// pods fulfilling a service to serve with.
 type ServiceServingCert struct {
 	// Signer holds the signing information used to automatically sign serving certificates.
 	// If this value is nil, then certs are not signed automatically.

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -345,7 +345,7 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 var codec = serializer.NewCodecFactory(internal.Scheme).LegacyCodec(SchemeGroupVersion)
 
 // Convert_runtime_Object_To_runtime_RawExtension is conversion function that assumes that the runtime.Object you've embedded is in
-// the same GroupVersion that your containing type is in.  This is signficantly better than simply breaking.
+// the same GroupVersion that your containing type is in.  This is significantly better than simply breaking.
 // Given an ordered list of preferred external versions for a given encode or conversion call, the behavior of this function could be
 // made generic, predictable, and controllable.
 func convert_runtime_Object_To_runtime_RawExtension(in runtime.Object, out *runtime.RawExtension, s conversion.Scope) error {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -117,7 +117,7 @@ func (CertInfo) SwaggerDoc() map[string]string {
 
 var map_ControllerConfig = map[string]string{
 	"":                   "ControllerConfig holds configuration values for controllers",
-	"serviceServingCert": "ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for pods fullfilling a service to serve with.",
+	"serviceServingCert": "ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for pods fulfilling a service to serve with.",
 }
 
 func (ControllerConfig) SwaggerDoc() map[string]string {
@@ -726,7 +726,7 @@ func (ServiceAccountConfig) SwaggerDoc() map[string]string {
 }
 
 var map_ServiceServingCert = map[string]string{
-	"":       "ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for pods fullfilling a service to serve with.",
+	"":       "ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for pods fulfilling a service to serve with.",
 	"signer": "Signer holds the signing information used to automatically sign serving certificates. If this value is nil, then certs are not signed automatically.",
 }
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -1196,12 +1196,12 @@ type AdmissionConfig struct {
 // ControllerConfig holds configuration values for controllers
 type ControllerConfig struct {
 	// ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for
-	// pods fullfilling a service to serve with.
+	// pods fulfilling a service to serve with.
 	ServiceServingCert ServiceServingCert `json:"serviceServingCert"`
 }
 
 // ServiceServingCert holds configuration for service serving cert signer which creates cert/key pairs for
-// pods fullfilling a service to serve with.
+// pods fulfilling a service to serve with.
 type ServiceServingCert struct {
 	// Signer holds the signing information used to automatically sign serving certificates.
 	// If this value is nil, then certs are not signed automatically.

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -586,7 +586,7 @@ func initAPIVersionRoute(root *restful.WebService, prefix string, versions ...st
 		Consumes(restful.MIME_JSON))
 }
 
-// initHealthCheckRoute initalizes an HTTP endpoint for health checking.
+// initHealthCheckRoute initializes an HTTP endpoint for health checking.
 // OpenShift is deemed healthy if the API server can respond with an OK messages
 func initHealthCheckRoute(root *restful.WebService, path string) {
 	root.Route(root.GET(path).To(func(req *restful.Request, resp *restful.Response) {
@@ -613,7 +613,7 @@ func initReadinessCheckRoute(root *restful.WebService, path string, readyFunc fu
 		Produces(restful.MIME_JSON))
 }
 
-// initHealthCheckRoute initalizes an HTTP endpoint for health checking.
+// initHealthCheckRoute initializes an HTTP endpoint for health checking.
 // OpenShift is deemed healthy if the API server can respond with an OK messages
 func initMetricsRoute(root *restful.WebService, path string) {
 	h := prometheus.Handler()

--- a/pkg/cmd/util/clientcmd/cached_discovery.go
+++ b/pkg/cmd/util/clientcmd/cached_discovery.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
-// CachedDiscoveryClient implements the functions that dicovery server-supported API groups,
+// CachedDiscoveryClient implements the functions that discovery server-supported API groups,
 // versions and resources.
 type CachedDiscoveryClient struct {
 	discovery.DiscoveryInterface

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -497,7 +497,7 @@ func (f *Factory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpe
 
 // ApproximatePodTemplateForObject returns a pod template object for the provided source.
 // It may return both an error and a object. It attempt to return the best possible template
-// avaliable at the current time.
+// available at the current time.
 func (w *Factory) ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
 	switch t := object.(type) {
 	case *imageapi.ImageStreamTag:

--- a/pkg/cmd/util/pullprogress/writer.go
+++ b/pkg/cmd/util/pullprogress/writer.go
@@ -15,7 +15,7 @@ const (
 
 // NewPullProgressWriter creates a writer that periodically reports
 // on pull progress of an image. It only reports when the state of the
-// different layers has changed and uses time threshholds to limit the
+// different layers has changed and uses time thresholds to limit the
 // rate of the reports.
 func NewPullProgressWriter(reportFn func(*ProgressReport)) io.Writer {
 	pipeIn, pipeOut := io.Pipe()

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -445,7 +445,7 @@ type DeploymentLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64
 	// An RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -127,7 +127,7 @@ var map_DeploymentLogOptions = map[string]string{
 	"follow":       "Follow if true indicates that the build log should be streamed until the build terminates.",
 	"previous":     "Return previous deployment logs. Defaults to false.",
 	"sinceSeconds": "A relative time in seconds before the current time from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
-	"sinceTime":    "An RFC3339 timestamp from which to show logs. If this value preceeds the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
+	"sinceTime":    "An RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
 	"timestamps":   "If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.",
 	"tailLines":    "If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime",
 	"limitBytes":   "If set, the number of bytes to read from the server before terminating the log output. This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.",

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -402,7 +402,7 @@ type DeploymentLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64 `json:"sinceSeconds,omitempty"`
 	// An RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -413,7 +413,7 @@ type DeploymentLogOptions struct {
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceSeconds *int64 `json:"sinceSeconds,omitempty"`
 	// An RFC3339 timestamp from which to show logs. If this value
-	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// precedes the time a pod was started, only logs since the pod start will be returned.
 	// If this value is in the future, no logs will be returned.
 	// Only one of sinceSeconds or sinceTime may be specified.
 	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`

--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -104,7 +104,7 @@ func canTrigger(config, decoded *deployapi.DeploymentConfig) (bool, []deployapi.
 		}
 		ictCount++
 
-		// If this is the inital deployment then we need to wait for the image change controller
+		// If this is the initial deployment then we need to wait for the image change controller
 		// to resolve the image inside the pod template.
 		lastTriggered := t.ImageChangeParams.LastTriggeredImage
 		if len(lastTriggered) == 0 {

--- a/pkg/deploy/controller/deployerpod/controller.go
+++ b/pkg/deploy/controller/deployerpod/controller.go
@@ -146,7 +146,7 @@ func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 		}
 		glog.V(4).Infof("Updated deployment %s status from %s to %s (scale: %d)", deployutil.LabelForDeployment(deployment), currentStatus, nextStatus, deployment.Spec.Replicas)
 
-		// If the deployment was canceled, trigger a reconcilation of its deployment config
+		// If the deployment was canceled, trigger a reconciliation of its deployment config
 		// so that the latest complete deployment can immediately rollback in place of the
 		// canceled deployment.
 		if nextStatus == deployapi.DeploymentStatusFailed && deployutil.IsDeploymentCancelled(deployment) {

--- a/pkg/deploy/controller/deployerpod/controller_test.go
+++ b/pkg/deploy/controller/deployerpod/controller_test.go
@@ -411,7 +411,7 @@ func TestHandle_cleanupDesiredReplicasAnnotation(t *testing.T) {
 }
 
 // TestHandle_canceledDeploymentTrigger ensures that a canceled deployment
-// will trigger a reconcilation of its deploymentconfig (via an annotation
+// will trigger a reconciliation of its deploymentconfig (via an annotation
 // update) so that rolling back can happen on the spot and not rely on the
 // deploymentconfig cache resync interval.
 func TestHandle_canceledDeploymentTriggerTest(t *testing.T) {

--- a/pkg/diagnostics/types/systemd_unit.go
+++ b/pkg/diagnostics/types/systemd_unit.go
@@ -1,6 +1,6 @@
 package types
 
-// SystemdUnit represents the information we gather about a single sytemd unit of interest.
+// SystemdUnit represents the information we gather about a single systemd unit of interest.
 type SystemdUnit struct {
 	// The systemd unit name, e.g. "openshift-master"
 	Name string

--- a/pkg/dockerregistry/client.go
+++ b/pkg/dockerregistry/client.go
@@ -491,7 +491,7 @@ func (repo *v2repository) getTags(c *connection) (map[string]string, error) {
 				return repo.getTags(c)
 			}
 			delete(c.cached, repo.name)
-			// docker will not return a NotFound on any repository URL - for backwards compatibilty, return NotFound on the
+			// docker will not return a NotFound on any repository URL - for backwards compatibility, return NotFound on the
 			// repo
 			return nil, errRepositoryNotFound{repo.name}
 		}
@@ -549,7 +549,7 @@ func (repo *v2repository) getTaggedImage(c *connection, tag, userTag string) (*I
 				return repo.getTaggedImage(c, tag, userTag)
 			}
 			delete(c.cached, repo.name)
-			// docker will not return a NotFound on any repository URL - for backwards compatibilty, return NotFound on the
+			// docker will not return a NotFound on any repository URL - for backwards compatibility, return NotFound on the
 			// repo
 			body, _ := ioutil.ReadAll(resp.Body)
 			glog.V(4).Infof("passed valid auth token, but unable to find tagged image at %q, %d %v: %s", req.URL.String(), resp.StatusCode, resp.Header, body)

--- a/pkg/gitserver/gitserver.go
+++ b/pkg/gitserver/gitserver.go
@@ -142,8 +142,8 @@ func NewDefaultConfig() *Config {
 	}
 }
 
-// NewEnviromentConfig sets up the initial config from environment variables
-func NewEnviromentConfig() (*Config, error) {
+// NewEnvironmentConfig sets up the initial config from environment variables
+func NewEnvironmentConfig() (*Config, error) {
 	config := NewDefaultConfig()
 
 	home := os.Getenv("GIT_HOME")

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -198,7 +198,7 @@ type ImageStreamTag struct {
 	kapi.ObjectMeta
 
 	// Tag is the spec tag associated with this image stream tag, and it may be null
-	// if only pushes have occured to this image stream.
+	// if only pushes have occurred to this image stream.
 	Tag *TagReference
 
 	// Generation is the current generation of the tagged image - if tag is provided

--- a/pkg/image/api/v1/swagger_doc.go
+++ b/pkg/image/api/v1/swagger_doc.go
@@ -173,7 +173,7 @@ func (ImageStreamStatus) SwaggerDoc() map[string]string {
 var map_ImageStreamTag = map[string]string{
 	"":           "ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream.",
 	"metadata":   "Standard object's metadata.",
-	"tag":        "Tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occured to this image stream.",
+	"tag":        "Tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.",
 	"generation": "Generation is the current generation of the tagged image - if tag is provided and this value is not equal to the tag generation, a user has requested an import that has not completed, or Conditions will be filled out indicating any error.",
 	"conditions": "Conditions is an array of conditions that apply to the image stream tag.",
 	"image":      "Image associated with the ImageStream and tag.",

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -175,7 +175,7 @@ type ImageStreamTag struct {
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Tag is the spec tag associated with this image stream tag, and it may be null
-	// if only pushes have occured to this image stream.
+	// if only pushes have occurred to this image stream.
 	Tag *TagReference `json:"tag"`
 
 	// Generation is the current generation of the tagged image - if tag is provided

--- a/pkg/router/f5/f5.go
+++ b/pkg/router/f5/f5.go
@@ -68,7 +68,7 @@ type f5LTM struct {
 	passthroughRoutes map[string]passthroughRoute
 }
 
-// f5LTMCfg holds configuration for connecting to and issueing iControl
+// f5LTMCfg holds configuration for connecting to and issuing iControl
 // requests against an F5 BIG-IP instance.
 type f5LTMCfg struct {
 	// host specifies the hostname or IP address of the F5 BIG-IP host.
@@ -708,7 +708,7 @@ func (f5 *f5LTM) checkPartitionPathExists(pathName string) (bool, error) {
 	return true, nil
 }
 
-// addPartitionPath adds a new partition path to the folder heirarchy.
+// addPartitionPath adds a new partition path to the folder hierarchy.
 func (f5 *f5LTM) addPartitionPath(pathName string) (bool, error) {
 	glog.V(4).Infof("Creating partition path %q ...", pathName)
 
@@ -744,7 +744,7 @@ func (f5 *f5LTM) ensurePartitionPathExists(pathName string) error {
 		return nil
 	}
 
-	// We have to loop thru the path hierarchy and add components
+	// We have to loop through the path hierarchy and add components
 	// individually if they don't exist.
 
 	// Get path components - we need to remove the leading empty path

--- a/pkg/util/docker/dockerfile/builder/internals.go
+++ b/pkg/util/docker/dockerfile/builder/internals.go
@@ -42,7 +42,7 @@ func bashQuote(env string) string {
 	return string(out)
 }
 
-// hasEnvName returns true if the provided enviroment contains the named ENV var.
+// hasEnvName returns true if the provided environment contains the named ENV var.
 func hasEnvName(env []string, name string) bool {
 	for _, e := range env {
 		if strings.HasPrefix(e, name+"=") {

--- a/test/extended/jenkins/plugin.go
+++ b/test/extended/jenkins/plugin.go
@@ -48,7 +48,7 @@ func waitForJenkinsActivity(uri, verificationString string, status int) error {
 		req.SetBasicAuth("admin", "password")
 		client := &http.Client{}
 		resp, _ := client.Do(req)
-		// the http req failing here (which we see occassionally in the ci.jenkins runs) could stem
+		// the http req failing here (which we see occasionally in the ci.jenkins runs) could stem
 		// from simply hitting our test jenkins server too soon ... so rather than returning false,err
 		// and aborting the poll, we return false, nil to try again
 		if resp == nil {
@@ -163,7 +163,7 @@ var _ = g.Describe("[jenkins][Slow] openshift pipeline plugin", func() {
 
 			// the build and deployment is by far the most time consuming portion of the test jenkins job;
 			// we leverage some of the openshift utilities for waiting for the deployment before we poll
-			// jenkins for the sucessful job completion
+			// jenkins for the successful job completion
 			g.By("waiting for frontend, frontend-prod deployments as signs that the build has finished")
 			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend")
 			if err != nil {

--- a/tools/junitreport/pkg/builder/interfaces.go
+++ b/tools/junitreport/pkg/builder/interfaces.go
@@ -7,6 +7,6 @@ type TestSuitesBuilder interface {
 	// AddSuite adds a test suite to the collection
 	AddSuite(suite *api.TestSuite)
 
-	// Build retuns the built structure
+	// Build returns the built structure
 	Build() *api.TestSuites
 }

--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -25,7 +25,7 @@ type testDataParser struct {
 	testResultPattern *regexp.Regexp
 }
 
-// MarksBeginning determines if the line marks the begining of a test case
+// MarksBeginning determines if the line marks the beginning of a test case
 func (p *testDataParser) MarksBeginning(line string) bool {
 	return p.testStartPattern.MatchString(line)
 }

--- a/tools/junitreport/pkg/parser/oscmd/data_parser.go
+++ b/tools/junitreport/pkg/parser/oscmd/data_parser.go
@@ -38,7 +38,7 @@ type testDataParser struct {
 	testEndPattern         *regexp.Regexp
 }
 
-// MarksBeginning determines if the line marks the begining of a test case
+// MarksBeginning determines if the line marks the beginning of a test case
 func (p *testDataParser) MarksBeginning(line string) bool {
 	return p.testStartPattern.MatchString(line)
 }
@@ -82,7 +82,7 @@ func (p *testDataParser) ExtractDuration(line string) (string, bool) {
 	return "", false
 }
 
-// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occured) from a test output line
+// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occurred) from a test output line
 func (p *testDataParser) ExtractMessage(line string) (string, bool) {
 	if matches := p.testConclusionPattern.FindStringSubmatch(line); len(matches) > 5 && len(matches[5]) > 0 {
 		return matches[5], true
@@ -112,7 +112,7 @@ type testSuiteDataParser struct {
 	suiteConclusionPattern  *regexp.Regexp
 }
 
-// MarksBeginning determines if the line marks the begining of a test suite
+// MarksBeginning determines if the line marks the beginning of a test suite
 func (p *testSuiteDataParser) MarksBeginning(line string) bool {
 	return p.suiteDeclarationPattern.MatchString(line)
 }

--- a/tools/junitreport/pkg/parser/stack/interfaces.go
+++ b/tools/junitreport/pkg/parser/stack/interfaces.go
@@ -4,7 +4,7 @@ import "github.com/openshift/origin/tools/junitreport/pkg/api"
 
 // TestDataParser knows how to take raw test data and extract the useful information from it
 type TestDataParser interface {
-	// MarksBeginning determines if the line marks the begining of a test case
+	// MarksBeginning determines if the line marks the beginning of a test case
 	MarksBeginning(line string) bool
 
 	// ExtractName extracts the name of the test case from test output lines
@@ -16,7 +16,7 @@ type TestDataParser interface {
 	// ExtractDuration extracts the test duration from a test output line
 	ExtractDuration(line string) (duration string, succeeded bool)
 
-	// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occured) from a test output line
+	// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occurred) from a test output line
 	ExtractMessage(line string) (message string, succeeded bool)
 
 	// MarksCompletion determines if the line marks the completion of a test case
@@ -25,7 +25,7 @@ type TestDataParser interface {
 
 // TestSuiteDataParser knows how to take raw test suite data and extract the useful information from it
 type TestSuiteDataParser interface {
-	// MarksBeginning determines if the line marks the begining of a test suite
+	// MarksBeginning determines if the line marks the beginning of a test suite
 	MarksBeginning(line string) bool
 
 	// ExtractName extracts the name of the test suite from a test output line


### PR DESCRIPTION
from https://goreportcard.com/report/github.com/openshift/origin#misspell

mostly comments, but also a method name (gitserver.NewEnvironmentConfig)