### PR TITLE
Bugfix #1343358: Enforce --tty=false flag for "oc debug"

### DIFF
--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -175,6 +175,9 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 		return kcmdutil.UsageError(cmd, "you may not specify -t and -T together")
 	case o.ForceTTY:
 		o.Attach.TTY = true
+	// since ForceTTY is defaulted to false, check if user specifically passed in "=false" flag
+	case !o.ForceTTY && cmd.Flags().Changed("tty"):
+		o.Attach.TTY = false
 	case o.DisableTTY:
 		o.Attach.TTY = false
 	// don't default TTY to true if a command is passed

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -28,6 +28,7 @@ os::cmd::expect_success_and_text "oc debug dc/test-deployment-config --keep-live
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" '\- /bin/env'
 os::cmd::expect_success_and_text "oc debug -t dc/test-deployment-config -o yaml" 'stdinOnce'
 os::cmd::expect_success_and_text "oc debug -t dc/test-deployment-config -o yaml" 'tty'
+os::cmd::expect_success_and_not_text "oc debug --tty=false dc/test-deployment-config -o yaml" 'tty'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'stdin'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'tty'
 os::cmd::expect_failure_and_text "oc debug dc/test-deployment-config --node-name=invalid -- /bin/env" 'on node "invalid"'


### PR DESCRIPTION
Changes behavior for "oc debug" command, specifically with `--tty` flag. Prior behavior left `--tty` essentially useless, as it was not checked if the user specifically requested to disable TTY by passing `--tty=false` (if the command was run in a terminal, and `--no-tty` was not set to `true`, it would always default to a TTY, even with `--tty=false` set.

This change allows both flags to remain for compliance with any other programs that might use them, at least until one is deprecated as it has been suggested that having both is redundant.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1343358