### PR TITLE
[RPMS] Create our own pkgdir for golang-1.6 dynamic runtime creation

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -196,8 +196,8 @@ go test -c -o _build/bin/extended.test -ldflags "%{ldflags}" %{import_path}/test
 
 %if 0%{?make_redistributable}
 # Build clients for other platforms
-GOOS=windows GOARCH=386 go install -ldflags "%{ldflags}" %{import_path}/cmd/oc
-GOOS=darwin GOARCH=amd64 go install -ldflags "%{ldflags}" %{import_path}/cmd/oc
+GOOS=windows GOARCH=386 go install -pkgdir %{buildroot}/pkgdir -ldflags "%{ldflags}" %{import_path}/cmd/oc
+GOOS=darwin GOARCH=amd64 go install -pkgdir %{buildroot}/pkgdir -ldflags "%{ldflags}" %{import_path}/cmd/oc
 %endif
 
 #Build our pod


### PR DESCRIPTION
Without this go will attempt to write to a path that only root can write to.

See https://bugzilla.redhat.com/show_bug.cgi?id=1350010

CC: @tdawson 