### PR TITLE
Surround namespace with quotes when outputting DOT

### DIFF
--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	dotutil "github.com/openshift/origin/pkg/util/dot"
 )
 
 // StatusRecommendedName is the recommended command name.
@@ -160,7 +161,7 @@ func (o StatusOptions) RunStatus() error {
 		if err != nil {
 			return err
 		}
-		data, err := dot.Marshal(g, o.namespace, "", "  ", false)
+		data, err := dot.Marshal(g, dotutil.Quote(o.namespace), "", "  ", false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/cli/describe/chaindescriber.go
+++ b/pkg/cmd/cli/describe/chaindescriber.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
+	dotutil "github.com/openshift/origin/pkg/util/dot"
 	"github.com/openshift/origin/pkg/util/parallel"
 )
 
@@ -106,7 +107,7 @@ func (d *ChainDescriber) Describe(ist *imageapi.ImageStreamTag, includeInputImag
 
 	switch strings.ToLower(d.outputFormat) {
 	case "dot":
-		data, err := dot.Marshal(partitioned, fmt.Sprintf("%q", ist.Name), "", "  ", false)
+		data, err := dot.Marshal(partitioned, dotutil.Quote(ist.Name), "", "  ", false)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/util/dot/dot.go
+++ b/pkg/util/dot/dot.go
@@ -1,0 +1,14 @@
+package dot
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Quote takes an arbitrary DOT ID and escapes any quotes that is contains.
+// The resulting string is quoted again to guarantee that it is a valid ID.
+// DOT graph IDs can be any double-quoted string
+// See http://www.graphviz.org/doc/info/lang.html
+func Quote(id string) string {
+	return fmt.Sprintf(`"%s"`, strings.Replace(id, `"`, `\"`, -1))
+}

--- a/pkg/util/dot/dot_test.go
+++ b/pkg/util/dot/dot_test.go
@@ -1,0 +1,26 @@
+package dot
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	for _, tt := range []struct {
+		id       string
+		expected string
+	}{
+		{`test`, `"test"`},
+		{``, `""`},
+		{`test-name`, `"test-name"`},
+		{`test"`, `"test\""`},
+		{`lots"of"quotes"in"this`, `"lots\"of\"quotes\"in\"this"`},
+		{`"""`, `"\"\"\""`},
+		{`""a"`, `"\"\"a\""`},
+		{`0-"name`, `"0-\"name"`},
+		{`"project"`, `"\"project\""`},
+		{`foo\`, `"foo\"`},
+	} {
+		actual := Quote(tt.id)
+		if actual != tt.expected {
+			t.Errorf("Quote(%s): expected %s, actual %s", tt.id, tt.expected, actual)
+		}
+	}
+}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -331,7 +331,7 @@ os::cmd::expect_success 'oc process -f examples/sample-app/application-template-
 # Test both the type/name resource syntax and the fact that istag/origin-ruby-sample:latest is still
 # not created but due to a buildConfig pointing to it, we get back its graph of deps.
 os::cmd::expect_success_and_text 'oadm build-chain istag/origin-ruby-sample' 'istag/origin-ruby-sample:latest'
-os::cmd::expect_success_and_text 'oadm build-chain ruby-22-centos7 -o dot' 'digraph'
+os::cmd::expect_success_and_text 'oadm build-chain ruby-22-centos7 -o dot' 'digraph "ruby-22-centos7:latest"'
 os::cmd::expect_success 'oc delete all -l build=sti'
 echo "ex build-chain: ok"
 os::test::junit::declare_suite_end
@@ -342,7 +342,7 @@ os::cmd::expect_success 'oc project example'
 os::cmd::try_until_success 'oc get serviceaccount default'
 os::cmd::expect_success 'oc create -f test/testdata/app-scenarios'
 os::cmd::expect_success 'oc status'
-os::cmd::expect_success 'oc status -o dot'
+os::cmd::expect_success_and_text 'oc status -o dot' '"example"'
 echo "complex-scenarios: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
fixes #9317

Per the [DOT Language specification](http://www.graphviz.org/doc/info/lang.html) an ID cannot contain a dash.  The simplest fix while preserving our naming scheme is to surround the names with a quote.  An ID can be any double-quoted string.