### PR TITLE
let the rules review endpoint respect scopes

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -23056,6 +23056,9 @@
    "v1.SelfSubjectRulesReview": {
     "id": "v1.SelfSubjectRulesReview",
     "description": "SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace",
+    "required": [
+     "spec"
+    ],
     "properties": {
      "kind": {
       "type": "string",
@@ -23065,9 +23068,29 @@
       "type": "string",
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
+     "spec": {
+      "$ref": "v1.SelfSubjectRulesReviewSpec",
+      "description": "Spec adds information about how to conduct the check"
+     },
      "status": {
       "$ref": "v1.SubjectRulesReviewStatus",
       "description": "Status is completed by the server to tell which permissions you have"
+     }
+    }
+   },
+   "v1.SelfSubjectRulesReviewSpec": {
+    "id": "v1.SelfSubjectRulesReviewSpec",
+    "description": "SelfSubjectRulesReviewSpec adds information about how to conduct the check",
+    "required": [
+     "scopes"
+    ],
+    "properties": {
+     "scopes": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Scopes to use for the evaluation.  Empty means \"use the unscoped (full) permissions of the user/groups\". Nil means \"use the scopes on this request\"."
      }
     }
    },

--- a/pkg/authorization/api/deep_copy_generated.go
+++ b/pkg/authorization/api/deep_copy_generated.go
@@ -38,6 +38,7 @@ func init() {
 		DeepCopy_api_RoleBindingList,
 		DeepCopy_api_RoleList,
 		DeepCopy_api_SelfSubjectRulesReview,
+		DeepCopy_api_SelfSubjectRulesReviewSpec,
 		DeepCopy_api_SubjectAccessReview,
 		DeepCopy_api_SubjectAccessReviewResponse,
 		DeepCopy_api_SubjectRulesReviewStatus,
@@ -598,8 +599,22 @@ func DeepCopy_api_SelfSubjectRulesReview(in SelfSubjectRulesReview, out *SelfSub
 	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
+	if err := DeepCopy_api_SelfSubjectRulesReviewSpec(in.Spec, &out.Spec, c); err != nil {
+		return err
+	}
 	if err := DeepCopy_api_SubjectRulesReviewStatus(in.Status, &out.Status, c); err != nil {
 		return err
+	}
+	return nil
+}
+
+func DeepCopy_api_SelfSubjectRulesReviewSpec(in SelfSubjectRulesReviewSpec, out *SelfSubjectRulesReviewSpec, c *conversion.Cloner) error {
+	if in.Scopes != nil {
+		in, out := in.Scopes, &out.Scopes
+		*out = make([]string, len(in))
+		copy(*out, in)
+	} else {
+		out.Scopes = nil
 	}
 	return nil
 }

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -327,3 +327,11 @@ func (r *PolicyRuleBuilder) Rule() (PolicyRule, error) {
 
 	return r.PolicyRule, nil
 }
+
+type SortableRuleSlice []PolicyRule
+
+func (s SortableRuleSlice) Len() int      { return len(s) }
+func (s SortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s SortableRuleSlice) Less(i, j int) bool {
+	return strings.Compare(s[i].String(), s[j].String()) < 0
+}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -138,8 +138,19 @@ type PolicyBinding struct {
 type SelfSubjectRulesReview struct {
 	unversioned.TypeMeta
 
+	// Spec adds information about how to conduct the check
+	Spec SelfSubjectRulesReviewSpec
+
 	// Status is completed by the server to tell which permissions you have
 	Status SubjectRulesReviewStatus
+}
+
+// SelfSubjectRulesReviewSpec adds information about how to conduct the check
+type SelfSubjectRulesReviewSpec struct {
+	// Scopes to use for the evaluation.  Empty means "use the unscoped (full) permissions of the user/groups".
+	// Nil for a self-SubjectRulesReview, means "use the scopes on this request".
+	// Nil for a regular SubjectRulesReview, means the same as empty.
+	Scopes []string
 }
 
 // SubjectRulesReviewStatus is contains the result of a rules check

--- a/pkg/authorization/api/v1/conversion_generated.go
+++ b/pkg/authorization/api/v1/conversion_generated.go
@@ -63,6 +63,8 @@ func init() {
 		Convert_api_RoleList_To_v1_RoleList,
 		Convert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview,
 		Convert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview,
+		Convert_v1_SelfSubjectRulesReviewSpec_To_api_SelfSubjectRulesReviewSpec,
+		Convert_api_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec,
 		Convert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
 		Convert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
 		Convert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse,
@@ -774,6 +776,9 @@ func autoConvert_v1_SelfSubjectRulesReview_To_api_SelfSubjectRulesReview(in *Sel
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
+	if err := Convert_v1_SelfSubjectRulesReviewSpec_To_api_SelfSubjectRulesReviewSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
 	if err := Convert_v1_SubjectRulesReviewStatus_To_api_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
@@ -791,6 +796,9 @@ func autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in *aut
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
 	}
+	if err := Convert_api_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
 	if err := Convert_api_SubjectRulesReviewStatus_To_v1_SubjectRulesReviewStatus(&in.Status, &out.Status, s); err != nil {
 		return err
 	}
@@ -799,6 +807,42 @@ func autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in *aut
 
 func Convert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in *authorization_api.SelfSubjectRulesReview, out *SelfSubjectRulesReview, s conversion.Scope) error {
 	return autoConvert_api_SelfSubjectRulesReview_To_v1_SelfSubjectRulesReview(in, out, s)
+}
+
+func autoConvert_v1_SelfSubjectRulesReviewSpec_To_api_SelfSubjectRulesReviewSpec(in *SelfSubjectRulesReviewSpec, out *authorization_api.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*SelfSubjectRulesReviewSpec))(in)
+	}
+	if in.Scopes != nil {
+		in, out := &in.Scopes, &out.Scopes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	} else {
+		out.Scopes = nil
+	}
+	return nil
+}
+
+func Convert_v1_SelfSubjectRulesReviewSpec_To_api_SelfSubjectRulesReviewSpec(in *SelfSubjectRulesReviewSpec, out *authorization_api.SelfSubjectRulesReviewSpec, s conversion.Scope) error {
+	return autoConvert_v1_SelfSubjectRulesReviewSpec_To_api_SelfSubjectRulesReviewSpec(in, out, s)
+}
+
+func autoConvert_api_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec(in *authorization_api.SelfSubjectRulesReviewSpec, out *SelfSubjectRulesReviewSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorization_api.SelfSubjectRulesReviewSpec))(in)
+	}
+	if in.Scopes != nil {
+		in, out := &in.Scopes, &out.Scopes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	} else {
+		out.Scopes = nil
+	}
+	return nil
+}
+
+func Convert_api_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec(in *authorization_api.SelfSubjectRulesReviewSpec, out *SelfSubjectRulesReviewSpec, s conversion.Scope) error {
+	return autoConvert_api_SelfSubjectRulesReviewSpec_To_v1_SelfSubjectRulesReviewSpec(in, out, s)
 }
 
 func autoConvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse(in *SubjectAccessReviewResponse, out *authorization_api.SubjectAccessReviewResponse, s conversion.Scope) error {

--- a/pkg/authorization/api/v1/deep_copy_generated.go
+++ b/pkg/authorization/api/v1/deep_copy_generated.go
@@ -42,6 +42,7 @@ func init() {
 		DeepCopy_v1_RoleBindingList,
 		DeepCopy_v1_RoleList,
 		DeepCopy_v1_SelfSubjectRulesReview,
+		DeepCopy_v1_SelfSubjectRulesReviewSpec,
 		DeepCopy_v1_SubjectAccessReview,
 		DeepCopy_v1_SubjectAccessReviewResponse,
 		DeepCopy_v1_SubjectRulesReviewStatus,
@@ -604,8 +605,22 @@ func DeepCopy_v1_SelfSubjectRulesReview(in SelfSubjectRulesReview, out *SelfSubj
 	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
 	}
+	if err := DeepCopy_v1_SelfSubjectRulesReviewSpec(in.Spec, &out.Spec, c); err != nil {
+		return err
+	}
 	if err := DeepCopy_v1_SubjectRulesReviewStatus(in.Status, &out.Status, c); err != nil {
 		return err
+	}
+	return nil
+}
+
+func DeepCopy_v1_SelfSubjectRulesReviewSpec(in SelfSubjectRulesReviewSpec, out *SelfSubjectRulesReviewSpec, c *conversion.Cloner) error {
+	if in.Scopes != nil {
+		in, out := in.Scopes, &out.Scopes
+		*out = make([]string, len(in))
+		copy(*out, in)
+	} else {
+		out.Scopes = nil
 	}
 	return nil
 }

--- a/pkg/authorization/api/v1/swagger_doc.go
+++ b/pkg/authorization/api/v1/swagger_doc.go
@@ -294,11 +294,21 @@ func (RoleList) SwaggerDoc() map[string]string {
 
 var map_SelfSubjectRulesReview = map[string]string{
 	"":       "SelfSubjectRulesReview is a resource you can create to determine which actions you can perform in a namespace",
+	"spec":   "Spec adds information about how to conduct the check",
 	"status": "Status is completed by the server to tell which permissions you have",
 }
 
 func (SelfSubjectRulesReview) SwaggerDoc() map[string]string {
 	return map_SelfSubjectRulesReview
+}
+
+var map_SelfSubjectRulesReviewSpec = map[string]string{
+	"":       "SelfSubjectRulesReviewSpec adds information about how to conduct the check",
+	"scopes": "Scopes to use for the evaluation.  Empty means \"use the unscoped (full) permissions of the user/groups\". Nil means \"use the scopes on this request\".",
+}
+
+func (SelfSubjectRulesReviewSpec) SwaggerDoc() map[string]string {
+	return map_SelfSubjectRulesReviewSpec
 }
 
 var map_SubjectAccessReview = map[string]string{

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -120,8 +120,18 @@ type NamedRoleBinding struct {
 type SelfSubjectRulesReview struct {
 	unversioned.TypeMeta `json:",inline"`
 
+	// Spec adds information about how to conduct the check
+	Spec SelfSubjectRulesReviewSpec `json:"spec"`
+
 	// Status is completed by the server to tell which permissions you have
 	Status SubjectRulesReviewStatus `json:"status,omitempty"`
+}
+
+// SelfSubjectRulesReviewSpec adds information about how to conduct the check
+type SelfSubjectRulesReviewSpec struct {
+	// Scopes to use for the evaluation.  Empty means "use the unscoped (full) permissions of the user/groups".
+	// Nil means "use the scopes on this request".
+	Scopes []string `json:"scopes"`
 }
 
 // SubjectRulesReviewStatus is contains the result of a rules check

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -113,8 +113,18 @@ type NamedRoleBinding struct {
 type SelfSubjectRulesReview struct {
 	unversioned.TypeMeta `json:",inline"`
 
+	// Spec adds information about how to conduct the check
+	Spec SelfSubjectRulesReviewSpec `json:"spec"`
+
 	// Status is completed by the server to tell which permissions you have
 	Status SubjectRulesReviewStatus `json:"status,omitempty"`
+}
+
+// SelfSubjectRulesReviewSpec adds information about how to conduct the check
+type SelfSubjectRulesReviewSpec struct {
+	// Scopes to use for the evaluation.  Empty means "use the unscoped (full) permissions of the user/groups".
+	// Nil means "use the scopes on this request".
+	Scopes []string `json:"scopes"`
 }
 
 // SubjectRulesReviewStatus is contains the result of a rules check

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -126,6 +126,7 @@ func (userEvaluator) ResolveRules(scope, namespace string, clusterPolicyGetter r
 	case UserIndicator + UserAccessCheck:
 		return []authorizationapi.PolicyRule{
 			{Verbs: sets.NewString("create"), APIGroups: []string{authorizationapi.GroupName}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+			authorizationapi.NewRule("create").Groups(authorizationapi.GroupName).Resources("selfsubjectrulesreviews").RuleOrDie(),
 		}, nil
 	case UserIndicator + UserListProject:
 		return []authorizationapi.PolicyRule{
@@ -214,8 +215,7 @@ func (e clusterRoleEvaluator) ResolveRules(scope, namespace string, clusterPolic
 		return []authorizationapi.PolicyRule{}, nil
 	}
 
-	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
-	policy, err := clusterPolicyGetter.GetClusterPolicy(ctx, "default")
+	policy, err := clusterPolicyGetter.GetClusterPolicy(kapi.NewContext(), "default")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -45,12 +45,12 @@ func TestUserEvaluator(t *testing.T) {
 		{
 			name:     "access",
 			scopes:   []string{UserIndicator + UserAccessCheck},
-			numRules: 2,
+			numRules: 3,
 		},
 		{
 			name:     "both",
 			scopes:   []string{UserIndicator + UserInfo, UserIndicator + UserAccessCheck},
-			numRules: 3,
+			numRules: 4,
 		},
 		{
 			name:     "list-projects",

--- a/pkg/authorization/registry/selfsubjectrulesreview/storage.go
+++ b/pkg/authorization/registry/selfsubjectrulesreview/storage.go
@@ -1,19 +1,25 @@
 package selfsubjectrulesreview
 
 import (
+	"fmt"
+	"sort"
+
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/runtime"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 )
 
 type REST struct {
-	ruleResolver rulevalidation.AuthorizationRuleResolver
+	ruleResolver        rulevalidation.AuthorizationRuleResolver
+	clusterPolicyGetter rulevalidation.ClusterPolicyGetter
 }
 
-func NewREST(ruleResolver rulevalidation.AuthorizationRuleResolver) *REST {
-	return &REST{ruleResolver: ruleResolver}
+func NewREST(ruleResolver rulevalidation.AuthorizationRuleResolver, clusterPolicyGetter rulevalidation.ClusterPolicyGetter) *REST {
+	return &REST{ruleResolver: ruleResolver, clusterPolicyGetter: clusterPolicyGetter}
 }
 
 func (r *REST) New() runtime.Object {
@@ -22,12 +28,50 @@ func (r *REST) New() runtime.Object {
 
 // Create registers a given new ResourceAccessReview instance to r.registry.
 func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
-	// the input object has no valuable input, so don't bother checking it.false
+	rulesReview, ok := obj.(*authorizationapi.SelfSubjectRulesReview)
+	if !ok {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a SelfSubjectRulesReview: %#v", obj))
+	}
+	namespace := kapi.NamespaceValue(ctx)
+	if len(namespace) == 0 {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("namespace is required on this type: %v", namespace))
+	}
+	user, exists := kapi.UserFrom(ctx)
+	if !exists {
+		return nil, fmt.Errorf("user missing from context")
+	}
+
 	policyRules, err := r.ruleResolver.GetEffectivePolicyRules(ctx)
+	rules := []authorizationapi.PolicyRule{}
+	for _, rule := range policyRules {
+		rules = append(rules, rulevalidation.BreakdownRule(rule)...)
+	}
+
+	switch {
+	case rulesReview.Spec.Scopes == nil:
+		if scopes, _ := user.GetExtra()[authorizationapi.ScopesKey]; len(scopes) > 0 {
+			rules, err = r.filterRulesByScopes(rules, scopes, namespace)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+	case len(rulesReview.Spec.Scopes) > 0:
+		rules, err = r.filterRulesByScopes(rules, rulesReview.Spec.Scopes, namespace)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	if compactedRules, err := rulevalidation.CompactRules(rules); err == nil {
+		rules = compactedRules
+	}
+	sort.Sort(authorizationapi.SortableRuleSlice(rules))
 
 	ret := &authorizationapi.SelfSubjectRulesReview{
 		Status: authorizationapi.SubjectRulesReviewStatus{
-			Rules: policyRules,
+			Rules: rules,
 		},
 	}
 
@@ -36,4 +80,20 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	}
 
 	return ret, nil
+}
+
+func (r *REST) filterRulesByScopes(rules []authorizationapi.PolicyRule, scopes []string, namespace string) ([]authorizationapi.PolicyRule, error) {
+	scopeRules, err := scope.ScopesToRules(scopes, namespace, r.clusterPolicyGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredRules := []authorizationapi.PolicyRule{}
+	for _, rule := range rules {
+		if allowed, _ := rulevalidation.Covers(scopeRules, []authorizationapi.PolicyRule{rule}); allowed {
+			filteredRules = append(filteredRules, rule)
+		}
+	}
+
+	return filteredRules, nil
 }

--- a/pkg/authorization/rulevalidation/compact_rules_test.go
+++ b/pkg/authorization/rulevalidation/compact_rules_test.go
@@ -3,7 +3,6 @@ package rulevalidation
 import (
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -12,14 +11,6 @@ import (
 
 	"github.com/openshift/origin/pkg/authorization/api"
 )
-
-type sortableRuleSlice []api.PolicyRule
-
-func (s sortableRuleSlice) Len() int      { return len(s) }
-func (s sortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s sortableRuleSlice) Less(i, j int) bool {
-	return strings.Compare(s[i].String(), s[j].String()) < 0
-}
 
 func TestCompactRules(t *testing.T) {
 	testcases := map[string]struct {
@@ -138,8 +129,8 @@ func TestCompactRules(t *testing.T) {
 			continue
 		}
 
-		sort.Stable(sortableRuleSlice(compacted))
-		sort.Stable(sortableRuleSlice(tc.Expected))
+		sort.Stable(api.SortableRuleSlice(compacted))
+		sort.Stable(api.SortableRuleSlice(tc.Expected))
 		if !reflect.DeepEqual(compacted, tc.Expected) {
 			t.Errorf("%s: Expected\n%#v\ngot\n%#v", k, tc.Expected, compacted)
 			continue

--- a/pkg/authorization/rulevalidation/policy_comparator.go
+++ b/pkg/authorization/rulevalidation/policy_comparator.go
@@ -16,7 +16,7 @@ func Covers(ownerRules, servantRules []authorizationapi.PolicyRule) (bool, []aut
 
 	subrules := []authorizationapi.PolicyRule{}
 	for _, servantRule := range servantRules {
-		subrules = append(subrules, breakdownRule(servantRule)...)
+		subrules = append(subrules, BreakdownRule(servantRule)...)
 	}
 
 	// fmt.Printf("subrules: %v\n", subrules)
@@ -40,9 +40,9 @@ func Covers(ownerRules, servantRules []authorizationapi.PolicyRule) (bool, []aut
 	return (len(uncoveredRules) == 0), uncoveredRules
 }
 
-// breadownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one
+// BreakdownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one
 // resource, and one resource name
-func breakdownRule(rule authorizationapi.PolicyRule) []authorizationapi.PolicyRule {
+func BreakdownRule(rule authorizationapi.PolicyRule) []authorizationapi.PolicyRule {
 	subrules := []authorizationapi.PolicyRule{}
 
 	for _, group := range rule.APIGroups {

--- a/pkg/cmd/admin/policy/cani.go
+++ b/pkg/cmd/admin/policy/cani.go
@@ -169,7 +169,12 @@ func (o *canIOptions) Run() (bool, error) {
 }
 
 func (o *canIOptions) listAllPermissions() error {
-	whatCanIDo, err := o.RulesReviewClient.SelfSubjectRulesReviews(o.Namespace).Create(&authorizationapi.SelfSubjectRulesReview{})
+	rulesReview := &authorizationapi.SelfSubjectRulesReview{}
+	if len(o.Scopes) > 0 {
+		rulesReview.Spec.Scopes = o.Scopes
+	}
+
+	whatCanIDo, err := o.RulesReviewClient.SelfSubjectRulesReviews(o.Namespace).Create(rulesReview)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -406,8 +406,6 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	groupStorage, err := groupetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 
-	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver)
-
 	policyStorage, err := policyetcd.NewStorage(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	policyRegistry := policyregistry.NewRegistry(policyStorage)
@@ -422,6 +420,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	checkStorageErr(err)
 	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewRegistry(clusterPolicyBindingStorage)
 
+	// TODO collapse onto common cache once we've gotten shared informers from kube
+	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, clusterPolicyRegistry)
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		policyRegistry,
 		policyBindingRegistry,


### PR DESCRIPTION
Adds a `Scopes` field for a self subject rules review.

@openshift/api-review 