### PR TITLE
Improve escalation error message

### DIFF
--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -70,7 +70,39 @@ func needsNormalizing(in string) bool {
 }
 
 func (r PolicyRule) String() string {
-	return fmt.Sprintf("PolicyRule{Verbs:%v, APIGroups:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.APIGroups, r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
+	return "PolicyRule" + r.CompactString()
+}
+
+// CompactString exposes a compact string representation for use in escalation error messages
+func (r PolicyRule) CompactString() string {
+	formatStringParts := []string{}
+	formatArgs := []interface{}{}
+	if len(r.Verbs) > 0 {
+		formatStringParts = append(formatStringParts, "Verbs:%q")
+		formatArgs = append(formatArgs, r.Verbs.List())
+	}
+	if len(r.APIGroups) > 0 {
+		formatStringParts = append(formatStringParts, "APIGroups:%q")
+		formatArgs = append(formatArgs, r.APIGroups)
+	}
+	if len(r.Resources) > 0 {
+		formatStringParts = append(formatStringParts, "Resources:%q")
+		formatArgs = append(formatArgs, r.Resources.List())
+	}
+	if len(r.ResourceNames) > 0 {
+		formatStringParts = append(formatStringParts, "ResourceNames:%q")
+		formatArgs = append(formatArgs, r.ResourceNames.List())
+	}
+	if r.AttributeRestrictions != nil {
+		formatStringParts = append(formatStringParts, "Restrictions:%q")
+		formatArgs = append(formatArgs, r.AttributeRestrictions)
+	}
+	if len(r.NonResourceURLs) > 0 {
+		formatStringParts = append(formatStringParts, "NonResourceURLs:%q")
+		formatArgs = append(formatArgs, r.NonResourceURLs.List())
+	}
+	formatString := "{" + strings.Join(formatStringParts, ", ") + "}"
+	return fmt.Sprintf(formatString, formatArgs...)
 }
 
 func getRoleBindingValues(roleBindingMap map[string]*RoleBinding) []*RoleBinding {

--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -116,7 +116,7 @@ func (m *VirtualStorage) createRole(ctx kapi.Context, obj runtime.Object, allowE
 
 	role := obj.(*authorizationapi.Role)
 	if !allowEscalation {
-		if err := rulevalidation.ConfirmNoEscalation(ctx, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
+		if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
 			return nil, err
 		}
 	}
@@ -163,7 +163,7 @@ func (m *VirtualStorage) updateRole(ctx kapi.Context, obj runtime.Object, allowE
 	}
 
 	if !allowEscalation {
-		if err := rulevalidation.ConfirmNoEscalation(ctx, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
+		if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
 			return nil, false, err
 		}
 	}

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -218,7 +218,7 @@ func (m *VirtualStorage) confirmNoEscalation(ctx kapi.Context, roleBinding *auth
 		return err
 	}
 
-	return rulevalidation.ConfirmNoEscalation(ctx, m.RuleResolver, modifyingRole)
+	return rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("rolebinding"), roleBinding.Name, m.RuleResolver, modifyingRole)
 }
 
 // ensurePolicyBindingToMaster returns a PolicyBinding object that has a PolicyRef pointing to the Policy in the passed namespace.

--- a/pkg/authorization/rulevalidation/compact_rules.go
+++ b/pkg/authorization/rulevalidation/compact_rules.go
@@ -1,0 +1,75 @@
+package rulevalidation
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// CompactRules combines rules that contain a single APIGroup/Resource, differ only by verb, and contain no other attributes.
+// this is a fast check, and works well with the decomposed "missing rules" list from a Covers check.
+func CompactRules(rules []authorizationapi.PolicyRule) ([]authorizationapi.PolicyRule, error) {
+	compacted := make([]authorizationapi.PolicyRule, 0, len(rules))
+
+	simpleRules := map[unversioned.GroupResource]*authorizationapi.PolicyRule{}
+	for _, rule := range rules {
+		if resource, isSimple := isSimpleResourceRule(&rule); isSimple {
+			if existingRule, ok := simpleRules[resource]; ok {
+				// Add the new verbs to the existing simple resource rule
+				if existingRule.Verbs == nil {
+					existingRule.Verbs = sets.NewString()
+				}
+				existingRule.Verbs.Insert(rule.Verbs.List()...)
+			} else {
+				// Copy the rule to accumulate matching simple resource rules into
+				objCopy, err := api.Scheme.DeepCopy(rule)
+				if err != nil {
+					// Unit tests ensure this should not ever happen
+					return nil, err
+				}
+				ruleCopy, ok := objCopy.(authorizationapi.PolicyRule)
+				if !ok {
+					// Unit tests ensure this should not ever happen
+					return nil, fmt.Errorf("expected authorizationapi.PolicyRule, got %#v", objCopy)
+				}
+				simpleRules[resource] = &ruleCopy
+			}
+		} else {
+			compacted = append(compacted, rule)
+		}
+	}
+
+	// Once we've consolidated the simple resource rules, add them to the compacted list
+	for _, simpleRule := range simpleRules {
+		compacted = append(compacted, *simpleRule)
+	}
+
+	return compacted, nil
+}
+
+// isSimpleResourceRule returns true if the given rule contains verbs, a single resource, a single API group, and no other values
+func isSimpleResourceRule(rule *authorizationapi.PolicyRule) (unversioned.GroupResource, bool) {
+	resource := unversioned.GroupResource{}
+
+	// If we have "complex" rule attributes, return early without allocations or expensive comparisons
+	if len(rule.ResourceNames) > 0 || len(rule.NonResourceURLs) > 0 || rule.AttributeRestrictions != nil {
+		return resource, false
+	}
+	// If we have multiple api groups or resources, return early
+	if len(rule.APIGroups) != 1 || len(rule.Resources) != 1 {
+		return resource, false
+	}
+
+	// Test if this rule only contains APIGroups/Resources/Verbs
+	simpleRule := &authorizationapi.PolicyRule{APIGroups: rule.APIGroups, Resources: rule.Resources, Verbs: rule.Verbs}
+	if !reflect.DeepEqual(simpleRule, rule) {
+		return resource, false
+	}
+	resource = unversioned.GroupResource{Group: rule.APIGroups[0], Resource: rule.Resources.List()[0]}
+	return resource, true
+}

--- a/pkg/authorization/rulevalidation/compact_rules_test.go
+++ b/pkg/authorization/rulevalidation/compact_rules_test.go
@@ -1,0 +1,225 @@
+package rulevalidation
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/authorization/api"
+)
+
+type sortableRuleSlice []api.PolicyRule
+
+func (s sortableRuleSlice) Len() int      { return len(s) }
+func (s sortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s sortableRuleSlice) Less(i, j int) bool {
+	return strings.Compare(s[i].String(), s[j].String()) < 0
+}
+
+func TestCompactRules(t *testing.T) {
+	testcases := map[string]struct {
+		Rules    []api.PolicyRule
+		Expected []api.PolicyRule
+	}{
+		"empty": {
+			Rules:    []api.PolicyRule{},
+			Expected: []api.PolicyRule{},
+		},
+		"simple": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+				{Verbs: sets.NewString("update", "patch"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+
+				{Verbs: sets.NewString("create"), APIGroups: []string{"extensions"}, Resources: sets.NewString("daemonsets")},
+				{Verbs: sets.NewString("delete"), APIGroups: []string{"extensions"}, Resources: sets.NewString("daemonsets")},
+
+				{Verbs: sets.NewString("educate"), APIGroups: []string{""}, Resources: sets.NewString("dolphins")},
+
+				// nil verbs are preserved in non-merge cases.
+				// these are the pirates who don't do anything.
+				{Verbs: nil, APIGroups: []string{""}, Resources: sets.NewString("pirates")},
+
+				// Test merging into a nil Verbs string set
+				{Verbs: nil, APIGroups: []string{""}, Resources: sets.NewString("pods")},
+				{Verbs: sets.NewString("create"), APIGroups: []string{""}, Resources: sets.NewString("pods")},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("create", "delete"), APIGroups: []string{"extensions"}, Resources: sets.NewString("daemonsets")},
+				{Verbs: sets.NewString("get", "list", "update", "patch"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+				{Verbs: sets.NewString("educate"), APIGroups: []string{""}, Resources: sets.NewString("dolphins")},
+				{Verbs: nil, APIGroups: []string{""}, Resources: sets.NewString("pirates")},
+				{Verbs: sets.NewString("create"), APIGroups: []string{""}, Resources: sets.NewString("pods")},
+			},
+		},
+		"complex multi-group": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
+			},
+		},
+
+		"complex multi-resource": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+			},
+		},
+
+		"complex named-resource": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild2")},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild")},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild2")},
+			},
+		},
+
+		"complex non-resource": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/foo")},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/foo")},
+			},
+		},
+
+		"complex attributes": {
+			Rules: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			},
+			Expected: []api.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		rules := tc.Rules
+		originalRules, err := kapi.Scheme.DeepCopy(tc.Rules)
+		if err != nil {
+			t.Errorf("%s: couldn't copy rules: %v", k, err)
+			continue
+		}
+		compacted, err := CompactRules(tc.Rules)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		if !reflect.DeepEqual(rules, originalRules) {
+			t.Errorf("%s: CompactRules mutated rules. Expected\n%#v\ngot\n%#v", k, originalRules, rules)
+			continue
+		}
+		if covers, missing := Covers(compacted, rules); !covers {
+			t.Errorf("%s: compacted rules did not cover original rules. missing: %#v", k, missing)
+			continue
+		}
+		if covers, missing := Covers(rules, compacted); !covers {
+			t.Errorf("%s: original rules did not cover compacted rules. missing: %#v", k, missing)
+			continue
+		}
+
+		sort.Stable(sortableRuleSlice(compacted))
+		sort.Stable(sortableRuleSlice(tc.Expected))
+		if !reflect.DeepEqual(compacted, tc.Expected) {
+			t.Errorf("%s: Expected\n%#v\ngot\n%#v", k, tc.Expected, compacted)
+			continue
+		}
+	}
+}
+
+func TestIsSimpleResourceRule(t *testing.T) {
+	testcases := map[string]struct {
+		Rule     api.PolicyRule
+		Simple   bool
+		Resource unversioned.GroupResource
+	}{
+		"simple, no verbs": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString(), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Simple:   true,
+			Resource: unversioned.GroupResource{Group: "", Resource: "builds"},
+		},
+		"simple, one verb": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Simple:   true,
+			Resource: unversioned.GroupResource{Group: "", Resource: "builds"},
+		},
+		"simple, multi verb": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get", "list"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Simple:   true,
+			Resource: unversioned.GroupResource{Group: "", Resource: "builds"},
+		},
+
+		"complex, empty": {
+			Rule:     api.PolicyRule{},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, no group": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{}, Resources: sets.NewString("builds")},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, multi group": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{"a", "b"}, Resources: sets.NewString("builds")},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, no resource": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString()},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, multi resource": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, resource names": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("foo")},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, attribute restrictions": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+		"complex, non-resource urls": {
+			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
+			Simple:   false,
+			Resource: unversioned.GroupResource{},
+		},
+	}
+
+	for k, tc := range testcases {
+		resource, simple := isSimpleResourceRule(&tc.Rule)
+		if simple != tc.Simple {
+			t.Errorf("%s: expected simple=%v, got simple=%v", k, tc.Simple, simple)
+			continue
+		}
+		if resource != tc.Resource {
+			t.Errorf("%s: expected resource=%v, got resource=%v", k, tc.Resource, resource)
+			continue
+		}
+	}
+}

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -121,7 +121,7 @@ os::cmd::try_until_failure "oc policy who-can update hpa.extensions | grep -q al
 resourceversion=$(oc get clusterrole/alternate-cluster-admin -o=jsonpath="{.metadata.resourceVersion}")
 cp ${OS_ROOT}/test/fixtures/bootstrappolicy/alternate_cluster_admin.yaml ${workingdir}
 os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_cluster_admin.yaml
-os::cmd::expect_failure_and_text "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml" "attempt to grant extra privileges"
+os::cmd::expect_failure_and_text "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml" "cannot grant extra privileges"
 
 echo "policy: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Fixes #9030

Sample output from running these commands as a project admin:
```
$ oc policy add-role-to-user cluster-admin bob
$ oc policy add-role-to-user cluster-reader bob
```

New output:
```
Error from server: rolebinding "cluster-admin" is forbidden: user "bob" cannot grant extra privileges:
{Verbs:["*"], APIGroups:["*"], Resources:["*"]}
```
and
```
Error from server: rolebinding "cluster-reader" is forbidden: user "bob" cannot grant extra privileges:
{Verbs:["create" "get"], APIGroups:[""], Resources:["nodes/stats"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["buildconfigs/instantiate"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["buildconfigs/instantiatebinary"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["builds/clone"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["builds/details"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["clusternetworks"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["clusterpolicies"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["clusterpolicybindings"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["clusterrolebindings"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["groups"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["hostsubnets"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["identities"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["images"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["imagestreamimports"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["localresourceaccessreviews"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["localsubjectaccessreviews"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["minions"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["netnamespaces"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["nodes"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["oauthclientauthorizations"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["oauthclients"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["persistentvolumes"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["resourceaccessreviews"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["securitycontextconstraints"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["selfsubjectrulesreviews"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["subjectaccessreviews"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["useridentitymappings"]}
{Verbs:["get" "list" "watch"], APIGroups:[""], Resources:["users"]}
{Verbs:["get" "watch"], APIGroups:[""], Resources:["projectrequests"]}
{Verbs:["get"], APIGroups:[""], Resources:["nodes/metrics"]}
{Verbs:["watch"], APIGroups:[""], Resources:["clusterroles"]}
```

Old output:
`error: You must be logged in to the server (attempt to grant extra privileges: [PolicyRule{Verbs:[*], APIGroups:[*], Resources:[*], ResourceNames:[], Restrictions:<nil>}] user=&{bob 1765b68b-2831-11e6-80ea-00e092001f34 [system:authenticated:oauth system:authenticated] map[authorization.openshift.io/scopes:[]]} ownerrules=[PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[pods pods/attach pods/exec pods/portforward pods/proxy], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[configmaps endpoints persistentvolumeclaims replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[bindings events limitranges namespaces namespaces/status pods/log pods/status replicationcontrollers/status resourcequotas resourcequotas/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[impersonate], APIGroups:[], Resources:[serviceaccounts], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[autoscaling], Resources:[horizontalpodautoscalers], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[batch], Resources:[jobs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[extensions], Resources:[horizontalpodautoscalers jobs replicationcontrollers/scale], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[extensions], Resources:[daemonsets], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[rolebindings roles], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[localresourceaccessreviews localsubjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[policies policybindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[buildconfigs buildconfigs/webhooks builds], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[builds/log], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[buildconfigs/instantiate buildconfigs/instantiatebinary builds/clone], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[deploymentconfigrollbacks deploymentconfigs deploymentconfigs/scale generatedeploymentconfigs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[deploymentconfigs/log deploymentconfigs/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[imagestreamimages imagestreammappings imagestreams imagestreams/secrets imagestreamtags], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[imagestreams/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get update], APIGroups:[], Resources:[imagestreams/layers], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[imagestreamimports], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[delete get patch update], APIGroups:[], Resources:[projects], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[routes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[routes/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[update], APIGroups:[], Resources:[routes/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[processedtemplates templateconfigs templates], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[buildlogs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[resourcequotausages], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[resourceaccessreviews subjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/source], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create get], APIGroups:[], Resources:[buildconfigs/webhooks], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/docker], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/jenkinspipeline], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[delete], APIGroups:[], Resources:[oauthaccesstokens oauthauthorizetokens], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[users], ResourceNames:[~], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list], APIGroups:[], Resources:[clusterroles], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list watch], APIGroups:[], Resources:[projects], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[selfsubjectrulesreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[localsubjectaccessreviews subjectaccessreviews], ResourceNames:[], Restrictions:&{{ }}} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/custom], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>}] ruleResolutionErrors=[])`

and

`error: You must be logged in to the server (attempt to grant extra privileges: [PolicyRule{Verbs:[get], APIGroups:[], Resources:[nodes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[nodes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[nodes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[useridentitymappings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[useridentitymappings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[useridentitymappings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[builds/details], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[builds/details], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[builds/details], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[groups], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[groups], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[groups], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[builds/clone], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[builds/clone], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[builds/clone], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[hostsubnets], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[hostsubnets], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[hostsubnets], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[images], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[images], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[images], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[users], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[users], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[users], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[clusterroles], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[oauthclientauthorizations], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[oauthclientauthorizations], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[oauthclientauthorizations], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[clusterpolicies], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[clusterpolicies], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[clusterpolicies], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[netnamespaces], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[netnamespaces], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[netnamespaces], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[clusternetworks], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[clusternetworks], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[clusternetworks], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[localresourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[localresourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[localresourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[resourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[resourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[resourceaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[identities], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[identities], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[identities], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[clusterrolebindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[clusterrolebindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[clusterrolebindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[localsubjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[localsubjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[localsubjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[oauthclients], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[oauthclients], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[oauthclients], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[persistentvolumes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[persistentvolumes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[persistentvolumes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[selfsubjectrulesreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[selfsubjectrulesreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[selfsubjectrulesreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[buildconfigs/instantiate], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[buildconfigs/instantiate], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[buildconfigs/instantiate], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[subjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[subjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[subjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[imagestreamimports], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[imagestreamimports], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[imagestreamimports], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[buildconfigs/instantiatebinary], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[buildconfigs/instantiatebinary], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[buildconfigs/instantiatebinary], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[clusterpolicybindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[clusterpolicybindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[clusterpolicybindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[minions], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[minions], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[minions], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[securitycontextconstraints], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[securitycontextconstraints], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[watch], APIGroups:[], Resources:[securitycontextconstraints], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[nodes/metrics], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[nodes/stats], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[nodes/stats], ResourceNames:[], Restrictions:<nil>}] user=&{bob 1765b68b-2831-11e6-80ea-00e092001f34 [system:authenticated:oauth system:authenticated] map[authorization.openshift.io/scopes:[]]} ownerrules=[PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[pods pods/attach pods/exec pods/portforward pods/proxy], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[configmaps endpoints persistentvolumeclaims replicationcontrollers replicationcontrollers/scale secrets serviceaccounts services services/proxy], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[bindings events limitranges namespaces namespaces/status pods/log pods/status replicationcontrollers/status resourcequotas resourcequotas/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[impersonate], APIGroups:[], Resources:[serviceaccounts], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[autoscaling], Resources:[horizontalpodautoscalers], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[batch], Resources:[jobs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[extensions], Resources:[horizontalpodautoscalers jobs replicationcontrollers/scale], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[extensions], Resources:[daemonsets], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[rolebindings roles], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[localresourceaccessreviews localsubjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[policies policybindings], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[buildconfigs buildconfigs/webhooks builds], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[builds/log], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[buildconfigs/instantiate buildconfigs/instantiatebinary builds/clone], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[deploymentconfigrollbacks deploymentconfigs deploymentconfigs/scale generatedeploymentconfigs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[deploymentconfigs/log deploymentconfigs/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[imagestreamimages imagestreammappings imagestreams imagestreams/secrets imagestreamtags], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[imagestreams/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get update], APIGroups:[], Resources:[imagestreams/layers], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[imagestreamimports], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[delete get patch update], APIGroups:[], Resources:[projects], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[routes], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[routes/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[update], APIGroups:[], Resources:[routes/status], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[processedtemplates templateconfigs templates], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create delete deletecollection get list patch update watch], APIGroups:[], Resources:[buildlogs], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list watch], APIGroups:[], Resources:[resourcequotausages], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[resourceaccessreviews subjectaccessreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/jenkinspipeline], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/docker], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/custom], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[users], ResourceNames:[~], Restrictions:<nil>} PolicyRule{Verbs:[list], APIGroups:[], Resources:[projectrequests], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get list], APIGroups:[], Resources:[clusterroles], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[list watch], APIGroups:[], Resources:[projects], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[selfsubjectrulesreviews], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[localsubjectaccessreviews subjectaccessreviews], ResourceNames:[], Restrictions:&{{ }}} PolicyRule{Verbs:[delete], APIGroups:[], Resources:[oauthaccesstokens oauthauthorizetokens], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create get], APIGroups:[], Resources:[buildconfigs/webhooks], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[get], APIGroups:[], Resources:[], ResourceNames:[], Restrictions:<nil>} PolicyRule{Verbs:[create], APIGroups:[], Resources:[builds/source], ResourceNames:[], Restrictions:<nil>}] ruleResolutionErrors=[])`
