### PR TITLE
Avoid mutating the cached deployment config in image change controller

### DIFF
--- a/pkg/deploy/controller/imagechange/factory.go
+++ b/pkg/deploy/controller/imagechange/factory.go
@@ -69,7 +69,7 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 				if _, isFatal := err.(fatalError); isFatal {
 					return false
 				}
-				if retries.Count > 0 {
+				if retries.Count > 2 {
 					return false
 				}
 				return true

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -331,7 +331,7 @@ out:
 			}
 
 			if e, a := updated, newConfig.Spec.Template.Spec.Containers[0].Image; e == a {
-				t.Fatalf("unexpected image update, expected initial image to be the same")
+				t.Fatalf("unexpected image update, expected initial image to be the same: %#v", newConfig)
 			}
 		case <-timeout:
 			return


### PR DESCRIPTION
Will ensure we handle retries correctly.

[test]