### PR TITLE
Fix --show-events=false for build configs and deployment configs

### DIFF
--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -102,10 +102,12 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string, settings kc
 			}
 		}
 
-		// Events
-		if events, err := d.kubeClient.Events(deploymentConfig.Namespace).Search(deploymentConfig); err == nil && events != nil {
-			fmt.Fprintln(out)
-			kctl.DescribeEvents(events, out)
+		if settings.ShowEvents {
+			// Events
+			if events, err := d.kubeClient.Events(deploymentConfig.Namespace).Search(deploymentConfig); err == nil && events != nil {
+				fmt.Fprintln(out)
+				kctl.DescribeEvents(events, out)
+			}
 		}
 		return nil
 	})

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -136,7 +136,9 @@ func (d *BuildDescriber) Describe(namespace, name string, settings kctl.Describe
 		describeCommonSpec(build.Spec.CommonSpec, out)
 		describeBuildTriggerCauses(build.Spec.TriggeredBy, out)
 
-		kctl.DescribeEvents(events, out)
+		if settings.ShowEvents {
+			kctl.DescribeEvents(events, out)
+		}
 
 		return nil
 	})


### PR DESCRIPTION
Users can use `--show-events=false` for all describers in kubernetes. Our describers should respect that setting as well (builds/deployment configs)