### PR TITLE
Fix incorrect master leases ttl setting

### DIFF
--- a/pkg/cmd/server/kubernetes/master_test.go
+++ b/pkg/cmd/server/kubernetes/master_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
+)
+
+func TestNewMasterLeasesHasCorrectTTL(t *testing.T) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
+	defer server.Terminate(t)
+
+	masterLeases := newMasterLeases(etcdStorage)
+	if err := masterLeases.UpdateLease("1.2.3.4"); err != nil {
+		t.Fatalf("error updating lease: %v", err)
+	}
+
+	etcdClient := server.Client
+	keys := client.NewKeysAPI(etcdClient)
+	resp, err := keys.Get(context.Background(), etcdtest.PathPrefix()+"/masterleases/1.2.3.4", nil)
+	if err != nil {
+		t.Fatalf("error getting key: %v", err)
+	}
+	ttl := resp.Node.TTLDuration()
+	if ttl > 15*time.Second || ttl < 10*time.Second {
+		t.Errorf("ttl %v should be ~ 15s", ttl)
+	}
+}


### PR DESCRIPTION
Fix incorrect master leases ttl setting. It needs to be in seconds (numeric) instead of a
time.Duration. i.e. ttl=15 means 15 seconds, whereas ttl=15*time.Second means a really large number
of seconds, which resulted in the ttl effectively ending up as 0 (infinite) :-/

Not sure how this passed my local testing before (but I swear it did).

Added a unit test to ensure the TTL is correct.