### PR TITLE
HACK make /sys/fs/cgroup a docker volume for dind

### DIFF
--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -40,4 +40,8 @@ RUN systemctl enable docker
 
 VOLUME /var/lib/docker
 
+# HACK(ncdc) to work around /sys/fs/cgroup/* getting mounted read-only for some reason
+# REMOVE once we figure out why this is happening
+VOLUME /sys/fs/cgroup
+
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
For some reason /sys/fs/cgroup/* is getting mounted read-only when running a dind cluster. This
makes it impossible to run any containers. Until we can figure out why this is happening, switch
/sys/fs/cgroup to be a docker volume, so it's read-write.