### PR TITLE
Unmarshal ports given in integer format

### DIFF
--- a/third_party/github.com/docker/libcompose/project/types_yaml.go
+++ b/third_party/github.com/docker/libcompose/project/types_yaml.go
@@ -3,6 +3,7 @@ package project
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/flynn/go-shlex"
@@ -299,6 +300,8 @@ func toSepMapParts(value map[interface{}]interface{}, sep string) ([]string, err
 		if sk, ok := k.(string); ok {
 			if sv, ok := v.(string); ok {
 				parts = append(parts, sk+sep+sv)
+			} else if sv, ok := v.(int); ok {
+				parts = append(parts, sk+sep+strconv.FormatInt(int64(sv), 10))
 			} else {
 				return nil, fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
 			}


### PR DESCRIPTION
When docker-compose had a port number written in integer format, while conversion, it was not being marshalled to string format, added a type check which will do the int to string conversion.

Fixes issue #8859