### PR TITLE
add clusterquota to API server

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/resourceListing.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/resourceListing.json
@@ -26,6 +26,14 @@
     "description": "get information of a group"
    },
    {
+    "path": "/apis/apps/v1alpha1",
+    "description": "API at /apis/apps/v1alpha1"
+   },
+   {
+    "path": "/apis/apps",
+    "description": "get information of a group"
+   },
+   {
     "path": "/apis/autoscaling/v1",
     "description": "API at /apis/autoscaling/v1"
    },

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/genericapiserver/resource_config.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/genericapiserver/resource_config.go
@@ -27,6 +27,7 @@ type APIResourceConfigSource interface {
 	ResourceEnabled(resource unversioned.GroupVersionResource) bool
 	AllResourcesForVersionEnabled(version unversioned.GroupVersion) bool
 	AnyResourcesForVersionEnabled(version unversioned.GroupVersion) bool
+	AnyResourcesForGroupEnabled(group string) bool
 }
 
 // Specifies the overrides for various API group versions.
@@ -169,4 +170,16 @@ func (o *ResourceConfig) AnyResourcesForVersionEnabled(version unversioned.Group
 	}
 
 	return versionOverride.Enable
+}
+
+func (o *ResourceConfig) AnyResourcesForGroupEnabled(group string) bool {
+	for version := range o.GroupVersionResourceConfigs {
+		if version.Group == group {
+			if o.AnyResourcesForVersionEnabled(version) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
@@ -461,7 +461,7 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 		},
 	}
 
-	assert.Equal(3, len(groupList.Groups))
+	assert.Equal(4, len(groupList.Groups))
 	for _, group := range groupList.Groups {
 		if !expectGroupNames.Has(group.Name) {
 			t.Errorf("got unexpected group %s", group.Name)
@@ -488,7 +488,7 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assert.Equal(4, len(groupList.Groups))
+	assert.Equal(5, len(groupList.Groups))
 
 	expectGroupNames.Insert("company.com")
 	expectVersions["company.com"] = []unversioned.GroupVersionForDiscovery{thirdPartyGV}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/cacher.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/cacher.go
@@ -130,6 +130,10 @@ func NewCacher(
 		ResourcePrefix: resourcePrefix,
 		NewListFunc:    newListFunc,
 	}
+
+	if config.CacheCapacity == -1 {
+		config.CacheCapacity = 0
+	}
 	if scopeStrategy.NamespaceScoped() {
 		config.KeyFunc = func(obj runtime.Object) (string, error) {
 			return NamespaceKeyFunc(resourcePrefix, obj)

--- a/pkg/quota/api/fields.go
+++ b/pkg/quota/api/fields.go
@@ -1,0 +1,9 @@
+package api
+
+import "k8s.io/kubernetes/pkg/fields"
+
+func ClusterResourceQuotaToSelectableFields(quota *ClusterResourceQuota) fields.Set {
+	return fields.Set{
+		"metadata.name": quota.Name,
+	}
+}

--- a/pkg/quota/api/register.go
+++ b/pkg/quota/api/register.go
@@ -30,6 +30,9 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&kapi.ListOptions{},
 		&ClusterResourceQuota{},
 		&ClusterResourceQuotaList{},
+
+		&kapi.DeleteOptions{},
+		&kapi.ListOptions{},
 	)
 }
 

--- a/pkg/quota/api/v1/register.go
+++ b/pkg/quota/api/v1/register.go
@@ -3,7 +3,9 @@ package v1
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
+	versionedwatch "k8s.io/kubernetes/pkg/watch/versioned"
 )
 
 const GroupName = "quota.openshift.io"
@@ -30,7 +32,12 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&kapi.ListOptions{},
 		&ClusterResourceQuota{},
 		&ClusterResourceQuotaList{},
+
+		&kapiv1.DeleteOptions{},
+		&kapiv1.ListOptions{},
 	)
+
+	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }
 
 func (obj *ClusterResourceQuotaList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }

--- a/pkg/quota/registry/clusterresourcequota/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd.go
@@ -1,0 +1,52 @@
+package clusterresourcequota
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	"github.com/openshift/origin/pkg/util"
+	"github.com/openshift/origin/pkg/util/restoptions"
+)
+
+const ClusterResourceQuotaPath = "/" + quotaapi.GroupName + "/clusterresourcequotas"
+
+type REST struct {
+	*registry.Store
+}
+
+// NewStorage returns a RESTStorage object that will work against nodes.
+func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+	store := &registry.Store{
+		NewFunc:           func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
+		NewListFunc:       func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
+		QualifiedResource: quotaapi.Resource("clusterresourcequotas"),
+		KeyRootFunc: func(ctx kapi.Context) string {
+			return ClusterResourceQuotaPath
+		},
+		KeyFunc: func(ctx kapi.Context, id string) (string, error) {
+			return util.NoNamespaceKeyFunc(ctx, ClusterResourceQuotaPath, id)
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*quotaapi.ClusterResourceQuota).Name, nil
+		},
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return Matcher(label, field)
+		},
+
+		CreateStrategy:      Strategy,
+		UpdateStrategy:      Strategy,
+		DeleteStrategy:      Strategy,
+		ReturnDeletedObject: false,
+	}
+
+	if err := restoptions.ApplyOptions(optsGetter, store, ClusterResourceQuotaPath); err != nil {
+		return nil, err
+	}
+
+	return &REST{store}, nil
+}

--- a/pkg/quota/registry/clusterresourcequota/strategy.go
+++ b/pkg/quota/registry/clusterresourcequota/strategy.go
@@ -1,0 +1,75 @@
+package clusterresourcequota
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	"github.com/openshift/origin/pkg/quota/api/validation"
+)
+
+type strategy struct {
+	runtime.ObjectTyper
+}
+
+var Strategy = strategy{kapi.Scheme}
+
+func (strategy) NamespaceScoped() bool {
+	return false
+}
+
+// AllowCreateOnUpdate is false for policies.
+func (strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (strategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+func (strategy) GenerateName(base string) string {
+	return base
+}
+
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (strategy) PrepareForCreate(obj runtime.Object) {
+	_ = obj.(*quotaapi.ClusterResourceQuota)
+}
+
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+func (strategy) PrepareForUpdate(obj, old runtime.Object) {
+	_ = obj.(*quotaapi.ClusterResourceQuota)
+}
+
+// Canonicalize normalizes the object after validation.
+func (strategy) Canonicalize(obj runtime.Object) {
+}
+
+func (strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {
+	return validation.ValidateClusterResourceQuota(obj.(*quotaapi.ClusterResourceQuota))
+}
+
+func (strategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) field.ErrorList {
+	return validation.ValidateClusterResourceQuotaUpdate(obj.(*quotaapi.ClusterResourceQuota), old.(*quotaapi.ClusterResourceQuota))
+}
+
+// Matcher returns a generic matcher for a given label and field selector.
+func Matcher(label labels.Selector, field fields.Selector) generic.Matcher {
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			quota, ok := obj.(*quotaapi.ClusterResourceQuota)
+			if !ok {
+				return nil, nil, fmt.Errorf("not a quota")
+			}
+			return labels.Set(quota.ObjectMeta.Labels), quotaapi.ClusterResourceQuotaToSelectableFields(quota), nil
+		},
+	}
+}

--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -105,10 +105,14 @@ func (g *configRESTOptionsGetter) GetRESTOptions(resource unversioned.GroupResou
 		if err != nil {
 			return genericrest.RESTOptions{}, err
 		}
-		// TODO: choose destination group/version based on input group/resource
+		// TODO: choose destination group/version based on input group/resource, probably want to ALWAYS make a new etcd storage
 		// TODO: Tune the cache size
-		groupVersion := unversioned.GroupVersion{Group: "", Version: g.masterOptions.EtcdStorageConfig.OpenShiftStorageVersion}
-		g.etcdHelper = etcdstorage.NewEtcdStorage(etcdClient, kapi.Codecs.LegacyCodec(groupVersion), g.masterOptions.EtcdStorageConfig.OpenShiftStoragePrefix, false, genericapiserver.DefaultDeserializationCacheSize)
+		groupVersions := []unversioned.GroupVersion{
+			{Group: "", Version: g.masterOptions.EtcdStorageConfig.OpenShiftStorageVersion},
+			// TODO extend our storage config to describe targets for multiple groups
+			{Group: "quota.openshift.io", Version: "v1"},
+		}
+		g.etcdHelper = etcdstorage.NewEtcdStorage(etcdClient, kapi.Codecs.LegacyCodec(groupVersions...), g.masterOptions.EtcdStorageConfig.OpenShiftStoragePrefix, false, genericapiserver.DefaultDeserializationCacheSize)
 	}
 
 	configuredCacheSize, specified := g.cacheSizes[resource]

--- a/pkg/util/restoptions/interfaces.go
+++ b/pkg/util/restoptions/interfaces.go
@@ -8,3 +8,10 @@ import (
 type Getter interface {
 	GetRESTOptions(resource unversioned.GroupResource) (generic.RESTOptions, error)
 }
+
+type UpstreamGetterFunc func(resource unversioned.GroupResource) generic.RESTOptions
+
+func (f UpstreamGetterFunc) GetRESTOptions(resource unversioned.GroupResource) (generic.RESTOptions, error) {
+	options := f(resource)
+	return options, nil
+}


### PR DESCRIPTION
Adds the new `quota.openshift.io` group to the API server.  

@openshift/api-review Not for the faint of heart.  Turns out the API server is not set up in way that makes this easy/reasonable.  Should I try to make this work or should I give up and add them to the legacy group?  At some point we have to pay the piper...

@mfojtik fyi.  I might end up having to build out the full storage config API objects to make some of these changes more palatable.