### PR TITLE
Elongate pod lifetimes for pods used in `oc run --attach`

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -178,14 +178,17 @@ os::cmd::expect_success 'oc whoami'
 
 echo "[INFO] Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
-oc run cli-with-token --attach --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 > ${LOG_DIR}/cli-with-token.log 2>&1
+#TODO(skuznets): remove sleeps after k8s attach becomes more synchronized
+oc run cli-with-token --attach --image=openshift/origin:${TAG} --restart=Never -- 'sleep 10 && cli status --loglevel=4' > ${LOG_DIR}/cli-with-token.log 2>&1
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
 os::cmd::expect_success 'oc delete pod cli-with-token'
-oc run cli-with-token-2 --attach --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=4 > ${LOG_DIR}/cli-with-token2.log 2>&1
+#TODO(skuznets): remove sleeps after k8s attach becomes more synchronized
+oc run cli-with-token-2 --attach --image=openshift/origin:${TAG} --restart=Never -- 'sleep 10 && cli whoami --loglevel=4' > ${LOG_DIR}/cli-with-token2.log 2>&1
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
 os::cmd::expect_success 'oc delete pod cli-with-token-2'
-oc run kubectl-with-token --attach --image=openshift/origin:${TAG} --restart=Never --command -- kubectl get pods --loglevel=4 > ${LOG_DIR}/kubectl-with-token.log 2>&1
+#TODO(skuznets): remove sleeps after k8s attach becomes more synchronized
+oc run kubectl-with-token --attach --image=openshift/origin:${TAG} --restart=Never --command -- 'sleep 10 && kubectl get pods --loglevel=4' > ${LOG_DIR}/kubectl-with-token.log 2>&1
 cat ${LOG_DIR}/kubectl-with-token.log
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'


### PR DESCRIPTION
Wedges in the `oc run --attach` call were previously caused most likely by a race between the container exiting and the attach mechanism attaching to the file descriptors from the container. By keeping the containers alive for a long time before they become active, we should alleviate this flake.

The go-dockerclient library has a mechanism to coordinate the pod creation / attach routines, but Kubernetes has migrated away from the library, so it makes little sense to refactor code in the kubelet to use the library if the patch will be dropped in the upcoming rebase.

Since it was previously possible to reproduce the hang with 100% probability in https://github.com/openshift/origin/pull/9047, I will cherry-pick this commit on top of that pull, and once the other e2e blocker is done, if we cannot repro the hang again, maybe this will be useful to combat the flake until the rebase hits?

/cc ncdc
@smarterclayton 