### PR TITLE
collapse admission chains

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -71,6 +72,11 @@ func (l *lifecycle) Admit(a admission.Attributes) (err error) {
 				},
 			})
 		}
+		return nil
+	}
+
+	// always allow access review checks.  Returning status about the namespace would be leaking information
+	if isAccessReview(a) {
 		return nil
 	}
 
@@ -133,4 +139,17 @@ func NewLifecycle(c clientset.Interface, immortalNamespaces sets.String) admissi
 		store:              store,
 		immortalNamespaces: immortalNamespaces,
 	}
+}
+
+// TODO move this upstream once they have namespaced access review checks
+var accessReviewResources = map[unversioned.GroupResource]bool{
+	unversioned.GroupResource{Group: "", Resource: "subjectaccessreviews"}:       true,
+	unversioned.GroupResource{Group: "", Resource: "localsubjectaccessreviews"}:  true,
+	unversioned.GroupResource{Group: "", Resource: "resourceaccessreviews"}:      true,
+	unversioned.GroupResource{Group: "", Resource: "localresourceaccessreviews"}: true,
+	unversioned.GroupResource{Group: "", Resource: "selfsubjectrulesreviews"}:    true,
+}
+
+func isAccessReview(a admission.Attributes) bool {
+	return accessReviewResources[a.GetResource().GroupResource()]
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -23,7 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
-	clientadapter "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
@@ -35,38 +33,12 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	knet "k8s.io/kubernetes/pkg/util/net"
-	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
-	saadmit "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
-	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
 	"github.com/openshift/origin/pkg/controller/shared"
-	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
-	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 )
-
-// AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{
-	"RunOnceDuration",
-	lifecycle.PluginName,
-	"PodNodeConstraints",
-	"OriginPodNodeEnvironment",
-	overrideapi.PluginName,
-	serviceadmit.ExternalIPPluginName,
-	"LimitRanger",
-	"ServiceAccount",
-	"SecurityContextConstraint",
-	"BuildDefaults",
-	"BuildOverrides",
-	"AlwaysPullImages",
-	"LimitPodHardAntiAffinityTopology",
-	"ResourceQuota",
-	"SCCExecRestrictions",
-}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {
@@ -80,7 +52,7 @@ type MasterConfig struct {
 	Informers shared.InformerFactory
 }
 
-func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, informers shared.InformerFactory, pluginInitializer oadmission.PluginInitializer) (*MasterConfig, error) {
+func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, informers shared.InformerFactory, admissionControl admission.Interface) (*MasterConfig, error) {
 	if options.KubernetesMasterConfig == nil {
 		return nil, errors.New("insufficient information to build KubernetesMasterConfig")
 	}
@@ -119,7 +91,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	server.EventTTL = 2 * time.Hour
 	server.ServiceClusterIPRange = net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 	server.ServiceNodePortRange = *portRange
-	server.AdmissionControl = strings.Join(AdmissionPlugins, ",")
 	server.EnableLogsSupport = false // don't expose server logs
 	server.EnableProfiling = false
 	server.APIPrefix = KubeAPIPrefix
@@ -132,10 +103,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	// proper errors
 	if err := cmdflags.Resolve(options.KubernetesMasterConfig.APIServerArguments, server.AddFlags); len(err) > 0 {
 		return nil, kerrors.NewAggregate(err)
-	}
-
-	if len(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride) > 0 {
-		server.AdmissionControl = strings.Join(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride, ",")
 	}
 
 	// Defaults are tested in TestCMServerDefaults
@@ -159,54 +126,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	if cloud != nil {
 		glog.V(2).Infof("Successfully initialized cloud provider: %q from the config file: %q\n", server.CloudProvider, server.CloudConfigFile)
 	}
-
-	plugins := []admission.Interface{}
-	for _, pluginName := range strings.Split(server.AdmissionControl, ",") {
-		switch pluginName {
-		case lifecycle.PluginName:
-			// We need to include our infrastructure and shared resource namespaces in the immortal namespaces list
-			immortalNamespaces := sets.NewString(kapi.NamespaceDefault)
-			if len(options.PolicyConfig.OpenShiftSharedResourcesNamespace) > 0 {
-				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftSharedResourcesNamespace)
-			}
-			if len(options.PolicyConfig.OpenShiftInfrastructureNamespace) > 0 {
-				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftInfrastructureNamespace)
-			}
-			plugins = append(plugins, lifecycle.NewLifecycle(clientadapter.FromUnversionedClient(kubeClient), immortalNamespaces))
-
-		case serviceadmit.ExternalIPPluginName:
-			// this needs to be moved upstream to be part of core config
-			reject, admit, err := serviceadmit.ParseCIDRRules(options.NetworkConfig.ExternalIPNetworkCIDRs)
-			if err != nil {
-				// should have been caught with validation
-				return nil, err
-			}
-			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit))
-		case saadmit.PluginName:
-			// we need to set some custom parameters on the service account admission controller, so create that one by hand
-			saAdmitter := saadmit.NewServiceAccount(clientadapter.FromUnversionedClient(kubeClient))
-			saAdmitter.LimitSecretReferences = options.ServiceAccountConfig.LimitSecretReferences
-			saAdmitter.Run()
-			plugins = append(plugins, saAdmitter)
-
-		default:
-			configFile, err := pluginconfig.GetPluginConfigFile(options.KubernetesMasterConfig.AdmissionConfig.PluginConfig, pluginName, server.AdmissionControlConfigFile)
-			if err != nil {
-				return nil, err
-			}
-			plugin := admission.InitPlugin(pluginName, clientadapter.FromUnversionedClient(kubeClient), configFile)
-			if plugin != nil {
-				plugins = append(plugins, plugin)
-			}
-
-		}
-	}
-	pluginInitializer.Initialize(plugins)
-	// ensure that plugins have been properly initialized
-	if err := oadmission.Validate(plugins); err != nil {
-		return nil, err
-	}
-	admissionController := admission.NewChainHandler(plugins...)
 
 	var proxyClientCerts []tls.Certificate
 	if len(options.KubernetesMasterConfig.ProxyClientInfo.CertFile) > 0 {
@@ -277,7 +196,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 			ReadWritePort: port,
 
 			Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
-			AdmissionControl: admissionController,
+			AdmissionControl: admissionControl,
 
 			StorageFactory: storageFactory,
 

--- a/pkg/cmd/server/origin/admissionconfig_test.go
+++ b/pkg/cmd/server/origin/admissionconfig_test.go
@@ -1,0 +1,260 @@
+package origin
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+// TestAdmissionPluginChains makes sure that the admission plugin lists are coherent.
+// we have to maintain three different lists of plugins: default origin, default kube, default combined
+// the set of (default origin and default kube) and default combined, but must be equal
+// the order of default origin must follow the order of default combined
+// the order of default kube must follow the order of default combined
+func TestAdmissionPluginChains(t *testing.T) {
+	individualSet := sets.NewString(openshiftAdmissionControlPlugins...)
+	individualSet.Insert(KubeAdmissionPlugins...)
+	combinedSet := sets.NewString(combinedAdmissionControlPlugins...)
+
+	if !individualSet.Equal(combinedSet) {
+		t.Fatalf("individualSets are missing: %v combinedSet is missing: %v", combinedSet.Difference(individualSet), individualSet.Difference(combinedSet))
+	}
+
+	lastCurrIndex := -1
+	for _, plugin := range openshiftAdmissionControlPlugins {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
+			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+				break
+			}
+		}
+
+		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+			t.Errorf("openshift admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
+		}
+	}
+
+	lastCurrIndex = -1
+	for _, plugin := range KubeAdmissionPlugins {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
+			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+				break
+			}
+		}
+
+		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+			t.Errorf("kube admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
+		}
+	}
+}
+
+func TestSeparateAdmissionChainDetection(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		options               configapi.MasterConfig
+		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error)
+	}{
+		{
+			name: "stock everything",
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "stock everything", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission order 01",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginOrderOverride: []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				expectedKube := []string{"foo"}
+				isKube := reflect.DeepEqual(pluginNames, expectedKube)
+
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified kube admission order 01", expectedKube, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission order 02",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					APIServerArguments: configapi.ExtendedArguments{
+						"admission-control": []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				expectedKube := []string{"foo"}
+				isKube := reflect.DeepEqual(pluginNames, expectedKube)
+
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified kube admission order 01", expectedKube, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified origin admission order",
+			options: configapi.MasterConfig{
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginOrderOverride: []string{"foo"},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+
+				expectedOrigin := []string{"foo"}
+				isOrigin := reflect.DeepEqual(pluginNames, expectedOrigin)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified origin admission order", KubeAdmissionPlugins, expectedOrigin, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission config file",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					APIServerArguments: configapi.ExtendedArguments{
+						"admission-control-config-file": []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified conflicting plugin configs 01", KubeAdmissionPlugins, openshiftAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 01",
+			options: configapi.MasterConfig{
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 02",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "bar",
+							},
+							"third": {
+								Location: "bar",
+							},
+						},
+					},
+				},
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 02", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 03",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "bar",
+							},
+							"third": {
+								Location: "bar",
+							},
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 03", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified conflicting plugin configs 01",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "different",
+							},
+						},
+					},
+				},
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified conflicting plugin configs 01", KubeAdmissionPlugins, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		newAdmissionChainFunc = tc.admissionChainBuilder
+		_, _, _ = buildAdmissionChains(tc.options, nil, oadmission.PluginInitializer{})
+	}
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
+	"strings"
 	"time"
 
 	newetcdclient "github.com/coreos/etcd/client"
@@ -31,6 +33,8 @@ import (
 	kutilrand "k8s.io/kubernetes/pkg/util/rand"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	saadmit "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/authenticator/anonymous"
@@ -68,8 +72,10 @@ import (
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota"
+	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 	usercache "github.com/openshift/origin/pkg/user/cache"
 	groupregistry "github.com/openshift/origin/pkg/user/registry/group"
@@ -102,6 +108,11 @@ type MasterConfig struct {
 
 	AdmissionControl admission.Interface
 
+	// KubeAdmissionControl holds the kube admission chain.  Because of the way the plugin initializer is built
+	// you'll be passing information in this direction either way.  Knowing how to build this chain requires knowledge
+	// of both the origin config AND the kube config, so this spot makes more sense.
+	KubeAdmissionControl admission.Interface
+
 	TLS bool
 
 	ControllerPlug      plug.Plug
@@ -120,9 +131,6 @@ type MasterConfig struct {
 	ClientCAs *x509.CertPool
 	// APIClientCAs is used to verify client certificates presented for API auth
 	APIClientCAs *x509.CertPool
-
-	// PluginInitializer carries types used when instantiating both origin and kubernetes admission control plugins
-	PluginInitializer oadmission.PluginInitializer
 
 	// PrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from system components
 	// To apply different access control to a system component, create a client config specifically for that component.
@@ -203,20 +211,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
-	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{
-		"ProjectRequestLimit",
-		"OriginNamespaceLifecycle",
-		"PodNodeConstraints",
-		"JenkinsBootstrapper",
-		"BuildByStrategy",
-		imageadmission.PluginName,
-		quotaadmission.PluginName,
-	}
-	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
-		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
-	}
-
 	quotaRegistry := quota.NewOriginQuotaRegistry(privilegedLoopbackOpenShiftClient)
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		informerFactory.Policies().Lister(),
@@ -226,6 +220,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	)
 	authorizer := newAuthorizer(ruleResolver, informerFactory, options.ProjectConfig.ProjectRequestMessage)
 
+	kubeClientSet := clientadapter.FromUnversionedClient(privilegedLoopbackKubeClient)
 	pluginInitializer := oadmission.PluginInitializer{
 		OpenshiftClient:       privilegedLoopbackOpenShiftClient,
 		ProjectCache:          projectCache,
@@ -234,25 +229,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		JenkinsPipelineConfig: options.JenkinsPipelineConfig,
 		RESTClientConfig:      *privilegedLoopbackClientConfig,
 	}
-
-	plugins := []admission.Interface{}
-	clientsetClient := clientadapter.FromUnversionedClient(privilegedLoopbackKubeClient)
-	for _, pluginName := range admissionControlPluginNames {
-		configFile, err := pluginconfig.GetPluginConfig(options.AdmissionConfig.PluginConfig[pluginName])
-		if err != nil {
-			return nil, err
-		}
-		plugin := admission.InitPlugin(pluginName, clientsetClient, configFile)
-		if plugin != nil {
-			plugins = append(plugins, plugin)
-		}
-	}
-	pluginInitializer.Initialize(plugins)
-	// ensure that plugins have been properly initialized
-	if err := oadmission.Validate(plugins); err != nil {
-		return nil, err
-	}
-	admissionController := admission.NewChainHandler(plugins...)
+	originAdmission, kubeAdmission, err := buildAdmissionChains(options, kubeClientSet, pluginInitializer)
 
 	// TODO: look up storage by resource
 	serviceAccountTokenGetter, err := newServiceAccountTokenGetter(options, etcdClient)
@@ -284,7 +261,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 		RequestContextMapper: requestContextMapper,
 
-		AdmissionControl: admissionController,
+		AdmissionControl:     originAdmission,
+		KubeAdmissionControl: kubeAdmission,
 
 		TLS: configapi.UseTLS(options.ServingInfo.ServingInfo),
 
@@ -298,8 +276,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		ClientCAs:    clientCAs,
 		APIClientCAs: apiClientCAs,
 
-		PluginInitializer: pluginInitializer,
-
 		PrivilegedLoopbackClientConfig:     *privilegedLoopbackClientConfig,
 		PrivilegedLoopbackOpenShiftClient:  privilegedLoopbackOpenShiftClient,
 		PrivilegedLoopbackKubernetesClient: privilegedLoopbackKubeClient,
@@ -307,6 +283,205 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	}
 
 	return config, nil
+}
+
+var (
+	// openshiftAdmissionControlPlugins gives the in-order default admission chain for openshift resources.
+	openshiftAdmissionControlPlugins = []string{
+		"ProjectRequestLimit",
+		"OriginNamespaceLifecycle",
+		"PodNodeConstraints",
+		"JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		quotaadmission.PluginName,
+	}
+
+	// KubeAdmissionPlugins gives the in-order default admission chain for kube resources.
+	KubeAdmissionPlugins = []string{
+		"RunOnceDuration",
+		lifecycle.PluginName,
+		"PodNodeConstraints",
+		"OriginPodNodeEnvironment",
+		overrideapi.PluginName,
+		serviceadmit.ExternalIPPluginName,
+		"LimitRanger",
+		"ServiceAccount",
+		"SecurityContextConstraint",
+		"BuildDefaults",
+		"BuildOverrides",
+		"AlwaysPullImages",
+		"LimitPodHardAntiAffinityTopology",
+		"SCCExecRestrictions",
+		"ResourceQuota",
+	}
+
+	// combinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
+	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
+	// the order specified in the openshift and kube chains must match the order here.
+	combinedAdmissionControlPlugins = []string{
+		"ProjectRequestLimit",
+		"OriginNamespaceLifecycle",
+		"PodNodeConstraints",
+		"JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		"RunOnceDuration",
+		lifecycle.PluginName,
+		"PodNodeConstraints",
+		"OriginPodNodeEnvironment",
+		overrideapi.PluginName,
+		serviceadmit.ExternalIPPluginName,
+		"LimitRanger",
+		"ServiceAccount",
+		"SecurityContextConstraint",
+		"BuildDefaults",
+		"BuildOverrides",
+		"AlwaysPullImages",
+		"LimitPodHardAntiAffinityTopology",
+		"SCCExecRestrictions",
+		quotaadmission.PluginName,
+		"ResourceQuota",
+	}
+)
+
+func buildAdmissionChains(options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface /*origin*/, admission.Interface /*kube*/, error) {
+	// check to see if they've taken explicit control of the kube admission chain
+	// this happens when any of the following are true:
+	// 1. extended kube server args are used to change the admission plugin list
+	// 2. kube explicit config changes the admission plugin list
+	// 3. extended kube server args are used to change the admission config file
+	// 4. openshift explicit config changes the admission plugins list
+	// 5. kube and openshift plugin config try to configure the same plugin differently
+	// TODO: one release from now, I think we should start failing on setting the kube admission config
+	//       two releases from now, I think we should start removing it
+	//       two releases from now, I think we should remove the PluginOverrideOrder entirely
+	hasSeparateKubeAdmissionChain := false
+	KubeAdmissionPlugins := KubeAdmissionPlugins
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.APIServerArguments["admission-control"]) > 0 {
+		KubeAdmissionPlugins = strings.Split(options.KubernetesMasterConfig.APIServerArguments["admission-control"][0], ",")
+		hasSeparateKubeAdmissionChain = true
+	}
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride) > 0 {
+		KubeAdmissionPlugins = options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	kubeAdmissionPluginConfigFilename := ""
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.APIServerArguments["admission-control-config-file"]) > 0 {
+		kubeAdmissionPluginConfigFilename = options.KubernetesMasterConfig.APIServerArguments["admission-control-config-file"][0]
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	openshiftAdmissionPlugins := openshiftAdmissionControlPlugins
+	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
+		openshiftAdmissionPlugins = options.AdmissionConfig.PluginOrderOverride
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	if options.KubernetesMasterConfig != nil && !hasSeparateKubeAdmissionChain {
+		// check for collisions between openshift and kube plugin config
+		for pluginName, kubeConfig := range options.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
+			if openshiftConfig, exists := options.AdmissionConfig.PluginConfig[pluginName]; exists && !reflect.DeepEqual(kubeConfig, openshiftConfig) {
+				hasSeparateKubeAdmissionChain = true
+				break
+			}
+		}
+	}
+
+	if hasSeparateKubeAdmissionChain {
+		// build kube admission
+		var kubeAdmission admission.Interface
+		if options.KubernetesMasterConfig != nil {
+			var err error
+			kubeAdmission, err = newAdmissionChainFunc(KubeAdmissionPlugins, kubeAdmissionPluginConfigFilename, options.KubernetesMasterConfig.AdmissionConfig.PluginConfig, options, kubeClientSet, pluginInitializer)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// build openshift admission
+		openshiftAdmission, err := newAdmissionChainFunc(openshiftAdmissionPlugins, "", options.AdmissionConfig.PluginConfig, options, kubeClientSet, pluginInitializer)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return openshiftAdmission, kubeAdmission, nil
+	}
+
+	// if we have a unified chain, build the combined config
+	pluginConfig := map[string]configapi.AdmissionPluginConfig{}
+	if options.KubernetesMasterConfig != nil {
+		for pluginName, config := range options.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
+			pluginConfig[pluginName] = config
+		}
+	}
+	for pluginName, config := range options.AdmissionConfig.PluginConfig {
+		pluginConfig[pluginName] = config
+	}
+
+	admissionChain, err := newAdmissionChainFunc(combinedAdmissionControlPlugins, "", pluginConfig, options, kubeClientSet, pluginInitializer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return admissionChain, admissionChain, err
+}
+
+// newAdmissionChainFunc is for unit testing only.  You should NEVER OVERRIDE THIS outside of a unit test.
+var newAdmissionChainFunc = newAdmissionChain
+
+func newAdmissionChain(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+	plugins := []admission.Interface{}
+	for _, pluginName := range pluginNames {
+		switch pluginName {
+		case lifecycle.PluginName:
+			// We need to include our infrastructure and shared resource namespaces in the immortal namespaces list
+			immortalNamespaces := sets.NewString(kapi.NamespaceDefault)
+			if len(options.PolicyConfig.OpenShiftSharedResourcesNamespace) > 0 {
+				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftSharedResourcesNamespace)
+			}
+			if len(options.PolicyConfig.OpenShiftInfrastructureNamespace) > 0 {
+				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftInfrastructureNamespace)
+			}
+			plugins = append(plugins, lifecycle.NewLifecycle(kubeClientSet, immortalNamespaces))
+
+		case serviceadmit.ExternalIPPluginName:
+			// this needs to be moved upstream to be part of core config
+			reject, admit, err := serviceadmit.ParseCIDRRules(options.NetworkConfig.ExternalIPNetworkCIDRs)
+			if err != nil {
+				// should have been caught with validation
+				return nil, err
+			}
+			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit))
+
+		case saadmit.PluginName:
+			// we need to set some custom parameters on the service account admission controller, so create that one by hand
+			saAdmitter := saadmit.NewServiceAccount(kubeClientSet)
+			saAdmitter.LimitSecretReferences = options.ServiceAccountConfig.LimitSecretReferences
+			saAdmitter.Run()
+			plugins = append(plugins, saAdmitter)
+
+		default:
+			configFile, err := pluginconfig.GetPluginConfigFile(pluginConfig, pluginName, admissionConfigFilename)
+			if err != nil {
+				return nil, err
+			}
+			plugin := admission.InitPlugin(pluginName, kubeClientSet, configFile)
+			if plugin != nil {
+				plugins = append(plugins, plugin)
+			}
+
+		}
+	}
+
+	pluginInitializer.Initialize(plugins)
+	// ensure that plugins have been properly initialized
+	if err := oadmission.Validate(plugins); err != nil {
+		return nil, err
+	}
+
+	return admission.NewChainHandler(plugins...), nil
 }
 
 func newControllerPlug(options configapi.MasterConfig, client *etcdclient.Client) (plug.Plug, func()) {

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
+	"github.com/openshift/origin/pkg/cmd/server/origin"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 )
@@ -43,7 +43,7 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 func TestKubeAdmissionControllerUsage(t *testing.T) {
 	registeredKubePlugins := sets.NewString(admission.GetPlugins()...)
 
-	usedAdmissionPlugins := sets.NewString(kubernetes.AdmissionPlugins...)
+	usedAdmissionPlugins := sets.NewString(origin.KubeAdmissionPlugins...)
 
 	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
 		t.Errorf("%v not found", missingPlugins.List())

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -336,7 +336,7 @@ func BuildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kuberne
 	if openshiftConfig.Options.KubernetesMasterConfig == nil {
 		return nil, nil
 	}
-	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.Informers, openshiftConfig.PluginInitializer)
+	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.Informers, openshiftConfig.KubeAdmissionControl)
 	return kubeConfig, err
 }
 


### PR DESCRIPTION
This collapses the separate origin and kube admission chains into a single chain that is used twice.  There is a lot of code around figuring out whether you're allowed to collapse the chains, because this is not always allowed.

I plan to update configapi validation to warn if you have anything that prevents your chains from being combined.  Eventually I'd like to make it error, but we need to complete the default on/off combinations first.

@csrwng yours I think