### PR TITLE
allow for configurable server side timeouts on routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -226,6 +226,11 @@ backend be_edge_http_{{$cfgIdx}}
     {{ else }}
   balance leastconn
     {{ end }}
+    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+      {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
+  timeout server  {{$value}}
+      {{ end }}
+    {{ end }}
   timeout check 5000ms
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
@@ -259,6 +264,11 @@ backend be_tcp_{{$cfgIdx}}
     {{ else }}
   balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source" }}
     {{ end }}
+    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+      {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
+  timeout server  {{$value}}
+      {{ end }}
+    {{ end }}
   hash-type consistent
   timeout check 5000ms
     {{ range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
@@ -282,6 +292,12 @@ backend be_secure_{{$cfgIdx}}
     {{ else }}
   balance leastconn
     {{ end }}
+    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+      {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
+  timeout server  {{$value}}
+      {{ end }}
+    {{ end }}
+
   timeout check 5000ms
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
     {{ range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -97,11 +97,11 @@ func env(name, defaultValue string) string {
 func NewTemplatePlugin(cfg TemplatePluginConfig) (*TemplatePlugin, error) {
 	templateBaseName := filepath.Base(cfg.TemplatePath)
 	globalFuncs := template.FuncMap{
-		"endpointsForAlias": endpointsForAlias,
-		"env":               env,
-		"matchString":       matchString,
-		"isInteger":         isInteger,
-		"matchValues":       matchValues,
+		"endpointsForAlias": endpointsForAlias, //returns the list of valid endpoints
+		"env":               env,               //tries to get an environment variable if it can't return a default
+		"matchPattern":      matchPattern,      //anchors provided regular expression and evaluates against given string
+		"isInteger":         isInteger,         //determines if a given variable is an integer
+		"matchValues":       matchValues,       //compares a given string to a list of allowed strings
 	}
 	masterTemplate, err := template.New("config").Funcs(globalFuncs).ParseFiles(cfg.TemplatePath)
 	if err != nil {

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -187,14 +187,14 @@ func matchValues(s string, allowedValues ...string) bool {
 	return false
 }
 
-func matchString(pattern, s string) bool {
-	glog.V(4).Infof("Matchstring called with %s and %s", pattern, s)
-	status, err := regexp.MatchString(pattern, s)
+func matchPattern(pattern, s string) bool {
+	glog.V(4).Infof("matchPattern called with %s and %s", pattern, s)
+	status, err := regexp.MatchString("^("+pattern+")$", s)
 	if err == nil {
-		glog.V(4).Infof("Matchstring returning status: %v", status)
+		glog.V(4).Infof("matchPattern returning status: %v", status)
 		return status
 	}
-	glog.Errorf("Error with regex pattern in call to matchString: %v", err)
+	glog.Errorf("Error with regex pattern in call to matchPattern: %v", err)
 	return false
 }
 


### PR DESCRIPTION
using annotations configure a route to have it's own server side timeout

--beginning of route.yaml
apiVersion: v1
kind: Route
metadata:
  annotations:
    hello-again.timeout: 5s
  creationTimestamp: 2016-06-20T22:43:44Z
  name: hello-again
  namespace: default
  resourceVersion: "461544"
  selfLink: /oapi/v1/namespaces/default/routes/hello-again
  uid: 717b8a38-3738-11e6-8b7f-525400d6577c
...

matching against [routename].timeout: [time] is what creates the timeout