### PR TITLE
Usability improvements to failures in oc login

### DIFF
--- a/pkg/bootstrap/docker/openshift/login.go
+++ b/pkg/bootstrap/docker/openshift/login.go
@@ -11,14 +11,13 @@ import (
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kclientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // Login logs into the specified server using given credentials and CA file
 func Login(username, password, server, configDir string, f *clientcmd.Factory, c *cobra.Command, out io.Writer) error {
-
 	existingConfig, err := f.OpenShiftClientConfig.RawConfig()
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -41,7 +40,7 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 	if glog.V(1) {
 		output = out
 	}
-	opts := &cmd.LoginOptions{
+	opts := &login.LoginOptions{
 		Server:             server,
 		Username:           username,
 		Password:           password,
@@ -49,5 +48,5 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 		StartingKubeConfig: newConfig,
 		PathOptions:        config.NewPathOptions(c),
 	}
-	return cmd.RunLogin(nil, opts)
+	return login.RunLogin(nil, opts)
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/cluster"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/dockerbuild"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/importer"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/rollout"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/rsync"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/set"
@@ -86,7 +87,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 
 	f := clientcmd.New(cmds.PersistentFlags())
 
-	loginCmd := cmd.NewCmdLogin(fullName, f, in, out)
+	loginCmd := login.NewCmdLogin(fullName, f, in, out)
 	secretcmds := secrets.NewCmdSecrets(secrets.SecretsRecommendedName, fullName+" "+secrets.SecretsRecommendedName, f, in, out, fullName+" edit")
 
 	groups := templates.CommandGroups{
@@ -168,7 +169,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 		{
 			Message: "Settings Commands:",
 			Commands: []*cobra.Command{
-				cmd.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out),
+				login.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out),
 				cmd.NewCmdConfig(fullName, "config"),
 				cmd.NewCmdWhoAmI(cmd.WhoAmIRecommendedCommandName, fullName+" "+cmd.WhoAmIRecommendedCommandName, f, out),
 				cmd.NewCmdCompletion(fullName, f, out),

--- a/pkg/cmd/cli/cmd/login/helpers.go
+++ b/pkg/cmd/cli/cmd/login/helpers.go
@@ -1,0 +1,118 @@
+package login
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/user/api"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	kclientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/term"
+)
+
+// getMatchingClusters examines the kubeconfig for all clusters that point to the same server
+func getMatchingClusters(clientConfig restclient.Config, kubeconfig clientcmdapi.Config) sets.String {
+	ret := sets.String{}
+
+	for key, cluster := range kubeconfig.Clusters {
+		if (cluster.Server == clientConfig.Host) && (cluster.InsecureSkipTLSVerify == clientConfig.Insecure) && (cluster.CertificateAuthority == clientConfig.CAFile) && (bytes.Compare(cluster.CertificateAuthorityData, clientConfig.CAData) == 0) {
+			ret.Insert(key)
+		}
+	}
+
+	return ret
+}
+
+// findExistingClientCA returns *either* the existing client CA file name as a string,
+// *or* data in a []byte for a given host, and true if it exists in the given config
+func findExistingClientCA(host string, kubeconfig clientcmdapi.Config) (string, []byte, bool) {
+	for _, cluster := range kubeconfig.Clusters {
+		if cluster.Server == host {
+			if len(cluster.CertificateAuthority) > 0 {
+				return cluster.CertificateAuthority, nil, true
+			}
+			if len(cluster.CertificateAuthorityData) > 0 {
+				return "", cluster.CertificateAuthorityData, true
+			}
+		}
+	}
+	return "", nil, false
+}
+
+// dialToServer takes the Server URL from the given clientConfig and dials to
+// make sure the server is reachable. Note the config received is not mutated.
+func dialToServer(clientConfig restclient.Config) error {
+	// take a RoundTripper based on the config we already have (TLS, proxies, etc)
+	rt, err := restclient.TransportFor(&clientConfig)
+	if err != nil {
+		return err
+	}
+
+	parsedURL, err := url.Parse(clientConfig.Host)
+	if err != nil {
+		return err
+	}
+
+	// Do a HEAD request to serverPathToDial to make sure the server is alive.
+	// We don't care about the response, any err != nil is valid for the sake of reachability.
+	serverURLToDial := (&url.URL{Scheme: parsedURL.Scheme, Host: parsedURL.Host, Path: "/"}).String()
+	req, err := http.NewRequest("HEAD", serverURLToDial, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := rt.RoundTrip(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	return nil
+}
+
+func promptForInsecureTLS(reader io.Reader, out io.Writer) bool {
+	var input bool
+	if term.IsTerminal(reader) {
+		fmt.Fprintln(out, "The server uses a certificate signed by an unknown authority.")
+		fmt.Fprintln(out, "You can bypass the certificate check, but any data you send to the server could be intercepted by others.")
+		input = cmdutil.PromptForBool(os.Stdin, out, "Use insecure connections? (y/n): ")
+		fmt.Fprintln(out)
+	}
+	return input
+}
+
+func hasExistingInsecureCluster(clientConfigToTest restclient.Config, kubeconfig kclientcmdapi.Config) bool {
+	clientConfigToTest.Insecure = true
+	matchingClusters := getMatchingClusters(clientConfigToTest, kubeconfig)
+	return len(matchingClusters) > 0
+}
+
+// getHostPort returns the host and port parts of the given URL string. It's
+// expected that the provided URL is already normalized (always has host and port).
+func getHostPort(hostURL string) (string, string, *url.URL, error) {
+	parsedURL, err := url.Parse(hostURL)
+	if err != nil {
+		return "", "", nil, err
+	}
+	host, port, err := net.SplitHostPort(parsedURL.Host)
+	return host, port, parsedURL, err
+}
+
+func whoAmI(client *client.Client) (*api.User, error) {
+	me, err := client.Users().Get("~")
+	if err != nil {
+		return nil, err
+	}
+
+	return me, nil
+}

--- a/pkg/cmd/cli/cmd/login/login.go
+++ b/pkg/cmd/cli/cmd/login/login.go
@@ -1,9 +1,10 @@
-package cmd
+package login
 
 import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -107,7 +108,11 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 		o.CommandName = "oc"
 	}
 
-	addr := flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default()
+	parsedDefaultClusterURL, err := url.Parse(defaultClusterURL)
+	if err != nil {
+		return err
+	}
+	addr := flagtypes.Addr{Value: parsedDefaultClusterURL.Host, DefaultScheme: parsedDefaultClusterURL.Scheme, AllowPrefix: true}.Default()
 
 	if serverFlag := kcmdutil.GetFlagString(cmd, "server"); len(serverFlag) > 0 {
 		if err := addr.Set(serverFlag); err != nil {

--- a/pkg/cmd/cli/cmd/login/loginoptions_test.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions_test.go
@@ -1,0 +1,94 @@
+package login
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/cli/config"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+func TestNormalizeServerURL(t *testing.T) {
+	testCases := []struct {
+		originalServerURL   string
+		normalizedServerURL string
+	}{
+		{
+			originalServerURL:   "localhost",
+			normalizedServerURL: "https://localhost:443",
+		},
+		{
+			originalServerURL:   "https://localhost",
+			normalizedServerURL: "https://localhost:443",
+		},
+		{
+			originalServerURL:   "localhost:443",
+			normalizedServerURL: "https://localhost:443",
+		},
+		{
+			originalServerURL:   "https://localhost:443",
+			normalizedServerURL: "https://localhost:443",
+		},
+		{
+			originalServerURL:   "http://localhost",
+			normalizedServerURL: "http://localhost:80",
+		},
+		{
+			originalServerURL:   "localhost:8443",
+			normalizedServerURL: "https://localhost:8443",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Logf("evaluating test: normalize %s -> %s", test.originalServerURL, test.normalizedServerURL)
+		normalized, err := config.NormalizeServerURL(test.originalServerURL)
+		if err != nil {
+			t.Errorf("unexpected error normalizing %s: %s", test.originalServerURL, err)
+		}
+		if normalized != test.normalizedServerURL {
+			t.Errorf("unexpected server URL normalization result for %s: expected %s, got %s", test.originalServerURL, test.normalizedServerURL, normalized)
+		}
+	}
+}
+
+func TestDialToHTTPServer(t *testing.T) {
+	invoked := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		invoked <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	testCases := map[string]struct {
+		serverURL       string
+		evalExpectedErr func(error) bool
+	}{
+		"succeed dialing": {
+			serverURL: server.URL,
+		},
+		"try using HTTPS against HTTP server": {
+			serverURL:       "https:" + strings.TrimPrefix(server.URL, "http:"),
+			evalExpectedErr: clientcmd.IsTLSOversizedRecord,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Logf("evaluating test: %s", name)
+		clientConfig := &restclient.Config{
+			Host: test.serverURL,
+		}
+		if err := dialToServer(*clientConfig); err != nil {
+			if test.evalExpectedErr == nil || !test.evalExpectedErr(err) {
+				t.Errorf("%s: unexpected error: %v", name, err)
+			}
+		} else {
+			if test.evalExpectedErr != nil {
+				t.Errorf("%s: expected error but got nothing", name)
+			}
+		}
+	}
+}

--- a/pkg/cmd/cli/cmd/login/logout.go
+++ b/pkg/cmd/cli/cmd/login/logout.go
@@ -1,4 +1,4 @@
-package cmd
+package login
 
 import (
 	"errors"

--- a/pkg/cmd/util/clientcmd/errors.go
+++ b/pkg/cmd/util/clientcmd/errors.go
@@ -1,6 +1,8 @@
 package clientcmd
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
@@ -8,20 +10,28 @@ import (
 )
 
 const (
-	unknownReason                     = 0
-	noServerFoundReason               = 1
-	certificateAuthorityUnknownReason = 2
-	configurationInvalidReason        = 3
+	unknownReason = iota
+	noServerFoundReason
+	certificateAuthorityUnknownReason
+	configurationInvalidReason
+	tlsOversizedRecordReason
 
 	certificateAuthorityUnknownMsg = "The server uses a certificate signed by unknown authority. You may need to use the --certificate-authority flag to provide the path to a certificate file for the certificate authority, or --insecure-skip-tls-verify to bypass the certificate check and use insecure connections."
 	notConfiguredMsg               = `The client is not configured. You need to run the login command in order to create a default config for your server and credentials:
   oc login
 You can also run this command again providing the path to a config file directly, either through the --config flag of the KUBECONFIG environment variable.
 `
+	tlsOversizedRecordMsg = `Unable to connect to %[2]s using TLS: %[1]s.
+Ensure the specified server supports HTTPS.`
 )
 
 // GetPrettyMessageFor prettifys the message of the provided error
 func GetPrettyMessageFor(err error) string {
+	return GetPrettyMessageForServer(err, "")
+}
+
+// GetPrettyMessageForServer prettifys the message of the provided error
+func GetPrettyMessageForServer(err error, serverName string) string {
 	if err == nil {
 		return ""
 	}
@@ -34,9 +44,25 @@ func GetPrettyMessageFor(err error) string {
 
 	case certificateAuthorityUnknownReason:
 		return certificateAuthorityUnknownMsg
+
+	case tlsOversizedRecordReason:
+		if len(serverName) == 0 {
+			serverName = "server"
+		}
+		return fmt.Sprintf(tlsOversizedRecordMsg, err, serverName)
 	}
 
 	return err.Error()
+}
+
+// GetPrettyErrorFor prettifys the message of the provided error
+func GetPrettyErrorFor(err error) error {
+	return GetPrettyErrorForServer(err, "")
+}
+
+// GetPrettyErrorForServer prettifys the message of the provided error
+func GetPrettyErrorForServer(err error, serverName string) error {
+	return errors.New(GetPrettyMessageForServer(err, serverName))
 }
 
 // IsNoServerFound checks whether the provided error is a 'no server found' error or not
@@ -59,6 +85,12 @@ func IsForbidden(err error) bool {
 	return kerrors.IsForbidden(err)
 }
 
+// IsTLSOversizedRecord checks whether the provided error is a url.Error
+// with "tls: oversized record received", which usually means TLS not supported.
+func IsTLSOversizedRecord(err error) bool {
+	return detectReason(err) == tlsOversizedRecordReason
+}
+
 func detectReason(err error) int {
 	if err != nil {
 		switch {
@@ -68,6 +100,8 @@ func detectReason(err error) int {
 			return noServerFoundReason
 		case clientcmd.IsConfigurationInvalid(err):
 			return configurationInvalidReason
+		case strings.Contains(err.Error(), "tls: oversized record received"):
+			return tlsOversizedRecordReason
 		}
 	}
 	return unknownReason

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	newproject "github.com/openshift/origin/pkg/cmd/admin/project"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/user/api"
@@ -118,7 +119,7 @@ func TestLogin(t *testing.T) {
 
 }
 
-func newLoginOptions(server string, username string, password string, insecure bool) *cmd.LoginOptions {
+func newLoginOptions(server string, username string, password string, insecure bool) *login.LoginOptions {
 	flagset := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 	flags := []string{}
 	clientConfig := defaultClientConfig(flagset)
@@ -126,7 +127,7 @@ func newLoginOptions(server string, username string, password string, insecure b
 
 	startingConfig, _ := clientConfig.RawConfig()
 
-	loginOptions := &cmd.LoginOptions{
+	loginOptions := &login.LoginOptions{
 		Server:             server,
 		StartingKubeConfig: &startingConfig,
 		Username:           username,

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -157,7 +158,7 @@ func TestOAuthOIDC(t *testing.T) {
 
 	// Attempt a login using a redirecting auth proxy
 	loginOutput := &bytes.Buffer{}
-	loginOptions := &cmd.LoginOptions{
+	loginOptions := &login.LoginOptions{
 		Server:             clientConfig.Host,
 		CAFile:             masterCAFile,
 		StartingKubeConfig: &clientcmdapi.Config{},

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -15,7 +15,7 @@ import (
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -294,7 +294,7 @@ func TestOAuthRequestHeader(t *testing.T) {
 
 	// Attempt a login using a redirecting auth proxy
 	loginOutput := &bytes.Buffer{}
-	loginOptions := &cmd.LoginOptions{
+	loginOptions := &login.LoginOptions{
 		Server:             anonConfig.Host,
 		CAFile:             masterCAFile,
 		StartingKubeConfig: &clientcmdapi.Config{},
@@ -426,7 +426,7 @@ Certificate:
         X509v3 extensions:
             X509v3 Key Usage: critical
                 Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
+            X509v3 Extended Key Usage:
                 TLS Web Client Authentication
             X509v3 Basic Constraints: critical
                 CA:FALSE
@@ -533,7 +533,7 @@ Certificate:
         X509v3 extensions:
             X509v3 Key Usage: critical
                 Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
+            X509v3 Extended Key Usage:
                 TLS Web Client Authentication
             X509v3 Basic Constraints: critical
                 CA:FALSE
@@ -642,7 +642,7 @@ Certificate:
         X509v3 extensions:
             X509v3 Key Usage: critical
                 Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
+            X509v3 Extended Key Usage:
                 TLS Web Client Authentication
             X509v3 Basic Constraints: critical
                 CA:FALSE


### PR DESCRIPTION
Use just TCP when trying to check if server is reachable. Don't default to 8443 if port was not provided, but still tries it as a fallback if 443 isn't reachable. Improve error messages for better user experience.

Fixes https://github.com/openshift/origin/issues/9570
Fixes https://github.com/openshift/origin/issues/9585

@liggitt PTAL