### PR TITLE
cluster quota to namespace mapping controller

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/delta_fifo.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/delta_fifo.go
@@ -359,10 +359,12 @@ func (f *DeltaFIFO) GetByKey(key string) (item interface{}, exists bool, err err
 // added/updated. The item is removed from the queue (and the store) before it
 // is returned, so if you don't successfully process it, you need to add it back
 // with AddIfNotPresent().
+// process function is called under lock, so it is safe update data structures
+// in it that need to be in sync with the queue (e.g. knownKeys).
 //
 // Pop returns a 'Deltas', which has a complete list of all the things
 // that happened to the object (deltas) while it was sitting in the queue.
-func (f *DeltaFIFO) Pop() interface{} {
+func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	for {
@@ -382,7 +384,7 @@ func (f *DeltaFIFO) Pop() interface{} {
 		delete(f.items, id)
 		// Don't need to copyDeltas here, because we're transferring
 		// ownership to the caller.
-		return item
+		return item, process(item)
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/fifo.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/fifo.go
@@ -20,12 +20,17 @@ import (
 	"sync"
 )
 
+// PopProcessFunc is passed to Pop() method of Queue interface.
+// It is supposed to process the element popped from the queue.
+type PopProcessFunc func(interface{}) error
+
 // Queue is exactly like a Store, but has a Pop() method too.
 type Queue interface {
 	Store
 
-	// Pop blocks until it has something to return.
-	Pop() interface{}
+	// Pop blocks until it has something to process.
+	// It returns the object that was process and the result of processing.
+	Pop(PopProcessFunc) (interface{}, error)
 
 	// AddIfNotPresent adds a value previously
 	// returned by Pop back into the queue as long
@@ -35,6 +40,16 @@ type Queue interface {
 
 	// Return true if the first batch of items has been popped
 	HasSynced() bool
+}
+
+// Helper function for popping from Queue.
+func Pop(queue Queue) interface{} {
+	var result interface{}
+	queue.Pop(func(obj interface{}) error {
+		result = obj
+		return nil
+	})
+	return result
 }
 
 // FIFO receives adds and updates from a Reflector, and puts them in a queue for
@@ -181,12 +196,13 @@ func (f *FIFO) GetByKey(key string) (item interface{}, exists bool, err error) {
 	return item, exists, nil
 }
 
-// Pop waits until an item is ready and returns it. If multiple items are
+// Pop waits until an item is ready and processes it. If multiple items are
 // ready, they are returned in the order in which they were added/updated.
-// The item is removed from the queue (and the store) before it is returned,
-// so if you don't successfully process it, you need to add it back with
-// AddIfNotPresent().
-func (f *FIFO) Pop() interface{} {
+// The item is removed from the queue (and the store) before it is processed,
+// so if you don't successfully process it, it should be added back with
+// AddIfNotPresent(). process function is called under lock, so it is safe
+// update data structures in it that need to be in sync with the queue.
+func (f *FIFO) Pop(process PopProcessFunc) (interface{}, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	for {
@@ -204,7 +220,7 @@ func (f *FIFO) Pop() interface{} {
 			continue
 		}
 		delete(f.items, id)
-		return item
+		return item, process(item)
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/fifo_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/fifo_test.go
@@ -52,7 +52,7 @@ func TestFIFO_basic(t *testing.T) {
 	lastInt := int(0)
 	lastUint := uint64(0)
 	for i := 0; i < amount*2; i++ {
-		switch obj := f.Pop().(testFifoObject).val.(type) {
+		switch obj := Pop(f).(testFifoObject).val.(type) {
 		case int:
 			if obj <= lastInt {
 				t.Errorf("got %v (int) out of order, last was %v", obj, lastInt)
@@ -85,7 +85,7 @@ func TestFIFO_addUpdate(t *testing.T) {
 	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- f.Pop().(testFifoObject)
+			got <- Pop(f).(testFifoObject)
 		}
 	}()
 
@@ -111,7 +111,7 @@ func TestFIFO_addReplace(t *testing.T) {
 	got := make(chan testFifoObject, 2)
 	go func() {
 		for {
-			got <- f.Pop().(testFifoObject)
+			got <- Pop(f).(testFifoObject)
 		}
 	}()
 
@@ -139,21 +139,21 @@ func TestFIFO_detectLineJumpers(t *testing.T) {
 	f.Add(mkFifoObj("foo", 13))
 	f.Add(mkFifoObj("zab", 30))
 
-	if e, a := 13, f.Pop().(testFifoObject).val; a != e {
+	if e, a := 13, Pop(f).(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
 	f.Add(mkFifoObj("foo", 14)) // ensure foo doesn't jump back in line
 
-	if e, a := 1, f.Pop().(testFifoObject).val; a != e {
+	if e, a := 1, Pop(f).(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
-	if e, a := 30, f.Pop().(testFifoObject).val; a != e {
+	if e, a := 30, Pop(f).(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 
-	if e, a := 14, f.Pop().(testFifoObject).val; a != e {
+	if e, a := 14, Pop(f).(testFifoObject).val; a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
 }
@@ -172,7 +172,7 @@ func TestFIFO_addIfNotPresent(t *testing.T) {
 
 	expectedValues := []int{1, 2, 4}
 	for _, expected := range expectedValues {
-		if actual := f.Pop().(testFifoObject).val; actual != expected {
+		if actual := Pop(f).(testFifoObject).val; actual != expected {
 			t.Fatalf("expected value %d, got %d", expected, actual)
 		}
 	}
@@ -208,15 +208,15 @@ func TestFIFO_HasSynced(t *testing.T) {
 		{
 			actions: []func(f *FIFO){
 				func(f *FIFO) { f.Replace([]interface{}{mkFifoObj("a", 1), mkFifoObj("b", 2)}, "0") },
-				func(f *FIFO) { f.Pop() },
+				func(f *FIFO) { Pop(f) },
 			},
 			expectedSynced: false,
 		},
 		{
 			actions: []func(f *FIFO){
 				func(f *FIFO) { f.Replace([]interface{}{mkFifoObj("a", 1), mkFifoObj("b", 2)}, "0") },
-				func(f *FIFO) { f.Pop() },
-				func(f *FIFO) { f.Pop() },
+				func(f *FIFO) { Pop(f) },
+				func(f *FIFO) { Pop(f) },
 			},
 			expectedSynced: true,
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/reflector_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/cache/reflector_test.go
@@ -261,7 +261,7 @@ func TestReflectorListAndWatch(t *testing.T) {
 
 	// Verify we received the right ids with the right resource versions.
 	for i, id := range ids {
-		pod := s.Pop().(*api.Pod)
+		pod := Pop(s).(*api.Pod)
 		if e, a := id, pod.Name; e != a {
 			t.Errorf("%v: Expected %v, got %v", i, e, a)
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/framework/controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/framework/controller.go
@@ -124,8 +124,7 @@ func (c *Controller) Requeue(obj interface{}) error {
 // concurrently.
 func (c *Controller) processLoop() {
 	for {
-		obj := c.config.Queue.Pop()
-		err := c.config.Process(obj)
+		obj, err := c.config.Queue.Pop(cache.PopProcessFunc(c.config.Process))
 		if err != nil {
 			if c.config.RetryOnError {
 				// This is the safe way to re-enqueue.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/util.go
@@ -120,8 +120,7 @@ func (c *realRecyclerClient) WatchPod(name, namespace, resourceVersion string, s
 	cache.NewReflector(podLW, &api.Pod{}, queue, 1*time.Minute).RunUntil(stopChannel)
 
 	return func() *api.Pod {
-		obj := queue.Pop()
-		return obj.(*api.Pod)
+		return cache.Pop(queue).(*api.Pod)
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
@@ -392,7 +392,7 @@ func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 
 func (f *ConfigFactory) getNextPod() *api.Pod {
 	for {
-		pod := f.PodQueue.Pop().(*api.Pod)
+		pod := cache.Pop(f.PodQueue).(*api.Pod)
 		if f.responsibleForPod(pod) {
 			glog.V(4).Infof("About to try and schedule pod %v", pod.Name)
 			return pod

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/scheduler_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/scheduler_test.go
@@ -27,7 +27,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/client/cache"
+	clientcache "k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/diff"
@@ -196,8 +196,8 @@ func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
 	// Setup stores to test pod's workflow:
 	// - queuedPodStore: pods queued before processing
 	// - scheduledPodStore: pods that has a scheduling decision
-	scheduledPodStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	queuedPodStore := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+	scheduledPodStore := clientcache.NewStore(clientcache.MetaNamespaceKeyFunc)
+	queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
 
 	// Port is the easiest way to cause a fit predicate failure
 	podPort := 8080
@@ -227,7 +227,7 @@ func TestSchedulerForgetAssumedPodAfterDelete(t *testing.T) {
 			return nil
 		}},
 		NextPod: func() *api.Pod {
-			return queuedPodStore.Pop().(*api.Pod)
+			return clientcache.Pop(queuedPodStore).(*api.Pod)
 		},
 		Error: func(p *api.Pod, err error) {
 			t.Errorf("Unexpected error when scheduling pod %+v: %v", p, err)

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -95,9 +95,9 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			limitedLogAndRetry(factory.BuildUpdater, 30*time.Minute),
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),
@@ -134,9 +134,9 @@ func (factory *BuildControllerFactory) CreateDeleteController() controller.Runna
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			controller.RetryNever,
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),
@@ -201,9 +201,9 @@ func (factory *BuildPodControllerFactory) Create() controller.RunnableController
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			retryFunc("BuildPod", nil),
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),
@@ -250,9 +250,9 @@ func (factory *BuildPodControllerFactory) CreateDeleteController() controller.Ru
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			controller.RetryNever,
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),
@@ -292,9 +292,9 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			retryFunc("ImageStream update", func(err error) bool {
 				_, isFatal := err.(buildcontroller.ImageChangeControllerFatalError)
@@ -331,9 +331,9 @@ func (factory *BuildConfigControllerFactory) Create() controller.RunnableControl
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			retryFunc("BuildConfig", buildcontroller.IsFatal),
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),

--- a/pkg/client/cache/clusterresourcequota.go
+++ b/pkg/client/cache/clusterresourcequota.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller/framework"
+
+	oapi "github.com/openshift/origin/pkg/api"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	clusterresourcequotaregistry "github.com/openshift/origin/pkg/quota/registry/clusterresourcequota"
+)
+
+type IndexerToClusterResourceQuotaLister struct {
+	cache.Indexer
+}
+
+func (i *IndexerToClusterResourceQuotaLister) List(options kapi.ListOptions) ([]*quotaapi.ClusterResourceQuota, error) {
+	returnedList := i.Indexer.List()
+	ret := make([]*quotaapi.ClusterResourceQuota, 0, len(returnedList))
+	matcher := clusterresourcequotaregistry.Matcher(oapi.ListOptionsToSelectors(&options))
+
+	for i := range returnedList {
+		clusterResourceQuota := returnedList[i].(*quotaapi.ClusterResourceQuota)
+		if matches, err := matcher.Matches(clusterResourceQuota); err == nil && matches {
+			ret = append(ret, clusterResourceQuota)
+		}
+	}
+	return ret, nil
+}
+
+func (i *IndexerToClusterResourceQuotaLister) Get(name string) (*quotaapi.ClusterResourceQuota, error) {
+	keyObj := &quotaapi.ClusterResourceQuota{ObjectMeta: kapi.ObjectMeta{Name: name}}
+	key, _ := framework.DeletionHandlingMetaNamespaceKeyFunc(keyObj)
+
+	item, exists, getErr := i.GetByKey(key)
+	if getErr != nil {
+		return nil, getErr
+	}
+	if !exists {
+		existsErr := kapierrors.NewNotFound(quotaapi.Resource("clusterresourcequota"), name)
+		return nil, existsErr
+	}
+	return item.(*quotaapi.ClusterResourceQuota), nil
+}

--- a/pkg/client/cache/namespace.go
+++ b/pkg/client/cache/namespace.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/registry/namespace"
+
+	oapi "github.com/openshift/origin/pkg/api"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+)
+
+// TODO move upstream along with the InformerFactory
+
+type IndexerToNamespaceLister struct {
+	cache.Indexer
+}
+
+func (i *IndexerToNamespaceLister) List(options kapi.ListOptions) ([]*kapi.Namespace, error) {
+	returnedList := i.Indexer.List()
+	ret := make([]*kapi.Namespace, 0, len(returnedList))
+	matcher := namespace.MatchNamespace(oapi.ListOptionsToSelectors(&options))
+
+	for i := range returnedList {
+		clusterResourceQuota := returnedList[i].(*kapi.Namespace)
+		if matches, err := matcher.Matches(clusterResourceQuota); err == nil && matches {
+			ret = append(ret, clusterResourceQuota)
+		}
+	}
+	return ret, nil
+}
+
+func (i *IndexerToNamespaceLister) Get(name string) (*kapi.Namespace, error) {
+	keyObj := &kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: name}}
+	key, _ := framework.DeletionHandlingMetaNamespaceKeyFunc(keyObj)
+
+	item, exists, getErr := i.GetByKey(key)
+	if getErr != nil {
+		return nil, getErr
+	}
+	if !exists {
+		existsErr := kapierrors.NewNotFound(quotaapi.Resource("namespace"), name)
+		return nil, existsErr
+	}
+	return item.(*kapi.Namespace), nil
+}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -52,6 +52,7 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	quota "github.com/openshift/origin/pkg/quota"
 	quotacontroller "github.com/openshift/origin/pkg/quota/controller"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	serviceaccountcontrollers "github.com/openshift/origin/pkg/serviceaccounts/controllers"
 )
 
@@ -499,4 +500,9 @@ func (c *MasterConfig) RunResourceQuotaManager(cm *cmapp.CMServer) {
 		ReplenishmentResyncPeriod: replenishmentSyncPeriodFunc,
 	}
 	go kresourcequota.NewResourceQuotaController(resourceQuotaControllerOptions).Run(concurrentResourceQuotaSyncs, utilwait.NeverStop)
+}
+
+func (c *MasterConfig) RunClusterQuotaMappingController() {
+	controller := clusterquotamapping.NewClusterQuotaMappingController(c.Informers.Namespaces(), c.Informers.ClusterResourceQuotas())
+	go controller.Run(5, utilwait.NeverStop)
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -655,6 +655,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunImageImportController()
 	oc.RunOriginNamespaceController()
 	oc.RunSDNController()
+	oc.RunClusterQuotaMappingController()
 
 	_, _, serviceServingCertClient, err := oc.GetServiceAccountClients(bootstrappolicy.ServiceServingCertServiceAccountName)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,6 +41,21 @@ type Queue interface {
 	Pop() interface{}
 }
 
+func NewQueueWrapper(queue kcache.Queue) ReQueue {
+	return queueWrapper{queue: queue}
+}
+
+type queueWrapper struct {
+	queue kcache.Queue
+}
+
+func (q queueWrapper) Pop() interface{} {
+	return kcache.Pop(q.queue)
+}
+func (q queueWrapper) AddIfNotPresent(item interface{}) error {
+	return q.queue.AddIfNotPresent(item)
+}
+
 // Run begins processing resources from Queue asynchronously.
 func (c *RetryController) Run() {
 	go utilwait.Forever(func() { c.handleOne(c.Queue.Pop()) }, 0)

--- a/pkg/controller/shared/quota_informers.go
+++ b/pkg/controller/shared/quota_informers.go
@@ -1,0 +1,68 @@
+package shared
+
+import (
+	"reflect"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+)
+
+type ClusterResourceQuotaInformer interface {
+	Informer() framework.SharedIndexInformer
+	// still use an indexer, no telling what someone will want to index on someday
+	Indexer() cache.Indexer
+	Lister() *ocache.IndexerToClusterResourceQuotaLister
+}
+
+type clusterResourceQuotaInformer struct {
+	*sharedInformerFactory
+}
+
+func (f *clusterResourceQuotaInformer) Informer() framework.SharedIndexInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	informerObj := &quotaapi.ClusterResourceQuota{}
+	informerType := reflect.TypeOf(informerObj)
+	informer, exists := f.informers[informerType]
+	if exists {
+		return informer
+	}
+
+	lw := f.customListerWatchers.GetListerWatcher(kapi.Resource("clusterresourcequotas"))
+	if lw == nil {
+		lw = &cache.ListWatch{
+			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+				return f.originClient.ClusterResourceQuotas().List(options)
+			},
+			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+				return f.originClient.ClusterResourceQuotas().Watch(options)
+			},
+		}
+	}
+
+	informer = framework.NewSharedIndexInformer(
+		lw,
+		informerObj,
+		f.defaultResync,
+		cache.Indexers{},
+	)
+	f.informers[informerType] = informer
+
+	return informer
+}
+
+func (f *clusterResourceQuotaInformer) Indexer() cache.Indexer {
+	informer := f.Informer()
+	return informer.GetIndexer()
+}
+
+func (f *clusterResourceQuotaInformer) Lister() *ocache.IndexerToClusterResourceQuotaLister {
+	return &ocache.IndexerToClusterResourceQuotaLister{Indexer: f.Indexer()}
+}

--- a/pkg/controller/shared/shared_informer.go
+++ b/pkg/controller/shared/shared_informer.go
@@ -20,6 +20,7 @@ type InformerFactory interface {
 	StartCore(stopCh <-chan struct{})
 
 	Pods() PodInformer
+	Namespaces() NamespaceInformer
 	ReplicationControllers() ReplicationControllerInformer
 
 	ClusterPolicies() ClusterPolicyInformer
@@ -29,6 +30,8 @@ type InformerFactory interface {
 
 	DeploymentConfigs() DeploymentConfigInformer
 	ImageStreams() ImageStreamInformer
+
+	ClusterResourceQuotas() ClusterResourceQuotaInformer
 }
 
 // ListerWatcherOverrides allows a caller to specify special behavior for particular ListerWatchers
@@ -88,6 +91,10 @@ func (f *sharedInformerFactory) ReplicationControllers() ReplicationControllerIn
 	return &replicationControllerInformer{sharedInformerFactory: f}
 }
 
+func (f *sharedInformerFactory) Namespaces() NamespaceInformer {
+	return &namespaceInformer{sharedInformerFactory: f}
+}
+
 func (f *sharedInformerFactory) ClusterPolicies() ClusterPolicyInformer {
 	return &clusterPolicyInformer{sharedInformerFactory: f}
 }
@@ -110,4 +117,8 @@ func (f *sharedInformerFactory) DeploymentConfigs() DeploymentConfigInformer {
 
 func (f *sharedInformerFactory) ImageStreams() ImageStreamInformer {
 	return &imageStreamInformer{sharedInformerFactory: f}
+}
+
+func (f *sharedInformerFactory) ClusterResourceQuotas() ClusterResourceQuotaInformer {
+	return &clusterResourceQuotaInformer{sharedInformerFactory: f}
 }

--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -70,9 +70,9 @@ func (factory *DeployerPodControllerFactory) Create() controller.RunnableControl
 	}
 
 	return &controller.RetryController{
-		Queue: podQueue,
+		Queue: controller.NewQueueWrapper(podQueue),
 		RetryManager: controller.NewQueueRetryManager(
-			podQueue,
+			controller.NewQueueWrapper(podQueue),
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				utilruntime.HandleError(err)

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -102,9 +102,9 @@ func (factory *DeploymentControllerFactory) Create() controller.RunnableControll
 	}
 
 	return &controller.RetryController{
-		Queue: deploymentQueue,
+		Queue: controller.NewQueueWrapper(deploymentQueue),
 		RetryManager: controller.NewQueueRetryManager(
-			deploymentQueue,
+			controller.NewQueueWrapper(deploymentQueue),
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				if _, isFatal := err.(fatalError); isFatal {

--- a/pkg/deploy/controller/imagechange/factory.go
+++ b/pkg/deploy/controller/imagechange/factory.go
@@ -60,9 +60,9 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				utilruntime.HandleError(err)

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -424,7 +424,7 @@ func NewPodWatch(client kclient.PodsNamespacer, namespace, name, resourceVersion
 	cache.NewReflector(podLW, &kapi.Pod{}, queue, 1*time.Minute).RunUntil(stopChannel)
 
 	return func() *kapi.Pod {
-		obj := queue.Pop()
+		obj := cache.Pop(queue)
 		return obj.(*kapi.Pod)
 	}
 }

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -55,9 +55,9 @@ func (f *ImportControllerFactory) Create() (controller.RunnableController, contr
 
 	// instantiate an importer for changes that happen to the image stream
 	changed := &controller.RetryController{
-		Queue: q,
+		Queue: controller.NewQueueWrapper(q),
 		RetryManager: controller.NewQueueRetryManager(
-			q,
+			controller.NewQueueWrapper(q),
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				utilruntime.HandleError(err)

--- a/pkg/project/controller/factory.go
+++ b/pkg/project/controller/factory.go
@@ -42,9 +42,9 @@ func (factory *NamespaceControllerFactory) Create() controller.RunnableControlle
 	}
 
 	return &controller.RetryController{
-		Queue: queue,
+		Queue: controller.NewQueueWrapper(queue),
 		RetryManager: controller.NewQueueRetryManager(
-			queue,
+			controller.NewQueueWrapper(queue),
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				utilruntime.HandleError(err)

--- a/pkg/quota/api/register.go
+++ b/pkg/quota/api/register.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -38,3 +39,4 @@ func addKnownTypes(scheme *runtime.Scheme) {
 
 func (obj *ClusterResourceQuotaList) GetObjectKind() unversioned.ObjectKind { return &obj.TypeMeta }
 func (obj *ClusterResourceQuota) GetObjectKind() unversioned.ObjectKind     { return &obj.TypeMeta }
+func (obj *ClusterResourceQuota) GetObjectMeta() meta.Object                { return &obj.ObjectMeta }

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
@@ -1,0 +1,607 @@
+package clusterquotamapping
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/labels"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	"github.com/openshift/origin/pkg/controller/shared"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+)
+
+type ClusterQuotaMapper interface {
+	// GetClusterQuotasFor returns the list of clusterquota names that this namespace matches.  It also
+	// returns the labels associated with the namespace for the check so that callers can determine staleness
+	GetClusterQuotasFor(namespaceName string) ([]string, map[string]string)
+	// GetNamespacesFor returns the list of namespace names that this cluster quota matches.  It also
+	// returns the selector associated with the clusterquota for the check so that callers can determine staleness
+	GetNamespacesFor(quotaName string) ([]string, *unversioned.LabelSelector)
+}
+
+// Look out, here there be dragons!
+// There is a race when dealing with the DeltaFifo compression used to back a reflector for a controller that uses two
+// SharedInformers for both their watch events AND their caches.  The scenario looks like this
+//
+// 1. Add, Delete a namespace really fast, *before* the add is observed by the controller using the reflector.
+// 2. Add or Update a quota that matches the Add namespace
+// 3. The cache had the intermediate state for the namespace for some period of time.  This makes the quota update the mapping indicating a match.
+// 4. The ns Delete is compressed out and never delivered to the controller, so the improper match is never cleared.
+//
+// This sounds pretty bad, however, we fail in the "safe" direction and the consequences are detectable.
+// When going from quota to namespace, you can get back a namespace that doesn't exist.  There are no resource in a non-existance
+// namespace, so you know to clear all referenced resources.  In addition, this add/delete has to happen so fast
+// that it would be nearly impossible for any resources to be created.  If you do create resources, then we must be observing
+// their deletes.  When quota is replenished, we'll see that we need to clear any charges.
+//
+// When going from namespace to quota, you can get back a quota that doesn't exist.  Since the cache is shared,
+// we know that a missing quota means that there isn't anything for us to bill against, so we can skip it.
+//
+// If the mapping cache is wrong and a previously deleted quota or namespace is created, this controller
+// correctly adds the items back to the list and clears out all previous mappings.
+//
+// In addition to those constraints, the timing threshold for actually hitting this problem is really tight.  It's
+// basically a script that is creating and deleting things as fast as it possibly can.  Sub-millisecond in the fuzz
+// test where I caught the problem.
+
+// NewClusterQuotaMappingController builds a mapping between namespaces and clusterresourcequotas
+func NewClusterQuotaMappingController(namespaceInformer shared.NamespaceInformer, quotaInformer shared.ClusterResourceQuotaInformer) *ClusterQuotaMappingController {
+	c := &ClusterQuotaMappingController{
+		namespaceQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+
+		quotaQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+
+		clusterQuotaMapper: &clusterQuotaMapper{
+			requiredQuotaToSelector:    map[string]*unversioned.LabelSelector{},
+			requiredNamespaceToLabels:  map[string]map[string]string{},
+			completedQuotaToSelector:   map[string]*unversioned.LabelSelector{},
+			completedNamespaceToLabels: map[string]map[string]string{},
+
+			quotaToNamespaces: map[string]sets.String{},
+			namespaceToQuota:  map[string]sets.String{},
+		},
+	}
+
+	namespaceInformer.Informer().AddEventHandler(framework.ResourceEventHandlerFuncs{
+		AddFunc:    c.addNamespace,
+		UpdateFunc: c.updateNamespace,
+		DeleteFunc: c.deleteNamespace,
+	})
+	c.namespaceLister = namespaceInformer.Lister()
+	c.namespacesSynced = namespaceInformer.Informer().HasSynced
+
+	quotaInformer.Informer().AddEventHandler(framework.ResourceEventHandlerFuncs{
+		AddFunc:    c.addQuota,
+		UpdateFunc: c.updateQuota,
+		DeleteFunc: c.deleteQuota,
+	})
+	c.quotaLister = quotaInformer.Lister()
+	c.quotasSynced = quotaInformer.Informer().HasSynced
+
+	return c
+}
+
+type ClusterQuotaMappingController struct {
+	namespaceQueue   workqueue.RateLimitingInterface
+	namespaceLister  *ocache.IndexerToNamespaceLister
+	namespacesSynced func() bool
+
+	quotaQueue   workqueue.RateLimitingInterface
+	quotaLister  *ocache.IndexerToClusterResourceQuotaLister
+	quotasSynced func() bool
+
+	clusterQuotaMapper *clusterQuotaMapper
+}
+
+// clusterQuotaMapper gives thread safe access to the actual mappings that are being stored.
+// Many method use a shareable read lock to check status followed by a non-shareable
+// write lock which double checks the condition before proceding.  Since locks aren't escalatable
+// you have to perform the recheck because someone could have beaten you in.
+type clusterQuotaMapper struct {
+	lock sync.RWMutex
+
+	// requiredQuotaToSelector indicates the latest label selector this controller has observed for a quota
+	requiredQuotaToSelector map[string]*unversioned.LabelSelector
+	// requiredNamespaceToLabels indicates the latest labels this controller has observed for a namespace
+	requiredNamespaceToLabels map[string]map[string]string
+	// completedQuotaToSelector indicates the latest label selector this controller has scanned against namespaces
+	completedQuotaToSelector map[string]*unversioned.LabelSelector
+	// completedNamespaceToLabels indicates the latest labels this controller has scanned against cluster quotas
+	completedNamespaceToLabels map[string]map[string]string
+
+	quotaToNamespaces map[string]sets.String
+	namespaceToQuota  map[string]sets.String
+}
+
+func (m *clusterQuotaMapper) GetClusterQuotasFor(namespaceName string) ([]string, map[string]string) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	quotas, ok := m.namespaceToQuota[namespaceName]
+	if !ok {
+		return []string{}, m.completedNamespaceToLabels[namespaceName]
+	}
+	return quotas.List(), m.completedNamespaceToLabels[namespaceName]
+}
+
+func (m *clusterQuotaMapper) GetNamespacesFor(quotaName string) ([]string, *unversioned.LabelSelector) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	namespaces, ok := m.quotaToNamespaces[quotaName]
+	if !ok {
+		return []string{}, m.completedQuotaToSelector[quotaName]
+	}
+	return namespaces.List(), m.completedQuotaToSelector[quotaName]
+}
+
+// requireQuota updates the selector requirements for the given quota.  This prevents stale updates to the mapping itself.
+// returns true if a modification was made
+func (m *clusterQuotaMapper) requireQuota(quota *quotaapi.ClusterResourceQuota) bool {
+	m.lock.RLock()
+	selector, exists := m.requiredQuotaToSelector[quota.Name]
+	m.lock.RUnlock()
+
+	if selectorMatches(selector, exists, quota) {
+		return false
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	selector, exists = m.requiredQuotaToSelector[quota.Name]
+	if selectorMatches(selector, exists, quota) {
+		return false
+	}
+
+	m.requiredQuotaToSelector[quota.Name] = quota.Spec.Selector
+	return true
+}
+
+// completeQuota updates the latest selector used to generate the mappings for this quota.  The value is returned
+// by the Get methods for the mapping so that callers can determine staleness
+func (m *clusterQuotaMapper) completeQuota(quota *quotaapi.ClusterResourceQuota) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.completedQuotaToSelector[quota.Name] = quota.Spec.Selector
+}
+
+// removeQuota deletes a quota from all mappings
+func (m *clusterQuotaMapper) removeQuota(quotaName string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.requiredQuotaToSelector, quotaName)
+	delete(m.completedQuotaToSelector, quotaName)
+	delete(m.quotaToNamespaces, quotaName)
+	for _, quotas := range m.namespaceToQuota {
+		quotas.Delete(quotaName)
+	}
+}
+
+// requireNamespace updates the label requirements for the given namespace.  This prevents stale updates to the mapping itself.
+// returns true if a modification was made
+func (m *clusterQuotaMapper) requireNamespace(namespace *kapi.Namespace) bool {
+	m.lock.RLock()
+	labels, exists := m.requiredNamespaceToLabels[namespace.Name]
+	m.lock.RUnlock()
+
+	if labelsMatch(labels, exists, namespace) {
+		return false
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	labels, exists = m.requiredNamespaceToLabels[namespace.Name]
+	if labelsMatch(labels, exists, namespace) {
+		return false
+	}
+
+	m.requiredNamespaceToLabels[namespace.Name] = namespace.Labels
+	return true
+}
+
+// completeNamespace updates the latest labels used to generate the mappings for this namespace.  The value is returned
+// by the Get methods for the mapping so that callers can determine staleness
+func (m *clusterQuotaMapper) completeNamespace(namespace *kapi.Namespace) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.completedNamespaceToLabels[namespace.Name] = namespace.Labels
+}
+
+// removeNamespace deletes a namespace from all mappings
+func (m *clusterQuotaMapper) removeNamespace(namespaceName string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.requiredNamespaceToLabels, namespaceName)
+	delete(m.completedNamespaceToLabels, namespaceName)
+	delete(m.namespaceToQuota, namespaceName)
+	for _, namespaces := range m.quotaToNamespaces {
+		namespaces.Delete(namespaceName)
+	}
+}
+
+func selectorMatches(selector *unversioned.LabelSelector, exists bool, quota *quotaapi.ClusterResourceQuota) bool {
+	return exists && kapi.Semantic.DeepEqual(selector, quota.Spec.Selector)
+}
+func labelsMatch(labels map[string]string, exists bool, namespace *kapi.Namespace) bool {
+	return exists && kapi.Semantic.DeepEqual(labels, namespace.Labels)
+}
+
+// setMapping maps (or removes a mapping) between a clusterquota and a namespace
+// It returns whether the action worked, whether the quota is out of date, whether the namespace is out of date
+// This allows callers to decide whether to pull new information from the cache or simply skip execution
+func (m *clusterQuotaMapper) setMapping(quota *quotaapi.ClusterResourceQuota, namespace *kapi.Namespace, remove bool) (bool /*added*/, bool /*quota matches*/, bool /*namespace matches*/) {
+	m.lock.RLock()
+	selector, selectorExists := m.requiredQuotaToSelector[quota.Name]
+	labels, labelsExist := m.requiredNamespaceToLabels[namespace.Name]
+	m.lock.RUnlock()
+
+	if !selectorMatches(selector, selectorExists, quota) {
+		return false, false, true
+	}
+	if !labelsMatch(labels, labelsExist, namespace) {
+		return false, true, false
+	}
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	selector, selectorExists = m.requiredQuotaToSelector[quota.Name]
+	labels, labelsExist = m.requiredNamespaceToLabels[namespace.Name]
+	if !selectorMatches(selector, selectorExists, quota) {
+		return false, false, true
+	}
+	if !labelsMatch(labels, labelsExist, namespace) {
+		return false, true, false
+	}
+
+	if remove {
+		namespaces, ok := m.quotaToNamespaces[quota.Name]
+		if !ok {
+			m.quotaToNamespaces[quota.Name] = sets.String{}
+		} else {
+			namespaces.Delete(namespace.Name)
+		}
+
+		quotas, ok := m.namespaceToQuota[namespace.Name]
+		if !ok {
+			m.namespaceToQuota[namespace.Name] = sets.String{}
+		} else {
+			quotas.Delete(quota.Name)
+		}
+
+		return true, true, true
+	}
+
+	namespaces, ok := m.quotaToNamespaces[quota.Name]
+	if !ok {
+		m.quotaToNamespaces[quota.Name] = sets.NewString(namespace.Name)
+	} else {
+		namespaces.Insert(namespace.Name)
+	}
+
+	quotas, ok := m.namespaceToQuota[namespace.Name]
+	if !ok {
+		m.namespaceToQuota[namespace.Name] = sets.NewString(quota.Name)
+	} else {
+		quotas.Insert(quota.Name)
+	}
+
+	return true, true, true
+
+}
+
+func (c *ClusterQuotaMappingController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	// Wait for the stores to sync before starting any work in this controller.
+	ready := make(chan struct{})
+	go c.waitForSyncedStores(ready, stopCh)
+	select {
+	case <-ready:
+	case <-stopCh:
+		return
+	}
+
+	glog.V(4).Infof("Starting workers for quota mapping controller workers")
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.namespaceWorker, time.Second, stopCh)
+		go wait.Until(c.quotaWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	glog.Infof("Shutting down quota mapping controller")
+	c.namespaceQueue.ShutDown()
+	c.quotaQueue.ShutDown()
+}
+
+func (c *ClusterQuotaMappingController) syncQuota(quota *quotaapi.ClusterResourceQuota) error {
+	selector, err := unversioned.LabelSelectorAsSelector(quota.Spec.Selector)
+	if err != nil {
+		return err
+	}
+
+	allNamespaces, err := c.namespaceLister.List(kapi.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range allNamespaces {
+		namespace := allNamespaces[i]
+
+		// attempt to set the mapping. The quotas never collide with each other (same quota is never processed twice in parallel)
+		// so this means that the project we have is out of date, pull a more recent copy from the cache and retest
+		for {
+			matches := namespace != nil
+			if namespace != nil {
+				matches = selector.Matches(labels.Set(namespace.Labels))
+			}
+			success, quotaMatches, _ := c.clusterQuotaMapper.setMapping(quota, namespace, !matches)
+			if success {
+				break
+			}
+			// if the quota is mismatched, then someone has updated the quota or has deleted the entry entirely.
+			// if we've been updated, we'll be rekicked, if we've been deleted we should stop.  Either way, this
+			// execution is finished
+			if !quotaMatches {
+				return nil
+			}
+			namespace, err = c.namespaceLister.Get(namespace.Name)
+			if kapierrors.IsNotFound(err) {
+				// if the namespace is gone, then the deleteNamespace path will be called, just continue
+				break
+			}
+			if err != nil {
+				utilruntime.HandleError(err)
+				break
+			}
+		}
+
+	}
+
+	c.clusterQuotaMapper.completeQuota(quota)
+	return nil
+}
+
+func (c *ClusterQuotaMappingController) syncNamespace(namespace *kapi.Namespace) error {
+	allQuotas, err1 := c.quotaLister.List(kapi.ListOptions{})
+	if err1 != nil {
+		return err1
+	}
+	for i := range allQuotas {
+		quota := allQuotas[i]
+
+		for {
+			selector, err := unversioned.LabelSelectorAsSelector(quota.Spec.Selector)
+			if err != nil {
+				utilruntime.HandleError(err)
+				break
+			}
+
+			// attempt to set the mapping. The namespaces never collide with each other (same namespace is never processed twice in parallel)
+			// so this means that the quota we have is out of date, pull a more recent copy from the cache and retest
+			matches := namespace != nil
+			if namespace != nil {
+				matches = selector.Matches(labels.Set(namespace.Labels))
+			}
+			success, _, namespaceMatches := c.clusterQuotaMapper.setMapping(quota, namespace, !matches)
+			if success {
+				break
+			}
+			// if the namespace is mismatched, then someone has updated the namespace or has deleted the entry entirely.
+			// if we've been updated, we'll be rekicked, if we've been deleted we should stop.  Either way, this
+			// execution is finished
+			if !namespaceMatches {
+				return nil
+			}
+
+			quota, err = c.quotaLister.Get(quota.Name)
+			if kapierrors.IsNotFound(err) {
+				// if the quota is gone, then the deleteQuota path will be called, just continue
+				break
+			}
+			if err != nil {
+				utilruntime.HandleError(err)
+				break
+			}
+		}
+	}
+
+	c.clusterQuotaMapper.completeNamespace(namespace)
+	return nil
+}
+
+func (c *ClusterQuotaMappingController) quotaWork() bool {
+	key, quit := c.quotaQueue.Get()
+	if quit {
+		return true
+	}
+	defer c.quotaQueue.Done(key)
+
+	quota, exists, err := c.quotaLister.GetByKey(key.(string))
+	if !exists {
+		c.quotaQueue.Forget(key)
+		return false
+	}
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false
+	}
+
+	err = c.syncQuota(quota.(*quotaapi.ClusterResourceQuota))
+	outOfRetries := c.quotaQueue.NumRequeues(key) > 5
+	switch {
+	case err != nil && outOfRetries:
+		utilruntime.HandleError(err)
+		c.quotaQueue.Forget(key)
+
+	case err != nil && !outOfRetries:
+		c.quotaQueue.AddRateLimited(key)
+
+	default:
+		c.quotaQueue.Forget(key)
+	}
+
+	return false
+}
+
+func (c *ClusterQuotaMappingController) quotaWorker() {
+	for {
+		if quit := c.quotaWork(); quit {
+			return
+		}
+	}
+}
+
+func (c *ClusterQuotaMappingController) namespaceWork() bool {
+	key, quit := c.namespaceQueue.Get()
+	if quit {
+		return true
+	}
+	defer c.namespaceQueue.Done(key)
+
+	namespace, exists, err := c.namespaceLister.GetByKey(key.(string))
+	if !exists {
+		c.namespaceQueue.Forget(key)
+		return false
+	}
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false
+	}
+
+	err = c.syncNamespace(namespace.(*kapi.Namespace))
+	outOfRetries := c.namespaceQueue.NumRequeues(key) > 5
+	switch {
+	case err != nil && outOfRetries:
+		utilruntime.HandleError(err)
+		c.namespaceQueue.Forget(key)
+
+	case err != nil && !outOfRetries:
+		c.namespaceQueue.AddRateLimited(key)
+
+	default:
+		c.namespaceQueue.Forget(key)
+	}
+
+	return false
+}
+
+func (c *ClusterQuotaMappingController) namespaceWorker() {
+	for {
+		if quit := c.namespaceWork(); quit {
+			return
+		}
+	}
+}
+
+func (c *ClusterQuotaMappingController) waitForSyncedStores(ready chan<- struct{}, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	for !c.namespacesSynced() || !c.quotasSynced() {
+		glog.V(4).Infof("Waiting for the caches to sync before starting the quota mapping controller workers")
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-stopCh:
+			return
+		}
+	}
+	close(ready)
+}
+
+func (c *ClusterQuotaMappingController) deleteNamespace(obj interface{}) {
+	ns, ok1 := obj.(*kapi.Namespace)
+	if !ok1 {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %v", obj))
+			return
+		}
+		ns, ok = tombstone.Obj.(*kapi.Namespace)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace %v", obj))
+			return
+		}
+	}
+
+	c.clusterQuotaMapper.removeNamespace(ns.Name)
+}
+
+func (c *ClusterQuotaMappingController) addNamespace(cur interface{}) {
+	c.enqueueNamespace(cur)
+}
+func (c *ClusterQuotaMappingController) updateNamespace(old, cur interface{}) {
+	c.enqueueNamespace(cur)
+}
+func (c *ClusterQuotaMappingController) enqueueNamespace(obj interface{}) {
+	ns, ok := obj.(*kapi.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("not a Namespace %v", obj))
+		return
+	}
+	if !c.clusterQuotaMapper.requireNamespace(ns) {
+		return
+	}
+
+	key, err := controller.KeyFunc(ns)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.namespaceQueue.Add(key)
+}
+
+func (c *ClusterQuotaMappingController) deleteQuota(obj interface{}) {
+	quota, ok1 := obj.(*quotaapi.ClusterResourceQuota)
+	if !ok1 {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %v", obj))
+			return
+		}
+		quota, ok = tombstone.Obj.(*quotaapi.ClusterResourceQuota)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Quota %v", obj))
+			return
+		}
+	}
+
+	c.clusterQuotaMapper.removeQuota(quota.Name)
+}
+
+func (c *ClusterQuotaMappingController) addQuota(cur interface{}) {
+	c.enqueueQuota(cur)
+}
+func (c *ClusterQuotaMappingController) updateQuota(old, cur interface{}) {
+	c.enqueueQuota(cur)
+}
+func (c *ClusterQuotaMappingController) enqueueQuota(obj interface{}) {
+	quota, ok := obj.(*quotaapi.ClusterResourceQuota)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("not a Quota %v", obj))
+		return
+	}
+	if !c.clusterQuotaMapper.requireQuota(quota) {
+		return
+	}
+
+	key, err := controller.KeyFunc(quota)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.quotaQueue.Add(key)
+}

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
@@ -1,0 +1,303 @@
+package clusterquotamapping
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/controller/shared"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+)
+
+var (
+	keys           = []string{"different", "used", "important", "every", "large"}
+	values         = []string{"time", "person"}
+	namespaceNames = []string{
+		"tokillamockingbird", "harrypotter", "1984", "prideandprejudice", "thediaryofayounggirl", "animalfarm", "thehobbit",
+		"thelittleprince", "thegreatgatsby", "thecatcherintherye", "lordoftherings", "janeeyre", "romeoandjuliet", "thechroniclesofnarnia",
+		"lordoftheflies", "thegivingtree", "charlottesweb", "greeneggsandham", "alicesadventuresinwonderland", "littlewomen",
+		"ofmiceandmend", "wutheringheights", "thehungergames", "gonewiththewind", "thepictureofdoriangray", "theadventuresofhuckleberryfinn",
+		"fahrenheit451", "hamlet", "thehitchhikersguidetothegalaxy", "bravenewworld", "lesmiserables", "crimeandpunishment", "memoirsofageisha",
+	}
+	quotaNames = []string{"emma", "olivia", "sophia", "ava", "isabella", "mia", "abigail", "emily", "charlotte", "harper"}
+
+	maxSelectorKeys = 2
+	maxLabels       = 5
+)
+
+func TestClusterQuotaFuzzer(t *testing.T) {
+	for j := 0; j < 100; j++ {
+		t.Logf("attempt %d", (j + 1))
+		runFuzzer(t)
+	}
+}
+
+func runFuzzer(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	startingNamespaces := CreateStartingNamespaces()
+	kubeclient := ktestclient.NewSimpleFake(startingNamespaces...)
+	nsWatch := watch.NewFake()
+	kubeclient.PrependWatchReactor("namespaces", ktestclient.DefaultWatchReactor(nsWatch, nil))
+
+	startingQuotas := CreateStartingQuotas()
+	originclient := testclient.NewSimpleFake(startingQuotas...)
+	quotaWatch := watch.NewFake()
+	originclient.AddWatchReactor("clusterresourcequotas", ktestclient.DefaultWatchReactor(quotaWatch, nil))
+
+	informerFactory := shared.NewInformerFactory(kubeclient, originclient, shared.DefaultListerWatcherOverrides{}, 10*time.Minute)
+	controller := NewClusterQuotaMappingController(informerFactory.Namespaces(), informerFactory.ClusterResourceQuotas())
+	go controller.Run(5, stopCh)
+	informerFactory.Start(stopCh)
+
+	finalNamespaces := map[string]*kapi.Namespace{}
+	finalQuotas := map[string]*quotaapi.ClusterResourceQuota{}
+	quotaActions := map[string][]string{}
+	namespaceActions := map[string][]string{}
+	finishedNamespaces := make(chan struct{})
+	finishedQuotas := make(chan struct{})
+
+	for _, quota := range startingQuotas {
+		name := quota.(*quotaapi.ClusterResourceQuota).Name
+		quotaActions[name] = append(quotaActions[name], fmt.Sprintf("inserting %v to %v", name, quota.(*quotaapi.ClusterResourceQuota).Spec.Selector))
+		finalQuotas[name] = quota.(*quotaapi.ClusterResourceQuota)
+	}
+	for _, namespace := range startingNamespaces {
+		name := namespace.(*kapi.Namespace).Name
+		namespaceActions[name] = append(namespaceActions[name], fmt.Sprintf("inserting %v to %v", name, namespace.(*kapi.Namespace).Labels))
+		finalNamespaces[name] = namespace.(*kapi.Namespace)
+	}
+
+	go func() {
+		for i := 0; i < 200; i++ {
+			name := quotaNames[rand.Intn(len(quotaNames))]
+			_, exists := finalQuotas[name]
+			if rand.Intn(50) == 0 {
+				if !exists {
+					continue
+				}
+				// due to the compression race (see big comment for impl), clear the queue then delete
+				for {
+					if len(quotaWatch.ResultChan()) == 0 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+
+				quotaActions[name] = append(quotaActions[name], "deleting "+name)
+				quotaWatch.Delete(finalQuotas[name])
+				delete(finalQuotas, name)
+				continue
+			}
+
+			quota := NewQuota(name)
+			finalQuotas[name] = quota
+			copied, err := kapi.Scheme.Copy(quota)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exists {
+				quotaActions[name] = append(quotaActions[name], fmt.Sprintf("updating %v to %v", name, quota.Spec.Selector))
+				quotaWatch.Modify(copied)
+			} else {
+				quotaActions[name] = append(quotaActions[name], fmt.Sprintf("adding %v to %v", name, quota.Spec.Selector))
+				quotaWatch.Add(copied)
+			}
+		}
+		close(finishedQuotas)
+	}()
+
+	go func() {
+		for i := 0; i < 200; i++ {
+			name := namespaceNames[rand.Intn(len(namespaceNames))]
+			_, exists := finalNamespaces[name]
+			if rand.Intn(50) == 0 {
+				if !exists {
+					continue
+				}
+				// due to the compression race (see big comment for impl), clear the queue then delete
+				for {
+					if len(nsWatch.ResultChan()) == 0 {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+
+				namespaceActions[name] = append(namespaceActions[name], "deleting "+name)
+				nsWatch.Delete(finalNamespaces[name])
+				delete(finalNamespaces, name)
+				continue
+			}
+
+			ns := NewNamespace(name)
+			finalNamespaces[name] = ns
+			copied, err := kapi.Scheme.Copy(ns)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exists {
+				namespaceActions[name] = append(namespaceActions[name], fmt.Sprintf("updating %v to %v", name, ns.Labels))
+				nsWatch.Modify(copied)
+			} else {
+				namespaceActions[name] = append(namespaceActions[name], fmt.Sprintf("adding %v to %v", name, ns.Labels))
+				nsWatch.Add(copied)
+			}
+		}
+		close(finishedNamespaces)
+	}()
+
+	<-finishedQuotas
+	<-finishedNamespaces
+
+	finalFailures := []string{}
+	for i := 0; i < 200; i++ {
+		// better suggestions for testing doneness?  Check the condition a few times?
+		time.Sleep(50 * time.Millisecond)
+
+		finalFailures = checkState(controller, finalNamespaces, finalQuotas, t, quotaActions, namespaceActions)
+		if len(finalFailures) == 0 {
+			break
+		}
+	}
+
+	if len(finalFailures) > 0 {
+		t.Logf("have %d quotas and %d namespaces", len(quotaWatch.ResultChan()), len(nsWatch.ResultChan()))
+		t.Fatalf("failed on \n%v", strings.Join(finalFailures, "\n"))
+	}
+}
+
+func checkState(controller *ClusterQuotaMappingController, finalNamespaces map[string]*kapi.Namespace, finalQuotas map[string]*quotaapi.ClusterResourceQuota, t *testing.T, quotaActions, namespaceActions map[string][]string) []string {
+	failures := []string{}
+
+	quotaToNamespaces := map[string]sets.String{}
+	for _, quotaName := range quotaNames {
+		quotaToNamespaces[quotaName] = sets.String{}
+	}
+	namespacesToQuota := map[string]sets.String{}
+	for _, namespaceName := range namespaceNames {
+		namespacesToQuota[namespaceName] = sets.String{}
+	}
+	for _, quota := range finalQuotas {
+		selector, err := unversioned.LabelSelectorAsSelector(quota.Spec.Selector)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, namespace := range finalNamespaces {
+			if selector.Matches(labels.Set(namespace.Labels)) {
+				quotaToNamespaces[quota.Name].Insert(namespace.Name)
+				namespacesToQuota[namespace.Name].Insert(quota.Name)
+			}
+		}
+	}
+
+	for _, quotaName := range quotaNames {
+		namespaces, selector := controller.clusterQuotaMapper.GetNamespacesFor(quotaName)
+		nsSet := sets.NewString(namespaces...)
+		if !nsSet.Equal(quotaToNamespaces[quotaName]) {
+			failures = append(failures, fmt.Sprintf("quota %v, expected %v, got %v", quotaName, quotaToNamespaces[quotaName].List(), nsSet.List()))
+			failures = append(failures, quotaActions[quotaName]...)
+		}
+		if quota, ok := finalQuotas[quotaName]; ok && !reflect.DeepEqual(quota.Spec.Selector, selector) {
+			failures = append(failures, fmt.Sprintf("quota %v, expected %v, got %v", quotaName, quota.Spec.Selector, selector))
+		}
+	}
+
+	for _, namespaceName := range namespaceNames {
+		quotas, labels := controller.clusterQuotaMapper.GetClusterQuotasFor(namespaceName)
+		quotaSet := sets.NewString(quotas...)
+		if !quotaSet.Equal(namespacesToQuota[namespaceName]) {
+			failures = append(failures, fmt.Sprintf("namespace %v, expected %v, got %v", namespaceName, namespacesToQuota[namespaceName].List(), quotaSet.List()))
+			failures = append(failures, namespaceActions[namespaceName]...)
+		}
+		if namespace, ok := finalNamespaces[namespaceName]; ok && !reflect.DeepEqual(namespace.Labels, labels) {
+			failures = append(failures, fmt.Sprintf("namespace %v, expected %v, got %v", namespaceName, namespace.Labels, labels))
+		}
+	}
+
+	return failures
+}
+
+func CreateStartingQuotas() []runtime.Object {
+	count := rand.Intn(len(quotaNames))
+	used := sets.String{}
+	ret := []runtime.Object{}
+
+	for i := 0; i < count; i++ {
+		name := quotaNames[rand.Intn(len(quotaNames))]
+		if !used.Has(name) {
+			ret = append(ret, NewQuota(name))
+			used.Insert(name)
+		}
+	}
+
+	return ret
+}
+
+func CreateStartingNamespaces() []runtime.Object {
+	count := rand.Intn(len(namespaceNames))
+	used := sets.String{}
+	ret := []runtime.Object{}
+
+	for i := 0; i < count; i++ {
+		name := namespaceNames[rand.Intn(len(namespaceNames))]
+		if !used.Has(name) {
+			ret = append(ret, NewNamespace(name))
+			used.Insert(name)
+		}
+	}
+
+	return ret
+}
+
+func NewQuota(name string) *quotaapi.ClusterResourceQuota {
+	ret := &quotaapi.ClusterResourceQuota{}
+	ret.Name = name
+
+	numSelectorKeys := rand.Intn(maxSelectorKeys) + 1
+	if numSelectorKeys == 0 {
+		return ret
+	}
+
+	ret.Spec.Selector = &unversioned.LabelSelector{MatchLabels: map[string]string{}}
+	for i := 0; i < numSelectorKeys; i++ {
+		key := keys[rand.Intn(len(keys))]
+		value := values[rand.Intn(len(values))]
+
+		ret.Spec.Selector.MatchLabels[key] = value
+	}
+
+	return ret
+}
+
+func NewNamespace(name string) *kapi.Namespace {
+	ret := &kapi.Namespace{}
+	ret.Name = name
+
+	numLabels := rand.Intn(maxLabels) + 1
+	if numLabels == 0 {
+		return ret
+	}
+
+	ret.Labels = map[string]string{}
+	for i := 0; i < numLabels; i++ {
+		key := keys[rand.Intn(len(keys))]
+		value := values[rand.Intn(len(values))]
+
+		ret.Labels[key] = value
+	}
+
+	return ret
+}

--- a/pkg/security/controller/factory.go
+++ b/pkg/security/controller/factory.go
@@ -38,7 +38,7 @@ func (f *AllocationFactory) Create() controller.RunnableController {
 		}
 		q := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
 		cache.NewReflector(lw, &kapi.Namespace{}, q, 10*time.Minute).Run()
-		f.Queue = q
+		f.Queue = controller.NewQueueWrapper(q)
 	}
 
 	c := &Allocation{

--- a/pkg/util/ratelimiter/ratelimiter.go
+++ b/pkg/util/ratelimiter/ratelimiter.go
@@ -39,7 +39,7 @@ func NewRateLimitedFunction(keyFunc kcache.KeyFunc, interval int, handlerFunc Ha
 // RunUntil begins processes the resources from queue asynchronously until
 // stopCh is closed.
 func (rlf *RateLimitedFunction) RunUntil(stopCh <-chan struct{}) {
-	go utilwait.Until(func() { rlf.handleOne(rlf.queue.Pop()) }, 0, stopCh)
+	go utilwait.Until(func() { rlf.handleOne(kcache.Pop(rlf.queue)) }, 0, stopCh)
 }
 
 // handleOne processes a request in the queue invoking the rate limited


### PR DESCRIPTION
Third commit: Needs to be moved and lacks any tests, but I'm interested in whether anyone has concerns about intent.

@derekwaynecarr This is like a doubly-linked project authz cache that cannot rely resource versions since quota tracks status.

Also added a create clusterquota command that I'll probably split into another pull.  This should match `create quota` if we ever make one.