### PR TITLE
Make deployment config reaper remove deployer pods

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -313,6 +313,12 @@ func IsTerminatedDeployment(deployment *api.ReplicationController) bool {
 	return current == deployapi.DeploymentStatusComplete || current == deployapi.DeploymentStatusFailed
 }
 
+// IsFailedDeployment returns true if the passed deployment failed.
+func IsFailedDeployment(deployment *api.ReplicationController) bool {
+	current := DeploymentStatusFor(deployment)
+	return current == deployapi.DeploymentStatusFailed
+}
+
 // CanTransitionPhase returns whether it is allowed to go from the current to the next phase.
 func CanTransitionPhase(current, next deployapi.DeploymentStatus) bool {
 	switch current {

--- a/test/extended/testdata/test-deployment-broken.yaml
+++ b/test/extended/testdata/test-deployment-broken.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: brokendeployment
+spec:
+  replicas: 1
+  selector:
+    name: brokendeployment
+  strategy:
+    type: Rolling
+    rollingParams:
+      pre:
+        failurePolicy: Abort
+        execNewPod:
+          containerName: myapp
+          command:
+          - /bin/false
+  template:
+    metadata:
+      labels:
+        name: brokendeployment
+    spec:
+      containers:
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        command:
+        - /bin/sleep
+        - "100"
+  triggers:
+  - type: ConfigChange


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/9293

This will cause all removal of all deployer pods and hook pods when the parent deployment config is deleted.