### PR TITLE
Implemented `os::text::clear_string' to remove a string from TTY output

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -174,7 +174,8 @@ function os::cmd::internal::expect_exit_code_run_grep() {
 	os::test::junit::declare_test_start
 
 	local name=$(os::cmd::internal::describe_call "${cmd}" "${cmd_eval_func}" "${grep_args}" "${test_eval_func}")
-	echo "Running ${name}..."
+    local preamble="Running ${name}..."
+	echo "${preamble}"
 	# for ease of parsing, we want the entire declaration on one line, so we replace '\n' with ';'	
 	junit_log+=( "${name//$'\n'/;}" )
 
@@ -193,11 +194,8 @@ function os::cmd::internal::expect_exit_code_run_grep() {
 	local end_time=$(os::cmd::internal::seconds_since_epoch)
 	local time_elapsed=$(echo "scale=3; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
 
-	# some commands are multi-line, so we may need to clear more than just the previous line
-	local cmd_length=$(echo "${cmd}" | wc -l)
-	for (( i=0; i<${cmd_length}; i++ )); do
-		os::text::clear_last_line
-	done
+    # clear the preamble so we can print out the success or error message
+	os::text::clear_string "${preamble}"
 
 	local return_code
 	if (( cmd_succeeded && test_succeeded )); then
@@ -460,7 +458,8 @@ function os::cmd::internal::run_until_exit_code() {
 	local description=$(os::cmd::internal::describe_call "${cmd}" "${cmd_eval_func}")
 	local duration_seconds=$(echo "scale=3; $(( duration )) / 1000" | bc | xargs printf '%5.3f')
 	local description="${description}; re-trying every ${interval}s until completion or ${duration_seconds}s"
-	echo "Running ${description}..."
+    local preamble="Running ${description}..."
+	echo "${preamble}"
 	# for ease of parsing, we want the entire declaration on one line, so we replace '\n' with ';'
 	junit_log+=( "${description//$'\n'/;}" )
 	
@@ -481,11 +480,8 @@ function os::cmd::internal::run_until_exit_code() {
 	local end_time=$(os::cmd::internal::seconds_since_epoch)
 	local time_elapsed=$(echo "scale=9; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
 
-	# some commands are multi-line, so we may need to clear more than just the previous line
-	local cmd_length=$(echo "${cmd}" | wc -l)
-	for (( i=0; i<${cmd_length}; i++ )); do
-		os::text::clear_last_line
-	done
+    # clear the preamble so we can print out the success or error message
+    os::text::clear_string "${preamble}"
 
 	local return_code
 	if (( cmd_succeeded )); then
@@ -541,7 +537,8 @@ function os::cmd::internal::run_until_text() {
 	local description=$(os::cmd::internal::describe_call "${cmd}" "" "${text}" "os::cmd::internal::success_func")
 	local duration_seconds=$(echo "scale=3; $(( duration )) / 1000" | bc | xargs printf '%5.3f')
 	local description="${description}; re-trying every ${interval}s until completion or ${duration_seconds}s"
-	echo "Running ${description}..."
+    local preamble="Running ${description}..."
+	echo "${preamble}"
 	# for ease of parsing, we want the entire declaration on one line, so we replace '\n' with ';'
 	junit_log+=( "${description//$'\n'/;}" )
 	
@@ -564,11 +561,8 @@ function os::cmd::internal::run_until_text() {
 	local end_time=$(os::cmd::internal::seconds_since_epoch)
 	local time_elapsed=$(echo "scale=9; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
 
-	# some commands are multi-line, so we may need to clear more than just the previous line
-	local cmd_length=$(echo "${cmd}" | wc -l)
-	for (( i=0; i<${cmd_length}; i++ )); do
-		os::text::clear_last_line
-	done
+    # clear the preamble so we can print out the success or error message
+    os::text::clear_string "${preamble}"
 
 	local return_code
 	if (( test_succeeded )); then

--- a/hack/text.sh
+++ b/hack/text.sh
@@ -55,6 +55,25 @@ function os::text::clear_last_line() {
 	fi
 }
 
+# os::text::clear_string attempts to clear the entirety of a string from the terminal.
+# If the string contains literal tabs or other characters that take up more than one
+# character space in output, or if the window size is changed before this function
+# is called, it will not function correctly.
+# No action is taken if this is called outside of a TTY
+function os::text::clear_string() {
+    local -r string="$1"
+    if [[ -t 1 ]]; then
+        echo "${string}" | while read line; do
+            # num_lines is the number of terminal lines this one line of output
+            # would have taken up with the current terminal width in columns
+            local num_lines=$(( ${#line} / $( tput cols ) ))
+            for (( i = 0; i <= num_lines; i++ )); do
+                os::text::clear_last_line
+            done
+        done
+    fi
+}
+
 # os::text::print_bold prints all input in bold text
 function os::text::print_bold() {
 	os::text::bold


### PR DESCRIPTION
One annoying bug in all of our Bash code is that when we clear output
in order to replace it with new output, for instance when test preamble
lines are cleared to make way for success or failure output, we cannot
correctly clear all of the text as we do not take into account the
line wraps introduced by the terminal window. This new function in the
library helps us to remedy this. We still cannot appropriately handle
cases where there are many non-printing characters or many characters
that take up more than one character-width when printed, and we can't
handle the case where someone re-sizes the window before calling this
function, but for the majority of cases this correctly clear the text
as one would expect.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@Miciah please review -- I'm very happy with this!
@smarterclayton tagged so you can merge when ready