### PR TITLE
UPSTREAM: 28379: allow handler to join after the informer has started

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/framework/shared_informer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/framework/shared_informer.go
@@ -91,6 +91,10 @@ type sharedIndexInformer struct {
 
 	started     bool
 	startedLock sync.Mutex
+
+	// blockDeltas gives a way to stop all event distribution so that a late event handler
+	// can safely join the shared informer.
+	blockDeltas sync.Mutex
 }
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
@@ -203,16 +207,35 @@ func (s *sharedIndexInformer) AddEventHandler(handler ResourceEventHandler) erro
 	s.startedLock.Lock()
 	defer s.startedLock.Unlock()
 
-	if s.started {
-		return fmt.Errorf("informer has already started")
+	if !s.started {
+		listener := newProcessListener(handler)
+		s.processor.listeners = append(s.processor.listeners, listener)
+		return nil
 	}
+
+	// in order to safely join, we have to
+	// stop sending add/update/delete notification
+	// do a list against the store
+	// send synthetic "Add" events to the new handler
+	// unblock
+	s.blockDeltas.Lock()
+	defer s.blockDeltas.Unlock()
 
 	listener := newProcessListener(handler)
 	s.processor.listeners = append(s.processor.listeners, listener)
+
+	items := s.indexer.List()
+	for i := range items {
+		listener.add(addNotification{newObj: items[i]})
+	}
+
 	return nil
 }
 
 func (s *sharedIndexInformer) HandleDeltas(obj interface{}) error {
+	s.blockDeltas.Lock()
+	defer s.blockDeltas.Unlock()
+
 	// from oldest to newest
 	for _, d := range obj.(cache.Deltas) {
 		switch d.Type {


### PR DESCRIPTION
Allows handlers to join after a shared informer has started.  It's expensive, but it works and we need it for ordering problems.

lgtm'ed upstream, needed for cluster quota [test]