### PR TITLE
Add Dockerfiles.centos7 and job-id files for CentOS image building

### DIFF
--- a/images/base/.cccp.yml
+++ b/images/base/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-base

--- a/images/base/Dockerfile.centos7
+++ b/images/base/Dockerfile.centos7
@@ -1,0 +1,17 @@
+#
+# This is the base image from which all OpenShift Origin images inherit. Only packages
+# common to all downstream images should be here. Depends on Centos 7.2+
+#
+# The standard name for this image is openshift/origin-base
+#
+FROM centos:centos7
+
+RUN INSTALL_PKGS="which git tar wget hostname sysvinit-tools util-linux bsdtar centos-release-openshift-origin \
+      socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/origin
+
+LABEL io.k8s.display-name="OpenShift Origin Centos 7 Base" \
+      io.k8s.description="This is the base image from which all OpenShift Origin images inherit."

--- a/images/builder/docker/custom-docker-builder/.cccp.yml
+++ b/images/builder/docker/custom-docker-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-custom-docker-builder

--- a/images/builder/docker/custom-docker-builder/Dockerfile
+++ b/images/builder/docker/custom-docker-builder/Dockerfile
@@ -17,7 +17,7 @@
 FROM openshift/origin-base
 
 RUN INSTALL_PKGS="gettext automake make docker" && \
-    yum install -y --enablerepo=centosplus $INSTALL_PKGS && \
+    yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
 

--- a/images/builder/docker/docker-builder/.cccp.yml
+++ b/images/builder/docker/docker-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-docker-builder

--- a/images/builder/docker/sti-builder/.cccp.yml
+++ b/images/builder/docker/sti-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-sti-builder

--- a/images/deployer/.cccp.yml
+++ b/images/deployer/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-deployer

--- a/images/dind/Dockerfile.centos7
+++ b/images/dind/Dockerfile.centos7
@@ -1,0 +1,67 @@
+#
+# This image is used for running a host of an openshift dev cluster. This image is
+# a development support image and should not be used in production environments.
+#
+# The standard name for this image is openshift/dind
+#
+FROM centos:centos7
+
+## Configure systemd to run in a container
+ENV container=docker
+
+RUN systemctl mask\
+ auditd.service\
+ console-getty.service\
+ dev-hugepages.mount\
+ dnf-makecache.service\
+ docker-storage-setup.service\
+ getty.target\
+ lvm2-lvmetad.service\
+ sys-fs-fuse-connections.mount\
+ systemd-logind.service\
+ systemd-remount-fs.service\
+ systemd-udev-hwdb-update.service\
+ systemd-udev-trigger.service\
+ systemd-udevd.service\
+ systemd-vconsole-setup.service
+
+RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; \
+  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+
+VOLUME ["/run", "/tmp"]
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="git golang mercurial tar make findutils \
+      gcc hostname bind-utils iproute iputils which procps-ng openssh-server \
+      docker openvswitch bridge-utils ethtool iptables-services" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V --nofiles $INSTALL_PKGS && \
+    yum clean all
+
+# sshd should be enabled as needed
+RUN systemctl disable sshd.service
+
+## Configure dind
+ENV DIND_COMMIT 81aa1b507f51901eafcfaad70a656da376cf937d
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" \
+  -o /usr/local/bin/dind && chmod +x /usr/local/bin/dind
+RUN mkdir -p /etc/systemd/system/docker.service.d
+COPY dind.conf /etc/systemd/system/docker.service.d/
+
+RUN systemctl enable docker
+
+VOLUME /var/lib/docker
+
+## Hardlink init to another name to avoid having oci-systemd-hooks
+## detect containers using this image as requiring read-only cgroup
+## mounts.  dind containers should be run with --privileged to ensure
+## cgroups mounted with read-write permissions.
+RUN ln /usr/sbin/init /usr/sbin/dind_init
+
+CMD ["/usr/sbin/dind_init"]

--- a/images/dockerregistry/.cccp.yml
+++ b/images/dockerregistry/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-docker-registry

--- a/images/dockerregistry/Dockerfile.centos7
+++ b/images/dockerregistry/Dockerfile.centos7
@@ -1,0 +1,25 @@
+#
+# This is the integrated OpenShift Origin Docker registry. It is configured to
+# publish metadata to OpenShift to provide automatic management of images on push.
+#
+# The standard name for this image is openshift/origin-docker-registry
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="origin-dockerregistry" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+COPY config.yml $REGISTRY_CONFIGURATION_PATH
+
+LABEL io.k8s.display-name="OpenShift Origin Image Registry" \
+      io.k8s.description="This is a component of OpenShift Origin and exposes a Docker registry that is integrated with the cluster for authentication and management."
+
+# The registry doesn't require a root user.
+USER 1001
+EXPOSE 5000
+VOLUME /registry
+ENV REGISTRY_CONFIGURATION_PATH=/config.yml
+
+CMD DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} /usr/bin/dockerregistry ${REGISTRY_CONFIGURATION_PATH}

--- a/images/ipfailover/keepalived/.cccp.yml
+++ b/images/ipfailover/keepalived/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-keepalived-ipfailover

--- a/images/node/.cccp.yml
+++ b/images/node/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: node

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -1,0 +1,29 @@
+#
+# This is an OpenShift Origin node image with integrated OpenvSwitch SDN
+# If you do not require OVS SDN use the openshift/origin image instead.
+#
+# This image expects to have a volume mounted at /etc/origin/node that contains
+# a KUBECONFIG file giving the node permission to talk to the master and a
+# node configuration file.
+#
+# The standard name for this image is openshift/node
+#
+FROM openshift/origin
+
+COPY scripts/* /usr/local/bin/
+
+RUN INSTALL_PKGS="origin-sdn-ovs libmnl libnetfilter_conntrack openvswitch \
+      libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
+      binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
+      ceph-common iscsi-initiator-utils" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /usr/lib/systemd/system/origin-node.service.d /usr/lib/systemd/system/docker.service.d && \
+    chmod +x /usr/local/bin/* /usr/bin/openshift-*
+
+LABEL io.k8s.display-name="OpenShift Origin Node" \
+      io.k8s.description="This is a component of OpenShift Origin and contains the software for individual nodes when using SDN."
+VOLUME /etc/origin/node
+ENV KUBECONFIG=/etc/origin/node/node.kubeconfig
+ENTRYPOINT [ "/usr/local/bin/origin-node-run.sh" ]

--- a/images/openvswitch/.cccp.yml
+++ b/images/openvswitch/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: openvswitch

--- a/images/origin/.cccp.yml
+++ b/images/origin/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin

--- a/images/origin/Dockerfile.centos7
+++ b/images/origin/Dockerfile.centos7
@@ -1,0 +1,27 @@
+#
+# This is the official OpenShift Origin image. It has as its entrypoint the OpenShift
+# all-in-one binary.
+#
+# While this image can be used for a simple node it does not support OVS based
+# SDN or storage plugins required for EBS, GCE, Gluster, Ceph, or iSCSI volume
+# management. For those features please use 'openshift/node' 
+#
+# The standard name for this image is openshift/origin
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    setcap 'cap_net_bind_service=ep' /usr/bin/openshift
+
+LABEL io.k8s.display-name="OpenShift Origin Application Platform" \
+      io.k8s.description="OpenShift Origin is a platform for developing, building, and deploying containerized applications. See https://docs.openshift.org/latest for more on running OpenShift Origin."
+ENV HOME=/root \
+    OPENSHIFT_CONTAINERIZED=true \
+    KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig
+VOLUME /var/lib/origin
+WORKDIR /var/lib/origin
+EXPOSE 8443 53
+ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/pod/.cccp.yml
+++ b/images/pod/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-pod

--- a/images/pod/Dockerfile.centos7
+++ b/images/pod/Dockerfile.centos7
@@ -1,0 +1,27 @@
+#
+# This is the official OpenShift Origin pod infrastructure image. It will stay running
+# until terminated by a signal and is the heart of each running pod. It holds on to
+# the network and IPC namespaces as containers come and go during the lifetime of the
+# pod.
+#
+# The standard name for this image is openshift/origin-pod
+#
+FROM centos:centos7
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="origin-pod" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    ln -s /usr/bin/pod /pod
+
+USER 1001
+LABEL io.k8s.display-name="OpenShift Origin Pod Infrastructure" \
+      io.k8s.description="This is a component of OpenShift Origin and holds on to the shared Linux namespaces within a Pod."
+ENTRYPOINT ["/pod"]

--- a/images/recycler/.cccp.yml
+++ b/images/recycler/.cccp.yml
@@ -1,0 +1,2 @@
+job-id: origin-recycler
+

--- a/images/release/.cccp.yml
+++ b/images/release/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-release

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.6 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.4.2 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel golang golang-vet golang-cover golang-pkg-darwin-amd64 golang-pkg-windows-amd64 golang-pkg-linux-386" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar golang golang-vet golang-cover golang-pkg-darwin-amd64 golang-pkg-windows-amd64 golang-pkg-linux-386" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.6.2 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.7beta1 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/router/egress/.cccp.yml
+++ b/images/router/egress/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-egress-router

--- a/images/router/egress/Dockerfile
+++ b/images/router/egress/Dockerfile
@@ -5,7 +5,9 @@
 
 FROM openshift/origin-base
 
-RUN yum install -y iproute iputils && \
+RUN INSTALL_PKGS="iproute iputils" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum clean all
 
 ADD egress-router.sh /bin/egress-router.sh

--- a/images/router/f5/.cccp.yml
+++ b/images/router/f5/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-f5-router

--- a/images/router/haproxy-base/.cccp.yml
+++ b/images/router/haproxy-base/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-haproxy-router-base

--- a/images/router/haproxy/.cccp.yml
+++ b/images/router/haproxy/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-haproxy-router

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -10,12 +10,14 @@ FROM openshift/origin
 #       this is temporary and should be removed when the container is switch to an empty-dir
 #       with gid support.
 #
-RUN yum -y install haproxy && \
+RUN INSTALL_PKGS="haproxy" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
     mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_edge_http_expose,os_edge_http_redirect}.map,haproxy.config} && \
     chmod -R 777 /var && \
-    yum clean all && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy
 
 COPY . /var/lib/haproxy/


### PR DESCRIPTION
These files should not interfere with any non-CentOS work.
They make it possible to build OpenShift Origin images in CentOS's enviroment.