### PR TITLE
Bug 1339754 - Fix tag sorting according to semantic versioning rules

### DIFF
--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -1412,10 +1412,25 @@ func TestDockerImageReferenceEquality(t *testing.T) {
 }
 
 func TestPrioritizeTags(t *testing.T) {
-	tags := []string{"5", "other", "latest", "v5.5", "v6", "5.2.3", "v5.3.6-bother", "5.3.6-abba", "5.6"}
-	PrioritizeTags(tags)
-	if !reflect.DeepEqual(tags, []string{"latest", "v6", "5", "5.6", "v5.5", "v5.3.6-bother", "5.3.6-abba", "5.2.3", "other"}) {
-		t.Errorf("unexpected order: %v", tags)
+	tests := []struct {
+		tags     []string
+		expected []string
+	}{
+		{
+			tags:     []string{"other", "latest", "v5.5", "5.2.3", "v5.3.6-bother", "5.3.6-abba", "5.6"},
+			expected: []string{"latest", "5.6", "v5.5", "v5.3.6-bother", "5.3.6-abba", "5.2.3", "other"},
+		},
+		{
+			tags:     []string{"1.1-beta1", "1.2-rc1", "1.1-rc1", "1.1-beta2", "1.2-beta1", "1.2-alpha1", "1.2-beta4", "latest"},
+			expected: []string{"latest", "1.2-rc1", "1.2-beta4", "1.2-beta1", "1.2-alpha1", "1.1-rc1", "1.1-beta2", "1.1-beta1"},
+		},
+	}
+
+	for i, tc := range tests {
+		PrioritizeTags(tc.tags)
+		if !reflect.DeepEqual(tc.tags, tc.expected) {
+			t.Errorf("%d: unexpected order: %v", i, tc.tags)
+		}
 	}
 }
 

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -239,13 +239,13 @@ func TestImport(t *testing.T) {
 				},
 			},
 			expect: func(isi *api.ImageStreamImport, t *testing.T) {
-				if !reflect.DeepEqual(isi.Status.Repository.AdditionalTags, []string{"other"}) {
+				if !reflect.DeepEqual(isi.Status.Repository.AdditionalTags, []string{"v2"}) {
 					t.Errorf("unexpected additional tags: %#v", isi.Status.Repository)
 				}
 				if len(isi.Status.Repository.Images) != 5 {
 					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
 				}
-				expectedTags := []string{"3", "v2", "v1", "3.1", "abc"}
+				expectedTags := []string{"3.1", "3", "abc", "other", "v1"}
 				for i, image := range isi.Status.Repository.Images {
 					if image.Status.Status != unversioned.StatusFailure || image.Status.Message != "Internal error occurred: no such manifest tag" {
 						t.Errorf("unexpected status %d: %#v", i, isi.Status.Repository.Images)

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -579,7 +579,7 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 	}
 	for i, image := range isi.Status.Repository.Images {
 		switch i {
-		case 2:
+		case 1:
 			if image.Status.Status != unversioned.StatusSuccess {
 				t.Errorf("import of image %d did not succeed: %#v", i, image.Status)
 			}
@@ -599,7 +599,7 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 			if image.Status.Status != unversioned.StatusFailure || image.Status.Reason != unversioned.StatusReasonInternalError {
 				t.Fatalf("import of image %d did not report internal server error: %#v", i, image.Status)
 			}
-			expectedTags := []string{"latest", "v2"}[i]
+			expectedTags := []string{"latest", "", "v2"}[i]
 			if image.Tag != expectedTags {
 				t.Errorf("unexpected tag at position %d (%s != %s)", i, image.Tag, expectedTags)
 			}


### PR DESCRIPTION
Partially fixes [bug 1339754](https://bugzilla.redhat.com/show_bug.cgi?id=1339754) in that it correctly reads patch part from non-full versions (eg. `1.1-beta1`).

@smarterclayton ptal and help me understand why our current sorting algorithm prefers `9.5` over `9.5.1`. I know the former isn't fully specified semver but since we're expanding it to make it through semver parsing why not sorting it accordingly? 
I'd love to live in a perfect world, but we're not and we need to deal with problems as such from the bug I'm trying to solve. Although that bug is too far from semver we support.
