### PR TITLE
display cache mutation errors in stdout

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -21,6 +21,10 @@ function cleanup()
     set +e
     kill_all_processes
 
+    # pull information out of the server log so that we can get failure management in jenkins to highlight it and 
+    # really have it smack people in their logs.  This is a severe correctness problem
+    grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/openshift.log
+
     echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/etcd_dump.json"
     set_curl_args 0 1
     curl -s ${clientcert_args} -L "${API_SCHEME}://${API_HOST}:${ETCD_PORT}/v2/keys/?recursive=true" > "${ARTIFACT_DIR}/etcd_dump.json"

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -33,6 +33,11 @@ function cleanup()
 	set +e
 	dump_container_logs
 
+	# pull information out of the server log so that we can get failure management in jenkins to highlight it and 
+	# really have it smack people in their logs.  This is a severe correctness problem
+    grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/container-origin.log
+
+
 	echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
 	if [[ -n "${ADMIN_KUBECONFIG:-}" ]]; then
 		oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -560,6 +560,10 @@ function cleanup_openshift() {
 	set +e
 	dump_container_logs
 
+ 	# pull information out of the server log so that we can get failure management in jenkins to highlight it and 
+	# really have it smack people in their logs.  This is a severe correctness problem
+	grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/openshift.log
+
 	if [[ -e "${ADMIN_KUBECONFIG:-}" ]]; then
 		echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
 		oc login -u system:admin -n default --config=${ADMIN_KUBECONFIG}


### PR DESCRIPTION
The server logs contain a message that indicates that the cache has been mutated.  These errors are P1 or P0 correctness bugs since they can destroy all of our controllers.  I want to pull the errors into stdout, so they are clearly visible and add a failure cause that indicates that these failures are not flakes.

@kargakis @stevekuznetsov 

[test]