### PR TITLE
Ensure main binary is built / up-to-date before new completions are generated

### DIFF
--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -9,6 +9,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/lib/init.sh"
 
+# ensure we have the latest compiled binaries
+(cd ${OS_ROOT} && make clean); "${OS_ROOT}/hack/build-go.sh"
+
 platform="$(os::build::host_platform)"
 if [[ "${platform}" != "linux/amd64" ]]; then
   echo "WARNING: Generating completions on ${platform} may not be identical to running on linux/amd64 due to conditional compilation."


### PR DESCRIPTION
`./hack/update-generated-completions.sh` uses an existing binary to generate "new" completions. This makes sure up-to-date binary is generated before generating new completions.