### PR TITLE
Added checks in build path for docker-compose import

### DIFF
--- a/third_party/github.com/docker/libcompose/project/merge.go
+++ b/third_party/github.com/docker/libcompose/project/merge.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -166,6 +167,9 @@ func resolveBuild(inFile string, serviceData rawService) (rawService, error) {
 		if strings.HasPrefix(build, remote) {
 			return serviceData, nil
 		}
+	}
+	if filepath.IsAbs(build) {
+		return serviceData, nil
 	}
 
 	current := path.Dir(inFile)


### PR DESCRIPTION
So when build path is resolved, or when it is being converted from relative path to absolute path, a check has been added which checks if the path is already absolute, if it is, no further operations performed and value of Build path is kept unaltered.

Fixes #9815