### PR TITLE
Revert "use cache for referential integrity and escalation checks"

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/registry.go
+++ b/pkg/authorization/registry/clusterpolicy/registry.go
@@ -115,3 +115,15 @@ func (s *simulatedStorage) GetPolicy(ctx kapi.Context, name string) (*authorizat
 func (s *simulatedStorage) DeletePolicy(ctx kapi.Context, name string) error {
 	return s.clusterRegistry.DeleteClusterPolicy(ctx, name)
 }
+
+type ReadOnlyClusterPolicy struct {
+	Registry
+}
+
+func (s ReadOnlyClusterPolicy) List(options kapi.ListOptions) (*authorizationapi.ClusterPolicyList, error) {
+	return s.ListClusterPolicies(kapi.WithNamespace(kapi.NewContext(), ""), &options)
+}
+
+func (s ReadOnlyClusterPolicy) Get(name string) (*authorizationapi.ClusterPolicy, error) {
+	return s.GetClusterPolicy(kapi.WithNamespace(kapi.NewContext(), ""), name)
+}

--- a/pkg/authorization/registry/clusterpolicybinding/registry.go
+++ b/pkg/authorization/registry/clusterpolicybinding/registry.go
@@ -115,3 +115,15 @@ func (s *simulatedStorage) GetPolicyBinding(ctx kapi.Context, name string) (*aut
 func (s *simulatedStorage) DeletePolicyBinding(ctx kapi.Context, name string) error {
 	return s.clusterRegistry.DeleteClusterPolicyBinding(ctx, name)
 }
+
+type ReadOnlyClusterPolicyBinding struct {
+	Registry
+}
+
+func (s ReadOnlyClusterPolicyBinding) List(options kapi.ListOptions) (*authorizationapi.ClusterPolicyBindingList, error) {
+	return s.ListClusterPolicyBindings(kapi.WithNamespace(kapi.NewContext(), ""), &options)
+}
+
+func (s ReadOnlyClusterPolicyBinding) Get(name string) (*authorizationapi.ClusterPolicyBinding, error) {
+	return s.GetClusterPolicyBinding(kapi.WithNamespace(kapi.NewContext(), ""), name)
+}

--- a/pkg/authorization/registry/clusterrole/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
+	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
 	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
@@ -16,8 +17,15 @@ type ClusterRoleStorage struct {
 	roleStorage rolestorage.VirtualStorage
 }
 
-func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleStorage {
+func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterBindingRegistry clusterpolicybindingregistry.Registry) *ClusterRoleStorage {
 	simulatedPolicyRegistry := clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry)
+
+	ruleResolver := rulevalidation.NewDefaultRuleResolver(
+		nil,
+		nil,
+		clusterpolicyregistry.ReadOnlyClusterPolicy{Registry: clusterPolicyRegistry},
+		clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterBindingRegistry},
+	)
 
 	return &ClusterRoleStorage{
 		roleStorage: rolestorage.VirtualStorage{

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
@@ -16,8 +17,15 @@ type ClusterRoleBindingStorage struct {
 	roleBindingStorage rolebindingstorage.VirtualStorage
 }
 
-func NewClusterRoleBindingStorage(clusterPolicyBindingRegistry clusterpolicybindingregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleBindingStorage {
+func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterPolicyBindingRegistry clusterpolicybindingregistry.Registry) *ClusterRoleBindingStorage {
 	simulatedPolicyBindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterPolicyBindingRegistry)
+
+	ruleResolver := rulevalidation.NewDefaultRuleResolver(
+		nil,
+		nil,
+		clusterpolicyregistry.ReadOnlyClusterPolicy{Registry: clusterPolicyRegistry},
+		clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
+	)
 
 	return &ClusterRoleBindingStorage{
 		rolebindingstorage.VirtualStorage{

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -154,14 +154,14 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		policyListerNamespacer{registry: policyRegistry},
 		policyBindingListerNamespacer{registry: policyBindingRegistry},
-		clusterPolicyLister{registry: clusterPolicyRegistry},
-		clusterPolicyBindingLister{registry: clusterPolicyBindingRegistry},
+		clusterpolicyregistry.ReadOnlyClusterPolicy{Registry: clusterPolicyRegistry},
+		clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
 	)
 
 	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver)
 	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver)
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, ruleResolver)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyBindingRegistry, ruleResolver)
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -280,28 +280,4 @@ func (s policyBindingLister) List(options kapi.ListOptions) (*authorizationapi.P
 
 func (s policyBindingLister) Get(name string) (*authorizationapi.PolicyBinding, error) {
 	return s.registry.GetPolicyBinding(kapi.WithNamespace(kapi.NewContext(), s.namespace), name)
-}
-
-type clusterPolicyLister struct {
-	registry clusterpolicyregistry.Registry
-}
-
-func (s clusterPolicyLister) List(options kapi.ListOptions) (*authorizationapi.ClusterPolicyList, error) {
-	return s.registry.ListClusterPolicies(kapi.WithNamespace(kapi.NewContext(), ""), &options)
-}
-
-func (s clusterPolicyLister) Get(name string) (*authorizationapi.ClusterPolicy, error) {
-	return s.registry.GetClusterPolicy(kapi.WithNamespace(kapi.NewContext(), ""), name)
-}
-
-type clusterPolicyBindingLister struct {
-	registry clusterpolicybindingregistry.Registry
-}
-
-func (s clusterPolicyBindingLister) List(options kapi.ListOptions) (*authorizationapi.ClusterPolicyBindingList, error) {
-	return s.registry.ListClusterPolicyBindings(kapi.WithNamespace(kapi.NewContext(), ""), &options)
-}
-
-func (s clusterPolicyBindingLister) Get(name string) (*authorizationapi.ClusterPolicyBinding, error) {
-	return s.registry.GetClusterPolicyBinding(kapi.WithNamespace(kapi.NewContext(), ""), name)
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -443,24 +443,23 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	policyStorage, err := policyetcd.NewStorage(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	policyRegistry := policyregistry.NewRegistry(policyStorage)
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver)
-
 	policyBindingStorage, err := policybindingetcd.NewStorage(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	policyBindingRegistry := policybindingregistry.NewRegistry(policyBindingStorage)
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver)
 
 	clusterPolicyStorage, err := clusterpolicystorage.NewStorage(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	clusterPolicyRegistry := clusterpolicyregistry.NewRegistry(clusterPolicyStorage)
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, c.RuleResolver)
-
 	clusterPolicyBindingStorage, err := clusterpolicybindingstorage.NewStorage(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewRegistry(clusterPolicyBindingStorage)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyBindingRegistry, c.RuleResolver)
 
 	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, c.Informers.ClusterPolicies().Lister().ClusterPolicies())
+
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver)
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver)
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)


### PR DESCRIPTION
This reverts commit 4a72554bdb8e590c435e8edc43ca9ca6bc530136.

Fixes https://github.com/openshift/origin/issues/9528

Fixes

```
FAILURE after 0.133s: test/cmd/admin.sh:247: executing 'oc create -f test/extended/testdata/roles/policy-clusterroles.yaml' expecting success: the command returned the wrong error code
Standard output from the command:
clusterrole "basic-user2" created

Standard error from the command:
Error from server: role "basic-user2" not found

```