### PR TITLE
bump(github.com/AaronO/go-git-http/auth) but not really because mfojtik was just too tired to type those last 2 character

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"ImportPath": "github.com/AaronO/go-git-http",
-			"Rev": "0ebecedc64b67a3a8674c56724082660be4821"
+			"Rev": "0ebecedc64b67a3a8674c56724082660be48216e"
 		},
 		{
 			"ImportPath": "github.com/AaronO/go-git-http/auth",


### PR DESCRIPTION
So we don't end up with
```
godep: error restoring dep (github.com/AaronO/go-git-http/auth): Wanted to restore rev 0ebecedc64b67a3a8674c56724082660be48216e, already restored rev 0ebecedc64b67a3a8674c56724082660be4821 for another package in the repo
```