### PR TITLE
no need to build networking pkg in build-tests session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ all build:
 #   make build-tests
 build-tests:
 	hack/build-go.sh test/extended/extended.test
-	hack/build-go.sh test/extended/networking/extended.test
 	hack/build-go.sh test/integration/integration.test -tags='integration docker'
 .PHONY: build-tests
 


### PR DESCRIPTION
I don't  think we  need a separate building this module for testing，there is no *_test.go file in networking directory.