### PR TITLE
start using shared informer

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -44,6 +44,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
+	"github.com/openshift/origin/pkg/controller"
 	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 )
@@ -75,9 +76,11 @@ type MasterConfig struct {
 	Master            *master.Config
 	ControllerManager *cmapp.CMServer
 	CloudProvider     cloudprovider.Interface
+
+	Informers controller.InformerFactory
 }
 
-func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, pluginInitializer oadmission.PluginInitializer) (*MasterConfig, error) {
+func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, informers controller.InformerFactory, pluginInitializer oadmission.PluginInitializer) (*MasterConfig, error) {
 	if options.KubernetesMasterConfig == nil {
 		return nil, errors.New("insufficient information to build KubernetesMasterConfig")
 	}
@@ -347,6 +350,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 		Master:            m,
 		ControllerManager: cmserver,
 		CloudProvider:     cloud,
+		Informers:         informers,
 	}
 
 	return kmaster, nil

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -23,6 +23,7 @@ import (
 	clientadapter "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -335,7 +336,7 @@ func BuildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kuberne
 	if openshiftConfig.Options.KubernetesMasterConfig == nil {
 		return nil, nil
 	}
-	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.PluginInitializer)
+	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.Informers, openshiftConfig.PluginInitializer)
 	return kubeConfig, err
 }
 
@@ -410,6 +411,8 @@ func (m *Master) Start() error {
 			if err := startControllers(openshiftConfig, kubeMasterConfig); err != nil {
 				glog.Fatal(err)
 			}
+
+			openshiftConfig.Informers.Start(utilwait.NeverStop)
 		}()
 	}
 

--- a/pkg/controller/shared_informer.go
+++ b/pkg/controller/shared_informer.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"reflect"
+	"sync"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+
+	oclient "github.com/openshift/origin/pkg/client"
+)
+
+type InformerFactory interface {
+	Start(stopCh <-chan struct{})
+
+	Pods() PodInformer
+}
+
+type PodInformer interface {
+	Informer() framework.SharedIndexInformer
+	Indexer() cache.Indexer
+	Lister() *cache.StoreToPodLister
+}
+
+func NewInformerFactory(kubeClient kclient.Interface, originClient oclient.Interface, defaultResync time.Duration) InformerFactory {
+	return &sharedInformerFactory{
+		kubeClient:    kubeClient,
+		originClient:  originClient,
+		defaultResync: defaultResync,
+
+		informers: map[reflect.Type]framework.SharedIndexInformer{},
+	}
+}
+
+type sharedInformerFactory struct {
+	kubeClient    kclient.Interface
+	originClient  oclient.Interface
+	defaultResync time.Duration
+
+	informers map[reflect.Type]framework.SharedIndexInformer
+
+	lock sync.Mutex
+}
+
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	for _, informer := range f.informers {
+		go informer.Run(stopCh)
+	}
+}
+
+func (f *sharedInformerFactory) Pods() PodInformer {
+	return &podInformer{sharedInformerFactory: f}
+}
+
+type podInformer struct {
+	*sharedInformerFactory
+}
+
+func (f *podInformer) Informer() framework.SharedIndexInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	informerObj := &kapi.Pod{}
+	informerType := reflect.TypeOf(informerObj)
+	informer, exists := f.informers[informerType]
+	if exists {
+		return informer
+	}
+
+	informer = framework.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+				return f.kubeClient.Pods(kapi.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+				return f.kubeClient.Pods(kapi.NamespaceAll).Watch(options)
+			},
+		},
+		informerObj,
+		f.defaultResync,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	f.informers[informerType] = informer
+
+	return informer
+}
+
+func (f *podInformer) Indexer() cache.Indexer {
+	informer := f.Informer()
+	return informer.GetIndexer()
+}
+
+func (f *podInformer) Lister() *cache.StoreToPodLister {
+	informer := f.Informer()
+	return &cache.StoreToPodLister{Indexer: informer.GetIndexer()}
+}


### PR DESCRIPTION
Adds an `InformerFactory` interface to unify access for `SharedInformers` and their shared caches.  I've started with pods to demonstrate, but I expect to use the same technique across all types.

@smarterclayton @liggitt comments on the shape of the API?

[test]