### PR TITLE
[DO NOT MERGE] Handle cross repository mount

### DIFF
--- a/pkg/dockerregistry/server/errorblobstore.go
+++ b/pkg/dockerregistry/server/errorblobstore.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/storage"
+)
+
+// errorBlobStore wraps a distribution.BlobStore for a particular repo.
+// before delegating, it ensures auth completed and there were no errors relevant to the repo.
+type errorBlobStore struct {
+	store distribution.BlobStore
+	repo  *repository
+}
+
+var _ distribution.BlobStore = &errorBlobStore{}
+
+func (r *errorBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return r.store.Stat(ctx, dgst)
+}
+
+func (r *errorBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Get(ctx, dgst)
+}
+
+func (r *errorBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Open(ctx, dgst)
+}
+
+func (r *errorBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return r.store.Put(ctx, mediaType, p)
+}
+
+func (r *errorBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+
+	options = append(options, storage.WithRepositoryMiddlewareWrapper(
+		func(ctx context.Context, repo distribution.Repository, name reference.Named) (distribution.Repository, error) {
+			context.GetLogger(r.repo.ctx).Debugf("(*errorBlobStore).Create: called injected middleware wrapper function")
+			nameParts := strings.SplitN(name.Name(), "/", 2)
+			if len(nameParts) != 2 {
+				return nil, fmt.Errorf("invalid repository name %q: it must be of the format <project>/<name>", repo.Named().Name())
+			}
+			middleware := *r.repo
+			middleware.Repository = repo
+			middleware.namespace = nameParts[0]
+			middleware.name = nameParts[1]
+			context.GetLogger(r.repo.ctx).Infof("(*errorBlobStore).Create: returning new middleware for repository=%s", middleware.Name())
+			return &middleware, nil
+		}))
+
+	return r.store.Create(ctx, options...)
+}
+
+func (r *errorBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Resume(ctx, id)
+}
+
+func (r *errorBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return r.store.ServeBlob(ctx, w, req, dgst)
+}
+
+func (r *errorBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return r.store.Delete(ctx, dgst)
+}

--- a/pkg/dockerregistry/server/errortagservice.go
+++ b/pkg/dockerregistry/server/errortagservice.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+)
+
+// errorTagService wraps a distribution.TagService for a particular repo.
+// before delegating, it ensures auth completed and there were no errors relevant to the repo.
+type errorTagService struct {
+	tags distribution.TagService
+	repo *repository
+}
+
+var _ distribution.TagService = &errorTagService{}
+
+func (t *errorTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return t.tags.Get(ctx, tag)
+}
+
+func (t *errorTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return t.tags.Tag(ctx, tag, desc)
+}
+
+func (t *errorTagService) Untag(ctx context.Context, tag string) error {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return t.tags.Untag(ctx, tag)
+}
+
+func (t *errorTagService) All(ctx context.Context) ([]string, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return t.tags.All(ctx)
+}
+
+func (t *errorTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return t.tags.Lookup(ctx, digest)
+}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -220,15 +220,6 @@ echo "[INFO] Run pod diagnostics"
 # Requires a node to run the origin-deployer pod; expects registry deployed, deployer image pulled
 os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
 
-# This needed because docker 1.10+ utilizes cross-repo mount feature. Docker client keeps track of source
-# repositories for all the blobs. If it uploads a blob to a repository of registry having an entry in this
-# mapping, it will request a mount from this repository. The authorization check is done for both destination
-# and mounted repository. Without the next statement, the auth check for mounted repository
-# (cache/ruby-22-centos7) will fail.
-# TODO: remove this once the registry can access global blob store without a layer link authorization check
-oc policy -n cache add-role-to-user system:image-puller system:serviceaccount:test:builder
-
-
 echo "[INFO] Applying STI application config"
 os::cmd::expect_success "oc create -f ${STI_CONFIG_FILE}"
 


### PR DESCRIPTION
During a push with a cross-repo mount, authorize only against target
repository, not against source repository.

In OpenShift we allow to pull any blob stored in the registry as long as
the user is authorized to pull from repository he requested.

Closes #9540 
Not sure whether #6841 is close-able with this. The issue mentions proper association of credentials with repositories (and especially the remote once if a pull through is in play). I'll verify.