### PR TITLE
Fix examples for port-forwarding cmd

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -554,7 +554,7 @@ This forwards one or more local ports to a pod.
 The general form is:
 
 ```bash
-$ oc port-forward -p <pod> <forwarding-spec> [...]
+$ oc port-forward <pod> <forwarding-spec> [...]
 ```
 
 where *forwarding-spec* is either a single port (integer), or a pair of ports separated by a colon `<outside>:<inside>`.
@@ -565,15 +565,15 @@ Some examples are:
 ```bash
 # Listen on ports 5000 and 6000 locally, forwarding data
 # to/from ports 5000 and 6000 in the pod.
-$ oc port-forward -p mypod 5000 6000
+$ oc port-forward mypod 5000 6000
 
 # Listen on 8888 locally, forwarding to 5000 in the pod.
-$ oc port-forward -p mypod 8888:5000
+$ oc port-forward mypod 8888:5000
 
 # Listen on a random port locally, forwarding to 5000 in the pod.
 # (These invocations are equivalent.)
-$ oc port-forward -p mypod :5000
-$ oc port-forward -p mypod 0:5000
+$ oc port-forward mypod :5000
+$ oc port-forward mypod 0:5000
 ```
 
 ### oc proxy

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1560,16 +1560,16 @@ Forward one or more local ports to a pod.
 [options="nowrap"]
 ----
   # Listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
-  oc port-forward -p mypod 5000 6000
+  oc port-forward mypod 5000 6000
 
   # Listens on port 8888 locally, forwarding to 5000 in the pod
-  oc port-forward -p mypod 8888:5000
+  oc port-forward mypod 8888:5000
 
   # Listens on a random port locally, forwarding to 5000 in the pod
-  oc port-forward -p mypod :5000
+  oc port-forward mypod :5000
 
   # Listens on a random port locally, forwarding to 5000 in the pod
-  oc port-forward -p mypod 0:5000
+  oc port-forward mypod 0:5000
 ----
 ====
 

--- a/examples/gitserver/README.md
+++ b/examples/gitserver/README.md
@@ -74,7 +74,7 @@ a 'git clone' of the repository.
 
    ```
    $ oc get pods | grep git           ## get the git server pod
-   $ oc port-forward -p PODNAME 8080  ## start port-forward where PODNAME is the git server pod
+   $ oc port-forward PODNAME 8080     ## start port-forward where PODNAME is the git server pod
    ```
 
    In this case, the URL of your git server will be your local host:

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -198,16 +198,16 @@ const (
 	portForwardLong = `Forward 1 or more local ports to a pod`
 
 	portForwardExample = `  # Listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
-  %[1]s port-forward -p mypod 5000 6000
+  %[1]s port-forward mypod 5000 6000
 
   # Listens on port 8888 locally, forwarding to 5000 in the pod
-  %[1]s port-forward -p mypod 8888:5000
+  %[1]s port-forward mypod 8888:5000
 
   # Listens on a random port locally, forwarding to 5000 in the pod
-  %[1]s port-forward -p mypod :5000
+  %[1]s port-forward mypod :5000
 
   # Listens on a random port locally, forwarding to 5000 in the pod
-  %[1]s port-forward -p mypod 0:5000`
+  %[1]s port-forward mypod 0:5000`
 )
 
 // NewCmdPortForward is a wrapper for the Kubernetes cli port-forward command


### PR DESCRIPTION
removes usage of the deprecated '-p' flag. Fixes #7144