### PR TITLE
ignore build version on bc update if version is older than existing value

### DIFF
--- a/pkg/build/registry/buildconfig/strategy.go
+++ b/pkg/build/registry/buildconfig/strategy.go
@@ -48,8 +48,14 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (strategy) PrepareForUpdate(obj, old runtime.Object) {
-	bc := obj.(*api.BuildConfig)
-	dropUnknownTriggers(bc)
+	newBC := obj.(*api.BuildConfig)
+	oldBC := old.(*api.BuildConfig)
+	dropUnknownTriggers(newBC)
+	// Do not allow the build version to go backwards or we'll
+	// get conflicts with existing builds.
+	if newBC.Status.LastVersion < oldBC.Status.LastVersion {
+		newBC.Status.LastVersion = oldBC.Status.LastVersion
+	}
 }
 
 // Validate validates a new policy.

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -47,6 +47,44 @@ func TestBuildConfigStrategy(t *testing.T) {
 				},
 			},
 		},
+		Status: buildapi.BuildConfigStatus{
+			LastVersion: 10,
+		},
+	}
+	newBC := &buildapi.BuildConfig{
+		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
+		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
+			Triggers: []buildapi.BuildTriggerPolicy{
+				{
+					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
+					Type:          buildapi.GitHubWebHookBuildTriggerType,
+				},
+				{
+					Type: "unknown",
+				},
+			},
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+					ContextDir: "context",
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildConfigStatus{
+			LastVersion: 9,
+		},
 	}
 	Strategy.PrepareForCreate(buildConfig)
 	errs := Strategy.Validate(ctx, buildConfig)
@@ -54,11 +92,26 @@ func TestBuildConfigStrategy(t *testing.T) {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
 
-	buildConfig.ResourceVersion = "foo"
-	errs = Strategy.ValidateUpdate(ctx, buildConfig, buildConfig)
+	// lastversion cannot go backwards
+	newBC.Status.LastVersion = 9
+	Strategy.PrepareForUpdate(newBC, buildConfig)
+	if newBC.Status.LastVersion != buildConfig.Status.LastVersion {
+		t.Errorf("Expected version=%d, got %d", buildConfig.Status.LastVersion, newBC.Status.LastVersion)
+	}
+
+	// lastversion can go forwards
+	newBC.Status.LastVersion = 11
+	Strategy.PrepareForUpdate(newBC, buildConfig)
+	if newBC.Status.LastVersion != 11 {
+		t.Errorf("Expected version=%d, got %d", 11, newBC.Status.LastVersion)
+	}
+
+	Strategy.PrepareForCreate(buildConfig)
+	errs = Strategy.Validate(ctx, buildConfig)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
+
 	invalidBuildConfig := &buildapi.BuildConfig{}
 	errs = Strategy.Validate(ctx, invalidBuildConfig)
 	if len(errs) == 0 {


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/9301

@kargakis @csrwng ptal.  I know the "right" fix here is to change the default bc resource to ignore status updates, and introduce a new resource that accepts status updates (and possibly spec updates) and use that from our clone/instantiate logic when updating a BC, but this seems simpler and sufficient for now.  I can't think of any reason we'd want to let someone update a BC to make the status older than the current value (especially if the right fix wouldn't let them update the BC status at all anyway).
