### PR TITLE
Typo fix - oc dockerbuild example

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1194,7 +1194,7 @@ Perform a direct Docker build
 [options="nowrap"]
 ----
   # Build the current directory into a single layer and tag
-  oc dockerbuild . myimage:latest
+  oc ex dockerbuild . myimage:latest
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/dockerbuild/dockerbuild.go
+++ b/pkg/cmd/cli/cmd/dockerbuild/dockerbuild.go
@@ -28,7 +28,7 @@ Builds the provided directory with a Dockerfile into a single layered image.
 Requires that you have a working connection to a Docker engine.`
 
 	dockerbuildExample = `  # Build the current directory into a single layer and tag
-  %[1]s dockerbuild . myimage:latest`
+  %[1]s ex dockerbuild . myimage:latest`
 )
 
 type DockerbuildOptions struct {


### PR DESCRIPTION
There is a minor typo in the oc dockerbuild command example.

previously it was :
oc dockerbuild . myimage:latest

modified to 
oc ex dockerbuild . myimage:latest 

where ex was missing in the example and added part of this PR