### PR TITLE
setup_tmpdir_vars(): TPMDIR -> TMPDIR

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -132,7 +132,7 @@ function os::util::environment::update_path_var() {
 function os::util::environment::setup_tmpdir_vars() {
     local sub_dir=$1
 
-    BASETMPDIR="${TPMDIR:-/tmp}/openshift/${sub_dir}"
+    BASETMPDIR="${TMPDIR:-/tmp}/openshift/${sub_dir}"
     export BASETMPDIR
     LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
     export LOG_DIR


### PR DESCRIPTION
Fix a typo in `os::util::environment::setup_tmpdir_vars()`, used by the test scripts: `TPMDIR` should be `TMPDIR`.