### PR TITLE
bypass k8s container image validation when ict's defined (allow for e…

### DIFF
--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -160,6 +160,18 @@ func OkPodTemplate() *kapi.PodTemplateSpec {
 	}
 }
 
+func OkPodTemplateMissingImage(missing ...string) *kapi.PodTemplateSpec {
+	set := sets.NewString(missing...)
+	template := OkPodTemplate()
+	for i, c := range template.Spec.Containers {
+		if set.Has(c.Name) {
+			// rememeber that slices use copies, so have to ref array entry explicitly
+			template.Spec.Containers[i].Image = ""
+		}
+	}
+	return template
+}
+
 func OkConfigChangeTrigger() deployapi.DeploymentTriggerPolicy {
 	return deployapi.DeploymentTriggerPolicy{
 		Type: deployapi.DeploymentTriggerOnConfigChange,


### PR DESCRIPTION
…mpty string)

per a discussion between @smarterclayton , @bparees , and myself (and perhaps @kargakis as well, though maybe he got pulled in later on), @smarterclayton asked that we introduce a change to bypass the k8s validation in the container image field when an openshift ICT is defined (which will populate said field).

While the OpenShift sample templates will still set this field to non-empty for backward compatibility, we can at least allow customers with new templates to not have to put a meaningless value for the container.image field.

PTAL gentlemen