### PR TITLE
Allow size of image to be zero when schema1 from Hub

### DIFF
--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -103,8 +103,17 @@ func TestImageStreamImport(t *testing.T) {
 		t.Fatalf("unexpected responses: %v %#v %#v", err, isi, isi.Status.Import)
 	}
 
-	if isi.Status.Images[0].Image == nil || isi.Status.Images[0].Image.DockerImageMetadata.Size == 0 || len(isi.Status.Images[0].Image.DockerImageLayers) == 0 {
+	if isi.Status.Images[0].Image == nil || len(isi.Status.Images[0].Image.DockerImageLayers) == 0 {
 		t.Fatalf("unexpected image output: %#v", isi.Status.Images[0].Image)
+	}
+	if isi.Status.Images[0].Image.DockerImageMetadata.Size == 0 {
+		image, err := c.Images().Get(isi.Status.Images[0].Image.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(image.DockerImageManifest, `"schemaVersion": 1,`) {
+			t.Fatalf("image has zero size, but schema version was not 1: %#v\n%s", isi.Status.Images[0].Image, image.DockerImageManifest)
+		}
 	}
 
 	stream := isi.Status.Import


### PR DESCRIPTION
The DockerHub now converts schema2 image manifests pushed by Docker 1.10
or higher clients into schema1, but when it does that it drops all
v1Compatibility objects except the top layer.  When it does that it
loses size info.  Since we anticipate moving to schema2 soon, and the
number of schema1 images should decline, adapt the tests to flag this
error.

[merge]