### PR TITLE
Added REST storage for images/signatures resource

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -8810,6 +8810,96 @@
     ]
    },
    {
+    "path": "/oapi/v1/imagesignatures",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.ImageSignature",
+      "method": "POST",
+      "summary": "create a ImageSignature",
+      "nickname": "createImageSignature",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.ImageSignature",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ImageSignature"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/imagesignatures/{name}",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete a ImageSignature",
+      "nickname": "deleteImageSignature",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ImageSignature",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/namespaces/{namespace}/imagestreamimages/{name}",
     "description": "OpenShift REST API, version v1",
     "operations": [
@@ -23440,12 +23530,24 @@
    },
    "v1.ImageSignature": {
     "id": "v1.ImageSignature",
-    "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. There are two mandatory fields provided by client: Type and Content. They should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose.",
+    "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose.",
     "required": [
      "type",
      "content"
     ],
     "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata."
+     },
      "type": {
       "type": "string",
       "description": "Required: Describes a type of stored blob."
@@ -23496,7 +23598,7 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type of job condition, Complete or Failed."
+      "description": "Type of signature condition, Complete or Failed."
      },
      "status": {
       "type": "string",

--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -283,6 +283,17 @@ func init() {
 				return true, imagev1.Convert_api_Image_To_v1_Image(a, b, s)
 			}
 
+		case *imagev1.ImageSignature:
+			switch b := objB.(type) {
+			case *imageapi.ImageSignature:
+				return true, imagev1.Convert_v1_ImageSignature_To_api_ImageSignature(a, b, s)
+			}
+		case *imageapi.ImageSignature:
+			switch b := objB.(type) {
+			case *imagev1.ImageSignature:
+				return true, imagev1.Convert_api_ImageSignature_To_v1_ImageSignature(a, b, s)
+			}
+
 		case *imagev1.ImageStreamImport:
 			switch b := objB.(type) {
 			case *imageapi.ImageStreamImport:

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -196,10 +196,20 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 		func(j *image.Image, c fuzz.Continue) {
 			c.Fuzz(&j.ObjectMeta)
 			c.Fuzz(&j.DockerImageMetadata)
+			c.Fuzz(&j.Signatures)
 			j.DockerImageMetadata.APIVersion = ""
 			j.DockerImageMetadata.Kind = ""
 			j.DockerImageMetadataVersion = []string{"pre012", "1.0"}[c.Rand.Intn(2)]
 			j.DockerImageReference = c.RandString()
+		},
+		func(j *image.ImageSignature, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			j.Conditions = nil
+			j.ImageIdentity = ""
+			j.SignedClaims = nil
+			j.Created = nil
+			j.IssuedBy = nil
+			j.IssuedTo = nil
 		},
 		func(j *image.ImageStreamMapping, c fuzz.Continue) {
 			c.FuzzNoCustom(j)

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -67,6 +67,7 @@ func registerAll() {
 	Validator.MustRegister(&extensions.Scale{}, extvalidation.ValidateScale, nil)
 
 	Validator.MustRegister(&imageapi.Image{}, imagevalidation.ValidateImage, imagevalidation.ValidateImageUpdate)
+	Validator.MustRegister(&imageapi.ImageSignature{}, imagevalidation.ValidateImageSignature, imagevalidation.ValidateImageSignatureUpdate)
 	Validator.MustRegister(&imageapi.ImageStream{}, imagevalidation.ValidateImageStream, imagevalidation.ValidateImageStreamUpdate)
 	Validator.MustRegister(&imageapi.ImageStreamImport{}, imagevalidation.ValidateImageStreamImport, nil)
 	Validator.MustRegister(&imageapi.ImageStreamMapping{}, imagevalidation.ValidateImageStreamMapping, nil)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,7 @@ type Interface interface {
 	BuildConfigsNamespacer
 	BuildLogsNamespacer
 	ImagesInterfacer
+	ImageSignaturesInterfacer
 	ImageStreamsNamespacer
 	ImageStreamMappingsNamespacer
 	ImageStreamTagsNamespacer
@@ -82,6 +83,11 @@ func (c *Client) BuildLogs(namespace string) BuildLogsInterface {
 // Images provides a REST client for Images
 func (c *Client) Images() ImageInterface {
 	return newImages(c)
+}
+
+// ImageSignatures provides a REST client for ImageSignatures
+func (c *Client) ImageSignatures() ImageSignatureInterface {
+	return newImageSignatures(c)
 }
 
 // ImageStreamImages provides a REST client for retrieving image secrets in a namespace

--- a/pkg/client/images.go
+++ b/pkg/client/images.go
@@ -16,6 +16,7 @@ type ImageInterface interface {
 	List(opts kapi.ListOptions) (*imageapi.ImageList, error)
 	Get(name string) (*imageapi.Image, error)
 	Create(image *imageapi.Image) (*imageapi.Image, error)
+	Update(image *imageapi.Image) (*imageapi.Image, error)
 	Delete(name string) error
 }
 
@@ -53,6 +54,14 @@ func (c *images) Get(name string) (result *imageapi.Image, err error) {
 func (c *images) Create(image *imageapi.Image) (result *imageapi.Image, err error) {
 	result = &imageapi.Image{}
 	err = c.r.Post().Resource("images").Body(image).Do().Into(result)
+	return
+}
+
+// Update allows to modify existing image. Since most of image's attributes are immutable, this call allows
+// mainly for updating image signatures.
+func (c *images) Update(image *imageapi.Image) (result *imageapi.Image, err error) {
+	result = &imageapi.Image{}
+	err = c.r.Put().Resource("images").Name(image.Name).Body(image).Do().Into(result)
 	return
 }
 

--- a/pkg/client/imagesignatures.go
+++ b/pkg/client/imagesignatures.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// ImageSignaturesInterfacer has methods to work with ImageSignature resource.
+type ImageSignaturesInterfacer interface {
+	ImageSignatures() ImageSignatureInterface
+}
+
+// ImageSignatureInterface exposes methods on ImageSignature virtual resource.
+type ImageSignatureInterface interface {
+	Create(signature *imageapi.ImageSignature) (*imageapi.ImageSignature, error)
+	Delete(name string) error
+}
+
+// imageSignatures implements ImageSignatureInterface.
+type imageSignatures struct {
+	r *Client
+}
+
+// newImageSignatures returns imageSignatures
+func newImageSignatures(c *Client) ImageSignatureInterface {
+	return &imageSignatures{
+		r: c,
+	}
+}
+
+// Create creates a new ImageSignature. Returns the server's representation of the signature and error if one
+// occurs.
+func (c *imageSignatures) Create(signature *imageapi.ImageSignature) (result *imageapi.ImageSignature, err error) {
+	result = &imageapi.ImageSignature{}
+	err = c.r.Post().Resource("imageSignatures").Body(signature).Do().Into(result)
+	return
+}
+
+// Delete deletes an ImageSignature, returns error if one occurs.
+func (c *imageSignatures) Delete(name string) error {
+	return c.r.Delete().Resource("imageSignatures").Name(name).Do().Error()
+}

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -141,6 +141,11 @@ func (c *Fake) Images() client.ImageInterface {
 	return &FakeImages{Fake: c}
 }
 
+// ImageSignatures provides a fake REST client for ImageSignatures
+func (c *Fake) ImageSignatures() client.ImageSignatureInterface {
+	return &FakeImageSignatures{Fake: c}
+}
+
 // ImageStreams provides a fake REST client for ImageStreams
 func (c *Fake) ImageStreamSecrets(namespace string) client.ImageStreamSecretInterface {
 	return &FakeImageStreamSecrets{Fake: c, Namespace: namespace}

--- a/pkg/client/testclient/fake_images.go
+++ b/pkg/client/testclient/fake_images.go
@@ -44,6 +44,15 @@ func (c *FakeImages) Create(inObj *imageapi.Image) (*imageapi.Image, error) {
 	return obj.(*imageapi.Image), err
 }
 
+func (c *FakeImages) Update(inObj *imageapi.Image) (*imageapi.Image, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootUpdateAction("images", inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*imageapi.Image), err
+}
+
 func (c *FakeImages) Delete(name string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("images", name), &imageapi.Image{})
 	return err

--- a/pkg/client/testclient/fake_imagesignatures.go
+++ b/pkg/client/testclient/fake_imagesignatures.go
@@ -1,0 +1,27 @@
+package testclient
+
+import (
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+
+	"github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// FakeImageSignatures implements ImageSignatureInterface. Meant to
+// be embedded into a struct to get a default implementation. This makes faking
+// out just the methods you want to test easier.
+type FakeImageSignatures struct {
+	Fake *Fake
+}
+
+var _ client.ImageSignatureInterface = &FakeImageSignatures{}
+
+func (c *FakeImageSignatures) Create(inObj *imageapi.ImageSignature) (*imageapi.ImageSignature, error) {
+	_, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("imagesignatures", inObj), inObj)
+	return inObj, err
+}
+
+func (c *FakeImageSignatures) Delete(name string) error {
+	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("imagesignatures", name), &imageapi.ImageSignature{})
+	return err
+}

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -59,6 +59,8 @@ var DescriberCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&oauthapi.OAuthClientAuthorization{}),              // normal users don't ever look at these
 	reflect.TypeOf(&projectapi.ProjectRequest{}),                      // normal users don't ever look at these
 	reflect.TypeOf(&authorizationapi.IsPersonalSubjectAccessReview{}), // not a top level resource
+	// ATM image signature doesn't provide any human readable information
+	reflect.TypeOf(&imageapi.ImageSignature{}),
 
 	// these resources can't be "GET"ed, so you can't make a describer for them
 	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),

--- a/pkg/cmd/cli/describe/printer_test.go
+++ b/pkg/cmd/cli/describe/printer_test.go
@@ -37,6 +37,7 @@ var PrinterCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
 	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
 	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
+	reflect.TypeOf(&imageapi.ImageSignature{}),
 	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalSubjectAccessReview{}),
 	reflect.TypeOf(&authorizationapi.LocalResourceAccessReview{}),

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -76,6 +76,7 @@ const (
 	ImagePusherRoleName       = "system:image-pusher"
 	ImageBuilderRoleName      = "system:image-builder"
 	ImagePrunerRoleName       = "system:image-pruner"
+	ImageSignerRoleName       = "system:image-signer"
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
 	RegistryRoleName          = "system:registry"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -130,7 +130,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs", "deploymentconfigs/scale", "deploymentconfigs/log",
 					"deploymentconfigs/status").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("images", "imagestreams", "imagestreamtags", "imagestreamimages",
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("images", "imagesignatures", "imagestreams", "imagestreamtags", "imagestreamimages",
 					"imagestreams/status").RuleOrDie(),
 				// pull images
 				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
@@ -446,6 +446,15 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("delete").Groups(imageGroup).Resources("images").RuleOrDie(),
 				authorizationapi.NewRule("get", "list").Groups(imageGroup).Resources("images", "imagestreams").RuleOrDie(),
 				authorizationapi.NewRule("update").Groups(imageGroup).Resources("imagestreams/status").RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ImageSignerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule("get").Groups(imageGroup).Resources("images", "imagestreams/layers").RuleOrDie(),
+				authorizationapi.NewRule("create", "delete").Groups(imageGroup).Resources("imagesignatures").RuleOrDie(),
 			},
 		},
 		{

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -58,6 +58,7 @@ import (
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagesecret"
+	"github.com/openshift/origin/pkg/image/registry/imagesignature"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 	imagestreametcd "github.com/openshift/origin/pkg/image/registry/imagestream/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagestreamimage"
@@ -467,6 +468,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	imageStorage, err := imageetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	imageRegistry := image.NewRegistry(imageStorage)
+	imageSignatureStorage := imagesignature.NewREST(c.PrivilegedLoopbackOpenShiftClient.Images())
 	imageStreamLimitVerifier := imageadmission.NewLimitVerifier(c.KubeClient())
 	imageStreamSecretsStorage := imagesecret.NewREST(c.ImageStreamSecretClient())
 	imageStreamStorage, imageStreamStatusStorage, internalImageStreamStorage, err := imagestreametcd.NewREST(c.RESTOptionsGetter, imageapi.DefaultRegistryFunc(defaultRegistryFunc), subjectAccessReviewRegistry, imageStreamLimitVerifier)
@@ -558,6 +560,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 	storage := map[string]rest.Storage{
 		"images":               imageStorage,
+		"imagesignatures":      imageSignatureStorage,
 		"imageStreams/secrets": imageStreamSecretsStorage,
 		"imageStreams":         imageStreamStorage,
 		"imageStreams/status":  imageStreamStatusStorage,

--- a/pkg/image/api/deep_copy_generated.go
+++ b/pkg/image/api/deep_copy_generated.go
@@ -493,6 +493,12 @@ func DeepCopy_api_ImageList(in ImageList, out *ImageList, c *conversion.Cloner) 
 }
 
 func DeepCopy_api_ImageSignature(in ImageSignature, out *ImageSignature, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := api.DeepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
 	out.Type = in.Type
 	if in.Content != nil {
 		in, out := in.Content, &out.Content

--- a/pkg/image/api/install/install.go
+++ b/pkg/image/api/install/install.go
@@ -95,7 +95,7 @@ func addVersionsToScheme(externalVersions ...unversioned.GroupVersion) {
 }
 
 func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper {
-	rootScoped := sets.NewString("Image")
+	rootScoped := sets.NewString("Image", "ImageSignature")
 	ignoredKinds := sets.NewString()
 	return kapi.NewDefaultRESTMapper(externalVersions, interfacesFor, importPrefix, ignoredKinds, rootScoped)
 }

--- a/pkg/image/api/register.go
+++ b/pkg/image/api/register.go
@@ -31,6 +31,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&Image{},
 		&ImageList{},
 		&DockerImage{},
+		&ImageSignature{},
 		&ImageStream{},
 		&ImageStreamList{},
 		&ImageStreamMapping{},
@@ -44,6 +45,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 func (obj *Image) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
 func (obj *ImageList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
 func (obj *DockerImage) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
+func (obj *ImageSignature) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *ImageStream) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
 func (obj *ImageStreamList) GetObjectKind() unversioned.ObjectKind    { return &obj.TypeMeta }
 func (obj *ImageStreamMapping) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -96,10 +96,12 @@ const (
 // ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims
 // as long as the signature is trusted. Based on this information it is possible to restrict runnable images
 // to those matching cluster-wide policy.
-// There are two mandatory fields provided by client: Type and Content. They should be parsed by clients doing
-// image verification. The others are parsed from signature's content by the server. They serve just an
-// informative purpose.
+// Mandatory fields should be parsed by clients doing image verification. The others are parsed from
+// signature's content by the server. They serve just an informative purpose.
 type ImageSignature struct {
+	unversioned.TypeMeta
+	kapi.ObjectMeta
+
 	// Required: Describes a type of stored blob.
 	Type string
 	// Required: An opaque binary string which is an image's signature.
@@ -144,7 +146,7 @@ type SignatureConditionType string
 
 // SignatureCondition describes an image signature condition of particular kind at particular probe time.
 type SignatureCondition struct {
-	// Type of job condition, Complete or Failed.
+	// Type of signature condition, Complete or Failed.
 	Type SignatureConditionType
 	// Status of the condition, one of True, False, Unknown.
 	Status kapi.ConditionStatus

--- a/pkg/image/api/v1/conversion_generated.go
+++ b/pkg/image/api/v1/conversion_generated.go
@@ -261,6 +261,12 @@ func Convert_api_ImageList_To_v1_ImageList(in *image_api.ImageList, out *ImageLi
 }
 
 func autoConvert_v1_ImageSignature_To_api_ImageSignature(in *ImageSignature, out *image_api.ImageSignature, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api_v1.Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
 	out.Type = in.Type
 	if err := conversion.Convert_Slice_byte_To_Slice_byte(&in.Content, &out.Content, s); err != nil {
 		return err
@@ -305,6 +311,12 @@ func Convert_v1_ImageSignature_To_api_ImageSignature(in *ImageSignature, out *im
 }
 
 func autoConvert_api_ImageSignature_To_v1_ImageSignature(in *image_api.ImageSignature, out *ImageSignature, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api_v1.Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
 	out.Type = in.Type
 	if err := conversion.Convert_Slice_byte_To_Slice_byte(&in.Content, &out.Content, s); err != nil {
 		return err

--- a/pkg/image/api/v1/deep_copy_generated.go
+++ b/pkg/image/api/v1/deep_copy_generated.go
@@ -177,6 +177,12 @@ func DeepCopy_v1_ImageList(in ImageList, out *ImageList, c *conversion.Cloner) e
 }
 
 func DeepCopy_v1_ImageSignature(in ImageSignature, out *ImageSignature, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := api_v1.DeepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
 	out.Type = in.Type
 	if in.Content != nil {
 		in, out := in.Content, &out.Content

--- a/pkg/image/api/v1/generated.pb.go
+++ b/pkg/image/api/v1/generated.pb.go
@@ -502,17 +502,25 @@ func (m *ImageSignature) MarshalTo(data []byte) (int, error) {
 	_ = l
 	data[i] = 0xa
 	i++
+	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
+	n9, err := m.ObjectMeta.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n9
+	data[i] = 0x12
+	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Type)))
 	i += copy(data[i:], m.Type)
 	if m.Content != nil {
-		data[i] = 0x12
+		data[i] = 0x1a
 		i++
 		i = encodeVarintGenerated(data, i, uint64(len(m.Content)))
 		i += copy(data[i:], m.Content)
 	}
 	if len(m.Conditions) > 0 {
 		for _, msg := range m.Conditions {
-			data[i] = 0x1a
+			data[i] = 0x22
 			i++
 			i = encodeVarintGenerated(data, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(data[i:])
@@ -522,13 +530,13 @@ func (m *ImageSignature) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
-	data[i] = 0x22
+	data[i] = 0x2a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.ImageIdentity)))
 	i += copy(data[i:], m.ImageIdentity)
 	if len(m.SignedClaims) > 0 {
 		for k := range m.SignedClaims {
-			data[i] = 0x2a
+			data[i] = 0x32
 			i++
 			v := m.SignedClaims[k]
 			mapSize := 1 + len(k) + sovGenerated(uint64(len(k))) + 1 + len(v) + sovGenerated(uint64(len(v)))
@@ -544,34 +552,34 @@ func (m *ImageSignature) MarshalTo(data []byte) (int, error) {
 		}
 	}
 	if m.Created != nil {
-		data[i] = 0x32
-		i++
-		i = encodeVarintGenerated(data, i, uint64(m.Created.Size()))
-		n9, err := m.Created.MarshalTo(data[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n9
-	}
-	if m.IssuedBy != nil {
 		data[i] = 0x3a
 		i++
-		i = encodeVarintGenerated(data, i, uint64(m.IssuedBy.Size()))
-		n10, err := m.IssuedBy.MarshalTo(data[i:])
+		i = encodeVarintGenerated(data, i, uint64(m.Created.Size()))
+		n10, err := m.Created.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n10
 	}
-	if m.IssuedTo != nil {
+	if m.IssuedBy != nil {
 		data[i] = 0x42
 		i++
-		i = encodeVarintGenerated(data, i, uint64(m.IssuedTo.Size()))
-		n11, err := m.IssuedTo.MarshalTo(data[i:])
+		i = encodeVarintGenerated(data, i, uint64(m.IssuedBy.Size()))
+		n11, err := m.IssuedBy.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n11
+	}
+	if m.IssuedTo != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintGenerated(data, i, uint64(m.IssuedTo.Size()))
+		n12, err := m.IssuedTo.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n12
 	}
 	return i, nil
 }
@@ -594,27 +602,27 @@ func (m *ImageStream) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n12, err := m.ObjectMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n12
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Spec.Size()))
-	n13, err := m.Spec.MarshalTo(data[i:])
+	n13, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n13
-	data[i] = 0x1a
+	data[i] = 0x12
 	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Status.Size()))
-	n14, err := m.Status.MarshalTo(data[i:])
+	i = encodeVarintGenerated(data, i, uint64(m.Spec.Size()))
+	n14, err := m.Spec.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n14
+	data[i] = 0x1a
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.Status.Size()))
+	n15, err := m.Status.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n15
 	return i, nil
 }
 
@@ -636,19 +644,19 @@ func (m *ImageStreamImage) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n15, err := m.ObjectMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n15
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Image.Size()))
-	n16, err := m.Image.MarshalTo(data[i:])
+	n16, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n16
+	data[i] = 0x12
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.Image.Size()))
+	n17, err := m.Image.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n17
 	return i, nil
 }
 
@@ -670,27 +678,27 @@ func (m *ImageStreamImport) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n17, err := m.ObjectMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n17
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Spec.Size()))
-	n18, err := m.Spec.MarshalTo(data[i:])
+	n18, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n18
-	data[i] = 0x1a
+	data[i] = 0x12
 	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Status.Size()))
-	n19, err := m.Status.MarshalTo(data[i:])
+	i = encodeVarintGenerated(data, i, uint64(m.Spec.Size()))
+	n19, err := m.Spec.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n19
+	data[i] = 0x1a
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.Status.Size()))
+	n20, err := m.Status.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n20
 	return i, nil
 }
 
@@ -721,11 +729,11 @@ func (m *ImageStreamImportSpec) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x12
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.Repository.Size()))
-		n20, err := m.Repository.MarshalTo(data[i:])
+		n21, err := m.Repository.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n20
+		i += n21
 	}
 	if len(m.Images) > 0 {
 		for _, msg := range m.Images {
@@ -761,21 +769,21 @@ func (m *ImageStreamImportStatus) MarshalTo(data []byte) (int, error) {
 		data[i] = 0xa
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.Import.Size()))
-		n21, err := m.Import.MarshalTo(data[i:])
+		n22, err := m.Import.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n21
+		i += n22
 	}
 	if m.Repository != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.Repository.Size()))
-		n22, err := m.Repository.MarshalTo(data[i:])
+		n23, err := m.Repository.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n22
+		i += n23
 	}
 	if len(m.Images) > 0 {
 		for _, msg := range m.Images {
@@ -810,11 +818,11 @@ func (m *ImageStreamList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n23, err := m.ListMeta.MarshalTo(data[i:])
+	n24, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n23
+	i += n24
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -848,19 +856,19 @@ func (m *ImageStreamMapping) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n24, err := m.ObjectMeta.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n24
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.Image.Size()))
-	n25, err := m.Image.MarshalTo(data[i:])
+	n25, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n25
+	data[i] = 0x12
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.Image.Size()))
+	n26, err := m.Image.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n26
 	data[i] = 0x1a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Tag)))
@@ -954,20 +962,20 @@ func (m *ImageStreamTag) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n26, err := m.ObjectMeta.MarshalTo(data[i:])
+	n27, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n26
+	i += n27
 	if m.Tag != nil {
 		data[i] = 0x12
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.Tag.Size()))
-		n27, err := m.Tag.MarshalTo(data[i:])
+		n28, err := m.Tag.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n27
+		i += n28
 	}
 	data[i] = 0x18
 	i++
@@ -987,11 +995,11 @@ func (m *ImageStreamTag) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x2a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.Image.Size()))
-	n28, err := m.Image.MarshalTo(data[i:])
+	n29, err := m.Image.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n29
 	return i, nil
 }
 
@@ -1013,11 +1021,11 @@ func (m *ImageStreamTagList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n29, err := m.ListMeta.MarshalTo(data[i:])
+	n30, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n29
+	i += n30
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -1097,19 +1105,19 @@ func (m *RepositoryImportSpec) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.From.Size()))
-	n30, err := m.From.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n30
-	data[i] = 0x12
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.ImportPolicy.Size()))
-	n31, err := m.ImportPolicy.MarshalTo(data[i:])
+	n31, err := m.From.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n31
+	data[i] = 0x12
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.ImportPolicy.Size()))
+	n32, err := m.ImportPolicy.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n32
 	data[i] = 0x18
 	i++
 	if m.IncludeManifest {
@@ -1139,11 +1147,11 @@ func (m *RepositoryImportStatus) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.Status.Size()))
-	n32, err := m.Status.MarshalTo(data[i:])
+	n33, err := m.Status.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n32
+	i += n33
 	if len(m.Images) > 0 {
 		for _, msg := range m.Images {
 			data[i] = 0x12
@@ -1200,19 +1208,19 @@ func (m *SignatureCondition) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.LastProbeTime.Size()))
-	n33, err := m.LastProbeTime.MarshalTo(data[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n33
-	data[i] = 0x22
-	i++
-	i = encodeVarintGenerated(data, i, uint64(m.LastTransitionTime.Size()))
-	n34, err := m.LastTransitionTime.MarshalTo(data[i:])
+	n34, err := m.LastProbeTime.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n34
+	data[i] = 0x22
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.LastTransitionTime.Size()))
+	n35, err := m.LastTransitionTime.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n35
 	data[i] = 0x2a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Reason)))
@@ -1268,11 +1276,11 @@ func (m *SignatureIssuer) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.SignatureGenericEntity.Size()))
-	n35, err := m.SignatureGenericEntity.MarshalTo(data[i:])
+	n36, err := m.SignatureGenericEntity.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n35
+	i += n36
 	return i, nil
 }
 
@@ -1294,11 +1302,11 @@ func (m *SignatureSubject) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.SignatureGenericEntity.Size()))
-	n36, err := m.SignatureGenericEntity.MarshalTo(data[i:])
+	n37, err := m.SignatureGenericEntity.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n36
+	i += n37
 	data[i] = 0x12
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.PublicKeyID)))
@@ -1324,11 +1332,11 @@ func (m *TagEvent) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.Created.Size()))
-	n37, err := m.Created.MarshalTo(data[i:])
+	n38, err := m.Created.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n37
+	i += n38
 	data[i] = 0x12
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.DockerImageReference)))
@@ -1369,11 +1377,11 @@ func (m *TagEventCondition) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x1a
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.LastTransitionTime.Size()))
-	n38, err := m.LastTransitionTime.MarshalTo(data[i:])
+	n39, err := m.LastTransitionTime.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n38
+	i += n39
 	data[i] = 0x22
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Reason)))
@@ -1462,11 +1470,11 @@ func (m *TagReference) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x1a
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.From.Size()))
-		n39, err := m.From.MarshalTo(data[i:])
+		n40, err := m.From.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n39
+		i += n40
 	}
 	data[i] = 0x20
 	i++
@@ -1484,11 +1492,11 @@ func (m *TagReference) MarshalTo(data []byte) (int, error) {
 	data[i] = 0x32
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ImportPolicy.Size()))
-	n40, err := m.ImportPolicy.MarshalTo(data[i:])
+	n41, err := m.ImportPolicy.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n40
+	i += n41
 	return i, nil
 }
 
@@ -1630,6 +1638,8 @@ func (m *ImageList) Size() (n int) {
 func (m *ImageSignature) Size() (n int) {
 	var l int
 	_ = l
+	l = m.ObjectMeta.Size()
+	n += 1 + l + sovGenerated(uint64(l))
 	l = len(m.Type)
 	n += 1 + l + sovGenerated(uint64(l))
 	if m.Content != nil {
@@ -3116,6 +3126,36 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ObjectMeta", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ObjectMeta.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
 			}
 			var stringLen uint64
@@ -3143,7 +3183,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 			}
 			m.Type = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 2:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Content", wireType)
 			}
@@ -3174,7 +3214,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 				m.Content = []byte{}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Conditions", wireType)
 			}
@@ -3205,7 +3245,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ImageIdentity", wireType)
 			}
@@ -3234,7 +3274,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 			}
 			m.ImageIdentity = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SignedClaims", wireType)
 			}
@@ -3345,7 +3385,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 			}
 			m.SignedClaims[mapkey] = mapvalue
 			iNdEx = postIndex
-		case 6:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Created", wireType)
 			}
@@ -3378,7 +3418,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 7:
+		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field IssuedBy", wireType)
 			}
@@ -3411,7 +3451,7 @@ func (m *ImageSignature) Unmarshal(data []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 8:
+		case 9:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field IssuedTo", wireType)
 			}

--- a/pkg/image/api/v1/generated.proto
+++ b/pkg/image/api/v1/generated.proto
@@ -116,36 +116,38 @@ message ImageList {
 // ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims
 // as long as the signature is trusted. Based on this information it is possible to restrict runnable images
 // to those matching cluster-wide policy.
-// There are two mandatory fields provided by client: Type and Content. They should be parsed by clients doing
-// image verification. The others are parsed from signature's content by the server. They serve just an
-// informative purpose.
+// Mandatory fields should be parsed by clients doing image verification. The others are parsed from
+// signature's content by the server. They serve just an informative purpose.
 message ImageSignature {
+  // Standard object's metadata.
+  optional k8s.io.kubernetes.pkg.api.v1.ObjectMeta metadata = 1;
+
   // Required: Describes a type of stored blob.
-  optional string type = 1;
+  optional string type = 2;
 
   // Required: An opaque binary string which is an image's signature.
-  optional bytes content = 2;
+  optional bytes content = 3;
 
   // Conditions represent the latest available observations of a signature's current state.
-  repeated SignatureCondition conditions = 3;
+  repeated SignatureCondition conditions = 4;
 
   // A human readable string representing image's identity. It could be a product name and version, or an
   // image pull spec (e.g. "registry.access.redhat.com/rhel7/rhel:7.2").
-  optional string imageIdentity = 4;
+  optional string imageIdentity = 5;
 
   // Contains claims from the signature.
-  map<string, string> signedClaims = 5;
+  map<string, string> signedClaims = 6;
 
   // If specified, it is the time of signature's creation.
-  optional k8s.io.kubernetes.pkg.api.unversioned.Time created = 6;
+  optional k8s.io.kubernetes.pkg.api.unversioned.Time created = 7;
 
   // If specified, it holds information about an issuer of signing certificate or key (a person or entity
   // who signed the signing certificate or key).
-  optional SignatureIssuer issuedBy = 7;
+  optional SignatureIssuer issuedBy = 8;
 
   // If specified, it holds information about a subject of signing certificate or key (a person or entity
   // who signed the image).
-  optional SignatureSubject issuedTo = 8;
+  optional SignatureSubject issuedTo = 9;
 }
 
 // ImageStream stores a mapping of tags to images, metadata overrides that are applied
@@ -321,7 +323,7 @@ message RepositoryImportStatus {
 
 // SignatureCondition describes an image signature condition of particular kind at particular probe time.
 message SignatureCondition {
-  // Type of job condition, Complete or Failed.
+  // Type of signature condition, Complete or Failed.
   optional string type = 1;
 
   // Status of the condition, one of True, False, Unknown.

--- a/pkg/image/api/v1/register.go
+++ b/pkg/image/api/v1/register.go
@@ -26,6 +26,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Image{},
 		&ImageList{},
+		&ImageSignature{},
 		&ImageStream{},
 		&ImageStreamList{},
 		&ImageStreamMapping{},
@@ -38,6 +39,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 
 func (obj *Image) GetObjectKind() unversioned.ObjectKind              { return &obj.TypeMeta }
 func (obj *ImageList) GetObjectKind() unversioned.ObjectKind          { return &obj.TypeMeta }
+func (obj *ImageSignature) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
 func (obj *ImageStream) GetObjectKind() unversioned.ObjectKind        { return &obj.TypeMeta }
 func (obj *ImageStreamList) GetObjectKind() unversioned.ObjectKind    { return &obj.TypeMeta }
 func (obj *ImageStreamMapping) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/image/api/v1/swagger_doc.go
+++ b/pkg/image/api/v1/swagger_doc.go
@@ -81,7 +81,8 @@ func (ImageList) SwaggerDoc() map[string]string {
 }
 
 var map_ImageSignature = map[string]string{
-	"":              "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. There are two mandatory fields provided by client: Type and Content. They should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose.",
+	"":              "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose.",
+	"metadata":      "Standard object's metadata.",
 	"type":          "Required: Describes a type of stored blob.",
 	"content":       "Required: An opaque binary string which is an image's signature.",
 	"conditions":    "Conditions represent the latest available observations of a signature's current state.",
@@ -249,7 +250,7 @@ func (RepositoryImportStatus) SwaggerDoc() map[string]string {
 
 var map_SignatureCondition = map[string]string{
 	"":                   "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
-	"type":               "Type of job condition, Complete or Failed.",
+	"type":               "Type of signature condition, Complete or Failed.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastProbeTime":      "Last time the condition was checked.",
 	"lastTransitionTime": "Last time the condition transit from one status to another.",

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -35,7 +35,7 @@ type Image struct {
 	// DockerImageLayers represents the layers in the image. May not be set if the image does not define that data.
 	DockerImageLayers []ImageLayer `json:"dockerImageLayers" protobuf:"bytes,6,rep,name=dockerImageLayers"`
 	// Signatures holds all signatures of the image.
-	Signatures []ImageSignature `json:"signatures,omitempty" protobuf:"bytes,7,rep,name=signatures"`
+	Signatures []ImageSignature `json:"signatures,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=signatures"`
 	// DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.
 	DockerImageSignatures [][]byte `json:"dockerImageSignatures,omitempty" protobuf:"bytes,8,rep,name=dockerImageSignatures"`
 	// DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.
@@ -57,33 +57,36 @@ type ImageLayer struct {
 // ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims
 // as long as the signature is trusted. Based on this information it is possible to restrict runnable images
 // to those matching cluster-wide policy.
-// There are two mandatory fields provided by client: Type and Content. They should be parsed by clients doing
-// image verification. The others are parsed from signature's content by the server. They serve just an
-// informative purpose.
+// Mandatory fields should be parsed by clients doing image verification. The others are parsed from
+// signature's content by the server. They serve just an informative purpose.
 type ImageSignature struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	kapi.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
 	// Required: Describes a type of stored blob.
-	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
+	Type string `json:"type" protobuf:"bytes,2,opt,name=type"`
 	// Required: An opaque binary string which is an image's signature.
-	Content []byte `json:"content" protobuf:"bytes,2,opt,name=content"`
+	Content []byte `json:"content" protobuf:"bytes,3,opt,name=content"`
 	// Conditions represent the latest available observations of a signature's current state.
-	Conditions []SignatureCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"`
+	Conditions []SignatureCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 
 	// Following metadata fields will be set by server if the signature content is successfully parsed and
 	// the information available.
 
 	// A human readable string representing image's identity. It could be a product name and version, or an
 	// image pull spec (e.g. "registry.access.redhat.com/rhel7/rhel:7.2").
-	ImageIdentity string `json:"imageIdentity,omitempty" protobuf:"bytes,4,opt,name=imageIdentity"`
+	ImageIdentity string `json:"imageIdentity,omitempty" protobuf:"bytes,5,opt,name=imageIdentity"`
 	// Contains claims from the signature.
-	SignedClaims map[string]string `json:"signedClaims,omitempty" protobuf:"bytes,5,rep,name=signedClaims"`
+	SignedClaims map[string]string `json:"signedClaims,omitempty" protobuf:"bytes,6,rep,name=signedClaims"`
 	// If specified, it is the time of signature's creation.
-	Created *unversioned.Time `json:"created,omitempty" protobuf:"bytes,6,opt,name=created"`
+	Created *unversioned.Time `json:"created,omitempty" protobuf:"bytes,7,opt,name=created"`
 	// If specified, it holds information about an issuer of signing certificate or key (a person or entity
 	// who signed the signing certificate or key).
-	IssuedBy *SignatureIssuer `json:"issuedBy,omitempty" protobuf:"bytes,7,opt,name=issuedBy"`
+	IssuedBy *SignatureIssuer `json:"issuedBy,omitempty" protobuf:"bytes,8,opt,name=issuedBy"`
 	// If specified, it holds information about a subject of signing certificate or key (a person or entity
 	// who signed the image).
-	IssuedTo *SignatureSubject `json:"issuedTo,omitempty" protobuf:"bytes,8,opt,name=issuedTo"`
+	IssuedTo *SignatureSubject `json:"issuedTo,omitempty" protobuf:"bytes,9,opt,name=issuedTo"`
 }
 
 /// SignatureConditionType is a type of image signature condition.
@@ -91,7 +94,7 @@ type SignatureConditionType string
 
 // SignatureCondition describes an image signature condition of particular kind at particular probe time.
 type SignatureCondition struct {
-	// Type of job condition, Complete or Failed.
+	// Type of signature condition, Complete or Failed.
 	Type SignatureConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=SignatureConditionType"`
 	// Status of the condition, one of True, False, Unknown.
 	Status kapi.ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/kubernetes/pkg/api/v1.ConditionStatus"`

--- a/pkg/image/registry/image/strategy_test.go
+++ b/pkg/image/registry/image/strategy_test.go
@@ -1,0 +1,106 @@
+package image
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/google/gofuzz"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/util/diff"
+
+	"github.com/openshift/origin/pkg/api/v1"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+func fuzzImage(t *testing.T, image *api.Image, seed int64) *api.Image {
+	f := apitesting.FuzzerFor(t, v1.SchemeGroupVersion, rand.NewSource(seed))
+	f.Funcs(
+		func(j *api.Image, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			j.Annotations = make(map[string]string)
+			j.Labels = make(map[string]string)
+			j.Signatures = make([]api.ImageSignature, c.Rand.Intn(3)+2)
+			for i := range j.Signatures {
+				sign := &j.Signatures[i]
+				c.Fuzz(sign)
+				sign.Conditions = make([]api.SignatureCondition, c.Rand.Intn(3)+2)
+				for ci := range sign.Conditions {
+					cond := &sign.Conditions[ci]
+					c.Fuzz(cond)
+				}
+			}
+			for i := 0; i < c.Rand.Intn(3)+2; i++ {
+				j.Labels[c.RandString()] = c.RandString()
+				j.Annotations[c.RandString()] = c.RandString()
+			}
+		},
+	)
+
+	updated := api.Image{}
+	f.Fuzz(&updated)
+	updated.Namespace = image.Namespace
+	updated.Name = image.Name
+
+	j, err := meta.TypeAccessor(image)
+	if err != nil {
+		t.Fatalf("Unexpected error %v for %#v", err, image)
+	}
+	j.SetKind("")
+	j.SetAPIVersion("")
+
+	return &updated
+}
+
+func TestStrategyPrepareForCreate(t *testing.T) {
+	original := api.Image{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "image",
+		},
+	}
+
+	seed := int64(2703387474910584091) //rand.Int63()
+	fuzzed := fuzzImage(t, &original, seed)
+	obj, err := kapi.Scheme.DeepCopy(fuzzed)
+	if err != nil {
+		t.Fatalf("faild to deep copy fuzzed image: %v", err)
+	}
+	image := obj.(*api.Image)
+
+	if len(image.Signatures) == 0 {
+		t.Fatalf("fuzzifier failed to generate signatures")
+	}
+
+	Strategy.PrepareForCreate(image)
+
+	if len(image.Signatures) != len(fuzzed.Signatures) {
+		t.Errorf("unexpected number of signatures: %d != %d", len(image.Signatures), len(fuzzed.Signatures))
+	}
+
+	for i, sig := range image.Signatures {
+		vi := reflect.ValueOf(&sig).Elem()
+		vf := reflect.ValueOf(&fuzzed.Signatures[i]).Elem()
+		typeOfT := vf.Type()
+
+		for j := 0; j < vf.NumField(); j++ {
+			iField := vi.Field(j)
+			fField := vf.Field(j)
+			typeOfF := fField.Type()
+
+			switch typeOfT.Field(j).Name {
+			case "Content", "Type", "TypeMeta", "ObjectMeta":
+				if !reflect.DeepEqual(iField.Interface(), fField.Interface()) {
+					t.Errorf("%s field should not differ: %s", typeOfT.Field(j).Name, diff.ObjectGoPrintDiff(iField.Interface(), fField.Interface()))
+				}
+
+			default:
+				if !reflect.DeepEqual(iField.Interface(), reflect.Zero(typeOfF).Interface()) {
+					t.Errorf("expected Signatures.%s to be unset, not %#+v", typeOfF.Field(j).Name, iField.Interface())
+				}
+			}
+		}
+	}
+}

--- a/pkg/image/registry/imagesignature/rest.go
+++ b/pkg/image/registry/imagesignature/rest.go
@@ -1,0 +1,93 @@
+package imagesignature
+
+import (
+	"errors"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// REST implements the RESTStorage interface for ImageSignature
+type REST struct {
+	imageClient client.ImageInterface
+}
+
+// NewREST returns a new REST.
+func NewREST(imageClient client.ImageInterface) *REST {
+	return &REST{imageClient: imageClient}
+}
+
+// New is only implemented to make REST implement RESTStorage
+func (r *REST) New() runtime.Object {
+	return &imageapi.ImageSignature{}
+}
+
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	signature := obj.(*imageapi.ImageSignature)
+
+	if err := rest.BeforeCreate(Strategy, ctx, obj); err != nil {
+		return nil, err
+	}
+
+	imageName, _, err := imageapi.SplitImageSignatureName(signature.Name)
+	if err != nil {
+		return nil, kapierrors.NewBadRequest(err.Error())
+	}
+
+	image, err := r.imageClient.Get(imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	// ensure that given signature already doesn't exist - either by its name or type:content
+	if byName, byContent := imageapi.IndexOfImageSignatureByName(image.Signatures, signature.Name), imageapi.IndexOfImageSignature(image.Signatures, signature.Type, signature.Content); byName >= 0 || byContent >= 0 {
+		return nil, kapierrors.NewAlreadyExists(imageapi.Resource("imageSignatures"), signature.Name)
+	}
+
+	image.Signatures = append(image.Signatures, *signature)
+
+	image, err = r.imageClient.Update(image)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := imageapi.IndexOfImageSignatureByName(image.Signatures, signature.Name)
+	if byName < 0 {
+		return nil, kapierrors.NewInternalError(errors.New("failed to store given signature"))
+	}
+
+	return &image.Signatures[byName], nil
+}
+
+func (r *REST) Delete(ctx kapi.Context, name string) (runtime.Object, error) {
+	imageName, _, err := imageapi.SplitImageSignatureName(name)
+	if err != nil {
+		return nil, kapierrors.NewBadRequest("ImageSignatures must be accessed with <imageName>@<signatureName>")
+	}
+
+	image, err := r.imageClient.Get(imageName)
+	if err != nil {
+		return nil, err
+	}
+
+	index := imageapi.IndexOfImageSignatureByName(image.Signatures, name)
+	if index < 0 {
+		return nil, kapierrors.NewNotFound(imageapi.Resource("imageSignatures"), name)
+	}
+
+	size := len(image.Signatures)
+	copy(image.Signatures[index:size-1], image.Signatures[index+1:size])
+	image.Signatures = image.Signatures[0 : size-1]
+
+	if _, err := r.imageClient.Update(image); err != nil {
+		return nil, err
+	}
+
+	return &unversioned.Status{Status: unversioned.StatusSuccess}, nil
+}

--- a/pkg/image/registry/imagesignature/strategy.go
+++ b/pkg/image/registry/imagesignature/strategy.go
@@ -1,0 +1,56 @@
+package imagesignature
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/api/validation"
+)
+
+// strategy implements behavior for ImageStreamTags.
+type strategy struct {
+	runtime.ObjectTyper
+}
+
+var Strategy = &strategy{
+	ObjectTyper: kapi.Scheme,
+}
+
+func (s *strategy) NamespaceScoped() bool {
+	return false
+}
+
+func (s *strategy) PrepareForCreate(obj runtime.Object) {
+	signature := obj.(*imageapi.ImageSignature)
+
+	signature.Conditions = nil
+	signature.ImageIdentity = ""
+	signature.SignedClaims = nil
+	signature.Created = nil
+	signature.IssuedBy = nil
+	signature.IssuedTo = nil
+}
+
+func (s *strategy) GenerateName(base string) string {
+	return base
+}
+
+func (s *strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
+	signature := obj.(*imageapi.ImageSignature)
+
+	return validation.ValidateImageSignature(signature)
+}
+
+func (s *strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (*strategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+// Canonicalize normalizes the object after validation.
+func (strategy) Canonicalize(obj runtime.Object) {
+}

--- a/pkg/image/registry/imagesignature/strategy_test.go
+++ b/pkg/image/registry/imagesignature/strategy_test.go
@@ -1,0 +1,91 @@
+package imagesignature
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/google/gofuzz"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+
+	"github.com/openshift/origin/pkg/api/v1"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+func fuzzImageSignature(t *testing.T, signature *api.ImageSignature, seed int64) *api.ImageSignature {
+	f := apitesting.FuzzerFor(t, v1.SchemeGroupVersion, rand.NewSource(seed))
+	f.Funcs(
+		func(j *api.ImageSignature, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			j.Annotations = make(map[string]string)
+			j.Labels = make(map[string]string)
+			j.Conditions = []api.SignatureCondition{}
+			j.SignedClaims = make(map[string]string)
+
+			j.Content = []byte(c.RandString())
+			for i := 0; i < c.Rand.Intn(3)+2; i++ {
+				j.Labels[c.RandString()] = c.RandString()
+				j.Annotations[c.RandString()] = c.RandString()
+				j.SignedClaims[c.RandString()] = c.RandString()
+			}
+			for i := 0; i < c.Rand.Intn(3)+2; i++ {
+				cond := api.SignatureCondition{}
+				c.Fuzz(&cond)
+				j.Conditions = append(j.Conditions, cond)
+			}
+		},
+	)
+
+	updated := api.ImageSignature{}
+	f.Fuzz(&updated)
+	updated.Namespace = signature.Namespace
+	updated.Name = signature.Name
+
+	j, err := meta.TypeAccessor(signature)
+	if err != nil {
+		t.Fatalf("Unexpected error %v for %#v", err, signature)
+	}
+	j.SetKind("")
+	j.SetAPIVersion("")
+
+	return &updated
+}
+
+func TestStrategyPrepareForCreate(t *testing.T) {
+	signature := &api.ImageSignature{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "image",
+		},
+	}
+
+	seed := int64(2703387474910584091) //rand.Int63()
+	signature = fuzzImageSignature(t, signature, seed)
+
+	Strategy.PrepareForCreate(signature)
+
+	sValue := reflect.ValueOf(signature).Elem()
+	typeOfT := sValue.Type()
+	for i := 0; i < sValue.NumField(); i++ {
+		f := sValue.Field(i)
+		switch typeOfT.Field(i).Name {
+		case "Type":
+			if len(f.Interface().(string)) == 0 {
+				t.Errorf("type must not be empty")
+			}
+		case "Content":
+			if len(f.Interface().([]byte)) == 0 {
+				t.Errorf("content must not be empty")
+			}
+		case "ObjectMeta":
+		default:
+			value := f.Interface()
+			vType := f.Type()
+			if !reflect.DeepEqual(value, reflect.Zero(vType).Interface()) {
+				t.Errorf("field %q expected unset, got instead: %v", typeOfT.Field(i).Name, value)
+			}
+		}
+	}
+}

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -331,6 +331,7 @@ func (r *REST) importSuccessful(
 	image *api.Image, stream *api.ImageStream, tag string, from string, nextGeneration int64, now unversioned.Time, importPolicy api.TagImportPolicy,
 	importedImages map[string]error, updatedImages map[string]*api.Image,
 ) (*api.Image, bool) {
+	Strategy.PrepareImageForCreate(image)
 
 	pullSpec, _ := api.MostAccuratePullSpec(image.DockerImageReference, image.Name, "")
 	tagEvent := api.TagEvent{

--- a/pkg/image/registry/imagestreamimport/strategy.go
+++ b/pkg/image/registry/imagestreamimport/strategy.go
@@ -32,6 +32,13 @@ func (s *strategy) PrepareForCreate(obj runtime.Object) {
 	newIST.Status = api.ImageStreamImportStatus{}
 }
 
+func (s *strategy) PrepareImageForCreate(obj runtime.Object) {
+	image := obj.(*api.Image)
+
+	// signatures can be added using "images" or "imagesignatures" resources
+	image.Signatures = nil
+}
+
 func (s *strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
 	isi := obj.(*api.ImageStreamImport)
 	return validation.ValidateImageStreamImport(isi)

--- a/pkg/image/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/registry/imagestreammapping/rest_test.go
@@ -589,6 +589,7 @@ type fakeImageRegistry struct {
 	createImage func(ctx kapi.Context, image *api.Image) error
 	deleteImage func(ctx kapi.Context, id string) error
 	watchImages func(ctx kapi.Context, options *kapi.ListOptions) (watch.Interface, error)
+	updateImage func(ctx kapi.Context, image *api.Image) (*api.Image, error)
 }
 
 func (f *fakeImageRegistry) ListImages(ctx kapi.Context, options *kapi.ListOptions) (*api.ImageList, error) {
@@ -605,6 +606,9 @@ func (f *fakeImageRegistry) DeleteImage(ctx kapi.Context, id string) error {
 }
 func (f *fakeImageRegistry) WatchImages(ctx kapi.Context, options *kapi.ListOptions) (watch.Interface, error) {
 	return f.watchImages(ctx, options)
+}
+func (f *fakeImageRegistry) UpdateImage(ctx kapi.Context, image *api.Image) (*api.Image, error) {
+	return f.updateImage(ctx, image)
 }
 
 type fakeImageStreamRegistry struct {

--- a/pkg/image/registry/imagestreammapping/strategy.go
+++ b/pkg/image/registry/imagestreammapping/strategy.go
@@ -46,6 +46,9 @@ func (s Strategy) PrepareForCreate(obj runtime.Object) {
 			}.Exact()
 		}
 	}
+
+	// signatures can be added using "images" or "imagesignatures" resources
+	ism.Image.Signatures = nil
 }
 
 // Canonicalize normalizes the object after validation.

--- a/test/integration/imagesigning_test.go
+++ b/test/integration/imagesigning_test.go
@@ -1,0 +1,256 @@
+// +build integration
+
+package integration
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/diff"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const testUserName = "bob"
+
+func TestImageAddSignature(t *testing.T) {
+	adminClient, userClient, image := testSetupImageSignatureTest(t, testUserName)
+
+	if len(image.Signatures) != 0 {
+		t.Fatalf("expected empty signatures, not: %s", diff.ObjectDiff(image.Signatures, []imageapi.ImageSignature{}))
+	}
+
+	// add some dummy signature
+	signature := imageapi.ImageSignature{
+		Type:    "unknown",
+		Content: []byte("binaryblob"),
+	}
+
+	sigName, err := imageapi.JoinImageSignatureName(image.Name, "signaturename")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	signature.Name = sigName
+
+	created, err := userClient.ImageSignatures().Create(&signature)
+	if err == nil {
+		t.Fatalf("unexpected success updating image signatures")
+	}
+	if !kerrors.IsForbidden(err) {
+		t.Fatalf("expected forbidden error, not: %v", err)
+	}
+
+	makeUserAnImageSigner(adminClient, userClient, testUserName)
+
+	// try to create the signature again
+	created, err = userClient.ImageSignatures().Create(&signature)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	image, err = adminClient.Images().Get(image.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(image.Signatures) != 1 {
+		t.Fatalf("unexpected number of signatures in created image (%d != %d)", len(image.Signatures), 1)
+	}
+	for _, sig := range []*imageapi.ImageSignature{created, &image.Signatures[0]} {
+		if sig.Name != sigName || sig.Type != "unknown" ||
+			!bytes.Equal(sig.Content, []byte("binaryblob")) || len(sig.Conditions) != 0 {
+			t.Errorf("unexpected signature received: %#+v", sig)
+		}
+	}
+	compareSignatures(t, image.Signatures[0], *created)
+
+	// try to create the signature yet again
+	created, err = userClient.ImageSignatures().Create(&signature)
+	if !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("expected already exists error, not: %v", err)
+	}
+
+	// try to create a signature with different name but the same conent
+	newName, err := imageapi.JoinImageSignatureName(image.Name, "newone")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	signature.Name = newName
+	created, err = userClient.ImageSignatures().Create(&signature)
+	if !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("expected already exists error, not: %v", err)
+	}
+
+	// try to create a signature with the same name but different content
+	signature.Name = sigName
+	signature.Content = []byte("different")
+	_, err = userClient.ImageSignatures().Create(&signature)
+	if !kerrors.IsAlreadyExists(err) {
+		t.Fatalf("expected already exists error, not: %v", err)
+	}
+}
+
+func TestImageRemoveSignature(t *testing.T) {
+	adminClient, userClient, image := testSetupImageSignatureTest(t, testUserName)
+	makeUserAnImageSigner(adminClient, userClient, testUserName)
+
+	// create some signatures
+	sigData := []struct {
+		sigName string
+		content string
+	}{
+		{"a", "binaryblob"},
+		{"b", "security without obscurity"},
+		{"c", "distrust and caution are the parents of security"},
+		{"d", "he who sacrifices freedom for security deserves neither"},
+	}
+	for i, d := range sigData {
+		name, err := imageapi.JoinImageSignatureName(image.Name, d.sigName)
+		if err != nil {
+			t.Fatalf("creating signature %d: unexpected error: %v", i, err)
+		}
+		signature := imageapi.ImageSignature{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: name,
+			},
+			Type:    "unknown",
+			Content: []byte(d.content),
+		}
+		_, err = userClient.ImageSignatures().Create(&signature)
+		if err != nil {
+			t.Fatalf("creating signature %d: unexpected error: %v", i, err)
+		}
+	}
+
+	image, err := userClient.Images().Get(image.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(image.Signatures) != 4 {
+		t.Fatalf("expected 4 signatures, not %d", len(image.Signatures))
+	}
+
+	// try to delete blob that does not exist
+	err = userClient.ImageSignatures().Delete(image.Name + "@doesnotexist")
+	if !kerrors.IsNotFound(err) {
+		t.Fatalf("expected not found error, not: %#+v", err)
+	}
+
+	// try to delete blob with missing signature name
+	err = userClient.ImageSignatures().Delete(image.Name + "@")
+	if !kerrors.IsBadRequest(err) {
+		t.Fatalf("expected bad request, not: %#+v", err)
+	}
+
+	// delete the first
+	err = userClient.ImageSignatures().Delete(image.Name + "@" + sigData[0].sigName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// try to delete it once more
+	err = userClient.ImageSignatures().Delete(image.Name + "@" + sigData[0].sigName)
+	if err == nil {
+		t.Fatalf("unexpected nont error")
+	} else if !kerrors.IsNotFound(err) {
+		t.Errorf("expected not found error, not: %#+v", err)
+	}
+
+	// delete the one in the middle
+	err = userClient.ImageSignatures().Delete(image.Name + "@" + sigData[2].sigName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if image, err = userClient.Images().Get(image.Name); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if len(image.Signatures) != 2 {
+		t.Fatalf("expected 2 signatures, not %d", len(image.Signatures))
+	}
+
+	// delete the one at the end
+	err = userClient.ImageSignatures().Delete(image.Name + "@" + sigData[3].sigName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// delete the last one
+	err = userClient.ImageSignatures().Delete(image.Name + "@" + sigData[1].sigName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if image, err = userClient.Images().Get(image.Name); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if len(image.Signatures) != 0 {
+		t.Fatalf("expected 2 signatures, not %d", len(image.Signatures))
+	}
+}
+
+func testSetupImageSignatureTest(t *testing.T, userName string) (adminClient *client.Client, userClient *client.Client, image *imageapi.Image) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adminClient, err = testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	image, err = testutil.GetImageFixture("testdata/test-image.json")
+	if err != nil {
+		t.Fatalf("failed to read image fixture: %v", err)
+	}
+
+	image, err = adminClient.Images().Create(image)
+	if err != nil {
+		t.Fatalf("unexpected error creating image: %v", err)
+	}
+
+	if len(image.Signatures) != 0 {
+		t.Fatalf("expected empty signatures, not: %s", diff.ObjectDiff(image.Signatures, []imageapi.ImageSignature{}))
+	}
+
+	clusterAdminConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	userClient, _, _, err = testutil.GetClientForUser(*clusterAdminConfig, userName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return adminClient, userClient, image
+}
+
+func makeUserAnImageSigner(clusterAdminClient *client.Client, userClient *client.Client, userName string) error {
+	// give bob permissions to update image signatures
+	addImageSignerRole := &policy.RoleModificationOptions{
+		RoleNamespace:       "",
+		RoleName:            bootstrappolicy.ImageSignerRoleName,
+		RoleBindingAccessor: policy.NewClusterRoleBindingAccessor(clusterAdminClient),
+		Users:               []string{userName},
+	}
+	if err := addImageSignerRole.AddRole(); err != nil {
+		return err
+	}
+	return testutil.WaitForClusterPolicyUpdate(userClient, "create", kapi.Resource("imagesignatures"), true)
+}
+
+func compareSignatures(t *testing.T, a, b imageapi.ImageSignature) {
+	aName := a.Name
+	a.ObjectMeta = b.ObjectMeta
+	a.Name = aName
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("created and contained signatures differ: %v", diff.ObjectDiff(a, b))
+	}
+}

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -26,8 +26,6 @@ import (
 // TestOAuthOIDC checks CLI password login against an OIDC provider
 func TestOAuthOIDC(t *testing.T) {
 
-	tokenCalled := false
-	userinfoCalled := false
 	expectedTokenPost := url.Values{
 		"grant_type":    []string{"password"},
 		"client_id":     []string{"myclient"},
@@ -90,14 +88,12 @@ func TestOAuthOIDC(t *testing.T) {
 			}
 
 			w.Write([]byte(tokenResponse))
-			tokenCalled = true
 
 		case "/userinfo":
 			if r.Header.Get("Authorization") != "Bearer 12345" {
 				t.Fatalf("Expected authorization header, got %#v", r.Header)
 			}
 			w.Write([]byte(userinfoResponse))
-			userinfoCalled = true
 
 		default:
 			t.Fatalf("Unexpected OIDC request: %v", r.URL.String())

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -180,6 +180,7 @@ items:
     attributeRestrictions: null
     resources:
     - images
+    - imagesignatures
     - imagestreamimages
     - imagestreams
     - imagestreams/status
@@ -1497,6 +1498,28 @@ items:
     - imagestreams/status
     verbs:
     - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:image-signer
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - images
+    - imagestreams/layers
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagesignatures
+    verbs:
+    - create
+    - delete
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/util/helpers.go
+++ b/test/util/helpers.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	kyaml "k8s.io/kubernetes/pkg/util/yaml"
 
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
@@ -24,4 +25,20 @@ func GetTemplateFixture(filename string) (*templateapi.Template, error) {
 		return nil, err
 	}
 	return obj.(*templateapi.Template), nil
+}
+
+func GetImageFixture(filename string) (*imageapi.Image, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := kyaml.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := runtime.Decode(kapi.Codecs.UniversalDecoder(), jsonData)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*imageapi.Image), nil
 }


### PR DESCRIPTION
The new `images/signatures` resource allows to update image' signatures. There's a new images API client call `images.UpdateSignatures()` for this purpose.

A cluster-wide role `system:image-signer` is necessary to add/remove/modify signatures.

A follow-up for #8371