### PR TITLE
oc: restore legacy behavior for deploy --latest

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -233,7 +233,7 @@ func (o DeployOptions) deploy(config *deployapi.DeploymentConfig, out io.Writer)
 		}
 	}
 
-	deployutil.Instantiate(config)
+	config.Status.LatestVersion++
 	dc, err := o.osClient.DeploymentConfigs(config.Namespace).Update(config)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -65,8 +65,8 @@ func TestCmdDeploy_latestOk(t *testing.T) {
 		if updatedConfig == nil {
 			t.Fatalf("expected updated config")
 		}
-		if !deployutil.IsInstantiated(updatedConfig) {
-			t.Fatalf("expected deployment config instantiation")
+		if exp, got := updatedConfig.Status.LatestVersion, int64(2); exp != got {
+			t.Fatalf("expected deployment config version: %d, got: %d", exp, got)
 		}
 	}
 }

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -245,9 +245,6 @@ const (
 	// DeploymentReplicasAnnotation is for internal use only and is for
 	// detecting external modifications to deployment replica counts.
 	DeploymentReplicasAnnotation = "openshift.io/deployment.replicas"
-	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
-	// The annotation value does not matter and its mere presence indicates instantiation.
-	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
 	// PostHookPodSuffix is the suffix added to all pre hook pods
 	PreHookPodSuffix = "hook-pre"
 	// PostHookPodSuffix is the suffix added to all mid hook pods

--- a/pkg/deploy/registry/deployconfig/strategy.go
+++ b/pkg/deploy/registry/deployconfig/strategy.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/api/validation"
-	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
 // strategy implements behavior for DeploymentConfig objects
@@ -62,14 +61,6 @@ func (strategy) PrepareForUpdate(obj, old runtime.Object) {
 
 	// Persist status
 	newDc.Status = oldDc.Status
-
-	// oc deploy --latest from new clients and image change controller updates on deployment
-	// configs without config change triggers.
-	if newVersion == oldVersion && deployutil.IsInstantiated(newDc) {
-		// TODO: Have an endpoint for this and avoid hacking it here.
-		newDc.Status.LatestVersion = oldVersion + 1
-		delete(newDc.Annotations, api.DeploymentInstantiatedAnnotation)
-	}
 
 	// oc deploy --latest from old clients
 	// TODO: Remove once we drop support for older clients

--- a/pkg/deploy/registry/deployconfig/strategy_test.go
+++ b/pkg/deploy/registry/deployconfig/strategy_test.go
@@ -50,7 +50,7 @@ func TestDeploymentConfigStrategy(t *testing.T) {
 	}
 }
 
-// TestPrepareForUpdate exercises updates made by both old and new clients.
+// TestPrepareForUpdate exercises various client updates.
 func TestPrepareForUpdate(t *testing.T) {
 	tests := []struct {
 		name string
@@ -60,16 +60,10 @@ func TestPrepareForUpdate(t *testing.T) {
 		expected runtime.Object
 	}{
 		{
-			name:     "old client update",
+			name:     "latestVersion bump",
 			prev:     prevDeployment(),
-			after:    afterDeploymentByOldClient(),
-			expected: expectedAfterByOldClient(),
-		},
-		{
-			name:     "new client update",
-			prev:     prevDeployment(),
-			after:    afterDeploymentByNewClient(),
-			expected: expectedAfterByNewClient(),
+			after:    afterDeploymentVersionBump(),
+			expected: expectedAfterVersionBump(),
 		},
 		{
 			name:     "spec change",
@@ -110,31 +104,16 @@ func expectedAfterDeployment() *deployapi.DeploymentConfig {
 	return dc
 }
 
-// afterDeploymentByOldClient is a deployment updated by an old oc client.
-func afterDeploymentByOldClient() *deployapi.DeploymentConfig {
+// afterDeploymentVersionBump is a deployment config updated to a newer version.
+func afterDeploymentVersionBump() *deployapi.DeploymentConfig {
 	dc := prevDeployment()
 	dc.Status.LatestVersion++
 	return dc
 }
 
-// expectedAfterByOldClient is the object we expect from the update hook after an old client update.
-func expectedAfterByOldClient() *deployapi.DeploymentConfig {
-	dc := afterDeploymentByOldClient()
-	dc.Generation++
-	return dc
-}
-
-// afterDeploymentByNewClient is a deployment updated by an new oc client.
-func afterDeploymentByNewClient() *deployapi.DeploymentConfig {
-	dc := prevDeployment()
-	dc.Annotations[deployapi.DeploymentInstantiatedAnnotation] = deployapi.DeploymentInstantiatedAnnotationValue
-	return dc
-}
-
-// expectedAfterByNewClient is the object we expect from the update hook after a new client update.
-func expectedAfterByNewClient() *deployapi.DeploymentConfig {
-	dc := prevDeployment()
-	dc.Status.LatestVersion++
+// expectedAfterVersionBump is the object we expect after a version bump.
+func expectedAfterVersionBump() *deployapi.DeploymentConfig {
+	dc := afterDeploymentVersionBump()
 	dc.Generation++
 	return dc
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -290,18 +290,6 @@ func IsDeploymentCancelled(deployment *api.ReplicationController) bool {
 	return strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
 }
 
-func Instantiate(dc *deployapi.DeploymentConfig) {
-	if dc.Annotations == nil {
-		dc.Annotations = make(map[string]string)
-	}
-	dc.Annotations[deployapi.DeploymentInstantiatedAnnotation] = deployapi.DeploymentInstantiatedAnnotationValue
-}
-
-func IsInstantiated(dc *deployapi.DeploymentConfig) bool {
-	value := annotationFor(dc, deployapi.DeploymentInstantiatedAnnotation)
-	return strings.EqualFold(value, deployapi.DeploymentInstantiatedAnnotationValue)
-}
-
 func HasSynced(dc *deployapi.DeploymentConfig) bool {
 	return dc.Status.ObservedGeneration >= dc.Generation
 }


### PR DESCRIPTION
@smarterclayton new clients won't work on servers that aren't supporting the annotation. We didn't ship this in 1.2 and we should ship it in 1.3 either. Once we move to /instantiate things will be better.