### PR TITLE
Enable PersistentVolumeLabel admission plugin

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -316,6 +316,9 @@ var (
 		"AlwaysPullImages",
 		"LimitPodHardAntiAffinityTopology",
 		"SCCExecRestrictions",
+		"PersistentVolumeLabel",
+		// NOTE: quotaadmission and ClusterResourceQuota must be the last 2 plugins.
+		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		quotaadmission.PluginName,
 		"ClusterResourceQuota",
 	}
@@ -345,6 +348,9 @@ var (
 		"AlwaysPullImages",
 		"LimitPodHardAntiAffinityTopology",
 		"SCCExecRestrictions",
+		"PersistentVolumeLabel",
+		// NOTE: quotaadmission and ClusterResourceQuota must be the last 2 plugins.
+		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		quotaadmission.PluginName,
 		"ClusterResourceQuota",
 	}

--- a/pkg/cmd/server/origin/master_config_test.go
+++ b/pkg/cmd/server/origin/master_config_test.go
@@ -1,0 +1,31 @@
+package origin
+
+import (
+	"testing"
+
+	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
+)
+
+func TestQuotaAdmissionPluginsAreLast(t *testing.T) {
+	kubeLen := len(KubeAdmissionPlugins)
+	if kubeLen < 2 {
+		t.Fatalf("must have at least the 2 quota plugins")
+	}
+
+	if KubeAdmissionPlugins[kubeLen-2] != quotaadmission.PluginName {
+		t.Errorf("KubeAdmissionPlugins must have %s as the next to last plugin", quotaadmission.PluginName)
+	}
+
+	if KubeAdmissionPlugins[kubeLen-1] != "ClusterResourceQuota" {
+		t.Errorf("KubeAdmissionPlugins must have ClusterResourceQuota as the last plugin")
+	}
+
+	combinedLen := len(combinedAdmissionControlPlugins)
+	if combinedAdmissionControlPlugins[combinedLen-2] != quotaadmission.PluginName {
+		t.Errorf("combinedAdmissionControlPlugins must have %s as the next to last plugin", quotaadmission.PluginName)
+	}
+
+	if combinedAdmissionControlPlugins[combinedLen-1] != "ClusterResourceQuota" {
+		t.Errorf("combinedAdmissionControlPlugins must have ClusterResourceQuota as the last plugin")
+	}
+}

--- a/pkg/cmd/server/start/admission.go
+++ b/pkg/cmd/server/start/admission.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 


### PR DESCRIPTION
Enable PersistentVolumeLabel admission plugin. This labels AWS and GCE volumes with their zone, so the scheduler can limit the nodes for a pod to only those in the same zone as the peristent volumes being used by the pod.

Fixes bug 1356010

@smarterclayton @deads2k @liggitt 