### PR TITLE
implement basic DDOS protections in the HAProxy template router

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -219,18 +219,41 @@ backend be_edge_http_{{$cfgIdx}}
   mode http
   option redispatch
   option forwardfor
-    {{ with $balanceAlgo := index $cfg.Annotations "router.openshift.io/haproxy.balance" }}
+    {{ with $balanceAlgo := index $cfg.Annotations "haproxy.router.openshift.io/balance" }}
       {{ with $matchValue := (matchValues $balanceAlgo "roundrobin" "leastconn" "source" ) }}
   balance {{ $balanceAlgo }}
       {{ end }}
     {{ else }}
   balance leastconn
     {{ end }}
-    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+    {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout server  {{$value}}
       {{ end }}
     {{ end }}
+
+{{ if index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections" }}
+  stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
+  tcp-request content track-sc2 src
+  {{ if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }} 
+  tcp-request content reject if { src_conn_cur ge  {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp" }} }
+  {{ else }}
+  # concurrent TCP connections not restricted
+  {{ end }}
+
+  {{ if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp")) }} 
+  tcp-request content reject if { src_conn_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-tcp" }} }
+  {{ else }}
+  #TCP connection rate not restricted
+  {{ end }}
+
+  {{ if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http")) }} 
+  tcp-request content reject if { src_http_req_rate ge {{ index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.rate-http" }} }
+  {{ else }}
+  #HTTP request rate not restricted
+  {{ end }}
+{{ end }}
+
   timeout check 5000ms
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
@@ -257,14 +280,14 @@ backend be_tcp_{{$cfgIdx}}
 {{ if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
   option tcplog
 {{ end }}
-    {{ with $balanceAlgo := index $cfg.Annotations "router.openshift.io/haproxy.balance" }}
+    {{ with $balanceAlgo := index $cfg.Annotations "haproxy.router.openshift.io/balance" }}
       {{ with $matchValue := (matchValues $balanceAlgo "roundrobin" "leastconn" "source" ) }}
   balance {{ $balanceAlgo }}
       {{ end }}
     {{ else }}
   balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source" }}
     {{ end }}
-    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+    {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout server  {{$value}}
       {{ end }}
@@ -285,14 +308,14 @@ backend be_tcp_{{$cfgIdx}}
 backend be_secure_{{$cfgIdx}}
   mode http
   option redispatch
-    {{ with $balanceAlgo := index $cfg.Annotations "router.openshift.io/haproxy.balance" }}
+    {{ with $balanceAlgo := index $cfg.Annotations "haproxy.router.openshift.io/balance" }}
       {{ with $matchValue := (matchValues $balanceAlgo "roundrobin" "leastconn" "source" ) }}
   balance {{ $balanceAlgo }}
       {{ end }}
     {{ else }}
   balance leastconn
     {{ end }}
-    {{ with $value := index $cfg.Annotations "router.openshift.io/haproxy.timeout"}}
+    {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout server  {{$value}}
       {{ end }}

--- a/test/extended/testdata/weighted-router.yaml
+++ b/test/extended/testdata/weighted-router.yaml
@@ -47,7 +47,7 @@ items:
       test: router
       select: weighted
     annotations:
-      router.openshift.io/haproxy.balance: roundrobin
+      haproxy.router.openshift.io/balance: roundrobin
   spec:
     host: weighted.example.com
     to:


### PR DESCRIPTION
Using annotations implement basic DDOS protections in the HAProxy router
   - ability to limit the number of concurrent TCP connections
   - limit the rate at which a client can request TCP connections
   - limit the rate at which HTTP requests can be made

These are enabled on a per route bases because apps could have extremely
different traffic patterns

setting "router.openshift.io/haproxy.DDOS" enables the settings to be
configured

setting "router.openshift.io/haproxy.DDOS.concurrentTCP" changes the
number concurrent TCP connections that can be made by the same IP
address on this route.

setting "router.openshift.io/haproxy.DDOS.rateTCP" changes the number of
TCP connections that can be opened by a client IP.

setting "router.openshift.io/haproxy.DDOS.rateHTTP" changes the number
of HTTP requests that a client IP can make in a 3s period.

Since traffic patterns can vary wildly I provided no default values for
these protections

If the DDOS conditions are violated the router closes the connection to
the client.