### PR TITLE
UPSTREAM: 27644: Use preferred group version when discovery fails due to 403

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
@@ -173,6 +173,11 @@ func NegotiateVersion(client *Client, c *restclient.Config, requestedGV *unversi
 			return nil, fmt.Errorf("client does not support API version %q; client supported API versions: %v", preferredGV, clientVersions)
 
 		}
+		// If the server supports no versions, then we should just use the preferredGV
+		// This can happen because discovery fails due to 403 Forbidden errors
+		if len(serverVersions) == 0 {
+			return preferredGV, nil
+		}
 		if serverVersions.Has(preferredGV.String()) {
 			return preferredGV, nil
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_blackbox_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_blackbox_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/runtime"
 )
 
 func objBody(object interface{}) io.ReadCloser {
@@ -51,6 +52,7 @@ func TestNegotiateVersion(t *testing.T) {
 		config          *restclient.Config
 		expectErr       func(err error) bool
 		sendErr         error
+		statusCode      int
 	}{
 		{
 			name:            "server supports client default",
@@ -59,6 +61,7 @@ func TestNegotiateVersion(t *testing.T) {
 			serverVersions:  []string{"version1", testapi.Default.GroupVersion().String()},
 			clientVersions:  []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
 			expectedVersion: &uapi.GroupVersion{Version: "version1"},
+			statusCode:      http.StatusOK,
 		},
 		{
 			name:            "server falls back to client supported",
@@ -67,6 +70,7 @@ func TestNegotiateVersion(t *testing.T) {
 			serverVersions:  []string{"version1"},
 			clientVersions:  []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
 			expectedVersion: &uapi.GroupVersion{Version: "version1"},
+			statusCode:      http.StatusOK,
 		},
 		{
 			name:            "explicit version supported",
@@ -74,6 +78,7 @@ func TestNegotiateVersion(t *testing.T) {
 			serverVersions:  []string{"/version1", testapi.Default.GroupVersion().String()},
 			clientVersions:  []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
 			expectedVersion: testapi.Default.GroupVersion(),
+			statusCode:      http.StatusOK,
 		},
 		{
 			name:           "explicit version not supported",
@@ -81,6 +86,7 @@ func TestNegotiateVersion(t *testing.T) {
 			serverVersions: []string{"version1"},
 			clientVersions: []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
 			expectErr:      func(err error) bool { return strings.Contains(err.Error(), `server does not support API version "v1"`) },
+			statusCode:     http.StatusOK,
 		},
 		{
 			name:           "connection refused error",
@@ -89,6 +95,29 @@ func TestNegotiateVersion(t *testing.T) {
 			clientVersions: []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
 			sendErr:        errors.New("connection refused"),
 			expectErr:      func(err error) bool { return strings.Contains(err.Error(), "connection refused") },
+			statusCode:     http.StatusOK,
+		},
+		{
+			name:            "discovery fails due to 403 Forbidden errors and thus serverVersions is empty, use default GroupVersion",
+			config:          &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}},
+			clientVersions:  []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
+			expectedVersion: testapi.Default.GroupVersion(),
+			statusCode:      http.StatusForbidden,
+		},
+		{
+			name:            "discovery fails due to 404 Not Found errors and thus serverVersions is empty, use requested GroupVersion",
+			version:         &uapi.GroupVersion{Version: "version1"},
+			config:          &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}},
+			clientVersions:  []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
+			expectedVersion: &uapi.GroupVersion{Version: "version1"},
+			statusCode:      http.StatusNotFound,
+		},
+		{
+			name:           "discovery fails due to 403 Forbidden errors and thus serverVersions is empty, no fallback GroupVersion",
+			config:         &restclient.Config{},
+			clientVersions: []uapi.GroupVersion{{Version: "version1"}, *testapi.Default.GroupVersion()},
+			expectErr:      func(err error) bool { return strings.Contains(err.Error(), "failed to negotiate an api version;") },
+			statusCode:     http.StatusForbidden,
 		},
 	}
 	codec := testapi.Default.Codec()
@@ -97,14 +126,16 @@ func TestNegotiateVersion(t *testing.T) {
 		fakeClient := &fake.RESTClient{
 			Codec: codec,
 			Resp: &http.Response{
-				StatusCode: 200,
+				StatusCode: test.statusCode,
 				Body:       objBody(&uapi.APIVersions{Versions: test.serverVersions}),
 			},
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				if test.sendErr != nil {
 					return nil, test.sendErr
 				}
-				return &http.Response{StatusCode: 200, Body: objBody(&uapi.APIVersions{Versions: test.serverVersions})}, nil
+				header := http.Header{}
+				header.Set("Content-Type", runtime.ContentTypeJSON)
+				return &http.Response{StatusCode: test.statusCode, Header: header, Body: objBody(&uapi.APIVersions{Versions: test.serverVersions})}, nil
 			}),
 		}
 		c := unversioned.NewOrDie(test.config)


### PR DESCRIPTION
fixes #9307 

`serverVersions` is empty when discovery fails, thus we fallback to the `preferredGV`.

Please review @deads2k @liggitt 