### PR TITLE
Do not duplicate haproxy-base steps in haproxy

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -5,17 +5,7 @@
 #
 FROM openshift/origin
 
-#
-# Note: /var is changed to 777 to allow access when running this container as a non-root uid
-#       this is temporary and should be removed when the container is switch to an empty-dir
-#       with gid support.
-#
-RUN yum -y install haproxy && \
-    mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
-    mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
-    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_edge_http_expose,os_edge_http_redirect}.map,haproxy.config} && \
-    chmod -R 777 /var && \
-    yum clean all && \
+RUN mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy
 
 COPY . /var/lib/haproxy/


### PR DESCRIPTION
The haproxy image does several RUN steps that are already in haproxy-base.
This pull request removes the duplicates.