### PR TITLE
Changing secrets.go to avoid unreliable docker build output capture. …

### DIFF
--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -5,7 +5,6 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-
 	exutil "github.com/openshift/origin/test/extended/util"
 	kapi "k8s.io/kubernetes/pkg/api"
 )
@@ -13,39 +12,38 @@ import (
 var _ = g.Describe("[builds][Slow] can use build secrets", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildSecretBaseDir   = exutil.FixturePath("testdata", "build-secrets")
-		secretsFixture       = filepath.Join(buildSecretBaseDir, "test-secret.json")
-		secondSecretsFixture = filepath.Join(buildSecretBaseDir, "test-secret-2.json")
-		isFixture            = filepath.Join(buildSecretBaseDir, "test-is.json")
-		dockerBuildFixture   = filepath.Join(buildSecretBaseDir, "test-docker-build.json")
-		sourceBuildFixture   = filepath.Join(buildSecretBaseDir, "test-s2i-build.json")
-		oc                   = exutil.NewCLI("build-secrets", exutil.KubeConfigPath())
+		buildSecretBaseDir    = exutil.FixturePath("testdata", "build-secrets")
+		secretsFixture        = filepath.Join(buildSecretBaseDir, "test-secret.json")
+		secondSecretsFixture  = filepath.Join(buildSecretBaseDir, "test-secret-2.json")
+		isFixture             = filepath.Join(buildSecretBaseDir, "test-is.json")
+		dockerBuildFixture    = filepath.Join(buildSecretBaseDir, "test-docker-build.json")
+		dockerBuildDockerfile = filepath.Join(buildSecretBaseDir, "Dockerfile")
+		sourceBuildFixture    = filepath.Join(buildSecretBaseDir, "test-s2i-build.json")
+		sourceBuildBinDir     = filepath.Join(buildSecretBaseDir, "s2i-binary-dir")
+		oc                    = exutil.NewCLI("build-secrets", exutil.KubeConfigPath())
 	)
 
 	g.Describe("build with secrets", func() {
 		oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-		g.It("should print the secrets during the source strategy build", func() {
-			g.By("creating the sample secret files")
+		g.It("should contain secrets during the source strategy build", func() {
+			g.By("creating secret fixtures")
 			err := oc.Run("create").Args("-f", secretsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("create").Args("-f", secondSecretsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("creating the sample source build config and image stream")
+			g.By("creating test image stream")
 			err = oc.Run("create").Args("-f", isFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
+			g.By("creating test build config")
 			err = oc.Run("create").Args("-f", sourceBuildFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("starting the sample source build")
-			out, err := oc.Run("start-build").Args("test", "--follow", "--wait").Output()
+			g.By("starting the test source build")
+			err = oc.Run("start-build").Args("test", "--from-dir", sourceBuildBinDir).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(out).To(o.ContainSubstring("secret1=secret1"))
-			o.Expect(out).To(o.ContainSubstring("secret3=secret3"))
-			o.Expect(out).To(o.ContainSubstring("relative-secret1=secret1"))
-			o.Expect(out).To(o.ContainSubstring("relative-secret3=secret3"))
 
 			g.By("checking the status of the build")
 			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), "test-1", exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
@@ -58,33 +56,36 @@ var _ = g.Describe("[builds][Slow] can use build secrets", func() {
 			image, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("verifying the build secrets are not present in the output image")
+			g.By("verifying the build secrets were available during build and not present in the output image")
 			pod := exutil.GetPodForContainer(kapi.Container{Name: "test", Image: image})
 			oc.KubeFramework().TestContainerOutput("test-build-secret-source", pod, 0, []string{
-				"relative-secret1=empty",
-				"secret3=empty",
+				"testsecret/secret1=secret1",
+				"testsecret/secret2=secret2",
+				"testsecret/secret3=secret3",
+				"testsecret2/secret1=secret1",
+				"testsecret2/secret2=secret2",
+				"testsecret2/secret3=secret3",
 			})
 		})
 
-		g.It("should print the secrets during the docker strategy build", func() {
-			g.By("creating the sample secret files")
+		g.It("should contain secrets during the docker strategy build", func() {
+			g.By("creating secret fixtures")
 			err := oc.Run("create").Args("-f", secretsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("create").Args("-f", secondSecretsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("creating the sample source build config and image stream")
+			g.By("creating test image stream")
 			err = oc.Run("create").Args("-f", isFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
+			g.By("creating test build config")
 			err = oc.Run("create").Args("-f", dockerBuildFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("starting the sample source build")
-			out, err := oc.Run("start-build").Args("test", "--follow", "--wait").Output()
+			g.By("starting the test docker build")
+			err = oc.Run("start-build").Args("test", "--from-file", dockerBuildDockerfile).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(out).To(o.ContainSubstring("secret1=secret1"))
-			o.Expect(out).To(o.ContainSubstring("relative-secret2=secret2"))
 
 			g.By("checking the status of the build")
 			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), "test-1", exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
@@ -92,6 +93,18 @@ var _ = g.Describe("[builds][Slow] can use build secrets", func() {
 				exutil.DumpBuildLogs("test", oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("getting the image name")
+			image, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "test", "latest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying the secrets are present in container output")
+			pod := exutil.GetPodForContainer(kapi.Container{Name: "test", Image: image})
+			oc.KubeFramework().TestContainerOutput("test-build-secret-docker", pod, 0, []string{
+				"secret1=secret1",
+				"relative-secret2=secret2",
+			})
+
 		})
 
 	})

--- a/test/extended/testdata/build-secrets/Dockerfile
+++ b/test/extended/testdata/build-secrets/Dockerfile
@@ -4,8 +4,10 @@ USER root
 ADD ./secret-dir /secrets
 COPY ./secret2 /
 
-RUN test -f /secrets/secret1 && echo -n "secret1=" && cat /secrets/secret1
-RUN test -f /secret2 && echo -n "relative-secret2=" && cat /secret2
-RUN rm -rf /secrets && rm -rf /secret2
+# Create a shell script that will output secrets when the image is run
+RUN echo '#!/bin/sh' > /secret_report.sh
+RUN echo '(test -f /secrets/secret1 && echo -n "secret1=" && cat /secrets/secret1)' >> /secret_report.sh
+RUN echo '(test -f /secret2 && echo -n "relative-secret2=" && cat /secret2)' >> /secret_report.sh
+RUN chmod 755 /secret_report.sh
 
-CMD ["true"]
+CMD ["/bin/sh", "-c", "/secret_report.sh"]

--- a/test/extended/testdata/build-secrets/s2i-binary-dir/.s2i/bin/assemble
+++ b/test/extended/testdata/build-secrets/s2i-binary-dir/.s2i/bin/assemble
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copy secrets into a location they can be output during image run
+
+mkdir -p "${HOME}/testsecret"
+if [[ -f /tmp/secret1 ]]; then
+    # Copy three secrets defined in testsecret fixture to directory
+    cp /tmp/secret? "${HOME}/testsecret"
+else
+    echo "Unable to locate testsecret fixture files"
+    exit 1
+fi
+
+mkdir -p "${HOME}/testsecret2"
+if [[ -f secret1  ]]; then
+    # Copy three secrets defined in testsecret2 fixture to directory
+    cp secret? "${HOME}/testsecret2"
+else
+    echo "Unable to locate testsecret2 fixture files"
+    exit 2
+fi 

--- a/test/extended/testdata/build-secrets/s2i-binary-dir/.s2i/bin/run
+++ b/test/extended/testdata/build-secrets/s2i-binary-dir/.s2i/bin/run
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Ensure none of the build config inject secrets still exist in the file system
+for s in /tmp/secret? secret?; do
+    if [[ -s "${s}" ]]; then
+        echo "Found secret file which should have been removed: ${s}"
+        exit 1
+    fi
+done
+
+# Print out the secrets copied into the image during assemble
+cd "${HOME}"
+for s in testsecret/* testsecret2/*; do
+    echo -n "${s}=" && cat "${s}"
+done

--- a/test/extended/testdata/build-secrets/s2i-binary-dir/Gemfile
+++ b/test/extended/testdata/build-secrets/s2i-binary-dir/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rack"

--- a/test/extended/testdata/build-secrets/s2i-binary-dir/config.ru
+++ b/test/extended/testdata/build-secrets/s2i-binary-dir/config.ru
@@ -1,0 +1,1 @@
+run Proc.new {|env| [200, {"Content-Type" => "text/html"}, [ENV['TEST_ENV']]]}

--- a/test/extended/testdata/build-secrets/s2i/assemble
+++ b/test/extended/testdata/build-secrets/s2i/assemble
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-[[ -f secret1 ]] && echo "relative-secret1=$(cat secret1)"
-[[ -f secret2 ]] && echo "relative-secret2=$(cat secret2)"
-[[ -f secret3 ]] && echo "relative-secret3=$(cat secret3)"
-
-[[ -f /tmp/secret1 ]] && echo "secret1=$(cat /tmp/secret1)"
-[[ -f /tmp/secret2 ]] && echo "secret2=$(cat /tmp/secret2)"
-[[ -f /tmp/secret3 ]] && echo "secret3=$(cat /tmp/secret3)"

--- a/test/extended/testdata/build-secrets/s2i/run
+++ b/test/extended/testdata/build-secrets/s2i/run
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-[[ ! -s secret1 ]] && echo "relative-secret1=empty"
-[[ ! -s /tmp/secret3 ]] && echo "secret3=empty"

--- a/test/extended/testdata/build-secrets/test-docker-build.json
+++ b/test/extended/testdata/build-secrets/test-docker-build.json
@@ -10,12 +10,9 @@
   "spec":{
     "triggers":[],
     "source":{
-      "type":"Git",
-      "git":{
-        "uri":"https://github.com/openshift/origin",
-        "ref": "secrets"
+      "type":"Binary",
+      "binary": {
       },
-      "contextDir":"test/extended/testdata/build-secrets",
       "secrets": [
         {
           "secret": { "name": "testsecret" },

--- a/test/extended/testdata/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/build-secrets/test-s2i-build.json
@@ -1,51 +1,51 @@
 {
-  "kind":"BuildConfig",
-  "apiVersion":"v1",
-  "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "name": "test"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Git",
-      "git":{
-        "uri":"https://github.com/openshift/origin",
-        "ref": "secrets"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Binary",
+      "binary": {
       },
-      "contextDir":"test/extended/testdata/test-build-app",
       "secrets": [
         {
-          "secret": { "name": "testsecret" },
+          "secret": {
+            "name": "testsecret"
+          },
           "destinationDir": "/tmp"
         },
         {
-          "secret": { "name": "testsecret2" }
+          "secret": {
+            "name": "testsecret2"
+          }
         }
       ]
     },
-    "strategy":{
-      "type":"Source",
+    "strategy": {
+      "type": "Source",
       "env": [
         {
           "name": "BUILD_LOGLEVEL",
           "value": "5"
         }
       ],
-      "sourceStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
-        },
-        "scripts":"https://raw.githubusercontent.com/openshift/origin/secrets/test/extended/testdata/build-secrets/s2i"
+      "sourceStrategy": {
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-22-centos7"
+        }
       }
     },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "test:latest"
       }
     }
   }


### PR DESCRIPTION
…Also changing test cases so that BuildConfig resources are local to the tree and do not need to be current in origin/master HEAD.