### PR TITLE
add a validateServiceAccount to the creation of ipfailover pods

### DIFF
--- a/docs/man/man1/oadm-ipfailover.1
+++ b/docs/man/man1/oadm-ipfailover.1
@@ -71,7 +71,7 @@ value that matches the number of nodes for the given labeled selector.
     Selector (label query) to filter nodes on.
 
 .PP
-\fB\-\-service\-account\fP=""
+\fB\-\-service\-account\fP="ipfailover"
     Name of the service account to use to run the ipfailover pod.
 
 .PP

--- a/docs/man/man1/oc-adm-ipfailover.1
+++ b/docs/man/man1/oc-adm-ipfailover.1
@@ -71,7 +71,7 @@ value that matches the number of nodes for the given labeled selector.
     Selector (label query) to filter nodes on.
 
 .PP
-\fB\-\-service\-account\fP=""
+\fB\-\-service\-account\fP="ipfailover"
     Name of the service account to use to run the ipfailover pod.
 
 .PP

--- a/docs/man/man1/openshift-admin-ipfailover.1
+++ b/docs/man/man1/openshift-admin-ipfailover.1
@@ -71,7 +71,7 @@ value that matches the number of nodes for the given labeled selector.
     Selector (label query) to filter nodes on.
 
 .PP
-\fB\-\-service\-account\fP=""
+\fB\-\-service\-account\fP="ipfailover"
     Name of the service account to use to run the ipfailover pod.
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ipfailover.1
+++ b/docs/man/man1/openshift-cli-adm-ipfailover.1
@@ -71,7 +71,7 @@ value that matches the number of nodes for the given labeled selector.
     Selector (label query) to filter nodes on.
 
 .PP
-\fB\-\-service\-account\fP=""
+\fB\-\-service\-account\fP="ipfailover"
     Name of the service account to use to run the ipfailover pod.
 
 .PP

--- a/docs/man/man1/openshift-ex-ipfailover.1
+++ b/docs/man/man1/openshift-ex-ipfailover.1
@@ -71,7 +71,7 @@ value that matches the number of nodes for the given labeled selector.
     Selector (label query) to filter nodes on.
 
 .PP
-\fB\-\-service\-account\fP=""
+\fB\-\-service\-account\fP="ipfailover"
     Name of the service account to use to run the ipfailover pod.
 
 .PP

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -65,15 +65,20 @@ os::cmd::expect_success_and_text 'oc get dc/router -o yaml' 'readinessProbe'
 
 # only when using hostnetwork should we force the probes to use localhost
 os::cmd::expect_success_and_not_text "oadm router -o yaml --credentials=${KUBECONFIG} --host-network=false" 'host: localhost'
+os::cmd::expect_success "oc delete dc/router"
+os::cmd::expect_success "oc delete service router"
 echo "router: ok"
 
 # test ipfailover
 os::cmd::expect_failure_and_text 'oadm ipfailover --dry-run' 'you must specify at least one virtual IP address'
-os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run' 'Creating IP failover'
-os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run' 'Success \(DRY RUN\)'
-os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o yaml' 'name: ipfailover'
-os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o name' 'deploymentconfig/ipfailover'
-os::cmd::expect_success_and_text 'oadm ipfailover --credentials=${KUBECONFIG} --virtual-ips="1.2.3.4" --dry-run -o yaml' '1.2.3.4'
+os::cmd::expect_failure_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run' 'error: ipfailover could not be created'
+os::cmd::expect_success 'oadm policy add-scc-to-user privileged -z ipfailover'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run' 'Creating IP failover'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run' 'Success \(DRY RUN\)'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run -o yaml' 'name: ipfailover'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run -o name' 'deploymentconfig/ipfailover'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run -o yaml' '1.2.3.4'
+os::cmd::expect_success 'oadm policy remove-scc-from-user privileged -z ipfailover'
 # TODO add tests for normal ipfailover creation
 # os::cmd::expect_success_and_text 'oadm ipfailover' 'deploymentconfig "ipfailover" created'
 # os::cmd::expect_failure_and_text 'oadm ipfailover' 'Error from server: deploymentconfig "ipfailover" already exists'

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -76,9 +76,8 @@ echo "[INFO] Pre-pulling and pushing ruby-22-centos7"
 os::cmd::expect_success 'docker pull centos/ruby-22-centos7:latest'
 echo "[INFO] Pulled ruby-22-centos7"
 
-os::cmd::expect_success "oc create serviceaccount ipfailover"
 os::cmd::expect_success "openshift admin policy add-scc-to-user privileged -z ipfailover"
-os::cmd::expect_success "openshift admin ipfailover --images='${USE_IMAGES}' --virtual-ips='1.2.3.4' --credentials=${KUBECONFIG} --service-account=ipfailover"
+os::cmd::expect_success "openshift admin ipfailover --images='${USE_IMAGES}' --virtual-ips='1.2.3.4' --service-account=ipfailover"
 
 echo "[INFO] Waiting for Docker registry pod to start"
 wait_for_registry


### PR DESCRIPTION
make the 'oadm ipfailover' command act more like 'oadm router'.
Attempting to create an ipfailover pod without a priviliged sa
will now fail

$ oadm ipfailover ipf1 --credentials=openshift.local.config/master/openshift-router.kubeconfig --virtual-ips="10.66.127.100-101"  --service-account=new --dry-run
error: ipfailover could not be created; add "-systerm:serviceaccount:default:new" to scc priviledged

$ oadm ipfailover ipf1 --credentials=openshift.local.config/master/openshift-router.kubeconfig --virtual-ips="10.66.127.100-101"  --service-account=ipfailover --dry-run
--> Creating IP failover testing ...
    serviceaccount "ipfailover" created
    deploymentconfig "testing" created
--> Success (DRY RUN)


[BZ1326281](https://bugzilla.redhat.com/show_bug.cgi?id=1326281)