### PR TITLE
Removed fields added to the build strategy when using --strategy=docker.

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -204,7 +204,7 @@ func (s *BuildStrategyRef) BuildStrategy(env Environment) (*buildapi.BuildStrate
 		strategy := &buildapi.DockerBuildStrategy{
 			Env: env.List(),
 		}
-		if s.Base != nil {
+		if s.Base != nil && !s.Base.FromDockerfile {
 			ref := s.Base.ObjectReference()
 			strategy.From = &ref
 			triggers = s.Base.BuildTriggers()
@@ -247,6 +247,7 @@ func (r *BuildRef) BuildConfig() (*buildapi.BuildConfig, error) {
 	}
 	strategy := &buildapi.BuildStrategy{}
 	strategyTriggers := []buildapi.BuildTriggerPolicy{}
+
 	if r.Strategy != nil {
 		strategy, strategyTriggers = r.Strategy.BuildStrategy(r.Env)
 	}

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -322,6 +322,9 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 						glog.Warningf(msg, from)
 					}
 					image = inputImage
+					if image != nil {
+						image.FromDockerfile = refInput.FromDockerfile
+					}
 				}
 
 				glog.V(4).Infof("will use %q as the base image for a source build of %q", ref, refInput.Uses)

--- a/pkg/generate/app/cmd/resolve.go
+++ b/pkg/generate/app/cmd/resolve.go
@@ -506,6 +506,7 @@ func AddMissingComponentsToRefBuilder(
 			refs := b.AddComponents([]string{baseImage}, func(input *app.ComponentInput) app.ComponentReference {
 				input.Resolver = dockerfileResolver
 				input.Use(repo)
+				input.FromDockerfile = true
 				input.ExpectToBuild = true
 				repo.UsedBy(input)
 				repo.BuildWithDocker()

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -28,11 +28,14 @@ func componentWithSource(s string) (component, repo string, builder bool, err er
 		if len(segs) == 2 {
 			builder = true
 			switch {
+			// ~[code]
 			case len(segs[0]) == 0:
 				err = fmt.Errorf("when using '[image]~[code]' form for %q, you must specify a image name", s)
 				return
+			// [image]~
 			case len(segs[1]) == 0:
 				component = segs[0]
+			// [image]~[code]
 			default:
 				component = segs[0]
 				repo = segs[1]
@@ -299,6 +302,11 @@ type ComponentInput struct {
 
 	ExpectToBuild bool
 	ScratchImage  bool
+	// FromDockerFile keeps track of whether this image was retrieved from a
+	// Dockerfile, which changes our BuildConfig results.  If true, the
+	// ImageChangeTrigger for this run is left blank, and the strategy will not
+	// have a from: component
+	FromDockerfile bool
 
 	Uses          *SourceRepository
 	ResolvedMatch *ComponentMatch

--- a/pkg/generate/app/imageref.go
+++ b/pkg/generate/app/imageref.go
@@ -140,6 +140,11 @@ type ImageRef struct {
 	OutputImage     bool
 	Insecure        bool
 	HasEmptyDir     bool
+	// FromDockerFile keeps track of whether this image was retrieved from a
+	// Dockerfile, which changes our BuildConfig results.  If true, the
+	// ImageChangeTrigger for this run is left blank, and the strategy will not
+	// have a from: component
+	FromDockerfile bool
 	// TagDirectly will create the image stream using a tag for this reference, not a bulk
 	// import.
 	TagDirectly bool

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -36,6 +36,19 @@ os::cmd::expect_success_and_text 'oc new-app mysql -o yaml --as-test' 'test: tru
 
 # docker strategy with repo that has no dockerfile
 os::cmd::expect_failure_and_text 'oc new-app https://github.com/openshift/nodejs-ex --strategy=docker' 'No Dockerfile was found'
+# test docker strategy with repo that has a dockerfile, making sure the
+# dockerStrategy has no From: field
+os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/ruby-hello-world --strategy=docker -o jsonpath={.items[2].spec.strategy}' 'map[type:Docker dockerStrategy:map[]]'
+# test docker strategy with repo that has a dockerfile, making sure an
+# ImageChangeTrigger isn't included
+os::cmd::expect_success_and_not_text 'oc new-app https://github.com/openshift/ruby-hello-world --strategy=docker -o jsonpath={.items[2].spec.triggers}' 'type:ImageChange'
+# test docker strategy with repo that has a dockerfile and a user specified
+# image, making sure an ImageChangeTrigger is included
+os::cmd::expect_success_and_text 'oc new-app openshift/origin:latest~https://github.com/openshift/ruby-hello-world --strategy=docker -o jsonpath={.items[2].spec.triggers}' 'type:ImageChange'
+# test docker strategy with repo that has a dockerfile and a user specified
+# image, making sure the right dockerStrategy is used
+os::cmd::expect_success_and_text 'oc new-app openshift/origin:latest~https://github.com/openshift/ruby-hello-world --strategy=docker -o jsonpath={.items[2].spec.strategy.dockerStrategy.from}' 'origin:latest'
+
 
 # check label creation
 os::cmd::try_until_success 'oc get imagestreamtags php:latest'


### PR DESCRIPTION
Fixes #6347 

Old output:

```
$ oc new-app https://github.com/openshift/ruby-hello-world --strategy=docker -o yaml
...
- apiVersion: v1
  kind: BuildConfig
  metadata:
    annotations:
      openshift.io/generated-by: OpenShiftNewApp
    creationTimestamp: null
    labels:
      app: ruby-hello-world
    name: ruby-hello-world
  spec:
    output:
      to:
        kind: ImageStreamTag
        name: ruby-hello-world:latest
    postCommit: {}
    resources: {}
    source:
      git:
        uri: https://github.com/openshift/ruby-hello-world
      secrets: []
      type: Git
    strategy:
      dockerStrategy:
        from:
          kind: ImageStreamTag
          name: ruby-22-centos7:latest
      type: Docker
    triggers:
    - github:
        secret: 9kT3d_Dtngco-2amnzkE
      type: GitHub
    - generic:
        secret: b5HW8CYUDQqVK7UgTO7F
      type: Generic
    - type: ConfigChange
    - imageChange: {}
      type: ImageChange
  status:
    lastVersion: 0
...
```

New Output:

```
$ oc new-app https://github.com/openshift/ruby-hello-world --strategy=docker -o yaml
...
- apiVersion: v1
  kind: BuildConfig
  metadata:
    annotations:
      openshift.io/generated-by: OpenShiftNewApp
    creationTimestamp: null
    labels:
      app: ruby-hello-world
    name: ruby-hello-world
  spec:
    output:
      to:
        kind: ImageStreamTag
        name: ruby-hello-world:latest
    postCommit: {}
    resources: {}
    source:
      git:
        uri: https://github.com/openshift/ruby-hello-world
      secrets: []
      type: Git
    strategy:
      dockerStrategy: {}
      type: Docker
    triggers:
    - github:
        secret: ue-VeLrxT1w_OnBpdQhp
      type: GitHub
    - generic:
        secret: oS3Jr_kkqLvLPQJqsntn
      type: Generic
    - type: ConfigChange
    - imageChange: {}
      type: ImageChange
  status:
    lastVersion: 0
...
```
