### PR TITLE
udpate jenkinsfile to use new DSL

### DIFF
--- a/examples/jenkins/pipeline/pipelinetemplate.json
+++ b/examples/jenkins/pipeline/pipelinetemplate.json
@@ -48,7 +48,7 @@
         "strategy": {
           "type": "JenkinsPipeline",
           "jenkinsPipelineStrategy": {
-            "jenkinsfile": "node('agent') {\nstage 'build'\ndef builder = new com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder(\"\", \"ruby-sample-build\", \"pipelineproject\", \"\", \"\", \"\", \"\", \"true\", \"\", \"\")\nstep builder\nstage 'deploy'\ndef deployer = new com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer(\"\",\"frontend\",\"pipelineproject\",\"\",\"\")\nstep deployer\n}"
+            "jenkinsfile": "node('agent') {\nstage 'build'\nopenShiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenShiftDeploy(deploymentConfig: 'frontend')\n}"
           }
         }
       }

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -2834,7 +2834,7 @@ var _examplesJenkinsPipelinePipelinetemplateJson = []byte(`{
         "strategy": {
           "type": "JenkinsPipeline",
           "jenkinsPipelineStrategy": {
-            "jenkinsfile": "node('agent') {\nstage 'build'\ndef builder = new com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder(\"\", \"ruby-sample-build\", \"pipelineproject\", \"\", \"\", \"\", \"\", \"true\", \"\", \"\")\nstep builder\nstage 'deploy'\ndef deployer = new com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer(\"\",\"frontend\",\"pipelineproject\",\"\",\"\")\nstep deployer\n}"
+            "jenkinsfile": "node('agent') {\nstage 'build'\nopenShiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenShiftDeploy(deploymentConfig: 'frontend')\n}"
           }
         }
       }


### PR DESCRIPTION
@csrwng or @bparees PTAL

This updates the jenkins pipeline example to leverage the new workflow DSL implementation in the plugin.
Aside from looking cleaner, they avoided in my testing the whitelist exceptions that the prior java constructor invocations were hitting, where we had to approve those invocations.

The new groovy scriplet will look like this in the jenkins UI's job configure panel:

```
node('agent') {
stage 'build'
openShiftBuild(buildConfig: 'ruby-sample-build')
stage 'deploy'
openShiftDeploy(deploymentConfig: 'frontend')
}
```

@spadgett @jwforres FYI