### PR TITLE
import docker-compose env var substitution

### DIFF
--- a/pkg/generate/dockercompose/generate.go
+++ b/pkg/generate/dockercompose/generate.go
@@ -50,6 +50,9 @@ func Generate(paths ...string) (*templateapi.Template, error) {
 		ComposeFiles: paths,
 	}
 	p := project.NewProject(context)
+	if err := project.AddEnvironmentLookUp(context); err != nil {
+		return nil, err
+	}
 	if err := p.Parse(); err != nil {
 		return nil, err
 	}

--- a/third_party/github.com/docker/libcompose/project/lookup.go
+++ b/third_party/github.com/docker/libcompose/project/lookup.go
@@ -1,0 +1,101 @@
+package project
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Lookup creates a string slice of string containing a "docker-friendly" environment string
+// in the form of 'key=value'. It loop through the lookups and returns the latest value if
+// more than one lookup return a result.
+func (l *ComposableEnvLookup) Lookup(key, serviceName string, config *ServiceConfig) []string {
+	result := []string{}
+	for _, lookup := range l.Lookups {
+		env := lookup.Lookup(key, serviceName, config)
+		if len(env) == 1 {
+			result = env
+		}
+	}
+	return result
+}
+
+// Lookup creates a string slice of string containing a "docker-friendly" environment string
+// in the form of 'key=value'. It gets environment values using a '.env' file in the specified
+// path.
+func (l *EnvfileLookup) Lookup(key, serviceName string, config *ServiceConfig) []string {
+	envs, err := ParseEnvFile(l.Path)
+	if err != nil {
+		return []string{}
+	}
+	for _, env := range envs {
+		e := strings.Split(env, "=")
+		if e[0] == key {
+			return []string{env}
+		}
+	}
+	return []string{}
+}
+
+// Lookup creates a string slice of string containing a "docker-friendly" environment string
+// in the form of 'key=value'. It gets environment values using os.Getenv.
+// If the os environment variable does not exists, the slice is empty. serviceName and config
+// are not used at all in this implementation.
+func (o *OsEnvLookup) Lookup(key, serviceName string, config *ServiceConfig) []string {
+	ret := os.Getenv(key)
+	if ret == "" {
+		return []string{}
+	}
+	return []string{fmt.Sprintf("%s=%s", key, ret)}
+}
+
+var whiteSpaces = " \t"
+
+// ParseEnvFile reads a file with environment variables enumerated by lines
+//
+// ``Environment variable names used by the utilities in the Shell and
+// Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase
+// letters, digits, and the '_' (underscore) from the characters defined in
+// Portable Character Set and do not begin with a digit. *But*, other
+// characters may be permitted by an implementation; applications shall
+// tolerate the presence of such names.''
+// -- http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
+//
+// As of #16585, it's up to application inside docker to validate or not
+// environment variables, that's why we just strip leading whitespace and
+// nothing more.
+func ParseEnvFile(filename string) ([]string, error) {
+	fh, err := os.Open(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	defer fh.Close()
+
+	lines := []string{}
+	scanner := bufio.NewScanner(fh)
+	for scanner.Scan() {
+		// trim the line from all leading whitespace first
+		line := strings.TrimLeft(scanner.Text(), whiteSpaces)
+		// line is not empty, and not starting with '#'
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			data := strings.SplitN(line, "=", 2)
+
+			// trim the front of a variable, but nothing else
+			variable := strings.TrimLeft(data[0], whiteSpaces)
+			if strings.ContainsAny(variable, whiteSpaces) {
+				return []string{}, fmt.Errorf("variable '%s' has white spaces", variable)
+			}
+
+			if len(data) > 1 {
+
+				// pass the value through, no trimming
+				lines = append(lines, fmt.Sprintf("%s=%s", variable, data[1]))
+			} else {
+				// if only a pass-through variable is given, clean it up.
+				lines = append(lines, fmt.Sprintf("%s=%s", strings.TrimSpace(line), os.Getenv(line)))
+			}
+		}
+	}
+	return lines, scanner.Err()
+}

--- a/third_party/github.com/docker/libcompose/project/project.go
+++ b/third_party/github.com/docker/libcompose/project/project.go
@@ -3,6 +3,8 @@ package project
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	log "github.com/golang/glog"
@@ -28,6 +30,26 @@ type Event struct {
 	EventType   EventType
 	ServiceName string
 	Data        map[string]string
+}
+
+// AddEnvironmentLookUp adds mechanism for extracting environment
+// variables, from operating system or .env file
+func AddEnvironmentLookUp(context *Context) error {
+	if context.EnvironmentLookup == nil {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		context.EnvironmentLookup = &ComposableEnvLookup{
+			Lookups: []EnvironmentLookup{
+				&EnvfileLookup{
+					Path: filepath.Join(cwd, ".env"),
+				},
+				&OsEnvLookup{},
+			},
+		}
+	}
+	return nil
 }
 
 // NewProject create a new project with the specified context.

--- a/third_party/github.com/docker/libcompose/project/types.go
+++ b/third_party/github.com/docker/libcompose/project/types.go
@@ -222,6 +222,22 @@ type EnvironmentLookup interface {
 	Lookup(key, serviceName string, config *ServiceConfig) []string
 }
 
+// ComposableEnvLookup is a structure that implements the EnvironmentLookup interface.
+// It holds an ordered list of EnvironmentLookup to call to look for the environment value.
+type ComposableEnvLookup struct {
+	Lookups []EnvironmentLookup
+}
+
+// EnvfileLookup is a structure that implements the EnvironmentLookup interface.
+// It holds the path of the file where to lookup environment values.
+type EnvfileLookup struct {
+	Path string
+}
+
+// OsEnvLookup is a "bare" structure that implements the EnvironmentLookup interface
+type OsEnvLookup struct {
+}
+
 // ResourceLookup defines methods to provides file loading.
 type ResourceLookup interface {
 	Lookup(file, relativeTo string) ([]byte, string, error)


### PR DESCRIPTION
docker-compose file supports environment variable substitution but `oc import docker-compose` failed to read environment variables so added a function which will read from environment variables.

Fixes #9058