### PR TITLE
Simplify calls to FixturePath in extended tests

### DIFF
--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -13,8 +13,8 @@ import (
 var _ = g.Describe("[builds][Slow] builds should have deadlines", func() {
 	defer g.GinkgoRecover()
 	var (
-		sourceFixture = exutil.FixturePath("..", "extended", "testdata", "test-cds-sourcebuild.json")
-		dockerFixture = exutil.FixturePath("..", "extended", "testdata", "test-cds-dockerbuild.json")
+		sourceFixture = exutil.FixturePath("testdata", "test-cds-sourcebuild.json")
+		dockerFixture = exutil.FixturePath("testdata", "test-cds-dockerbuild.json")
 		oc            = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -12,9 +12,9 @@ import (
 var _ = g.Describe("[builds] build with empty source", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture = exutil.FixturePath("..", "extended", "testdata", "test-nosrc-build.json")
+		buildFixture = exutil.FixturePath("testdata", "test-nosrc-build.json")
 		oc           = exutil.NewCLI("cli-build-nosrc", exutil.KubeConfigPath())
-		exampleBuild = exutil.FixturePath("..", "extended", "testdata", "test-build-app")
+		exampleBuild = exutil.FixturePath("testdata", "test-build-app")
 	)
 
 	g.JustBeforeEach(func() {

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -14,7 +14,7 @@ import (
 var _ = g.Describe("[builds][Slow] the s2i build should support proxies", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture = exutil.FixturePath("..", "extended", "testdata", "test-build-proxy.json")
+		buildFixture = exutil.FixturePath("testdata", "test-build-proxy.json")
 		oc           = exutil.NewCLI("build-proxy", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -14,7 +14,7 @@ import (
 var _ = g.Describe("[builds][Conformance] remove all builds when build configuration is removed", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture = exutil.FixturePath("..", "extended", "testdata", "test-build.json")
+		buildFixture = exutil.FixturePath("testdata", "test-build.json")
 		oc           = exutil.NewCLI("cli-remove-build", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -12,7 +12,7 @@ import (
 var _ = g.Describe("[builds] build have source revision metadata", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture = exutil.FixturePath("..", "extended", "testdata", "test-build-revision.json")
+		buildFixture = exutil.FixturePath("testdata", "test-build-revision.json")
 		oc           = exutil.NewCLI("cli-build-revision", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[builds][Slow] using build configuration runPolicy", func() 
 		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// Create all fixtures
-		oc.Run("create").Args("-f", exutil.FixturePath("..", "extended", "testdata", "run_policy")).Execute()
+		oc.Run("create").Args("-f", exutil.FixturePath("testdata", "run_policy")).Execute()
 	})
 
 	g.Describe("build configuration with Parallel build run policy", func() {

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -15,8 +15,8 @@ import (
 var _ = g.Describe("[builds][Slow] Capabilities should be dropped for s2i builders", func() {
 	defer g.GinkgoRecover()
 	var (
-		s2ibuilderFixture      = exutil.FixturePath("..", "extended", "testdata", "s2i-dropcaps", "rootable-ruby")
-		rootAccessBuildFixture = exutil.FixturePath("..", "extended", "testdata", "s2i-dropcaps", "root-access-build.yaml")
+		s2ibuilderFixture      = exutil.FixturePath("testdata", "s2i-dropcaps", "rootable-ruby")
+		rootAccessBuildFixture = exutil.FixturePath("testdata", "s2i-dropcaps", "root-access-build.yaml")
 		oc                     = exutil.NewCLI("build-s2i-dropcaps", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -16,9 +16,9 @@ import (
 var _ = g.Describe("[builds][Slow] starting a build using CLI", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture   = exutil.FixturePath("..", "extended", "testdata", "test-build.json")
-		exampleGemfile = exutil.FixturePath("..", "extended", "testdata", "test-build-app", "Gemfile")
-		exampleBuild   = exutil.FixturePath("..", "extended", "testdata", "test-build-app")
+		buildFixture   = exutil.FixturePath("testdata", "test-build.json")
+		exampleGemfile = exutil.FixturePath("testdata", "test-build-app", "Gemfile")
+		exampleBuild   = exutil.FixturePath("testdata", "test-build-app")
 		oc             = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
 	)
 

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -23,13 +23,13 @@ var _ = g.Describe("deploymentconfigs", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                      = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
-		deploymentFixture       = exutil.FixturePath("..", "extended", "testdata", "test-deployment-test.yaml")
-		simpleDeploymentFixture = exutil.FixturePath("..", "extended", "testdata", "deployment-simple.yaml")
-		customDeploymentFixture = exutil.FixturePath("..", "extended", "testdata", "custom-deployment.yaml")
-		generationFixture       = exutil.FixturePath("..", "extended", "testdata", "test-deployment.yaml")
-		pausedDeploymentFixture = exutil.FixturePath("..", "extended", "testdata", "paused-deployment.yaml")
-		failedHookFixture       = exutil.FixturePath("..", "extended", "testdata", "failing-pre-hook.yaml")
-		brokenDeploymentFixture = exutil.FixturePath("..", "extended", "testdata", "test-deployment-broken.yaml")
+		deploymentFixture       = exutil.FixturePath("testdata", "test-deployment-test.yaml")
+		simpleDeploymentFixture = exutil.FixturePath("testdata", "deployment-simple.yaml")
+		customDeploymentFixture = exutil.FixturePath("testdata", "custom-deployment.yaml")
+		generationFixture       = exutil.FixturePath("testdata", "test-deployment.yaml")
+		pausedDeploymentFixture = exutil.FixturePath("testdata", "paused-deployment.yaml")
+		failedHookFixture       = exutil.FixturePath("testdata", "failing-pre-hook.yaml")
+		brokenDeploymentFixture = exutil.FixturePath("testdata", "test-deployment-broken.yaml")
 	)
 
 	g.Describe("when run iteratively", func() {


### PR DESCRIPTION
The documentation of `exutil.FixturePath` says that "path is relative to
EXTENDED_TEST_PATH (./test/extended/*)".

We can remove all occurrences of `"..", "extended", `, since they bring
us back to the same directory where we'd be without it.