### PR TITLE
Change defaultExporter to be public (DefaultExporter)

### DIFF
--- a/pkg/cmd/cli/cmd/export.go
+++ b/pkg/cmd/cli/cmd/export.go
@@ -48,7 +48,7 @@ to generate the API structure for a template to which you can add parameters and
 )
 
 func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
-	exporter := &defaultExporter{}
+	exporter := &DefaultExporter{}
 	var filenames []string
 	cmd := &cobra.Command{
 		Use:     "export RESOURCE/NAME ... [options]",

--- a/pkg/cmd/cli/cmd/exporter.go
+++ b/pkg/cmd/cli/cmd/exporter.go
@@ -38,9 +38,9 @@ type Exporter interface {
 	Export(obj runtime.Object, exact bool) error
 }
 
-type defaultExporter struct{}
+type DefaultExporter struct{}
 
-func (e *defaultExporter) AddExportOptions(flags *pflag.FlagSet) {
+func (e *DefaultExporter) AddExportOptions(flags *pflag.FlagSet) {
 }
 
 func exportObjectMeta(objMeta *kapi.ObjectMeta, exact bool) {
@@ -57,7 +57,7 @@ func exportObjectMeta(objMeta *kapi.ObjectMeta, exact bool) {
 	}
 }
 
-func (e *defaultExporter) Export(obj runtime.Object, exact bool) error {
+func (e *DefaultExporter) Export(obj runtime.Object, exact bool) error {
 	if meta, err := kapi.ObjectMetaFor(obj); err == nil {
 		exportObjectMeta(meta, exact)
 	} else {

--- a/pkg/cmd/cli/cmd/exporter_test.go
+++ b/pkg/cmd/cli/cmd/exporter_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestExport(t *testing.T) {
-	exporter := &defaultExporter{}
+	exporter := &DefaultExporter{}
 
 	baseSA := &kapi.ServiceAccount{}
 	baseSA.Name = "my-sa"


### PR DESCRIPTION
Makes defaultExporter struct (used by `oc export`) public, so this functionality can be used by other packages