### PR TITLE
Increased timeout in TestTimedCommand integration test

### DIFF
--- a/pkg/generate/git/repository_test.go
+++ b/pkg/generate/git/repository_test.go
@@ -129,7 +129,7 @@ func TestTimedCommandTimeout(t *testing.T) {
 		if _, ok := output.err.(*TimeoutError); !ok {
 			t.Fatalf("expected command to fail due to timeout, got: %v", output.err)
 		}
-	case <-time.After(10 * timeout):
+	case <-time.After(1000 * timeout):
 		t.Fatalf("expected command to have timed out, but it didn't")
 	}
 }


### PR DESCRIPTION
In order to stop flakes on the Jenkins AWS boxes, the
minimum timedout for the command is increased to 45s
from the original value of 1ms.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/origin/issues/9089