### PR TITLE
DSL openShift -> openshift in Jenkinsfile

### DIFF
--- a/examples/jenkins/pipeline/pipelinetemplate.json
+++ b/examples/jenkins/pipeline/pipelinetemplate.json
@@ -48,7 +48,7 @@
         "strategy": {
           "type": "JenkinsPipeline",
           "jenkinsPipelineStrategy": {
-            "jenkinsfile": "node('agent') {\nstage 'build'\nopenShiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenShiftDeploy(deploymentConfig: 'frontend')\n}"
+            "jenkinsfile": "node('agent') {\nstage 'build'\nopenshiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenshiftDeploy(deploymentConfig: 'frontend')\n}"
           }
         }
       }

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -2834,7 +2834,7 @@ var _examplesJenkinsPipelinePipelinetemplateJson = []byte(`{
         "strategy": {
           "type": "JenkinsPipeline",
           "jenkinsPipelineStrategy": {
-            "jenkinsfile": "node('agent') {\nstage 'build'\nopenShiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenShiftDeploy(deploymentConfig: 'frontend')\n}"
+            "jenkinsfile": "node('agent') {\nstage 'build'\nopenshiftBuild(buildConfig: 'ruby-sample-build', showBuildLogs: 'true')\nstage 'deploy'\nopenshiftDeploy(deploymentConfig: 'frontend')\n}"
           }
         }
       }


### PR DESCRIPTION
@bparees PTAL

this completes the loop for the change @smarterclayton requested wrt the pipeline plugin's DSL method names and how "openshift" should be spelled in camel case mode.

the latest version of the images have v1.0.19 of the plugin now, so they will require this change in the Jenkinsfile to properly invoke the build steps (there was no way to support both "openshift..." and "openShift..." with the plug points that core Jenkins exposes).