### PR TITLE
Use randomness for REGISTRY_HTTP_SECRET in projectatomic/atomic-regis…

### DIFF
--- a/examples/atomic-registry/systemd/install.sh
+++ b/examples/atomic-registry/systemd/install.sh
@@ -46,7 +46,7 @@ set -x
 echo "OPENSHIFT_OAUTH_PROVIDER_URL=https://${INSTALL_HOST}:8443" >> /host/etc/sysconfig/atomic-registry-console
 echo "REGISTRY_HOST=${INSTALL_HOST}:5000" >> /host/etc/sysconfig/atomic-registry-console
 # generate random secret for multi-registry shared storage deployment
-echo "REGISTRY_HTTP_SECRET=`date | md5sum`" >> /host/etc/sysconfig/atomic-registry
+echo "REGISTRY_HTTP_SECRET=$(head -c 64 /dev/urandom | base64 -w0)" >> /host/etc/sysconfig/atomic-registry
 
 # load updated systemd unit files
 chroot /host systemctl daemon-reload


### PR DESCRIPTION
Currently `atomic install projectatomic/atomic-registry-install` generates a nonrandom `REGISTRY_HTTP_SECRET` make it random by getting bytes from  `/dev/urandom` instead.