### PR TITLE
If --public-hostname is an IP, use it for server IP in cluster up

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -686,7 +686,7 @@ Start OpenShift on Docker with reasonable defaults
 
   # Start OpenShift using a specific public host name
   oc cluster up --public-hostname=my.address.example.com
-  
+
   # Start OpenShift and preserve data and config between restarts
   oc cluster up --host-data-dir=/mydata --use-existing-config
 


### PR DESCRIPTION
Otherwise users have no way to force a public IP.

@csrwng let me know if there's an alternative way you'd like to fix this.  I guess it's possible users have a private server IP that they want to use, but they'd be no worse off than they are today.