### PR TITLE
Extended builds

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20463,6 +20463,17 @@
      "forcePull": {
       "type": "boolean",
       "description": "forcePull describes if the builder should pull the images from registry prior to building."
+     },
+     "runtimeImage": {
+      "$ref": "v1.ObjectReference",
+      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use."
+     },
+     "runtimeArtifacts": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ImageSourcePath"
+      },
+      "description": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR."
      }
     }
    },

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -908,6 +908,26 @@ func DeepCopy_api_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildSt
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := in.RuntimeImage, &out.RuntimeImage
+		*out = new(api.ObjectReference)
+		if err := api.DeepCopy_api_ObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]ImageSourcePath, len(in))
+		for i := range in {
+			if err := DeepCopy_api_ImageSourcePath(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -516,6 +516,18 @@ type SourceBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
+
+	// RuntimeImage is an optional image that is used to run an application
+	// without unneeded dependencies installed. The building of the application
+	// is still done in the builder image but, post build, you can copy the
+	// needed artifacts in the runtime image for use.
+	RuntimeImage *kapi.ObjectReference
+
+	// RuntimeArtifacts specifies a list of source/destination pairs that will be
+	// copied from the builder to a runtime image. sourcePath can be a file or
+	// directory. destinationDir must be a directory. destinationDir can also be
+	// empty or equal to ".", in this case it just refers to the root of WORKDIR.
+	RuntimeArtifacts []ImageSourcePath
 }
 
 // JenkinsPipelineStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -1764,6 +1764,26 @@ func autoConvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBui
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := &in.RuntimeImage, &out.RuntimeImage
+		*out = new(api.ObjectReference)
+		if err := api_v1.Convert_v1_ObjectReference_To_api_ObjectReference(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]build_api.ImageSourcePath, len(*in))
+		for i := range *in {
+			if err := Convert_v1_ImageSourcePath_To_api_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 
@@ -1794,6 +1814,26 @@ func autoConvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy(in *build_api
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := &in.RuntimeImage, &out.RuntimeImage
+		*out = new(api_v1.ObjectReference)
+		if err := api_v1.Convert_api_ObjectReference_To_v1_ObjectReference(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := &in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]ImageSourcePath, len(*in))
+		for i := range *in {
+			if err := Convert_api_ImageSourcePath_To_v1_ImageSourcePath(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -890,6 +890,26 @@ func DeepCopy_v1_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildStr
 	out.Scripts = in.Scripts
 	out.Incremental = in.Incremental
 	out.ForcePull = in.ForcePull
+	if in.RuntimeImage != nil {
+		in, out := in.RuntimeImage, &out.RuntimeImage
+		*out = new(api_v1.ObjectReference)
+		if err := api_v1.DeepCopy_v1_ObjectReference(*in, *out, c); err != nil {
+			return err
+		}
+	} else {
+		out.RuntimeImage = nil
+	}
+	if in.RuntimeArtifacts != nil {
+		in, out := in.RuntimeArtifacts, &out.RuntimeArtifacts
+		*out = make([]ImageSourcePath, len(in))
+		for i := range in {
+			if err := DeepCopy_v1_ImageSourcePath(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.RuntimeArtifacts = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/v1/generated.pb.go
+++ b/pkg/build/api/v1/generated.pb.go
@@ -1953,6 +1953,28 @@ func (m *SourceBuildStrategy) MarshalTo(data []byte) (int, error) {
 		data[i] = 0
 	}
 	i++
+	if m.RuntimeImage != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintGenerated(data, i, uint64(m.RuntimeImage.Size()))
+		n61, err := m.RuntimeImage.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n61
+	}
+	if len(m.RuntimeArtifacts) > 0 {
+		for _, msg := range m.RuntimeArtifacts {
+			data[i] = 0x42
+			i++
+			i = encodeVarintGenerated(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
 	return i, nil
 }
 
@@ -2005,11 +2027,11 @@ func (m *SourceRevision) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x12
 		i++
 		i = encodeVarintGenerated(data, i, uint64(m.Git.Size()))
-		n61, err := m.Git.MarshalTo(data[i:])
+		n62, err := m.Git.MarshalTo(data[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n61
+		i += n62
 	}
 	return i, nil
 }
@@ -2689,6 +2711,16 @@ func (m *SourceBuildStrategy) Size() (n int) {
 	n += 1 + l + sovGenerated(uint64(l))
 	n += 2
 	n += 2
+	if m.RuntimeImage != nil {
+		l = m.RuntimeImage.Size()
+		n += 1 + l + sovGenerated(uint64(l))
+	}
+	if len(m.RuntimeArtifacts) > 0 {
+		for _, e := range m.RuntimeArtifacts {
+			l = e.Size()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -8508,6 +8540,70 @@ func (m *SourceBuildStrategy) Unmarshal(data []byte) error {
 				}
 			}
 			m.ForcePull = bool(v != 0)
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeImage", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RuntimeImage == nil {
+				m.RuntimeImage = &k8s_io_kubernetes_pkg_api_v1.ObjectReference{}
+			}
+			if err := m.RuntimeImage.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeArtifacts", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RuntimeArtifacts = append(m.RuntimeArtifacts, ImageSourcePath{})
+			if err := m.RuntimeArtifacts[len(m.RuntimeArtifacts)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(data[iNdEx:])

--- a/pkg/build/api/v1/generated.proto
+++ b/pkg/build/api/v1/generated.proto
@@ -729,6 +729,18 @@ message SourceBuildStrategy {
 
   // forcePull describes if the builder should pull the images from registry prior to building.
   optional bool forcePull = 6;
+
+  // runtimeImage is an optional image that is used to run an application
+  // without unneeded dependencies installed. The building of the application
+  // is still done in the builder image but, post build, you can copy the
+  // needed artifacts in the runtime image for use.
+  optional k8s.io.kubernetes.pkg.api.v1.ObjectReference runtimeImage = 7;
+
+  // runtimeArtifacts specifies a list of source/destination pairs that will be
+  // copied from the builder to the runtime image. sourcePath can be a file or
+  // directory. destinationDir must be a directory. destinationDir can also be
+  // empty or equal to ".", in this case it just refers to the root of WORKDIR.
+  repeated ImageSourcePath runtimeArtifacts = 8;
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -413,13 +413,15 @@ func (SecretSpec) SwaggerDoc() map[string]string {
 }
 
 var map_SourceBuildStrategy = map[string]string{
-	"":            "SourceBuildStrategy defines input parameters specific to an Source build.",
-	"from":        "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled",
-	"pullSecret":  "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries",
-	"env":         "env contains additional environment variables you want to pass into a builder container",
-	"scripts":     "scripts is the location of Source scripts",
-	"incremental": "incremental flag forces the Source build to do incremental builds if true.",
-	"forcePull":   "forcePull describes if the builder should pull the images from registry prior to building.",
+	"":                 "SourceBuildStrategy defines input parameters specific to an Source build.",
+	"from":             "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the docker image should be pulled",
+	"pullSecret":       "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the Docker images from the private Docker registries",
+	"env":              "env contains additional environment variables you want to pass into a builder container",
+	"scripts":          "scripts is the location of Source scripts",
+	"incremental":      "incremental flag forces the Source build to do incremental builds if true.",
+	"forcePull":        "forcePull describes if the builder should pull the images from registry prior to building.",
+	"runtimeImage":     "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use.",
+	"runtimeArtifacts": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR.",
 }
 
 func (SourceBuildStrategy) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -479,6 +479,18 @@ type SourceBuildStrategy struct {
 
 	// forcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty" protobuf:"varint,6,opt,name=forcePull"`
+
+	// runtimeImage is an optional image that is used to run an application
+	// without unneeded dependencies installed. The building of the application
+	// is still done in the builder image but, post build, you can copy the
+	// needed artifacts in the runtime image for use.
+	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty" protobuf:"bytes,7,opt,name=runtimeImage"`
+
+	// runtimeArtifacts specifies a list of source/destination pairs that will be
+	// copied from the builder to the runtime image. sourcePath can be a file or
+	// directory. destinationDir must be a directory. destinationDir can also be
+	// empty or equal to ".", in this case it just refers to the root of WORKDIR.
+	RuntimeArtifacts []ImageSourcePath `json:"runtimeArtifacts,omitempty" protobuf:"bytes,8,rep,name=runtimeArtifacts"`
 }
 
 // JenkinsPipelineBuildStrategy holds parameters specific to a Jenkins Pipeline build.

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -503,6 +503,7 @@ func validateSourceStrategy(strategy *buildapi.SourceBuildStrategy, fldPath *fie
 	allErrs = append(allErrs, validateFromImageReference(&strategy.From, fldPath.Child("from"))...)
 	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret, fldPath.Child("pullSecret"))...)
 	allErrs = append(allErrs, ValidateStrategyEnv(strategy.Env, fldPath.Child("env"))...)
+	allErrs = append(allErrs, validateRuntimeImage(strategy, fldPath.Child("runtimeImage"))...)
 	return allErrs
 }
 
@@ -650,4 +651,22 @@ func validatePostCommit(spec buildapi.BuildPostCommitSpec, fldPath *field.Path) 
 		allErrs = append(allErrs, field.Invalid(fldPath, spec, "cannot use command and script together"))
 	}
 	return allErrs
+}
+
+// validateRuntimeImage verifies that the runtimeImage field in
+// SourceBuildStrategy is not empty if it was specified and also checks to see
+// if the incremental build flag was specified, which is incompatible since we
+// can't have extended incremental builds.
+func validateRuntimeImage(sourceStrategy *buildapi.SourceBuildStrategy, fldPath *field.Path) (allErrs field.ErrorList) {
+	if sourceStrategy.RuntimeImage == nil {
+		return
+	}
+	if sourceStrategy.RuntimeImage.Name == "" {
+		return append(allErrs, field.Required(fldPath, "name"))
+	}
+
+	if sourceStrategy.Incremental {
+		return append(allErrs, field.Invalid(fldPath, sourceStrategy.Incremental, "incremental cannot be set to true with extended builds"))
+	}
+	return
 }

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -123,5 +124,24 @@ func TestGetStrategyError(t *testing.T) {
 	})
 	if err := s2iBuilder.Build(); err != expErr {
 		t.Errorf("s2iBuilder.Build() = %v; want %v", err, expErr)
+	}
+}
+
+func TestCopyToVolumeList(t *testing.T) {
+	newArtifacts := []api.ImageSourcePath{
+		{
+			SourcePath:     "/path/to/source",
+			DestinationDir: "path/to/destination",
+		},
+	}
+	volumeList := s2iapi.VolumeList{
+		s2iapi.VolumeSpec{
+			Source:      "/path/to/source",
+			Destination: "path/to/destination",
+		},
+	}
+	newVolumeList := copyToVolumeList(newArtifacts)
+	if !reflect.DeepEqual(volumeList, newVolumeList) {
+		t.Errorf("Expected artifacts mapping to match %#v, got %#v instead!", volumeList, newVolumeList)
 	}
 }

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -504,6 +504,16 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 		if build.Spec.Strategy.SourceStrategy.PullSecret == nil {
 			build.Spec.Strategy.SourceStrategy.PullSecret = g.resolveImageSecret(ctx, builderSecrets, &build.Spec.Strategy.SourceStrategy.From, bc.Namespace)
 		}
+		if build.Spec.Strategy.SourceStrategy.RuntimeImage != nil {
+			runtimeImageName, err := g.resolveImageStreamReference(ctx, *build.Spec.Strategy.SourceStrategy.RuntimeImage, build.Status.Config.Namespace)
+			if err != nil {
+				return nil, err
+			}
+			build.Spec.Strategy.SourceStrategy.RuntimeImage = &kapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: runtimeImageName,
+			}
+		}
 	case build.Spec.Strategy.DockerStrategy != nil &&
 		build.Spec.Strategy.DockerStrategy.From != nil:
 		if image == "" {

--- a/test/extended/builds/s2i_extended_build.go
+++ b/test/extended/builds/s2i_extended_build.go
@@ -1,0 +1,170 @@
+package builds
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/kubernetes/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[builds][Slow] s2i extended build", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                 = exutil.NewCLI("extended-build", exutil.KubeConfigPath())
+		testDataDir        = exutil.FixturePath("testdata", "build-extended")
+		scriptsFromRepoBc  = filepath.Join(testDataDir, "bc-scripts-in-repo.json")
+		scriptsFromUrlBc   = filepath.Join(testDataDir, "bc-scripts-by-url.json")
+		scriptsFromImageBc = filepath.Join(testDataDir, "bc-scripts-in-the-image.json")
+	)
+
+	g.Describe("with scripts from the source repository", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.It("should use assemble-runtime script from the source repository", func() {
+			const buildConfigName = "java-extended-build-from-repo"
+			const buildName = buildConfigName + "-1"
+
+			g.By("creating build config")
+			err := oc.Run("create").Args("-f", scriptsFromRepoBc).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// we have to wait until image stream tag will be available, otherwise
+			// `oc start-build` will fail with 'imagestreamtags "wildfly:10.0" not found' error.
+			// See this issue for details: https://github.com/openshift/origin/issues/10103
+			g.By("waiting when image stream tag for wildfly will be available")
+			wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+				out, err := oc.Run("get").Args("imagestreamtags", "--namespace", "openshift", "--output", `jsonpath='{.items[?(@.metadata.name=="wildfly:10.0")].image.dockerImageReference}'`).Output()
+				if err != nil {
+					fmt.Fprintf(g.GinkgoWriter, "Could not get image stream tag for wildfly: %v\n", err)
+					return false, err
+				}
+				if len(out) > 0 && out != "''" {
+					fmt.Fprintf(g.GinkgoWriter, "Using image stream tag for wildfly: %s\n", out)
+					return true, nil
+				}
+
+				return false, nil
+			})
+
+			g.By("running the build")
+			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			if err != nil {
+				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the build to complete")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+			if err != nil {
+				exutil.DumpBuildLogs(buildConfigName, oc)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			buildLog, err := oc.Run("logs").Args("--follow", "build/"+buildName).Output()
+			if err != nil {
+				e2e.Failf("Failed to fetch build logs of %q: %v", buildLog, err)
+			}
+
+			g.By("expecting that .s2i/bin/assemble-runtime was executed")
+			o.Expect(buildLog).To(o.ContainSubstring(`Using "assemble-runtime" installed from "<source-dir>/.s2i/bin/assemble-runtime"`))
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: assembling app within runtime image"))
+
+			g.By("expecting that environment variable from BuildConfig is available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_BUILD_CONFIG=yes"))
+
+			g.By("expecting that environment variable from .s2i/environment is available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_FILE=yes"))
+		})
+	})
+
+	g.Describe("with scripts from URL", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.It("should use assemble-runtime script from URL", func() {
+			const buildConfigName = "java-extended-build-from-url"
+			const buildName = buildConfigName + "-1"
+
+			g.By("creating build config")
+			err := oc.Run("create").Args("-f", scriptsFromUrlBc).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("running the build")
+			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			if err != nil {
+				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the build to complete")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+			if err != nil {
+				exutil.DumpBuildLogs(buildConfigName, oc)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			buildLog, err := oc.Run("logs").Args("--follow", "build/"+buildName).Output()
+			if err != nil {
+				e2e.Failf("Failed to fetch build logs of %q: %v", buildLog, err)
+			}
+
+			g.By("expecting that .s2i/bin/assemble-runtime was executed")
+			o.Expect(buildLog).To(o.ContainSubstring(`Using "assemble-runtime" installed from "https://raw.githubusercontent.com/php-coder/java-maven-hello-world/s2i-assemble-and-assemble-runtime/.s2i/bin/assemble-runtime"`))
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: assembling app within runtime image"))
+
+			g.By("expecting that environment variable from BuildConfig is available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_BUILD_CONFIG=yes"))
+
+			g.By("expecting that environment variable from .s2i/environment isn't available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_FILE=no"))
+		})
+	})
+
+	g.Describe("with scripts from runtime image", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.It("should use assemble-runtime script from that image", func() {
+			const buildConfigName = "java-extended-build-from-image"
+			const buildName = buildConfigName + "-1"
+
+			g.By("creating build config")
+			err := oc.Run("create").Args("-f", scriptsFromImageBc).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("running the build")
+			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			if err != nil {
+				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for the build to complete")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+			if err != nil {
+				exutil.DumpBuildLogs(buildConfigName, oc)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			buildLog, err := oc.Run("logs").Args("--follow", "build/"+buildName).Output()
+			if err != nil {
+				e2e.Failf("Failed to fetch build logs of %q: %v", buildLog, err)
+			}
+
+			g.By("expecting that .s2i/bin/assemble-runtime was executed")
+			o.Expect(buildLog).To(o.ContainSubstring(`Using "assemble-runtime" installed from "image:///usr/libexec/s2i/assemble-runtime"`))
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: assembling app within runtime image"))
+
+			g.By("expecting that environment variable from BuildConfig is available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_BUILD_CONFIG=yes"))
+
+			g.By("expecting that environment variable from .s2i/environment isn't available")
+			o.Expect(buildLog).To(o.ContainSubstring(".s2i/bin/assemble-runtime: USING_ENV_FROM_FILE=no"))
+		})
+	})
+
+})

--- a/test/extended/testdata/build-extended/bc-scripts-by-url.json
+++ b/test/extended/testdata/build-extended/bc-scripts-by-url.json
@@ -1,0 +1,39 @@
+{
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "java-extended-build-from-url"
+  },
+  "spec": {
+    "source": {
+      "git": {
+        "uri": "https://github.com/php-coder/java-maven-hello-world.git"
+      }
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "wildfly:10.0",
+          "namespace": "openshift"
+        },
+        "runtimeImage": {
+          "kind": "DockerImage",
+          "name": "phpcoder/base-jdk:8"
+        },
+        "runtimeArtifacts": [
+          {
+            "sourcePath": "/opt/s2i/destination/src/target/hello.jar"
+          }
+        ],
+        "env": [
+          {
+            "name": "USING_ENV_FROM_BUILD_CONFIG",
+            "value": "yes"
+          }
+        ],
+        "scripts": "https://raw.githubusercontent.com/php-coder/java-maven-hello-world/s2i-assemble-and-assemble-runtime/.s2i/bin"
+      }
+    }
+  }
+}

--- a/test/extended/testdata/build-extended/bc-scripts-in-repo.json
+++ b/test/extended/testdata/build-extended/bc-scripts-in-repo.json
@@ -1,0 +1,39 @@
+{
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "java-extended-build-from-repo"
+  },
+  "spec": {
+    "source": {
+      "git": {
+        "uri": "https://github.com/php-coder/java-maven-hello-world.git",
+        "ref": "s2i-assemble-and-assemble-runtime"
+      }
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "wildfly:10.0",
+          "namespace": "openshift"
+        },
+        "runtimeImage": {
+          "kind": "DockerImage",
+          "name": "phpcoder/base-jdk:8"
+        },
+        "runtimeArtifacts": [
+          {
+            "sourcePath": "/opt/s2i/destination/src/target/hello.jar"
+          }
+        ],
+        "env": [
+          {
+            "name": "USING_ENV_FROM_BUILD_CONFIG",
+            "value": "yes"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/extended/testdata/build-extended/bc-scripts-in-the-image.json
+++ b/test/extended/testdata/build-extended/bc-scripts-in-the-image.json
@@ -1,0 +1,34 @@
+{
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "java-extended-build-from-image"
+  },
+  "spec": {
+    "source": {
+      "git": {
+        "uri": "https://github.com/php-coder/java-maven-hello-world.git",
+        "ref": "s2i-assemble-only"
+      }
+    },
+    "strategy": {
+      "sourceStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "wildfly:10.0",
+          "namespace": "openshift"
+        },
+        "runtimeImage": {
+          "kind": "DockerImage",
+          "name": "phpcoder/hello-world-runtime:0.2"
+        },
+        "env": [
+          {
+            "name": "USING_ENV_FROM_BUILD_CONFIG",
+            "value": "yes"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
OLD PR: https://github.com/openshift/origin/pull/9596 (had to close it)

Trello: https://trello.com/c/MWUAjl6k/237-13-extended-builds-separate-mvn-vs-jboss-evg
This is dependent on: https://github.com/openshift/source-to-image/pull/505
To make this work, in your bc

```
   strategy:
      sourceStrategy:
        env:
        - name: EXAMPLE
          value: sample-app
        from:
          kind: ImageStreamTag
          name: wildfly:latest
        runtimeArtifacts:
        - sourcePath: /path/to/1
          destinationDir: path/to/1
        - sourcePath: /path/to/2
          destinationDir: path/to/2
        - sourcePath: /path/to/3
          destinationDir: path/to/3
        - sourcePath: /path/to/4
          destinationDir: path/to/4
        runtimeImage:
          kind: ImageStreamTag
          name: openjdk:latest
```
cc: @php-coder @bparees 
NOTE: sourcePath needs to be a full path insider your builder image that points to the file/dir that you want to be copied, while destinationDir is the path relative to your runtimeImage WORKDIR where your files will be copied

NOTE:
In order to run this, you need to update your s2i builder image with the current compiled binary.

either using [bindmountproxy](https://github.com/csrwng/bindmountproxy) this works with ```oc cluster up```  instructions are in the repo.

or by using [openshift-devtools](https://github.com/rhcarvalho/openshift-devtools/tree/master/extras)
```
extras/rebuild-s2i-builder
```
this will rebuild the s2i-builder image and copy your openshift locally compiled binary inside it (you need to run openshift with --latest-images for openshift to use that rebuilt image)
