### PR TITLE
Changed glog V(1) and V(2) to V(0)

### DIFF
--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -138,7 +138,7 @@ func execPostCommitHook(client DockerClient, postCommitSpec api.BuildPostCommitS
 		// Post commit hook is not set, return early.
 		return nil
 	}
-	glog.V(1).Infof("Running post commit hook with image %s ...", image)
+	glog.V(0).Infof("Running post commit hook with image %s ...", image)
 	glog.V(4).Infof("Post commit hook spec: %+v", postCommitSpec)
 
 	if script != "" {

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -116,11 +116,11 @@ func (d *DockerBuilder) Build() error {
 		if authPresent {
 			glog.V(4).Infof("Authenticating Docker push with user %q", pushAuthConfig.Username)
 		}
-		glog.V(1).Infof("Pushing image %s ...", pushTag)
+		glog.V(0).Infof("Pushing image %s ...", pushTag)
 		if err := pushImage(d.dockerClient, pushTag, pushAuthConfig); err != nil {
 			return fmt.Errorf("Failed to push image: %v", err)
 		}
-		glog.V(1).Infof("Push successful")
+		glog.V(0).Infof("Push successful")
 	}
 	return nil
 }
@@ -260,12 +260,12 @@ func (d *DockerBuilder) setupPullSecret() (*docker.AuthConfigurations, error) {
 	if len(os.Getenv(dockercfg.PullAuthType)) == 0 {
 		return nil, nil
 	}
-	glog.V(2).Infof("Checking for Docker config file for %s in path %s", dockercfg.PullAuthType, os.Getenv(dockercfg.PullAuthType))
+	glog.V(0).Infof("Checking for Docker config file for %s in path %s", dockercfg.PullAuthType, os.Getenv(dockercfg.PullAuthType))
 	dockercfgPath := dockercfg.GetDockercfgFile(os.Getenv(dockercfg.PullAuthType))
 	if len(dockercfgPath) == 0 {
 		return nil, fmt.Errorf("no docker config file found in '%s'", os.Getenv(dockercfg.PullAuthType))
 	}
-	glog.V(2).Infof("Using Docker config file %s", dockercfgPath)
+	glog.V(0).Infof("Using Docker config file %s", dockercfgPath)
 	r, err := os.Open(dockercfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("'%s': %s", dockercfgPath, err)

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -58,7 +58,7 @@ type DockerClient interface {
 func pushImage(client DockerClient, name string, authConfig docker.AuthConfiguration) error {
 	repository, tag := docker.ParseRepositoryTag(name)
 	logProgress := func(s string) {
-		glog.V(1).Infof("%s", s)
+		glog.V(0).Infof("%s", s)
 	}
 	opts := docker.PushImageOptions{
 		Name:          repository,

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -166,7 +166,7 @@ func extractInputBinary(in io.Reader, source *api.BinaryBuildSource, dir string)
 
 	var path string
 	if len(source.AsFile) > 0 {
-		glog.V(2).Infof("Receiving source from STDIN as file %s", source.AsFile)
+		glog.V(0).Infof("Receiving source from STDIN as file %s", source.AsFile)
 		path = filepath.Join(dir, source.AsFile)
 
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0664)
@@ -182,13 +182,13 @@ func extractInputBinary(in io.Reader, source *api.BinaryBuildSource, dir string)
 		return nil
 	}
 
-	glog.V(1).Infof("Receiving source from STDIN as archive ...")
+	glog.V(0).Infof("Receiving source from STDIN as archive ...")
 
 	cmd := exec.Command("bsdtar", "-x", "-o", "-m", "-f", "-", "-C", dir)
 	cmd.Stdin = in
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		glog.V(2).Infof("Extracting...\n%s", string(out))
+		glog.V(0).Infof("Extracting...\n%s", string(out))
 		return fmt.Errorf("unable to extract binary build input, must be a zip, tar, or gzipped tar, or specified as a file: %v", err)
 	}
 	return nil
@@ -210,7 +210,7 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 	usingRef := len(gitSource.Ref) != 0 || (revision != nil && revision.Git != nil && len(revision.Git.Commit) != 0)
 
 	// Recursive clone if we're not going to checkout a ref and submodule update later
-	glog.V(2).Infof("Cloning source from %s", gitSource.URI)
+	glog.V(0).Infof("Cloning source from %s", gitSource.URI)
 
 	// Only use the quiet flag if Verbosity is not 5 or greater
 	quiet := !glog.Is(5)

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -161,7 +161,7 @@ func (s *S2IBuilder) Build() error {
 		return err
 	}
 	if scriptDownloadProxyConfig != nil {
-		glog.V(2).Infof("Using HTTP proxy %v and HTTPS proxy %v for script download",
+		glog.V(0).Infof("Using HTTP proxy %v and HTTPS proxy %v for script download",
 			scriptDownloadProxyConfig.HTTPProxy,
 			scriptDownloadProxyConfig.HTTPSProxy)
 	}
@@ -200,7 +200,7 @@ func (s *S2IBuilder) Build() error {
 	config.PreviousImagePullPolicy = s2iapi.PullAlways
 
 	allowedUIDs := os.Getenv(api.AllowedUIDs)
-	glog.V(2).Infof("The value of %s is [%s]", api.AllowedUIDs, allowedUIDs)
+	glog.V(0).Infof("The value of %s is [%s]", api.AllowedUIDs, allowedUIDs)
 	if len(allowedUIDs) > 0 {
 		err := config.AllowedUIDs.Set(allowedUIDs)
 		if err != nil {
@@ -208,7 +208,7 @@ func (s *S2IBuilder) Build() error {
 		}
 	}
 	dropCaps := os.Getenv(api.DropCapabilities)
-	glog.V(2).Infof("The value of %s is [%s]", api.DropCapabilities, dropCaps)
+	glog.V(0).Infof("The value of %s is [%s]", api.DropCapabilities, dropCaps)
 	if len(dropCaps) > 0 {
 		config.DropCapabilities = strings.Split(dropCaps, ",")
 	}
@@ -227,7 +227,7 @@ func (s *S2IBuilder) Build() error {
 	config.PullAuthentication, _ = dockercfg.NewHelper().GetDockerAuth(config.BuilderImage, dockercfg.PullAuthType)
 	config.IncrementalAuthentication, _ = dockercfg.NewHelper().GetDockerAuth(pushTag, dockercfg.PushAuthType)
 
-	glog.V(2).Infof("Creating a new S2I builder with build config: %#v\n", describe.DescribeConfig(config))
+	glog.V(0).Infof("Creating a new S2I builder with build config: %#v\n", describe.DescribeConfig(config))
 	builder, err := s.builder.Builder(config, s2ibuild.Overrides{Downloader: download})
 	if err != nil {
 		return err
@@ -261,11 +261,11 @@ func (s *S2IBuilder) Build() error {
 			dockercfg.PushAuthType,
 		)
 		if authPresent {
-			glog.V(2).Infof("Using provided push secret for pushing %s image", pushTag)
+			glog.V(0).Infof("Using provided push secret for pushing %s image", pushTag)
 		} else {
-			glog.V(2).Infof("No push secret provided")
+			glog.V(0).Infof("No push secret provided")
 		}
-		glog.V(1).Infof("Pushing image %s ...", pushTag)
+		glog.V(0).Infof("Pushing image %s ...", pushTag)
 		if err := pushImage(s.dockerClient, pushTag, pushAuthConfig); err != nil {
 			// write extended error message to assist in problem resolution
 			msg := fmt.Sprintf("Failed to push image. Response from registry is: %v", err)
@@ -281,7 +281,7 @@ func (s *S2IBuilder) Build() error {
 			}
 			return errors.New(msg)
 		}
-		glog.V(1).Infof("Push successful")
+		glog.V(0).Infof("Push successful")
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #9247 

Changed glog V(1) and V(2) to log at V(0) to ensure necessary log output is captured by extended build tests. 