### PR TITLE
Change extended test's DNS port to 8053 intead of 53

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -74,7 +74,7 @@ function configure_os_server() {
 	openshift start \
 	--write-config=${SERVER_CONFIG_DIR} \
 	--create-certs=false \
-	--dns="tcp://${API_HOST}:53" \
+	--dns="tcp://${API_HOST}:8053" \
 	--listen="${API_SCHEME}://${API_BIND_HOST}:${API_PORT}" \
 	--master="${MASTER_ADDR}" \
 	--public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}" \


### PR DESCRIPTION
Using a low port for DNS seems to cause issues.