### PR TITLE
Don't fallback to cert when given invalid token

### DIFF
--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -3,11 +3,17 @@
 package integration
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	oclient "github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/auth/user"
 	"k8s.io/kubernetes/pkg/client/restclient"
 
+	"github.com/openshift/origin/pkg/cmd/server/admin"
+	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -16,59 +22,13 @@ import (
 func TestOAuthCertFallback(t *testing.T) {
 
 	var (
-		invalidKeyData = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAuY3YLpZsU1HNFOb6n0EoeHyRRfgbu6tXdj0EjQWR8naSm7n0
-HxunYDBKf2XODaLAsWcFfvQ4m7XuECtznr3gAATv1AV00POgngQi+wGTI4qmenAh
-a8gBdoWnkQYlpdTtnsHHzOU80aEmszoMFtnBC86DLgyT43e5KNUxTtSP0AYuop7x
-NRDXcWd4vjByJ8S8CLmkRvQY91EJThMZDa68BgabATJKOyixKFeFW9VpJViK9rsE
-R2tsLB1TuTxrH5b6c/wK6DH9hN7HVVwbC1M7UcOGQthB6+3yvqSWPbUwgosCCdaD
-z1OnyaMjC5Ait1xjCZxeWDll6MPCWzU2bvRsYwIDAQABAoIBAA1a7T1lLETO9XDU
-syM1QGFzrc0Yb36RdYkYGTTBOuD1sdWti6mVhvWAZExJGoyWs0HRhW6+yzhB3vGg
-/wBk8DNwJ4beIatMbboR2Cay1VFQkGztlyo3ygsq0YW5qIoIClZL4kKYGUmJTMzH
-l8kpQSDFa2GsHBTaMCSFO7hNylARknfm70oAgrV8j3iIAKeBB/a17wCIP78jrX4v
-MroarxWr32z9dWFUANyBVNSTo+Tuq4EXslWUFBCRN30zBZ0b7YT4sM86Yt/GYo9s
-It79Y0BnUI/ykgrNKGmm0gA79Su1Obh2WQWMW9KpT66KrWuzqtIr5eOgRzZkQsZ3
-klGJ7kkCgYEA2TERKA84ZXDn2zgbabejGSuONoX6TjJvT594GVHzrwm8pj8FKmXS
-LbbRcUhjcY8e3a4O7NznZ5hfblqjn2NhqvdvRElI9DXwQmf6dXm8lzTacSLSy8j4
-W1Nvcf2RD+7J9AymOjF2vvBEnksNgaMGjr6jW3J+vEF4hiTl2plOXa0CgYEA2rWW
-uu6bkWzrPRPsQ8iqbhJOqqz9d6hrmHmnKSBUCFpmAmNep4Y+PmHUKEUh8elWzBGh
-NsUuc110aK9Fccy7U+NUSnOJWYNmAez2tyVbQS/SErkPgJdAvwwqQHgLFgMnD/Wy
-Bm8PXLfgUWs61GZjscjmA02YpJ/HWICkvWjEFE8CgYAXjzgCNWxzrISqBfMLS604
-fL4Hcg8NznC+nVjEvlwFn7PEANAJolPjO5KKjESlO9YoS8o4rVm4phGsAc7/6iLd
-DcwXBzAPtY4jVe4YMiVf7Y7IePOOwXUXSvyqy8uhg9CKVZjudREhcySuWwvTBSEf
-+NP1hnzy5NMzEeuRA9I5XQKBgGtWW5d6q1cAAaOEN5w8y4gh7AHPzMYBHm1Cp0uD
-1joTQ6VAZ6AIPlwXXyw0Yah8QGD+9gQPWfC8mPkXrBlhxT4yf5fahDouRs4DIkJY
-TyT69zrBIF6X3OrmaYYiZC51daJbjvehYgS7KZhL7B958Mu8MUbFunhxAkDpQfDD
-jhf5AoGAKuT+Wc2aeHguZaMmfnAoL3pOu9FH2+QPkHEGQp6vA55QKcAlWLkYd4Me
-Pxwj3BzCwiKE44kqBn36rhow9a7N177ATDJta1iUlli2J7PtTRBmM60TOpfU+3i5
-UeBTTl1GjZXtgxd486Aw6BsAD/rg2C+8ZcyUba+MYzuNzY4qw6o=
------END RSA PRIVATE KEY-----`)
-		invalidCertData = []byte(`-----BEGIN CERTIFICATE-----
-MIIDDTCCAfWgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
-c2hpZnQtc2lnbmVyQDE0NjY3OTI3MTAwHhcNMTYwNjI0MTgyNTExWhcNMTgwNjI0
-MTgyNTEyWjA3MR4wHAYDVQQKExVzeXN0ZW06Y2x1c3Rlci1hZG1pbnMxFTATBgNV
-BAMTDHN5c3RlbTphZG1pbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-ALmN2C6WbFNRzRTm+p9BKHh8kUX4G7urV3Y9BI0FkfJ2kpu59B8bp2AwSn9lzg2i
-wLFnBX70OJu17hArc5694AAE79QFdNDzoJ4EIvsBkyOKpnpwIWvIAXaFp5EGJaXU
-7Z7Bx8zlPNGhJrM6DBbZwQvOgy4Mk+N3uSjVMU7Uj9AGLqKe8TUQ13FneL4wcifE
-vAi5pEb0GPdRCU4TGQ2uvAYGmwEySjsosShXhVvVaSVYiva7BEdrbCwdU7k8ax+W
-+nP8Cugx/YTex1VcGwtTO1HDhkLYQevt8r6klj21MIKLAgnWg89Tp8mjIwuQIrdc
-YwmcXlg5ZejDwls1Nm70bGMCAwEAAaM1MDMwDgYDVR0PAQH/BAQDAgWgMBMGA1Ud
-JQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQADggEB
-AIKO3Qcl7lsmPImzLX+KZ1h54b0qp9LRbvNe1e9+SMkyMzNhyJExs3qqg7/Z9a8n
-LRqjyPPRLOFeoherM+14mnxg9BXxuhoKKZCln3hLiDgzEPZVb9vsDxMKjLy+gRiH
-oIyEuzexr/dldk3shmPLDAlpB0Mz+8eBWcXn8cRwXkUyEstY64nUSuMgnL72tU9y
-3Yt5D2gTLJ2MUpMxWv+cFz/UJZ0TBKtoKLjtLGRCGwFcUOz6rJzM7QGChfQxMzD7
-gydO+4blIu/i4strKbkR5jcRA1WgwS/1yW25F/hE0QglsWyXJJELf4ZCNpr+9zQb
-eUArEOSZyp5WmmRcn0v/YZc=
------END CERTIFICATE-----`)
-
 		invalidToken = "invalid"
 		noToken      = ""
 
 		invalidCert = restclient.TLSClientConfig{
-			CertData: invalidCertData,
-			KeyData:  invalidKeyData,
+		// We have to generate this dynamically in order to have an invalid cert signed by a signer with the same name as the valid CA
+		// CertData: ...,
+		// KeyData:  ...,
 		}
 		noCert = restclient.TLSClientConfig{}
 
@@ -78,9 +38,6 @@ eUArEOSZyp5WmmRcn0v/YZc=
 		unauthorizedError = "the server has asked for the client to provide credentials (get users ~)"
 		anonymousError    = `User "system:anonymous" cannot get users at the cluster scope`
 	)
-
-	// TODO see comment below
-	_ = invalidCert
 
 	testutil.RequireEtcd(t)
 	// Build master config
@@ -109,98 +66,122 @@ eUArEOSZyp5WmmRcn0v/YZc=
 		t.Fatalf("Expected valid token, got none")
 	}
 
-	for _, test := range []struct {
+	// make a client cert signed by a fake CA with the same name as the real CA.
+	// this is needed to get the go client to actually send the cert to the server,
+	// since the server advertises the signer name it requires
+	fakecadir, err := ioutil.TempDir("", "fakeca")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer os.RemoveAll(fakecadir)
+	cacerts, err := util.CertificatesFromFile(masterOptions.ServingInfo.ClientCA)
+	if err != nil || len(cacerts) != 1 {
+		t.Fatalf("Unexpected error or number of certs: %v, %d", err, len(cacerts))
+	}
+	fakeca, err := (&admin.CreateSignerCertOptions{
+		CertFile:   path.Join(fakecadir, "fakeca.crt"),
+		KeyFile:    path.Join(fakecadir, "fakeca.key"),
+		SerialFile: path.Join(fakecadir, "fakeca.serial"),
+		Name:       cacerts[0].Subject.CommonName,
+		Output:     ioutil.Discard,
+		Overwrite:  true,
+	}).CreateSignerCert()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	clientCertConfig, err := fakeca.MakeClientCertificate(
+		path.Join(fakecadir, "fakeclient.crt"),
+		path.Join(fakecadir, "fakeclient.key"),
+		&user.DefaultInfo{Name: "fakeuser"},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	invalidCert.CertData, invalidCert.KeyData, err = clientCertConfig.GetPEMBytes()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	for k, test := range map[string]struct {
 		token         string
 		cert          restclient.TLSClientConfig
 		expectedUser  string
 		errorExpected bool
 		errorString   string
-		insecure      bool
 	}{
-		{
+		"valid token, valid cert": {
 			token:        validToken,
 			cert:         validCert,
 			expectedUser: tokenUser,
 		},
-		// TODO find a way to test invalidCert
-		// Tests with invalidCert don't work because go does not send the client cert
-		// because it knows the server does not want certs that are not signed it's CA
-		// {
-		// 	token:        validToken,
-		// 	cert:         invalidCert,
-		// 	expectedUser: tokenUser,
-		// 	insecure:     true,
-		// },
-		{
+		"valid token, invalid cert": {
+			token:        validToken,
+			cert:         invalidCert,
+			expectedUser: tokenUser,
+		},
+		"valid token, no cert": {
 			token:        validToken,
 			cert:         noCert,
 			expectedUser: tokenUser,
-			insecure:     true,
 		},
-		{
+		"invalid token, valid cert": {
 			token:         invalidToken,
 			cert:          validCert,
 			errorExpected: true,
 			errorString:   unauthorizedError,
 		},
-		// {
-		// 	token:         invalidToken,
-		// 	cert:          invalidCert,
-		// 	errorExpected: true,
-		// 	errorString:   unauthorizedError,
-		// 	insecure:      true,
-		// },
-		{
+		"invalid token, invalid cert": {
+			token:         invalidToken,
+			cert:          invalidCert,
+			errorExpected: true,
+			errorString:   unauthorizedError,
+		},
+		"invalid token, no cert": {
 			token:         invalidToken,
 			cert:          noCert,
 			errorExpected: true,
 			errorString:   unauthorizedError,
-			insecure:      true,
 		},
-		{
+		"no token, valid cert": {
 			token:        noToken,
 			cert:         validCert,
 			expectedUser: certUser,
 		},
-		// {
-		// 	token:         noToken,
-		// 	cert:          invalidCert,
-		// 	errorExpected: true,
-		// 	errorString:   unauthorizedError,
-		// 	insecure:      true,
-		// },
-		{
+		"no token, invalid cert": {
+			token:         noToken,
+			cert:          invalidCert,
+			errorExpected: true,
+			errorString:   unauthorizedError,
+		},
+		"no token, no cert": {
 			token:         noToken,
 			cert:          noCert,
 			errorExpected: true,
 			errorString:   anonymousError,
-			insecure:      true,
 		},
 	} {
 		config := *adminConfig
 		config.BearerToken = test.token
 		config.TLSClientConfig = test.cert
-		config.Insecure = test.insecure
+		config.CAData = adminConfig.CAData
 
 		client := oclient.NewOrDie(&config)
 
 		user, err := client.Users().Get("~")
 
-		test.cert = noCert // Just to make errors more readible
-
 		if user.Name != test.expectedUser {
-			t.Errorf("unexpected user %q for test %+v", user.Name, test)
+			t.Errorf("%s: unexpected user %q", k, user.Name)
 		}
 
 		if test.errorExpected {
 			if err == nil {
-				t.Errorf("expected error but got nil for test %+v", test)
+				t.Errorf("%s: expected error but got nil", k)
 			} else if err.Error() != test.errorString {
-				t.Errorf("unexpected error string %q for test %+v", err.Error(), test)
+				t.Errorf("%s: unexpected error string %q", k, err.Error())
 			}
 		} else {
 			if err != nil {
-				t.Errorf("unexpected error %q for test %+v", err.Error(), test)
+				t.Errorf("%s: unexpected error %q", k, err.Error())
 			}
 		}
 	}

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -1,0 +1,208 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	oclient "github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/client/restclient"
+
+	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestOAuthCertFallback(t *testing.T) {
+
+	var (
+		invalidKeyData = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAuY3YLpZsU1HNFOb6n0EoeHyRRfgbu6tXdj0EjQWR8naSm7n0
+HxunYDBKf2XODaLAsWcFfvQ4m7XuECtznr3gAATv1AV00POgngQi+wGTI4qmenAh
+a8gBdoWnkQYlpdTtnsHHzOU80aEmszoMFtnBC86DLgyT43e5KNUxTtSP0AYuop7x
+NRDXcWd4vjByJ8S8CLmkRvQY91EJThMZDa68BgabATJKOyixKFeFW9VpJViK9rsE
+R2tsLB1TuTxrH5b6c/wK6DH9hN7HVVwbC1M7UcOGQthB6+3yvqSWPbUwgosCCdaD
+z1OnyaMjC5Ait1xjCZxeWDll6MPCWzU2bvRsYwIDAQABAoIBAA1a7T1lLETO9XDU
+syM1QGFzrc0Yb36RdYkYGTTBOuD1sdWti6mVhvWAZExJGoyWs0HRhW6+yzhB3vGg
+/wBk8DNwJ4beIatMbboR2Cay1VFQkGztlyo3ygsq0YW5qIoIClZL4kKYGUmJTMzH
+l8kpQSDFa2GsHBTaMCSFO7hNylARknfm70oAgrV8j3iIAKeBB/a17wCIP78jrX4v
+MroarxWr32z9dWFUANyBVNSTo+Tuq4EXslWUFBCRN30zBZ0b7YT4sM86Yt/GYo9s
+It79Y0BnUI/ykgrNKGmm0gA79Su1Obh2WQWMW9KpT66KrWuzqtIr5eOgRzZkQsZ3
+klGJ7kkCgYEA2TERKA84ZXDn2zgbabejGSuONoX6TjJvT594GVHzrwm8pj8FKmXS
+LbbRcUhjcY8e3a4O7NznZ5hfblqjn2NhqvdvRElI9DXwQmf6dXm8lzTacSLSy8j4
+W1Nvcf2RD+7J9AymOjF2vvBEnksNgaMGjr6jW3J+vEF4hiTl2plOXa0CgYEA2rWW
+uu6bkWzrPRPsQ8iqbhJOqqz9d6hrmHmnKSBUCFpmAmNep4Y+PmHUKEUh8elWzBGh
+NsUuc110aK9Fccy7U+NUSnOJWYNmAez2tyVbQS/SErkPgJdAvwwqQHgLFgMnD/Wy
+Bm8PXLfgUWs61GZjscjmA02YpJ/HWICkvWjEFE8CgYAXjzgCNWxzrISqBfMLS604
+fL4Hcg8NznC+nVjEvlwFn7PEANAJolPjO5KKjESlO9YoS8o4rVm4phGsAc7/6iLd
+DcwXBzAPtY4jVe4YMiVf7Y7IePOOwXUXSvyqy8uhg9CKVZjudREhcySuWwvTBSEf
++NP1hnzy5NMzEeuRA9I5XQKBgGtWW5d6q1cAAaOEN5w8y4gh7AHPzMYBHm1Cp0uD
+1joTQ6VAZ6AIPlwXXyw0Yah8QGD+9gQPWfC8mPkXrBlhxT4yf5fahDouRs4DIkJY
+TyT69zrBIF6X3OrmaYYiZC51daJbjvehYgS7KZhL7B958Mu8MUbFunhxAkDpQfDD
+jhf5AoGAKuT+Wc2aeHguZaMmfnAoL3pOu9FH2+QPkHEGQp6vA55QKcAlWLkYd4Me
+Pxwj3BzCwiKE44kqBn36rhow9a7N177ATDJta1iUlli2J7PtTRBmM60TOpfU+3i5
+UeBTTl1GjZXtgxd486Aw6BsAD/rg2C+8ZcyUba+MYzuNzY4qw6o=
+-----END RSA PRIVATE KEY-----`)
+		invalidCertData = []byte(`-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtvcGVu
+c2hpZnQtc2lnbmVyQDE0NjY3OTI3MTAwHhcNMTYwNjI0MTgyNTExWhcNMTgwNjI0
+MTgyNTEyWjA3MR4wHAYDVQQKExVzeXN0ZW06Y2x1c3Rlci1hZG1pbnMxFTATBgNV
+BAMTDHN5c3RlbTphZG1pbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALmN2C6WbFNRzRTm+p9BKHh8kUX4G7urV3Y9BI0FkfJ2kpu59B8bp2AwSn9lzg2i
+wLFnBX70OJu17hArc5694AAE79QFdNDzoJ4EIvsBkyOKpnpwIWvIAXaFp5EGJaXU
+7Z7Bx8zlPNGhJrM6DBbZwQvOgy4Mk+N3uSjVMU7Uj9AGLqKe8TUQ13FneL4wcifE
+vAi5pEb0GPdRCU4TGQ2uvAYGmwEySjsosShXhVvVaSVYiva7BEdrbCwdU7k8ax+W
++nP8Cugx/YTex1VcGwtTO1HDhkLYQevt8r6klj21MIKLAgnWg89Tp8mjIwuQIrdc
+YwmcXlg5ZejDwls1Nm70bGMCAwEAAaM1MDMwDgYDVR0PAQH/BAQDAgWgMBMGA1Ud
+JQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQADggEB
+AIKO3Qcl7lsmPImzLX+KZ1h54b0qp9LRbvNe1e9+SMkyMzNhyJExs3qqg7/Z9a8n
+LRqjyPPRLOFeoherM+14mnxg9BXxuhoKKZCln3hLiDgzEPZVb9vsDxMKjLy+gRiH
+oIyEuzexr/dldk3shmPLDAlpB0Mz+8eBWcXn8cRwXkUyEstY64nUSuMgnL72tU9y
+3Yt5D2gTLJ2MUpMxWv+cFz/UJZ0TBKtoKLjtLGRCGwFcUOz6rJzM7QGChfQxMzD7
+gydO+4blIu/i4strKbkR5jcRA1WgwS/1yW25F/hE0QglsWyXJJELf4ZCNpr+9zQb
+eUArEOSZyp5WmmRcn0v/YZc=
+-----END CERTIFICATE-----`)
+
+		invalidToken = "invalid"
+		noToken      = ""
+
+		invalidCert = restclient.TLSClientConfig{
+			CertData: invalidCertData,
+			KeyData:  invalidKeyData,
+		}
+		noCert = restclient.TLSClientConfig{}
+
+		tokenUser = "user"
+		certUser  = "system:admin"
+
+		unauthorizedError = "the server has asked for the client to provide credentials (get users ~)"
+		anonymousError    = `User "system:anonymous" cannot get users at the cluster scope`
+	)
+
+	// TODO see comment below
+	_ = invalidCert
+
+	testutil.RequireEtcd(t)
+	// Build master config
+	masterOptions, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Start server
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adminConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	validCert := adminConfig.TLSClientConfig
+
+	validToken, err := tokencmd.RequestToken(adminConfig, nil, tokenUser, "pass")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(validToken) == 0 {
+		t.Fatalf("Expected valid token, got none")
+	}
+
+	for _, test := range []struct {
+		token         string
+		cert          restclient.TLSClientConfig
+		expectedUser  string
+		errorExpected bool
+		errorString   string
+		insecure      bool
+	}{
+		{
+			token:        validToken,
+			cert:         validCert,
+			expectedUser: tokenUser,
+		},
+		// TODO find a way to test invalidCert
+		// Tests with invalidCert don't work because go does not send the client cert
+		// because it knows the server does not want certs that are not signed it's CA
+		// {
+		// 	token:        validToken,
+		// 	cert:         invalidCert,
+		// 	expectedUser: tokenUser,
+		// 	insecure:     true,
+		// },
+		{
+			token:        validToken,
+			cert:         noCert,
+			expectedUser: tokenUser,
+			insecure:     true,
+		},
+		{
+			token:         invalidToken,
+			cert:          validCert,
+			errorExpected: true,
+			errorString:   unauthorizedError,
+		},
+		// {
+		// 	token:         invalidToken,
+		// 	cert:          invalidCert,
+		// 	errorExpected: true,
+		// 	errorString:   unauthorizedError,
+		// 	insecure:      true,
+		// },
+		{
+			token:         invalidToken,
+			cert:          noCert,
+			errorExpected: true,
+			errorString:   unauthorizedError,
+			insecure:      true,
+		},
+		{
+			token:        noToken,
+			cert:         validCert,
+			expectedUser: certUser,
+		},
+		// {
+		// 	token:         noToken,
+		// 	cert:          invalidCert,
+		// 	errorExpected: true,
+		// 	errorString:   unauthorizedError,
+		// 	insecure:      true,
+		// },
+		{
+			token:         noToken,
+			cert:          noCert,
+			errorExpected: true,
+			errorString:   anonymousError,
+			insecure:      true,
+		},
+	} {
+		config := *adminConfig
+		config.BearerToken = test.token
+		config.TLSClientConfig = test.cert
+		config.Insecure = test.insecure
+
+		client := oclient.NewOrDie(&config)
+
+		user, err := client.Users().Get("~")
+
+		test.cert = noCert // Just to make errors more readible
+
+		if user.Name != test.expectedUser {
+			t.Errorf("unexpected user %q for test %+v", user.Name, test)
+		}
+
+		if test.errorExpected {
+			if err == nil {
+				t.Errorf("expected error but got nil for test %+v", test)
+			} else if err.Error() != test.errorString {
+				t.Errorf("unexpected error string %q for test %+v", err.Error(), test)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error %q for test %+v", err.Error(), test)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #4537 

There are three variations for both token and cert: valid, invalid and not provided.  This gives a total of nine combinations.  The only combination that this PR changes is with an invalid token and a valid cert.  The old behavior would authenticate using the cert; the new behavior considers this an error.

Both implementations currently return the anonymous user when no token and an invalid cert are provided.  It is unclear if this is the correct behavior or if an error should be returned instead.