### PR TITLE
Adding ENV's for Default Router timeout settings

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -39,17 +39,34 @@ defaults
   option httplog
   log global
 {{ end }}
+
+{{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_CONNECT_TIMEOUT" "")) }}
+  timeout connect {{env "ROUTER_DEFAULT_CONNECT_TIMEOUT" "5s"}}
+{{ else }}
+  timeout connect 5s
+{{ end }}
+{{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "")) }}
+  timeout client {{env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "30s"}}
+{{ else }}
+  timeout connect 30s
+{{ end }}
+{{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_SERVER_TIMEOUT" "")) }}
+  timeout server {{env "ROUTER_DEFAULT_SERVER_TIMEOUT" "30s"}}
+{{ else }}
+  timeout server 30s
+{{ end }}
 {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_SLOWLORIS_TIMEOUT" "")) }}
-  timeout http-request {{env "ROUTER_SLOWLORIS_TIMEOUT" "" }}
+  timeout http-request {{env "ROUTER_SLOWLORIS_TIMEOUT" "10s" }}
 {{ else }}
   timeout http-request 10s
 {{ end }}
-  timeout http-keep-alive 30s
-  timeout connect 5s
-  timeout client 30s
-  timeout server 30s
+
   # Long timeout for WebSocket connections.
+{{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "")) }}
+  timeout tunnel {{env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "1h" }}
+{{ else }}
   timeout tunnel 1h
+{{ end }}
 
 {{ if (gt .StatsPort 0) }}
 listen stats :{{.StatsPort}}


### PR DESCRIPTION
Deprecating: https://github.com/openshift/origin/pull/9518 due to git issues. 


Addressing the issues identified in BZ 1341312 #9099 
Default timeout vars overrride capabilities. openshift/openshift-docs #2348

Need to be aware of this commit. 
