### PR TITLE
Remove resource groups

### DIFF
--- a/pkg/authorization/api/deprecated_fields.go
+++ b/pkg/authorization/api/deprecated_fields.go
@@ -7,85 +7,85 @@ import (
 // NEVER TOUCH ANYTHING IN THIS FILE!
 
 const (
-	// ResourceGroupPrefix is the prefix for indicating that a resource entry is actually a group of resources.  The groups are defined in code and indicate resources that are commonly permissioned together
-	ResourceGroupPrefix = "resourcegroup:"
-	BuildGroupName      = ResourceGroupPrefix + "builds"
-	DeploymentGroupName = ResourceGroupPrefix + "deployments"
-	ImageGroupName      = ResourceGroupPrefix + "images"
-	OAuthGroupName      = ResourceGroupPrefix + "oauth"
-	UserGroupName       = ResourceGroupPrefix + "users"
-	TemplateGroupName   = ResourceGroupPrefix + "templates"
-	SDNGroupName        = ResourceGroupPrefix + "sdn"
-	// PolicyOwnerGroupName includes the physical resources behind the PermissionGrantingGroupName.  Unless these physical objects are created first, users with privileges to PermissionGrantingGroupName will
+	// resourceGroupPrefix is the prefix for indicating that a resource entry is actually a group of resources.  The groups are defined in code and indicate resources that are commonly permissioned together
+	resourceGroupPrefix = "resourcegroup:"
+	buildGroupName      = resourceGroupPrefix + "builds"
+	deploymentGroupName = resourceGroupPrefix + "deployments"
+	imageGroupName      = resourceGroupPrefix + "images"
+	oauthGroupName      = resourceGroupPrefix + "oauth"
+	userGroupName       = resourceGroupPrefix + "users"
+	templateGroupName   = resourceGroupPrefix + "templates"
+	sdnGroupName        = resourceGroupPrefix + "sdn"
+	// policyOwnerGroupName includes the physical resources behind the permissionGrantingGroupName.  Unless these physical objects are created first, users with privileges to permissionGrantingGroupName will
 	// only be able to bind to global roles
-	PolicyOwnerGroupName = ResourceGroupPrefix + "policy"
-	// PermissionGrantingGroupName includes resources that are necessary to maintain authorization roles and bindings.  By itself, this group is insufficient to create anything except for bindings
+	policyOwnerGroupName = resourceGroupPrefix + "policy"
+	// permissionGrantingGroupName includes resources that are necessary to maintain authorization roles and bindings.  By itself, this group is insufficient to create anything except for bindings
 	// to master roles.  If a local Policy already exists, then privileges to this group will allow for modification of local roles.
-	PermissionGrantingGroupName = ResourceGroupPrefix + "granter"
-	// OpenshiftExposedGroupName includes resources that are commonly viewed and modified by end users of the system.  It does not include any sensitive resources that control authentication or authorization
-	OpenshiftExposedGroupName = ResourceGroupPrefix + "exposedopenshift"
-	OpenshiftAllGroupName     = ResourceGroupPrefix + "allopenshift"
-	OpenshiftStatusGroupName  = ResourceGroupPrefix + "allopenshift-status"
+	permissionGrantingGroupName = resourceGroupPrefix + "granter"
+	// openshiftExposedGroupName includes resources that are commonly viewed and modified by end users of the system.  It does not include any sensitive resources that control authentication or authorization
+	openshiftExposedGroupName = resourceGroupPrefix + "exposedopenshift"
+	openshiftAllGroupName     = resourceGroupPrefix + "allopenshift"
+	openshiftStatusGroupName  = resourceGroupPrefix + "allopenshift-status"
 
-	QuotaGroupName = ResourceGroupPrefix + "quota"
-	// KubeInternalsGroupName includes those resources that should reasonably be viewable to end users, but that most users should probably not modify.  Kubernetes herself will maintain these resources
-	KubeInternalsGroupName = ResourceGroupPrefix + "privatekube"
-	// KubeExposedGroupName includes resources that are commonly viewed and modified by end users of the system.
-	KubeExposedGroupName = ResourceGroupPrefix + "exposedkube"
-	KubeAllGroupName     = ResourceGroupPrefix + "allkube"
-	KubeStatusGroupName  = ResourceGroupPrefix + "allkube-status"
+	quotaGroupName = resourceGroupPrefix + "quota"
+	// kubeInternalsGroupName includes those resources that should reasonably be viewable to end users, but that most users should probably not modify.  Kubernetes herself will maintain these resources
+	kubeInternalsGroupName = resourceGroupPrefix + "privatekube"
+	// kubeExposedGroupName includes resources that are commonly viewed and modified by end users of the system.
+	kubeExposedGroupName = resourceGroupPrefix + "exposedkube"
+	kubeAllGroupName     = resourceGroupPrefix + "allkube"
+	kubeStatusGroupName  = resourceGroupPrefix + "allkube-status"
 
-	// NonEscalatingResourcesGroupName contains all resources that can be viewed without exposing the risk of using view rights to locate a secret to escalate privileges.  For example, view
+	// nonescalatingResourcesGroupName contains all resources that can be viewed without exposing the risk of using view rights to locate a secret to escalate privileges.  For example, view
 	// rights on secrets could be used locate a secret that happened to be  serviceaccount token that has more privileges
-	NonEscalatingResourcesGroupName         = ResourceGroupPrefix + "non-escalating"
-	KubeNonEscalatingViewableGroupName      = ResourceGroupPrefix + "kube-non-escalating"
-	OpenshiftNonEscalatingViewableGroupName = ResourceGroupPrefix + "openshift-non-escalating"
+	nonescalatingResourcesGroupName         = resourceGroupPrefix + "non-escalating"
+	kubeNonEscalatingViewableGroupName      = resourceGroupPrefix + "kube-non-escalating"
+	openshiftNonEscalatingViewableGroupName = resourceGroupPrefix + "openshift-non-escalating"
 
-	// EscalatingResourcesGroupName contains all resources that can be used to escalate privileges when simply viewed
-	EscalatingResourcesGroupName         = ResourceGroupPrefix + "escalating"
-	KubeEscalatingViewableGroupName      = ResourceGroupPrefix + "kube-escalating"
-	OpenshiftEscalatingViewableGroupName = ResourceGroupPrefix + "openshift-escalating"
+	// escalatingResourcesGroupName contains all resources that can be used to escalate privileges when simply viewed
+	escalatingResourcesGroupName         = resourceGroupPrefix + "escalating"
+	kubeEscalatingViewableGroupName      = resourceGroupPrefix + "kube-escalating"
+	openshiftEscalatingViewableGroupName = resourceGroupPrefix + "openshift-escalating"
 )
 
 var (
-	GroupsToResources = map[string][]string{
-		BuildGroupName:       {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/log", "builds/clone", "buildconfigs/webhooks"},
-		ImageGroupName:       {"imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages", "imagestreamimports"},
-		DeploymentGroupName:  {"deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/log", "deploymentconfigs/scale"},
-		SDNGroupName:         {"clusternetworks", "hostsubnets", "netnamespaces"},
-		TemplateGroupName:    {"templates", "templateconfigs", "processedtemplates"},
-		UserGroupName:        {"identities", "users", "useridentitymappings", "groups"},
-		OAuthGroupName:       {"oauthauthorizetokens", "oauthaccesstokens", "oauthclients", "oauthclientauthorizations"},
-		PolicyOwnerGroupName: {"policies", "policybindings"},
+	groupsToResources = map[string][]string{
+		buildGroupName:       {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/log", "builds/clone", "buildconfigs/webhooks"},
+		imageGroupName:       {"imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages", "imagestreamimports"},
+		deploymentGroupName:  {"deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/log", "deploymentconfigs/scale"},
+		sdnGroupName:         {"clusternetworks", "hostsubnets", "netnamespaces"},
+		templateGroupName:    {"templates", "templateconfigs", "processedtemplates"},
+		userGroupName:        {"identities", "users", "useridentitymappings", "groups"},
+		oauthGroupName:       {"oauthauthorizetokens", "oauthaccesstokens", "oauthclients", "oauthclientauthorizations"},
+		policyOwnerGroupName: {"policies", "policybindings"},
 
 		// RAR and SAR are in this list to support backwards compatibility with clients that expect access to those resource in a namespace scope and a cluster scope.
 		// TODO remove once we have eliminated the namespace scoped resource.
-		PermissionGrantingGroupName: {"roles", "rolebindings", "resourceaccessreviews" /* cluster scoped*/, "subjectaccessreviews" /* cluster scoped*/, "localresourceaccessreviews", "localsubjectaccessreviews"},
-		OpenshiftExposedGroupName:   {BuildGroupName, ImageGroupName, DeploymentGroupName, TemplateGroupName, "routes"},
-		OpenshiftAllGroupName: {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects",
+		permissionGrantingGroupName: {"roles", "rolebindings", "resourceaccessreviews" /* cluster scoped*/, "subjectaccessreviews" /* cluster scoped*/, "localresourceaccessreviews", "localsubjectaccessreviews"},
+		openshiftExposedGroupName:   {buildGroupName, imageGroupName, deploymentGroupName, templateGroupName, "routes"},
+		openshiftAllGroupName: {openshiftExposedGroupName, userGroupName, oauthGroupName, policyOwnerGroupName, sdnGroupName, permissionGrantingGroupName, openshiftStatusGroupName, "projects",
 			"clusterroles", "clusterrolebindings", "clusterpolicies", "clusterpolicybindings", "images" /* cluster scoped*/, "projectrequests", "builds/details", "imagestreams/secrets",
 			"selfsubjectrulesreviews"},
-		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status", "deploymentconfigs/status"},
+		openshiftStatusGroupName: {"imagestreams/status", "routes/status", "deploymentconfigs/status"},
 
-		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
-		KubeExposedGroupName:   {"pods", "replicationcontrollers", "serviceaccounts", "services", "endpoints", "persistentvolumeclaims", "pods/log", "configmaps"},
-		KubeInternalsGroupName: {"minions", "nodes", "bindings", "events", "namespaces", "persistentvolumes", "securitycontextconstraints"},
-		KubeAllGroupName:       {KubeInternalsGroupName, KubeExposedGroupName, QuotaGroupName},
-		KubeStatusGroupName:    {"pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status"},
+		quotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
+		kubeExposedGroupName:   {"pods", "replicationcontrollers", "serviceaccounts", "services", "endpoints", "persistentvolumeclaims", "pods/log", "configmaps"},
+		kubeInternalsGroupName: {"minions", "nodes", "bindings", "events", "namespaces", "persistentvolumes", "securitycontextconstraints"},
+		kubeAllGroupName:       {kubeInternalsGroupName, kubeExposedGroupName, quotaGroupName},
+		kubeStatusGroupName:    {"pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status"},
 
-		OpenshiftEscalatingViewableGroupName: {"oauthauthorizetokens", "oauthaccesstokens", "imagestreams/secrets"},
-		KubeEscalatingViewableGroupName:      {"secrets"},
-		EscalatingResourcesGroupName:         {OpenshiftEscalatingViewableGroupName, KubeEscalatingViewableGroupName},
+		openshiftEscalatingViewableGroupName: {"oauthauthorizetokens", "oauthaccesstokens", "imagestreams/secrets"},
+		kubeEscalatingViewableGroupName:      {"secrets"},
+		escalatingResourcesGroupName:         {openshiftEscalatingViewableGroupName, kubeEscalatingViewableGroupName},
 
-		NonEscalatingResourcesGroupName: {OpenshiftNonEscalatingViewableGroupName, KubeNonEscalatingViewableGroupName},
+		nonescalatingResourcesGroupName: {openshiftNonEscalatingViewableGroupName, kubeNonEscalatingViewableGroupName},
 	}
 )
 
 func init() {
 	// set the non-escalating groups
-	GroupsToResources[OpenshiftNonEscalatingViewableGroupName] = NormalizeResources(sets.NewString(GroupsToResources[OpenshiftAllGroupName]...)).
-		Difference(NormalizeResources(sets.NewString(GroupsToResources[OpenshiftEscalatingViewableGroupName]...))).List()
+	groupsToResources[openshiftNonEscalatingViewableGroupName] = NormalizeResources(sets.NewString(groupsToResources[openshiftAllGroupName]...)).
+		Difference(NormalizeResources(sets.NewString(groupsToResources[openshiftEscalatingViewableGroupName]...))).List()
 
-	GroupsToResources[KubeNonEscalatingViewableGroupName] = NormalizeResources(sets.NewString(GroupsToResources[KubeAllGroupName]...)).
-		Difference(NormalizeResources(sets.NewString(GroupsToResources[KubeEscalatingViewableGroupName]...))).List()
+	groupsToResources[kubeNonEscalatingViewableGroupName] = NormalizeResources(sets.NewString(groupsToResources[kubeAllGroupName]...)).
+		Difference(NormalizeResources(sets.NewString(groupsToResources[kubeEscalatingViewableGroupName]...))).List()
 }

--- a/pkg/authorization/api/group_test.go
+++ b/pkg/authorization/api/group_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestEscalating(t *testing.T) {
-	escalatingResources := NormalizeResources(sets.NewString(GroupsToResources[EscalatingResourcesGroupName]...))
-	nonEscalatingResources := NormalizeResources(sets.NewString(GroupsToResources[NonEscalatingResourcesGroupName]...))
+	escalatingResources := NormalizeResources(sets.NewString(groupsToResources[escalatingResourcesGroupName]...))
+	nonEscalatingResources := NormalizeResources(sets.NewString(groupsToResources[nonescalatingResourcesGroupName]...))
 	if len(nonEscalatingResources) <= len(escalatingResources) {
 		t.Errorf("groups look bad: escalating=%v nonescalating=%v", escalatingResources.List(), nonEscalatingResources.List())
 	}
@@ -23,7 +23,7 @@ func TestNormalizeResources(t *testing.T) {
 		{"capA", "capA", "capa"},
 		{"capH", "capH", "caph"},
 		{"capZ", "capZ", "capz"},
-		{"group", BuildGroupName, "builds"},
+		{"group", buildGroupName, "builds"},
 	}
 
 	for _, test := range tests {
@@ -52,7 +52,7 @@ func TestNeedsNormalization(t *testing.T) {
 		{"/", "/", false},
 		{"-", "-", false},
 		{".", ".", false},
-		{ResourceGroupPrefix, ResourceGroupPrefix, true},
+		{resourceGroupPrefix, resourceGroupPrefix, true},
 	}
 
 	for _, test := range tests {

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -44,12 +44,12 @@ func NormalizeResources(rawResources sets.String) sets.String {
 		}
 		visited.Insert(currResource)
 
-		if !strings.HasPrefix(currResource, ResourceGroupPrefix) {
+		if !strings.HasPrefix(currResource, resourceGroupPrefix) {
 			ret.Insert(strings.ToLower(currResource))
 			continue
 		}
 
-		if resourceTypes, exists := GroupsToResources[currResource]; exists {
+		if resourceTypes, exists := groupsToResources[currResource]; exists {
 			toVisit = append(toVisit, resourceTypes...)
 		}
 	}
@@ -58,7 +58,7 @@ func NormalizeResources(rawResources sets.String) sets.String {
 }
 
 func needsNormalizing(in string) bool {
-	if strings.HasPrefix(in, ResourceGroupPrefix) {
+	if strings.HasPrefix(in, resourceGroupPrefix) {
 		return true
 	}
 	for _, r := range in {

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -52,15 +52,10 @@ func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Ro
 				Namespace: openshiftNamespace,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				{
-					Verbs:     sets.NewString("get", "list"),
-					Resources: sets.NewString("templates", authorizationapi.ImageGroupName),
-				},
-				{
-					// so anyone can pull from openshift/* image streams
-					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("imagestreams/layers"),
-				},
+				authorizationapi.NewRule(read...).Groups(templateGroup).Resources("templates").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(imageGroup).Resources("imagestreams", "imagestreamtags", "imagestreamimages").RuleOrDie(),
+				// so anyone can pull from openshift/* image streams
+				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),
 			},
 		},
 	}

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -2,7 +2,6 @@ package origin
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -11,11 +10,9 @@ import (
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 	"github.com/openshift/origin/pkg/api/validation"
-	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -66,22 +66,6 @@ func TestValidationRegistration(t *testing.T) {
 	}
 }
 
-// TestAllOpenShiftResourceCoverage checks to make sure that the openshift all group actually contains all openshift resources
-func TestAllOpenShiftResourceCoverage(t *testing.T) {
-	allOpenshift := authorizationapi.NormalizeResources(sets.NewString(authorizationapi.GroupsToResources[authorizationapi.OpenshiftAllGroupName]...))
-
-	config := fakeMasterConfig()
-
-	storageMap := config.GetRestStorage()
-	for key := range storageMap {
-		if allOpenshift.Has(strings.ToLower(key)) {
-			continue
-		}
-
-		t.Errorf("authorizationapi.GroupsToResources[authorizationapi.OpenshiftAllGroupName] is missing %v.  Check pkg/authorization/api/types.go.", strings.ToLower(key))
-	}
-}
-
 // fakeMasterConfig creates a new fake master config with an empty kubelet config and dummy storage.
 func fakeMasterConfig() *MasterConfig {
 	etcdHelper := etcdstorage.NewEtcdStorage(nil, api.Codecs.LegacyCodec(), "", false, genericapiserver.DefaultDeserializationCacheSize)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -11,16 +11,106 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierror "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	policy "github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
+
+func TestClusterReaderCoverage(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	discoveryClient := client.NewDiscoveryClient(clusterAdminClient.RESTClient)
+
+	// (map[string]*unversioned.APIResourceList, error)
+	allResourceList, err := discoveryClient.ServerResources()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	allResources := map[unversioned.GroupResource]bool{}
+	for _, resources := range allResourceList {
+		version, err := unversioned.ParseGroupVersion(resources.GroupVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		for _, resource := range resources.APIResources {
+			allResources[version.WithResource(resource.Name).GroupResource()] = true
+		}
+	}
+
+	escalatingResources := map[unversioned.GroupResource]bool{
+		oauthapi.Resource("oauthauthorizetokens"): true,
+		oauthapi.Resource("oauthaccesstokens"):    true,
+		oauthapi.Resource("oauthclients"):         true,
+		imageapi.Resource("imagestreams/secrets"): true,
+		kapi.Resource("secrets"):                  true,
+		kapi.Resource("pods/exec"):                true,
+		kapi.Resource("pods/proxy"):               true,
+		kapi.Resource("pods/portforward"):         true,
+		kapi.Resource("nodes/proxy"):              true,
+		kapi.Resource("services/proxy"):           true,
+	}
+
+	readerRole, err := clusterAdminClient.ClusterRoles().Get(bootstrappolicy.ClusterReaderRoleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, rule := range readerRole.Rules {
+		for _, group := range rule.APIGroups {
+			for resource := range rule.Resources {
+				gr := unversioned.GroupResource{Group: group, Resource: resource}
+				if escalatingResources[gr] {
+					t.Errorf("cluster-reader role has escalating resource %v.  Check pkg/cmd/server/bootstrappolicy/policy.go.", gr)
+				}
+				delete(allResources, gr)
+			}
+		}
+	}
+
+	// remove escalating resources that cluster-reader should not have access to
+	for resource := range escalatingResources {
+		delete(allResources, resource)
+	}
+
+	// remove resources without read APIs
+	nonreadingResources := []unversioned.GroupResource{
+		buildapi.Resource("buildconfigs/instantiatebinary"), buildapi.Resource("buildconfigs/instantiate"), buildapi.Resource("builds/clone"),
+		deployapi.Resource("deploymentconfigrollbacks"), deployapi.Resource("generatedeploymentconfigs"),
+		imageapi.Resource("imagestreamimports"), imageapi.Resource("imagestreammappings"),
+		extensionsapi.Resource("deployments/rollback"),
+		kapi.Resource("pods/attach"), kapi.Resource("namespaces/finalize"),
+	}
+	for _, resource := range nonreadingResources {
+		delete(allResources, resource)
+	}
+
+	// anything left in the map is missing from the permissions
+	if len(allResources) > 0 {
+		t.Errorf("cluster-reader role is missing %v.  Check pkg/cmd/server/bootstrappolicy/policy.go.", allResources)
+	}
+}
 
 func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
 	testutil.RequireEtcd(t)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -228,7 +228,7 @@ func TestAuthorizationResolution(t *testing.T) {
 	roleWithGroup.Name = "with-group"
 	roleWithGroup.Rules = append(roleWithGroup.Rules, authorizationapi.PolicyRule{
 		Verbs:     sets.NewString("list"),
-		Resources: sets.NewString(authorizationapi.BuildGroupName),
+		Resources: sets.NewString("resourcegroup:builds"),
 	})
 	if _, err := clusterAdminClient.ClusterRoles().Create(roleWithGroup); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1143,7 +1143,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
 			Users:     sets.NewString("harold", "system:serviceaccount:hammer-project:builder", "system:serviceaccount:openshift-infra:namespace-controller", "system:admin"),
-			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:serviceaccounts:hammer-project"),
+			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||
 			!reflect.DeepEqual(actualResponse.Users.List(), expectedResponse.Users.List()) ||
@@ -1170,7 +1170,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
 			Users:     sets.NewString("harold", "system:serviceaccount:hammer-project:builder", "system:serviceaccount:openshift-infra:namespace-controller", "system:admin"),
-			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:serviceaccounts:hammer-project"),
+			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||
 			!reflect.DeepEqual(actualResponse.Users.List(), expectedResponse.Users.List()) ||

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -46,74 +46,43 @@ items:
     attributeRestrictions: null
     resources:
     - bindings
-    - buildconfigs
-    - buildconfigs/instantiate
-    - buildconfigs/instantiatebinary
-    - buildconfigs/webhooks
-    - buildlogs
-    - builds
-    - builds/clone
-    - builds/details
-    - builds/log
-    - clusternetworks
-    - clusterpolicies
-    - clusterpolicybindings
-    - clusterrolebindings
-    - clusterroles
+    - componentstatuses
     - configmaps
-    - deploymentconfigrollbacks
-    - deploymentconfigs
-    - deploymentconfigs/log
-    - deploymentconfigs/scale
-    - deploymentconfigs/status
     - endpoints
     - events
-    - generatedeploymentconfigs
-    - groups
-    - hostsubnets
-    - identities
-    - images
-    - imagestreamimages
-    - imagestreamimports
-    - imagestreammappings
-    - imagestreams
-    - imagestreams/status
-    - imagestreamtags
     - limitranges
-    - localresourceaccessreviews
-    - localsubjectaccessreviews
-    - minions
     - namespaces
-    - netnamespaces
+    - namespaces/status
     - nodes
-    - oauthclientauthorizations
-    - oauthclients
+    - nodes/status
     - persistentvolumeclaims
+    - persistentvolumeclaims/status
     - persistentvolumes
+    - persistentvolumes/status
     - pods
+    - pods/binding
     - pods/log
-    - policies
-    - policybindings
-    - processedtemplates
-    - projectrequests
-    - projects
+    - pods/status
+    - podtemplates
     - replicationcontrollers
-    - resourceaccessreviews
+    - replicationcontrollers/scale
+    - replicationcontrollers/status
     - resourcequotas
-    - resourcequotausages
-    - rolebindings
-    - roles
-    - routes
-    - routes/status
+    - resourcequotas/status
     - securitycontextconstraints
-    - selfsubjectrulesreviews
     - serviceaccounts
     - services
-    - subjectaccessreviews
-    - templateconfigs
-    - templates
-    - useridentitymappings
-    - users
+    - services/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - petsets
+    - petsets/status
     verbs:
     - get
     - list
@@ -123,6 +92,7 @@ items:
     attributeRestrictions: null
     resources:
     - horizontalpodautoscalers
+    - horizontalpodautoscalers/status
     verbs:
     - get
     - list
@@ -132,6 +102,7 @@ items:
     attributeRestrictions: null
     resources:
     - jobs
+    - jobs/status
     verbs:
     - get
     - list
@@ -141,9 +112,23 @@ items:
     attributeRestrictions: null
     resources:
     - daemonsets
+    - daemonsets/status
+    - deployments
+    - deployments/scale
+    - deployments/status
     - horizontalpodautoscalers
+    - horizontalpodautoscalers/status
+    - ingresses
+    - ingresses/status
     - jobs
+    - jobs/status
+    - podsecuritypolicies
+    - replicasets
+    - replicasets/scale
+    - replicasets/status
+    - replicationcontrollers
     - replicationcontrollers/scale
+    - thirdpartyresources
     verbs:
     - get
     - list
@@ -152,7 +137,134 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - clusterpolicies
+    - clusterpolicybindings
+    - clusterrolebindings
+    - clusterroles
+    - policies
+    - policybindings
+    - rolebindings
+    - roles
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    - buildconfigs/webhooks
+    - builds
+    - builds/details
+    - builds/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs
+    - deploymentconfigs/log
+    - deploymentconfigs/scale
+    - deploymentconfigs/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - images
+    - imagestreamimages
+    - imagestreams
+    - imagestreams/status
+    - imagestreamtags
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreams/layers
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - oauthclientauthorizations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - projectrequests
+    - projects
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes
+    - routes/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - clusternetworks
+    - hostsubnets
+    - netnamespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - processedtemplates
+    - templateconfigs
+    - templates
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - groups
+    - identities
+    - useridentitymappings
+    - users
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - localresourceaccessreviews
+    - localsubjectaccessreviews
     - resourceaccessreviews
+    - selfsubjectrulesreviews
     - subjectaccessreviews
     verbs:
     - create
@@ -178,6 +290,24 @@ items:
     resources: []
     verbs:
     - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - buildlogs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotausages
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_openshift_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_openshift_roles.yaml
@@ -7,19 +7,28 @@ items:
     name: shared-resource-viewer
     namespace: openshift
   rules:
-  - apiGroups: null
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
-    - imagestreamimages
-    - imagestreamimports
-    - imagestreammappings
-    - imagestreams
-    - imagestreamtags
     - templates
     verbs:
     - get
     - list
-  - apiGroups: null
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - imagestreamimages
+    - imagestreams
+    - imagestreamtags
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - imagestreams/layers


### PR DESCRIPTION
Makes resource groups private, updates cluster-reader to be defined inline, updates the cluster-reader test to use discovery to locate all the API resources it should have access to.

@kargakis ptal