### PR TITLE
reject build requests for binary builds if not providing binary inputs

### DIFF
--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -142,7 +142,7 @@ func validateCommonSpec(spec *buildapi.CommonSpec, fldPath *field.Path) field.Er
 	s := spec.Strategy
 
 	if s.DockerStrategy != nil && s.JenkinsPipelineStrategy == nil && spec.Source.Git == nil && spec.Source.Binary == nil && spec.Source.Dockerfile == nil && spec.Source.Images == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("source"), spec.Source, "must provide a value for at least one of source, binary, images, or dockerfile"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("source"), "", "must provide a value for at least one source input(git, binary, dockerfile, images)."))
 	}
 
 	allErrs = append(allErrs,
@@ -202,7 +202,6 @@ func validateSource(input *buildapi.BuildSource, isCustomStrategy, isDockerStrat
 			allErrs = append(allErrs, validateImageSource(image, fldPath.Child("images").Index(i))...)
 		}
 	}
-
 	if isJenkinsPipelineStrategyFromRepo && input.Git == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("git"), "", "must be set when using Jenkins Pipeline strategy with Jenkinsfile from a git repo"))
 	}

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -46,7 +46,7 @@ func TestBuildValidationSuccess(t *testing.T) {
 
 func checkDockerStrategyEmptySourceError(result field.ErrorList) bool {
 	for _, err := range result {
-		if err.Type == field.ErrorTypeInvalid && strings.Contains(err.Field, "spec.source") && strings.Contains(err.Detail, "must provide a value for at least one of source, binary, images, or dockerfile") {
+		if err.Type == field.ErrorTypeInvalid && strings.Contains(err.Field, "spec.source") && strings.Contains(err.Detail, "must provide a value for at least one source input(git, binary, dockerfile, images).") {
 			return true
 		}
 	}
@@ -1632,7 +1632,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 17
+		// 18
 		// dockerfilePath can't equal ..
 		{
 			string(field.ErrorTypeInvalid) + "strategy.dockerStrategy.dockerfilePath",
@@ -1656,7 +1656,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 18
+		// 19
 		{
 			string(field.ErrorTypeInvalid) + "postCommit",
 			buildapi.CommonSpec{
@@ -1674,7 +1674,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 19
+		// 20
 		{
 			string(field.ErrorTypeInvalid) + "source.git",
 			buildapi.CommonSpec{
@@ -1683,7 +1683,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 20
+		// 21
 		{
 			string(field.ErrorTypeInvalid) + "source.git",
 			buildapi.CommonSpec{
@@ -1694,7 +1694,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 21
+		// 22
 		// jenkinsfilePath can't be an absolute path
 		{
 			string(field.ErrorTypeInvalid) + "strategy.jenkinsPipelineStrategy.jenkinsfilePath",
@@ -1711,7 +1711,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 22
+		// 23
 		// jenkinsfilePath can't start with ../
 		{
 			string(field.ErrorTypeInvalid) + "strategy.jenkinsPipelineStrategy.jenkinsfilePath",
@@ -1728,7 +1728,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 23
+		// 24
 		// jenkinsfilePath can't be a reference a path outside of the dir
 		{
 			string(field.ErrorTypeInvalid) + "strategy.jenkinsPipelineStrategy.jenkinsfilePath",
@@ -1745,7 +1745,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 24
+		// 25
 		// jenkinsfilePath can't be equal to ..
 		{
 			string(field.ErrorTypeInvalid) + "strategy.jenkinsPipelineStrategy.jenkinsfilePath",
@@ -1762,7 +1762,7 @@ func TestValidateCommonSpec(t *testing.T) {
 				},
 			},
 		},
-		// 25
+		// 26
 		// path must be shorter than 100k
 		{
 			string(field.ErrorTypeInvalid) + "strategy.jenkinsPipelineStrategy.jenkinsfile",

--- a/pkg/build/controller/image_change_controller_test.go
+++ b/pkg/build/controller/image_change_controller_test.go
@@ -302,12 +302,16 @@ func (m *mockBuildConfigUpdater) Update(buildcfg *buildapi.BuildConfig) error {
 }
 
 func mockBuildConfig(baseImage, triggerImage, repoName, repoTag string) *buildapi.BuildConfig {
+	dockerfile := "FROM foo"
 	return &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "testBuildCfg",
 		},
 		Spec: buildapi.BuildConfigSpec{
 			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Dockerfile: &dockerfile,
+				},
 				Strategy: buildapi.BuildStrategy{
 					DockerStrategy: &buildapi.DockerBuildStrategy{
 						From: &kapi.ObjectReference{

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -218,9 +218,8 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 	if err != nil {
 		return nil, err
 	}
-
 	if buildutil.IsPaused(bc) {
-		return nil, errors.NewInternalError(&GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", bc.Namespace, bc.Name)})
+		return nil, errors.NewBadRequest(fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", bc.Namespace, bc.Name))
 	}
 
 	if err := g.checkLastVersion(bc, request.LastVersion); err != nil {
@@ -333,7 +332,6 @@ func (g *BuildGenerator) Clone(ctx kapi.Context, request *buildapi.BuildRequest)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, err
 		}
-
 		if buildutil.IsPaused(buildConfig) {
 			return nil, errors.NewInternalError(&GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", buildConfig.Namespace, buildConfig.Name)})
 		}
@@ -366,7 +364,6 @@ func (g *BuildGenerator) createBuild(ctx kapi.Context, build *buildapi.Build) (*
 		return nil, errors.NewConflict(buildapi.Resource("build"), build.Namespace, fmt.Errorf("Build.Namespace does not match the provided context"))
 	}
 	kapi.FillObjectMetaSystemFields(ctx, &build.ObjectMeta)
-
 	err := g.Client.CreateBuild(ctx, build)
 	if err != nil {
 		return nil, err
@@ -416,13 +413,15 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 			},
 		},
 	}
-
 	if binary != nil {
 		build.Spec.Source.Git = nil
 		build.Spec.Source.Binary = binary
 		if build.Spec.Source.Dockerfile != nil && binary.AsFile == "Dockerfile" {
 			build.Spec.Source.Dockerfile = nil
 		}
+	} else {
+		// must explicitly set this because we copied the source values from the buildconfig.
+		build.Spec.Source.Binary = nil
 	}
 
 	build.Name = getNextBuildName(bc)
@@ -698,6 +697,8 @@ func generateBuildFromBuild(build *buildapi.Build, buildConfig *buildapi.BuildCo
 			Config: buildCopy.Status.Config,
 		},
 	}
+	// TODO remove/update this when we support cloning binary builds
+	newBuild.Spec.Source.Binary = nil
 	if newBuild.Annotations == nil {
 		newBuild.Annotations = make(map[string]string)
 	}

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -163,6 +163,9 @@ started=$(oc start-build ruby-sample-build-invalidtag)
 os::cmd::expect_success_and_text "oc describe build ${started}" 'centos/ruby-22-centos7$'
 frombuild=$(oc start-build --from-build="${started}")
 os::cmd::expect_success_and_text "oc describe build ${frombuild}" 'centos/ruby-22-centos7$'
+os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-dir=. --from-build=${started}" "Cannot use '--from-build' flag with binary builds"
+os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-file=. --from-build=${started}" "Cannot use '--from-build' flag with binary builds"
+os::cmd::expect_failure_and_text "oc start-build ruby-sample-build-invalid-tag --from-repo=. --from-build=${started}" "Cannot use '--from-build' flag with binary builds"
 echo "start-build: ok"
 os::test::junit::declare_suite_end
 

--- a/test/extended/testdata/test-build.json
+++ b/test/extended/testdata/test-build.json
@@ -53,6 +53,43 @@
       "status": {
         "lastVersion": 0
       }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sample-build-binary",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "imageChange",
+            "imageChange": {}
+          }
+        ],
+        "source": {
+          "type": "Binary",
+          "binary": {}
+        },
+        "strategy": {
+          "type": "Docker",
+          "dockerStrategy": {
+            "env": [
+              { "name": "FOO", "value": "test" },
+              { "name": "BAR", "value": "test" }
+            ],
+            "from": {
+              "kind": "DockerImage",
+              "name": "centos/ruby-22-centos7"
+            }
+          }
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
     }
   ]
 }


### PR DESCRIPTION
new output:
```
$ oc start-build somebinarybuildcfg
Error from server: can't instantiate binary BuildConfig p1/somebinarybuildcfg: must provide a build input via --from-dir|--from-file|--from-repo
```

fixes https://github.com/openshift/origin/issues/9261
