### PR TITLE
haproxy-router delete service endpoint problem

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -156,6 +156,10 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 		if commit {
 			p.Router.Commit()
 		}
+	case watch.Deleted:
+		glog.V(4).Infof("Deleting endpoints for %s", key)
+		p.Router.DeleteEndpoints(key)
+		p.Router.Commit()
 	}
 
 	return nil

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -328,6 +328,9 @@ func TestHandleEndpoints(t *testing.T) {
 		if !ok {
 			t.Errorf("TestHandleEndpoints test case %s failed.  Couldn't find expected service unit with name %s", tc.name, tc.expectedServiceUnit.Name)
 		} else {
+			if len(su.EndpointTable) != len(tc.expectedServiceUnit.EndpointTable) {
+				t.Errorf("TestHandleEndpoints test case %s failed. endpoints: %d expected %d", tc.name, len(su.EndpointTable), len(tc.expectedServiceUnit.EndpointTable))
+			}
 			for expectedKey, expectedEp := range tc.expectedServiceUnit.EndpointTable {
 				actualEp := su.EndpointTable[expectedKey]
 


### PR DESCRIPTION
Resolves: bz1335074
When a service is deleted, all routes that reference the service must
stop working. Internally, this requires that the service endpoints
must be removed.

Previously, the endpoints were not deleted and routes that referenced
the service continue to work.

Signed-off-by: Phil Cameron <pcameron@redhat.com>