### PR TITLE
[POC]  oc patch against master-config.yaml

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -202,7 +202,7 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		cachedDiscoverClient := NewCachedDiscoveryClient(client.NewDiscoveryClient(oclient.RESTClient), cacheDir, time.Duration(10*time.Minute))
 
 		mapper := restmapper.NewDiscoveryRESTMapper(cachedDiscoverClient)
-		mapper = NewShortcutExpander(cachedDiscoverClient, kubectl.ShortcutExpander{RESTMapper: mapper})
+		mapper = NewShortcutExpander(cachedDiscoverClient, kubectl.ShortcutExpander{RESTMapper: restMapper})
 		return kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []unversioned.GroupVersion{cmdApiVersion}}, api.Scheme
 	}
 


### PR DESCRIPTION
This makes `oc patch --local-file openshift.local.config/master/master-config.yaml --patch='{"auditConfig": {"enabled": true}}'` do what you expect.

This is hacked in to make it work across schemes.  I think we'll need to register in the same scheme (effectively claiming types), then expose a selective `RESTMapper` to union in.  Also, we need to make a non-discovery "backup" `RESTMapper` as a general matter of course.

@soltysh @stevekuznetsov let's fix our problems, not hack around them.