### PR TITLE
[DO NOT MERGE] stack dumps for every registry access not via the API

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
@@ -1,6 +1,11 @@
 package etcd
 
 import (
+	"fmt"
+	gruntime "runtime"
+	"runtime/debug"
+	"strings"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -49,4 +54,106 @@ func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 	}
 
 	return &REST{store}, nil
+}
+
+func (e *REST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	found := false
+	for _, apiCallStack := range allowedStacks {
+		failed := false
+		for i := range apiCallStack {
+			_, file, line, ok := gruntime.Caller(i + 1)
+			if !ok {
+				failed = true
+				break
+			}
+			if !strings.Contains(file, apiCallStack[i].file) {
+				failed = true
+				break
+			}
+			if apiCallStack[i].line != line {
+				failed = true
+				break
+			}
+		}
+		if !failed {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		fmt.Printf("#### DISALLOWED!\n")
+		debug.PrintStack()
+	}
+
+	return e.Store.Get(ctx, name)
+}
+
+var allowedStacks = [][]struct {
+	file string
+	line int
+}{
+	// REST API "get"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 65},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 48},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 145},
+	},
+	// REST API "delete"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 83},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 56},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 764},
+	},
+	// REST API "create"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 196},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 124},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 105},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 68},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 439},
+	},
+	// REST API "update"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 171},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 144},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 80},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 682},
+	},
+	// REST API "update"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 65},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 156},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 144},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 80},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 682},
+	},
+	// REST API "patch"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 65},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 156},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 144},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 80},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 552},
+	},
+	// REST API "patch"
+	{
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 77},
+		{"pkg/authorization/registry/clusterpolicy/registry.go", 111},
+		{"pkg/authorization/registry/role/policybased/virtual_storage.go", 65},
+		{"pkg/authorization/registry/clusterrole/proxy/proxy.go", 48},
+		{"k8s.io/kubernetes/pkg/apiserver/resthandler.go", 524},
+	},
 }


### PR DESCRIPTION
I only see 100-ish calls to `GetClusterPolicy` that aren't done via the API.  Our code never uses our internal client to get at the API since that would result in cyclical authorization checks.

@smarterclayton Is this still the call?