### PR TITLE
Don't enforce quota in registry by default

### DIFF
--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -520,6 +520,9 @@ Install the integrated Docker registry
 
   # Use a different registry image
   oadm registry --images=myrepo/docker-registry:mytag
+
+  # Enforce quota and limits on images
+  oadm registry --enforce-quota
 ----
 ====
 

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -520,6 +520,9 @@ Install the integrated Docker registry
 
   # Use a different registry image
   oc adm registry --images=myrepo/docker-registry:mytag
+
+  # Enforce quota and limits on images
+  oc adm registry --enforce-quota
 ----
 ====
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -656,7 +656,7 @@ function install_registry() {
 	echo "[INFO] Installing the registry"
 	# For testing purposes, ensure the quota objects are always up to date in the registry by
 	# disabling project cache.
-	openshift admin registry --config="${ADMIN_KUBECONFIG}" --images="${USE_IMAGES}" -o json | \
+	openshift admin registry --config="${ADMIN_KUBECONFIG}" --images="${USE_IMAGES}" --enforce-quota -o json | \
 		oc env -f - --output json "REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_PROJECTCACHETTL=0" | \
 		oc create -f -
 }

--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -64,7 +64,10 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
   %[1]s %[2]s --replicas=2
 
   # Use a different registry image
-  %[1]s %[2]s --images=myrepo/docker-registry:mytag`
+  %[1]s %[2]s --images=myrepo/docker-registry:mytag
+
+  # Enforce quota and limits on images
+  %[1]s %[2]s --enforce-quota`
 )
 
 // RegistryOptions contains the configuration for the registry as well as any other
@@ -140,7 +143,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 		Volume:         "/registry",
 		ServiceAccount: "registry",
 		Replicas:       1,
-		EnforceQuota:   true,
+		EnforceQuota:   false,
 	}
 
 	cmd := &cobra.Command{
@@ -330,11 +333,7 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 	env := app.Environment{}
 	env.Add(secretEnv)
 
-	enforceQuota := "false"
-	if opts.Config.EnforceQuota {
-		enforceQuota = "true"
-	}
-	env["REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA"] = enforceQuota
+	env["REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA"] = fmt.Sprintf("%t", opts.Config.EnforceQuota)
 	healthzPort := defaultPort
 	if len(opts.ports) > 0 {
 		healthzPort = int(opts.ports[0].ContainerPort)

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -168,7 +168,7 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 
 	bs := r.Repository.Blobs(ctx)
 
-	if quotaEnforcing != nil {
+	if !quotaEnforcing.enforcementDisabled {
 		bs = &quotaRestrictedBlobStore{
 			BlobStore: bs,
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -311,6 +311,7 @@ os::cmd::expect_success "oadm registry --credentials=${KUBECONFIG} --images='${U
 os::cmd::expect_success_and_text 'oadm registry' 'service exists'
 os::cmd::expect_success_and_text 'oc describe svc/docker-registry' 'Session Affinity:\s*ClientIP'
 os::cmd::expect_success_and_text 'oc get dc/docker-registry -o yaml' 'readinessProbe'
+os::cmd::expect_success_and_text 'oc env --list dc/docker-registry' 'REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=false'
 echo "registry: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
The quota enforcement has been off by default for existing deployments.
Let's keep it off by default for the new ones as well.

Resolves #9393