### PR TITLE
Add liveness and readiness probes for the ipfailover dc.

### DIFF
--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -88,6 +88,16 @@ func generateFailoverMonitorContainerConfig(name string, options *ipfailover.IPF
 		MountPath: libModulesPath,
 	}
 
+	livenessProbe := &kapi.Probe{
+		InitialDelaySeconds: 10,
+
+		Handler: kapi.Handler{
+			Exec: &kapi.ExecAction{
+				Command: []string{"pgrep", "keepalived"},
+			},
+		},
+	}
+
 	privileged := true
 	return &kapi.Container{
 		Name:  containerName,
@@ -99,6 +109,7 @@ func generateFailoverMonitorContainerConfig(name string, options *ipfailover.IPF
 		ImagePullPolicy: kapi.PullIfNotPresent,
 		VolumeMounts:    mounts,
 		Env:             env.List(),
+		LivenessProbe:   livenessProbe,
 	}
 }
 


### PR DESCRIPTION
As per a message on the mailing list, fixing the warnings `oc status -v` shows for ipfailover.
Add readiness and liveness probes.

@smarterclayton  PTAL thx