### PR TITLE
mutated cache filter

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/api_object_versioner.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/api_object_versioner.go
@@ -71,4 +71,28 @@ func (a APIObjectVersioner) ObjectResourceVersion(obj runtime.Object) (uint64, e
 }
 
 // APIObjectVersioner implements Versioner
-var _ storage.Versioner = APIObjectVersioner{}
+var Versioner storage.Versioner = APIObjectVersioner{}
+
+// CompareResourceVersion compares etcd resource versions.  Outside this API they are all strings,
+// but etcd resource versions are special, they're actually ints, so we can easily compare them.
+func (a APIObjectVersioner) CompareResourceVersion(lhs, rhs runtime.Object) int {
+	lhsVersion, err := Versioner.ObjectResourceVersion(lhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+	rhsVersion, err := Versioner.ObjectResourceVersion(rhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+
+	if lhsVersion == rhsVersion {
+		return 0
+	}
+	if lhsVersion < rhsVersion {
+		return -1
+	}
+
+	return 1
+}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -156,7 +156,7 @@ func (c *MasterConfig) RunServiceAccountPullSecretsControllers() {
 	serviceaccountcontrollers.NewDockercfgTokenDeletedController(c.KubeClient(), serviceaccountcontrollers.DockercfgTokenDeletedControllerOptions{}).Run()
 
 	dockercfgController := serviceaccountcontrollers.NewDockercfgController(c.KubeClient(), serviceaccountcontrollers.DockercfgControllerOptions{DefaultDockerURL: serviceaccountcontrollers.DefaultOpenshiftDockerURL})
-	dockercfgController.Run()
+	go dockercfgController.Run(5, utilwait.NeverStop)
 
 	dockerRegistryControllerOptions := serviceaccountcontrollers.DockerRegistryServiceControllerOptions{
 		RegistryNamespace:   "default",

--- a/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +12,7 @@ import (
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/registry/secret"
@@ -20,12 +20,16 @@ import (
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 
 	osautil "github.com/openshift/origin/pkg/serviceaccounts/util"
 )
 
-const ServiceAccountTokenSecretNameKey = "openshift.io/token-secret.name"
+const (
+	ServiceAccountTokenSecretNameKey = "openshift.io/token-secret.name"
+	MaxRetriesBeforeResync           = 5
+)
 
 // DockercfgControllerOptions contains options for the DockercfgController
 type DockercfgControllerOptions struct {
@@ -40,9 +44,10 @@ type DockercfgControllerOptions struct {
 func NewDockercfgController(cl client.Interface, options DockercfgControllerOptions) *DockercfgController {
 	e := &DockercfgController{
 		client: cl,
+		queue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	}
 
-	_, e.serviceAccountController = framework.NewInformer(
+	e.serviceAccountCache, e.serviceAccountController = framework.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
 				return e.client.ServiceAccounts(api.NamespaceAll).List(options)
@@ -54,11 +59,21 @@ func NewDockercfgController(cl client.Interface, options DockercfgControllerOpti
 		&api.ServiceAccount{},
 		options.Resync,
 		framework.ResourceEventHandlerFuncs{
-			AddFunc:    e.serviceAccountAdded,
-			UpdateFunc: e.serviceAccountUpdated,
+			AddFunc: func(obj interface{}) {
+				serviceAccount := obj.(*api.ServiceAccount)
+				glog.V(5).Infof("Adding service account %s", serviceAccount.Name)
+				e.enqueueServiceAccount(serviceAccount)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				serviceAccount := cur.(*api.ServiceAccount)
+				glog.V(5).Infof("Updating service account %s", serviceAccount.Name)
+				// Resync on service object relist.
+				e.enqueueServiceAccount(serviceAccount)
+			},
 		},
 	)
 
+	e.syncHandler = e.syncServiceAccount
 	e.dockerURL = options.DefaultDockerURL
 
 	return e
@@ -66,30 +81,81 @@ func NewDockercfgController(cl client.Interface, options DockercfgControllerOpti
 
 // DockercfgController manages dockercfg secrets for ServiceAccount objects
 type DockercfgController struct {
-	stopChan chan struct{}
-
 	client client.Interface
 
 	dockerURL     string
 	dockerURLLock sync.Mutex
 
+	serviceAccountCache      cache.Store
 	serviceAccountController *framework.Controller
+
+	queue workqueue.RateLimitingInterface
+
+	// syncHandler does the work. It's factored out for unit testing
+	syncHandler func(serviceKey string) error
 }
 
-// Runs controller loops and returns immediately
-func (e *DockercfgController) Run() {
-	if e.stopChan == nil {
-		e.stopChan = make(chan struct{})
-		go e.serviceAccountController.Run(e.stopChan)
+func (e *DockercfgController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	go e.serviceAccountController.Run(stopCh)
+	for i := 0; i < workers; i++ {
+		go wait.Until(e.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	glog.Infof("Shutting down dockercfg secret controller")
+	e.queue.ShutDown()
+}
+
+func (e *DockercfgController) enqueueServiceAccount(serviceAccount *api.ServiceAccount) {
+	if !needsDockercfgSecret(serviceAccount) {
+		return
+	}
+
+	key, err := controller.KeyFunc(serviceAccount)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", serviceAccount, err)
+		return
+	}
+
+	e.queue.Add(key)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (e *DockercfgController) worker() {
+	for {
+		if !e.worker_inner() {
+			return
+		}
 	}
 }
 
-// Stop gracefully shuts down this controller
-func (e *DockercfgController) Stop() {
-	if e.stopChan != nil {
-		close(e.stopChan)
-		e.stopChan = nil
+// worker_inner returns true if the worker thread should continue
+func (e *DockercfgController) worker_inner() bool {
+	key, quit := e.queue.Get()
+	if quit {
+		return false
 	}
+	defer e.queue.Done(key)
+
+	if err := e.syncHandler(key.(string)); err == nil {
+		// this means the request was successfully handled.  We should "forget" the item so that any retry
+		// later on is reset
+		e.queue.Forget(key)
+
+	} else {
+		// if we had an error it means that we didn't handle it, which means that we want to requeue the work
+		if e.queue.NumRequeues(key) > MaxRetriesBeforeResync {
+			utilruntime.HandleError(fmt.Errorf("error syncing service, it will be tried again on a resync %v: %v", key, err))
+			e.queue.Forget(key)
+		} else {
+			glog.V(4).Infof("error syncing service, it will be retried %v: %v", key, err)
+			e.queue.AddRateLimited(key)
+		}
+	}
+
+	return true
 }
 
 func (e *DockercfgController) SetDockerURL(newDockerURL string) {
@@ -99,67 +165,52 @@ func (e *DockercfgController) SetDockerURL(newDockerURL string) {
 	e.dockerURL = newDockerURL
 }
 
-// serviceAccountAdded reacts to a ServiceAccount creation by creating a corresponding ServiceAccountToken Secret
-func (e *DockercfgController) serviceAccountAdded(obj interface{}) {
-	serviceAccount := obj.(*api.ServiceAccount)
-
-	if err := e.createDockercfgSecretIfNeeded(serviceAccount); err != nil {
-		utilruntime.HandleError(err)
-	}
-}
-
-// serviceAccountUpdated reacts to a ServiceAccount update (or re-list) by ensuring a corresponding ServiceAccountToken Secret exists
-func (e *DockercfgController) serviceAccountUpdated(oldObj interface{}, newObj interface{}) {
-	newServiceAccount := newObj.(*api.ServiceAccount)
-
-	if err := e.createDockercfgSecretIfNeeded(newServiceAccount); err != nil {
-		utilruntime.HandleError(err)
-	}
-}
-
-// createDockercfgSecretIfNeeded makes sure at least one ServiceAccountToken secret exists, and is included in the serviceAccount's Secrets list
-func (e *DockercfgController) createDockercfgSecretIfNeeded(serviceAccount *api.ServiceAccount) error {
-
+func needsDockercfgSecret(serviceAccount *api.ServiceAccount) bool {
 	mountableDockercfgSecrets, imageDockercfgPullSecrets := getGeneratedDockercfgSecretNames(serviceAccount)
 
 	// look for an ImagePullSecret in the form
-	foundPullSecret := len(imageDockercfgPullSecrets) > 0
-	foundMountableSecret := len(mountableDockercfgSecrets) > 0
-
-	switch {
-	// if we already have a docker pull secret, simply return
-	case foundPullSecret && foundMountableSecret:
-		return nil
-
-	case foundPullSecret && !foundMountableSecret, !foundPullSecret && foundMountableSecret:
-		dockercfgSecretName := ""
-		switch {
-		case foundPullSecret:
-			dockercfgSecretName = imageDockercfgPullSecrets.List()[0]
-		case foundMountableSecret:
-			dockercfgSecretName = mountableDockercfgSecrets.List()[0]
-		}
-
-		err := e.createDockerPullSecretReference(serviceAccount, dockercfgSecretName)
-		if kapierrors.IsConflict(err) {
-			// nothing to do.  Our choice was stale or we got a conflict.  Either way that means that the service account was updated.  We simply need to return because we'll get an update notification later
-			return nil
-		}
-
-		return err
-
+	if len(imageDockercfgPullSecrets) > 0 && len(mountableDockercfgSecrets) > 0 {
+		return false
 	}
 
-	// if we get here, then we need to create a new dockercfg secret
-	// before we do expensive things, make sure our view of the service account is up to date
-	if liveServiceAccount, err := e.client.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name); err != nil {
+	return true
+}
+
+func (e *DockercfgController) syncServiceAccount(key string) error {
+	obj, exists, err := e.serviceAccountCache.GetByKey(key)
+	if err != nil {
+		glog.V(4).Infof("Unable to retrieve service account %v from store: %v", key, err)
 		return err
-	} else if liveServiceAccount.ResourceVersion != serviceAccount.ResourceVersion {
-		// our view of the service account is not up to date
-		// we'll get notified of an update event later and get to try again
-		// this only prevent interactions between successive runs of this controller's event handlers, but that is useful
-		glog.V(2).Infof("View of ServiceAccount %s/%s is not up to date, skipping dockercfg creation", serviceAccount.Namespace, serviceAccount.Name)
+	}
+	if !exists {
+		glog.V(4).Infof("Service account has been deleted %v", key)
 		return nil
+	}
+	if !needsDockercfgSecret(obj.(*api.ServiceAccount)) {
+		return nil
+	}
+
+	uncastSA, err := api.Scheme.DeepCopy(obj)
+	if err != nil {
+		return err
+	}
+	serviceAccount := uncastSA.(*api.ServiceAccount)
+
+	mountableDockercfgSecrets, imageDockercfgPullSecrets := getGeneratedDockercfgSecretNames(serviceAccount)
+
+	// If we have a pull secret in one list, use it for the other.  It must only be in one list because
+	// otherwise we wouldn't "needsDockercfgSecret"
+	foundPullSecret := len(imageDockercfgPullSecrets) > 0
+	foundMountableSecret := len(mountableDockercfgSecrets) > 0
+	if foundPullSecret || foundMountableSecret {
+		switch {
+		case foundPullSecret:
+			serviceAccount.Secrets = append(serviceAccount.Secrets, api.ObjectReference{Name: imageDockercfgPullSecrets.List()[0]})
+		case foundMountableSecret:
+			serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, api.LocalObjectReference{Name: mountableDockercfgSecrets.List()[0]})
+		}
+
+		return err
 	}
 
 	dockercfgSecret, err := e.createDockerPullSecret(serviceAccount)
@@ -167,53 +218,38 @@ func (e *DockercfgController) createDockercfgSecretIfNeeded(serviceAccount *api.
 		return err
 	}
 
-	err = e.createDockerPullSecretReference(serviceAccount, dockercfgSecret.Name)
-	if kapierrors.IsConflict(err) {
+	// I saw conflicts popping up.  Need to retry at least once, I chose five at random.
+	first := true
+	err = client.RetryOnConflict(client.DefaultBackoff, func() error {
+		if !first {
+			serviceAccount, err = e.client.ServiceAccounts(serviceAccount.Namespace).Get(serviceAccount.Name)
+			if err != nil {
+				return err
+			}
+
+			// somehow a dockercfg secret appeared.  cleanup the secret we made and return
+			if !needsDockercfgSecret(serviceAccount) {
+				glog.V(2).Infof("Deleting secret because the work is already done %s/%s", dockercfgSecret.Namespace, dockercfgSecret.Name)
+				e.client.Secrets(dockercfgSecret.Namespace).Delete(dockercfgSecret.Name)
+				return nil
+			}
+		}
+		first = false
+
+		serviceAccount.Secrets = append(serviceAccount.Secrets, api.ObjectReference{Name: dockercfgSecret.Name})
+		serviceAccount.ImagePullSecrets = append(serviceAccount.ImagePullSecrets, api.LocalObjectReference{Name: dockercfgSecret.Name})
+
+		_, err = e.client.ServiceAccounts(serviceAccount.Namespace).Update(serviceAccount)
+		return err
+	})
+
+	if err != nil {
 		// nothing to do.  Our choice was stale or we got a conflict.  Either way that means that the service account was updated.  We simply need to return because we'll get an update notification later
 		// we do need to clean up our dockercfgSecret.  token secrets are cleaned up by the controller handling service account dockercfg secret deletes
 		glog.V(2).Infof("Deleting secret %s/%s (err=%v)", dockercfgSecret.Namespace, dockercfgSecret.Name, err)
-		if err := e.client.Secrets(dockercfgSecret.Namespace).Delete(dockercfgSecret.Name); (err != nil) && !kapierrors.IsNotFound(err) {
-			utilruntime.HandleError(err)
-		}
-		return nil
+		e.client.Secrets(dockercfgSecret.Namespace).Delete(dockercfgSecret.Name)
 	}
-
 	return err
-}
-
-// createDockerPullSecretReference updates a service account to reference the dockercfgSecret as a Secret and an ImagePullSecret
-func (e *DockercfgController) createDockerPullSecretReference(staleServiceAccount *api.ServiceAccount, dockercfgSecretName string) error {
-	liveServiceAccount, err := e.client.ServiceAccounts(staleServiceAccount.Namespace).Get(staleServiceAccount.Name)
-	if err != nil {
-		return err
-	}
-
-	mountableDockercfgSecrets, imageDockercfgPullSecrets := getGeneratedDockercfgSecretNames(liveServiceAccount)
-	staleDockercfgMountableSecrets, staleImageDockercfgPullSecrets := getGeneratedDockercfgSecretNames(staleServiceAccount)
-
-	// if we're trying to create a reference based on stale lists of dockercfg secrets, let the caller know
-	if !reflect.DeepEqual(staleDockercfgMountableSecrets.List(), mountableDockercfgSecrets.List()) || !reflect.DeepEqual(staleImageDockercfgPullSecrets.List(), imageDockercfgPullSecrets.List()) {
-		return kapierrors.NewConflict(api.Resource("serviceaccount"), staleServiceAccount.Name, fmt.Errorf("cannot add reference to %s based on stale data.  decision made for %v,%v, but live version is %v,%v", dockercfgSecretName, staleDockercfgMountableSecrets.List(), staleImageDockercfgPullSecrets.List(), mountableDockercfgSecrets.List(), imageDockercfgPullSecrets.List()))
-	}
-
-	changed := false
-	if !mountableDockercfgSecrets.Has(dockercfgSecretName) {
-		liveServiceAccount.Secrets = append(liveServiceAccount.Secrets, api.ObjectReference{Name: dockercfgSecretName})
-		changed = true
-	}
-
-	if !imageDockercfgPullSecrets.Has(dockercfgSecretName) {
-		liveServiceAccount.ImagePullSecrets = append(liveServiceAccount.ImagePullSecrets, api.LocalObjectReference{Name: dockercfgSecretName})
-		changed = true
-	}
-
-	if changed {
-		if _, err = e.client.ServiceAccounts(liveServiceAccount.Namespace).Update(liveServiceAccount); err != nil {
-			// TODO: retry on API conflicts in case the conflict was unrelated to our generated dockercfg secrets?
-			return err
-		}
-	}
-	return nil
 }
 
 const (
@@ -267,6 +303,8 @@ func (e *DockercfgController) createTokenSecret(serviceAccount *api.ServiceAccou
 
 // createDockerPullSecret creates a dockercfg secret based on the token secret
 func (e *DockercfgController) createDockerPullSecret(serviceAccount *api.ServiceAccount) (*api.Secret, error) {
+	glog.V(4).Infof("Creating secret for %s/%s", serviceAccount.Namespace, serviceAccount.Name)
+
 	tokenSecret, err := e.createTokenSecret(serviceAccount)
 	if err != nil {
 		return nil, err

--- a/pkg/serviceaccounts/controllers/mutation_cache.go
+++ b/pkg/serviceaccounts/controllers/mutation_cache.go
@@ -1,0 +1,100 @@
+package controllers
+
+import (
+	lru "github.com/hashicorp/golang-lru"
+
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage/etcd"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+)
+
+// MutationCache is able to take the result of update operations and stores them in an LRU
+// that can be used to provide a more current view of a requested object.  It requires interpretting
+// resourceVersions for comparisons.
+// Implementations must be thread-safe.
+type MutationCache interface {
+	GetByKey(key string) (interface{}, bool, error)
+	Mutation(interface{})
+}
+
+type ResourceVersionComparator interface {
+	CompareResourceVersion(lhs, rhs runtime.Object) int
+}
+
+// NewEtcdMutationCache gives back a MutationCache that understands how to deal with etcd backed objects
+func NewEtcdMutationCache(backingCache cache.Store) MutationCache {
+	lru, err := lru.New(100)
+	if err != nil {
+		// errors only happen on invalid sizes, this would be programmer error
+		panic(err)
+	}
+
+	return &mutationCache{
+		backingCache:  backingCache,
+		mutationCache: lru,
+		comparator:    etcd.APIObjectVersioner{},
+	}
+}
+
+// mutationCache doesn't guarantee that it returns values added via Mutation since they can page out and
+// since you can't distinguish between, "didn't observe create" and "was deleted after create",
+// if the key is missing from the backing cache, we always return it as missing
+type mutationCache struct {
+	backingCache  cache.Store
+	mutationCache *lru.Cache
+
+	comparator ResourceVersionComparator
+}
+
+// GetByKey is never guaranteed to return back the value set in Mutation.  It could be paged out, it could
+// be older than another copy, the backingCache may be more recent or, you might have written twice into the same key.
+// You get a value that was valid at some snapshot of time and will always return the newer of backingCache and mutationCache.
+func (c *mutationCache) GetByKey(key string) (interface{}, bool, error) {
+	obj, exists, err := c.backingCache.GetByKey(key)
+	if err != nil {
+		return nil, false, err
+	}
+	if !exists {
+		// we can't distinguish between, "didn't observe create" and "was deleted after create", so
+		// if the key is missing, we always return it as missing
+		return nil, false, nil
+	}
+	objRuntime, ok := obj.(runtime.Object)
+	if !ok {
+		return obj, true, nil
+	}
+
+	mutatedObj, exists := c.mutationCache.Get(key)
+	if !exists {
+		return obj, true, nil
+	}
+	mutatedObjRuntime, ok := mutatedObj.(runtime.Object)
+	if !ok {
+		return obj, true, nil
+	}
+
+	if c.comparator.CompareResourceVersion(objRuntime, mutatedObjRuntime) >= 0 {
+		c.mutationCache.Remove(key)
+		return obj, true, nil
+	}
+
+	return mutatedObj, true, nil
+}
+
+// Mutation adds a change to the cache that can be returned in GetByKey if it is newer than the backingCache
+// copy.  If you call Mutation twice with the same object on different threads, one will win, but its not defined
+// which one.  This doesn't affect correctness, since the GetByKey guaranteed of "later of these two caches" is
+// preserved, but you may not get the version of the object you want.  The object you get is only guaranteed to
+// "one that was valid at some point in time", not "the one that I want".
+func (c *mutationCache) Mutation(obj interface{}) {
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		// this is a "nice to have", so failures shouldn't do anything weird
+		utilruntime.HandleError(err)
+		return
+	}
+
+	c.mutationCache.Add(key, obj)
+}


### PR DESCRIPTION
Last two commits.  This makes it possible to avoid getting back a stale object if you're the client that updated that same object.

@liggitt @derekwaynecarr @smarterclayton  I could actually make this a generic filter sitting on top of an indexer used by a `SharedIndexInformer` if we wanted to trust people to ONLY called `Mutation` when they've gotten back a confirmed correct object from `Update`.  There's certainly some utility to such an approach, but it does require some trust.