### PR TITLE
router: Add name and namespace templates params

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -418,8 +418,10 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string)
 	backendKey := r.routeKey(route)
 
 	config := ServiceAliasConfig{
-		Host: host,
-		Path: route.Spec.Path,
+		Name:      route.Name,
+		Namespace: route.Namespace,
+		Host:      host,
+		Path:      route.Spec.Path,
 	}
 
 	if route.Spec.Port != nil {

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -19,6 +19,10 @@ type ServiceUnit struct {
 
 // ServiceAliasConfig is a route for a service.  Uniquely identified by host + path.
 type ServiceAliasConfig struct {
+	// Name is the user-specified name of the route.
+	Name string
+	// Namespace is the namespace of the route.
+	Namespace string
 	// Host is a required host name ie. www.example.com
 	Host string
 	// Path is an optional path ie. www.example.com/myservice where "myservice" is the path


### PR DESCRIPTION
Add `Name` and `Namespace` to `ServiceAliasConfig`, and set them in the template router's `AddRoute`, in order to make these route parameters available for custom configuration templates.

-

[test]