### PR TITLE
deploy: update validation for deploymentconfigs

### DIFF
--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -54,7 +54,7 @@ func ValidateDeploymentConfigSpec(spec deployapi.DeploymentConfigSpec) field.Err
 		originalContainerImageNames := getContainerImageNames(spec.Template)
 		defer setContainerImageNames(spec.Template, originalContainerImageNames)
 		handleEmptyImageReferences(spec.Template, spec.Triggers)
-		allErrs = append(allErrs, validation.ValidatePodTemplateSpec(spec.Template, specPath.Child("template"))...)
+		allErrs = append(allErrs, validation.ValidatePodTemplateSpecForRC(spec.Template, spec.Selector, spec.Replicas, specPath.Child("template"))...)
 	}
 	if spec.Replicas < 0 {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), spec.Replicas, "replicas cannot be negative"))


### PR DESCRIPTION
Validate that the deployment config selector is matching the pod
template labels.

cc: @ironcladlou @smarterclayton @mfojtik 