### PR TITLE
builds: increase git check timeout exponentially

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -48,7 +48,7 @@ func NewDockerBuilder(dockerClient DockerClient, buildsClient client.BuildInterf
 		build:        build,
 		gitClient:    gitClient,
 		tar:          tar.New(),
-		urlTimeout:   urlCheckTimeout,
+		urlTimeout:   initialURLCheckTimeout,
 		client:       buildsClient,
 		cgLimits:     cgLimits,
 	}

--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -32,16 +32,6 @@ func TestCheckRemoteGit(t *testing.T) {
 		t.Errorf("expected gitAuthError, got %q", v)
 	}
 
-	t0 := time.Now()
-	err = checkRemoteGit(gitRepo, "https://254.254.254.254/foo/bar", 4*time.Second)
-	t1 := time.Now()
-	if err == nil || (err != nil && !strings.Contains(fmt.Sprintf("%s", err), "timeout")) {
-		t.Errorf("expected timeout error, got %q", err)
-	}
-	if t1.Sub(t0) > 5*time.Second {
-		t.Errorf("expected timeout in 4 seconds, it took %v", t1.Sub(t0))
-	}
-
 	err = checkRemoteGit(gitRepo, "https://github.com/openshift/origin", 10*time.Second)
 	if err != nil {
 		t.Errorf("unexpected error %q", err)

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -115,7 +115,7 @@ func (s *S2IBuilder) Build() error {
 	download := &downloader{
 		s:       s,
 		in:      os.Stdin,
-		timeout: urlCheckTimeout,
+		timeout: initialURLCheckTimeout,
 
 		dir:        srcDir,
 		contextDir: contextDir,


### PR DESCRIPTION
Repeatedly tries the git ls-remote call by growing the timeout exponentially. The git check will either succeed or the build will time out completely.