### PR TITLE
Clean up references to NETWORKING_DEBUG

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -321,9 +321,9 @@ https://github.com/onsi/ginkgo[ginkgo] test runner.
 
 To debug a test run with https://github.com/derekparker/delve[delve],
 make sure the dlv executable is installed in your path and run the
-tests with NETWORKING_DEBUG set to true:
+tests with DLV_DEBUG set:
 
-        $ NETWORKING_DEBUG=true test/extended/networking.sh
+        $ DLV_DEBUG=1 test/extended/networking.sh
 
 ==== Running networking tests against any cluster
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -19,8 +19,6 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/lib/init.sh"
 os::log::stacktrace::install
 
-NETWORKING_DEBUG=${NETWORKING_DEBUG:-false}
-
 # These strings filter the available tests.
 #
 # The EmptyDir test is a canary; it will fail if mount propagation is


### PR DESCRIPTION
#9601 attempted to rename NETWORKING_DEBUG to DLV_DEBUG but missed
a couple of references.

cc: @soltysh @stevekuznetsov 