### PR TITLE
Update oc projects to mark current project with asterisk

### DIFF
--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -318,6 +318,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 
 	case 1:
 		o.Project = projectsItems[0].Name
+		fmt.Fprintf(o.Out, "You have one project on this server: %q\n\n", o.Project)
 		fmt.Fprintf(o.Out, "Using project %q.\n", o.Project)
 
 	default:
@@ -344,9 +345,9 @@ func (o *LoginOptions) gatherProjectInfo() error {
 		fmt.Fprintf(o.Out, "You have access to the following projects and can switch between them with 'oc project <projectname>':\n\n")
 		for _, p := range projects.List() {
 			if o.Project == p {
-				fmt.Fprintf(o.Out, "  * %s (current)\n", p)
-			} else {
 				fmt.Fprintf(o.Out, "  * %s\n", p)
+			} else {
+				fmt.Fprintf(o.Out, "    %s\n", p)
 			}
 		}
 		fmt.Fprintln(o.Out)

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -113,20 +113,22 @@ func (o ProjectsOptions) RunProjects() error {
 	defaultContextName := cliconfig.GetContextNickname(currentContext.Namespace, currentContext.Cluster, currentContext.AuthInfo)
 
 	var msg string
-	var current string
 	projects, err := getProjects(client)
 	if err == nil {
 		switch len(projects) {
 		case 0:
 			msg += "You are not a member of any projects. You can request a project to be created with the 'new-project' command."
 		case 1:
-			msg += fmt.Sprintf("You have one project on this server: %q.", api.DisplayNameAndNameForProject(&projects[0]))
+			if o.DisplayShort {
+				msg += fmt.Sprintf("%s", api.DisplayNameAndNameForProject(&projects[0]))
+			} else {
+				msg += fmt.Sprintf("You have one project on this server: %q.", api.DisplayNameAndNameForProject(&projects[0]))
+			}
 		default:
 			asterisk := ""
 			count := 0
 			if !o.DisplayShort {
 				msg += "You have access to the following projects and can switch between them with 'oc project <projectname>':\n"
-				asterisk = "  * "
 			}
 			for _, project := range projects {
 				count = count + 1
@@ -136,17 +138,19 @@ func (o ProjectsOptions) RunProjects() error {
 					displayName = project.Annotations["displayName"]
 				}
 
-				current = ""
-				if currentProjectExists && currentProject == project.Name && !o.DisplayShort {
-					current = " (current)"
+				if currentProjectExists && !o.DisplayShort {
+					asterisk = "    "
+					if currentProject == project.Name {
+						asterisk = "  * "
+					}
 				}
 				if len(displayName) > 0 && displayName != project.Name && !o.DisplayShort {
-					msg += fmt.Sprintf("\n  * %s (%s)%s", displayName, project.Name, current)
+					msg += fmt.Sprintf("\n  "+asterisk+"%s (%s)", displayName, project.Name)
 				} else {
 					if o.DisplayShort && count == 1 {
 						linebreak = ""
 					}
-					msg += fmt.Sprintf(linebreak+asterisk+"%s%s", project.Name, current)
+					msg += fmt.Sprintf(linebreak+asterisk+"%s", project.Name)
 				}
 			}
 		}


### PR DESCRIPTION
Suggested in https://github.com/openshift/origin/pull/9199#issuecomment-227162766
Updates `oc projects` to highlight the current project with an asterisk, in a list of two or more projects:
![screenshot from 2016-06-20 16-57-11](https://cloud.githubusercontent.com/assets/3902875/16210064/1fb093de-3708-11e6-885f-0840c97a75de.png)

`oc projects`
```
You have access to the following projects and can switch between them with 'oc project <projectname>':

    test12
    test5
    test6
    test8
    openshift-infra
    test2
    test7
    test13
    test4
    test9
    openshift
    test
    test11
    default
    test10
  * test20

Using project "test20" on server "https://10.13.137.149:8443".
```