### PR TITLE
Made output of error more specific to bad parameter

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -19306,6 +19306,10 @@
       "type": "boolean",
       "description": "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action."
      },
+     "paused": {
+      "type": "boolean",
+      "description": "Paused indicates that the deployment config is paused resulting in no new deployments on template changes or changes in the template caused by other triggers."
+     },
      "selector": {
       "type": "any",
       "description": "Selector is a label query over pods that should match the Replicas count."

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1291,7 +1291,7 @@ Display one or many resources
 
 
 == oc import app.json
-Import an app.json definition into OpenShift
+Import an app.json definition into OpenShift (experimental)
 
 ====
 
@@ -1308,7 +1308,7 @@ Import an app.json definition into OpenShift
 
 
 == oc import docker-compose
-Import a docker-compose.yml project into OpenShift
+Import a docker-compose.yml project into OpenShift (experimental)
 
 ====
 

--- a/examples/quickstarts/django-postgresql.json
+++ b/examples/quickstarts/django-postgresql.json
@@ -437,7 +437,7 @@
     },
     {
       "name": "DJANGO_SECRET_KEY",
-      "displayName": "Djange Secret Key",
+      "displayName": "Django Secret Key",
       "description": "Set this to a long random string.",
       "generate": "expression",
       "from": "[\\w]{50}"

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -121,11 +121,11 @@ frontend public_ssl
 # traffic
 ##########################################################################
 backend be_sni
-  server fe_sni 127.0.0.1:10444 weight 1 send-proxy
+  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy
 
 frontend fe_sni
   # terminate ssl on edge
-  bind 127.0.0.1:10444 ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt {{ $workingDir }}/certs accept-proxy
+  bind 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt {{ $workingDir }}/certs accept-proxy
   mode http
 
   # Remove port from Host header
@@ -158,11 +158,11 @@ frontend fe_sni
 ##########################################################################
 # backend for when sni does not exist, or ssl term needs to happen on the edge
 backend be_no_sni
-  server fe_no_sni 127.0.0.1:10443 weight 1 send-proxy
+  server fe_no_sni 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} weight 1 send-proxy
 
 frontend fe_no_sni
   # terminate ssl on edge
-  bind 127.0.0.1:10443 ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
+  bind 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
   mode http
 
   # Remove port from Host header

--- a/pkg/client/localsubjectaccessreview.go
+++ b/pkg/client/localsubjectaccessreview.go
@@ -63,11 +63,11 @@ func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAcc
 		}
 		deprecatedResponse := &authorizationapi.SubjectAccessReviewResponse{}
 
-		req, err := overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews"))
-		if err != nil {
-			return &authorizationapi.SubjectAccessReviewResponse{}, err
+		deprecatedReq, deprecatedAttemptErr := overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews"))
+		if deprecatedAttemptErr != nil {
+			return &authorizationapi.SubjectAccessReviewResponse{}, deprecatedAttemptErr
 		}
-		deprecatedAttemptErr := req.Body(deprecatedSAR).Do().Into(deprecatedResponse)
+		deprecatedAttemptErr = deprecatedReq.Body(deprecatedSAR).Do().Into(deprecatedResponse)
 		if deprecatedAttemptErr == nil {
 			err = nil
 			result = deprecatedResponse

--- a/pkg/client/subjectaccessreview.go
+++ b/pkg/client/subjectaccessreview.go
@@ -64,13 +64,13 @@ func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview)
 	// if the namespace values don't match then we definitely hit an old server.  If we got a forbidden, then we might have hit an old server
 	// and should try the old endpoint
 	if (sar.Action.Namespace != result.Namespace) || kapierrors.IsForbidden(err) {
-		req, err := overrideAuth(c.token, c.r.Post().Namespace(sar.Action.Namespace).Resource("subjectAccessReviews"))
-		if err != nil {
-			return &authorizationapi.SubjectAccessReviewResponse{}, err
+		deprecatedReq, deprecatedAttemptErr := overrideAuth(c.token, c.r.Post().Namespace(sar.Action.Namespace).Resource("subjectAccessReviews"))
+		if deprecatedAttemptErr != nil {
+			return &authorizationapi.SubjectAccessReviewResponse{}, deprecatedAttemptErr
 		}
 
 		deprecatedResponse := &authorizationapi.SubjectAccessReviewResponse{}
-		deprecatedAttemptErr := req.Body(sar).Do().Into(deprecatedResponse)
+		deprecatedAttemptErr = deprecatedReq.Body(sar).Do().Into(deprecatedResponse)
 
 		// if we definitely hit an old server, then return the error and result you get from the older server.
 		if sar.Action.Namespace != result.Namespace {

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -211,6 +211,9 @@ func (o DeployOptions) RunDeploy() error {
 // deploy launches a new deployment unless there's already a deployment
 // process in progress for config.
 func (o DeployOptions) deploy(config *deployapi.DeploymentConfig, out io.Writer) error {
+	if config.Spec.Paused {
+		return fmt.Errorf("cannot deploy a paused deployment config")
+	}
 	// TODO: This implies that deploymentconfig.status.latestVersion is always synced. Currently,
 	// that's the case because clients (oc, trigger controllers) are updating the status directly.
 	// Clients should be acting either on spec or on annotations and status updates should be a
@@ -244,6 +247,9 @@ func (o DeployOptions) deploy(config *deployapi.DeploymentConfig, out io.Writer)
 // the deployment to be retried. An error is returned if the deployment is not
 // currently in a failed state.
 func (o DeployOptions) retry(config *deployapi.DeploymentConfig, out io.Writer) error {
+	if config.Spec.Paused {
+		return fmt.Errorf("cannot retry a paused deployment config")
+	}
 	if config.Status.LatestVersion == 0 {
 		return fmt.Errorf("no deployments found for %s/%s", config.Namespace, config.Name)
 	}
@@ -297,6 +303,9 @@ func (o DeployOptions) retry(config *deployapi.DeploymentConfig, out io.Writer) 
 
 // cancel cancels any deployment process in progress for config.
 func (o DeployOptions) cancel(config *deployapi.DeploymentConfig, out io.Writer) error {
+	if config.Spec.Paused {
+		return fmt.Errorf("cannot cancel a paused deployment config")
+	}
 	deployments, err := o.kubeClient.ReplicationControllers(config.Namespace).List(kapi.ListOptions{LabelSelector: deployutil.ConfigSelector(config.Name)})
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/importer/appjson.go
+++ b/pkg/cmd/cli/cmd/importer/appjson.go
@@ -39,7 +39,9 @@ During transformation fields in the app.json syntax that are not relevant when r
 a containerized platform will be ignored and a warning printed.
 
 The command will create objects unless you pass the -o yaml or --as-template flags to generate a
-configuration file for later use.`
+configuration file for later use.
+
+Experimental: This command is under active development and may change without notice.`
 
 	appJSONExample = `  # Import a directory containing an app.json file
   $ %[1]s app.json -f .
@@ -81,7 +83,7 @@ func NewCmdAppJSON(fullName string, f *clientcmd.Factory, in io.Reader, out, err
 	}
 	cmd := &cobra.Command{
 		Use:     "app.json -f APPJSON",
-		Short:   "Import an app.json definition into OpenShift",
+		Short:   "Import an app.json definition into OpenShift (experimental)",
 		Long:    appJSONLong,
 		Example: fmt.Sprintf(appJSONExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/importer/dockercompose.go
+++ b/pkg/cmd/cli/cmd/importer/dockercompose.go
@@ -34,7 +34,9 @@ During transformation fields in the compose syntax that are not relevant when ru
 a containerized platform will be ignored and a warning printed.
 
 The command will create objects unless you pass the -o yaml or --as-template flags to generate a
-configuration file for later use.`
+configuration file for later use.
+
+Experimental: This command is under active development and may change without notice.`
 
 	dockerComposeExample = `  # Import a docker-compose.yml file into OpenShift
   %[1]s docker-compose -f ./docker-compose.yml
@@ -74,7 +76,7 @@ func NewCmdDockerCompose(fullName string, f *clientcmd.Factory, in io.Reader, ou
 	}
 	cmd := &cobra.Command{
 		Use:     "docker-compose -f COMPOSEFILE",
-		Short:   "Import a docker-compose.yml project into OpenShift",
+		Short:   "Import a docker-compose.yml project into OpenShift (experimental)",
 		Long:    dockerComposeLong,
 		Example: fmt.Sprintf(dockerComposeExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/importimage_test.go
+++ b/pkg/cmd/cli/cmd/importimage_test.go
@@ -13,87 +13,193 @@ import (
 )
 
 func TestCreateImageImport(t *testing.T) {
-	testCases := []struct {
-		name     string
-		stream   *imageapi.ImageStream
-		all      bool
-		insecure *bool
-		err      string
-		expected []imageapi.ImageImportSpec
+	testCases := map[string]struct {
+		name               string
+		from               string
+		stream             *imageapi.ImageStream
+		all                bool
+		confirm            bool
+		insecure           *bool
+		err                string
+		expectedImages     []imageapi.ImageImportSpec
+		expectedRepository *imageapi.RepositoryImportSpec
 	}{
-		{
-			// 0: checking import's from when only .spec.dockerImageRepository is set, no status
+		"import from non-existing": {
+			name: "nonexisting",
+			err:  "pass --confirm to create and import",
+		},
+		"confirmed import from non-existing": {
+			name:    "nonexisting",
+			confirm: true,
+			expectedImages: []imageapi.ImageImportSpec{{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "nonexisting"},
+				To:   &kapi.LocalObjectReference{Name: "latest"},
+			}},
+		},
+		"confirmed import all from non-existing": {
+			name:    "nonexisting",
+			all:     true,
+			confirm: true,
+			expectedRepository: &imageapi.RepositoryImportSpec{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "nonexisting"},
+			},
+		},
+		"import from .spec.dockerImageRepository": {
 			name: "testis",
 			stream: &imageapi.ImageStream{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      "testis",
-					Namespace: "other",
-				},
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
 				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "repo.com/somens/someimage",
 					Tags: make(map[string]imageapi.TagReference),
 				},
 			},
-			expected: []imageapi.ImageImportSpec{{
-				From: kapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: "repo.com/somens/someimage",
-				},
+			expectedImages: []imageapi.ImageImportSpec{{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
+				To:   &kapi.LocalObjectReference{Name: "latest"},
 			}},
 		},
-		{
-			// 1: checking import's from when only .spec.dockerImageRepository is set, no status (with all flag set)
+		"import all from .spec.dockerImageRepository": {
 			name: "testis",
+			all:  true,
 			stream: &imageapi.ImageStream{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      "testis",
-					Namespace: "other",
-				},
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
 				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "repo.com/somens/someimage",
 					Tags: make(map[string]imageapi.TagReference),
 				},
 			},
-			all: true,
-			expected: []imageapi.ImageImportSpec{{
-				From: kapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: "repo.com/somens/someimage",
-				},
-			}},
+			expectedRepository: &imageapi.RepositoryImportSpec{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
+			},
 		},
-		{
-			// 2: with --all flag only .spec.dockerImageRepository is handled
+		"import all from .spec.dockerImageRepository with different from": {
 			name: "testis",
+			from: "totally_different_spec",
+			all:  true,
+			err:  "different import spec",
 			stream: &imageapi.ImageStream{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      "testis",
-					Namespace: "other",
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+				Spec: imageapi.ImageStreamSpec{
+					DockerImageRepository: "repo.com/somens/someimage",
+					Tags: make(map[string]imageapi.TagReference),
 				},
+			},
+		},
+		"import all from .spec.dockerImageRepository with confirmed different from": {
+			name:    "testis",
+			from:    "totally/different/spec",
+			all:     true,
+			confirm: true,
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+				Spec: imageapi.ImageStreamSpec{
+					DockerImageRepository: "repo.com/somens/someimage",
+					Tags: make(map[string]imageapi.TagReference),
+				},
+			},
+			expectedRepository: &imageapi.RepositoryImportSpec{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "totally/different/spec"},
+			},
+		},
+		"import all from .spec.tags": {
+			name: "testis",
+			all:  true,
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
 				Spec: imageapi.ImageStreamSpec{
 					Tags: map[string]imageapi.TagReference{
-						"latest": {
-							From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
-						},
+						"latest": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
+						"other":  {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"}},
 					},
 				},
 			},
-			all: true,
-			err: "all is applicable only to images with spec.dockerImageRepository",
-		},
-		{
-			// 3: empty image stream
-			name: "testis",
-			stream: &imageapi.ImageStream{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      "testis",
-					Namespace: "other",
+			expectedImages: []imageapi.ImageImportSpec{
+				{
+					From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
+					To:   &kapi.LocalObjectReference{Name: "latest"},
+				},
+				{
+					From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
+					To:   &kapi.LocalObjectReference{Name: "other"},
 				},
 			},
-			err: "image stream has not defined anything to import",
 		},
-		{
-			// 4: correct import of latest tag with tags specified in .spec.Tags
+		"import all from .spec.tags with insecure annotation": {
+			name: "testis",
+			all:  true,
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:        "testis",
+					Namespace:   "other",
+					Annotations: map[string]string{imageapi.InsecureRepositoryAnnotation: "true"},
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"latest": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
+						"other":  {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"}},
+					},
+				},
+			},
+			expectedImages: []imageapi.ImageImportSpec{
+				{
+					From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
+					To:           &kapi.LocalObjectReference{Name: "latest"},
+					ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+				},
+				{
+					From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
+					To:           &kapi.LocalObjectReference{Name: "other"},
+					ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+				},
+			},
+		},
+		"import all from .spec.tags with insecure flag": {
+			name:     "testis",
+			all:      true,
+			insecure: newBool(true),
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"latest": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
+						"other":  {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"}},
+					},
+				},
+			},
+			expectedImages: []imageapi.ImageImportSpec{
+				{
+					From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
+					To:           &kapi.LocalObjectReference{Name: "latest"},
+					ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+				},
+				{
+					From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:other"},
+					To:           &kapi.LocalObjectReference{Name: "other"},
+					ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+				},
+			},
+		},
+		"import all from .spec.tags no DockerImage tags": {
+			name: "testis",
+			all:  true,
+			err:  "does not have tags pointing to external docker images",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"latest": {From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "otheris:latest"}},
+					},
+				},
+			},
+		},
+		"empty image stream": {
+			name: "testis",
+			err:  "does not have valid docker images",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+			},
+		},
+		"import latest tag": {
 			name: "testis:latest",
 			stream: &imageapi.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{
@@ -102,22 +208,17 @@ func TestCreateImageImport(t *testing.T) {
 				},
 				Spec: imageapi.ImageStreamSpec{
 					Tags: map[string]imageapi.TagReference{
-						"latest": {
-							From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
-						},
+						"latest": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
 					},
 				},
 			},
-			expected: []imageapi.ImageImportSpec{{
-				From: kapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: "repo.com/somens/someimage:latest",
-				},
+			expectedImages: []imageapi.ImageImportSpec{{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
+				To:   &kapi.LocalObjectReference{Name: "latest"},
 			}},
 		},
-		{
-			// 5: import latest from image stream which has only tags specified and no latest
-			name: "testis:latest",
+		"import existing tag": {
+			name: "testis:existing",
 			stream: &imageapi.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{
 					Name:      "testis",
@@ -125,16 +226,31 @@ func TestCreateImageImport(t *testing.T) {
 				},
 				Spec: imageapi.ImageStreamSpec{
 					Tags: map[string]imageapi.TagReference{
-						"nonlatest": {
-							From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
-						},
+						"existing": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
 					},
 				},
 			},
-			err: "does not exist on the image stream",
+			expectedImages: []imageapi.ImageImportSpec{{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"},
+				To:   &kapi.LocalObjectReference{Name: "existing"},
+			}},
 		},
-		{
-			// 6: insecure annotation should be applied to tags if exists
+		"import non-existing tag": {
+			name: "testis:latest",
+			err:  "does not exist on the image stream",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "testis",
+					Namespace: "other",
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"nonlatest": {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:latest"}},
+					},
+				},
+			},
+		},
+		"use insecure annotation": {
 			name: "testis",
 			stream: &imageapi.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{
@@ -147,17 +263,15 @@ func TestCreateImageImport(t *testing.T) {
 					Tags: make(map[string]imageapi.TagReference),
 				},
 			},
-			expected: []imageapi.ImageImportSpec{{
-				From: kapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: "repo.com/somens/someimage",
-				},
+			expectedImages: []imageapi.ImageImportSpec{{
+				From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
+				To:           &kapi.LocalObjectReference{Name: "latest"},
 				ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
 			}},
 		},
-		{
-			// 7: insecure annotation should be overridden by the flag
-			name: "testis",
+		"insecure flag overrides insecure annotation": {
+			name:     "testis",
+			insecure: newBool(false),
 			stream: &imageapi.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{
 					Name:        "testis",
@@ -169,67 +283,77 @@ func TestCreateImageImport(t *testing.T) {
 					Tags: make(map[string]imageapi.TagReference),
 				},
 			},
-			insecure: newBool(false),
-			expected: []imageapi.ImageImportSpec{{
-				From: kapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: "repo.com/somens/someimage",
-				},
+			expectedImages: []imageapi.ImageImportSpec{{
+				From:         kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage"},
+				To:           &kapi.LocalObjectReference{Name: "latest"},
 				ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
 			}},
 		},
 	}
 
-	for idx, test := range testCases {
-		fake := testclient.NewSimpleFake(test.stream)
+	for name, test := range testCases {
+		var fake *testclient.Fake
+		if test.stream == nil {
+			fake = testclient.NewSimpleFake()
+		} else {
+			fake = testclient.NewSimpleFake(test.stream)
+		}
 		o := ImportImageOptions{
-			Target:    test.stream.Name,
-			All:       test.all,
-			Insecure:  test.insecure,
-			Namespace: test.stream.Namespace,
-			isClient:  fake.ImageStreams(test.stream.Namespace),
+			Target:   test.name,
+			From:     test.from,
+			All:      test.all,
+			Insecure: test.insecure,
+			Confirm:  test.confirm,
+			isClient: fake.ImageStreams(""),
 		}
 		// we need to run Validate, because it sets appropriate Name and Tag
 		if err := o.Validate(&cobra.Command{}); err != nil {
-			t.Errorf("(%d) unexpected error: %v", idx, err)
+			t.Errorf("%s: unexpected error: %v", name, err)
 		}
 
 		_, isi, err := o.createImageImport()
 		// check errors
 		if len(test.err) > 0 {
 			if err == nil || !strings.Contains(err.Error(), test.err) {
-				t.Errorf("(%d) unexpected error: expected %s, got %v", idx, test.err, err)
+				t.Errorf("%s: unexpected error: expected %s, got %v", name, test.err, err)
 			}
 			if isi != nil {
-				t.Errorf("(%d) unexpected import spec: expected nil, got %#v", idx, isi)
+				t.Errorf("%s: unexpected import spec: expected nil, got %#v", name, isi)
 			}
 			continue
 		}
 		if len(test.err) == 0 && err != nil {
-			t.Errorf("(%d) unexpected error: %v", idx, err)
+			t.Errorf("%s: unexpected error: %v", name, err)
 			continue
 		}
 		// check values
-		if test.all {
-			if !kapi.Semantic.DeepEqual(isi.Spec.Repository.From, test.expected[0].From) {
-				t.Errorf("(%d) unexpected import spec, expected %#v, got %#v", idx, test.expected[0].From, isi.Spec.Repository.From)
-			}
-		} else {
-			if len(isi.Spec.Images) != len(test.expected) {
-				t.Errorf("(%d) unexpected number of images, expected %d, got %d", idx, len(test.expected), len(isi.Spec.Images))
-			}
-			for i := 0; i < len(test.expected); i++ {
-				actual := isi.Spec.Images[i]
-				expected := test.expected[i]
-				if !kapi.Semantic.DeepEqual(actual.ImportPolicy, expected.ImportPolicy) {
-					t.Errorf("(%d) unexpected import[%d] policy, expected %v, got %v", idx, i, expected.ImportPolicy, actual.ImportPolicy)
-				}
-				if !kapi.Semantic.DeepEqual(actual.From, expected.From) {
-					t.Errorf("(%d) unexpected import[%d] from, expected %#v, got %#v", idx, i, expected.From, actual.From)
-				}
-			}
+		if !listEqual(isi.Spec.Images, test.expectedImages) {
+			t.Errorf("%s: unexpected import images, expected %#v, got %#v", name, test.expectedImages, isi.Spec.Images)
+		}
+		if !kapi.Semantic.DeepEqual(isi.Spec.Repository, test.expectedRepository) {
+			t.Errorf("%s: unexpected import repository, expected %#v, got %#v", name, test.expectedRepository, isi.Spec.Repository)
 		}
 	}
+}
+
+func listEqual(actual, expected []imageapi.ImageImportSpec) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	for _, a := range actual {
+		found := false
+		for _, e := range expected {
+			if kapi.Semantic.DeepEqual(a, e) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func newBool(a bool) *bool {

--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -337,7 +337,7 @@ func (d *LatestDeploymentsDescriber) Describe(namespace, name string) (string, e
 
 	var deployments []kapi.ReplicationController
 	if d.count == -1 || d.count > 1 {
-		list, err := d.kubeClient.ReplicationControllers(namespace).List(kapi.ListOptions{LabelSelector: labels.Set(config.Spec.Selector).AsSelector()})
+		list, err := d.kubeClient.ReplicationControllers(namespace).List(kapi.ListOptions{LabelSelector: deployutil.ConfigSelector(name)})
 		if err != nil && !kerrors.IsNotFound(err) {
 			return "", err
 		}

--- a/pkg/deploy/api/deep_copy_generated.go
+++ b/pkg/deploy/api/deep_copy_generated.go
@@ -160,6 +160,7 @@ func DeepCopy_api_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentC
 	}
 	out.Replicas = in.Replicas
 	out.Test = in.Test
+	out.Paused = in.Paused
 	if in.Selector != nil {
 		in, out := in.Selector, &out.Selector
 		*out = make(map[string]string)

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -311,6 +311,10 @@ type DeploymentConfigSpec struct {
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
 	Test bool
 
+	// Paused indicates that the deployment config is paused resulting in no new deployments on template
+	// changes or changes in the template caused by other triggers.
+	Paused bool
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string
 

--- a/pkg/deploy/api/v1/conversion_generated.go
+++ b/pkg/deploy/api/v1/conversion_generated.go
@@ -391,6 +391,7 @@ func autoConvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *Deploym
 	}
 	out.Replicas = in.Replicas
 	out.Test = in.Test
+	out.Paused = in.Paused
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = make(map[string]string, len(*in))
@@ -437,6 +438,7 @@ func autoConvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deploy_
 	}
 	out.Replicas = in.Replicas
 	out.Test = in.Test
+	out.Paused = in.Paused
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
 		*out = make(map[string]string, len(*in))

--- a/pkg/deploy/api/v1/deep_copy_generated.go
+++ b/pkg/deploy/api/v1/deep_copy_generated.go
@@ -159,6 +159,7 @@ func DeepCopy_v1_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentCo
 	}
 	out.Replicas = in.Replicas
 	out.Test = in.Test
+	out.Paused = in.Paused
 	if in.Selector != nil {
 		in, out := in.Selector, &out.Selector
 		*out = make(map[string]string)

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -84,6 +84,7 @@ var map_DeploymentConfigSpec = map[string]string{
 	"triggers": "Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers are defined, a new deployment can only occur as a result of an explicit client update to the DeploymentConfig with a new LatestVersion.",
 	"replicas": "Replicas is the number of desired replicas.",
 	"test":     "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.",
+	"paused":   "Paused indicates that the deployment config is paused resulting in no new deployments on template changes or changes in the template caused by other triggers.",
 	"selector": "Selector is a label query over pods that should match the Replicas count.",
 	"template": "Template is the object that describes the pod that will be created if insufficient replicas are detected.",
 }

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -268,6 +268,10 @@ type DeploymentConfigSpec struct {
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
 	Test bool `json:"test"`
 
+	// Paused indicates that the deployment config is paused resulting in no new deployments on template
+	// changes or changes in the template caused by other triggers.
+	Paused bool `json:"paused,omitempty"`
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string `json:"selector,omitempty"`
 

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -284,6 +284,10 @@ type DeploymentConfigSpec struct {
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
 	Test bool `json:"test"`
 
+	// Paused indicates that the deployment config is paused resulting in no new deployments on template
+	// changes or changes in the template caused by other triggers.
+	Paused bool `json:"paused,omitempty"`
+
 	// Selector is a label query over pods that should match the Replicas count.
 	Selector map[string]string `json:"selector,omitempty"`
 

--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -35,8 +35,7 @@ func (e fatalError) Error() string {
 
 // Handle processes change triggers for config.
 func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentConfig) error {
-	if !deployutil.HasChangeTrigger(config) {
-		glog.V(5).Infof("Ignoring deployment config %q; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
+	if !deployutil.HasChangeTrigger(config) || config.Spec.Paused {
 		return nil
 	}
 

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -119,6 +119,11 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		}
 		return c.reconcileDeployments(existingDeployments, config)
 	}
+	// If the config is paused we shouldn't create new deployments for it.
+	// TODO: Make sure cleanup policy will work for paused configs.
+	if config.Spec.Paused {
+		return c.updateStatus(config)
+	}
 	// No deployments are running and the latest deployment doesn't exist, so
 	// create the new deployment.
 	deployment, err := deployutil.MakeDeployment(config, c.codec)

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -54,7 +54,7 @@ func (c *ImageChangeController) Handle(stream *imageapi.ImageStream) error {
 			// be able to work and not try to pull non-existent images from DockerHub.
 			// Deployments with automatic set to false that have been deployed at least
 			// once shouldn't have their images updated.
-			if !params.Automatic && len(params.LastTriggeredImage) > 0 {
+			if (!params.Automatic || config.Spec.Paused) && len(params.LastTriggeredImage) > 0 {
 				continue
 			}
 

--- a/pkg/generate/app/cmd/template.go
+++ b/pkg/generate/app/cmd/template.go
@@ -40,7 +40,7 @@ func TransformTemplate(tpl *templateapi.Template, client client.TemplateConfigsN
 	// TODO: in the future, this should be more automatic
 	if errs := runtime.DecodeList(result.Objects, kapi.Codecs.UniversalDecoder()); len(errs) > 0 {
 		err = errors.NewAggregate(errs)
-		return nil, fmt.Errorf("error processing template %s: %v", name, errs)
+		return nil, fmt.Errorf("error processing template %s: %v", name, err)
 	}
 
 	return result, nil

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -88,6 +88,16 @@ func generateFailoverMonitorContainerConfig(name string, options *ipfailover.IPF
 		MountPath: libModulesPath,
 	}
 
+	livenessProbe := &kapi.Probe{
+		InitialDelaySeconds: 10,
+
+		Handler: kapi.Handler{
+			Exec: &kapi.ExecAction{
+				Command: []string{"pgrep", "keepalived"},
+			},
+		},
+	}
+
 	privileged := true
 	return &kapi.Container{
 		Name:  containerName,
@@ -99,6 +109,7 @@ func generateFailoverMonitorContainerConfig(name string, options *ipfailover.IPF
 		ImagePullPolicy: kapi.PullIfNotPresent,
 		VolumeMounts:    mounts,
 		Env:             env.List(),
+		LivenessProbe:   livenessProbe,
 	}
 }
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -163,7 +163,8 @@ func (p *Processor) GenerateParameterValues(t *api.Template) *field.Error {
 		if param.Generate != "" {
 			generator, ok := p.Generators[param.Generate]
 			if !ok {
-				return field.Invalid(templatePath.Child("Generate"), param.Generate, "")
+				err := fmt.Errorf("template.parameters[%v]: Invalid '%v' generator for parameter %s", i, param.Generate, param.Name)
+				return field.Invalid(templatePath.Child("Generate"), param.Generate, err.Error())
 			}
 			if generator == nil {
 				err := fmt.Errorf("template.parameters[%v]: Invalid '%v' generator for parameter %s", i, param.Generate, param.Name)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -163,7 +163,7 @@ func (p *Processor) GenerateParameterValues(t *api.Template) *field.Error {
 		if param.Generate != "" {
 			generator, ok := p.Generators[param.Generate]
 			if !ok {
-				return field.NotFound(templatePath, param)
+				return field.NotFound(templatePath.Child("Generate"), param.Generate)
 			}
 			if generator == nil {
 				err := fmt.Errorf("template.parameters[%v]: Invalid '%v' generator for parameter %s", i, param.Generate, param.Name)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -163,7 +163,7 @@ func (p *Processor) GenerateParameterValues(t *api.Template) *field.Error {
 		if param.Generate != "" {
 			generator, ok := p.Generators[param.Generate]
 			if !ok {
-				return field.NotFound(templatePath.Child("Generate"), param.Generate)
+				return field.Invalid(templatePath.Child("Generate"), param.Generate, "")
 			}
 			if generator == nil {
 				err := fmt.Errorf("template.parameters[%v]: Invalid '%v' generator for parameter %s", i, param.Generate, param.Name)

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -272,7 +272,8 @@ os::cmd::expect_success_and_text "oc exec -p ${frontend_pod} id" '1000'
 os::cmd::expect_success_and_text "oc rsh pod/${frontend_pod} id -u" '1000'
 os::cmd::expect_success_and_text "oc rsh -T ${frontend_pod} id -u" '1000'
 # Test retrieving application logs from dc
-oc logs dc/frontend | grep "Connecting to production database"
+os::cmd::expect_success_and_text "oc logs dc/frontend" 'Connecting to production database'
+os::cmd::expect_success_and_text "oc deploy frontend" 'deployed'
 
 # Port forwarding
 echo "[INFO] Validating port-forward"

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -2,6 +2,7 @@ package builds
 
 import (
 	"fmt"
+	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -26,16 +27,23 @@ var _ = g.Describe("[builds][Slow] the s2i build should support proxies", func()
 
 	g.Describe("start build with broken proxy", func() {
 		g.It("should start a build and wait for the build to to fail", func() {
-			g.By("starting the build with --wait and --follow flags")
-			out, err := oc.Run("start-build").Args("sample-build", "--follow", "--wait").Output()
+			g.By("starting the build")
+			out, err := oc.Run("start-build").Args("sample-build").Output()
 			if err != nil {
 				fmt.Fprintln(g.GinkgoWriter, out)
 			}
-			o.Expect(err).To(o.HaveOccurred())
-			g.By("verifying the build sample-app-1 output")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("verifying the build sample-build-1 output")
 			// The git ls-remote check should exit the build when the remote
 			// repository is not accessible. It should never get to the clone.
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), "sample-build-1", exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+			o.Expect(err).To(o.HaveOccurred())
+			out, err = oc.Run("logs").Args("-f", "bc/sample-build").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).NotTo(o.ContainSubstring("clone"))
+			if !strings.Contains(out, `unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to 127.0.0.1:3128`) {
+				fmt.Fprintf(g.GinkgoWriter, "\n: build logs: %s\n", out)
+			}
 			o.Expect(out).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to 127.0.0.1:3128`))
 			g.By("verifying the build sample-build-1 status")
 			build, err := oc.REST().Builds(oc.Namespace()).Get("sample-build-1")

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -3,7 +3,6 @@ package deployments
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"time"
 
@@ -11,11 +10,9 @@ import (
 	o "github.com/onsi/gomega"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e"
 
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -25,10 +22,12 @@ const deploymentRunTimeout = 5 * time.Minute
 var _ = g.Describe("deploymentconfigs", func() {
 	defer g.GinkgoRecover()
 	var (
+		oc                      = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
 		deploymentFixture       = exutil.FixturePath("..", "extended", "fixtures", "test-deployment-test.yaml")
 		simpleDeploymentFixture = exutil.FixturePath("..", "extended", "fixtures", "deployment-simple.yaml")
 		customDeploymentFixture = exutil.FixturePath("..", "extended", "fixtures", "custom-deployment.yaml")
-		oc                      = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
+		generationFixture       = exutil.FixturePath("..", "extended", "fixtures", "test-deployment.yaml")
+		pausedDeploymentFixture = exutil.FixturePath("..", "extended", "fixtures", "paused-deployment.yaml")
 	)
 
 	g.Describe("when run iteratively", func() {
@@ -210,265 +209,11 @@ var _ = g.Describe("deploymentconfigs", func() {
 			o.Expect(waitForLatestCondition(oc, "custom-deployment", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 	})
-})
 
-func deploymentStatuses(rcs []kapi.ReplicationController) []string {
-	statuses := []string{}
-	for _, rc := range rcs {
-		statuses = append(statuses, string(deployutil.DeploymentStatusFor(&rc)))
-	}
-	return statuses
-}
-
-func deploymentPods(pods []kapi.Pod) (map[string][]*kapi.Pod, error) {
-	deployers := make(map[string][]*kapi.Pod)
-	for i := range pods {
-		name, ok := pods[i].Labels[deployapi.DeployerPodForDeploymentLabel]
-		if !ok {
-			continue
-		}
-		deployers[name] = append(deployers[name], &pods[i])
-	}
-	return deployers, nil
-}
-
-var completedStatuses = sets.NewString(string(deployapi.DeploymentStatusComplete), string(deployapi.DeploymentStatusFailed))
-
-func checkDeployerPodInvariants(deploymentName string, pods []*kapi.Pod) (isRunning, isCompleted bool, err error) {
-	running := false
-	completed := false
-	succeeded := false
-	hasDeployer := false
-
-	// find deployment state
-	for _, pod := range pods {
-		switch {
-		case strings.HasSuffix(pod.Name, "-deploy"):
-			if hasDeployer {
-				return false, false, fmt.Errorf("multiple deployer pods for %q", deploymentName)
-			}
-			hasDeployer = true
-
-			switch pod.Status.Phase {
-			case kapi.PodSucceeded:
-				succeeded = true
-				completed = true
-			case kapi.PodFailed:
-				completed = true
-			default:
-				running = true
-			}
-		case strings.HasSuffix(pod.Name, "-pre"), strings.HasSuffix(pod.Name, "-mid"), strings.HasSuffix(pod.Name, "-post"):
-		default:
-			return false, false, fmt.Errorf("deployer pod %q not recognized as being a valid deployment pod", pod.Name)
-		}
-	}
-
-	// check hook pods
-	for _, pod := range pods {
-		switch {
-		case strings.HasSuffix(pod.Name, "-pre"), strings.HasSuffix(pod.Name, "-mid"), strings.HasSuffix(pod.Name, "-post"):
-			switch pod.Status.Phase {
-			case kapi.PodSucceeded:
-			case kapi.PodFailed:
-				if succeeded {
-					return false, false, fmt.Errorf("deployer hook pod %q failed but the deployment %q pod succeeded", pod.Name, deploymentName)
-				}
-			default:
-				if completed {
-					// TODO: we need to tighten guarantees around hook pods: https://github.com/openshift/origin/issues/8500
-					//for i := range pods {
-					//	e2e.Logf("deployment %q pod[%d]: %#v", deploymentName, i, pods[i])
-					//}
-					//return false, false, fmt.Errorf("deployer hook pod %q is still running but the deployment %q is complete", pod.Name, deploymentName)
-					//e2e.Logf("deployer hook pod %q is still running but the deployment %q is complete", pod.Name, deploymentName)
-				}
-			}
-		}
-	}
-	return running, completed, nil
-}
-
-func checkDeploymentInvariants(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController, pods []kapi.Pod) error {
-	deployers, err := deploymentPods(pods)
-	if err != nil {
-		return err
-	}
-	if len(deployers) > len(rcs) {
-		existing := sets.NewString()
-		for k := range deployers {
-			existing.Insert(k)
-		}
-		for _, rc := range rcs {
-			if existing.Has(rc.Name) {
-				existing.Delete(rc.Name)
-			} else {
-				e2e.Logf("ANOMALY: No deployer pod found for deployment %q", rc.Name)
-			}
-		}
-		for k := range existing {
-			// TODO: we are missing RCs? https://github.com/openshift/origin/pull/8483#issuecomment-209150611
-			e2e.Logf("ANOMALY: Deployer pod found for %q but no RC exists", k)
-			//return fmt.Errorf("more deployer pods found than deployments: %#v %#v", deployers, rcs)
-		}
-	}
-	running := sets.NewString()
-	completed := 0
-	for k, v := range deployers {
-		isRunning, isCompleted, err := checkDeployerPodInvariants(k, v)
-		if err != nil {
-			return err
-		}
-		if isCompleted {
-			completed++
-		}
-		if isRunning {
-			running.Insert(k)
-		}
-	}
-	if running.Len() > 1 {
-		return fmt.Errorf("found multiple running deployments: %v", running.List())
-	}
-	sawStatus := sets.NewString()
-	statuses := []string{}
-	for _, rc := range rcs {
-		status := deployutil.DeploymentStatusFor(&rc)
-		if sawStatus.Len() != 0 {
-			switch status {
-			case deployapi.DeploymentStatusComplete, deployapi.DeploymentStatusFailed:
-				if sawStatus.Difference(completedStatuses).Len() != 0 {
-					return fmt.Errorf("rc %s was %s, but earlier RCs were not completed: %v", rc.Name, status, statuses)
-				}
-			case deployapi.DeploymentStatusRunning, deployapi.DeploymentStatusPending:
-				if sawStatus.Has(string(status)) {
-					return fmt.Errorf("rc %s was %s, but so was an earlier RC: %v", rc.Name, status, statuses)
-				}
-				if sawStatus.Difference(completedStatuses).Len() != 0 {
-					return fmt.Errorf("rc %s was %s, but earlier RCs were not completed: %v", rc.Name, status, statuses)
-				}
-			case deployapi.DeploymentStatusNew:
-			default:
-				return fmt.Errorf("rc %s has unexpected status %s: %v", rc.Name, status, statuses)
-			}
-		}
-		sawStatus.Insert(string(status))
-		statuses = append(statuses, string(status))
-	}
-	return nil
-}
-
-func deploymentReachedCompletion(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error) {
-	if len(rcs) == 0 {
-		return false, nil
-	}
-	rc := rcs[len(rcs)-1]
-	version := deployutil.DeploymentVersionFor(&rc)
-	if version != dc.Status.LatestVersion {
-		return false, nil
-	}
-
-	status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
-	if deployapi.DeploymentStatus(status) != deployapi.DeploymentStatusComplete {
-		return false, nil
-	}
-	expectedReplicas := dc.Spec.Replicas
-	if dc.Spec.Test {
-		expectedReplicas = 0
-	}
-	if rc.Spec.Replicas != expectedReplicas {
-		return false, fmt.Errorf("deployment is complete but doesn't have expected spec replicas: %d %d", rc.Spec.Replicas, expectedReplicas)
-	}
-	if rc.Status.Replicas != expectedReplicas {
-		e2e.Logf("POSSIBLE_ANOMALY: deployment is complete but doesn't have expected status replicas: %d %d", rc.Status.Replicas, expectedReplicas)
-		return false, nil
-	}
-	return true, nil
-}
-
-func deploymentRunning(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error) {
-	if len(rcs) == 0 {
-		return false, nil
-	}
-	rc := rcs[len(rcs)-1]
-	version := deployutil.DeploymentVersionFor(&rc)
-	if version != dc.Status.LatestVersion {
-		//e2e.Logf("deployment %s is not the latest version on DC: %d", rc.Name, version)
-		return false, nil
-	}
-
-	status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
-	switch deployapi.DeploymentStatus(status) {
-	case deployapi.DeploymentStatusFailed:
-		if deployutil.IsDeploymentCancelled(&rc) {
-			return true, nil
-		}
-		reason := deployutil.DeploymentStatusReasonFor(&rc)
-		if reason == "deployer pod no longer exists" {
-			return true, nil
-		}
-		return false, fmt.Errorf("deployment failed: %v", deployutil.DeploymentStatusReasonFor(&rc))
-	case deployapi.DeploymentStatusRunning, deployapi.DeploymentStatusComplete:
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
-func deploymentInfo(oc *exutil.CLI, name string) (*deployapi.DeploymentConfig, []kapi.ReplicationController, []kapi.Pod, error) {
-	dc, err := oc.REST().DeploymentConfigs(oc.Namespace()).Get(name)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// get pods before RCs, so we see more RCs than pods.
-	pods, err := oc.KubeREST().Pods(oc.Namespace()).List(kapi.ListOptions{})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	rcs, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).List(kapi.ListOptions{
-		LabelSelector: deployutil.ConfigSelector(name),
-	})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	sort.Sort(deployutil.ByLatestVersionAsc(rcs.Items))
-
-	return dc, rcs.Items, pods.Items, nil
-}
-
-type deploymentConditionFunc func(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error)
-
-func waitForLatestCondition(oc *exutil.CLI, name string, timeout time.Duration, fn deploymentConditionFunc) error {
-	return wait.Poll(200*time.Millisecond, timeout, func() (bool, error) {
-		dc, rcs, pods, err := deploymentInfo(oc, name)
-		if err != nil {
-			return false, err
-		}
-		if err := checkDeploymentInvariants(dc, rcs, pods); err != nil {
-			return false, err
-		}
-		return fn(dc, rcs)
-	})
-}
-
-var _ = g.Describe("deployments: parallel: deployment generation", func() {
-	defer g.GinkgoRecover()
-	var (
-		generationFixture = exutil.FixturePath("..", "extended", "fixtures", "test-deployment.yaml")
-		oc                = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
-	)
-
-	g.Describe("deployment generation", func() {
+	g.Describe("generation", func() {
 		g.It("should deploy based on a status version bump", func() {
-			resource, err := oc.Run("create").Args("-f", generationFixture, "-o", "name").Output()
+			resource, name, err := createFixture(oc, generationFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
-
-			parts := strings.Split(resource, "/")
-			if len(parts) != 2 {
-				o.Expect(fmt.Errorf("expected type/name syntax, got: %s", resource)).NotTo(o.HaveOccurred())
-			}
-			dcName := parts[1]
 
 			g.By("verifying that both latestVersion and generation are updated")
 			version, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.latestVersion}\"").Output()
@@ -483,7 +228,7 @@ var _ = g.Describe("deployments: parallel: deployment generation", func() {
 
 			g.By("verifying the deployment is marked complete")
 			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
-				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get(dcName + "-" + version)
+				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get(name + "-" + version)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				return deployutil.IsTerminatedDeployment(rc), nil
 			})
@@ -498,7 +243,7 @@ var _ = g.Describe("deployments: parallel: deployment generation", func() {
 			o.Expect(generation).To(o.ContainSubstring("2"))
 
 			g.By("deploying a second time [new client]")
-			_, err = oc.Run("deploy").Args("--latest", dcName).Output()
+			_, err = oc.Run("deploy").Args("--latest", name).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying that both latestVersion and generation are updated")
@@ -512,13 +257,53 @@ var _ = g.Describe("deployments: parallel: deployment generation", func() {
 			g.By(fmt.Sprintf("checking the generation for %s: %s", resource, generation))
 			o.Expect(generation).To(o.ContainSubstring("3"))
 
-			g.By("verifying the second deployment is marked complete")
-			err = wait.Poll(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
-				rc, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).Get(dcName + "-" + version)
+			g.By("verifying that observedGeneration equals generation")
+			err = wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+				dc, _, _, err := deploymentInfo(oc, name)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				return deployutil.IsTerminatedDeployment(rc), nil
+				return deployutil.HasSynced(dc), nil
 			})
+		})
+	})
+
+	g.Describe("paused", func() {
+		g.It("should never run a new deployment", func() {
+			resource, name, err := createFixture(oc, pausedDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
+
+			_, rcs, _, err := deploymentInfo(oc, name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if len(rcs) != 0 {
+				o.Expect(fmt.Errorf("expected no deployment, found %#v", rcs[0])).NotTo(o.HaveOccurred())
+			}
+
+			out, err := oc.Run("deploy").Args(resource, "--latest").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cannot deploy a paused deploymentconfig"))
+
+			out, err = oc.Run("deploy").Args(resource, "--cancel").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cannot cancel a paused deploymentconfig"))
+
+			out, err = oc.Run("deploy").Args(resource, "--retry").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cannot retry a paused deploymentconfig"))
+
+			out, err = oc.Run("rollback").Args(resource, "--to-version", "1").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("cannot rollback a paused deploymentconfig"))
+
+			dc, rcs, _, err := deploymentInfo(oc, name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if len(rcs) != 0 {
+				o.Expect(fmt.Errorf("expected no deployment, found %#v", rcs[0])).NotTo(o.HaveOccurred())
+			}
+
+			dc.Spec.Paused = false
+			_, err = oc.REST().DeploymentConfigs(dc.Namespace).Update(dc)
+			// TODO: Retry on update conflicts
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 	})
 })

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -1,0 +1,272 @@
+package deployments
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+func deploymentStatuses(rcs []kapi.ReplicationController) []string {
+	statuses := []string{}
+	for _, rc := range rcs {
+		statuses = append(statuses, string(deployutil.DeploymentStatusFor(&rc)))
+	}
+	return statuses
+}
+
+func deploymentPods(pods []kapi.Pod) (map[string][]*kapi.Pod, error) {
+	deployers := make(map[string][]*kapi.Pod)
+	for i := range pods {
+		name, ok := pods[i].Labels[deployapi.DeployerPodForDeploymentLabel]
+		if !ok {
+			continue
+		}
+		deployers[name] = append(deployers[name], &pods[i])
+	}
+	return deployers, nil
+}
+
+var completedStatuses = sets.NewString(string(deployapi.DeploymentStatusComplete), string(deployapi.DeploymentStatusFailed))
+
+func checkDeployerPodInvariants(deploymentName string, pods []*kapi.Pod) (isRunning, isCompleted bool, err error) {
+	running := false
+	completed := false
+	succeeded := false
+	hasDeployer := false
+
+	// find deployment state
+	for _, pod := range pods {
+		switch {
+		case strings.HasSuffix(pod.Name, "-deploy"):
+			if hasDeployer {
+				return false, false, fmt.Errorf("multiple deployer pods for %q", deploymentName)
+			}
+			hasDeployer = true
+
+			switch pod.Status.Phase {
+			case kapi.PodSucceeded:
+				succeeded = true
+				completed = true
+			case kapi.PodFailed:
+				completed = true
+			default:
+				running = true
+			}
+		case strings.HasSuffix(pod.Name, "-pre"), strings.HasSuffix(pod.Name, "-mid"), strings.HasSuffix(pod.Name, "-post"):
+		default:
+			return false, false, fmt.Errorf("deployer pod %q not recognized as being a valid deployment pod", pod.Name)
+		}
+	}
+
+	// check hook pods
+	for _, pod := range pods {
+		switch {
+		case strings.HasSuffix(pod.Name, "-pre"), strings.HasSuffix(pod.Name, "-mid"), strings.HasSuffix(pod.Name, "-post"):
+			switch pod.Status.Phase {
+			case kapi.PodSucceeded:
+			case kapi.PodFailed:
+				if succeeded {
+					return false, false, fmt.Errorf("deployer hook pod %q failed but the deployment %q pod succeeded", pod.Name, deploymentName)
+				}
+			default:
+				if completed {
+					// TODO: we need to tighten guarantees around hook pods: https://github.com/openshift/origin/issues/8500
+					//for i := range pods {
+					//	e2e.Logf("deployment %q pod[%d]: %#v", deploymentName, i, pods[i])
+					//}
+					//return false, false, fmt.Errorf("deployer hook pod %q is still running but the deployment %q is complete", pod.Name, deploymentName)
+					//e2e.Logf("deployer hook pod %q is still running but the deployment %q is complete", pod.Name, deploymentName)
+				}
+			}
+		}
+	}
+	return running, completed, nil
+}
+
+func checkDeploymentInvariants(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController, pods []kapi.Pod) error {
+	deployers, err := deploymentPods(pods)
+	if err != nil {
+		return err
+	}
+	if len(deployers) > len(rcs) {
+		existing := sets.NewString()
+		for k := range deployers {
+			existing.Insert(k)
+		}
+		for _, rc := range rcs {
+			if existing.Has(rc.Name) {
+				existing.Delete(rc.Name)
+			} else {
+				e2e.Logf("ANOMALY: No deployer pod found for deployment %q", rc.Name)
+			}
+		}
+		for k := range existing {
+			// TODO: we are missing RCs? https://github.com/openshift/origin/pull/8483#issuecomment-209150611
+			e2e.Logf("ANOMALY: Deployer pod found for %q but no RC exists", k)
+			//return fmt.Errorf("more deployer pods found than deployments: %#v %#v", deployers, rcs)
+		}
+	}
+	running := sets.NewString()
+	completed := 0
+	for k, v := range deployers {
+		isRunning, isCompleted, err := checkDeployerPodInvariants(k, v)
+		if err != nil {
+			return err
+		}
+		if isCompleted {
+			completed++
+		}
+		if isRunning {
+			running.Insert(k)
+		}
+	}
+	if running.Len() > 1 {
+		return fmt.Errorf("found multiple running deployments: %v", running.List())
+	}
+	sawStatus := sets.NewString()
+	statuses := []string{}
+	for _, rc := range rcs {
+		status := deployutil.DeploymentStatusFor(&rc)
+		if sawStatus.Len() != 0 {
+			switch status {
+			case deployapi.DeploymentStatusComplete, deployapi.DeploymentStatusFailed:
+				if sawStatus.Difference(completedStatuses).Len() != 0 {
+					return fmt.Errorf("rc %s was %s, but earlier RCs were not completed: %v", rc.Name, status, statuses)
+				}
+			case deployapi.DeploymentStatusRunning, deployapi.DeploymentStatusPending:
+				if sawStatus.Has(string(status)) {
+					return fmt.Errorf("rc %s was %s, but so was an earlier RC: %v", rc.Name, status, statuses)
+				}
+				if sawStatus.Difference(completedStatuses).Len() != 0 {
+					return fmt.Errorf("rc %s was %s, but earlier RCs were not completed: %v", rc.Name, status, statuses)
+				}
+			case deployapi.DeploymentStatusNew:
+			default:
+				return fmt.Errorf("rc %s has unexpected status %s: %v", rc.Name, status, statuses)
+			}
+		}
+		sawStatus.Insert(string(status))
+		statuses = append(statuses, string(status))
+	}
+	return nil
+}
+
+func deploymentReachedCompletion(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error) {
+	if len(rcs) == 0 {
+		return false, nil
+	}
+	rc := rcs[len(rcs)-1]
+	version := deployutil.DeploymentVersionFor(&rc)
+	if version != dc.Status.LatestVersion {
+		return false, nil
+	}
+
+	status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
+	if deployapi.DeploymentStatus(status) != deployapi.DeploymentStatusComplete {
+		return false, nil
+	}
+	expectedReplicas := dc.Spec.Replicas
+	if dc.Spec.Test {
+		expectedReplicas = 0
+	}
+	if rc.Spec.Replicas != expectedReplicas {
+		return false, fmt.Errorf("deployment is complete but doesn't have expected spec replicas: %d %d", rc.Spec.Replicas, expectedReplicas)
+	}
+	if rc.Status.Replicas != expectedReplicas {
+		e2e.Logf("POSSIBLE_ANOMALY: deployment is complete but doesn't have expected status replicas: %d %d", rc.Status.Replicas, expectedReplicas)
+		return false, nil
+	}
+	return true, nil
+}
+
+func deploymentRunning(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error) {
+	if len(rcs) == 0 {
+		return false, nil
+	}
+	rc := rcs[len(rcs)-1]
+	version := deployutil.DeploymentVersionFor(&rc)
+	if version != dc.Status.LatestVersion {
+		//e2e.Logf("deployment %s is not the latest version on DC: %d", rc.Name, version)
+		return false, nil
+	}
+
+	status := rc.Annotations[deployapi.DeploymentStatusAnnotation]
+	switch deployapi.DeploymentStatus(status) {
+	case deployapi.DeploymentStatusFailed:
+		if deployutil.IsDeploymentCancelled(&rc) {
+			return true, nil
+		}
+		reason := deployutil.DeploymentStatusReasonFor(&rc)
+		if reason == "deployer pod no longer exists" {
+			return true, nil
+		}
+		return false, fmt.Errorf("deployment failed: %v", deployutil.DeploymentStatusReasonFor(&rc))
+	case deployapi.DeploymentStatusRunning, deployapi.DeploymentStatusComplete:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func deploymentInfo(oc *exutil.CLI, name string) (*deployapi.DeploymentConfig, []kapi.ReplicationController, []kapi.Pod, error) {
+	dc, err := oc.REST().DeploymentConfigs(oc.Namespace()).Get(name)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// get pods before RCs, so we see more RCs than pods.
+	pods, err := oc.KubeREST().Pods(oc.Namespace()).List(kapi.ListOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	rcs, err := oc.KubeREST().ReplicationControllers(oc.Namespace()).List(kapi.ListOptions{
+		LabelSelector: deployutil.ConfigSelector(name),
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	sort.Sort(deployutil.ByLatestVersionAsc(rcs.Items))
+
+	return dc, rcs.Items, pods.Items, nil
+}
+
+type deploymentConditionFunc func(dc *deployapi.DeploymentConfig, rcs []kapi.ReplicationController) (bool, error)
+
+func waitForLatestCondition(oc *exutil.CLI, name string, timeout time.Duration, fn deploymentConditionFunc) error {
+	return wait.Poll(200*time.Millisecond, timeout, func() (bool, error) {
+		dc, rcs, pods, err := deploymentInfo(oc, name)
+		if err != nil {
+			return false, err
+		}
+		if err := checkDeploymentInvariants(dc, rcs, pods); err != nil {
+			return false, err
+		}
+		return fn(dc, rcs)
+	})
+}
+
+// createFixture will create the provided fixture and return the resource and the
+// name separately.
+// TODO: Probably move to a more general location like test/extended/util/cli.go
+func createFixture(oc *exutil.CLI, fixture string) (string, string, error) {
+	resource, err := oc.Run("create").Args("-f", fixture, "-o", "name").Output()
+	if err != nil {
+		return "", "", err
+	}
+	parts := strings.Split(resource, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("expected type/name syntax, got: %s", resource)
+	}
+	return resource, parts[1], nil
+}

--- a/test/extended/fixtures/paused-deployment.yaml
+++ b/test/extended/fixtures/paused-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: paused
+spec:
+  paused: true
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: paused
+    spec:
+      containers:
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        command:
+        - /bin/sleep
+        - "100"

--- a/test/extended/images/mongodb_ephemeral.go
+++ b/test/extended/images/mongodb_ephemeral.go
@@ -21,14 +21,12 @@ var _ = g.Describe("[images][mongodb] openshift mongodb image", func() {
 	g.Describe("creating from a template", func() {
 		g.It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By("creating a new app")
 			o.Expect(oc.Run("new-app").Args("-f", templatePath).Execute()).Should(o.Succeed())
 
 			g.By("waiting for the deployment to complete")
-			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "mongodb")
-			if err != nil {
-				exutil.DumpDeploymentLogs("mongodb", oc)
-			}
+			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "mongodb", oc)
 			o.Expect(err).ShouldNot(o.HaveOccurred())
 
 			g.By("expecting the mongodb pod is running")

--- a/test/extended/images/mongodb_replica.go
+++ b/test/extended/images/mongodb_replica.go
@@ -32,14 +32,12 @@ var _ = g.Describe("[images][mongodb] openshift mongodb replication", func() {
 	g.Describe("creating from a template", func() {
 		g.It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By("creating a new app")
 			o.Expect(oc.Run("new-app").Args("-f", templatePath).Execute()).Should(o.Succeed())
 
 			g.By("waiting for the deployment to complete")
-			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), deploymentConfigName)
-			if err != nil {
-				exutil.DumpDeploymentLogs(deploymentConfigName, oc)
-			}
+			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), deploymentConfigName, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			podNames := waitForNumberOfPodsWithLabel(oc, expectedReplicasAfterDeployment, "mongodb-replica")

--- a/test/extended/images/mysql_ephemeral.go
+++ b/test/extended/images/mysql_ephemeral.go
@@ -29,10 +29,7 @@ var _ = g.Describe("[images][mysql][Slow] openshift mysql image", func() {
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "mysql")
-			if err != nil {
-				exutil.DumpDeploymentLogs("mysql", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "mysql", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("expecting the mysql service get endpoints")

--- a/test/extended/images/mysql_replica.go
+++ b/test/extended/images/mysql_replica.go
@@ -68,7 +68,9 @@ func CreateMySQLReplicationHelpers(c kclient.PodInterface, masterDeployment, sla
 }
 
 func cleanup(oc *exutil.CLI) {
+	exutil.DumpImageStreams(oc)
 	oc.AsAdmin().Run("delete").Args("all", "--all", "-n", oc.Namespace()).Execute()
+	exutil.DumpImageStreams(oc)
 	oc.AsAdmin().Run("delete").Args("pvc", "--all", "-n", oc.Namespace()).Execute()
 	exutil.CleanupHostPathVolumes(oc.AdminKubeREST().PersistentVolumes(), oc.Namespace())
 }
@@ -84,6 +86,7 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 		err = testutil.WaitForPolicyUpdate(oc.REST(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		exutil.CheckOpenShiftNamespaceImageStreams(oc)
 		err = oc.Run("new-app").Args("-f", tc.TemplatePath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -92,12 +95,11 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 
 		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), helperName)
-		if err != nil {
-			exutil.DumpDeploymentLogs(helperName, oc)
-		}
+		g.By("waiting for the deployment to complete")
+		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), helperName, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		g.By("waiting for an endpoint")
 		err = oc.KubeFramework().WaitForAnEndpoint(helperName)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -106,16 +108,19 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 			tableCounter++
 			table := fmt.Sprintf("table_%0.2d", tableCounter)
 
+			g.By("creating replication helpers")
 			master, slaves, helper := CreateMySQLReplicationHelpers(oc.KubeREST().Pods(oc.Namespace()), masterDeployment, slaveDeployment, fmt.Sprintf("%s-1", helperName), slaveCount)
 			o.Expect(exutil.WaitUntilAllHelpersAreUp(oc, []exutil.Database{master, helper})).NotTo(o.HaveOccurred())
 			o.Expect(exutil.WaitUntilAllHelpersAreUp(oc, slaves)).NotTo(o.HaveOccurred())
 
 			// Test if we can query as root
+			g.By("wait for mysql-master endpoint")
 			oc.KubeFramework().WaitForAnEndpoint("mysql-master")
 			err := helper.TestRemoteLogin(oc, "mysql-master")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// Create a new table with random name
+			g.By("create new table")
 			_, err = master.Query(oc, fmt.Sprintf("CREATE TABLE %s (col1 VARCHAR(20), col2 VARCHAR(20));", table))
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/images/s2i_perl.go
+++ b/test/extended/images/s2i_perl.go
@@ -27,6 +27,7 @@ var _ = g.Describe("[images][perl][Slow] hot deploy for openshift perl image", f
 		g.It(fmt.Sprintf("should work with hot deploy"), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By(fmt.Sprintf("calling oc new-app -f %q", dancerTemplate))
 			err := oc.Run("new-app").Args("-f", dancerTemplate).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -40,10 +41,7 @@ var _ = g.Describe("[images][perl][Slow] hot deploy for openshift perl image", f
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "dancer-mysql-example")
-			if err != nil {
-				exutil.DumpDeploymentLogs("dancer-mysql-example", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "dancer-mysql-example", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")

--- a/test/extended/images/s2i_php.go
+++ b/test/extended/images/s2i_php.go
@@ -25,6 +25,7 @@ var _ = g.Describe("[images][php][Slow] hot deploy for openshift php image", fun
 		g.It(fmt.Sprintf("should work with hot deploy"), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By(fmt.Sprintf("calling oc new-app -f %q -p %q", cakephpTemplate, hotDeployParam))
 			err := oc.Run("new-app").Args("-f", cakephpTemplate, "-p", hotDeployParam).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -38,10 +39,7 @@ var _ = g.Describe("[images][php][Slow] hot deploy for openshift php image", fun
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "cakephp-mysql-example")
-			if err != nil {
-				exutil.DumpDeploymentLogs("cakephp-mysql-example", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "cakephp-mysql-example", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")

--- a/test/extended/images/s2i_python.go
+++ b/test/extended/images/s2i_python.go
@@ -27,6 +27,7 @@ var _ = g.Describe("[images][python][Slow] hot deploy for openshift python image
 		g.It(fmt.Sprintf("should work with hot deploy"), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By(fmt.Sprintf("calling oc new-app %s", djangoRepository))
 			err := oc.Run("new-app").Args(djangoRepository, "--strategy=source").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -40,10 +41,7 @@ var _ = g.Describe("[images][python][Slow] hot deploy for openshift python image
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "django-ex")
-			if err != nil {
-				exutil.DumpDeploymentLogs("django-ex", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "django-ex", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")

--- a/test/extended/images/s2i_ruby.go
+++ b/test/extended/images/s2i_ruby.go
@@ -26,6 +26,7 @@ var _ = g.Describe("[images][ruby][Slow] hot deploy for openshift ruby image", f
 		g.It(fmt.Sprintf("should work with hot deploy"), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
+			exutil.CheckOpenShiftNamespaceImageStreams(oc)
 			g.By(fmt.Sprintf("calling oc new-app -f %q", railsTemplate))
 			err := oc.Run("new-app").Args("-f", railsTemplate).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -39,10 +40,7 @@ var _ = g.Describe("[images][ruby][Slow] hot deploy for openshift ruby image", f
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "rails-postgresql-example")
-			if err != nil {
-				exutil.DumpDeploymentLogs("rails-postgresql-example", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "rails-postgresql-example", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")

--- a/test/extended/jenkins/kubernetes_plugin.go
+++ b/test/extended/jenkins/kubernetes_plugin.go
@@ -70,10 +70,7 @@ var _ = g.Describe("[jenkins] schedule jobs on pod slaves", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("wait for jenkins deployment")
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins")
-			if err != nil {
-				exutil.DumpDeploymentLogs("jenkins", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("get ip and port for jenkins service")

--- a/test/extended/jenkins/plugin.go
+++ b/test/extended/jenkins/plugin.go
@@ -123,10 +123,7 @@ var _ = g.Describe("[jenkins][Slow] openshift pipeline plugin", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for jenkins deployment")
-		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins")
-		if err != nil {
-			exutil.DumpDeploymentLogs("jenkins", oc)
-		}
+		err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "jenkins", oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("get ip and port for jenkins service")
@@ -165,15 +162,9 @@ var _ = g.Describe("[jenkins][Slow] openshift pipeline plugin", func() {
 			// we leverage some of the openshift utilities for waiting for the deployment before we poll
 			// jenkins for the successful job completion
 			g.By("waiting for frontend, frontend-prod deployments as signs that the build has finished")
-			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend")
-			if err != nil {
-				exutil.DumpDeploymentLogs("frontend", oc)
-			}
+			err := exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend-prod")
-			if err != nil {
-				exutil.DumpDeploymentLogs("frontend-prod", oc)
-			}
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "frontend-prod", oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("get build console logs and see if succeeded")

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -94,6 +94,11 @@ function os::test::extended::setup {
           sudo chcon -t svirt_sandbox_file_t ${VOLUME_DIR}
     fi
     configure_os_server
+    #turn on audit logging for extended tests ... mimic what is done in util.sh configure_os_server, but don't
+    # put change there - only want this for extended tests
+    echo "[INFO] Turn on audit logging"
+    cp ${SERVER_CONFIG_DIR}/master/master-config.yaml ${SERVER_CONFIG_DIR}/master/master-config.orig2.yaml
+    openshift ex config patch ${SERVER_CONFIG_DIR}/master/master-config.orig2.yaml --patch="{\"auditConfig\": {\"enabled\": true}}"  > ${SERVER_CONFIG_DIR}/master/master-config.yaml
 
     # Similar to above check, if the XFS volume dir mount point exists enable
     # local storage quota in node-config.yaml so these tests can pass:

--- a/test/extended/util/docker.go
+++ b/test/extended/util/docker.go
@@ -62,6 +62,25 @@ func PushImage(name string, authCfg dockerClient.AuthConfiguration) error {
 	return client.PushImage(opts, authCfg)
 }
 
+//ListImages initiates the equivalent of a `docker images`
+func ListImages() ([]string, error) {
+	client, err := tutil.NewDockerClient()
+	if err != nil {
+		return nil, err
+	}
+	imageList, err := client.ListImages(dockerClient.ListImagesOptions{})
+	if err != nil {
+		return nil, err
+	}
+	returnIds := make([]string, 0)
+	for _, image := range imageList {
+		for _, tag := range image.RepoTags {
+			returnIds = append(returnIds, tag)
+		}
+	}
+	return returnIds, nil
+}
+
 //BuildAuthConfiguration constructs a non-standard dockerClient.AuthConfiguration that can be used to communicate with the openshift internal docker registry
 func BuildAuthConfiguration(credKey string, oc *CLI) (*dockerClient.AuthConfiguration, error) {
 	authCfg := &dockerClient.AuthConfiguration{}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1199391

Changed the returned field.NotFound error so that it returns a more specific description of the cause of the error.

Previous:
 error: error processing the template "ruby-helloworld-sample": Template "ruby-helloworld-sample" is invalid: template.parameters[0]: Not found: {"Name":"ADMIN_USERNAME","DisplayName":"","Description":"administrator
           : username","Value":"","Generate":"test","From":"admin[A-Z0-9]{3}","Required":false}

Current:
error: error processing the template "ruby-helloworld-sample": Template "ruby-helloworld-sample" is invalid: template.parameters[0].Generate: Not found: "test"

@bparees 