### PR TITLE
Prevent dind containers from being targeted by oci-systemd-hooks

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -161,7 +161,10 @@ function start() {
   echo "Launching containers"
   local root_volume="-v ${OS_ROOT}:${DEPLOYED_ROOT}"
   local config_volume="-v ${CONFIG_ROOT}:${DEPLOYED_CONFIG_ROOT}"
-  local base_run_cmd="${DOCKER_CMD} run -dt ${root_volume} ${config_volume}"
+  local volumes="${root_volume} ${config_volume}"
+  # systemd requires RTMIN+3 to shutdown properly
+  local stop="--stop-signal=$(kill -l RTMIN+3)"
+  local base_run_cmd="${DOCKER_CMD} run -dt ${stop} ${volumes}"
 
   local master_cid="$(${base_run_cmd} --privileged --name="${MASTER_NAME}" \
       --hostname="${MASTER_NAME}" "${DIND_IMAGE}")"

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -9,11 +9,22 @@ FROM fedora:23
 ## Configure systemd to run in a container
 ENV container=docker
 
-RUN systemctl mask systemd-remount-fs.service dev-hugepages.mount \
-  sys-fs-fuse-connections.mount systemd-logind.service getty.target \
-  console-getty.service dnf-makecache.service lvm2-lvmetad.service \
-  systemd-udevd.service systemd-udev-hwdb-update.service \
-  systemd-udev-trigger.service docker-storage-setup.service
+RUN systemctl mask\
+ auditd.service\
+ console-getty.service\
+ dev-hugepages.mount\
+ dnf-makecache.service\
+ docker-storage-setup.service\
+ getty.target\
+ lvm2-lvmetad.service\
+ sys-fs-fuse-connections.mount\
+ systemd-logind.service\
+ systemd-remount-fs.service\
+ systemd-udev-hwdb-update.service\
+ systemd-udev-trigger.service\
+ systemd-udevd.service\
+ systemd-vconsole-setup.service
+
 RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; \
   sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -51,4 +51,10 @@ RUN systemctl enable docker
 
 VOLUME /var/lib/docker
 
-CMD ["/usr/sbin/init"]
+## Hardlink init to another name to avoid having oci-systemd-hooks
+## detect containers using this image as requiring read-only cgroup
+## mounts.  dind containers should be run with --privileged to ensure
+## cgroups mounted with read-write permissions.
+RUN ln /usr/sbin/init /usr/sbin/dind_init
+
+CMD ["/usr/sbin/dind_init"]


### PR DESCRIPTION
oci-systemd-hooks detects that a container will run systemd by checking
for an entrypoint command of 'systemd' or 'init' and then mounts most
cgroups read-only to support running systemd in an unprivileged
container.  This is not compatible with dind containers, which require
running with --privileged to ensure cgroups mounted read-write.  This
change hardlinks 'init' to 'dind_init' and uses that as the entrypoint
to avoid having dind containers be targeted by the hook.

I'm including a couple of minor dind fixes with this that came up on the way to the fix.

Should supercede #9613 and fixes #9599.

cc: @openshift/networking @ncdc 