### PR TITLE
Limits the amount of suggestions of a faulty new-build command to 5, fixes #7729

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -359,15 +359,18 @@ func matchTag(image docker.APIImages, value, registry, namespace, name, tag stri
 		}
 		match := &ComponentMatch{}
 		ok, score := partialScorer(name, iRef.Name, true, 0.5, 1.0)
+		// If the name doesn't match, don't consider this image as a match
 		if !ok {
 			continue
 		}
+
+		// Add up the score, then get the average
 		match.Score += score
 		_, score = partialScorer(namespace, iRef.Namespace, false, 0.5, 1.0)
 		match.Score += score
 		_, score = partialScorer(registry, iRef.Registry, false, 0.5, 1.0)
 		match.Score += score
-		_, score = partialScorer(tag, iRef.Tag, false, 0.5, 1.0)
+		_, score = partialScorer(tag, iRef.Tag, true, 0.5, 1.0)
 		match.Score += score
 
 		if match.Score >= 4.0 {


### PR DESCRIPTION
Limits the amount of suggestions of a faulty new-build command to 5, with highest match score appearing first.

fixes #7729 

Old output: 
```
oc new-build -D $'FROM openshft/origin:v1.1\nENV ok=1' --to origin-test:v1.1
error: multiple images or templates matched "openshft/origin:v1.1": 15

The argument "openshft/origin:v1.1" could apply to the following Docker images, OpenShift image streams, or templates:

* Docker image "openshift/origin-base:latest", 3788e83, from local, 74.943mb
  Use --docker-image="openshift/origin-base:latest" to specify this image or template

* Docker image "docker.io/openshift/origin:latest", 819ca62, from local, 133.052mb
  Use --docker-image="docker.io/openshift/origin:latest" to specify this image or template

* Docker image "myproject/origin-test-1:6c16fcd3", 783819e, from local
  Use --docker-image="myproject/origin-test-1:6c16fcd3" to specify this image or template

* Docker image "openshift/origin-release:latest", 8968bf1, from local, 412.836mb
  Use --docker-image="openshift/origin-release:latest" to specify this image or template

* Docker image "openshift/origin-haproxy-router-base:latest", eeadaef, from local, 18.243mb
  Use --docker-image="openshift/origin-haproxy-router-base:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-docker-builder:latest", b171beb, from local
  Use --docker-image="docker.io/openshift/origin-docker-builder:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-docker-registry:latest", b2fbc24, from local, 48.080mb
  Use --docker-image="docker.io/openshift/origin-docker-registry:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-sti-builder:latest", 7464c40, from local
  Use --docker-image="docker.io/openshift/origin-sti-builder:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-deployer:latest", b449a8c, from local
  Use --docker-image="docker.io/openshift/origin-deployer:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-haproxy-router:latest", e77286e, from local, 18.265mb
  Use --docker-image="docker.io/openshift/origin-haproxy-router:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-docker-builder:v1.3.0-alpha.1", 51ecec8, from local
  Use --docker-image="docker.io/openshift/origin-docker-builder:v1.3.0-alpha.1" to specify this image or template

* Docker image "docker.io/openshift/origin-deployer:v1.3.0-alpha.1", 8dcfa74, from local
  Use --docker-image="docker.io/openshift/origin-deployer:v1.3.0-alpha.1" to specify this image or template

* Docker image "docker.io/openshift/origin-pod:latest", cf08328, from local, 1.517mb
  Use --docker-image="docker.io/openshift/origin-pod:latest" to specify this image or template

* Docker image "docker.io/openshift/origin-docker-registry:v1.3.0-alpha.1", 8663602, from local, 45.227mb
  Use --docker-image="docker.io/openshift/origin-docker-registry:v1.3.0-alpha.1" to specify this image or template

* Docker image "docker.io/openshift/origin-pod:v1.3.0-alpha.1", 1086c95, from local, 1.517mb
  Use --docker-image="docker.io/openshift/origin-pod:v1.3.0-alpha.1" to specify this image or template
```

New output:
```
oc new-build -D $'FROM openshft/origin:v1.1\nENV ok=1' --to origin-test:v1.1
error: multiple images or templates matched "openshft/origin:v1.1": 15

The argument "openshft/origin:v1.1" could apply to the following Docker images, OpenShift image streams, or templates:

* Docker image "openshift/origin-base:latest", 3788e83, from local, 74.943mb
  Use --docker-image="openshift/origin-base:latest" to specify this image or template

* Docker image "docker.io/openshift/origin:latest", 819ca62, from local, 133.052mb
  Use --docker-image="docker.io/openshift/origin:latest" to specify this image or template

* Docker image "myproject/origin-test-1:6c16fcd3", 783819e, from local
  Use --docker-image="myproject/origin-test-1:6c16fcd3" to specify this image or template

* Docker image "openshift/origin-release:latest", 8968bf1, from local, 412.836mb
  Use --docker-image="openshift/origin-release:latest" to specify this image or template

* Docker image "openshift/origin-haproxy-router-base:latest", eeadaef, from local, 18.243mb
  Use --docker-image="openshift/origin-haproxy-router-base:latest" to specify this image or template
```

@bparees 