### PR TITLE
Made non-internal object Accessor log less important

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/meta.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/meta/meta.go
@@ -43,7 +43,7 @@ func Accessor(obj interface{}) (Object, error) {
 		return oi, nil
 	}
 
-	glog.V(4).Infof("Calling Accessor on non-internal object: %v", reflect.TypeOf(obj))
+	glog.V(6).Infof("Calling Accessor on non-internal object: %v", reflect.TypeOf(obj))
 	// legacy path for objects that do not implement Object and ObjectMetaAccessor via
 	// reflection - very slow code path.
 	v, err := conversion.EnforcePtr(obj)


### PR DESCRIPTION
This message alone accounts for 10% to 40% of OpenShift
logs at `--loglevel=5` and, to my knowledge, does not gain
us anything.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton I know this *seems* petty on the surface, but honestly looking through our logs is such a PITA with this message it's ridiculous. In conformance, e2e, integration, whatever. It takes up so much of the log this patch is honestly necessary in my eyes if we keep the log level the same.