### PR TITLE
UPSTREAM: 0000: remove rsh error message on exit

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v2.go
@@ -94,7 +94,7 @@ func (e *streamProtocolV2) stream(conn httpstream.Connection) error {
 		case err != nil && err != io.EOF:
 			errorChan <- fmt.Errorf("error reading from error stream: %s", err)
 		case len(message) > 0:
-			errorChan <- fmt.Errorf("error executing remote command: %s", message)
+			errorChan <- nil
 		default:
 			errorChan <- nil
 		}


### PR DESCRIPTION
When oc rsh pod, user may easily type wrong command, or, right command which fails. If user exist then, there is message "error: error executing remote command: error executing command in container: Error executing in Docker Container". Better to remove it because it seems not needed

Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1353161
##### Before

```
$ oc rsh <database_pod>
sh-4.2$ fake_cmd
sh: fake_cmd: command not found
exit
error: error executing remote command: error executing command in container: Error executing in Docker Container: 127
```
##### After

```
$ oc rsh <database_pod>
sh-4.2$ fake_cmd
sh: fake_cmd: command not found
exit
```
