### PR TITLE
stop copying policyrules during authorization checks

### DIFF
--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -132,19 +132,21 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, passedAttributes AuthorizationAttributes) (bool, string, error) {
 	attributes := CoerceToDefaultAuthorizationAttributes(passedAttributes)
 
-	allRules, ruleRetrievalError := a.ruleResolver.GetEffectivePolicyRules(ctx)
+	allRuleSets, ruleRetrievalError := a.ruleResolver.GetEffectivePolicyRules(ctx)
 
-	for _, rule := range allRules {
-		matches, err := attributes.RuleMatches(rule)
-		if err != nil {
-			return false, "", err
-		}
-		if matches {
-			namespace := kapi.NamespaceValue(ctx)
-			if len(namespace) == 0 {
-				return true, "allowed by cluster rule", nil
+	for _, ruleSet := range allRuleSets {
+		for _, rule := range ruleSet {
+			matches, err := attributes.RuleMatches(rule)
+			if err != nil {
+				return false, "", err
 			}
-			return true, "allowed by rule in " + namespace, nil
+			if matches {
+				namespace := kapi.NamespaceValue(ctx)
+				if len(namespace) == 0 {
+					return true, "allowed by cluster rule", nil
+				}
+				return true, "allowed by rule in " + namespace, nil
+			}
 		}
 	}
 

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -134,9 +134,9 @@ func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, pass
 
 	allRuleSets, ruleRetrievalError := a.ruleResolver.GetEffectivePolicyRules(ctx)
 
-	for _, ruleSet := range allRuleSets {
-		for _, rule := range ruleSet {
-			matches, err := attributes.RuleMatches(rule)
+	for i := range allRuleSets {
+		for j := range allRuleSets[i] {
+			matches, err := attributes.RuleMatches(allRuleSets[i][j])
 			if err != nil {
 				return false, "", err
 			}

--- a/pkg/authorization/registry/selfsubjectrulesreview/storage.go
+++ b/pkg/authorization/registry/selfsubjectrulesreview/storage.go
@@ -46,20 +46,20 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	errors := []error{}
 
 	rules := []authorizationapi.PolicyRule{}
-	namespaceRules, err := r.ruleResolver.GetEffectivePolicyRules(ctx)
+	namespaceRuleSets, err := r.ruleResolver.GetEffectivePolicyRules(ctx)
 	if err != nil {
 		errors = append(errors, err)
 	}
-	for _, rule := range namespaceRules {
+	for _, rule := range rulevalidation.RulesFromRuleSets(namespaceRuleSets) {
 		rules = append(rules, rulevalidation.BreakdownRule(rule)...)
 	}
 	if len(namespace) != 0 {
 		masterContext := kapi.WithNamespace(ctx, kapi.NamespaceNone)
-		clusterRules, err := r.ruleResolver.GetEffectivePolicyRules(masterContext)
+		clusterRuleSets, err := r.ruleResolver.GetEffectivePolicyRules(masterContext)
 		if err != nil {
 			errors = append(errors, err)
 		}
-		for _, rule := range clusterRules {
+		for _, rule := range rulevalidation.RulesFromRuleSets(clusterRuleSets) {
 			rules = append(rules, rulevalidation.BreakdownRule(rule)...)
 		}
 	}


### PR DESCRIPTION
This stops copying rules from `GetEffectivePolicyRules` when using it for authorization.

@smarterclayton I get this
```
(pprof) top30 -cum
10549410 of 54554319 total (19.34%)
Dropped 4800 nodes (cum <= 272771)
Showing top 30 nodes out of 361 (cum >= 9154581)
      flat  flat%   sum%        cum   cum%
         0     0%     0%   28050448 51.42%  k8s.io/kubernetes/pkg/api/unversioned.(*Timestamp).Unmarshal
    209917  0.38%  0.38%   16677784 30.57%  k8s.io/kubernetes/pkg/apiserver.(*APIInstaller).registerResourceHandlers
         0     0%  0.38%   16180863 29.66%  k8s.io/kubernetes/pkg/controller/route.(*RouteController).reconcile.func1
      8715 0.016%   0.4%   16150536 29.60%  k8s.io/kubernetes/pkg/controller/route.New
         0     0%   0.4%   15174016 27.81%  k8s.io/kubernetes/pkg/controller/replicaset.(*overlappingReplicaSets).Less
       128 0.00023%   0.4%   15119332 27.71%  github.com/ugorji/go/codec.(*bincDecDriver).decStringAndBytes
         0     0%   0.4%   15115389 27.71%  crypto/x509.subjectBytes
      3331 0.0061%  0.41%   15097571 27.67%  github.com/godbus/dbus.(*Conn).Send
         0     0%  0.41%   14754575 27.05%  github.com/skynetservices/skydns/server.(*server).ServeDNSStubForward
         0     0%  0.41%   14394967 26.39%  crypto/x509.(*Certificate).CreateCRL
         0     0%  0.41%   14380251 26.36%  github.com/coreos/etcd/clientv3.OpGet
         0     0%  0.41%   14063273 25.78%  github.com/skynetservices/skydns/server.(*FirstBackend).Records
         0     0%  0.41%   14063273 25.78%  github.com/skynetservices/skydns/server.(*server).ServeDNS.func1
         0     0%  0.41%   13856713 25.40%  k8s.io/kubernetes/pkg/master.(*ThirdPartyController).syncResourceList
         0     0%  0.41%   13739770 25.19%  k8s.io/kubernetes/pkg/kubelet/config.(*podStorage).merge.func1
         0     0%  0.41%   13491413 24.73%  github.com/skynetservices/skydns/server.(*server).NewSOA
         0     0%  0.41%   13484339 24.72%  github.com/skynetservices/skydns/server.(*FirstBackend).ReverseRecord
     19147 0.035%  0.44%   11925053 21.86%  crypto/x509.buildExtensions
         0     0%  0.44%   11720595 21.48%  github.com/coreos/etcd/clientv3.(*maintenance).AlarmDisarm
         0     0%  0.44%   11682501 21.41%  github.com/openshift/origin/pkg/build/api/validation.validateTrigger
         0     0%  0.44%   11674072 21.40%  k8s.io/kubernetes/pkg/kubelet/rkt.New
         0     0%  0.44%   11192410 20.52%  github.com/skynetservices/skydns/server.(*server).dedup
    664790  1.22%  1.66%   10191718 18.68%  k8s.io/kubernetes/pkg/apis/extensions/v1beta1.(*HorizontalPodAutoscalerStatus).Unmarshal
     26835 0.049%  1.71%   10177390 18.66%  k8s.io/kubernetes/pkg/controller/node.(*NodeController).tryUpdateNodeStatus
         0     0%  1.71%    9515573 17.44%  github.com/fsouza/go-dockerclient/external/github.com/docker/docker/opts.parseDockerDaemonHost
         0     0%  1.71%    9475238 17.37%  k8s.io/kubernetes/pkg/apis/extensions/v1beta1.(*IngressSpec).Unmarshal
         0     0%  1.71%    9313197 17.07%  k8s.io/kubernetes/pkg/registry/node.nodeStatusStrategy.Export
   9282377 17.01% 18.72%    9282377 17.01%  github.com/openshift/origin/pkg/image/api/v1.DeepCopy_v1_TagEventCondition
    334170  0.61% 19.34%    9203741 16.87%  k8s.io/kubernetes/pkg/registry/persistentvolume.persistentvolumeStrategy.ValidateUpdate
         0     0% 19.34%    9154581 16.78%  github.com/openshift/origin/pkg/build/api/validation.validateJenkinsPipelineStrategy
```