### PR TITLE
remove unnecessary export

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -37,12 +37,6 @@ function cleanup()
 	# really have it smack people in their logs.  This is a severe correctness problem
     grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/container-origin.log
 
-
-	echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
-	if [[ -n "${ADMIN_KUBECONFIG:-}" ]]; then
-		oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
-	fi
-
 	echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/etcd_dump.json"
 	set_curl_args 0 1
 	ETCD_PORT="${ETCD_PORT:-4001}"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -550,7 +550,6 @@ readonly -f ensure_ginkgo_or_die
 
 # cleanup_openshift saves container logs, saves resources, and kills all processes and containers
 function cleanup_openshift() {
-	ADMIN_KUBECONFIG="${ADMIN_KUBECONFIG:-${BASETMPDIR}/openshift.local.config/master/admin.kubeconfig}"
 	LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
 	ARTIFACT_DIR="${ARTIFACT_DIR:-${LOG_DIR}}"
 	API_HOST="${API_HOST:-127.0.0.1}"
@@ -563,12 +562,6 @@ function cleanup_openshift() {
  	# pull information out of the server log so that we can get failure management in jenkins to highlight it and
 	# really have it smack people in their logs.  This is a severe correctness problem
 	grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/openshift.log
-
-	if [[ -e "${ADMIN_KUBECONFIG:-}" ]]; then
-		echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
-		oc login -u system:admin -n default --config=${ADMIN_KUBECONFIG}
-		oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
-	fi
 
 	echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/etcd_dump.json"
 	set_curl_args 0 1

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -103,9 +103,6 @@ function cleanup_openshift {
 	set +e
 	dump_container_logs
 
-	echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
-	oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
-
 	echo "[INFO] Dumping etcd contents to ${ARTIFACT_DIR}/etcd_dump.json"
 	set_curl_args 0 1
 	curl ${clientcert_args} -L "${API_SCHEME}://${API_HOST}:${ETCD_PORT}/v2/keys/?recursive=true" > "${ARTIFACT_DIR}/etcd_dump.json"


### PR DESCRIPTION
Found while inspecting a false error indication triggered on `Error from server: User "e2e-user" cannot list all buildconfigs in the cluster`.  Given the etcd dump, this is an unnecessary export.