### PR TITLE
Remove incorrect print statement from list pods

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -65,7 +65,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer, errout io.Writer) *co
 			Commands: []*cobra.Command{
 				buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, out),
 				diagnostics.NewCmdDiagnostics(diagnostics.DiagnosticsRecommendedName, fullName+" "+diagnostics.DiagnosticsRecommendedName, out),
-				node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out),
+				node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out, errout),
 				prune.NewCommandPrune(prune.PruneRecommendedName, fullName+" "+prune.PruneRecommendedName, f, out),
 			},
 		},

--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -115,7 +115,7 @@ func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
 		}
 
 		if firstPod {
-			fmt.Fprint(e.Options.Writer, "\nMigrating these pods on node: ", node.ObjectMeta.Name, "\n\n")
+			fmt.Fprint(e.Options.ErrWriter, "\nMigrating these pods on node: ", node.ObjectMeta.Name, "\n\n")
 			firstPod = false
 			printerWithHeaders.PrintObj(&pod, e.Options.Writer)
 		} else {

--- a/pkg/cmd/admin/node/evacuate_test.go
+++ b/pkg/cmd/admin/node/evacuate_test.go
@@ -1,9 +1,10 @@
 package node
 
 import (
-	"github.com/spf13/cobra"
 	"strconv"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestEvacuateFlags(t *testing.T) {
@@ -27,7 +28,7 @@ func TestEvacuateFlags(t *testing.T) {
 		},
 	}
 
-	cmd := NewCommandManageNode(nil, ManageNodeCommandName, ManageNodeCommandName, nil)
+	cmd := NewCommandManageNode(nil, ManageNodeCommandName, ManageNodeCommandName, nil, nil)
 	for _, v := range tests {
 		testFlag(cmd, v.flagName, v.defaultVal, t)
 	}

--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -61,7 +61,7 @@ func (l *ListPodsOptions) runListPods(node *kapi.Node, printer kubectl.ResourceP
 	if err != nil {
 		return err
 	}
-	fmt.Fprint(l.Options.Writer, "\nListing matched pods on node: ", node.ObjectMeta.Name, "\n\n")
+	fmt.Fprint(l.Options.ErrWriter, "\nListing matched pods on node: ", node.ObjectMeta.Name, "\n\n")
 	printer.PrintObj(pods, l.Options.Writer)
 
 	return err

--- a/pkg/cmd/admin/node/node.go
+++ b/pkg/cmd/admin/node/node.go
@@ -46,7 +46,7 @@ list-pods: List all/selected pods on given/selected nodes. It can list the outpu
 var schedulable, evacuate, listpods bool
 
 // NewCommandManageNode implements the OpenShift cli manage-node command
-func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, out io.Writer) *cobra.Command {
+func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, out, errout io.Writer) *cobra.Command {
 	opts := &NodeOptions{}
 	schedulableOp := &SchedulableOptions{Options: opts}
 	evacuateOp := NewEvacuateOptions(opts)
@@ -63,7 +63,7 @@ func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, ou
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
 			}
 
-			if err := opts.Complete(f, c, args, out); err != nil {
+			if err := opts.Complete(f, c, args, out, errout); err != nil {
 				kcmdutil.CheckErr(err)
 			}
 

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -28,6 +28,7 @@ type NodeOptions struct {
 	DefaultNamespace string
 	Kclient          *client.Client
 	Writer           io.Writer
+	ErrWriter        io.Writer
 
 	Mapper            meta.RESTMapper
 	Typer             runtime.ObjectTyper
@@ -44,7 +45,7 @@ type NodeOptions struct {
 	PodSelector string
 }
 
-func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out io.Writer) error {
+func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out, errout io.Writer) error {
 	defaultNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -62,6 +63,7 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	n.DefaultNamespace = defaultNamespace
 	n.Kclient = kc
 	n.Writer = out
+	n.ErrWriter = errout
 	n.Mapper = mapper
 	n.Typer = typer
 	n.RESTClientFactory = f.Factory.ClientForMapping


### PR DESCRIPTION
fixes #9244 

The print statements in `listpods.go` and `evacuate.go` cause issues when using `-o`.  These have been moved to `stderr`.

`oadm manage-node <node1> --list-pods -o json` now outputs the expected to `stdout`:

```json
{
    "metadata": {
        "selfLink": "/api/v1/pods",
        "resourceVersion": "3157"
    },
    "items": [
        {
...
```