### PR TITLE
Support network ingress on arbitrary ports

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -450,6 +450,11 @@ type MasterNetworkConfig struct {
 	// CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You
 	// should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.
 	ExternalIPNetworkCIDRs []string
+	// IngressIPNetworkCIDR controls the range to assign ingress ips from for services of type LoadBalancer on bare
+	// metal. If empty, ingress ips will not be assigned. It may contain a single CIDR that will be allocated from.
+	// For security reasons, you should ensure that this range does not overlap with the CIDRs reserved for external ips,
+	// nodes, pods, or services.
+	IngressIPNetworkCIDR string
 }
 
 type ImageConfig struct {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -482,6 +482,7 @@ var map_MasterNetworkConfig = map[string]string{
 	"hostSubnetLength":       "HostSubnetLength is the number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host",
 	"serviceNetworkCIDR":     "ServiceNetwork is the CIDR string to specify the service networks",
 	"externalIPNetworkCIDRs": "ExternalIPNetworkCIDRs controls what values are acceptable for the service external IP field. If empty, no externalIP may be set. It may contain a list of CIDRs which are checked for access. If a CIDR is prefixed with !, IPs in that CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.",
+	"ingressIPNetworkCIDR":   "IngressIPNetworkCIDR controls the range to assign ingress ips from for services of type LoadBalancer on bare metal. If empty, ingress ips will not be assigned. It may contain a single CIDR that will be allocated from. For security reasons, you should ensure that this range does not overlap with the CIDRs reserved for external ips, nodes, pods, or services.",
 }
 
 func (MasterNetworkConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -401,6 +401,11 @@ type MasterNetworkConfig struct {
 	// CIDR will be rejected. Rejections will be applied first, then the IP checked against one of the allowed CIDRs. You
 	// should ensure this range does not overlap with your nodes, pods, or service CIDRs for security reasons.
 	ExternalIPNetworkCIDRs []string `json:"externalIPNetworkCIDRs"`
+	// IngressIPNetworkCIDR controls the range to assign ingress ips from for services of type LoadBalancer on bare
+	// metal. If empty, ingress ips will not be assigned. It may contain a single CIDR that will be allocated from.
+	// For security reasons, you should ensure that this range does not overlap with the CIDRs reserved for external ips,
+	// nodes, pods, or services.
+	IngressIPNetworkCIDR string `json:"ingressIPNetworkCIDR"`
 }
 
 // ImageConfig holds the necessary configuration options for building image names for system components

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -199,6 +199,7 @@ networkConfig:
   clusterNetworkCIDR: ""
   externalIPNetworkCIDRs: null
   hostSubnetLength: 0
+  ingressIPNetworkCIDR: ""
   networkPluginName: ""
   serviceNetworkCIDR: ""
 oauthConfig:

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -157,6 +157,12 @@ func ValidateMasterConfig(config *api.MasterConfig, fldPath *field.Path) Validat
 			}
 		}
 	}
+	if len(config.NetworkConfig.IngressIPNetworkCIDR) > 0 {
+		cidr := config.NetworkConfig.IngressIPNetworkCIDR
+		if _, ipNet, err := net.ParseCIDR(cidr); err != nil || ipNet.IP.IsUnspecified() {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("networkConfig", "ingressIPNetworkCIDR").Index(0), cidr, "must be a valid CIDR notation IP range (e.g. 172.30.0.0/16)"))
+		}
+	}
 
 	validationResults.AddErrors(ValidateKubeConfig(config.MasterClients.OpenShiftLoopbackKubeConfig, fldPath.Child("masterClients", "openShiftLoopbackKubeConfig"))...)
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -464,7 +464,9 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, plu
 				// should have been caught with validation
 				return nil, err
 			}
-			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit))
+			// TODO need to disallow if a cloud provider is configured
+			allowIngressIP := len(options.NetworkConfig.IngressIPNetworkCIDR) > 0
+			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit, allowIngressIP))
 
 		case serviceadmit.RestrictedEndpointsPluginName:
 			// we need to set some customer parameters, so create by hand

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -669,6 +669,12 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	}
 	oc.RunServiceServingCertController(serviceServingCertClient)
 
+	_, _, ingressIPClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraServiceIngressIPControllerServiceAccountName)
+	if err != nil {
+		glog.Fatalf("Could not get client: %v", err)
+	}
+	oc.RunIngressIPController(ingressIPClient)
+
 	glog.Infof("Started Origin Controllers")
 
 	return nil

--- a/pkg/service/controller/ingressip/controller.go
+++ b/pkg/service/controller/ingressip/controller.go
@@ -1,0 +1,698 @@
+package ingressip
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/record"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/registry/service/allocator"
+	"k8s.io/kubernetes/pkg/registry/service/ipallocator"
+	"k8s.io/kubernetes/pkg/runtime"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const (
+	// It's necessary to allocate for the initial sync in consistent
+	// order rather than in the order received.  This requires waiting
+	// until the initial sync has been processed, and to avoid a hot
+	// loop, we'll wait this long between checks.
+	SyncProcessedPollPeriod = 100 * time.Millisecond
+
+	clientRetryCount    = 5
+	clientRetryInterval = 5 * time.Second
+)
+
+// IngressIPController is responsible for allocating ingress ip
+// addresses to Service objects of type LoadBalancer.
+type IngressIPController struct {
+	client kclient.ServicesNamespacer
+
+	controller *framework.Controller
+
+	maxRetries int
+
+	// Tracks ip allocation for the configured range
+	ipAllocator *ipallocator.Range
+	// Tracks ip -> service key to allow detection of duplicate ip
+	// allocations.
+	allocationMap map[string]string
+
+	// Tracks services requeued for allocation when the range is full.
+	requeuedAllocations sets.String
+
+	// Protects the transition between initial sync and regular processing
+	lock  sync.Mutex
+	cache cache.Store
+	queue workqueue.RateLimitingInterface
+
+	// recorder is used to record events.
+	recorder record.EventRecorder
+
+	// changeHandler does the work. It can be factored out for unit testing.
+	changeHandler func(change *serviceChange) error
+	// persistenceHandler persists service changes.  It can be factored out for unit testing
+	persistenceHandler func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error
+}
+
+type serviceChange struct {
+	key                string
+	oldService         *kapi.Service
+	requeuedAllocation bool
+}
+
+// NewIngressIPController creates a new IngressIPController.
+// TODO this should accept a shared informer
+func NewIngressIPController(kc kclient.Interface, ipNet *net.IPNet, resyncInterval time.Duration) *IngressIPController {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(kc.Events(""))
+	recorder := eventBroadcaster.NewRecorder(kapi.EventSource{Component: "ingressip-controller"})
+
+	ic := &IngressIPController{
+		client:     kc,
+		queue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		maxRetries: 10,
+		recorder:   recorder,
+	}
+
+	ic.cache, ic.controller = framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+				return ic.client.Services(kapi.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+				return ic.client.Services(kapi.NamespaceAll).Watch(options)
+			},
+		},
+		&kapi.Service{},
+		resyncInterval,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				service := obj.(*kapi.Service)
+				glog.V(5).Infof("Adding service %s/%s", service.Namespace, service.Name)
+				ic.enqueueChange(obj, nil)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				service := cur.(*kapi.Service)
+				glog.V(5).Infof("Updating service %s/%s", service.Namespace, service.Name)
+				ic.enqueueChange(cur, old)
+			},
+			DeleteFunc: func(obj interface{}) {
+				service := obj.(*kapi.Service)
+				glog.V(5).Infof("Deleting service %s/%s", service.Namespace, service.Name)
+				ic.enqueueChange(nil, obj)
+			},
+		},
+	)
+
+	ic.changeHandler = ic.processChange
+	ic.persistenceHandler = persistService
+
+	ic.ipAllocator = ipallocator.NewAllocatorCIDRRange(ipNet, func(max int, rangeSpec string) allocator.Interface {
+		return allocator.NewAllocationMap(max, rangeSpec)
+	})
+
+	ic.allocationMap = make(map[string]string)
+	ic.requeuedAllocations = sets.NewString()
+
+	return ic
+}
+
+// enqueueChange transforms the old and new objects into a change
+// object and queues it.  A lock is shared with processInitialSync to
+// avoid enqueueing while the changes from the initial sync are being
+// processed.
+func (ic *IngressIPController) enqueueChange(new interface{}, old interface{}) {
+	ic.lock.Lock()
+	defer ic.lock.Unlock()
+
+	change := &serviceChange{}
+
+	if new != nil {
+		// Queue the key needed to retrieve the lastest state from the
+		// cache when the change is processed.
+		key, err := controller.KeyFunc(new)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", new, err))
+			return
+		}
+		change.key = key
+	}
+
+	if old != nil {
+		change.oldService = old.(*kapi.Service)
+	}
+
+	ic.queue.Add(change)
+}
+
+// Run begins watching and syncing.
+func (ic *IngressIPController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	go ic.controller.Run(stopCh)
+
+	glog.V(5).Infof("Waiting for the initial sync to be completed")
+	for !ic.controller.HasSynced() {
+		select {
+		case <-time.After(SyncProcessedPollPeriod):
+		case <-stopCh:
+			return
+		}
+	}
+
+	if !ic.processInitialSync() {
+		return
+	}
+
+	glog.V(5).Infof("Starting normal worker")
+	for {
+		if !ic.work() {
+			break
+		}
+	}
+
+	glog.V(5).Infof("Shutting down ingress ip controller")
+	ic.queue.ShutDown()
+}
+
+type serviceAge []*kapi.Service
+
+func (s serviceAge) Len() int      { return len(s) }
+func (s serviceAge) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s serviceAge) Less(i, j int) bool {
+	if s[i].CreationTimestamp.Before(s[j].CreationTimestamp) {
+		return true
+	}
+	return (s[i].CreationTimestamp == s[j].CreationTimestamp && s[i].UID < s[j].UID)
+}
+
+// processInitialSync processes the items queued by informer's initial sync.
+// A lock is shared between this method and enqueueService to ensure
+// that queue additions are blocked while the sync is being processed.
+// Returns a boolean indication of whether processing should continue.
+func (ic *IngressIPController) processInitialSync() bool {
+	ic.lock.Lock()
+	defer ic.lock.Unlock()
+
+	glog.V(5).Infof("Processing initial sync")
+
+	// Track services that need to be processed after existing
+	// allocations are recorded.
+	var pendingServices []*kapi.Service
+
+	// Track post-sync changes that need to be added back the queue
+	// after allocations are recorded.  These changes may end up in
+	// the queue if watch events were queued before completion of the
+	// initial sync was detected.
+	var pendingChanges []*serviceChange
+
+	// Drain the queue.  Len() should be safe because enqueueService
+	// requires the same lock held by this method.
+	for ic.queue.Len() > 0 {
+		item, quit := ic.queue.Get()
+		if quit {
+			return false
+		}
+		ic.queue.Done(item)
+		ic.queue.Forget(item)
+		change := item.(*serviceChange)
+
+		// The initial sync only includes additions, so if an update
+		// or delete is seen (indicated by the presence of oldService),
+		// it and all subsequent changes are post-sync watch events that
+		// should be queued without processing.
+		postSyncChange := change.oldService != nil || len(pendingChanges) > 0
+		if postSyncChange {
+			pendingChanges = append(pendingChanges, change)
+			continue
+		}
+
+		service := ic.getCachedService(change.key)
+		if service == nil {
+			// Service was deleted
+			continue
+		}
+
+		if service.Spec.Type == kapi.ServiceTypeLoadBalancer {
+			// Save for subsequent addition back to the queue to
+			// ensure persistent state is updated during regular
+			// processing.
+			pendingServices = append(pendingServices, service)
+
+			if len(service.Status.LoadBalancer.Ingress) > 0 {
+				// The service has an existing allocation
+				ipString := service.Status.LoadBalancer.Ingress[0].IP
+				// Return values indicating that reallocation is
+				// necessary or that an error occurred can be ignored
+				// since the service will be processed again.
+				ic.recordLocalAllocation(change.key, ipString)
+			}
+		}
+	}
+
+	// Add pending service additions back to the queue in consistent order.
+	sort.Sort(serviceAge(pendingServices))
+	for _, service := range pendingServices {
+		if key, err := controller.KeyFunc(service); err == nil {
+			glog.V(5).Infof("Adding service back to queue: %v ", key)
+			change := &serviceChange{key: key}
+			ic.queue.Add(change)
+		} else {
+			// This error should have been caught by enqueueService
+			utilruntime.HandleError(fmt.Errorf("Couldn't get key for service %+v: %v", service, err))
+			continue
+		}
+	}
+
+	// Add watch events back to the queue
+	for _, change := range pendingChanges {
+		ic.queue.Add(change)
+	}
+
+	glog.V(5).Infof("Completed processing initial sync")
+
+	return true
+}
+
+// getCachedService logs if unable to retrieve a service for the given key.
+func (ic *IngressIPController) getCachedService(key string) *kapi.Service {
+	if len(key) == 0 {
+		return nil
+	}
+	if obj, exists, err := ic.cache.GetByKey(key); err != nil {
+		glog.V(5).Infof("Unable to retrieve service %v from store: %v", key, err)
+	} else if !exists {
+		glog.V(6).Infof("Service %v has been deleted", key)
+	} else {
+		return obj.(*kapi.Service)
+	}
+	return nil
+}
+
+// recordLocalAllocation attempts to update local state for the given
+// service key and ingress ip.  Returns a boolean indication of
+// whether reallocation is necessary and an error indicating the
+// reason for reallocation.  If reallocation is not indicated, a
+// non-nil error indicates an exceptional condition.
+func (ic *IngressIPController) recordLocalAllocation(key, ipString string) (reallocate bool, err error) {
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return true, fmt.Errorf("Service %v has an invalid ingress ip %v.  A new ip will be allocated.", key, ipString)
+	}
+
+	ipKey, ok := ic.allocationMap[ipString]
+	switch {
+	case ok && ipKey == key:
+		// Allocation exists for this service
+		return false, nil
+	case ok && ipKey != key:
+		// TODO prefer removing the allocation from a service that does not have a matching LoadBalancerIP
+		return true, fmt.Errorf("Another service is using ingress ip %v.  A new ip will be allocated for %v.", ipString, key)
+	}
+
+	err = ic.ipAllocator.Allocate(ip)
+	switch {
+	case err == ipallocator.ErrNotInRange:
+		return true, fmt.Errorf("The ingress ip %v for service %v is not in the ingress range.  A new ip will be allocated.", ipString, key)
+	case err != nil:
+		// The only other error that Allocate() can throw is ErrAllocated, but that
+		// should not happen after the check against the allocation map.
+		return false, fmt.Errorf("Unexpected error from ip allocator for service %v: %v", key, err)
+	}
+	ic.allocationMap[ipString] = key
+	glog.V(5).Infof("Recorded allocation of ip %v for service %v", ipString, key)
+	return false, nil
+}
+
+// work dispatches the next item in the queue to the change handler.
+// If the change handler returns an error, the change will be added to
+// the end of the queue to be processed again.  Returns a boolean
+// indication of whether processing should continue.
+func (ic *IngressIPController) work() bool {
+	item, quit := ic.queue.Get()
+	if quit {
+		return false
+	}
+	change := item.(*serviceChange)
+	defer ic.queue.Done(change)
+
+	if change.requeuedAllocation {
+		// Reset the allocation state so that the change can be
+		// requeued if necessary.  Only additions/updates are requeued
+		// for allocation so change.key should be non-empty.
+		change.requeuedAllocation = false
+		ic.requeuedAllocations.Delete(change.key)
+	}
+
+	if err := ic.changeHandler(change); err == nil {
+		// No further processing required
+		ic.queue.Forget(change)
+	} else {
+		if err == ipallocator.ErrFull {
+			// When the range is full, avoid requeueing more than a
+			// single change requiring allocation per service.
+			// Otherwise the queue could grow without bounds as every
+			// service update would add another change that would be
+			// endlessly requeued.
+			if ic.requeuedAllocations.Has(change.key) {
+				return true
+			}
+			change.requeuedAllocation = true
+			ic.requeuedAllocations.Insert(change.key)
+			service := ic.getCachedService(change.key)
+			if service != nil {
+				ic.recorder.Eventf(service, kapi.EventTypeWarning, "IngressIPRangeFull", "No available ingress ip to allocate to service %s", change.key)
+			}
+		}
+		// Failed but can be retried
+		utilruntime.HandleError(fmt.Errorf("error syncing service, it will be retried: %v", err))
+		ic.queue.AddRateLimited(change)
+	}
+
+	return true
+}
+
+// processChange responds to a service change by synchronizing the
+// local and persisted ingress ip allocation state of the service.
+func (ic *IngressIPController) processChange(change *serviceChange) error {
+	service := ic.getCachedService(change.key)
+
+	ic.clearOldAllocation(service, change.oldService)
+
+	if service == nil {
+		// Service was deleted - no further processing required
+		return nil
+	}
+
+	typeLoadBalancer := service.Spec.Type == kapi.ServiceTypeLoadBalancer
+	hasAllocation := len(service.Status.LoadBalancer.Ingress) > 0
+	switch {
+	case typeLoadBalancer && hasAllocation:
+		return ic.recordAllocation(service, change.key)
+	case typeLoadBalancer && !hasAllocation:
+		return ic.allocate(service, change.key)
+	case !typeLoadBalancer && hasAllocation:
+		return ic.deallocate(service, change.key)
+	default:
+		return nil
+	}
+}
+
+// clearOldAllocation clears the old allocation for a service if it
+// differs from a new allocation.  Returns a boolean indication of
+// whether the old allocation was cleared.
+func (ic *IngressIPController) clearOldAllocation(new, old *kapi.Service) bool {
+	oldIP := ""
+	if old != nil && old.Spec.Type == kapi.ServiceTypeLoadBalancer && len(old.Status.LoadBalancer.Ingress) > 0 {
+		oldIP = old.Status.LoadBalancer.Ingress[0].IP
+	}
+	noOldAllocation := len(oldIP) == 0
+	if noOldAllocation {
+		return false
+	}
+
+	newIP := ""
+	if new != nil && new.Spec.Type == kapi.ServiceTypeLoadBalancer && len(new.Status.LoadBalancer.Ingress) > 0 {
+		newIP = new.Status.LoadBalancer.Ingress[0].IP
+	}
+	allocationUnchanged := newIP == oldIP
+	if allocationUnchanged {
+		return false
+	}
+
+	// New allocation differs from old due to update or deletion
+
+	// Get the key from the old service since the new service may be nil
+	if key, err := controller.KeyFunc(old); err == nil {
+		ic.clearLocalAllocation(key, oldIP)
+		return true
+	} else {
+		// Recovery/retry not possible for this error
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", old, err))
+		return false
+	}
+}
+
+// recordAllocation updates local state with the ingress ip indicated
+// in a service's status and ensures that the ingress ip appears in
+// the service's list of external ips.  If the service's ingress ip is
+// invalid for any reason, a new ip will be allocated.
+func (ic *IngressIPController) recordAllocation(service *kapi.Service, key string) error {
+	// If more than one ingress ip is present, it will be ignored
+	ipString := service.Status.LoadBalancer.Ingress[0].IP
+
+	reallocate, err := ic.recordLocalAllocation(key, ipString)
+	if !reallocate && err != nil {
+		return err
+	}
+	reallocateMessage := ""
+	if err != nil {
+		reallocateMessage = err.Error()
+	}
+
+	// Make a copy to modify to avoid mutating cache state
+	t, err := kapi.Scheme.DeepCopy(service)
+	if err != nil {
+		return err
+	}
+	service = t.(*kapi.Service)
+
+	if reallocate {
+		// TODO update the external ips but not the status since
+		// allocate() will overwrite any existing allocation.
+		if err = ic.clearPersistedAllocation(service, key, reallocateMessage); err != nil {
+			return err
+		}
+		ic.recorder.Eventf(service, kapi.EventTypeWarning, "IngressIPReallocated", reallocateMessage)
+		return ic.allocate(service, key)
+	} else {
+		// Ensure that the ingress ip is present in the service's spec.
+		return ic.ensureExternalIP(service, key, ipString)
+	}
+}
+
+// allocate assigns an unallocated ip to a service and updates the
+// service's persisted state.
+func (ic *IngressIPController) allocate(service *kapi.Service, key string) error {
+	// Make a copy to avoid mutating cache state
+	t, err := kapi.Scheme.DeepCopy(service)
+	if err != nil {
+		return err
+	}
+	service = t.(*kapi.Service)
+
+	ip, err := ic.allocateIP(service.Spec.LoadBalancerIP)
+	if err != nil {
+		return err
+	}
+	ipString := ip.String()
+
+	glog.V(5).Infof("Allocating ip %v to service %v", ipString, key)
+	service.Status = kapi.ServiceStatus{
+		LoadBalancer: kapi.LoadBalancerStatus{
+			Ingress: []kapi.LoadBalancerIngress{
+				{
+					IP: ipString,
+				},
+			},
+		},
+	}
+	if err = ic.persistServiceStatus(service); err != nil {
+		if releaseErr := ic.ipAllocator.Release(ip); releaseErr != nil {
+			// Release from contiguous allocator should never return an error, but just in case...
+			utilruntime.HandleError(fmt.Errorf("Error releasing ip %v for service %v: %v", ipString, key, releaseErr))
+		}
+		return err
+	}
+	ic.allocationMap[ipString] = key
+
+	return ic.ensureExternalIP(service, key, ipString)
+}
+
+// deallocate ensures that the ip currently allocated to a service is
+// removed and that its loadbalancer status is cleared.
+func (ic *IngressIPController) deallocate(service *kapi.Service, key string) error {
+	glog.V(5).Infof("Clearing allocation state for %v", key)
+
+	// Make a copy to modify to avoid mutating cache state
+	t, err := kapi.Scheme.DeepCopy(service)
+	if err != nil {
+		return err
+	}
+	service = t.(*kapi.Service)
+
+	// Get the ingress ip to remove from local allocation state before
+	// it is removed from the service.
+	ipString := service.Status.LoadBalancer.Ingress[0].IP
+
+	if err = ic.clearPersistedAllocation(service, key, ""); err != nil {
+		return err
+	}
+
+	ic.clearLocalAllocation(key, ipString)
+	return nil
+}
+
+// clearLocalAllocation clears an in-memory allocation if it belongs
+// to the specified service key.
+func (ic *IngressIPController) clearLocalAllocation(key, ipString string) bool {
+	glog.V(5).Infof("Attempting to clear local allocation of ip %v for service %v", ipString, key)
+
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		// An invalid ip address cannot be deallocated
+		utilruntime.HandleError(fmt.Errorf("Error parsing ip: %v", ipString))
+		return false
+	}
+
+	ipKey, ok := ic.allocationMap[ipString]
+	switch {
+	case !ok:
+		glog.V(6).Infof("IP address %v is not currently allocated", ipString)
+		return false
+	case key != ipKey:
+		glog.V(6).Infof("IP address %v is not allocated to service %v", ipString, key)
+		return false
+	}
+
+	// Remove allocation
+	if err := ic.ipAllocator.Release(ip); err != nil {
+		// Release from contiguous allocator should never return an error.
+		utilruntime.HandleError(fmt.Errorf("Error releasing ip %v for service %v: %v", ipString, key, err))
+		return false
+	}
+	delete(ic.allocationMap, ipString)
+	glog.V(5).Infof("IP address %v is now available for allocation", ipString)
+	return true
+}
+
+// clearPersistedAllocation ensures there is no ingress ip in the
+// service's spec and that the service's status is cleared.
+func (ic *IngressIPController) clearPersistedAllocation(service *kapi.Service, key, errMessage string) error {
+	// Assume it is safe to modify the service without worrying about changing the local cache
+
+	if len(errMessage) > 0 {
+		utilruntime.HandleError(fmt.Errorf(errMessage))
+	} else {
+		glog.V(5).Infof("Attempting to clear persisted allocation for service: %v", key)
+	}
+
+	// An ingress ip is only allowed in ExternalIPs when a
+	// corresponding status exists, so update the spec first to avoid
+	// failing admission control.
+	ingressIP := service.Status.LoadBalancer.Ingress[0].IP
+	for i, ip := range service.Spec.ExternalIPs {
+		if ip == ingressIP {
+			glog.V(5).Infof("Removing ip %v from the external ips of service %v", ingressIP, key)
+			service.Spec.ExternalIPs = append(service.Spec.ExternalIPs[:i], service.Spec.ExternalIPs[i+1:]...)
+			if err := ic.persistServiceSpec(service); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	service.Status.LoadBalancer = kapi.LoadBalancerStatus{}
+	glog.V(5).Infof("Clearing the load balancer status of service: %v", key)
+	return ic.persistServiceStatus(service)
+}
+
+// ensureExternalIP ensures that the provided service has the ingress
+// ip persisted as an external ip.
+func (ic *IngressIPController) ensureExternalIP(service *kapi.Service, key, ingressIP string) error {
+	// Assume it is safe to modify the service without worrying about changing the local cache
+
+	ipExists := false
+	for _, ip := range service.Spec.ExternalIPs {
+		if ip == ingressIP {
+			ipExists = true
+			glog.V(6).Infof("Service %v already has ip %v as an external ip", key, ingressIP)
+			break
+		}
+	}
+	if !ipExists {
+		service.Spec.ExternalIPs = append(service.Spec.ExternalIPs, ingressIP)
+		glog.V(5).Infof("Adding ip %v to service %v as an external ip", ingressIP, key)
+		return ic.persistServiceSpec(service)
+	}
+	return nil
+}
+
+// allocateIP attempts to allocate the requested ip, and if that is
+// not possible, allocates the next available address.
+func (ic *IngressIPController) allocateIP(requestedIP string) (net.IP, error) {
+	if len(requestedIP) == 0 {
+		// Specific ip not requested
+		return ic.ipAllocator.AllocateNext()
+	}
+	var ip net.IP
+	if ip = net.ParseIP(requestedIP); ip == nil {
+		// Invalid ip
+		return ic.ipAllocator.AllocateNext()
+	}
+	if err := ic.ipAllocator.Allocate(ip); err != nil {
+		// Unable to allocate requested ip
+		return ic.ipAllocator.AllocateNext()
+	}
+	// Allocated requested ip
+	return ip, nil
+}
+
+func (ic *IngressIPController) persistServiceSpec(service *kapi.Service) error {
+	return ic.persistenceHandler(ic.client, service, false)
+}
+
+func (ic *IngressIPController) persistServiceStatus(service *kapi.Service) error {
+	return ic.persistenceHandler(ic.client, service, true)
+}
+
+func persistService(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+	backoff := wait.Backoff{
+		Steps:    clientRetryCount,
+		Duration: clientRetryInterval,
+	}
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
+		var err error
+		if targetStatus {
+			_, err = client.Services(service.Namespace).UpdateStatus(service)
+		} else {
+			_, err = client.Services(service.Namespace).Update(service)
+		}
+		switch {
+		case err == nil:
+			return true, nil
+		case kerrors.IsNotFound(err):
+			// If the service no longer exists, we don't want to recreate
+			// it. Just bail out so that we can process the delete, which
+			// we should soon be receiving if we haven't already.
+			glog.V(5).Infof("Not persisting update to service '%s/%s' that no longer exists: %v",
+				service.Namespace, service.Name, err)
+			return true, nil
+		case kerrors.IsConflict(err):
+			// TODO: Try to resolve the conflict if the change was
+			// unrelated to load balancer status. For now, just rely on
+			// the fact that we'll also process the update that caused the
+			// resource version to change.
+			glog.V(5).Infof("Not persisting update to service '%s/%s' that has been changed since we received it: %v",
+				service.Namespace, service.Name, err)
+			return true, nil
+		default:
+			err = fmt.Errorf("Failed to persist updated LoadBalancerStatus to service '%s/%s': %v",
+				service.Namespace, service.Name, err)
+			return false, err
+		}
+	})
+}

--- a/pkg/service/controller/ingressip/controller_test.go
+++ b/pkg/service/controller/ingressip/controller_test.go
@@ -1,0 +1,610 @@
+package ingressip
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/registry/service/ipallocator"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+const namespace = "ns"
+
+func newController(t *testing.T, client *ktestclient.Fake) *IngressIPController {
+	_, ipNet, err := net.ParseCIDR("172.16.0.12/28")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return NewIngressIPController(client, ipNet, 10*time.Minute)
+}
+
+func controllerSetup(t *testing.T, startingObjects []runtime.Object) (*ktestclient.Fake, *watch.FakeWatcher, *IngressIPController) {
+	client := ktestclient.NewSimpleFake(startingObjects...)
+
+	fakeWatch := watch.NewFake()
+	client.PrependWatchReactor("*", ktestclient.DefaultWatchReactor(fakeWatch, nil))
+
+	client.PrependReactor("create", "*", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		obj := action.(ktestclient.CreateAction).GetObject()
+		fakeWatch.Add(obj)
+		return true, obj, nil
+	})
+
+	// Ensure that updates the controller makes are passed through to the watcher.
+	client.PrependReactor("update", "*", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		obj := action.(ktestclient.CreateAction).GetObject()
+		fakeWatch.Modify(obj)
+		return true, obj, nil
+	})
+
+	controller := newController(t, client)
+
+	return client, fakeWatch, controller
+}
+
+func newService(name, ip string, typeLoadBalancer bool) *kapi.Service {
+	serviceType := kapi.ServiceTypeClusterIP
+	if typeLoadBalancer {
+		serviceType = kapi.ServiceTypeLoadBalancer
+	}
+	service := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: kapi.ServiceSpec{
+			Type: serviceType,
+		},
+	}
+	if len(ip) > 0 {
+		service.Status = kapi.ServiceStatus{
+			LoadBalancer: kapi.LoadBalancerStatus{
+				Ingress: []kapi.LoadBalancerIngress{
+					{
+						IP: ip,
+					},
+				},
+			},
+		}
+	}
+	return service
+}
+
+func TestProcessInitialSync(t *testing.T) {
+	c := newController(t, nil)
+
+	allocatedKey := "lb-allocated"
+	allocatedIP := "172.16.0.1"
+	services := []*kapi.Service{
+		newService("regular", "", false),
+		newService(allocatedKey, allocatedIP, true),
+		newService("lb-reallocate", "foo", true),
+		newService("lb-unallocated", "", true),
+	}
+	for _, service := range services {
+		c.enqueueChange(service, nil)
+		c.cache.Add(service)
+	}
+	// Queue a change without caching it to validate that it is ignored
+	c.enqueueChange(newService("ignored", "", true), nil)
+
+	// Enqueue post-sync changes to validate that they are added back
+	// to the queue without being processed.
+	postSyncUpdate := services[0]
+	c.enqueueChange(postSyncUpdate, postSyncUpdate)
+	c.cache.Update(postSyncUpdate)
+	postSyncAddition := newService("lb-post-sync-addition", "", true)
+	c.enqueueChange(postSyncAddition, nil)
+	c.cache.Add(postSyncAddition)
+
+	c.processInitialSync()
+
+	// Validate allocation
+	expectedMap := map[string]string{
+		allocatedIP: fmt.Sprintf("%s/%s", namespace, allocatedKey),
+	}
+	if !reflect.DeepEqual(c.allocationMap, expectedMap) {
+		t.Errorf("Expected allocation map %v, got %v", expectedMap, c.allocationMap)
+	}
+	if !c.ipAllocator.Has(net.ParseIP(allocatedIP)) {
+		t.Errorf("IP %v was not marked as allocated", allocatedIP)
+	}
+
+	// Validate queue contents
+	expectedQueueLength := 5 // 3 from initial sync, 2 from post-sync changes
+	if c.queue.Len() != expectedQueueLength {
+		t.Errorf("Expected queue length of %d, got %d", expectedQueueLength, c.queue.Len())
+	}
+}
+
+func TestWorkRequeuesWhenFull(t *testing.T) {
+	tests := []struct {
+		testName        string
+		requeuedChange  bool
+		requeuedService bool
+		requeued        bool
+	}{
+		{
+			testName: "Previously requeued change should be requeued",
+			requeued: true,
+		},
+		{
+			testName:        "The only pending allocation should be requeued",
+			requeuedChange:  true,
+			requeuedService: true,
+			requeued:        true,
+		},
+		{
+			testName:        "Already requeued allocation should not be requeued",
+			requeuedService: true,
+			requeued:        false,
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		c.changeHandler = func(change *serviceChange) error {
+			return ipallocator.ErrFull
+		}
+		// Use a queue with no delay to avoid timing issues
+		c.queue = workqueue.NewRateLimitingQueue(workqueue.NewMaxOfRateLimiter())
+		change := &serviceChange{
+			key:                "foo",
+			requeuedAllocation: test.requeuedChange,
+		}
+		if test.requeuedService {
+			c.requeuedAllocations.Insert(change.key)
+		}
+		c.queue.Add(change)
+
+		c.work()
+
+		requeued := (c.queue.Len() == 1)
+		if test.requeued != requeued {
+			t.Errorf("Expected requeued == %v, got %v", test.requeued, requeued)
+		}
+	}
+}
+
+func TestProcessChange(t *testing.T) {
+	tests := []struct {
+		testName    string
+		ip          string
+		lb          bool
+		deleted     bool
+		allocatedIP string
+		ipAllocated bool
+	}{
+		{
+			testName: "Deleted service",
+			deleted:  true,
+		},
+		{
+			testName:    "Existing allocation",
+			ip:          "172.16.0.1",
+			lb:          true,
+			allocatedIP: "172.16.0.1",
+		},
+		{
+			testName:    "Needs allocation",
+			lb:          true,
+			ipAllocated: true,
+		},
+		{
+			testName: "Needs deallocation",
+			ip:       "172.16.0.1",
+			lb:       false,
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		c.persistenceHandler = func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+			return nil
+		}
+		s := newService("svc", test.ip, test.lb)
+		if !test.deleted {
+			c.cache.Add(s)
+		}
+		key := fmt.Sprintf("%s/%s", namespace, s.Name)
+		addAllocation := len(test.ip) > 0 && len(test.allocatedIP) == 0
+		if addAllocation {
+			c.allocationMap[test.ip] = key
+		}
+		change := &serviceChange{key: key}
+
+		freeBefore := c.ipAllocator.Free()
+
+		c.processChange(change)
+
+		switch {
+		case len(test.allocatedIP) > 0:
+			if _, ok := c.allocationMap[test.allocatedIP]; !ok {
+				t.Errorf("%s: %v was not allocated as expected", test.testName, test.allocatedIP)
+			}
+		case test.ipAllocated:
+			if freeBefore == c.ipAllocator.Free() {
+				t.Errorf("%s: ip was not allocated", test.testName)
+			}
+		case len(test.ip) > 0:
+			if _, ok := c.allocationMap[test.ip]; ok {
+				t.Errorf("%s: %v was not deallocated as expected", test.testName, test.ip)
+			}
+		}
+	}
+}
+
+func TestClearOldAllocation(t *testing.T) {
+	tests := []struct {
+		testName string
+		oldIP    string
+		newIP    string
+		cleared  bool
+	}{
+		{
+			testName: "No old allocation",
+			oldIP:    "",
+			newIP:    "foo",
+		},
+		{
+			testName: "Unchanged allocation",
+			oldIP:    "172.16.0.1",
+			newIP:    "172.16.0.1",
+		},
+		{
+			testName: "Old allocation should be cleared",
+			oldIP:    "172.16.0.1",
+			newIP:    "172.16.0.2",
+			cleared:  true,
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		new := newService("new", test.newIP, true)
+		old := newService("old", test.oldIP, true)
+		if cleared := c.clearOldAllocation(new, old); test.cleared != cleared {
+			t.Errorf("%s: expected cleared %v, got %v", test.testName, test.cleared, cleared)
+		}
+	}
+}
+
+func TestRecordAllocationReallocates(t *testing.T) {
+	c := newController(t, nil)
+	var persisted *kapi.Service
+	// Keep track of the last-persisted service
+	c.persistenceHandler = func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+		persisted = service
+		return nil
+	}
+	s := newService("bad-ip", "foo", true)
+	key := fmt.Sprintf("%s/%s", namespace, s.Name)
+	err := c.recordAllocation(s, key)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if persisted == nil {
+		t.Errorf("Service was not persisted")
+	}
+	if len(c.allocationMap) != 1 {
+		t.Errorf("Service ip was not reallocated")
+	}
+	if ingress := persisted.Status.LoadBalancer.Ingress; len(ingress) == 0 {
+		t.Errorf("Ingress ip was not persisted")
+	}
+}
+
+func TestAllocateReleasesOnPersistenceFailure(t *testing.T) {
+	c := newController(t, nil)
+	expectedFree := c.ipAllocator.Free()
+	expectedErr := errors.New("Persistence failure")
+	c.persistenceHandler = func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+		return expectedErr
+	}
+	s := newService("svc", "", true)
+	key := fmt.Sprintf("%s/%s", namespace, s.Name)
+	err := c.allocate(s, key)
+	if !reflect.DeepEqual(expectedErr, err) {
+		t.Fatalf("Expected err %v, got %v", expectedErr, err)
+	}
+	if expectedFree != c.ipAllocator.Free() {
+		t.Fatalf("IP wasn't released on error")
+	}
+}
+
+func TestClearLocalAllocation(t *testing.T) {
+	tests := []struct {
+		testName     string
+		key          string
+		ip           string
+		allocatedKey string
+		cleared      bool
+	}{
+		{
+			testName: "Invalid ip",
+			ip:       "foo",
+		},
+		{
+			testName: "IP not allocated",
+			ip:       "172.16.0.1",
+		},
+		{
+			testName:     "IP not allocated to service",
+			key:          "foo",
+			ip:           "172.16.0.1",
+			allocatedKey: "bar",
+		},
+		{
+			testName:     "Local ip allocation cleared",
+			key:          "foo",
+			ip:           "172.16.0.1",
+			allocatedKey: "foo",
+			cleared:      true,
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		if len(test.allocatedKey) > 0 {
+			c.allocationMap[test.ip] = test.allocatedKey
+			c.ipAllocator.Allocate(net.ParseIP(test.ip))
+		}
+		if cleared := c.clearLocalAllocation(test.key, test.ip); test.cleared != cleared {
+			t.Errorf("%s: expected cleared %v, got %v", test.testName, test.cleared, cleared)
+		} else if cleared {
+			if _, ok := c.allocationMap[test.ip]; ok {
+				t.Errorf("%s: allocation map was not cleared", test.testName)
+			}
+			if c.ipAllocator.Has(net.ParseIP(test.ip)) {
+				t.Errorf("%s: ip %v is still allocated", test.testName, test.ip)
+			}
+		}
+	}
+}
+
+func TestEnsureExternalIPRespectsNonIngress(t *testing.T) {
+	c := newController(t, nil)
+	c.persistenceHandler = func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+		return nil
+	}
+	ingressIP := "172.16.0.1"
+	s := newService("foo", ingressIP, true)
+	externalIP := "172.16.1.1"
+	s.Spec.ExternalIPs = append(s.Spec.ExternalIPs, externalIP)
+	c.ensureExternalIP(s, s.Name, ingressIP)
+	expectedExternalIPs := []string{externalIP, ingressIP}
+	externalIPs := s.Spec.ExternalIPs
+	if !reflect.DeepEqual(expectedExternalIPs, externalIPs) {
+		t.Errorf("Expected ExternalIPs %v, got %v", expectedExternalIPs, externalIPs)
+	}
+}
+
+func TestAllocateIP(t *testing.T) {
+	tests := []struct {
+		testName    string
+		requestedIP string
+		allocated   bool
+		asRequested bool
+	}{
+		{
+			testName:    "No requested ip",
+			requestedIP: "",
+			asRequested: false,
+		},
+		{
+			testName:    "Invalid ip",
+			requestedIP: "foo",
+			asRequested: false,
+		},
+		{
+			testName:    "IP not available",
+			requestedIP: "172.16.0.1",
+			allocated:   true,
+			asRequested: false,
+		},
+		{
+			testName:    "Available",
+			requestedIP: "172.16.0.1",
+			asRequested: true,
+		},
+	}
+	for _, test := range tests {
+		controller := newController(t, nil)
+		if test.allocated {
+			ip := net.ParseIP(test.requestedIP)
+			controller.ipAllocator.Allocate(ip)
+		}
+		// Expect no error for these
+		ip, err := controller.allocateIP(test.requestedIP)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if test.asRequested && ip.String() != test.requestedIP {
+			t.Errorf("%s: expected %s but got %s", test.testName, test.requestedIP, ip.String())
+		}
+		if !test.asRequested && ip.String() == test.requestedIP {
+			t.Errorf("%s: did not expect %s", test.testName, test.requestedIP)
+		}
+	}
+}
+
+func TestRecordLocalAllocation(t *testing.T) {
+	key := "svc1"
+	ip := "172.16.0.1"
+	otherKey := "svc2"
+	tests := []struct {
+		testName      string
+		allocationMap map[string]string
+		ip            string
+		reallocate    bool
+		errExpected   bool
+	}{
+		{
+			testName:    "Invalid ip",
+			ip:          "foo",
+			reallocate:  true,
+			errExpected: true,
+		},
+		{
+			testName: "Allocation exists for service",
+			allocationMap: map[string]string{
+				ip: key,
+			},
+			ip: ip,
+		},
+		{
+			testName: "Allocation exists for another service",
+			allocationMap: map[string]string{
+				ip: otherKey,
+			},
+			ip:          ip,
+			reallocate:  true,
+			errExpected: true,
+		},
+		{
+			testName:    "IP not in range",
+			ip:          "172.16.1.1",
+			reallocate:  true,
+			errExpected: true,
+		},
+		{
+			testName: "Allocation successful",
+			ip:       "172.16.0.1",
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		if test.allocationMap != nil {
+			c.allocationMap = test.allocationMap
+			for ipString := range test.allocationMap {
+				c.ipAllocator.Allocate(net.ParseIP(ipString))
+			}
+		}
+
+		reallocate, err := c.recordLocalAllocation(key, test.ip)
+
+		if test.reallocate != reallocate {
+			t.Errorf("%s: expected reallocate == %v but got %v", test.testName, test.reallocate, reallocate)
+		}
+		switch {
+		case test.errExpected && (err == nil):
+			t.Errorf("%s: expected error but didn't see one", test.testName)
+		case !test.errExpected && (err != nil):
+			t.Errorf("%s: saw unexpected error: %v", test.testName, err)
+		}
+
+		// Ensure allocation was successfully recorded
+		checkAllocation := !test.reallocate && !test.errExpected
+		if checkAllocation {
+			ipKey, ok := c.allocationMap[test.ip]
+			inMap := ok && ipKey == key
+			inAllocator := c.ipAllocator.Has(net.ParseIP(test.ip))
+			if !(inMap && inAllocator) {
+				t.Errorf("%s: allocation not recorded", test.testName)
+			}
+		}
+	}
+}
+
+func TestClearPersistedAllocation(t *testing.T) {
+	tests := []struct {
+		testName         string
+		persistenceError error
+		ingressIPCount   int
+	}{
+		{
+			testName:         "Status not cleared if external ip not removed",
+			persistenceError: errors.New(""),
+			ingressIPCount:   1,
+		},
+		{
+			testName: "Status cleared",
+		},
+	}
+	for _, test := range tests {
+		c := newController(t, nil)
+		var persistedService *kapi.Service
+		c.persistenceHandler = func(client kclient.ServicesNamespacer, service *kapi.Service, targetStatus bool) error {
+			// Save the last persisted service
+			persistedService = service
+			return test.persistenceError
+		}
+		ip := "172.16.0.1"
+		s := newService("svc", ip, true)
+		// Add other external ips to ensure they are not affected by controller
+		s.Spec.ExternalIPs = []string{"172.16.1.1", ip, "172.16.1.2"}
+		key := fmt.Sprintf("%s/%s", namespace, s.Name)
+		c.clearPersistedAllocation(s, key, "")
+
+		expectedExternalIPs := []string{"172.16.1.1", "172.16.1.2"}
+		externalIPs := persistedService.Spec.ExternalIPs
+		if !reflect.DeepEqual(expectedExternalIPs, externalIPs) {
+			t.Errorf("%s: Expected ExternalIPs %v, got %v", test.testName, expectedExternalIPs, externalIPs)
+		}
+		ingressIPCount := len(persistedService.Status.LoadBalancer.Ingress)
+		if test.ingressIPCount != ingressIPCount {
+			t.Errorf("%s: Expected %d ingress ips, got %d", test.testName, test.ingressIPCount, ingressIPCount)
+		}
+	}
+}
+
+// TestBasicControllerFlow validates controller start, initial sync
+// processing, and post-sync processing.
+func TestBasicControllerFlow(t *testing.T) {
+	startingObjects := []runtime.Object{
+		newService("lb-unallocated", "", true),
+	}
+
+	stopChannel := make(chan struct{})
+	defer close(stopChannel)
+
+	_, fakeWatch, controller := controllerSetup(t, startingObjects)
+
+	updated := make(chan bool)
+	deleted := make(chan bool)
+
+	controller.changeHandler = func(change *serviceChange) error {
+		defer func() {
+			if len(change.key) == 0 {
+				deleted <- true
+			} else if change.oldService != nil {
+				updated <- true
+			}
+		}()
+
+		err := controller.processChange(change)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		return err
+	}
+
+	go controller.Run(stopChannel)
+
+	waitForUpdate := func(msg string) {
+		t.Logf("waiting for: %v", msg)
+		select {
+		case <-updated:
+		case <-time.After(time.Duration(30 * time.Second)):
+			t.Fatalf("failed to see: %v", msg)
+		}
+	}
+
+	waitForUpdate("spec update")
+	waitForUpdate("status update")
+
+	fakeWatch.Delete(startingObjects[0])
+
+	t.Log("waiting for the service to be deleted")
+	select {
+	case <-deleted:
+	case <-time.After(time.Duration(30 * time.Second)):
+		t.Fatalf("failed to see expected service deletion")
+	}
+}

--- a/test/integration/ingressip_test.go
+++ b/test/integration/ingressip_test.go
@@ -1,0 +1,217 @@
+package integration
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/service/controller/ingressip"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const sentinelName = "sentinel"
+
+// TestIngressIPAllocation validates that ingress ip allocation is
+// performed correctly even when multiple controllers are running.
+func TestIngressIPAllocation(t *testing.T) {
+	testutil.RequireEtcd(t)
+
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	masterConfig.NetworkConfig.ExternalIPNetworkCIDRs = []string{"172.16.0.0/24"}
+	masterConfig.NetworkConfig.IngressIPNetworkCIDR = "172.16.1.0/24"
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterWithOptions(masterConfig, testserver.TestOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	kc, _, err := configapi.GetKubeClient(clusterAdminKubeConfig, &configapi.ClientConnectionOverrides{
+		QPS:   20,
+		Burst: 50,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	stopChannel := make(chan struct{})
+	defer close(stopChannel)
+	received := make(chan bool)
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	t.Log("start informer to watch for sentinel")
+	_, informerController := framework.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+				return kc.Services(kapi.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+				return kc.Services(kapi.NamespaceAll).Watch(options)
+			},
+		},
+		&kapi.Service{},
+		time.Minute*10,
+		framework.ResourceEventHandlerFuncs{
+			UpdateFunc: func(old, cur interface{}) {
+				service := cur.(*kapi.Service)
+				if service.Name == sentinelName && len(service.Spec.ExternalIPs) > 0 {
+					received <- true
+				}
+			},
+		},
+	)
+	go informerController.Run(stopChannel)
+
+	t.Log("start generating service events")
+	go generateServiceEvents(t, kc)
+
+	// Start a second controller that will be out of sync with the first
+	_, ipNet, err := net.ParseCIDR(masterConfig.NetworkConfig.IngressIPNetworkCIDR)
+	c := ingressip.NewIngressIPController(kc, ipNet, 10*time.Minute)
+	go c.Run(stopChannel)
+
+	t.Log("waiting for sentinel to be updated with external ip")
+	select {
+	case <-received:
+	case <-time.After(time.Duration(90 * time.Second)):
+		t.Fatal("took too long")
+	}
+
+	// Validate that all services of type load balancer have a unique
+	// ingress ip and corresponding external ip.
+	services, err := kc.Services(kapi.NamespaceDefault).List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	ips := sets.NewString()
+	for _, s := range services.Items {
+		typeLoadBalancer := s.Spec.Type == kapi.ServiceTypeLoadBalancer
+		hasAllocation := len(s.Status.LoadBalancer.Ingress) > 0
+		switch {
+		case !typeLoadBalancer && !hasAllocation:
+			continue
+		case !typeLoadBalancer && hasAllocation:
+			t.Errorf("A service not of type load balancer has an ingress ip allocation")
+			continue
+		case typeLoadBalancer && !hasAllocation:
+			t.Errorf("A service of type load balancer has not been allocated an ingress ip")
+			continue
+		}
+		ingressIP := s.Status.LoadBalancer.Ingress[0].IP
+		if ips.Has(ingressIP) {
+			t.Errorf("One or more services have the same ingress ip")
+			continue
+		}
+		ips.Insert(ingressIP)
+		if len(s.Spec.ExternalIPs) == 0 || s.Spec.ExternalIPs[0] != ingressIP {
+			t.Errorf("Service does not have the ingress ip as an external ip")
+			continue
+		}
+	}
+}
+
+const (
+	createOp = iota
+	updateOp
+	deleteOp
+)
+
+func generateServiceEvents(t *testing.T, kc kclient.Interface) {
+	maxMillisecondInterval := 25
+	minServiceCount := 10
+	maxOperations := minServiceCount + 30
+	var services []*kapi.Service
+	for i := 0; i < maxOperations; {
+		op := createOp
+		if len(services) > minServiceCount {
+			op = rand.Intn(deleteOp + 1)
+		}
+		switch op {
+		case createOp:
+			typeChoice := rand.Intn(2)
+			typeLoadBalancer := false
+			if typeChoice == 1 {
+				typeLoadBalancer = true
+			}
+			s, err := createService(kc, "", typeLoadBalancer)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			services = append(services, s)
+			t.Logf("Added service %s", s.Name)
+		case updateOp:
+			targetIndex := rand.Intn(len(services))
+			name := services[targetIndex].Name
+			s, err := kc.Services(kapi.NamespaceDefault).Get(name)
+			if err != nil {
+				continue
+			}
+			// Flip the service type
+			if s.Spec.Type == kapi.ServiceTypeLoadBalancer {
+				s.Spec.Type = kapi.ServiceTypeClusterIP
+				s.Spec.Ports[0].NodePort = 0
+			} else {
+				s.Spec.Type = kapi.ServiceTypeLoadBalancer
+			}
+			s, err = kc.Services(kapi.NamespaceDefault).Update(s)
+			if err != nil {
+				continue
+			}
+			t.Logf("Updated service %s", name)
+		case deleteOp:
+			targetIndex := rand.Intn(len(services))
+			name := services[targetIndex].Name
+			err := kc.Services(kapi.NamespaceDefault).Delete(name)
+			if err != nil {
+				continue
+			}
+			services = append(services[:targetIndex], services[targetIndex+1:]...)
+			t.Logf("Deleted service %s", name)
+		}
+		i++
+		time.Sleep(time.Duration(rand.Intn(maxMillisecondInterval)) * time.Millisecond)
+	}
+
+	// Create one last service to serve as a sentinel. The service
+	// will be created after a slight delay so that it can be assured
+	// of being the last service a controller will see, and with a
+	// known name so its processing can be detected.
+	time.Sleep(time.Millisecond * 100)
+	_, err := createService(kc, sentinelName, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func createService(kc kclient.Interface, name string, typeLoadBalancer bool) (*kapi.Service, error) {
+	serviceType := kapi.ServiceTypeClusterIP
+	if typeLoadBalancer {
+		serviceType = kapi.ServiceTypeLoadBalancer
+	}
+	service := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			GenerateName: "service-",
+			Name:         name,
+		},
+		Spec: kapi.ServiceSpec{
+			Type: serviceType,
+			Ports: []kapi.ServicePort{{
+				Protocol: "TCP",
+				Port:     8080,
+			}},
+		},
+	}
+	return kc.Services(kapi.NamespaceDefault).Create(service)
+}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2894,6 +2894,43 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: system:service-ingress-ip-controller
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - services
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - services
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - services/status
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: system:service-load-balancer-controller
   rules:
   - apiGroups:


### PR DESCRIPTION
Add a new ExternalIP type to enable tracking of allocated IPs and make it possible to have an external address be allocated to a service automatically from the range indicated by ExternalIPNetworkCIDRs. The type is global in scope with the name an ip address to ensure an ip is allocated at most once. For simplicity, an IP will be dedicated to a single service rather than having the port space of an ip be shared between many services.

TODO:
 - Decide what policy and quota should be applied to the new type
 - Prevent deletion of an ExternalIP if a service is still using it
 - Delete ExternalIPs that are no longer referenced by a service
 - ~~Update the admission controller~~ Done
    - ~~Return an error if a requested external ip is already in use~~
    - ~~Create a new ExternalIP object for each requested external ip~~
 - Add support for automatically allocating an external ip for a service that defines an appropriate annotation (e.g. allocateExternalIP)
   - Store the automatically allocated ip address in the service's externalIP list.  This should eventually be replaced by ingress and use of a status field to separate spec/intent from cluster state.  For now, provide a degree of separation by supporting the allocation of a single address and refusing to allocate if externalIPs are specified statically.  


cc: @openshift/networking @smarterclayton 