### PR TITLE
add validation to prevent filters on dn lookups

### DIFF
--- a/pkg/cmd/admin/groups/examples/examples_test.go
+++ b/pkg/cmd/admin/groups/examples/examples_test.go
@@ -23,7 +23,9 @@ func TestLDAPSyncConfigFixtures(t *testing.T) {
 		fixtures = append(fixtures, schema+"/sync-config-dn-everywhere.yaml")
 		fixtures = append(fixtures, schema+"/sync-config-partially-user-defined.yaml")
 		fixtures = append(fixtures, schema+"/sync-config-user-defined.yaml")
+		fixtures = append(fixtures, schema+"/sync-config-paging.yaml")
 	}
+	fixtures = append(fixtures, "rfc2307/sync-config-tolerating.yaml")
 
 	for _, fixture := range fixtures {
 		var config api.LDAPSyncConfig

--- a/pkg/cmd/server/api/validation/ldap.go
+++ b/pkg/cmd/server/api/validation/ldap.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/ldap.v2"
 
@@ -111,7 +112,8 @@ func ValidateRFC2307Config(config *api.RFC2307Config) ValidationResults {
 		validationResults.AddErrors(field.Required(field.NewPath("groupMembershipAttributes"), ""))
 	}
 
-	validationResults.Append(ValidateLDAPQuery(config.AllUsersQuery, field.NewPath("usersQuery")))
+	isUserDNQuery := strings.TrimSpace(strings.ToLower(config.UserUIDAttribute)) == "dn"
+	validationResults.Append(validateLDAPQuery(config.AllUsersQuery, field.NewPath("usersQuery"), isUserDNQuery))
 	if len(config.UserUIDAttribute) == 0 {
 		validationResults.AddErrors(field.Required(field.NewPath("userUIDAttribute"), ""))
 	}
@@ -147,7 +149,8 @@ func ValidateAugmentedActiveDirectoryConfig(config *api.AugmentedActiveDirectory
 		validationResults.AddErrors(field.Required(field.NewPath("groupMembershipAttributes"), ""))
 	}
 
-	validationResults.Append(ValidateLDAPQuery(config.AllGroupsQuery, field.NewPath("groupsQuery")))
+	isGroupDNQuery := strings.TrimSpace(strings.ToLower(config.GroupUIDAttribute)) == "dn"
+	validationResults.Append(validateLDAPQuery(config.AllGroupsQuery, field.NewPath("groupsQuery"), isGroupDNQuery))
 	if len(config.GroupUIDAttribute) == 0 {
 		validationResults.AddErrors(field.Required(field.NewPath("groupUIDAttribute"), ""))
 	}
@@ -159,6 +162,9 @@ func ValidateAugmentedActiveDirectoryConfig(config *api.AugmentedActiveDirectory
 }
 
 func ValidateLDAPQuery(query api.LDAPQuery, fldPath *field.Path) ValidationResults {
+	return validateLDAPQuery(query, fldPath, false)
+}
+func validateLDAPQuery(query api.LDAPQuery, fldPath *field.Path, isDNOnly bool) ValidationResults {
 	validationResults := ValidationResults{}
 
 	if _, err := ldap.ParseDN(query.BaseDN); err != nil {
@@ -183,6 +189,13 @@ func ValidateLDAPQuery(query api.LDAPQuery, fldPath *field.Path) ValidationResul
 	if query.TimeLimit < 0 {
 		validationResults.AddErrors(field.Invalid(fldPath.Child("timeout"), query.TimeLimit,
 			"timeout must be equal to or greater than zero"))
+	}
+
+	if isDNOnly {
+		if len(query.Filter) != 0 {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("filter"), query.Filter, `cannot specify a filter when using "dn" as the UID attribute`))
+		}
+		return validationResults
 	}
 
 	if _, err := ldap.CompileFilter(query.Filter); err != nil {

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-dn-everywhere.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-dn-everywhere.yaml
@@ -14,6 +14,5 @@ augmentedActiveDirectory:
         baseDN: "ou=groups,ou=adextended,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
     groupUIDAttribute: dn
     groupNameAttributes: [ dn ]

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-paging.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-paging.yaml
@@ -15,7 +15,6 @@ augmentedActiveDirectory:
         baseDN: "ou=groups,ou=adextended,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
         pageSize: 1
     groupUIDAttribute: dn
     groupNameAttributes: [ cn ]

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-partially-user-defined.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-partially-user-defined.yaml
@@ -17,6 +17,5 @@ augmentedActiveDirectory:
     baseDN: "ou=groups,ou=adextended,dc=example,dc=com"
     scope: sub
     derefAliases: never
-    filter: (objectclass=groupOfNames)
   groupUIDAttribute: dn
   groupNameAttributes: [ cn ]

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-user-defined.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-user-defined.yaml
@@ -18,6 +18,5 @@ augmentedActiveDirectory:
     baseDN: "ou=groups,ou=adextended,dc=example,dc=com"
     scope: sub
     derefAliases: never
-    filter: (objectclass=groupOfNames)
   groupUIDAttribute: dn
   groupNameAttributes: [ cn ]

--- a/test/extended/authentication/ldap/augmented-ad/sync-config.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config.yaml
@@ -14,6 +14,5 @@ augmentedActiveDirectory:
         baseDN: "ou=groups,ou=adextended,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=groupOfNames)
     groupUIDAttribute: dn
     groupNameAttributes: [ cn ]

--- a/test/extended/authentication/ldap/rfc2307/sync-config-dn-everywhere.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-dn-everywhere.yaml
@@ -15,6 +15,5 @@ rfc2307:
         baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
     userUIDAttribute: dn
     userNameAttributes: [ dn ]

--- a/test/extended/authentication/ldap/rfc2307/sync-config-paging.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-paging.yaml
@@ -16,7 +16,6 @@ rfc2307:
         baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
         pageSize: 1
     userUIDAttribute: dn
     userNameAttributes: [ mail ]

--- a/test/extended/authentication/ldap/rfc2307/sync-config-partially-user-defined.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-partially-user-defined.yaml
@@ -18,6 +18,5 @@ rfc2307:
     baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
     scope: sub
     derefAliases: never
-    filter: (objectclass=inetOrgPerson)
   userUIDAttribute: dn
   userNameAttributes: [ mail ]

--- a/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
@@ -15,7 +15,6 @@ rfc2307:
         baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
     userUIDAttribute: dn
     userNameAttributes: [ mail ]
     tolerateMemberNotFoundErrors: true

--- a/test/extended/authentication/ldap/rfc2307/sync-config-user-defined.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-user-defined.yaml
@@ -19,6 +19,5 @@ rfc2307:
     baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
     scope: sub
     derefAliases: never
-    filter: (objectclass=inetOrgPerson)
   userUIDAttribute: dn
   userNameAttributes: [ mail ]

--- a/test/extended/authentication/ldap/rfc2307/sync-config.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config.yaml
@@ -15,6 +15,5 @@ rfc2307:
         baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
         scope: sub
         derefAliases: never
-        filter: (objectclass=inetOrgPerson)
     userUIDAttribute: dn
     userNameAttributes: [ mail ]


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1339325

Tightens validation for ldap sync config.  Filters on dn lookups don't work.

@stevekuznetsov can you tag this for the right extended test?