### PR TITLE
Strip build tags from integration, they are not needed

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -169,7 +169,7 @@ readonly -f os::util::environment::setup_tmpdir_vars
 function os::util::environment::setup_kubelet_vars() {
     KUBELET_SCHEME="${KUBELET_SCHEME:-https}"
     export KUBELET_SCHEME
-    KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip)}"
+    KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip || echo "127.0.0.1")}"
     export KUBELET_BIND_HOST
     KUBELET_HOST="${KUBELET_HOST:-${KUBELET_BIND_HOST}}"
     export KUBELET_HOST
@@ -208,7 +208,7 @@ function os::util::environment::setup_etcd_vars() {
 readonly -f os::util::environment::setup_etcd_vars
 
 # os::util::environment::setup_server_vars sets up environment variables necessary for interacting with the server
-# 
+#
 # Globals:
 #  - BASETMPDIR
 #  - KUBELET_HOST
@@ -235,7 +235,7 @@ function os::util::environment::setup_server_vars() {
     KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
     export KUBE_CACHE_MUTATION_DETECTOR
 
-    API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip)}"
+    API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip || echo "127.0.0.1")}"
     export API_BIND_HOST
     API_HOST="${API_HOST:-${API_BIND_HOST}}"
     export API_HOST

--- a/hack/listtests.go
+++ b/hack/listtests.go
@@ -20,7 +20,6 @@ var reLine = regexp.MustCompile("^\\s*(\\w+)\\s+(\\w+)\\s+(.+)$")
 func main() {
 	log.SetFlags(0)
 
-	dir := flag.String("dir", "", "the directory that contains the binary; if empty, the same as the first argument")
 	prefix := flag.String("prefix", "", "the function prefix to scan for; if not specified will use *<dirBasename>.Test*")
 	help := flag.Bool("help", false, "display help")
 	flag.Parse()
@@ -35,19 +34,9 @@ func main() {
 		log.Fatalf("Must specify the name of a single directory, e.g. ./test/integration")
 	}
 
-	path := args[0]
-	_ = args[1:]
-	base := filepath.Base(path)
-
-	execDir := path
-	if len(*dir) > 0 {
-		execDir = *dir
-	}
-
-	pkg := filepath.Join(execDir, fmt.Sprintf("%s.test", base))
-	test, err := filepath.Abs(pkg)
+	test, err := filepath.Abs(args[0])
 	if err != nil {
-		log.Fatalf("Unable to make path %q absolute: %v", execDir, err)
+		log.Fatalf("Unable to make path %q absolute: %v", args[0], err)
 	}
 	if _, err := os.Stat(test); err != nil {
 		log.Fatalf("No test executable %q exits, did you run `go test -c` on the named package?", test)
@@ -93,10 +82,6 @@ func main() {
 		parts := strings.Split(last, ".")
 		if len(parts) != 2 {
 			//log.Printf("bad_name: %s", last)
-			continue
-		}
-		if parts[0] != base {
-			//log.Printf("ignore: %s", last)
 			continue
 		}
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -29,28 +29,11 @@ function cleanup() {
 
 trap cleanup EXIT SIGINT
 
-package="${OS_TEST_PACKAGE:-test/integration}"
-
-if docker version >/dev/null 2>&1; then
-	tags="${OS_TEST_TAGS:-integration docker}"
-else
-	echo "++ Docker not available, running only integration tests without the 'docker' tag"
-	tags="${OS_TEST_TAGS:-integration !docker}"
-fi
-
 export GOMAXPROCS="$(grep "processor" -c /proc/cpuinfo 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || 1)"
 
-echo
-echo "Test ${package} -tags='${tags}' ..."
-echo
-
-# setup the test dirs
-testdir="${OS_ROOT}/_output/testbin/${package}"
-name="$(basename ${testdir})"
-testexec="${testdir}/${name}.test"
-mkdir -p "${testdir}"
-
 # Internalize environment variables we consume and default if they're not set
+package="${OS_TEST_PACKAGE:-test/integration}"
+name="$(basename ${package})"
 dlv_debug="${DLV_DEBUG:-}"
 verbose="${VERBOSE:-}"
 
@@ -58,11 +41,9 @@ verbose="${VERBOSE:-}"
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
   echo "WARNING: Skipping build due to OPENSHIFT_SKIP_BUILD"
 else
-  pushd "${testdir}" &>/dev/null
-    echo "Building test executable..."
-    CGO_ENABLED=0 go test -c -tags="${tags}" "${OS_GO_PACKAGE}/${package}"
-  popd &>/dev/null
+	CGO_ENABLED=0 "${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test" -a -installsuffix=cgo
 fi
+testexec="$(pwd)/$(os::build::find-binary "${name}.test")"
 
 os::log::start_system_logger
 
@@ -108,7 +89,6 @@ export testexec
 export childargs
 
 loop="${TIMES:-1}"
-pushd "./${package}" &>/dev/null
 # $1 is passed to grep -E to filter the list of tests; this may be the name of a single test,
 # a fragment of a test name, or a regular expression.
 #
@@ -117,9 +97,10 @@ pushd "./${package}" &>/dev/null
 # hack/test-integration.sh WatchBuilds
 # hack/test-integration.sh Template*
 # hack/test-integration.sh "(WatchBuilds|Template)"
-tests=( $(go run "${OS_ROOT}/hack/listtests.go" -prefix="${OS_GO_PACKAGE}/${package}.Test" "${testdir}" | grep -E "${1-Test}") )
+tests=( $(go run "${OS_ROOT}/hack/listtests.go" -prefix="${OS_GO_PACKAGE}/${package}.Test" "${testexec}" | grep -E "${1-Test}") )
 # run each test as its own process
 ret=0
+pushd "${OS_ROOT}/${package}" &>/dev/null
 for test in "${tests[@]}"; do
 	for((i=0;i<${loop};i+=1)); do
 		if ! (exectest "${test}" ${@:2}); then

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -528,11 +528,11 @@ readonly -f delete_empty_logs
 # truncate_large_logs truncates large logs so we only download the last 20MB
 function truncate_large_logs() {
 	# Clean up large log files so they don't end up on jenkins
-	local large_files=$(find "${ARTIFACT_DIR}" "${LOG_DIR}" -type f -name '*.log' \( -size +20M \))
+	local large_files=$(find "${ARTIFACT_DIR}" "${LOG_DIR}" -type f -name '*.log' \( -size +50M \))
 	for file in ${large_files}; do
-		cp "${file}" "${file}.tmp"
-		echo "LOGFILE TOO LONG, PREVIOUS BYTES TRUNCATED. LAST 20M BYTES OF LOGFILE:" > "${file}"
-		tail -c 20M "${file}.tmp" >> "${file}"
+		mv "${file}" "${file}.tmp"
+		echo "LOGFILE TOO LONG $(du -h "${file}"), LAST 50M OF LOGFILE:" > "${file}"
+		tail -c 50M "${file}.tmp" >> "${file}"
 		rm "${file}.tmp"
 	done
 }

--- a/pkg/quota/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission.go
@@ -74,7 +74,7 @@ func newClusterResourceOverride(client clientset.Interface, config *api.ClusterR
 		}
 	}
 
-	limitRanger, err := limitranger.NewLimitRanger(client, &limitRangerActions{})
+	limitRanger, err := limitranger.NewLimitRanger(client, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/api_paths_test.go
+++ b/test/integration/api_paths_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -1,5 +1,3 @@
-// +build integration,etcd
-
 package integration
 
 import (
@@ -139,7 +137,9 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkErr(t, testserver.WaitForServiceAccounts(clusterAdminKubeClient, testutil.Namespace(), []string{bootstrappolicy.DefaultServiceAccountName}))
+	if err := testserver.WaitForServiceAccounts(clusterAdminKubeClient, testutil.Namespace(), []string{bootstrappolicy.DefaultServiceAccountName}); err != nil {
+		t.Fatal(err)
+	}
 	return clusterAdminKubeClient
 }
 

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -99,6 +99,7 @@ func TestClusterResourceOverridePluginWithLimits(t *testing.T) {
 }
 
 func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.ClusterResourceOverrideConfig) kclient.Interface {
+	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/diag_nodes_test.go
+++ b/test/integration/diag_nodes_test.go
@@ -1,5 +1,3 @@
-// +build integration,!no-etcd
-
 package integration
 
 import (

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/external_kube_test.go
+++ b/test/integration/external_kube_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -187,7 +185,11 @@ func TestGroupCommands(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	newGroup := &groupscmd.NewGroupOptions{clusterAdminClient.Groups(), "group1", []string{"first", "second", "third", "first"}}
+	newGroup := &groupscmd.NewGroupOptions{
+		GroupClient: clusterAdminClient.Groups(),
+		Group:       "group1",
+		Users:       []string{"first", "second", "third", "first"},
+	}
 	if err := newGroup.AddGroup(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -199,7 +201,11 @@ func TestGroupCommands(t *testing.T) {
 		t.Errorf("expected %v, actual %v", e, a)
 	}
 
-	modifyUsers := &groupscmd.GroupModificationOptions{clusterAdminClient.Groups(), "group1", []string{"second", "fourth", "fifth"}}
+	modifyUsers := &groupscmd.GroupModificationOptions{
+		GroupClient: clusterAdminClient.Groups(),
+		Group:       "group1",
+		Users:       []string{"second", "fourth", "fifth"},
+	}
 	if err := modifyUsers.AddUsers(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -465,7 +463,7 @@ func TestImageStreamImportAuthenticated(t *testing.T) {
 		}
 		tag, ok := is.Spec.Tags["latest"]
 		if !ok {
-			t.Fatalf("object at generation %d did not have tag latest: %#v", is.Generation)
+			t.Fatalf("object at generation %d did not have tag latest: %#v", is.Generation, is)
 		}
 		tagGen := tag.Generation
 		if is.Generation != expectedGen || tagGen == nil || *tagGen != expectedGen {
@@ -560,7 +558,7 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 			}
 			expectedTags := []string{"latest", "v2"}[i]
 			if image.Tag != expectedTags {
-				t.Errorf("unexpected tag at position %d (%s != %s)", i, image.Tag, expectedTags[i])
+				t.Errorf("unexpected tag at position %d (%s != %s)", i, image.Tag, expectedTags)
 			}
 		}
 	}
@@ -706,14 +704,14 @@ func TestImageStreamImportScheduled(t *testing.T) {
 
 	tag, ok := change.Spec.Tags["latest"]
 	if !ok {
-		t.Fatalf("object at generation %d did not have tag latest: %#v", change.Generation)
+		t.Fatalf("object at generation %d did not have tag latest: %#v", change.Generation, change)
 	}
 	if gen := tag.Generation; gen == nil || *gen != 2 {
 		t.Fatalf("object at generation %d had spec tag: %#v", change.Generation, tag)
 	}
 	items := change.Status.Tags["latest"].Items
 	if len(items) != 2 {
-		t.Fatalf("object at generation %d should have two tagged images", change.Generation, change.Status.Tags["latest"])
+		t.Fatalf("object at generation %d should have two tagged images: %#v", change.Generation, change.Status.Tags["latest"])
 	}
 	if items[0].Image != phpDigest || items[0].DockerImageReference != url.Host+"/test/image@"+phpDigest {
 		t.Fatalf("expected tagged image: %#v", items[0])

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -1,5 +1,3 @@
-// +build integration,!no-etcd
-
 package integration
 
 import (

--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauth_disabled_test.go
+++ b/test/integration/oauth_disabled_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -116,7 +114,7 @@ func TestOAuthLDAP(t *testing.T) {
 			URL:    fmt.Sprintf("ldap://%s/%s?%s?%s?%s", ldapAddress, searchDN, searchAttr, searchScope, searchFilter),
 			BindDN: bindDN,
 			BindPassword: configapi.StringSource{
-				configapi.StringSourceSpec{
+				StringSourceSpec: configapi.StringSourceSpec{
 					File:    bindPasswordFile.Name(),
 					KeyFile: bindPasswordKeyFile.Name(),
 				},

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/patch_test.go
+++ b/test/integration/patch_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/project_reqlimit_test.go
+++ b/test/integration/project_reqlimit_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/root_redirect_test.go
+++ b/test/integration/root_redirect_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/sa_oauthclient_test.go
+++ b/test/integration/sa_oauthclient_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/shortcut_expansion_test.go
+++ b/test/integration/shortcut_expansion_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/storage_versions_test.go
+++ b/test/integration/storage_versions_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/template_test.go
+++ b/test/integration/template_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -296,7 +294,7 @@ func postFile(client restclient.HTTPClient, event, filename, url string, expStat
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != expStatusCode {
-		t.Errorf("Wrong response code, expecting %d, got %s: %s!", expStatusCode, resp.StatusCode, string(body))
+		t.Errorf("Wrong response code, expecting %d, got %d: %s!", expStatusCode, resp.StatusCode, string(body))
 	}
 }
 


### PR DESCRIPTION
@liggitt follow up from rebase, we don't need tags because we can either a) fail the tests (what this PR does) or b) skip the test if docker can't be connected to.  For now, just going with fail.

One step closer to being a standard build / test.

[test]