### PR TITLE
Print warning next to deployment with restarting pods

### DIFF
--- a/pkg/api/kubegraph/analysis/pod.go
+++ b/pkg/api/kubegraph/analysis/pod.go
@@ -77,7 +77,7 @@ func FindRestartingPods(g osgraph.Graph, f osgraph.Namer, logsCommandName, secur
 						f.ResourceName(podNode)),
 					Suggestion: osgraph.Suggestion(suggestion),
 				})
-			case containerRestartedRecently(containerStatus, nowFn()):
+			case ContainerRestartedRecently(containerStatus, nowFn()):
 				markers = append(markers, osgraph.Marker{
 					Node: podNode,
 
@@ -120,7 +120,7 @@ func containerCrashLoopBackOff(status kapi.ContainerStatus) bool {
 	return status.State.Waiting != nil && status.State.Waiting.Reason == "CrashLoopBackOff"
 }
 
-func containerRestartedRecently(status kapi.ContainerStatus, now unversioned.Time) bool {
+func ContainerRestartedRecently(status kapi.ContainerStatus, now unversioned.Time) bool {
 	if status.RestartCount == 0 {
 		return false
 	}

--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -390,7 +390,7 @@ func (d *LatestDeploymentsDescriber) Describe(namespace, name string) (string, e
 	activeDeployment, inactiveDeployments := deployedges.RelevantDeployments(g, dcNode)
 
 	return tabbedString(func(out *tabwriter.Writer) error {
-		descriptions := describeDeployments(f, dcNode, activeDeployment, inactiveDeployments, d.count)
+		descriptions := describeDeployments(f, dcNode, activeDeployment, inactiveDeployments, int32(0), d.count)
 		for i, description := range descriptions {
 			descriptions[i] = fmt.Sprintf("%v %v", name, description)
 		}


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/6289

This is just a WIP, I have to polish this a little bit and replace the `int32` with a function that will compute the restart counts using the `ActiveDeployment` .

Also need to account only restarts happened in last 10 minutes.

```console
[root@localhost origin]# oc status
In project Dev sample (test) on server https://10.1.2.2:8443

http://test-test.router.default.svc.cluster.local to pod port 8080-tcp (svc/test)
  dc/test deploys istag/test:latest <-
    bc/test builds https://github.com/openshift/cakephp-ex.git#master with openshift/php:5.6
    deployment #10 deployed about an hour ago - 1 pod (warning: 5 restarts)
    deployment #9 deployed about an hour ago
    deployment #8 deployed 2 hours ago
```