### PR TITLE
Fully specify DeleteHostSubnet() rules

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -350,7 +350,8 @@ func (plugin *OsdnNode) DeleteHostSubnetRules(subnet *osapi.HostSubnet) error {
 
 	otx := ovs.NewTransaction(kexec.New(), BR)
 	otx.DeleteFlows("table=1, tun_src=%s", subnet.HostIP)
-	otx.DeleteFlows("table=8, nw_dst=%s", subnet.Subnet)
+	otx.DeleteFlows("table=8, ip, nw_dst=%s", subnet.Subnet)
+	otx.DeleteFlows("table=8, arp, nw_dst=%s", subnet.Subnet)
 	err := otx.EndTransaction()
 	if err != nil {
 		return fmt.Errorf("Error deleting OVS flows for subnet: %v, %v", subnet, err)


### PR DESCRIPTION
ovs-ofctl "helpfully" ignores nw_dst if you didn't also specify a protocol (ip or arp) where nw_dst is meaningful, meaning that DeleteHostSubnet() ended up always deleting the rules for *all* nodes
whenever any node was deleted.

----

We're going to have to backport this too... it means "oc delete node" in 1.2 is basically a trap.

Probably this didn't get caught in testing because you'd need a cluster with at least 3 schedulable nodes for it to be noticeable. There is a trello card about adding a test case for this (https://trello.com/c/qR9PftKg) but I hadn't gotten around to implementing it because to do it completely we need to be able to do an "ovs-ofctl dump-flows" on a node *after deleting that node*.

@openshift/networking 