### PR TITLE
Added a check for empty template in DeployConfig

### DIFF
--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -179,9 +179,14 @@ func addDeploymentConfigNestedLabels(obj *deployapi.DeploymentConfig, labels lab
 }
 
 func addDeploymentConfigNestedAnnotations(obj *deployapi.DeploymentConfig, annotations map[string]string) error {
+	if obj.Spec.Template == nil {
+		return nil
+	}
+
 	if obj.Spec.Template.Annotations == nil {
 		obj.Spec.Template.Annotations = make(map[string]string)
 	}
+
 	if err := MergeInto(obj.Spec.Template.Annotations, annotations, OverwriteExistingDstKey); err != nil {
 		return fmt.Errorf("unable to add annotations to Template.DeploymentConfig.Template.ControllerTemplate.Template: %v", err)
 	}


### PR DESCRIPTION
Added a check for if Spec.Template is nil.

Fixes #9835 

example content:
```
apiVersion: v1
kind: Template
objects:
- apiVersion: v1
  kind: DeploymentConfig
  metadata:
    name: example-deploymentconfig
  spec:
    template:
```

Old output:
```
oc new-app -f example.yaml 
--> Deploying template  for "example.yaml"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x98 pc=0x1088f4b]

goroutine 1 [running]:
panic(0x2220420, 0xc82000e0e0)
        /usr/lib/golang/src/runtime/panic.go:481 +0x3e6
github.com/openshift/origin/pkg/util.addDeploymentConfigNestedAnnotations(0xc82037e340, 0xc820656bd0, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/util/labels.go:182 +0x3b
github.com/openshift/origin/pkg/util.AddObjectAnnotations(0x7f8b599f09f0, 0xc82037e340, 0xc820656bd0, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/util/labels.go:118 +0x6f6
github.com/openshift/origin/pkg/cmd/cli/cmd.setAnnotations(0xc820656bd0, 0xc820650b00, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/cmd/cli/cmd/newapp.go:495 +0xc6
github.com/openshift/origin/pkg/cmd/cli/cmd.(*NewAppOptions).Run(0xc820282b60, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/cmd/cli/cmd/newapp.go:257 +0x6a6
github.com/openshift/origin/pkg/cmd/cli/cmd.NewCmdNewApplication.func1(0xc820546200, 0xc8205e7fe0, 0x0, 0x2)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/cmd/cli/cmd/newapp.go:147 +0xe8
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc820546200, 0xc8205e7e80, 0x2, 0x2, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:565 +0x85a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc8200b7800, 0xc820546200, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:651 +0x55c
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc8200b7800, 0x0, 0x0)
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:610 +0x2d
main.main()
        /home/rymurphy/documents/projects/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:29 +0x180
```

New output:
```
oc new-app -f example.yaml 
--> Deploying template  for "example.yaml"
error: unable to add nested annotations to /, Kind=/example-deploymentconfig: 
   DeploymentConfig example-deploymentconfig is invalid: undefined Template
```
@bparees ptal?