### PR TITLE
[WIP] Extended builds

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20367,7 +20367,7 @@
       },
       "description": "runtimeArtifacts holds the mapping between the artifacts paths in the builder image and the paths in the runtime image where they should be copied."
      },
-     "RuntimePullSecret": {
+     "runtimePullSecret": {
       "$ref": "v1.LocalObjectReference",
       "description": "runtimePullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker runtime images from private Docker registries."
      }

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20331,18 +20331,18 @@
     "properties": {
      "from": {
       "$ref": "v1.ObjectReference",
-      "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled"
+      "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled."
      },
      "pullSecret": {
       "$ref": "v1.LocalObjectReference",
-      "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries"
+      "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries."
      },
      "env": {
       "type": "array",
       "items": {
        "$ref": "v1.EnvVar"
       },
-      "description": "env contains additional environment variables you want to pass into a builder container"
+      "description": "env contains additional environment variables you want to pass into a builder container."
      },
      "scripts": {
       "type": "string",
@@ -20358,14 +20358,18 @@
      },
      "runtimeImage": {
       "$ref": "v1.ObjectReference",
-      "description": "RuntimeImage is the optinal image that is used to run an application without unneeded dependencies installed."
+      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed."
      },
      "runtimeArtifacts": {
       "type": "array",
       "items": {
        "$ref": "v1.ImageSourcePath"
       },
-      "description": "RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied."
+      "description": "runtimeArtifacts holds the mapping between the artifacts paths in the builder image and the paths in the runtime image where they should be copied."
+     },
+     "RuntimePullSecret": {
+      "$ref": "v1.LocalObjectReference",
+      "description": "runtimePullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker runtime images from private Docker registries."
      }
     }
    },

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20355,6 +20355,31 @@
      "forcePull": {
       "type": "boolean",
       "description": "forcePull describes if the builder should pull the images from registry prior to building."
+     },
+     "runtimeImage": {
+      "$ref": "v1.ObjectReference",
+      "description": "RuntimeImage is the optinal image that is used to run an application without unneeded dependencies installed."
+     },
+     "runtimeArtifacts": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.VolumeSpec"
+      },
+      "description": "RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied."
+     }
+    }
+   },
+   "v1.VolumeSpec": {
+    "id": "v1.VolumeSpec",
+    "description": "VolumeSpec is a mapping between paths on the builder image and paths on the runtime image where files should be copied.",
+    "properties": {
+     "source": {
+      "type": "string",
+      "description": "Source is the path on the builder image of the artifact."
+     },
+     "destination": {
+      "type": "string",
+      "description": "Destination is the path on the runtime image where the artifact should be copied."
      }
     }
    },

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20363,23 +20363,9 @@
      "runtimeArtifacts": {
       "type": "array",
       "items": {
-       "$ref": "v1.VolumeSpec"
+       "$ref": "v1.ImageSourcePath"
       },
       "description": "RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied."
-     }
-    }
-   },
-   "v1.VolumeSpec": {
-    "id": "v1.VolumeSpec",
-    "description": "VolumeSpec is a mapping between paths on the builder image and paths on the runtime image where files should be copied.",
-    "properties": {
-     "source": {
-      "type": "string",
-      "description": "Source is the path on the builder image of the artifact."
-     },
-     "destination": {
-      "type": "string",
-      "description": "Destination is the path on the runtime image where the artifact should be copied."
      }
     }
    },

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -51,6 +51,7 @@ func init() {
 		DeepCopy_api_SourceBuildStrategy,
 		DeepCopy_api_SourceControlUser,
 		DeepCopy_api_SourceRevision,
+		DeepCopy_api_VolumeSpec,
 		DeepCopy_api_WebHookTrigger,
 	); err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
@@ -908,6 +909,26 @@ func DeepCopy_api_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildSt
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := in.RuntimeImage, &out.RuntimeImage
+		*out = new(api.ObjectReference)
+		if err := api.DeepCopy_api_ObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]VolumeSpec, len(in))
+		for i := range in {
+			if err := DeepCopy_api_VolumeSpec(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 
@@ -927,6 +948,12 @@ func DeepCopy_api_SourceRevision(in SourceRevision, out *SourceRevision, c *conv
 	} else {
 		out.Git = nil
 	}
+	return nil
+}
+
+func DeepCopy_api_VolumeSpec(in VolumeSpec, out *VolumeSpec, c *conversion.Cloner) error {
+	out.Source = in.Source
+	out.Destination = in.Destination
 	return nil
 }
 

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -928,6 +928,15 @@ func DeepCopy_api_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildSt
 	} else {
 		out.RuntimeArtifacts = nil
 	}
+	if in.RuntimePullSecret != nil {
+		in, out := in.RuntimePullSecret, &out.RuntimePullSecret
+		*out = new(api.LocalObjectReference)
+		if err := api.DeepCopy_api_LocalObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimePullSecret = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -51,7 +51,6 @@ func init() {
 		DeepCopy_api_SourceBuildStrategy,
 		DeepCopy_api_SourceControlUser,
 		DeepCopy_api_SourceRevision,
-		DeepCopy_api_VolumeSpec,
 		DeepCopy_api_WebHookTrigger,
 	); err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
@@ -920,9 +919,9 @@ func DeepCopy_api_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildSt
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]VolumeSpec, len(in))
+		*out = make([]ImageSourcePath, len(in))
 		for i := range in {
-			if err := DeepCopy_api_VolumeSpec(in[i], &(*out)[i], c); err != nil {
+			if err := DeepCopy_api_ImageSourcePath(in[i], &(*out)[i], c); err != nil {
 				return err
 			}
 		}
@@ -948,12 +947,6 @@ func DeepCopy_api_SourceRevision(in SourceRevision, out *SourceRevision, c *conv
 	} else {
 		out.Git = nil
 	}
-	return nil
-}
-
-func DeepCopy_api_VolumeSpec(in VolumeSpec, out *VolumeSpec, c *conversion.Cloner) error {
-	out.Source = in.Source
-	out.Destination = in.Destination
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -496,16 +496,17 @@ type DockerBuildStrategy struct {
 
 // SourceBuildStrategy defines input parameters specific to an Source build.
 type SourceBuildStrategy struct {
-	// From is reference to an DockerImage, ImageStream, ImageStreamTag, or ImageStreamImage from which
-	// the docker image should be pulled
+	// From is reference to an DockerImage, ImageStream, ImageStreamTag, or
+	// ImageStreamImage from which the docker image should be pulled.
 	From kapi.ObjectReference
 
-	// PullSecret is the name of a Secret that would be used for setting up
-	// the authentication for pulling the Docker images from the private Docker
-	// registries
+	// PullSecret is the name of a Secret that would be used for setting up the
+	// authentication for pulling the Docker images from private Docker
+	// registries.
 	PullSecret *kapi.LocalObjectReference
 
-	// Env contains additional environment variables you want to pass into a builder container
+	// Env contains additional environment variables you want to pass into a
+	// builder container.
 	Env []kapi.EnvVar
 
 	// Scripts is the location of Source scripts
@@ -514,15 +515,23 @@ type SourceBuildStrategy struct {
 	// Incremental flag forces the Source build to do incremental builds if true.
 	Incremental bool
 
-	// ForcePull describes if the builder should pull the images from registry prior to building.
+	// ForcePull describes if the builder should pull the images from registry
+	// prior to building.
 	ForcePull bool
 
-	// RuntimeImage is the optinal image that is used to run an application
-	// without unneeded dependencies installed.
+	// RuntimeImage is an optional image that is used to run an application
+	// without build-time dependencies installed.
 	RuntimeImage *kapi.ObjectReference
 
-	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
+	// RuntimeArtifacts holds the mapping between the artifacts paths in the
+	// builder image and the paths in the runtime image where they should be
+	// copied.
 	RuntimeArtifacts []ImageSourcePath
+
+	// RuntimePullSecret is the name of a Secret that would be used for setting up
+	// the authentication for pulling the Docker runtime images from private
+	// Docker registries.
+	RuntimePullSecret *kapi.LocalObjectReference
 }
 
 // JenkinsPipelineStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -522,18 +522,7 @@ type SourceBuildStrategy struct {
 	RuntimeImage *kapi.ObjectReference
 
 	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
-	RuntimeArtifacts []VolumeSpec
-}
-
-// VolumeSpec is a mapping between paths on the builder image and paths on the
-// runtime image where files should be copied.
-type VolumeSpec struct {
-	// Source is the path on the builder image of the artifact.
-	Source string
-
-	// Destination is the path on the runtime image where the artifact should be
-	// copied.
-	Destination string
+	RuntimeArtifacts []ImageSourcePath
 }
 
 // JenkinsPipelineStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -509,7 +509,7 @@ type SourceBuildStrategy struct {
 	// builder container.
 	Env []kapi.EnvVar
 
-	// Scripts is the location of Source scripts
+	// Scripts is the location of Source scripts.
 	Scripts string
 
 	// Incremental flag forces the Source build to do incremental builds if true.

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -516,6 +516,24 @@ type SourceBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
+
+	// RuntimeImage is the optinal image that is used to run an application
+	// without unneeded dependencies installed.
+	RuntimeImage *kapi.ObjectReference
+
+	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
+	RuntimeArtifacts []VolumeSpec
+}
+
+// VolumeSpec is a mapping between paths on the builder image and paths on the
+// runtime image where files should be copied.
+type VolumeSpec struct {
+	// Source is the path on the builder image of the artifact.
+	Source string
+
+	// Destination is the path on the runtime image where the artifact should be
+	// copied.
+	Destination string
 }
 
 // JenkinsPipelineStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -88,6 +88,8 @@ func init() {
 		Convert_api_SourceControlUser_To_v1_SourceControlUser,
 		Convert_v1_SourceRevision_To_api_SourceRevision,
 		Convert_api_SourceRevision_To_v1_SourceRevision,
+		Convert_v1_VolumeSpec_To_api_VolumeSpec,
+		Convert_api_VolumeSpec_To_v1_VolumeSpec,
 		Convert_v1_WebHookTrigger_To_api_WebHookTrigger,
 		Convert_api_WebHookTrigger_To_v1_WebHookTrigger,
 	); err != nil {
@@ -1764,6 +1766,27 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := &in.RuntimeImage, &out.RuntimeImage
+		*out = new(api_v1.ObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]VolumeSpec, len(*in))
+		for i := range *in {
+			if err := Convert_api_VolumeSpec_To_v1_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 
@@ -1794,6 +1817,27 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := &in.RuntimeImage, &out.RuntimeImage
+		*out = new(api.ObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]build_api.VolumeSpec, len(*in))
+		for i := range *in {
+			if err := Convert_v1_VolumeSpec_To_api_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 
@@ -1849,6 +1893,26 @@ func autoConvert_api_SourceRevision_To_v1_SourceRevision(in *build_api.SourceRev
 		out.Git = nil
 	}
 	return nil
+}
+
+func autoConvert_v1_VolumeSpec_To_api_VolumeSpec(in *VolumeSpec, out *build_api.VolumeSpec, s conversion.Scope) error {
+	out.Source = in.Source
+	out.Destination = in.Destination
+	return nil
+}
+
+func Convert_v1_VolumeSpec_To_api_VolumeSpec(in *VolumeSpec, out *build_api.VolumeSpec, s conversion.Scope) error {
+	return autoConvert_v1_VolumeSpec_To_api_VolumeSpec(in, out, s)
+}
+
+func autoConvert_api_VolumeSpec_To_v1_VolumeSpec(in *build_api.VolumeSpec, out *VolumeSpec, s conversion.Scope) error {
+	out.Source = in.Source
+	out.Destination = in.Destination
+	return nil
+}
+
+func Convert_api_VolumeSpec_To_v1_VolumeSpec(in *build_api.VolumeSpec, out *VolumeSpec, s conversion.Scope) error {
+	return autoConvert_api_VolumeSpec_To_v1_VolumeSpec(in, out, s)
 }
 
 func autoConvert_v1_WebHookTrigger_To_api_WebHookTrigger(in *WebHookTrigger, out *build_api.WebHookTrigger, s conversion.Scope) error {

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -88,8 +88,6 @@ func init() {
 		Convert_api_SourceControlUser_To_v1_SourceControlUser,
 		Convert_v1_SourceRevision_To_api_SourceRevision,
 		Convert_api_SourceRevision_To_v1_SourceRevision,
-		Convert_v1_VolumeSpec_To_api_VolumeSpec,
-		Convert_api_VolumeSpec_To_v1_VolumeSpec,
 		Convert_v1_WebHookTrigger_To_api_WebHookTrigger,
 		Convert_api_WebHookTrigger_To_v1_WebHookTrigger,
 	); err != nil {
@@ -1778,9 +1776,9 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]VolumeSpec, len(*in))
+		*out = make([]ImageSourcePath, len(*in))
 		for i := range *in {
-			if err := Convert_api_VolumeSpec_To_v1_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
+			if err := Convert_api_ImageSourcePath_To_v1_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -1829,9 +1827,9 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]build_api.VolumeSpec, len(*in))
+		*out = make([]build_api.ImageSourcePath, len(*in))
 		for i := range *in {
-			if err := Convert_v1_VolumeSpec_To_api_VolumeSpec(&(*in)[i], &(*out)[i], s); err != nil {
+			if err := Convert_v1_ImageSourcePath_To_api_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -1893,26 +1891,6 @@ func autoConvert_api_SourceRevision_To_v1_SourceRevision(in *build_api.SourceRev
 		out.Git = nil
 	}
 	return nil
-}
-
-func autoConvert_v1_VolumeSpec_To_api_VolumeSpec(in *VolumeSpec, out *build_api.VolumeSpec, s conversion.Scope) error {
-	out.Source = in.Source
-	out.Destination = in.Destination
-	return nil
-}
-
-func Convert_v1_VolumeSpec_To_api_VolumeSpec(in *VolumeSpec, out *build_api.VolumeSpec, s conversion.Scope) error {
-	return autoConvert_v1_VolumeSpec_To_api_VolumeSpec(in, out, s)
-}
-
-func autoConvert_api_VolumeSpec_To_v1_VolumeSpec(in *build_api.VolumeSpec, out *VolumeSpec, s conversion.Scope) error {
-	out.Source = in.Source
-	out.Destination = in.Destination
-	return nil
-}
-
-func Convert_api_VolumeSpec_To_v1_VolumeSpec(in *build_api.VolumeSpec, out *VolumeSpec, s conversion.Scope) error {
-	return autoConvert_api_VolumeSpec_To_v1_VolumeSpec(in, out, s)
 }
 
 func autoConvert_v1_WebHookTrigger_To_api_WebHookTrigger(in *WebHookTrigger, out *build_api.WebHookTrigger, s conversion.Scope) error {

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -1766,9 +1766,8 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	out.ForcePull = in.ForcePull
 	if in.RuntimeImage != nil {
 		in, out := &in.RuntimeImage, &out.RuntimeImage
-		*out = new(api_v1.ObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
+		*out = new(api.ObjectReference)
+		if err := api_v1.Convert_v1_ObjectReference_To_api_ObjectReference(*in, *out, s); err != nil {
 			return err
 		}
 	} else {
@@ -1776,9 +1775,9 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]ImageSourcePath, len(*in))
+		*out = make([]build_api.ImageSourcePath, len(*in))
 		for i := range *in {
-			if err := Convert_api_ImageSourcePath_To_v1_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
+			if err := Convert_v1_ImageSourcePath_To_api_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -1787,9 +1786,8 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	}
 	if in.RuntimePullSecret != nil {
 		in, out := &in.RuntimePullSecret, &out.RuntimePullSecret
-		*out = new(api_v1.LocalObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
+		*out = new(api.LocalObjectReference)
+		if err := api_v1.Convert_v1_LocalObjectReference_To_api_LocalObjectReference(*in, *out, s); err != nil {
 			return err
 		}
 	} else {
@@ -1827,9 +1825,8 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	out.ForcePull = in.ForcePull
 	if in.RuntimeImage != nil {
 		in, out := &in.RuntimeImage, &out.RuntimeImage
-		*out = new(api.ObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
+		*out = new(api_v1.ObjectReference)
+		if err := api_v1.Convert_api_ObjectReference_To_v1_ObjectReference(*in, *out, s); err != nil {
 			return err
 		}
 	} else {
@@ -1837,9 +1834,9 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]build_api.ImageSourcePath, len(*in))
+		*out = make([]ImageSourcePath, len(*in))
 		for i := range *in {
-			if err := Convert_v1_ImageSourcePath_To_api_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
+			if err := Convert_api_ImageSourcePath_To_v1_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
 				return err
 			}
 		}
@@ -1848,9 +1845,8 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	}
 	if in.RuntimePullSecret != nil {
 		in, out := &in.RuntimePullSecret, &out.RuntimePullSecret
-		*out = new(api.LocalObjectReference)
-		// TODO: Inefficient conversion - can we improve it?
-		if err := s.Convert(*in, *out, 0); err != nil {
+		*out = new(api_v1.LocalObjectReference)
+		if err := api_v1.Convert_api_LocalObjectReference_To_v1_LocalObjectReference(*in, *out, s); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -1785,6 +1785,16 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	} else {
 		out.RuntimeArtifacts = nil
 	}
+	if in.RuntimePullSecret != nil {
+		in, out := &in.RuntimePullSecret, &out.RuntimePullSecret
+		*out = new(api_v1.LocalObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimePullSecret = nil
+	}
 	return nil
 }
 
@@ -1835,6 +1845,16 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 		}
 	} else {
 		out.RuntimeArtifacts = nil
+	}
+	if in.RuntimePullSecret != nil {
+		in, out := &in.RuntimePullSecret, &out.RuntimePullSecret
+		*out = new(api.LocalObjectReference)
+		// TODO: Inefficient conversion - can we improve it?
+		if err := s.Convert(*in, *out, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimePullSecret = nil
 	}
 	return nil
 }

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -51,7 +51,6 @@ func init() {
 		DeepCopy_v1_SourceBuildStrategy,
 		DeepCopy_v1_SourceControlUser,
 		DeepCopy_v1_SourceRevision,
-		DeepCopy_v1_VolumeSpec,
 		DeepCopy_v1_WebHookTrigger,
 	); err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
@@ -902,9 +901,9 @@ func DeepCopy_v1_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildStr
 	}
 	if in.RuntimeArtifacts != nil {
 		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
-		*out = make([]VolumeSpec, len(in))
+		*out = make([]ImageSourcePath, len(in))
 		for i := range in {
-			if err := DeepCopy_v1_VolumeSpec(in[i], &(*out)[i], c); err != nil {
+			if err := DeepCopy_v1_ImageSourcePath(in[i], &(*out)[i], c); err != nil {
 				return err
 			}
 		}
@@ -931,12 +930,6 @@ func DeepCopy_v1_SourceRevision(in SourceRevision, out *SourceRevision, c *conve
 	} else {
 		out.Git = nil
 	}
-	return nil
-}
-
-func DeepCopy_v1_VolumeSpec(in VolumeSpec, out *VolumeSpec, c *conversion.Cloner) error {
-	out.Source = in.Source
-	out.Destination = in.Destination
 	return nil
 }
 

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -51,6 +51,7 @@ func init() {
 		DeepCopy_v1_SourceBuildStrategy,
 		DeepCopy_v1_SourceControlUser,
 		DeepCopy_v1_SourceRevision,
+		DeepCopy_v1_VolumeSpec,
 		DeepCopy_v1_WebHookTrigger,
 	); err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.
@@ -890,6 +891,26 @@ func DeepCopy_v1_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildStr
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := in.RuntimeImage, &out.RuntimeImage
+		*out = new(api_v1.ObjectReference)
+		if err := api_v1.DeepCopy_v1_ObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]VolumeSpec, len(in))
+		for i := range in {
+			if err := DeepCopy_v1_VolumeSpec(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 
@@ -910,6 +931,12 @@ func DeepCopy_v1_SourceRevision(in SourceRevision, out *SourceRevision, c *conve
 	} else {
 		out.Git = nil
 	}
+	return nil
+}
+
+func DeepCopy_v1_VolumeSpec(in VolumeSpec, out *VolumeSpec, c *conversion.Cloner) error {
+	out.Source = in.Source
+	out.Destination = in.Destination
 	return nil
 }
 

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -910,6 +910,15 @@ func DeepCopy_v1_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildStr
 	} else {
 		out.RuntimeArtifacts = nil
 	}
+	if in.RuntimePullSecret != nil {
+		in, out := in.RuntimePullSecret, &out.RuntimePullSecret
+		*out = new(api_v1.LocalObjectReference)
+		if err := api_v1.DeepCopy_v1_LocalObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimePullSecret = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -448,16 +448,6 @@ func (SourceRevision) SwaggerDoc() map[string]string {
 	return map_SourceRevision
 }
 
-var map_VolumeSpec = map[string]string{
-	"":            "VolumeSpec is a mapping between paths on the builder image and paths on the runtime image where files should be copied.",
-	"source":      "Source is the path on the builder image of the artifact.",
-	"destination": "Destination is the path on the runtime image where the artifact should be copied.",
-}
-
-func (VolumeSpec) SwaggerDoc() map[string]string {
-	return map_VolumeSpec
-}
-
 var map_WebHookTrigger = map[string]string{
 	"":         "WebHookTrigger is a trigger that gets invoked using a webhook type of post",
 	"secret":   "secret used to validate requests.",

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -413,13 +413,15 @@ func (SecretSpec) SwaggerDoc() map[string]string {
 }
 
 var map_SourceBuildStrategy = map[string]string{
-	"":            "SourceBuildStrategy defines input parameters specific to an Source build.",
-	"from":        "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled",
-	"pullSecret":  "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries",
-	"env":         "env contains additional environment variables you want to pass into a builder container",
-	"scripts":     "scripts is the location of Source scripts",
-	"incremental": "incremental flag forces the Source build to do incremental builds if true.",
-	"forcePull":   "forcePull describes if the builder should pull the images from registry prior to building.",
+	"":                 "SourceBuildStrategy defines input parameters specific to an Source build.",
+	"from":             "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled",
+	"pullSecret":       "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries",
+	"env":              "env contains additional environment variables you want to pass into a builder container",
+	"scripts":          "scripts is the location of Source scripts",
+	"incremental":      "incremental flag forces the Source build to do incremental builds if true.",
+	"forcePull":        "forcePull describes if the builder should pull the images from registry prior to building.",
+	"runtimeImage":     "RuntimeImage is the optinal image that is used to run an application without unneeded dependencies installed.",
+	"runtimeArtifacts": "RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.",
 }
 
 func (SourceBuildStrategy) SwaggerDoc() map[string]string {
@@ -444,6 +446,16 @@ var map_SourceRevision = map[string]string{
 
 func (SourceRevision) SwaggerDoc() map[string]string {
 	return map_SourceRevision
+}
+
+var map_VolumeSpec = map[string]string{
+	"":            "VolumeSpec is a mapping between paths on the builder image and paths on the runtime image where files should be copied.",
+	"source":      "Source is the path on the builder image of the artifact.",
+	"destination": "Destination is the path on the runtime image where the artifact should be copied.",
+}
+
+func (VolumeSpec) SwaggerDoc() map[string]string {
+	return map_VolumeSpec
 }
 
 var map_WebHookTrigger = map[string]string{

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -413,15 +413,16 @@ func (SecretSpec) SwaggerDoc() map[string]string {
 }
 
 var map_SourceBuildStrategy = map[string]string{
-	"":                 "SourceBuildStrategy defines input parameters specific to an Source build.",
-	"from":             "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled",
-	"pullSecret":       "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries",
-	"env":              "env contains additional environment variables you want to pass into a builder container",
-	"scripts":          "scripts is the location of Source scripts",
-	"incremental":      "incremental flag forces the Source build to do incremental builds if true.",
-	"forcePull":        "forcePull describes if the builder should pull the images from registry prior to building.",
-	"runtimeImage":     "RuntimeImage is the optinal image that is used to run an application without unneeded dependencies installed.",
-	"runtimeArtifacts": "RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.",
+	"":                  "SourceBuildStrategy defines input parameters specific to an Source build.",
+	"from":              "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled.",
+	"pullSecret":        "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries.",
+	"env":               "env contains additional environment variables you want to pass into a builder container.",
+	"scripts":           "scripts is the location of Source scripts",
+	"incremental":       "incremental flag forces the Source build to do incremental builds if true.",
+	"forcePull":         "forcePull describes if the builder should pull the images from registry prior to building.",
+	"runtimeImage":      "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed.",
+	"runtimeArtifacts":  "runtimeArtifacts holds the mapping between the artifacts paths in the builder image and the paths in the runtime image where they should be copied.",
+	"RuntimePullSecret": "runtimePullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker runtime images from private Docker registries.",
 }
 
 func (SourceBuildStrategy) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -422,7 +422,7 @@ var map_SourceBuildStrategy = map[string]string{
 	"forcePull":         "forcePull describes if the builder should pull the images from registry prior to building.",
 	"runtimeImage":      "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed.",
 	"runtimeArtifacts":  "runtimeArtifacts holds the mapping between the artifacts paths in the builder image and the paths in the runtime image where they should be copied.",
-	"RuntimePullSecret": "runtimePullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker runtime images from private Docker registries.",
+	"runtimePullSecret": "runtimePullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker runtime images from private Docker registries.",
 }
 
 func (SourceBuildStrategy) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -479,6 +479,24 @@ type SourceBuildStrategy struct {
 
 	// forcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty"`
+
+	// RuntimeImage is the optinal image that is used to run an application
+	// without unneeded dependencies installed.
+	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty"`
+
+	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
+	RuntimeArtifacts []VolumeSpec `json:"runtimeArtifacts,omitempty"`
+}
+
+// VolumeSpec is a mapping between paths on the builder image and paths on the
+// runtime image where files should be copied.
+type VolumeSpec struct {
+	// Source is the path on the builder image of the artifact.
+	Source string `json:"source,omitempty"`
+
+	// Destination is the path on the runtime image where the artifact should be
+	// copied.
+	Destination string `json:"destination,omitempty"`
 }
 
 // JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -459,16 +459,17 @@ type DockerBuildStrategy struct {
 
 // SourceBuildStrategy defines input parameters specific to an Source build.
 type SourceBuildStrategy struct {
-	// from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which
-	// the docker image should be pulled
+	// from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage
+	// from which the docker image should be pulled.
 	From kapi.ObjectReference `json:"from"`
 
 	// pullSecret is the name of a Secret that would be used for setting up
 	// the authentication for pulling the Docker images from the private Docker
-	// registries
+	// registries.
 	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty"`
 
-	// env contains additional environment variables you want to pass into a builder container
+	// env contains additional environment variables you want to pass into a
+	// builder container.
 	Env []kapi.EnvVar `json:"env,omitempty"`
 
 	// scripts is the location of Source scripts
@@ -477,15 +478,23 @@ type SourceBuildStrategy struct {
 	// incremental flag forces the Source build to do incremental builds if true.
 	Incremental bool `json:"incremental,omitempty"`
 
-	// forcePull describes if the builder should pull the images from registry prior to building.
+	// forcePull describes if the builder should pull the images from registry
+	// prior to building.
 	ForcePull bool `json:"forcePull,omitempty"`
 
-	// RuntimeImage is the optinal image that is used to run an application
+	// runtimeImage is an optional image that is used to run an application
 	// without unneeded dependencies installed.
 	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty"`
 
-	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
+	// runtimeArtifacts holds the mapping between the artifacts paths in the
+	// builder image and the paths in the runtime image where they should be
+	// copied.
 	RuntimeArtifacts []ImageSourcePath `json:"runtimeArtifacts,omitempty"`
+
+	// runtimePullSecret is the name of a Secret that would be used for setting up
+	// the authentication for pulling the Docker runtime images from private
+	// Docker registries.
+	RuntimePullSecret *kapi.LocalObjectReference `json:"RuntimePullSecret,omitempty"`
 }
 
 // JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -485,18 +485,7 @@ type SourceBuildStrategy struct {
 	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty"`
 
 	// RuntimeArtifacts holds the mapping between the artifacts paths on the builder image and the paths on the runtime image where they should be copied.
-	RuntimeArtifacts []VolumeSpec `json:"runtimeArtifacts,omitempty"`
-}
-
-// VolumeSpec is a mapping between paths on the builder image and paths on the
-// runtime image where files should be copied.
-type VolumeSpec struct {
-	// Source is the path on the builder image of the artifact.
-	Source string `json:"source,omitempty"`
-
-	// Destination is the path on the runtime image where the artifact should be
-	// copied.
-	Destination string `json:"destination,omitempty"`
+	RuntimeArtifacts []ImageSourcePath `json:"runtimeArtifacts,omitempty"`
 }
 
 // JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -494,7 +494,7 @@ type SourceBuildStrategy struct {
 	// runtimePullSecret is the name of a Secret that would be used for setting up
 	// the authentication for pulling the Docker runtime images from private
 	// Docker registries.
-	RuntimePullSecret *kapi.LocalObjectReference `json:"RuntimePullSecret,omitempty"`
+	RuntimePullSecret *kapi.LocalObjectReference `json:"runtimePullSecret,omitempty"`
 }
 
 // JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -498,7 +498,9 @@ func validateSourceStrategy(strategy *buildapi.SourceBuildStrategy, fldPath *fie
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateFromImageReference(&strategy.From, fldPath.Child("from"))...)
 	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret, fldPath.Child("pullSecret"))...)
+	allErrs = append(allErrs, validateSecretRef(strategy.RuntimePullSecret, fldPath.Child("runtimePullSecret"))...)
 	allErrs = append(allErrs, ValidateStrategyEnv(strategy.Env, fldPath.Child("env"))...)
+	allErrs = append(allErrs, validateRuntimeImage(strategy, fldPath.Child("runtimeImage"))...)
 	return allErrs
 }
 
@@ -646,4 +648,13 @@ func validatePostCommit(spec buildapi.BuildPostCommitSpec, fldPath *field.Path) 
 		allErrs = append(allErrs, field.Invalid(fldPath, spec, "cannot use command and script together"))
 	}
 	return allErrs
+}
+
+// validateRuntimeImage verifies that the runtimeImage field in
+// SourceBuildStrategy is not empty if it was specified.
+func validateRuntimeImage(sourceStrategy *buildapi.SourceBuildStrategy, fldPath *field.Path) (allErrs field.ErrorList) {
+	if sourceStrategy.RuntimeImage != nil && sourceStrategy.RuntimeImage.Name == "" {
+		return append(allErrs, field.Invalid(fldPath, sourceStrategy.RuntimeImage, "the runtime image name cannot be empty"))
+	}
+	return
 }

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -93,13 +93,16 @@ func (s *S2IBuilder) Build() error {
 		return fmt.Errorf("the source to image builder must be used with the source strategy")
 	}
 	var runtimeImageName string
+	var runtimeArtifacts string
+	var runtimePullSecret string
 	var push bool
 
 	runtimeImage := s.build.Spec.Strategy.SourceStrategy.RuntimeImage
 	runtimeArtifacts := copyArtifactSourceList(s.build.Spec.Strategy.SourceStrategy.RuntimeArtifacts)
 
-	if runtimeImage != nil && runtimeImage.Name != "" {
+	if runtimeImage != nil {
 		runtimeImageName = runtimeImage.Name
+		runtimePullSecret = s.build.Spec.Strategy.SourceStrategy.RuntimePullSecret
 	}
 
 	contextDir := filepath.Clean(s.build.Spec.Source.ContextDir)
@@ -197,6 +200,7 @@ func (s *S2IBuilder) Build() error {
 		BlockOnBuild:              true,
 		RuntimeImage:              runtimeImageName,
 		RuntimeArtifacts:          runtimeArtifacts,
+		RuntimePullSecret:         runtimePullSecret,
 	}
 
 	if s.build.Spec.Strategy.SourceStrategy.ForcePull {

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -94,10 +94,11 @@ func (s *S2IBuilder) Build() error {
 	}
 	var runtimeImageName string
 	var push bool
+
 	runtimeImage := s.build.Spec.Strategy.SourceStrategy.RuntimeImage
 	runtimeArtifacts := copyArtifactSourceList(s.build.Spec.Strategy.SourceStrategy.RuntimeArtifacts)
 
-	if runtimeImage != nil && len(runtimeImage.Name) > 0 {
+	if runtimeImage != nil && runtimeImage.Name != "" {
 		runtimeImageName = runtimeImage.Name
 	}
 

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -342,8 +342,9 @@ func buildEnvVars(build *api.Build) s2iapi.EnvironmentList {
 // the strategy's environment. There is no preference given to either lowercase
 // or uppercase form of the variable.
 func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
-	httpProxy := ""
-	httpsProxy := ""
+	var httpProxy string
+	var httpsProxy string
+
 	for _, env := range build.Spec.Strategy.SourceStrategy.Env {
 		switch env.Name {
 		case "HTTP_PROXY", "http_proxy":

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -390,7 +390,6 @@ func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 }
 
 func getDockerAuth() (dockerAuth docker.AuthConfiguration) {
-
 	return
 }
 

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fsouza/go-dockerclient"
+
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/api/describe"
 	"github.com/openshift/source-to-image/pkg/api/validation"
@@ -87,22 +89,22 @@ func newS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient 
 	}
 }
 
-// Build executes STI build based on configured builder, S2I builder factory and S2I config validator
+// Build executes STI build based on configured builder, S2I builder factory and
+// S2I config validator
 func (s *S2IBuilder) Build() error {
 	if s.build.Spec.Strategy.SourceStrategy == nil {
-		return fmt.Errorf("the source to image builder must be used with the source strategy")
+		return errors.New("the source to image builder must be used with the source strategy")
 	}
 	var runtimeImageName string
-	var runtimeArtifacts string
-	var runtimePullSecret string
+	var runtimeDockerAuth docker.AuthConfiguration
 	var push bool
 
 	runtimeImage := s.build.Spec.Strategy.SourceStrategy.RuntimeImage
-	runtimeArtifacts := copyArtifactSourceList(s.build.Spec.Strategy.SourceStrategy.RuntimeArtifacts)
+	runtimeArtifacts := copyToVolumeList(s.build.Spec.Strategy.SourceStrategy.RuntimeArtifacts)
 
 	if runtimeImage != nil {
-		runtimeImageName = runtimeImage.Name
-		runtimePullSecret = s.build.Spec.Strategy.SourceStrategy.RuntimePullSecret
+		runtimeImageName = s.build.Spec.Strategy.SourceStrategy.RuntimeImage.Name
+		runtimeDockerAuth = getDockerAuth()
 	}
 
 	contextDir := filepath.Clean(s.build.Spec.Source.ContextDir)
@@ -198,9 +200,10 @@ func (s *S2IBuilder) Build() error {
 		Injections:                injections,
 		ScriptDownloadProxyConfig: scriptDownloadProxyConfig,
 		BlockOnBuild:              true,
-		RuntimeImage:              runtimeImageName,
-		RuntimeArtifacts:          runtimeArtifacts,
-		RuntimePullSecret:         runtimePullSecret,
+
+		RuntimeImage:          runtimeImageName,
+		RuntimeArtifacts:      runtimeArtifacts,
+		RuntimeAuthentication: runtimeDockerAuth,
 	}
 
 	if s.build.Spec.Strategy.SourceStrategy.ForcePull {
@@ -235,7 +238,7 @@ func (s *S2IBuilder) Build() error {
 		return errors.New(buffer.String())
 	}
 
-	// If DockerCfgPath is provided in api.Config, then attempt to read the the
+	// If DockerCfgPath is provided in api.Config, then attempt to read the
 	// dockercfg file and get the authentication for pulling the builder image.
 	config.PullAuthentication, _ = dockercfg.NewHelper().GetDockerAuth(config.BuilderImage, dockercfg.PullAuthType)
 	config.IncrementalAuthentication, _ = dockercfg.NewHelper().GetDockerAuth(pushTag, dockercfg.PushAuthType)
@@ -357,7 +360,6 @@ func buildEnvVars(build *api.Build) s2iapi.EnvironmentList {
 func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 	httpProxy := ""
 	httpsProxy := ""
-
 	for _, env := range build.Spec.Strategy.SourceStrategy.Env {
 		switch env.Name {
 		case "HTTP_PROXY", "http_proxy":
@@ -387,13 +389,14 @@ func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 	return config, nil
 }
 
-func (s *S2IBuilder) resolveRuntimeImageRef() error {
-	return nil
+func getDockerAuth() (dockerAuth docker.AuthConfiguration) {
+
+	return
 }
 
-// copyArtifactSourceList copies the artifacts set in the build config to the
+// copyToVolumeList copies the artifacts set in the build config to the
 // VolumeList struct in the s2iapi.Config
-func copyArtifactSourceList(artifactsMapping []api.ImageSourcePath) (volumeList s2iapi.VolumeList) {
+func copyToVolumeList(artifactsMapping []api.ImageSourcePath) (volumeList s2iapi.VolumeList) {
 	for _, mappedPath := range artifactsMapping {
 		volumeList = append(volumeList, s2iapi.VolumeSpec{
 			Source:      mappedPath.SourcePath,

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -387,9 +387,13 @@ func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 	return config, nil
 }
 
+func (s *S2IBuilder) resolveRuntimeImageRef() error {
+	return nil
+}
+
 // copyArtifactSourceList copies the artifacts set in the build config to the
 // VolumeList struct in the s2iapi.Config
-func copyArtifactSourceList(artifactsMapping []api.ImageSourcePath) (volumeList []s2iapi.VolumeSpec) {
+func copyArtifactSourceList(artifactsMapping []api.ImageSourcePath) (volumeList s2iapi.VolumeList) {
 	for _, mappedPath := range artifactsMapping {
 		volumeList = append(volumeList, s2iapi.VolumeSpec{
 			Source:      mappedPath.SourcePath,

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -350,8 +350,8 @@ func buildEnvVars(build *api.Build) s2iapi.EnvironmentList {
 // the strategy's environment. There is no preference given to either lowercase
 // or uppercase form of the variable.
 func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
-	var httpProxy string
-	var httpsProxy string
+	httpProxy := ""
+	httpsProxy := ""
 
 	for _, env := range build.Spec.Strategy.SourceStrategy.Env {
 		switch env.Name {

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -382,6 +382,8 @@ func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 	return config, nil
 }
 
+// copyArtifactSourceList copies the artifacts set in the build config to the
+// VolumeList struct in the s2iapi.Config
 func copyArtifactSourceList(artifactsMapping []api.ImageSourcePath) (volumeList []s2iapi.VolumeSpec) {
 	for _, mappedPath := range artifactsMapping {
 		volumeList = append(volumeList, s2iapi.VolumeSpec{
@@ -389,5 +391,5 @@ func copyArtifactSourceList(artifactsMapping []api.ImageSourcePath) (volumeList 
 			Destination: mappedPath.DestinationDir,
 		})
 	}
-	return volumeList
+	return
 }

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -502,6 +502,23 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 		if build.Spec.Strategy.SourceStrategy.PullSecret == nil {
 			build.Spec.Strategy.SourceStrategy.PullSecret = g.resolveImageSecret(ctx, builderSecrets, &build.Spec.Strategy.SourceStrategy.From, bc.Namespace)
 		}
+
+		if build.Spec.Strategy.SourceStrategy.RuntimeImage != nil {
+			runtimeImage, err := g.resolveImageStreamReference(ctx, *build.Spec.Strategy.SourceStrategy.RuntimeImage, bc.Namespace)
+			if err != nil {
+				return nil, err
+			}
+
+			build.Spec.Strategy.SourceStrategy.RuntimeImage = &kapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: runtimeImage,
+			}
+
+			if build.Spec.Strategy.SourceStrategy.RuntimePullSecret == nil {
+				build.Spec.Strategy.SourceStrategy.RuntimePullSecret = g.resolveImageSecret(ctx, builderSecrets, build.Spec.Strategy.SourceStrategy.RuntimeImage, bc.Namespace)
+			}
+
+		}
 	case build.Spec.Strategy.DockerStrategy != nil &&
 		build.Spec.Strategy.DockerStrategy.From != nil:
 		if image == "" {


### PR DESCRIPTION
Trello: https://trello.com/c/MWUAjl6k/237-13-extended-builds-separate-mvn-vs-jboss-evg
This is dependent on: https://github.com/openshift/source-to-image/pull/505/files
Limited functionality.
to make this work, in your bc

```
   strategy:
      sourceStrategy:
        env:
        - name: EXAMPLE
          value: sample-app
        from:
          kind: ImageStreamTag
          name: ruby-22-centos7:latest
        runtimeArtifacts:
        - sourcePath: path/to/1
          destinationDir: path/to/1
       - sourcePath: path/to/2
          destinationDir: path/to/2
        - sourcePath: path/to/3
          destinationDir: path/to/3
        - sourcePath: path/to/4
          destinationDir: path/to/4
        runtimeImage:
          name: centos:latest
```
cc: @php-coder @bparees 

LE: changed paths in mapping to be relative