### PR TITLE
collapse to a single quota admission plugin that understands all resources

### DIFF
--- a/docs/man/man1/openshift-start-kubernetes-apiserver.1
+++ b/docs/man/man1/openshift-start-kubernetes-apiserver.1
@@ -26,7 +26,7 @@ This command launches an instance of the Kubernetes apiserver (kube\-apiserver).
 
 .PP
 \fB\-\-admission\-control\fP="AlwaysAdmit"
-    Ordered list of plug\-ins to do admission control of resources into cluster. Comma\-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, BuildByStrategy, BuildDefaults, BuildOverrides, ClusterResourceOverride, DenyEscalatingExec, DenyExecOnPrivileged, ExternalIPRanger, ImageLimitRange, InitialResources, JenkinsBootstrapper, LimitPodHardAntiAffinityTopology, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, OriginNamespaceLifecycle, OriginPodNodeEnvironment, OriginResourceQuota, PersistentVolumeLabel, PodNodeConstraints, PodSecurityPolicy, ProjectRequestLimit, ResourceQuota, RunOnceDuration, SCCExecRestrictions, SecurityContextConstraint, SecurityContextDeny, ServiceAccount
+    Ordered list of plug\-ins to do admission control of resources into cluster. Comma\-delimited list of: AlwaysAdmit, AlwaysDeny, AlwaysPullImages, BuildByStrategy, BuildDefaults, BuildOverrides, ClusterResourceOverride, ClusterResourceQuota, DenyEscalatingExec, DenyExecOnPrivileged, ExternalIPRanger, ImageLimitRange, InitialResources, JenkinsBootstrapper, LimitPodHardAntiAffinityTopology, LimitRanger, NamespaceAutoProvision, NamespaceExists, NamespaceLifecycle, OriginNamespaceLifecycle, OriginPodNodeEnvironment, OriginResourceQuota, PersistentVolumeLabel, PodNodeConstraints, PodSecurityPolicy, ProjectRequestLimit, ResourceQuota, RunOnceDuration, SCCExecRestrictions, SecurityContextConstraint, SecurityContextDeny, ServiceAccount
 
 .PP
 \fB\-\-admission\-control\-config\-file\fP=""

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -8,7 +8,9 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/controller/shared"
 	"github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 )
 
 type PluginInitializer struct {
@@ -18,6 +20,8 @@ type PluginInitializer struct {
 	Authorizer            authorizer.Authorizer
 	JenkinsPipelineConfig configapi.JenkinsPipelineConfig
 	RESTClientConfig      restclient.Config
+	Informers             shared.InformerFactory
+	ClusterQuotaMapper    clusterquotamapping.ClusterQuotaMapper
 }
 
 // Initialize will check the initialization interfaces implemented by each plugin
@@ -41,6 +45,12 @@ func (i *PluginInitializer) Initialize(plugins []admission.Interface) {
 		}
 		if wantsRESTClientConfig, ok := plugin.(WantsRESTClientConfig); ok {
 			wantsRESTClientConfig.SetRESTClientConfig(i.RESTClientConfig)
+		}
+		if wantsInformers, ok := plugin.(WantsInformers); ok {
+			wantsInformers.SetInformers(i.Informers)
+		}
+		if wantsClusterQuotaMapper, ok := plugin.(WantsClusterQuotaMapper); ok {
+			wantsClusterQuotaMapper.SetClusterQuotaMapper(i.ClusterQuotaMapper)
 		}
 	}
 }

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -7,7 +7,9 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/controller/shared"
 	"github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 )
 
 // WantsOpenshiftClient should be implemented by admission plugins that need
@@ -48,4 +50,13 @@ type WantsJenkinsPipelineConfig interface {
 // WantsRESTClientConfig gives access to a RESTClientConfig.  It's useful for doing unusual things with transports.
 type WantsRESTClientConfig interface {
 	SetRESTClientConfig(restclient.Config)
+}
+
+// WantsInformers should be implemented by admission plugins that wil select its own informer
+type WantsInformers interface {
+	SetInformers(shared.InformerFactory)
+}
+
+type WantsClusterQuotaMapper interface {
+	SetClusterQuotaMapper(clusterquotamapping.ClusterQuotaMapper)
 }

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -52,11 +52,13 @@ type WantsRESTClientConfig interface {
 	SetRESTClientConfig(restclient.Config)
 }
 
-// WantsInformers should be implemented by admission plugins that wil select its own informer
+// WantsInformers should be implemented by admission plugins that will select its own informer
 type WantsInformers interface {
 	SetInformers(shared.InformerFactory)
 }
 
+// WantsClusterQuotaMapper should be implemented by admission plugins that need to know how to map between
+// cluster quota and namespaces
 type WantsClusterQuotaMapper interface {
 	SetClusterQuotaMapper(clusterquotamapping.ClusterQuotaMapper)
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -65,8 +65,9 @@ var AdmissionPlugins = []string{
 	"BuildOverrides",
 	"AlwaysPullImages",
 	"LimitPodHardAntiAffinityTopology",
-	"ResourceQuota",
 	"SCCExecRestrictions",
+	"ResourceQuota",
+	"ClusterResourceQuota",
 }
 
 // MasterConfig defines the required values to start a Kubernetes master

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -23,7 +22,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apiserver"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
-	clientadapter "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	genericapiserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -36,39 +34,12 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	knet "k8s.io/kubernetes/pkg/util/net"
-	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
-	saadmit "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
-	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
 	"github.com/openshift/origin/pkg/controller/shared"
-	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
-	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 )
-
-// AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{
-	"RunOnceDuration",
-	lifecycle.PluginName,
-	"PodNodeConstraints",
-	"OriginPodNodeEnvironment",
-	overrideapi.PluginName,
-	serviceadmit.ExternalIPPluginName,
-	"LimitRanger",
-	"ServiceAccount",
-	"SecurityContextConstraint",
-	"BuildDefaults",
-	"BuildOverrides",
-	"AlwaysPullImages",
-	"LimitPodHardAntiAffinityTopology",
-	"SCCExecRestrictions",
-	"ResourceQuota",
-	"ClusterResourceQuota",
-}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {
@@ -82,7 +53,7 @@ type MasterConfig struct {
 	Informers shared.InformerFactory
 }
 
-func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, informers shared.InformerFactory, pluginInitializer oadmission.PluginInitializer) (*MasterConfig, error) {
+func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client, informers shared.InformerFactory, admissionControl admission.Interface) (*MasterConfig, error) {
 	if options.KubernetesMasterConfig == nil {
 		return nil, errors.New("insufficient information to build KubernetesMasterConfig")
 	}
@@ -121,7 +92,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	server.EventTTL = 2 * time.Hour
 	server.ServiceClusterIPRange = net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 	server.ServiceNodePortRange = *portRange
-	server.AdmissionControl = strings.Join(AdmissionPlugins, ",")
 	server.EnableLogsSupport = false // don't expose server logs
 	server.EnableProfiling = false
 	server.APIPrefix = KubeAPIPrefix
@@ -134,10 +104,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	// proper errors
 	if err := cmdflags.Resolve(options.KubernetesMasterConfig.APIServerArguments, server.AddFlags); len(err) > 0 {
 		return nil, kerrors.NewAggregate(err)
-	}
-
-	if len(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride) > 0 {
-		server.AdmissionControl = strings.Join(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride, ",")
 	}
 
 	// Defaults are tested in TestCMServerDefaults
@@ -162,54 +128,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	if cloud != nil {
 		glog.V(2).Infof("Successfully initialized cloud provider: %q from the config file: %q\n", server.CloudProvider, server.CloudConfigFile)
 	}
-
-	plugins := []admission.Interface{}
-	for _, pluginName := range strings.Split(server.AdmissionControl, ",") {
-		switch pluginName {
-		case lifecycle.PluginName:
-			// We need to include our infrastructure and shared resource namespaces in the immortal namespaces list
-			immortalNamespaces := sets.NewString(kapi.NamespaceDefault)
-			if len(options.PolicyConfig.OpenShiftSharedResourcesNamespace) > 0 {
-				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftSharedResourcesNamespace)
-			}
-			if len(options.PolicyConfig.OpenShiftInfrastructureNamespace) > 0 {
-				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftInfrastructureNamespace)
-			}
-			plugins = append(plugins, lifecycle.NewLifecycle(clientadapter.FromUnversionedClient(kubeClient), immortalNamespaces))
-
-		case serviceadmit.ExternalIPPluginName:
-			// this needs to be moved upstream to be part of core config
-			reject, admit, err := serviceadmit.ParseCIDRRules(options.NetworkConfig.ExternalIPNetworkCIDRs)
-			if err != nil {
-				// should have been caught with validation
-				return nil, err
-			}
-			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit))
-		case saadmit.PluginName:
-			// we need to set some custom parameters on the service account admission controller, so create that one by hand
-			saAdmitter := saadmit.NewServiceAccount(clientadapter.FromUnversionedClient(kubeClient))
-			saAdmitter.LimitSecretReferences = options.ServiceAccountConfig.LimitSecretReferences
-			saAdmitter.Run()
-			plugins = append(plugins, saAdmitter)
-
-		default:
-			configFile, err := pluginconfig.GetPluginConfigFile(options.KubernetesMasterConfig.AdmissionConfig.PluginConfig, pluginName, server.AdmissionControlConfigFile)
-			if err != nil {
-				return nil, err
-			}
-			plugin := admission.InitPlugin(pluginName, clientadapter.FromUnversionedClient(kubeClient), configFile)
-			if plugin != nil {
-				plugins = append(plugins, plugin)
-			}
-
-		}
-	}
-	pluginInitializer.Initialize(plugins)
-	// ensure that plugins have been properly initialized
-	if err := oadmission.Validate(plugins); err != nil {
-		return nil, err
-	}
-	admissionController := admission.NewChainHandler(plugins...)
 
 	var proxyClientCerts []tls.Certificate
 	if len(options.KubernetesMasterConfig.ProxyClientInfo.CertFile) > 0 {
@@ -280,7 +198,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 			ReadWritePort: port,
 
 			Authorizer:       apiserver.NewAlwaysAllowAuthorizer(),
-			AdmissionControl: admissionController,
+			AdmissionControl: admissionControl,
 
 			StorageFactory: storageFactory,
 

--- a/pkg/cmd/server/origin/admissionconfig_test.go
+++ b/pkg/cmd/server/origin/admissionconfig_test.go
@@ -1,0 +1,260 @@
+package origin
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+// TestAdmissionPluginChains makes sure that the admission plugin lists are coherent.
+// we have to maintain three different lists of plugins: default origin, default kube, default combined
+// the set of (default origin and default kube) and default combined, but must be equal
+// the order of default origin must follow the order of default combined
+// the order of default kube must follow the order of default combined
+func TestAdmissionPluginChains(t *testing.T) {
+	individualSet := sets.NewString(openshiftAdmissionControlPlugins...)
+	individualSet.Insert(KubeAdmissionPlugins...)
+	combinedSet := sets.NewString(combinedAdmissionControlPlugins...)
+
+	if !individualSet.Equal(combinedSet) {
+		t.Fatalf("individualSets are missing: %v combinedSet is missing: %v", combinedSet.Difference(individualSet), individualSet.Difference(combinedSet))
+	}
+
+	lastCurrIndex := -1
+	for _, plugin := range openshiftAdmissionControlPlugins {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
+			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+				break
+			}
+		}
+
+		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+			t.Errorf("openshift admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
+		}
+	}
+
+	lastCurrIndex = -1
+	for _, plugin := range KubeAdmissionPlugins {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
+			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+				break
+			}
+		}
+
+		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+			t.Errorf("kube admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
+		}
+	}
+}
+
+func TestSeparateAdmissionChainDetection(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		options               configapi.MasterConfig
+		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error)
+	}{
+		{
+			name: "stock everything",
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "stock everything", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission order 01",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginOrderOverride: []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				expectedKube := []string{"foo"}
+				isKube := reflect.DeepEqual(pluginNames, expectedKube)
+
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified kube admission order 01", expectedKube, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission order 02",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					APIServerArguments: configapi.ExtendedArguments{
+						"admission-control": []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				expectedKube := []string{"foo"}
+				isKube := reflect.DeepEqual(pluginNames, expectedKube)
+
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified kube admission order 01", expectedKube, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified origin admission order",
+			options: configapi.MasterConfig{
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginOrderOverride: []string{"foo"},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+
+				expectedOrigin := []string{"foo"}
+				isOrigin := reflect.DeepEqual(pluginNames, expectedOrigin)
+
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified origin admission order", KubeAdmissionPlugins, expectedOrigin, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+		{
+			name: "specified kube admission config file",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					APIServerArguments: configapi.ExtendedArguments{
+						"admission-control-config-file": []string{"foo"},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified conflicting plugin configs 01", KubeAdmissionPlugins, openshiftAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 01",
+			options: configapi.MasterConfig{
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 02",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "bar",
+							},
+							"third": {
+								Location: "bar",
+							},
+						},
+					},
+				},
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 02", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified, non-conflicting plugin configs 03",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "bar",
+							},
+							"third": {
+								Location: "bar",
+							},
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 03", combinedAdmissionControlPlugins, pluginNames)
+				}
+				return nil, nil
+			},
+		},
+		{
+			name: "specified conflicting plugin configs 01",
+			options: configapi.MasterConfig{
+				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+					AdmissionConfig: configapi.AdmissionConfig{
+						PluginConfig: map[string]configapi.AdmissionPluginConfig{
+							"foo": {
+								Location: "different",
+							},
+						},
+					},
+				},
+				AdmissionConfig: configapi.AdmissionConfig{
+					PluginConfig: map[string]configapi.AdmissionPluginConfig{
+						"foo": {
+							Location: "bar",
+						},
+					},
+				},
+			},
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
+				if !isKube && !isOrigin {
+					t.Errorf("%s: expected either %v or %v, got %v", "specified conflicting plugin configs 01", KubeAdmissionPlugins, openshiftAdmissionControlPlugins, pluginNames)
+				}
+
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		newAdmissionChainFunc = tc.admissionChainBuilder
+		_, _, _ = buildAdmissionChains(tc.options, nil, oadmission.PluginInitializer{})
+	}
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
+	"strings"
 	"time"
 
 	newetcdclient "github.com/coreos/etcd/client"
@@ -31,6 +33,8 @@ import (
 	kutilrand "k8s.io/kubernetes/pkg/util/rand"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	saadmit "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/authenticator/anonymous"
@@ -68,8 +72,10 @@ import (
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota"
+	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 	usercache "github.com/openshift/origin/pkg/user/cache"
 	groupregistry "github.com/openshift/origin/pkg/user/registry/group"
@@ -102,6 +108,11 @@ type MasterConfig struct {
 
 	AdmissionControl admission.Interface
 
+	// KubeAdmissionControl holds the kube admission chain.  Because of the way the plugin initializer is built
+	// you'll be passing information in this direction either way.  Knowing how to build this chain requires knowledge
+	// of both the origin config AND the kube config, so this spot makes more sense.
+	KubeAdmissionControl admission.Interface
+
 	TLS bool
 
 	ControllerPlug      plug.Plug
@@ -120,9 +131,6 @@ type MasterConfig struct {
 	ClientCAs *x509.CertPool
 	// APIClientCAs is used to verify client certificates presented for API auth
 	APIClientCAs *x509.CertPool
-
-	// PluginInitializer carries types used when instantiating both origin and kubernetes admission control plugins
-	PluginInitializer oadmission.PluginInitializer
 
 	// PrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from system components
 	// To apply different access control to a system component, create a client config specifically for that component.
@@ -203,20 +211,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
-	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{
-		"ProjectRequestLimit",
-		"OriginNamespaceLifecycle",
-		"PodNodeConstraints",
-		"JenkinsBootstrapper",
-		"BuildByStrategy",
-		imageadmission.PluginName,
-		quotaadmission.PluginName,
-	}
-	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
-		admissionControlPluginNames = options.AdmissionConfig.PluginOrderOverride
-	}
-
 	quotaRegistry := quota.NewOriginQuotaRegistry(privilegedLoopbackOpenShiftClient)
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		informerFactory.Policies().Lister(),
@@ -226,6 +220,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	)
 	authorizer := newAuthorizer(ruleResolver, informerFactory, options.ProjectConfig.ProjectRequestMessage)
 
+	kubeClientSet := clientadapter.FromUnversionedClient(privilegedLoopbackKubeClient)
 	pluginInitializer := oadmission.PluginInitializer{
 		OpenshiftClient:       privilegedLoopbackOpenShiftClient,
 		ProjectCache:          projectCache,
@@ -236,25 +231,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		Informers:             informerFactory,
 		ClusterQuotaMapper:    clusterQuotaMappingController.GetClusterQuotaMapper(),
 	}
-
-	plugins := []admission.Interface{}
-	clientsetClient := clientadapter.FromUnversionedClient(privilegedLoopbackKubeClient)
-	for _, pluginName := range admissionControlPluginNames {
-		configFile, err := pluginconfig.GetPluginConfig(options.AdmissionConfig.PluginConfig[pluginName])
-		if err != nil {
-			return nil, err
-		}
-		plugin := admission.InitPlugin(pluginName, clientsetClient, configFile)
-		if plugin != nil {
-			plugins = append(plugins, plugin)
-		}
-	}
-	pluginInitializer.Initialize(plugins)
-	// ensure that plugins have been properly initialized
-	if err := oadmission.Validate(plugins); err != nil {
-		return nil, err
-	}
-	admissionController := admission.NewChainHandler(plugins...)
+	originAdmission, kubeAdmission, err := buildAdmissionChains(options, kubeClientSet, pluginInitializer)
 
 	// TODO: look up storage by resource
 	serviceAccountTokenGetter, err := newServiceAccountTokenGetter(options, etcdClient)
@@ -286,7 +263,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 		RequestContextMapper: requestContextMapper,
 
-		AdmissionControl: admissionController,
+		AdmissionControl:     originAdmission,
+		KubeAdmissionControl: kubeAdmission,
 
 		TLS: configapi.UseTLS(options.ServingInfo.ServingInfo),
 
@@ -300,8 +278,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		ClientCAs:    clientCAs,
 		APIClientCAs: apiClientCAs,
 
-		PluginInitializer: pluginInitializer,
-
 		PrivilegedLoopbackClientConfig:     *privilegedLoopbackClientConfig,
 		PrivilegedLoopbackOpenShiftClient:  privilegedLoopbackOpenShiftClient,
 		PrivilegedLoopbackKubernetesClient: privilegedLoopbackKubeClient,
@@ -309,6 +285,205 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	}
 
 	return config, nil
+}
+
+var (
+	// openshiftAdmissionControlPlugins gives the in-order default admission chain for openshift resources.
+	openshiftAdmissionControlPlugins = []string{
+		"ProjectRequestLimit",
+		"OriginNamespaceLifecycle",
+		"PodNodeConstraints",
+		"JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		quotaadmission.PluginName,
+	}
+
+	// KubeAdmissionPlugins gives the in-order default admission chain for kube resources.
+	KubeAdmissionPlugins = []string{
+		"RunOnceDuration",
+		lifecycle.PluginName,
+		"PodNodeConstraints",
+		"OriginPodNodeEnvironment",
+		overrideapi.PluginName,
+		serviceadmit.ExternalIPPluginName,
+		"LimitRanger",
+		"ServiceAccount",
+		"SecurityContextConstraint",
+		"BuildDefaults",
+		"BuildOverrides",
+		"AlwaysPullImages",
+		"LimitPodHardAntiAffinityTopology",
+		"SCCExecRestrictions",
+		"ResourceQuota",
+	}
+
+	// combinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
+	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
+	// the order specified in the openshift and kube chains must match the order here.
+	combinedAdmissionControlPlugins = []string{
+		"ProjectRequestLimit",
+		"OriginNamespaceLifecycle",
+		"PodNodeConstraints",
+		"JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		"RunOnceDuration",
+		lifecycle.PluginName,
+		"PodNodeConstraints",
+		"OriginPodNodeEnvironment",
+		overrideapi.PluginName,
+		serviceadmit.ExternalIPPluginName,
+		"LimitRanger",
+		"ServiceAccount",
+		"SecurityContextConstraint",
+		"BuildDefaults",
+		"BuildOverrides",
+		"AlwaysPullImages",
+		"LimitPodHardAntiAffinityTopology",
+		"SCCExecRestrictions",
+		quotaadmission.PluginName,
+		"ResourceQuota",
+	}
+)
+
+func buildAdmissionChains(options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface /*origin*/, admission.Interface /*kube*/, error) {
+	// check to see if they've taken explicit control of the kube admission chain
+	// this happens when any of the following are true:
+	// 1. extended kube server args are used to change the admission plugin list
+	// 2. kube explicit config changes the admission plugin list
+	// 3. extended kube server args are used to change the admission config file
+	// 4. openshift explicit config changes the admission plugins list
+	// 5. kube and openshift plugin config try to configure the same plugin differently
+	// TODO: one release from now, I think we should start failing on setting the kube admission config
+	//       two releases from now, I think we should start removing it
+	//       two releases from now, I think we should remove the PluginOverrideOrder entirely
+	hasSeparateKubeAdmissionChain := false
+	KubeAdmissionPlugins := KubeAdmissionPlugins
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.APIServerArguments["admission-control"]) > 0 {
+		KubeAdmissionPlugins = strings.Split(options.KubernetesMasterConfig.APIServerArguments["admission-control"][0], ",")
+		hasSeparateKubeAdmissionChain = true
+	}
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride) > 0 {
+		KubeAdmissionPlugins = options.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	kubeAdmissionPluginConfigFilename := ""
+	if options.KubernetesMasterConfig != nil && len(options.KubernetesMasterConfig.APIServerArguments["admission-control-config-file"]) > 0 {
+		kubeAdmissionPluginConfigFilename = options.KubernetesMasterConfig.APIServerArguments["admission-control-config-file"][0]
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	openshiftAdmissionPlugins := openshiftAdmissionControlPlugins
+	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
+		openshiftAdmissionPlugins = options.AdmissionConfig.PluginOrderOverride
+		hasSeparateKubeAdmissionChain = true
+	}
+
+	if options.KubernetesMasterConfig != nil && !hasSeparateKubeAdmissionChain {
+		// check for collisions between openshift and kube plugin config
+		for pluginName, kubeConfig := range options.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
+			if openshiftConfig, exists := options.AdmissionConfig.PluginConfig[pluginName]; exists && !reflect.DeepEqual(kubeConfig, openshiftConfig) {
+				hasSeparateKubeAdmissionChain = true
+				break
+			}
+		}
+	}
+
+	if hasSeparateKubeAdmissionChain {
+		// build kube admission
+		var kubeAdmission admission.Interface
+		if options.KubernetesMasterConfig != nil {
+			var err error
+			kubeAdmission, err = newAdmissionChainFunc(KubeAdmissionPlugins, kubeAdmissionPluginConfigFilename, options.KubernetesMasterConfig.AdmissionConfig.PluginConfig, options, kubeClientSet, pluginInitializer)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// build openshift admission
+		openshiftAdmission, err := newAdmissionChainFunc(openshiftAdmissionPlugins, "", options.AdmissionConfig.PluginConfig, options, kubeClientSet, pluginInitializer)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return openshiftAdmission, kubeAdmission, nil
+	}
+
+	// if we have a unified chain, build the combined config
+	pluginConfig := map[string]configapi.AdmissionPluginConfig{}
+	if options.KubernetesMasterConfig != nil {
+		for pluginName, config := range options.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
+			pluginConfig[pluginName] = config
+		}
+	}
+	for pluginName, config := range options.AdmissionConfig.PluginConfig {
+		pluginConfig[pluginName] = config
+	}
+
+	admissionChain, err := newAdmissionChainFunc(combinedAdmissionControlPlugins, "", pluginConfig, options, kubeClientSet, pluginInitializer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return admissionChain, admissionChain, err
+}
+
+// newAdmissionChainFunc is for unit testing only.  You should NEVER OVERRIDE THIS outside of a unit test.
+var newAdmissionChainFunc = newAdmissionChain
+
+func newAdmissionChain(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
+	plugins := []admission.Interface{}
+	for _, pluginName := range pluginNames {
+		switch pluginName {
+		case lifecycle.PluginName:
+			// We need to include our infrastructure and shared resource namespaces in the immortal namespaces list
+			immortalNamespaces := sets.NewString(kapi.NamespaceDefault)
+			if len(options.PolicyConfig.OpenShiftSharedResourcesNamespace) > 0 {
+				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftSharedResourcesNamespace)
+			}
+			if len(options.PolicyConfig.OpenShiftInfrastructureNamespace) > 0 {
+				immortalNamespaces.Insert(options.PolicyConfig.OpenShiftInfrastructureNamespace)
+			}
+			plugins = append(plugins, lifecycle.NewLifecycle(kubeClientSet, immortalNamespaces))
+
+		case serviceadmit.ExternalIPPluginName:
+			// this needs to be moved upstream to be part of core config
+			reject, admit, err := serviceadmit.ParseCIDRRules(options.NetworkConfig.ExternalIPNetworkCIDRs)
+			if err != nil {
+				// should have been caught with validation
+				return nil, err
+			}
+			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit))
+
+		case saadmit.PluginName:
+			// we need to set some custom parameters on the service account admission controller, so create that one by hand
+			saAdmitter := saadmit.NewServiceAccount(kubeClientSet)
+			saAdmitter.LimitSecretReferences = options.ServiceAccountConfig.LimitSecretReferences
+			saAdmitter.Run()
+			plugins = append(plugins, saAdmitter)
+
+		default:
+			configFile, err := pluginconfig.GetPluginConfigFile(pluginConfig, pluginName, admissionConfigFilename)
+			if err != nil {
+				return nil, err
+			}
+			plugin := admission.InitPlugin(pluginName, kubeClientSet, configFile)
+			if plugin != nil {
+				plugins = append(plugins, plugin)
+			}
+
+		}
+	}
+
+	pluginInitializer.Initialize(plugins)
+	// ensure that plugins have been properly initialized
+	if err := oadmission.Validate(plugins); err != nil {
+		return nil, err
+	}
+
+	return admission.NewChainHandler(plugins...), nil
 }
 
 func newControllerPlug(options configapi.MasterConfig, client *etcdclient.Client) (plug.Plug, func()) {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -233,6 +233,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		Authorizer:            authorizer,
 		JenkinsPipelineConfig: options.JenkinsPipelineConfig,
 		RESTClientConfig:      *privilegedLoopbackClientConfig,
+		Informers:             informerFactory,
+		ClusterQuotaMapper:    clusterQuotaMappingController.GetClusterQuotaMapper(),
 	}
 
 	plugins := []admission.Interface{}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
 	sacontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
-	quotainstall "k8s.io/kubernetes/pkg/quota/install"
 	"k8s.io/kubernetes/pkg/registry/service/allocator"
 	etcdallocator "k8s.io/kubernetes/pkg/registry/service/allocator/etcd"
 	"k8s.io/kubernetes/pkg/serviceaccount"
@@ -50,7 +49,6 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	imageapi "github.com/openshift/origin/pkg/image/api"
 	quota "github.com/openshift/origin/pkg/quota"
 	quotacontroller "github.com/openshift/origin/pkg/quota/controller"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotareconciliation"
@@ -491,13 +489,13 @@ func (c *MasterConfig) RunResourceQuotaManager(cm *cmapp.CMServer) {
 	}
 
 	osClient, kClient := c.ResourceQuotaManagerClients()
-	resourceQuotaRegistry := quota.NewOriginQuotaRegistry(osClient)
+	resourceQuotaRegistry := quota.NewAllResourceQuotaRegistry(osClient, kClient)
 	resourceQuotaControllerOptions := &kresourcequota.ResourceQuotaControllerOptions{
 		KubeClient:                kClient,
 		ResyncPeriod:              controller.StaticResyncPeriodFunc(resourceQuotaSyncPeriod),
 		Registry:                  resourceQuotaRegistry,
-		GroupKindsToReplenish:     []unversioned.GroupKind{imageapi.Kind("ImageStream")},
-		ControllerFactory:         quotacontroller.NewReplenishmentControllerFactory(osClient),
+		GroupKindsToReplenish:     quota.AllEvaluatedGroupKinds,
+		ControllerFactory:         quotacontroller.NewAllResourceReplenishmentControllerFactory(c.Informers, osClient, kClient),
 		ReplenishmentResyncPeriod: replenishmentSyncPeriodFunc,
 	}
 	go kresourcequota.NewResourceQuotaController(resourceQuotaControllerOptions).Run(concurrentResourceQuotaSyncs, utilwait.NeverStop)
@@ -511,18 +509,10 @@ func (c *MasterConfig) RunClusterQuotaMappingController() {
 	})
 }
 
-//InitClusterQuotaReconciliationController returns a start function
 func (c *MasterConfig) RunClusterQuotaReconciliationController() {
 	osClient, kClient := c.ResourceQuotaManagerClients()
-	resourceQuotaRegistry := quotainstall.NewRegistry(kClient)
-	groupKindsToReplenish := []unversioned.GroupKind{
-		kapi.Kind("Pod"),
-		kapi.Kind("Service"),
-		kapi.Kind("ReplicationController"),
-		kapi.Kind("PersistentVolumeClaim"),
-		kapi.Kind("Secret"),
-		kapi.Kind("ConfigMap"),
-	}
+	resourceQuotaRegistry := quota.NewAllResourceQuotaRegistry(osClient, kClient)
+	groupKindsToReplenish := quota.AllEvaluatedGroupKinds
 
 	options := clusterquotareconciliation.ClusterQuotaReconcilationControllerOptions{
 		ClusterQuotaInformer: c.Informers.ClusterResourceQuotas(),
@@ -531,7 +521,7 @@ func (c *MasterConfig) RunClusterQuotaReconciliationController() {
 
 		Registry:                  resourceQuotaRegistry,
 		ResyncPeriod:              defaultResourceQuotaSyncPeriod,
-		ControllerFactory:         kresourcequota.NewReplenishmentControllerFactory(c.Informers.Pods().Informer(), kClient),
+		ControllerFactory:         quotacontroller.NewAllResourceReplenishmentControllerFactory(c.Informers, osClient, kClient),
 		ReplenishmentResyncPeriod: controller.StaticResyncPeriodFunc(defaultReplenishmentSyncPeriod),
 		GroupKindsToReplenish:     groupKindsToReplenish,
 	}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -511,6 +511,7 @@ func (c *MasterConfig) RunClusterQuotaMappingController() {
 	})
 }
 
+//InitClusterQuotaReconciliationController returns a start function
 func (c *MasterConfig) RunClusterQuotaReconciliationController() {
 	osClient, kClient := c.ResourceQuotaManagerClients()
 	resourceQuotaRegistry := quotainstall.NewRegistry(kClient)

--- a/pkg/cmd/server/start/admission.go
+++ b/pkg/cmd/server/start/admission.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"
 	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride"
+	_ "github.com/openshift/origin/pkg/quota/admission/clusterresourcequota"
 	_ "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 	_ "github.com/openshift/origin/pkg/quota/admission/runonceduration"
 	_ "github.com/openshift/origin/pkg/scheduler/admission/podnodeconstraints"
@@ -39,6 +40,7 @@ var (
 
 func init() {
 	defaultOffPlugins.Insert("AlwaysPullImages")
+	defaultOnPlugins.Insert("ClusterResourceQuota")
 	admission.PluginEnabledFn = IsAdmissionPluginActivated
 }
 

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
-	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 )
 
 var admissionPluginsNotUsedByKube = sets.NewString(
@@ -24,6 +23,7 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"DenyExecOnPrivileged",   // from kube (deprecated, see below), it denies exec to pods that have certain privileges.  This is superseded in origin by SCCExecRestrictions that checks against SCC rules.
 	"DenyEscalatingExec",     // from kube, it denies exec to pods that have certain privileges.  This is superseded in origin by SCCExecRestrictions that checks against SCC rules.
 	"PodSecurityPolicy",      // from kube, this will eventually replace SecurityContextConstraints but for now origin does not use it.
+	"ResourceQuota",          // from kube, we replace this with quotaadmission.PluginName
 
 	"BuildByStrategy",          // from origin, only needed for managing builds, not kubernetes resources
 	"BuildDefaults",            // from origin, only needed for managing builds, not kubernetes resources
@@ -33,7 +33,6 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube
 	"ProjectRequestLimit",      // from origin, used for limiting project requests by user (online use case)
 	"RunOnceDuration",          // from origin, used for overriding the ActiveDeadlineSeconds for run-once pods
-	quotaadmission.PluginName,  // from origin, used for quota abuse checks of openshift resources
 
 	"NamespaceExists",  // superseded by NamespaceLifecycle
 	"InitialResources", // do we want this? https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/initial-resources.md

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
+	"github.com/openshift/origin/pkg/cmd/server/origin"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
 )
@@ -44,7 +44,7 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 func TestKubeAdmissionControllerUsage(t *testing.T) {
 	registeredKubePlugins := sets.NewString(admission.GetPlugins()...)
 
-	usedAdmissionPlugins := sets.NewString(kubernetes.AdmissionPlugins...)
+	usedAdmissionPlugins := sets.NewString(origin.KubeAdmissionPlugins...)
 
 	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
 		t.Errorf("%v not found", missingPlugins.List())

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -336,7 +336,7 @@ func BuildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kuberne
 	if openshiftConfig.Options.KubernetesMasterConfig == nil {
 		return nil, nil
 	}
-	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.Informers, openshiftConfig.PluginInitializer)
+	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.Informers, openshiftConfig.KubeAdmissionControl)
 	return kubeConfig, err
 }
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -597,10 +597,6 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		namespaceControllerClientSet := clientadapter.FromUnversionedClient(namespaceControllerKubeClient)
 		namespaceControllerClientPool := dynamic.NewClientPool(namespaceControllerClientConfig, dynamic.LegacyAPIPathResolverFunc)
 
-		// called by admission control
-		kc.RunResourceQuotaManager()
-		oc.RunResourceQuotaManager(controllerManagerOptions)
-
 		// no special order
 		kc.RunNodeController()
 		kc.RunScheduler()
@@ -630,8 +626,6 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunServiceLoadBalancerController(serviceLoadBalancerClient)
 
 		glog.Infof("Started Kubernetes Controllers")
-	} else {
-		oc.RunResourceQuotaManager(nil)
 	}
 
 	// no special order
@@ -649,6 +643,9 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunImageImportController()
 	oc.RunOriginNamespaceController()
 	oc.RunSDNController()
+
+	// initializes quota docs used by admission
+	oc.RunResourceQuotaManager(nil)
 	oc.RunClusterQuotaReconciliationController()
 	oc.RunClusterQuotaMappingController()
 

--- a/pkg/controller/shared/quota_informers.go
+++ b/pkg/controller/shared/quota_informers.go
@@ -20,6 +20,8 @@ type ClusterResourceQuotaInformer interface {
 	Lister() *ocache.IndexerToClusterResourceQuotaLister
 }
 
+// clusterResourceQuotaInformer is a core informer because quota needs to be working before the "ensure"
+// steps in the API server can complete
 type clusterResourceQuotaInformer struct {
 	*sharedInformerFactory
 }
@@ -30,7 +32,7 @@ func (f *clusterResourceQuotaInformer) Informer() framework.SharedIndexInformer 
 
 	informerObj := &quotaapi.ClusterResourceQuota{}
 	informerType := reflect.TypeOf(informerObj)
-	informer, exists := f.informers[informerType]
+	informer, exists := f.coreInformers[informerType]
 	if exists {
 		return informer
 	}
@@ -53,7 +55,7 @@ func (f *clusterResourceQuotaInformer) Informer() framework.SharedIndexInformer 
 		f.defaultResync,
 		cache.Indexers{},
 	)
-	f.informers[informerType] = informer
+	f.coreInformers[informerType] = informer
 
 	return informer
 }

--- a/pkg/controller/shared/shared_informer.go
+++ b/pkg/controller/shared/shared_informer.go
@@ -58,8 +58,10 @@ func NewInformerFactory(kubeClient kclient.Interface, originClient oclient.Inter
 		customListerWatchers: customListerWatchers,
 		defaultResync:        defaultResync,
 
-		informers:     map[reflect.Type]framework.SharedIndexInformer{},
-		coreInformers: map[reflect.Type]framework.SharedIndexInformer{},
+		informers:            map[reflect.Type]framework.SharedIndexInformer{},
+		coreInformers:        map[reflect.Type]framework.SharedIndexInformer{},
+		startedInformers:     map[reflect.Type]bool{},
+		startedCoreInformers: map[reflect.Type]bool{},
 	}
 }
 
@@ -69,20 +71,34 @@ type sharedInformerFactory struct {
 	customListerWatchers ListerWatcherOverrides
 	defaultResync        time.Duration
 
-	informers     map[reflect.Type]framework.SharedIndexInformer
-	coreInformers map[reflect.Type]framework.SharedIndexInformer
-	lock          sync.Mutex
+	informers            map[reflect.Type]framework.SharedIndexInformer
+	coreInformers        map[reflect.Type]framework.SharedIndexInformer
+	startedInformers     map[reflect.Type]bool
+	startedCoreInformers map[reflect.Type]bool
+	lock                 sync.Mutex
 }
 
 func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
-	for _, informer := range f.informers {
-		go informer.Run(stopCh)
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
 	}
 }
 
 func (f *sharedInformerFactory) StartCore(stopCh <-chan struct{}) {
-	for _, informer := range f.coreInformers {
-		go informer.Run(stopCh)
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.coreInformers {
+		if !f.startedCoreInformers[informerType] {
+			go informer.Run(stopCh)
+			f.startedCoreInformers[informerType] = true
+		}
 	}
 }
 

--- a/pkg/quota/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor.go
@@ -1,0 +1,161 @@
+package clusterresourcequota
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	utilquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/storage/etcd"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
+
+	oclient "github.com/openshift/origin/pkg/client"
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+)
+
+// QuotaAccessor abstracts the get/set logic from the rest of the Evaluator.  This could be a test stub, a straight passthrough,
+// or most commonly a series of deconflicting caches.
+type QuotaAccessor interface {
+	// UpdateQuotaStatus is called to persist final status.  This method should write to persistent storage.
+	// An error indicates that write didn't complete successfully.
+	UpdateQuotaStatus(newQuota *kapi.ResourceQuota) error
+
+	// GetQuotas gets all possible quotas for a given namespace
+	GetQuotas(namespace string) ([]kapi.ResourceQuota, error)
+}
+
+type quotaAccessor struct {
+	quotaLister     *ocache.IndexerToClusterResourceQuotaLister
+	namespaceLister *ocache.IndexerToNamespaceLister
+	quotaClient     oclient.ClusterResourceQuotasInterface
+
+	quotaMapper clusterquotamapping.ClusterQuotaMapper
+
+	// updatedQuotas holds a cache of quotas that we've updated.  This is used to pull the "really latest" during back to
+	// back quota evaluations that touch the same quota doc.  This only works because we can compare etcd resourceVersions
+	// for the same resource as integers.  Before this change: 22 updates with 12 conflicts.  after this change: 15 updates with 0 conflicts
+	updatedQuotas *lru.Cache
+}
+
+// newQuotaAccessor creates an object that conforms to the QuotaAccessor interface to be used to retrieve quota objects.
+func newQuotaAccessor(quotaLister *ocache.IndexerToClusterResourceQuotaLister, namespaceLister *ocache.IndexerToNamespaceLister, quotaClient oclient.ClusterResourceQuotasInterface, quotaMapper clusterquotamapping.ClusterQuotaMapper) *quotaAccessor {
+	updatedCache, err := lru.New(100)
+	if err != nil {
+		// this should never happen
+		panic(err)
+	}
+
+	return &quotaAccessor{
+		quotaLister:     quotaLister,
+		namespaceLister: namespaceLister,
+		quotaClient:     quotaClient,
+		quotaMapper:     quotaMapper,
+		updatedQuotas:   updatedCache,
+	}
+}
+
+func (e *quotaAccessor) UpdateQuotaStatus(newQuota *kapi.ResourceQuota) error {
+	quota, err := e.quotaLister.Get(newQuota.Name)
+	if err != nil {
+		return err
+	}
+	quota = e.checkCache(quota)
+
+	// make a copy
+	obj, err := kapi.Scheme.Copy(quota)
+	if err != nil {
+		return err
+	}
+	quota = obj.(*quotaapi.ClusterResourceQuota)
+	usageDiff := utilquota.Subtract(newQuota.Status.Used, quota.Status.Total.Used)
+
+	// re-assign objectmeta
+	quota.ObjectMeta = newQuota.ObjectMeta
+	quota.Namespace = ""
+
+	oldNamespaceTotals, _ := quota.Status.Namespaces.Get(newQuota.Namespace)
+	namespaceTotalCopy, err := kapi.Scheme.DeepCopy(oldNamespaceTotals)
+	if err != nil {
+		return err
+	}
+	newNamespaceTotals := namespaceTotalCopy.(kapi.ResourceQuotaStatus)
+	newNamespaceTotals.Used = utilquota.Add(newNamespaceTotals.Used, usageDiff)
+	quota.Status.Namespaces.Insert(newQuota.Namespace, newNamespaceTotals)
+
+	quota.Status.Total.Used = utilquota.Add(quota.Status.Total.Used, usageDiff)
+
+	updatedQuota, err := e.quotaClient.ClusterResourceQuotas().Update(quota)
+	if err != nil {
+		return err
+	}
+
+	e.updatedQuotas.Add(quota.Name, updatedQuota)
+	return nil
+}
+
+var etcdVersioner = etcd.APIObjectVersioner{}
+
+// checkCache compares the passed quota against the value in the look-aside cache and returns the newer
+// if the cache is out of date, it deletes the stale entry.  This only works because of etcd resourceVersions
+// being monotonically increasing integers
+func (e *quotaAccessor) checkCache(quota *quotaapi.ClusterResourceQuota) *quotaapi.ClusterResourceQuota {
+	uncastCachedQuota, ok := e.updatedQuotas.Get(quota.Name)
+	if !ok {
+		return quota
+	}
+	cachedQuota := uncastCachedQuota.(*quotaapi.ClusterResourceQuota)
+
+	if etcdVersioner.CompareResourceVersion(quota, cachedQuota) >= 0 {
+		e.updatedQuotas.Remove(quota.Name)
+		return quota
+	}
+	return cachedQuota
+}
+
+func (e *quotaAccessor) GetQuotas(namespaceName string) ([]kapi.ResourceQuota, error) {
+	var quotaNames []string
+	// wait for a valid mapping cache.  The overall response can be delayed for up to 10 seconds.
+	err := utilwait.PollImmediate(100*time.Millisecond, 8*time.Second, func() (done bool, err error) {
+		var namespacelabels map[string]string
+		quotaNames, namespacelabels = e.quotaMapper.GetClusterQuotasFor(namespaceName)
+		namespace, err := e.namespaceLister.Get(namespaceName)
+		if err != nil {
+			return false, err
+		}
+		if kapi.Semantic.DeepEqual(namespacelabels, namespace.Labels) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resourceQuotas := []kapi.ResourceQuota{}
+	for _, quotaName := range quotaNames {
+		quota, err := e.quotaLister.Get(quotaName)
+		if kapierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		quota = e.checkCache(quota)
+
+		// now convert to a ResourceQuota
+		convertedQuota := kapi.ResourceQuota{}
+		convertedQuota.ObjectMeta = quota.ObjectMeta
+		convertedQuota.Namespace = namespaceName
+		convertedQuota.Spec = quota.Spec.Quota
+		convertedQuota.Status = quota.Status.Total
+		resourceQuotas = append(resourceQuotas, convertedQuota)
+
+	}
+
+	return resourceQuotas, nil
+}

--- a/pkg/quota/admission/clusterresourcequota/accessor_test.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor_test.go
@@ -1,0 +1,369 @@
+package clusterresourcequota
+
+import (
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/cache"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	utildiff "k8s.io/kubernetes/pkg/util/diff"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	"github.com/openshift/origin/pkg/client/testclient"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	quotaapiv1 "github.com/openshift/origin/pkg/quota/api/v1"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+)
+
+func TestUpdateQuota(t *testing.T) {
+	testCases := []struct {
+		name            string
+		availableQuotas func() []*quotaapi.ClusterResourceQuota
+		quotaToUpdate   *kapi.ResourceQuota
+
+		expectedQuota func() *quotaapi.ClusterResourceQuota
+		expectedError string
+	}{
+		{
+			name: "update properly",
+			availableQuotas: func() []*quotaapi.ClusterResourceQuota {
+				user1 := defaultQuota()
+				user1.Name = "user-one"
+				user1.Status.Total.Hard = user1.Spec.Quota.Hard
+				user1.Status.Total.Used = kapi.ResourceList{kapi.ResourcePods: resource.MustParse("15")}
+				user1.Status.Namespaces.Insert("foo", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")},
+				})
+				user1.Status.Namespaces.Insert("bar", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("10")},
+				})
+
+				user2 := defaultQuota()
+				user2.Name = "user-two"
+				user2.Status.Total.Hard = user2.Spec.Quota.Hard
+				user2.Status.Total.Used = kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")}
+				user2.Status.Namespaces.Insert("foo", kapi.ResourceQuotaStatus{
+					Hard: user2.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")},
+				})
+
+				return []*quotaapi.ClusterResourceQuota{user1, user2}
+			},
+			quotaToUpdate: &kapi.ResourceQuota{
+				ObjectMeta: kapi.ObjectMeta{Namespace: "foo", Name: "user-one"},
+				Spec: kapi.ResourceQuotaSpec{
+					Hard: kapi.ResourceList{
+						kapi.ResourcePods:    resource.MustParse("10"),
+						kapi.ResourceSecrets: resource.MustParse("5"),
+					},
+				},
+				Status: kapi.ResourceQuotaStatus{
+					Hard: kapi.ResourceList{
+						kapi.ResourcePods:    resource.MustParse("10"),
+						kapi.ResourceSecrets: resource.MustParse("5"),
+					},
+					Used: kapi.ResourceList{
+						kapi.ResourcePods: resource.MustParse("20"),
+					},
+				}},
+
+			expectedQuota: func() *quotaapi.ClusterResourceQuota {
+				user1 := defaultQuota()
+				user1.Name = "user-one"
+				user1.Status.Total.Hard = user1.Spec.Quota.Hard
+				user1.Status.Total.Used = kapi.ResourceList{kapi.ResourcePods: resource.MustParse("20")}
+				user1.Status.Namespaces.Insert("foo", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("10")},
+				})
+				user1.Status.Namespaces.Insert("bar", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("10")},
+				})
+
+				return user1
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		quotaIndexer := cache.NewIndexer(framework.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+		availableQuotas := tc.availableQuotas()
+		objs := []runtime.Object{}
+		for i := range availableQuotas {
+			quotaIndexer.Add(availableQuotas[i])
+			objs = append(objs, availableQuotas[i])
+		}
+		quotaLister := &ocache.IndexerToClusterResourceQuotaLister{Indexer: quotaIndexer}
+
+		client := testclient.NewSimpleFake(objs...)
+
+		accessor := newQuotaAccessor(quotaLister, nil, client, nil)
+
+		actualErr := accessor.UpdateQuotaStatus(tc.quotaToUpdate)
+		switch {
+		case len(tc.expectedError) == 0 && actualErr == nil:
+		case len(tc.expectedError) == 0 && actualErr != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+			continue
+		case len(tc.expectedError) != 0 && actualErr == nil:
+			t.Errorf("%s: missing expected error: %v", tc.name, tc.expectedError)
+			continue
+		case len(tc.expectedError) != 0 && actualErr != nil && !strings.Contains(actualErr.Error(), tc.expectedError):
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedError, actualErr)
+			continue
+		}
+
+		var actualQuota *quotaapi.ClusterResourceQuota
+		for _, action := range client.Actions() {
+			updateAction, ok := action.(ktestclient.UpdateAction)
+			if !ok {
+				continue
+			}
+			if updateAction.Matches("update", "clusterresourcequotas") {
+				actualQuota = updateAction.GetObject().(*quotaapi.ClusterResourceQuota)
+				break
+			}
+		}
+
+		expectedV1, err := kapi.Scheme.ConvertToVersion(tc.expectedQuota(), quotaapiv1.SchemeGroupVersion.String())
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		actualV1, err := kapi.Scheme.ConvertToVersion(actualQuota, quotaapiv1.SchemeGroupVersion.String())
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if !kapi.Semantic.DeepEqual(expectedV1, actualV1) {
+			t.Errorf("%s: %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1))
+			continue
+		}
+	}
+
+}
+
+func defaultQuota() *quotaapi.ClusterResourceQuota {
+	return &quotaapi.ClusterResourceQuota{
+		ObjectMeta: kapi.ObjectMeta{Name: "foo"},
+		Spec: quotaapi.ClusterResourceQuotaSpec{
+			Quota: kapi.ResourceQuotaSpec{
+				Hard: kapi.ResourceList{
+					kapi.ResourcePods:    resource.MustParse("10"),
+					kapi.ResourceSecrets: resource.MustParse("5"),
+				},
+			},
+		},
+	}
+}
+
+func TestGetQuota(t *testing.T) {
+	testCases := []struct {
+		name                string
+		availableQuotas     func() []*quotaapi.ClusterResourceQuota
+		availableNamespaces []*kapi.Namespace
+		mapperFunc          func() clusterquotamapping.ClusterQuotaMapper
+		requestedNamespace  string
+
+		expectedQuotas func() []*kapi.ResourceQuota
+		expectedError  string
+	}{
+		{
+			name: "namespace not synced",
+			availableQuotas: func() []*quotaapi.ClusterResourceQuota {
+				return nil
+			},
+			availableNamespaces: []*kapi.Namespace{
+				{ObjectMeta: kapi.ObjectMeta{Name: "foo", Labels: map[string]string{"one": "alfa"}}},
+			},
+			mapperFunc: func() clusterquotamapping.ClusterQuotaMapper {
+				mapper := newFakeClusterQuotaMapper()
+				mapper.namespaceToQuota["foo"] = sets.NewString("user-one")
+				mapper.namespaceToLabels["foo"] = map[string]string{"two": "bravo"}
+				return mapper
+			},
+			requestedNamespace: "foo",
+
+			expectedError: "timed out waiting for the condition",
+		},
+		{
+			name: "no hits on namespace",
+			availableQuotas: func() []*quotaapi.ClusterResourceQuota {
+				return nil
+			},
+			availableNamespaces: []*kapi.Namespace{
+				{ObjectMeta: kapi.ObjectMeta{Name: "foo", Labels: map[string]string{"one": "alfa"}}},
+			},
+			mapperFunc: func() clusterquotamapping.ClusterQuotaMapper {
+				mapper := newFakeClusterQuotaMapper()
+				mapper.namespaceToQuota["foo"] = sets.NewString()
+				mapper.namespaceToLabels["foo"] = map[string]string{"one": "alfa"}
+				mapper.namespaceToQuota["bar"] = sets.NewString("user-one")
+				mapper.namespaceToLabels["bar"] = map[string]string{"two": "bravo"}
+				return mapper
+			},
+			requestedNamespace: "foo",
+
+			expectedQuotas: func() []*kapi.ResourceQuota {
+				return []*kapi.ResourceQuota{}
+			},
+			expectedError: "",
+		},
+		{
+			name: "correct quota and namespaces",
+			availableQuotas: func() []*quotaapi.ClusterResourceQuota {
+				user1 := defaultQuota()
+				user1.Name = "user-one"
+				user1.Status.Total.Hard = user1.Spec.Quota.Hard
+				user1.Status.Total.Used = kapi.ResourceList{kapi.ResourcePods: resource.MustParse("15")}
+				user1.Status.Namespaces.Insert("foo", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")},
+				})
+				user1.Status.Namespaces.Insert("bar", kapi.ResourceQuotaStatus{
+					Hard: user1.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("10")},
+				})
+
+				user2 := defaultQuota()
+				user2.Name = "user-two"
+				user2.Status.Total.Hard = user2.Spec.Quota.Hard
+				user2.Status.Total.Used = kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")}
+				user2.Status.Namespaces.Insert("foo", kapi.ResourceQuotaStatus{
+					Hard: user2.Spec.Quota.Hard,
+					Used: kapi.ResourceList{kapi.ResourcePods: resource.MustParse("5")},
+				})
+
+				return []*quotaapi.ClusterResourceQuota{user1, user2}
+			},
+			availableNamespaces: []*kapi.Namespace{
+				{ObjectMeta: kapi.ObjectMeta{Name: "foo", Labels: map[string]string{"one": "alfa"}}},
+			},
+			mapperFunc: func() clusterquotamapping.ClusterQuotaMapper {
+				mapper := newFakeClusterQuotaMapper()
+				mapper.namespaceToQuota["foo"] = sets.NewString("user-one")
+				mapper.namespaceToLabels["foo"] = map[string]string{"one": "alfa"}
+				return mapper
+			},
+			requestedNamespace: "foo",
+
+			expectedQuotas: func() []*kapi.ResourceQuota {
+				return []*kapi.ResourceQuota{
+					{
+						ObjectMeta: kapi.ObjectMeta{Namespace: "foo", Name: "user-one"},
+						Spec: kapi.ResourceQuotaSpec{
+							Hard: kapi.ResourceList{
+								kapi.ResourcePods:    resource.MustParse("10"),
+								kapi.ResourceSecrets: resource.MustParse("5"),
+							},
+						},
+						Status: kapi.ResourceQuotaStatus{
+							Hard: kapi.ResourceList{
+								kapi.ResourcePods:    resource.MustParse("10"),
+								kapi.ResourceSecrets: resource.MustParse("5"),
+							},
+							Used: kapi.ResourceList{
+								kapi.ResourcePods: resource.MustParse("15"),
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		quotaIndexer := cache.NewIndexer(framework.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+		availableQuotas := tc.availableQuotas()
+		for i := range availableQuotas {
+			quotaIndexer.Add(availableQuotas[i])
+		}
+		quotaLister := &ocache.IndexerToClusterResourceQuotaLister{Indexer: quotaIndexer}
+
+		namespaceIndexer := cache.NewIndexer(framework.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+		for i := range tc.availableNamespaces {
+			namespaceIndexer.Add(tc.availableNamespaces[i])
+		}
+		namespaceLister := &ocache.IndexerToNamespaceLister{Indexer: namespaceIndexer}
+
+		client := testclient.NewSimpleFake()
+
+		accessor := newQuotaAccessor(quotaLister, namespaceLister, client, tc.mapperFunc())
+
+		actualQuotas, actualErr := accessor.GetQuotas(tc.requestedNamespace)
+		switch {
+		case len(tc.expectedError) == 0 && actualErr == nil:
+		case len(tc.expectedError) == 0 && actualErr != nil:
+			t.Errorf("%s: unexpected error: %v", tc.name, actualErr)
+			continue
+		case len(tc.expectedError) != 0 && actualErr == nil:
+			t.Errorf("%s: missing expected error: %v", tc.name, tc.expectedError)
+			continue
+		case len(tc.expectedError) != 0 && actualErr != nil && !strings.Contains(actualErr.Error(), tc.expectedError):
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedError, actualErr)
+			continue
+		}
+
+		if tc.expectedQuotas == nil {
+			continue
+		}
+
+		actualQuotaPointers := []*kapi.ResourceQuota{}
+		for i := range actualQuotas {
+			actualQuotaPointers = append(actualQuotaPointers, &actualQuotas[i])
+		}
+
+		expectedQuotas := tc.expectedQuotas()
+		if !kapi.Semantic.DeepEqual(expectedQuotas, actualQuotaPointers) {
+			t.Errorf("%s: expectedLen: %v actualLen: %v", tc.name, len(expectedQuotas), len(actualQuotas))
+			for i := range expectedQuotas {
+				expectedV1, err := kapi.Scheme.ConvertToVersion(expectedQuotas[i], quotaapiv1.SchemeGroupVersion.String())
+				if err != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, err)
+					continue
+				}
+				actualV1, err := kapi.Scheme.ConvertToVersion(actualQuotaPointers[i], quotaapiv1.SchemeGroupVersion.String())
+				if err != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, err)
+					continue
+				}
+				t.Errorf("%s: %v equal? %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1), kapi.Semantic.DeepEqual(expectedV1, actualV1))
+			}
+			continue
+		}
+	}
+}
+
+type fakeClusterQuotaMapper struct {
+	quotaToSelector   map[string]*unversioned.LabelSelector
+	namespaceToLabels map[string]map[string]string
+
+	quotaToNamespaces map[string]sets.String
+	namespaceToQuota  map[string]sets.String
+}
+
+func newFakeClusterQuotaMapper() *fakeClusterQuotaMapper {
+	return &fakeClusterQuotaMapper{
+		quotaToSelector:   map[string]*unversioned.LabelSelector{},
+		namespaceToLabels: map[string]map[string]string{},
+		quotaToNamespaces: map[string]sets.String{},
+		namespaceToQuota:  map[string]sets.String{},
+	}
+}
+
+func (m *fakeClusterQuotaMapper) GetClusterQuotasFor(namespaceName string) ([]string, map[string]string) {
+	return m.namespaceToQuota[namespaceName].List(), m.namespaceToLabels[namespaceName]
+}
+func (m *fakeClusterQuotaMapper) GetNamespacesFor(quotaName string) ([]string, *unversioned.LabelSelector) {
+	return m.quotaToNamespaces[quotaName].List(), m.quotaToSelector[quotaName]
+}
+func (m *fakeClusterQuotaMapper) AddListener(listener clusterquotamapping.MappingChangeListener) {}

--- a/pkg/quota/admission/clusterresourcequota/accessor_test.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor_test.go
@@ -134,12 +134,12 @@ func TestUpdateQuota(t *testing.T) {
 			}
 		}
 
-		expectedV1, err := kapi.Scheme.ConvertToVersion(tc.expectedQuota(), quotaapiv1.SchemeGroupVersion.String())
+		expectedV1, err := kapi.Scheme.ConvertToVersion(tc.expectedQuota(), quotaapiv1.SchemeGroupVersion)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			continue
 		}
-		actualV1, err := kapi.Scheme.ConvertToVersion(actualQuota, quotaapiv1.SchemeGroupVersion.String())
+		actualV1, err := kapi.Scheme.ConvertToVersion(actualQuota, quotaapiv1.SchemeGroupVersion)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			continue
@@ -326,12 +326,12 @@ func TestGetQuota(t *testing.T) {
 		if !kapi.Semantic.DeepEqual(expectedQuotas, actualQuotaPointers) {
 			t.Errorf("%s: expectedLen: %v actualLen: %v", tc.name, len(expectedQuotas), len(actualQuotas))
 			for i := range expectedQuotas {
-				expectedV1, err := kapi.Scheme.ConvertToVersion(expectedQuotas[i], quotaapiv1.SchemeGroupVersion.String())
+				expectedV1, err := kapi.Scheme.ConvertToVersion(expectedQuotas[i], quotaapiv1.SchemeGroupVersion)
 				if err != nil {
 					t.Errorf("%s: unexpected error: %v", tc.name, err)
 					continue
 				}
-				actualV1, err := kapi.Scheme.ConvertToVersion(actualQuotaPointers[i], quotaapiv1.SchemeGroupVersion.String())
+				actualV1, err := kapi.Scheme.ConvertToVersion(actualQuotaPointers[i], quotaapiv1.SchemeGroupVersion)
 				if err != nil {
 					t.Errorf("%s: unexpected error: %v", tc.name, err)
 					continue

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -1,0 +1,132 @@
+package clusterresourcequota
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/install"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
+
+	oclient "github.com/openshift/origin/pkg/client"
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	"github.com/openshift/origin/pkg/controller/shared"
+	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+)
+
+func init() {
+	admission.RegisterPlugin("ClusterResourceQuota",
+		func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+			registry := install.NewRegistry(client)
+			// TODO: expose a stop channel in admission factory
+			return NewClusterResourceQuota(registry)
+		})
+}
+
+// quotaAdmission implements an admission controller that can enforce quota constraints
+type quotaAdmission struct {
+	*admission.Handler
+
+	// these are used to create the accessor
+	quotaLister     *ocache.IndexerToClusterResourceQuotaLister
+	namespaceLister *ocache.IndexerToNamespaceLister
+	quotaSynced     func() bool
+	namespaceSynced func() bool
+	quotaClient     oclient.ClusterResourceQuotasInterface
+	quotaMapper     clusterquotamapping.ClusterQuotaMapper
+
+	// these are used to create the evaluator
+	registry quota.Registry
+
+	init      sync.Once
+	evaluator resourcequota.Evaluator
+}
+
+var _ oadmission.WantsInformers = &quotaAdmission{}
+var _ oadmission.WantsOpenshiftClient = &quotaAdmission{}
+var _ oadmission.WantsClusterQuotaMapper = &quotaAdmission{}
+var _ oadmission.Validator = &quotaAdmission{}
+
+// NewResourceQuota configures an admission controller that can enforce quota constraints
+// using the provided registry.  The registry must have the capability to handle group/kinds that
+// are persisted by the server this admission controller is intercepting
+func NewClusterResourceQuota(registry quota.Registry) (admission.Interface, error) {
+	return &quotaAdmission{
+		Handler:  admission.NewHandler(admission.Create),
+		registry: registry,
+	}, nil
+}
+
+// Admit makes admission decisions while enforcing quota
+func (q *quotaAdmission) Admit(a admission.Attributes) (err error) {
+	// ignore all operations that correspond to sub-resource actions
+	if len(a.GetSubresource()) != 0 {
+		return nil
+	}
+	// ignore cluster level resources
+	if len(a.GetNamespace()) == 0 {
+		return nil
+	}
+
+	if !q.waitForSyncedStore(time.After(10 * time.Second)) {
+		return admission.NewForbidden(a, errors.New("caches not synchronized"))
+	}
+
+	q.init.Do(func() {
+		quotaAccessor := newQuotaAccessor(q.quotaLister, q.namespaceLister, q.quotaClient, q.quotaMapper)
+		q.evaluator = resourcequota.NewQuotaEvaluator(quotaAccessor, q.registry, nil, 10, utilwait.NeverStop)
+	})
+
+	return q.evaluator.Evaluate(a)
+}
+
+func (q *quotaAdmission) waitForSyncedStore(timeout <-chan time.Time) bool {
+	for !q.quotaSynced() || !q.namespaceSynced() {
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-timeout:
+			return q.quotaSynced() && q.namespaceSynced()
+		}
+	}
+
+	return true
+}
+
+func (q *quotaAdmission) SetInformers(informers shared.InformerFactory) {
+	q.quotaLister = informers.ClusterResourceQuotas().Lister()
+	q.quotaSynced = informers.ClusterResourceQuotas().Informer().HasSynced
+	q.namespaceLister = informers.Namespaces().Lister()
+	q.namespaceSynced = informers.Namespaces().Informer().HasSynced
+}
+
+func (q *quotaAdmission) SetOpenshiftClient(client oclient.Interface) {
+	q.quotaClient = client
+}
+
+func (q *quotaAdmission) SetClusterQuotaMapper(clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper) {
+	q.quotaMapper = clusterQuotaMapper
+}
+
+func (q *quotaAdmission) Validate() error {
+	if q.quotaLister == nil {
+		return errors.New("missing quotaLister")
+	}
+	if q.namespaceLister == nil {
+		return errors.New("missing namespaceLister")
+	}
+	if q.quotaClient == nil {
+		return errors.New("missing quotaClient")
+	}
+	if q.quotaMapper == nil {
+		return errors.New("missing quotaMapper")
+	}
+
+	return nil
+}

--- a/pkg/quota/admission/clusterresourcequota/lockfactory.go
+++ b/pkg/quota/admission/clusterresourcequota/lockfactory.go
@@ -1,0 +1,40 @@
+package clusterresourcequota
+
+import (
+	"sync"
+)
+
+type LockFactory interface {
+	GetLock(string) sync.Locker
+}
+
+type DefaultLockFactory struct {
+	lock sync.RWMutex
+
+	locks map[string]sync.Locker
+}
+
+func NewDefaultLockFactory() *DefaultLockFactory {
+	return &DefaultLockFactory{locks: map[string]sync.Locker{}}
+}
+
+func (f *DefaultLockFactory) GetLock(key string) sync.Locker {
+	lock, exists := f.getExistingLock(key)
+	if exists {
+		return lock
+	}
+
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	lock = &sync.Mutex{}
+	f.locks[key] = lock
+	return lock
+}
+
+func (f *DefaultLockFactory) getExistingLock(key string) (sync.Locker, bool) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	lock, exists := f.locks[key]
+	return lock, exists
+}

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
@@ -62,6 +62,7 @@ func runFuzzer(t *testing.T) {
 	controller := NewClusterQuotaMappingController(informerFactory.Namespaces(), informerFactory.ClusterResourceQuotas())
 	go controller.Run(5, stopCh)
 	informerFactory.Start(stopCh)
+	informerFactory.StartCore(stopCh)
 
 	finalNamespaces := map[string]*kapi.Namespace{}
 	finalQuotas := map[string]*quotaapi.ClusterResourceQuota{}

--- a/pkg/quota/controller/clusterquotareconciliation/workqueuebucket.go
+++ b/pkg/quota/controller/clusterquotareconciliation/workqueuebucket.go
@@ -100,9 +100,9 @@ func (e *workQueueBucket) GetWithData() (interface{}, []interface{}, bool) {
 	work := e.work[key]
 	delete(e.work, key)
 	delete(e.dirtyWork, key)
+	e.inProgress[key] = true
 
 	if len(work) != 0 {
-		e.inProgress[key] = true
 		return key, work, false
 	}
 

--- a/pkg/quota/registry.go
+++ b/pkg/quota/registry.go
@@ -1,9 +1,14 @@
 package quota
 
 import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kquota "k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/install"
 
 	osclient "github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/quota/image"
 )
 
@@ -11,4 +16,21 @@ import (
 // resources.
 func NewOriginQuotaRegistry(osClient osclient.Interface) kquota.Registry {
 	return image.NewImageQuotaRegistry(osClient)
+}
+
+// NewAllResourceQuotaRegistry returns a registry object that knows how to evaluate all resources
+func NewAllResourceQuotaRegistry(osClient osclient.Interface, kubeClientSet clientset.Interface) kquota.Registry {
+	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet), NewOriginQuotaRegistry(osClient)}
+}
+
+// AllEvaluatedGroupKinds is the list of all group kinds that we evaluate for quotas in openshift and kube
+var AllEvaluatedGroupKinds = []unversioned.GroupKind{
+	kapi.Kind("Pod"),
+	kapi.Kind("Service"),
+	kapi.Kind("ReplicationController"),
+	kapi.Kind("PersistentVolumeClaim"),
+	kapi.Kind("Secret"),
+	kapi.Kind("ConfigMap"),
+
+	imageapi.Kind("ImageStream"),
 }

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -1,0 +1,128 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
+
+	"github.com/openshift/origin/pkg/client"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestClusterQuota(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// time.Sleep(10 * time.Second)
+
+	cq := &quotaapi.ClusterResourceQuota{
+		ObjectMeta: kapi.ObjectMeta{Name: "overall"},
+		Spec: quotaapi.ClusterResourceQuotaSpec{
+			Selector: &unversioned.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			Quota: kapi.ResourceQuotaSpec{
+				Hard: kapi.ResourceList{
+					kapi.ResourceConfigMaps: resource.MustParse("2"),
+				},
+			},
+		},
+	}
+	if _, err := clusterAdminClient.ClusterResourceQuotas().Create(cq); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "first", "harold"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "second", "harold"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := labelNamespace(clusterAdminKubeClient, "first"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := labelNamespace(clusterAdminKubeClient, "second"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := waitForQuotaLabeling(clusterAdminClient, "first"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := waitForQuotaLabeling(clusterAdminClient, "second"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	configmap := &kapi.ConfigMap{}
+	configmap.GenerateName = "test"
+	if _, err := clusterAdminKubeClient.ConfigMaps("first").Create(configmap); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := clusterAdminKubeClient.ConfigMaps("second").Create(configmap); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := clusterAdminKubeClient.ConfigMaps("second").Create(configmap); !kapierrors.IsForbidden(err) {
+		list, err := clusterAdminClient.AppliedClusterResourceQuotas("second").List(kapi.ListOptions{})
+		if err == nil {
+			t.Errorf("quota is %#v", list)
+		}
+
+		list2, err := clusterAdminKubeClient.ConfigMaps("").List(kapi.ListOptions{})
+		if err == nil {
+			t.Errorf("ConfigMaps is %#v", list2)
+		}
+
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func waitForQuotaLabeling(clusterAdminClient client.AppliedClusterResourceQuotasNamespacer, namespaceName string) error {
+	return utilwait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+		list, err := clusterAdminClient.AppliedClusterResourceQuotas(namespaceName).List(kapi.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if len(list.Items) > 0 && len(list.Items[0].Status.Total.Hard) > 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func labelNamespace(clusterAdminKubeClient kclient.NamespacesInterface, namespaceName string) error {
+	ns1, err := clusterAdminKubeClient.Namespaces().Get(namespaceName)
+	if err != nil {
+		return err
+	}
+	if ns1.Labels == nil {
+		ns1.Labels = map[string]string{}
+	}
+	ns1.Labels["foo"] = "bar"
+	if _, err := clusterAdminKubeClient.Namespaces().Update(ns1); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/controller/framework/shared_informer.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/framework/shared_informer.go
@@ -95,6 +95,9 @@ type sharedIndexInformer struct {
 	// blockDeltas gives a way to stop all event distribution so that a late event handler
 	// can safely join the shared informer.
 	blockDeltas sync.Mutex
+	// stopCh is the channel used to stop the main Run process.  We have to track it so that
+	// late joiners can have a proper stop
+	stopCh <-chan struct{}
 }
 
 // dummyController hides the fact that a SharedInformer is different from a dedicated one
@@ -149,6 +152,7 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 		s.started = true
 	}()
 
+	s.stopCh = stopCh
 	s.cacheMutationDetector.Run(stopCh)
 	s.processor.run(stopCh)
 	s.controller.Run(stopCh)
@@ -223,6 +227,9 @@ func (s *sharedIndexInformer) AddEventHandler(handler ResourceEventHandler) erro
 
 	listener := newProcessListener(handler)
 	s.processor.listeners = append(s.processor.listeners, listener)
+
+	go listener.run(s.stopCh)
+	go listener.pop(s.stopCh)
 
 	items := s.indexer.List()
 	for i := range items {

--- a/vendor/k8s.io/kubernetes/pkg/quota/interfaces.go
+++ b/vendor/k8s.io/kubernetes/pkg/quota/interfaces.go
@@ -64,3 +64,19 @@ type Registry interface {
 	// Evaluators returns the set Evaluator objects registered to a groupKind
 	Evaluators() map[unversioned.GroupKind]Evaluator
 }
+
+// UnionRegistry combines multiple registries.  Order matters because first registry to claim a GroupKind
+// is the "winner"
+type UnionRegistry []Registry
+
+func (r UnionRegistry) Evaluators() map[unversioned.GroupKind]Evaluator {
+	ret := map[unversioned.GroupKind]Evaluator{}
+
+	for i := len(r) - 1; i >= 0; i-- {
+		for k, v := range r[i].Evaluators() {
+			ret[k] = v
+		}
+	}
+
+	return ret
+}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -71,6 +72,11 @@ func (l *lifecycle) Admit(a admission.Attributes) (err error) {
 				},
 			})
 		}
+		return nil
+	}
+
+	// always allow access review checks.  Returning status about the namespace would be leaking information
+	if isAccessReview(a) {
 		return nil
 	}
 
@@ -133,4 +139,17 @@ func NewLifecycle(c clientset.Interface, immortalNamespaces sets.String) admissi
 		store:              store,
 		immortalNamespaces: immortalNamespaces,
 	}
+}
+
+// TODO move this upstream once they have namespaced access review checks
+var accessReviewResources = map[unversioned.GroupResource]bool{
+	unversioned.GroupResource{Group: "", Resource: "subjectaccessreviews"}:       true,
+	unversioned.GroupResource{Group: "", Resource: "localsubjectaccessreviews"}:  true,
+	unversioned.GroupResource{Group: "", Resource: "resourceaccessreviews"}:      true,
+	unversioned.GroupResource{Group: "", Resource: "localresourceaccessreviews"}: true,
+	unversioned.GroupResource{Group: "", Resource: "selfsubjectrulesreviews"}:    true,
+}
+
+func isAccessReview(a admission.Attributes) bool {
+	return accessReviewResources[a.GetResource().GroupResource()]
 }

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission.go
@@ -59,7 +59,7 @@ func NewResourceQuota(client clientset.Interface, registry quota.Registry, numEv
 	}
 	go quotaAccessor.Run(stopCh)
 
-	evaluator := NewQuotaEvaluator(quotaAccessor, registry, numEvaluators, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, registry, nil, numEvaluators, stopCh)
 
 	return &quotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/admission_test.go
@@ -150,7 +150,7 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -194,7 +194,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -277,7 +277,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	handler := &quotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -367,7 +367,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -411,7 +411,7 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -465,7 +465,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 	quotaAccessor.indexer = indexer
 	quotaAccessor.liveLookupCache = liveLookupCache
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -531,7 +531,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -636,7 +636,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -728,7 +728,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 
 	defer utilruntime.HandleCrash()
 	handler := &quotaAdmission{
@@ -846,7 +846,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
 	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(kubeClient), nil, 5, stopCh)
 	evaluator.(*quotaEvaluator).registry = registry
 
 	defer utilruntime.HandleCrash()

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/controller.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/resourcequota/controller.go
@@ -44,6 +44,8 @@ type Evaluator interface {
 
 type quotaEvaluator struct {
 	quotaAccessor QuotaAccessor
+	// lockAquisitionFunc acquires any required locks and returns a cleanup method to defer
+	lockAquisitionFunc func([]api.ResourceQuota) func()
 
 	// registry that knows how to measure usage for objects
 	registry quota.Registry
@@ -96,9 +98,10 @@ func newAdmissionWaiter(a admission.Attributes) *admissionWaiter {
 // NewQuotaEvaluator configures an admission controller that can enforce quota constraints
 // using the provided registry.  The registry must have the capability to handle group/kinds that
 // are persisted by the server this admission controller is intercepting
-func NewQuotaEvaluator(quotaAccessor QuotaAccessor, registry quota.Registry, workers int, stopCh <-chan struct{}) Evaluator {
+func NewQuotaEvaluator(quotaAccessor QuotaAccessor, registry quota.Registry, lockAquisitionFunc func([]api.ResourceQuota) func(), workers int, stopCh <-chan struct{}) Evaluator {
 	return &quotaEvaluator{
-		quotaAccessor: quotaAccessor,
+		quotaAccessor:      quotaAccessor,
+		lockAquisitionFunc: lockAquisitionFunc,
 
 		registry: registry,
 
@@ -167,6 +170,11 @@ func (e *quotaEvaluator) checkAttributes(ns string, admissionAttributes []*admis
 			admissionAttribute.result = nil
 		}
 		return
+	}
+
+	if e.lockAquisitionFunc != nil {
+		releaseLocks := e.lockAquisitionFunc(quotas)
+		defer releaseLocks()
 	}
 
 	e.checkQuotas(quotas, admissionAttributes, 3)


### PR DESCRIPTION
This collapses us onto a single namespace scoped admission plugin and allows the clusterquota admission and replenishment controller to understand all the available types.

@derekwaynecarr ptal