### PR TITLE
bump registry xfs quota; re-enable disk usage diag; add docker info

### DIFF
--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -18,8 +18,8 @@ import (
 
 const (
 	volDirEnvVar       = "VOLUME_DIR"
-	podCreationTimeout = 120    // seconds
-	expectedQuotaKb    = 917504 // launcher script sets 896Mi, xfs_quota reports in Kb.
+	podCreationTimeout = 120     // seconds
+	expectedQuotaKb    = 4587520 // launcher script sets 4480Mi, xfs_quota reports in Kb.
 )
 
 func lookupFSGroup(oc *exutil.CLI, project string) (int, error) {

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -101,9 +101,9 @@ function os::test::extended::setup {
     # Similar to above check, if the XFS volume dir mount point exists enable
     # local storage quota in node-config.yaml so these tests can pass:
     if [ -d "/mnt/openshift-xfs-vol-dir" ]; then
-	# The ec2 images have have 1Gi of space defined; want to give /registry a good chunk of that
+	# The ec2 images usually have ~5Gi of space defined for the xfs vol for the registry; want to give /registry a good chunk of that
 	# to store the images created when the extended tests run
-      sed -i 's/perFSGroup: null/perFSGroup: 896Mi/' $NODE_CONFIG_DIR/node-config.yaml
+      sed -i 's/perFSGroup: null/perFSGroup: 4480Mi/' $NODE_CONFIG_DIR/node-config.yaml
     fi
     echo "[INFO] Using VOLUME_DIR=${VOLUME_DIR}"
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -119,10 +119,10 @@ func DumpBuildLogs(bc string, oc *CLI) {
 		}*/
 	}
 
-	// if we suspect that we are filling up the registry file syste, call ExamineDiskUsage / ExaminePodDiskUsage
+	// if we suspect that we are filling up the registry file system, call ExamineDiskUsage / ExaminePodDiskUsage
 	// also see if manipulations of the quota around /mnt/openshift-xfs-vol-dir exist in the extended test set up scripts
-	//ExamineDiskUsage()
-	//ExaminePodDiskUsage(oc)
+	ExamineDiskUsage()
+	ExaminePodDiskUsage(oc)
 }
 
 // DumpDeploymentLogs will dump the latest deployment logs for a DeploymentConfig for debug purposes
@@ -178,6 +178,12 @@ func ExamineDiskUsage() {
 		fmt.Fprintf(g.GinkgoWriter, "\n\n df -m output: %s\n\n", string(out))
 	} else {
 		fmt.Fprintf(g.GinkgoWriter, "\n\n got error on df %v\n\n", err)
+	}
+	out, err = exec.Command("/bin/docker", "info").Output()
+	if err == nil {
+		fmt.Fprintf(g.GinkgoWriter, "\n\n docker info output: \n%s\n\n", string(out))
+	} else {
+		fmt.Fprintf(g.GinkgoWriter, "\n\n got error on docker inspect %v\n\n", err)
 	}
 }
 


### PR DESCRIPTION
@bparees PTAL

The ami's are updated and I confirmed the reallocation has occurred (the registry xfs vol now has 4.98GiB).

This is the origin side change to bump the quota during the extended tests.  I also re-enabled the disk related diagnostics for build failures, as well as added a `docker info` call (this will show us the usage stats for the docker data (where the actual images are stored) and docker metadata volumes.