### PR TITLE
Description of (run the unit tests) is incorrect in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ See [HACKING.md](https://github.com/openshift/origin/blob/master/HACKING.md) for
 If you want to run the test suite, make sure you have your environment set up, and from the `origin` directory run:
 
 ```
-# run the unit tests
+# run the verifiers, unit tests, and command tests
 $ make check
 
 # run a command-line integration test suite


### PR DESCRIPTION
Description of how run unit tests is inaccurate, in current version, "make check " contains test-unit and test- cmd . It should be replaced by ”make test-unit“.