### PR TITLE
address typecast panic

### DIFF
--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -285,6 +285,17 @@ func SplitImageStreamTag(nameAndTag string) (name string, tag string, ok bool) {
 	return name, tag, len(parts) == 2
 }
 
+// SplitImageStreamImage turns the name of an ImageStreamImage into Name and ID.
+// It returns false if the ID was not properly specified in the name.
+func SplitImageStreamImage(nameAndID string) (name string, id string, ok bool) {
+	parts := strings.SplitN(nameAndID, "@", 2)
+	name = parts[0]
+	if len(parts) > 1 {
+		id = parts[1]
+	}
+	return name, id, len(parts) == 2
+}
+
 // JoinImageStreamTag turns a name and tag into the name of an ImageStreamTag
 func JoinImageStreamTag(name, tag string) string {
 	if len(tag) == 0 {

--- a/pkg/image/graph/nodes/types.go
+++ b/pkg/image/graph/nodes/types.go
@@ -102,6 +102,15 @@ type ImageStreamImageNode struct {
 	IsFound bool
 }
 
+func (n ImageStreamImageNode) ImageSpec() string {
+	return n.ImageStreamImage.Namespace + "/" + n.ImageStreamImage.Name
+}
+
+func (n ImageStreamImageNode) ImageTag() string {
+	_, id, _ := imageapi.SplitImageStreamImage(n.ImageStreamImage.Name)
+	return id
+}
+
 func (n ImageStreamImageNode) Object() interface{} {
 	return n.ImageStreamImage
 }


### PR DESCRIPTION
@deads2k or @kargakis PTAL

@bparees FYI

Note:  based on what I saw of the usage of https://github.com/openshift/origin/blob/master/pkg/api/graph/graphview/image_pipeline.go#L35-L39 I believe what this change outputs for an ImageStreamImage type is OK.  But of course correct me if I'm missing something. 