### PR TITLE
IPFailover was broken for alpha.1

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -36,7 +36,9 @@ function cleanup()
 	dump_container_logs
 
 	echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
-	oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
+	if [[ -n "${ADMIN_KUBECONFIG:-}" ]]; then
+		oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
+	fi
 
 	echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/etcd_dump.json"
 	set_curl_args 0 1
@@ -56,7 +58,6 @@ function cleanup()
 		set -u
 	fi
 
-	# TODO soltysh: restore the if back once #8399 is resolved
 	journalctl --unit docker.service --since -15minutes > "${LOG_DIR}/docker.log"
 
 	delete_empty_logs

--- a/images/ipfailover/keepalived/Dockerfile
+++ b/images/ipfailover/keepalived/Dockerfile
@@ -9,9 +9,10 @@ RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
-COPY . /var/lib/origin/ipfailover/keepalived/
+COPY . /var/lib/ipfailover/keepalived/
 
 LABEL io.k8s.display-name="OpenShift Origin IP Failover" \
       io.k8s.description="This is a component of OpenShift Origin and runs a clustered keepalived instance across multiple hosts to allow highly available IP addresses."
 EXPOSE 1985
-ENTRYPOINT ["/var/lib/origin/ipfailover/keepalived/monitor.sh"]
+WORKDIR /var/lib/ipfailover
+ENTRYPOINT ["/var/lib/ipfailover/keepalived/monitor.sh"]

--- a/pkg/ipfailover/keepalived/generator_test.go
+++ b/pkg/ipfailover/keepalived/generator_test.go
@@ -90,6 +90,7 @@ func TestGenerateDeploymentConfig(t *testing.T) {
 		dc, err := GenerateDeploymentConfig(tc.Name, options, selector)
 		if err != nil {
 			t.Errorf("Test case for %s got an error %v where none was expected", tc.Name, err)
+			continue
 		}
 		if tc.Name != dc.Name {
 			t.Errorf("Test case for %s got DeploymentConfig name %v where %v was expected", tc.Name, dc.Name, tc.Name)

--- a/pkg/ipfailover/keepalived/plugin.go
+++ b/pkg/ipfailover/keepalived/plugin.go
@@ -114,6 +114,10 @@ func (p *KeepalivedPlugin) Generate() (*kapi.List, error) {
 		return nil, fmt.Errorf("error getting selector: %v", err)
 	}
 
+	if len(p.Options.VirtualIPs) == 0 {
+		return nil, fmt.Errorf("you must specify at least one virtual IP address for keepalived to expose")
+	}
+
 	dc, err := GenerateDeploymentConfig(p.Name, p.Options, selector)
 	if err != nil {
 		return nil, fmt.Errorf("error generating DeploymentConfig: %v", err)

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -70,10 +70,12 @@ os::cmd::expect_success_and_not_text "oadm router -o yaml --credentials=${KUBECO
 echo "router: ok"
 
 # test ipfailover
-os::cmd::expect_success_and_text 'oadm ipfailover --dry-run' 'Creating IP failover'
-os::cmd::expect_success_and_text 'oadm ipfailover --dry-run' 'Success \(DRY RUN\)'
-os::cmd::expect_success_and_text 'oadm ipfailover --dry-run -o yaml' 'name: ipfailover'
-os::cmd::expect_success_and_text 'oadm ipfailover --dry-run -o name' 'deploymentconfig/ipfailover'
+os::cmd::expect_failure_and_text 'oadm ipfailover --dry-run' 'you must specify at least one virtual IP address'
+os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run' 'Creating IP failover'
+os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run' 'Success \(DRY RUN\)'
+os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o yaml' 'name: ipfailover'
+os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o name' 'deploymentconfig/ipfailover'
+os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o yaml' '1.2.3.4'
 # TODO add tests for normal ipfailover creation
 # os::cmd::expect_success_and_text 'oadm ipfailover' 'deploymentconfig "ipfailover" created'
 # os::cmd::expect_failure_and_text 'oadm ipfailover' 'Error from server: deploymentconfig "ipfailover" already exists'


### PR DESCRIPTION
/var/lib/origin is now a docker volume, which results in the contents
being lost. Moved it to /var/lib/ipfailover, and added a slightly better
error message when no arguments are provided.

Fixes #9077

@ramr will repush this image as v1.3.0-alpha.1 afterwards