### PR TITLE
Don't let users create endpoints inside ClusterNetworkCIDR

### DIFF
--- a/docs/man/man1/openshift-start-kubernetes-apiserver.1
+++ b/docs/man/man1/openshift-start-kubernetes-apiserver.1
@@ -26,7 +26,7 @@ This command launches an instance of the Kubernetes apiserver (kube\-apiserver).
 
 .PP
 \fB\-\-admission\-control\fP="AlwaysAdmit"
-    Ordered list of plug\-ins to do admission control of resources into cluster. Comma\-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, BuildByStrategy, BuildDefaults, BuildOverrides, ClusterResourceOverride, ClusterResourceQuota, DenyEscalatingExec, DenyExecOnPrivileged, ExternalIPRanger, ImageLimitRange, InitialResources, JenkinsBootstrapper, LimitPodHardAntiAffinityTopology, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, OriginNamespaceLifecycle, OriginPodNodeEnvironment, OriginResourceQuota, PersistentVolumeLabel, PodNodeConstraints, PodSecurityPolicy, ProjectRequestLimit, ResourceQuota, RunOnceDuration, SCCExecRestrictions, SecurityContextConstraint, SecurityContextDeny, ServiceAccount
+    Ordered list of plug\-ins to do admission control of resources into cluster. Comma\-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, BuildByStrategy, BuildDefaults, BuildOverrides, ClusterResourceOverride, ClusterResourceQuota, DenyEscalatingExec, DenyExecOnPrivileged, ExternalIPRanger, ImageLimitRange, InitialResources, JenkinsBootstrapper, LimitPodHardAntiAffinityTopology, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, OriginNamespaceLifecycle, OriginPodNodeEnvironment, OriginResourceQuota, PersistentVolumeLabel, PodNodeConstraints, PodSecurityPolicy, ProjectRequestLimit, ResourceQuota, RestrictedEndpointsAdmission, RunOnceDuration, SCCExecRestrictions, SecurityContextConstraint, SecurityContextDeny, ServiceAccount
 
 .PP
 \fB\-\-admission\-control\-config\-file\fP=""

--- a/pkg/authorization/api/synthetic.go
+++ b/pkg/authorization/api/synthetic.go
@@ -10,4 +10,6 @@ const (
 	NodeMetricsResource = "nodes/metrics"
 	NodeStatsResource   = "nodes/stats"
 	NodeLogResource     = "nodes/log"
+
+	RestrictedEndpointsResource = "endpoints/restricted"
 )

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -51,6 +51,9 @@ const (
 
 	ServiceServingCertServiceAccountName = "service-serving-cert-controller"
 	ServiceServingCertControllerRoleName = "system:service-serving-cert-controller"
+
+	InfraEndpointControllerServiceAccountName = "endpoint-controller"
+	EndpointControllerRoleName                = "system:endpoint-controller"
 )
 
 type InfraServiceAccounts struct {
@@ -646,6 +649,32 @@ func init() {
 					APIGroups: []string{kapi.GroupName},
 					Verbs:     sets.NewString("get", "create"),
 					Resources: sets.NewString("secrets"),
+				},
+			},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = InfraSAs.addServiceAccount(
+		InfraEndpointControllerServiceAccountName,
+		authorizationapi.ClusterRole{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: EndpointControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// Watching services and pods
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("services", "pods"),
+				},
+				// Managing endpoints
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("get", "list", "create", "update", "delete"),
+					Resources: sets.NewString("endpoints"),
 				},
 			},
 		},

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -676,6 +676,12 @@ func init() {
 					Verbs:     sets.NewString("get", "list", "create", "update", "delete"),
 					Resources: sets.NewString("endpoints"),
 				},
+				// Permission for RestrictedEndpointsAdmission
+				{
+					APIGroups: []string{kapi.GroupName},
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString("endpoints/restricted"),
+				},
 			},
 		},
 	)

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -280,8 +280,8 @@ func (c *MasterConfig) RunDaemonSetsController(client *client.Client) {
 }
 
 // RunEndpointController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunEndpointController() {
-	endpoints := endpointcontroller.NewEndpointController(c.Informers.Pods().Informer(), clientadapter.FromUnversionedClient(c.KubeClient))
+func (c *MasterConfig) RunEndpointController(client *client.Client) {
+	endpoints := endpointcontroller.NewEndpointController(c.Informers.Pods().Informer(), clientadapter.FromUnversionedClient(client))
 	go endpoints.Run(int(c.ControllerManager.ConcurrentEndpointSyncs), utilwait.NeverStop)
 
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -597,6 +597,11 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		namespaceControllerClientSet := clientadapter.FromUnversionedClient(namespaceControllerKubeClient)
 		namespaceControllerClientPool := dynamic.NewClientPool(namespaceControllerClientConfig, dynamic.LegacyAPIPathResolverFunc)
 
+		_, _, endpointControllerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraEndpointControllerServiceAccountName)
+		if err != nil {
+			glog.Fatalf("Could not get client for endpoint controller: %v", err)
+		}
+
 		// no special order
 		kc.RunNodeController()
 		kc.RunScheduler()
@@ -618,7 +623,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 			kc.RunDaemonSetsController(daemonSetClient)
 		}
 
-		kc.RunEndpointController()
+		kc.RunEndpointController(endpointControllerClient)
 		kc.RunNamespaceController(namespaceControllerClientSet, namespaceControllerClientPool)
 		kc.RunPersistentVolumeController(binderClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace, oc.ImageFor("recycler"), bootstrappolicy.InfraPersistentVolumeRecyclerControllerServiceAccountName)
 		kc.RunGCController(gcClient)

--- a/pkg/diagnostics/cluster/service_externalip.go
+++ b/pkg/diagnostics/cluster/service_externalip.go
@@ -53,7 +53,7 @@ func (d *ServiceExternalIPs) Check() types.DiagnosticResult {
 
 	admit, reject := []*net.IPNet{}, []*net.IPNet{}
 	if cidrs := masterConfig.NetworkConfig.ExternalIPNetworkCIDRs; cidrs != nil {
-		reject, admit, err = admission.ParseCIDRRules(cidrs)
+		reject, admit, err = admission.ParseRejectAdmitCIDRRules(cidrs)
 		if err != nil {
 			r.Error("DH2007", err, fmt.Sprintf("Could not parse master config NetworkConfig.ExternalIPNetworkCIDRs: (%[1]T) %[1]v", err))
 			return r

--- a/pkg/service/admission/endpoint_admission.go
+++ b/pkg/service/admission/endpoint_admission.go
@@ -1,0 +1,117 @@
+package admission
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/client"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+
+	kadmission "k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+)
+
+const RestrictedEndpointsPluginName = "RestrictedEndpointsAdmission"
+
+func init() {
+	kadmission.RegisterPlugin("RestrictedEndpointsAdmission", func(client clientset.Interface, config io.Reader) (kadmission.Interface, error) {
+		return NewRestrictedEndpointsAdmission(nil), nil
+	})
+}
+
+type restrictedEndpointsAdmission struct {
+	*kadmission.Handler
+
+	client             client.Interface
+	authorizer         authorizer.Authorizer
+	restrictedNetworks []*net.IPNet
+}
+
+var _ = oadmission.WantsAuthorizer(&restrictedEndpointsAdmission{})
+
+// ParseSimpleCIDRRules parses a list of CIDR strings
+func ParseSimpleCIDRRules(rules []string) (networks []*net.IPNet, err error) {
+	for _, s := range rules {
+		_, cidr, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, err
+		}
+		networks = append(networks, cidr)
+	}
+	return networks, nil
+}
+
+// NewRestrictedEndpointsAdmission creates a new endpoints admission plugin.
+func NewRestrictedEndpointsAdmission(restrictedNetworks []*net.IPNet) *restrictedEndpointsAdmission {
+	return &restrictedEndpointsAdmission{
+		Handler:            kadmission.NewHandler(kadmission.Create, kadmission.Update),
+		restrictedNetworks: restrictedNetworks,
+	}
+}
+
+func (r *restrictedEndpointsAdmission) SetAuthorizer(a authorizer.Authorizer) {
+	r.authorizer = a
+}
+
+func (r *restrictedEndpointsAdmission) findRestrictedIP(ep *kapi.Endpoints) string {
+	for _, subset := range ep.Subsets {
+		for _, addr := range subset.Addresses {
+			ip := net.ParseIP(addr.IP)
+			if ip == nil {
+				continue
+			}
+			for _, net := range r.restrictedNetworks {
+				if net.Contains(ip) {
+					return addr.IP
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (r *restrictedEndpointsAdmission) checkAccess(attr kadmission.Attributes) (bool, error) {
+	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), attr.GetNamespace()), attr.GetUserInfo())
+	authzAttr := authorizer.DefaultAuthorizationAttributes{
+		Verb:         "create",
+		Resource:     authorizationapi.RestrictedEndpointsResource,
+		APIGroup:     kapi.GroupName,
+		ResourceName: attr.GetName(),
+	}
+	allow, _, err := r.authorizer.Authorize(ctx, authzAttr)
+	return allow, err
+}
+
+// Admit determines if the endpoints object should be admitted
+func (r *restrictedEndpointsAdmission) Admit(a kadmission.Attributes) error {
+	if a.GetResource().GroupResource() != kapi.Resource("endpoints") {
+		return nil
+	}
+	ep, ok := a.GetObject().(*kapi.Endpoints)
+	if !ok {
+		return nil
+	}
+	old, ok := a.GetOldObject().(*kapi.Endpoints)
+	if ok && reflect.DeepEqual(ep.Subsets, old.Subsets) {
+		return nil
+	}
+
+	restrictedIP := r.findRestrictedIP(ep)
+	if restrictedIP == "" {
+		return nil
+	}
+
+	allow, err := r.checkAccess(a)
+	if err != nil {
+		return err
+	}
+	if !allow {
+		return kadmission.NewForbidden(a, fmt.Errorf("endpoint address %s is not allowed", restrictedIP))
+	}
+	return nil
+}

--- a/pkg/service/admission/externalip_admission.go
+++ b/pkg/service/admission/externalip_admission.go
@@ -28,9 +28,9 @@ type externalIPRanger struct {
 
 var _ kadmission.Interface = &externalIPRanger{}
 
-// ParseCIDRRules calculates a blacklist and whitelist from a list of string CIDR rules (treating
+// ParseRejectAdmitCIDRRules calculates a blacklist and whitelist from a list of string CIDR rules (treating
 // a leading ! as a negation). Returns an error if any rule is invalid.
-func ParseCIDRRules(rules []string) (reject, admit []*net.IPNet, err error) {
+func ParseRejectAdmitCIDRRules(rules []string) (reject, admit []*net.IPNet, err error) {
 	for _, s := range rules {
 		negate := false
 		if strings.HasPrefix(s, "!") {

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -1,0 +1,127 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const (
+	clusterNetworkCIDR = "10.128.0.0/14"
+	serviceNetworkCIDR = "172.30.0.0/16"
+)
+
+var exampleAddresses = map[string]string{
+	"cluster":  "10.128.0.2",
+	"service":  "172.30.0.2",
+	"external": "1.2.3.4",
+}
+
+func testOne(t *testing.T, client *kclient.Client, namespace, addrType string, success bool) *kapi.Endpoints {
+	testEndpoint := &kapi.Endpoints{}
+	testEndpoint.GenerateName = "test"
+	testEndpoint.Subsets = []kapi.EndpointSubset{
+		{
+			Addresses: []kapi.EndpointAddress{
+				{
+					IP: exampleAddresses[addrType],
+				},
+			},
+			Ports: []kapi.EndpointPort{
+				{
+					Port:     9999,
+					Protocol: kapi.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	ep, err := client.Endpoints(namespace).Create(testEndpoint)
+	if err != nil && success {
+		t.Fatalf("unexpected error creating %s network endpoint: %v", addrType, err)
+	} else if err == nil && !success {
+		t.Fatalf("unexpected success creating %s network endpoint", addrType)
+	}
+	return ep
+}
+
+func TestEndpointAdmission(t *testing.T) {
+	testutil.RequireEtcd(t)
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("error creating config: %v", err)
+	}
+	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		"RestrictedEndpointsAdmission": {
+			Configuration: &configapi.DefaultAdmissionConfig{},
+		},
+	}
+	masterConfig.NetworkConfig.ClusterNetworkCIDR = clusterNetworkCIDR
+	masterConfig.NetworkConfig.ServiceNetworkCIDR = serviceNetworkCIDR
+
+	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("error starting server: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting kube client: %v", err)
+	}
+	clusterAdminOSClient, err := testutil.GetClusterAdminClient(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting client: %v", err)
+	}
+	clientConfig, err := testutil.GetClusterAdminClientConfig(kubeConfigFile)
+	if err != nil {
+		t.Fatalf("error getting client config: %v", err)
+	}
+
+	// Cluster admin
+	testOne(t, clusterAdminKubeClient, "default", "cluster", true)
+	testOne(t, clusterAdminKubeClient, "default", "service", true)
+	testOne(t, clusterAdminKubeClient, "default", "external", true)
+
+	// Endpoint controller service account
+	_, serviceAccountClient, _, err := testutil.GetClientForServiceAccount(clusterAdminKubeClient, *clientConfig, bootstrappolicy.DefaultOpenShiftInfraNamespace, bootstrappolicy.InfraEndpointControllerServiceAccountName)
+	if err != nil {
+		t.Fatalf("error getting endpoint controller service account: %v", err)
+	}
+	testOne(t, serviceAccountClient, "default", "cluster", true)
+	testOne(t, serviceAccountClient, "default", "service", true)
+	testOne(t, serviceAccountClient, "default", "external", true)
+
+	// Project admin
+	_, err = testserver.CreateNewProject(clusterAdminOSClient, *clientConfig, "myproject", "myadmin")
+	if err != nil {
+		t.Fatalf("error creating project: %v", err)
+	}
+	_, projectAdminClient, _, err := testutil.GetClientForUser(*clientConfig, "myadmin")
+	if err != nil {
+		t.Fatalf("error getting project admin client: %v", err)
+	}
+
+	testOne(t, projectAdminClient, "myproject", "cluster", false)
+	testOne(t, projectAdminClient, "myproject", "service", false)
+	testOne(t, projectAdminClient, "myproject", "external", true)
+
+	// User without restricted endpoint permission can't modify IPs but can still do other modifications
+	ep := testOne(t, clusterAdminKubeClient, "myproject", "cluster", true)
+	ep.Annotations = map[string]string{"foo": "bar"}
+	ep, err = projectAdminClient.Endpoints("myproject").Update(ep)
+	if err != nil {
+		t.Fatalf("unexpected error updating endpoint annotation: %v", err)
+	}
+	ep.Subsets[0].Addresses[0].IP = exampleAddresses["service"]
+	ep, err = projectAdminClient.Endpoints("myproject").Update(ep)
+	if err == nil {
+		t.Fatalf("unexpected success modifying endpoint")
+	}
+}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2276,6 +2276,13 @@ items:
     - get
     - list
     - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - endpoints/restricted
+    verbs:
+    - create
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2253,6 +2253,33 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: system:endpoint-controller
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: system:gc-controller
   rules:
   - apiGroups:


### PR DESCRIPTION
If a service has a selector then it's pointless to manually create endpoints for it, because the endpoints controller will (eventually) just overwrite your manually-created endpoints with the correct value according to the selector. ("Eventually" meaning 30 seconds at the most, or sooner if something related to the service changes before then.) Nonetheless, it's currently possible for a user to temporarily override the Endpoints with an incorrect value. This patch adds an admission controller that prevents that.

This is part of the fix for #9255; the only reason openshift-sdn needs to track IP-to-pod/namespace mappings is because it can't 100% reliably distinguish endpoints-that-point-to-pod-IPs that were added by the endpoints controller (which are always safe) from endpoints-that-point-to-pod-IPs that were added by users (which probably indicate an attempt to bypass isolation), so it has to check that each endpoint points into the right namespace. With the admission controller in place, we can just make it accept all auto-created endpoints and reject all manually-created ClusterNetwork-internal endpoints.

(#9255 talked about making the admission controller do the pointing-into-ClusterNetworkCIDR check itself, and then getting rid of openshift-sdn's endpoint filter entirely. However, it looks like we're going to need to keep the endpoint filter around for 1.3 to do egress-firewall-related endpoint filtering anyway, so we might as well keep the other endpoint filtering there as well and just go with the simpler admission controller at least for now. The discussion there also suggested allowing cluster admins to override the admission controller, but I didn't bother to do that here, since there isn't much point in allowing even admins to manually create these Endpoints given that they'll just get overwritten anyway.)

Not sure about the use of `a.GetUserInfo().GetName() == bootstrappolicy.MasterUsername` to identify the endpoints controller... (It works but I don't know if it's "right".)

@smarterclayton @openshift/networking PTAL
