### PR TITLE
Fix auth checks for cross-repo mount requests

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/linkedblobstore.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/linkedblobstore.go
@@ -101,9 +101,9 @@ func (lbs *linkedBlobStore) Put(ctx context.Context, mediaType string, p []byte)
 	return desc, lbs.linkBlob(ctx, desc)
 }
 
-// createOptions is a collection of blob creation modifiers relevant to general
+// CreateOptions is a collection of blob creation modifiers relevant to general
 // blob storage intended to be configured by the BlobCreateOption.Apply method.
-type createOptions struct {
+type CreateOptions struct {
 	Mount struct {
 		ShouldMount bool
 		From        reference.Canonical
@@ -120,7 +120,7 @@ func (f optionFunc) Apply(v interface{}) error {
 // mounted from the given canonical reference.
 func WithMountFrom(ref reference.Canonical) distribution.BlobCreateOption {
 	return optionFunc(func(v interface{}) error {
-		opts, ok := v.(*createOptions)
+		opts, ok := v.(*CreateOptions)
 		if !ok {
 			return fmt.Errorf("unexpected options type: %T", v)
 		}
@@ -136,7 +136,7 @@ func WithMountFrom(ref reference.Canonical) distribution.BlobCreateOption {
 func (lbs *linkedBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	context.GetLogger(ctx).Debug("(*linkedBlobStore).Writer")
 
-	var opts createOptions
+	var opts CreateOptions
 
 	for _, option := range options {
 		err := option.Apply(&opts)

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -21,6 +21,19 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
+type deferredErrors map[string]error
+
+func (d deferredErrors) Add(namespace string, name string, err error) {
+	d[namespace+"/"+name] = err
+}
+func (d deferredErrors) Get(namespace string, name string) (error, bool) {
+	err, exists := d[namespace+"/"+name]
+	return err, exists
+}
+func (d deferredErrors) Empty() bool {
+	return len(d) == 0
+}
+
 // DefaultRegistryClient is exposed for testing the registry with fake client.
 var DefaultRegistryClient = NewRegistryClient(clientcmd.NewConfig().BindToFile())
 
@@ -59,6 +72,27 @@ func WithUserClient(parent context.Context, userClient client.Interface) context
 func UserClientFrom(ctx context.Context) (client.Interface, bool) {
 	userClient, ok := ctx.Value(userClientKey).(client.Interface)
 	return userClient, ok
+}
+
+const authPerformedKey = "openshift.auth.performed"
+
+func WithAuthPerformed(parent context.Context) context.Context {
+	return context.WithValue(parent, authPerformedKey, true)
+}
+
+func AuthPerformed(ctx context.Context) bool {
+	authPerformed, ok := ctx.Value(authPerformedKey).(bool)
+	return ok && authPerformed
+}
+
+const deferredErrorsKey = "openshift.auth.deferredErrors"
+
+func WithDeferredErrors(parent context.Context, errs deferredErrors) context.Context {
+	return context.WithValue(parent, deferredErrorsKey, errs)
+}
+func DeferredErrorsFrom(ctx context.Context) (deferredErrors, bool) {
+	errs, ok := ctx.Value(deferredErrorsKey).(deferredErrors)
+	return errs, ok
 }
 
 type AccessController struct {
@@ -160,6 +194,11 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 		}
 	}
 
+	// pushChecks remembers which ns/name pairs had push access checks done
+	pushChecks := map[string]bool{}
+	// possibleCrossMountErrors holds errors which may be related to cross mount errors
+	possibleCrossMountErrors := deferredErrors{}
+
 	verifiedPrune := false
 
 	// Validate all requested accessRecords
@@ -178,6 +217,7 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 			switch access.Action {
 			case "push":
 				verb = "update"
+				pushChecks[imageStreamNS+"/"+imageStreamName] = true
 			case "pull":
 				verb = "get"
 			case "*":
@@ -197,7 +237,11 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 				verifiedPrune = true
 			default:
 				if err := verifyImageStreamAccess(ctx, imageStreamNS, imageStreamName, verb, osClient); err != nil {
-					return nil, ac.wrapErr(err)
+					if access.Action == "pull" {
+						possibleCrossMountErrors.Add(imageStreamNS, imageStreamName, ac.wrapErr(err))
+					} else {
+						return nil, ac.wrapErr(err)
+					}
 				}
 			}
 
@@ -218,6 +262,26 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 			return nil, ac.wrapErr(ErrUnsupportedResource)
 		}
 	}
+
+	// deal with any possible cross-mount errors
+	for namespaceAndName, err := range possibleCrossMountErrors {
+		// If we have no push requests, this can't be a cross-mount request, so error
+		if len(pushChecks) == 0 {
+			return nil, err
+		}
+		// If we also requested a push to this ns/name, this isn't a cross-mount request, so error
+		if pushChecks[namespaceAndName] {
+			return nil, err
+		}
+	}
+
+	// Conditionally add auth errors we want to handle later to the context
+	if !possibleCrossMountErrors.Empty() {
+		context.GetLogger(ctx).Debugf("Origin auth: deferring errors: %#v", possibleCrossMountErrors)
+		ctx = WithDeferredErrors(ctx, possibleCrossMountErrors)
+	}
+	// Always add a marker to the context so we know auth was run
+	ctx = WithAuthPerformed(ctx)
 
 	return WithUserClient(ctx, osClient), nil
 }

--- a/pkg/dockerregistry/server/errorblobstore.go
+++ b/pkg/dockerregistry/server/errorblobstore.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/registry/storage"
+)
+
+// errorBlobStore wraps a distribution.BlobStore for a particular repo.
+// before delegating, it ensures auth completed and there were no errors relevant to the repo.
+type errorBlobStore struct {
+	store distribution.BlobStore
+	repo  *repository
+}
+
+var _ distribution.BlobStore = &errorBlobStore{}
+
+func (r *errorBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return r.store.Stat(ctx, dgst)
+}
+
+func (r *errorBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Get(ctx, dgst)
+}
+
+func (r *errorBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Open(ctx, dgst)
+}
+
+func (r *errorBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return r.store.Put(ctx, mediaType, p)
+}
+
+func (r *errorBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+
+	opts, err := effectiveCreateOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkPendingCrossMountErrors(ctx, opts); err != nil {
+		context.GetLogger(r.repo.ctx).Debugf("disabling cross-mount because of pending error: %v", err)
+		options = append(options, guardCreateOptions{DisableCrossMount: true})
+	} else {
+		options = append(options, guardCreateOptions{})
+	}
+
+	return r.store.Create(ctx, options...)
+}
+
+func (r *errorBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return r.store.Resume(ctx, id)
+}
+
+func (r *errorBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return r.store.ServeBlob(ctx, w, req, dgst)
+}
+
+func (r *errorBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := r.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return r.store.Delete(ctx, dgst)
+}
+
+// Find out what the blob creation options are going to do by dry-running them
+func effectiveCreateOptions(options []distribution.BlobCreateOption) (*storage.CreateOptions, error) {
+	opts := &storage.CreateOptions{}
+	for _, createOptions := range options {
+		err := createOptions.Apply(opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+func checkPendingCrossMountErrors(ctx context.Context, opts *storage.CreateOptions) error {
+	if !opts.Mount.ShouldMount {
+		return nil
+	}
+	namespace, name, err := getNamespaceName(opts.Mount.From.Name())
+	if err != nil {
+		return err
+	}
+	return checkPendingErrors(context.GetLogger(ctx), ctx, namespace, name)
+}
+
+// guardCreateOptions ensures the expected options type is passed, and optionally disables cross mounting
+type guardCreateOptions struct {
+	DisableCrossMount bool
+}
+
+var _ distribution.BlobCreateOption = guardCreateOptions{}
+
+func (f guardCreateOptions) Apply(v interface{}) error {
+	opts, ok := v.(*storage.CreateOptions)
+	if !ok {
+		return fmt.Errorf("Unexpected create options: %#v", v)
+	}
+	if f.DisableCrossMount {
+		opts.Mount.ShouldMount = false
+	}
+	return nil
+}

--- a/pkg/dockerregistry/server/errortagservice.go
+++ b/pkg/dockerregistry/server/errortagservice.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+)
+
+// errorTagService wraps a distribution.TagService for a particular repo.
+// before delegating, it ensures auth completed and there were no errors relevant to the repo.
+type errorTagService struct {
+	tags distribution.TagService
+	repo *repository
+}
+
+var _ distribution.TagService = &errorTagService{}
+
+func (t *errorTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
+	return t.tags.Get(ctx, tag)
+}
+
+func (t *errorTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return t.tags.Tag(ctx, tag, desc)
+}
+
+func (t *errorTagService) Untag(ctx context.Context, tag string) error {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return t.tags.Untag(ctx, tag)
+}
+
+func (t *errorTagService) All(ctx context.Context) ([]string, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return t.tags.All(ctx)
+}
+
+func (t *errorTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	if err := t.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return t.tags.Lookup(ctx, digest)
+}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -215,19 +215,37 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		}
 	}
 
+	bs = &errorBlobStore{
+		store: bs,
+		repo:  &repo,
+	}
+
 	return bs
 }
 
 // Tags returns a reference to this repository tag service.
 func (r *repository) Tags(ctx context.Context) distribution.TagService {
-	return &tagService{
+	var ts distribution.TagService
+
+	ts = &tagService{
 		TagService: r.Repository.Tags(ctx),
 		repo:       r,
 	}
+
+	ts = &errorTagService{
+		tags: ts,
+		repo: r,
+	}
+
+	return ts
 }
 
 // Exists returns true if the manifest specified by dgst exists.
 func (r *repository) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	if err := r.checkPendingErrors(ctx); err != nil {
+		return false, err
+	}
+
 	image, err := r.getImage(dgst)
 	if err != nil {
 		return false, err
@@ -237,6 +255,10 @@ func (r *repository) Exists(ctx context.Context, dgst digest.Digest) (bool, erro
 
 // Get retrieves the manifest with digest `dgst`.
 func (r *repository) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	if err := r.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+
 	if _, err := r.getImageStreamImage(dgst); err != nil {
 		context.GetLogger(r.ctx).Errorf("error retrieving ImageStreamImage %s/%s@%s: %v", r.namespace, r.name, dgst.String(), err)
 		return nil, err
@@ -256,6 +278,10 @@ func (r *repository) Get(ctx context.Context, dgst digest.Digest, options ...dis
 
 // Put creates or updates the named manifest.
 func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	if err := r.checkPendingErrors(ctx); err != nil {
+		return "", err
+	}
+
 	var canonical []byte
 
 	// Resolve the payload in the manifest.
@@ -451,6 +477,10 @@ func (r *repository) deserializedManifestFillImageMetadata(manifest *schema2.Des
 // in OpenShift are deleted via 'oadm prune images'. This function deletes
 // the content related to the manifest in the registry's storage (signatures).
 func (r *repository) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := r.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+
 	ms, err := r.Repository.Manifests(r.ctx)
 	if err != nil {
 		return err
@@ -598,4 +628,27 @@ func (r *repository) deserializedManifestFromImage(image *imageapi.Image) (*sche
 		return nil, err
 	}
 	return &manifest, nil
+}
+
+func (r *repository) checkPendingErrors(ctx context.Context) error {
+	return checkPendingErrors(context.GetLogger(r.ctx), ctx, r.namespace, r.name)
+}
+
+func checkPendingErrors(logger context.Logger, ctx context.Context, namespace, name string) error {
+	if !AuthPerformed(ctx) {
+		return fmt.Errorf("openshift.auth.completed missing from context")
+	}
+
+	deferredErrors, haveDeferredErrors := DeferredErrorsFrom(ctx)
+	if !haveDeferredErrors {
+		return nil
+	}
+
+	repoErr, haveRepoErr := deferredErrors.Get(namespace, name)
+	if !haveRepoErr {
+		return nil
+	}
+
+	logger.Debugf("Origin auth: found deferred error for %s/%s: %v", namespace, name, repoErr)
+	return repoErr
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -220,15 +220,6 @@ echo "[INFO] Run pod diagnostics"
 # Requires a node to run the origin-deployer pod; expects registry deployed, deployer image pulled
 os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
 
-# This needed because docker 1.10+ utilizes cross-repo mount feature. Docker client keeps track of source
-# repositories for all the blobs. If it uploads a blob to a repository of registry having an entry in this
-# mapping, it will request a mount from this repository. The authorization check is done for both destination
-# and mounted repository. Without the next statement, the auth check for mounted repository
-# (cache/ruby-22-centos7) will fail.
-# TODO: remove this once the registry can access global blob store without a layer link authorization check
-oc policy -n cache add-role-to-user system:image-puller system:serviceaccount:test:builder
-
-
 echo "[INFO] Applying STI application config"
 os::cmd::expect_success "oc create -f ${STI_CONFIG_FILE}"
 


### PR DESCRIPTION
Fixes #9540

When pushing blobs to a target repo `t`, clients may request the server mount a blob from a source repo `s` as an optimization. Before allowing that, the server authorizes the following permissions:

* `pull` and `push` on `t`
* `pull` on `s`

In cases where the user is not authorized to `pull` from `s`, rather than an authorization error, the blob push should just proceed unoptimized (allowing the user to push the full content of the blob to `t`, which proves they have access to it, since they just pushed it)

This PR:

* detects if `pull` access check failures are likely to be related to cross-repo mounts:
  * there was no `push` access request for the repo which failed the `pull` access check
  * there was at least one `push` access request for some other repo (which is required to pass)
* adds errors related to those `pull` access checks to the request context, keyed by repo (ns+name)
* updates the blobstore, tagregistry, and manifestregistry to check the request context for access errors for the relevant repo before performing any action
* updates the blobstore `Create` method to disable cross-repo mounting if the request context contains an access error for the source repo