### PR TITLE
test-end-to-end-docker.sh: Run configure_os_server

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -21,6 +21,8 @@ os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
 os::util::environment::use_sudo
 reset_tmp_dir
 
+configure_os_server
+
 function cleanup()
 {
 	out=$?


### PR DESCRIPTION
Call `configure_os_server` from `test-end-to-end-docker.sh` to ensure that `ADMIN_KUBECONFIG` is set when `cleanup()` references it.

Fixes the following error:

    [FAIL] !!!!! Test Failed !!!!
    
    [INFO] Dumping container logs to /tmp/openshift/test-end-to-end-docker//logs
    Error: No such image or container: 7f179536a9f6
    Error: No such image or container: 64fd0b643c77
    Error: No such image or container: 3a5560eb83c3
    Error: No such image or container: 41cb4fa6dd7c
    [INFO] Dumping all resources to /tmp/openshift/test-end-to-end-docker//logs/export_all.json
    hack/../hack/test-end-to-end-docker.sh: line 39: ADMIN_KUBECONFIG: unbound variable

-

openshift-bot, please [test]!