### PR TITLE
oc describe for JenkinsBuildStrategy

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -345,6 +345,18 @@ func describeCustomStrategy(s *buildapi.CustomBuildStrategy, out *tabwriter.Writ
 }
 
 func describeJenkinsPipelineStrategy(s *buildapi.JenkinsPipelineBuildStrategy, out *tabwriter.Writer) {
+	if len(s.JenkinsfilePath) != 0 {
+		formatString(out, "Jenkinsfile path", s.JenkinsfilePath)
+	}
+	if len(s.Jenkinsfile) != 0 {
+		fmt.Fprintf(out, "Jenkinsfile contents:\n")
+		for _, s := range strings.Split(s.Jenkinsfile, "\n") {
+			fmt.Fprintf(out, "  %s\n", s)
+		}
+	}
+	if len(s.Jenkinsfile) == 0 && len(s.JenkinsfilePath) == 0 {
+		formatString(out, "Jenkinsfile", "from source repository root")
+	}
 }
 
 // DescribeTriggers generates information about the triggers associated with a

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -437,6 +437,19 @@ func TestDescribeBuildSpec(t *testing.T) {
 			},
 			want: "Empty Source",
 		},
+		{
+			spec: buildapi.BuildSpec{
+				CommonSpec: buildapi.CommonSpec{
+					Source: buildapi.BuildSource{},
+					Strategy: buildapi.BuildStrategy{
+						JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{
+							Jenkinsfile: "openshiftBuild",
+						},
+					},
+				},
+			},
+			want: "openshiftBuild",
+		},
 	}
 	for _, tt := range tests {
 		var b bytes.Buffer


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/9441

@bparees PTAL

btw, my reading of the types.go is that both Jenkinsfile and JenkinsfilePath can be empty, and I don't see any validation insuring at least one of them is set.  Is that intended?