### PR TITLE
Test gssapi library load when selecting available challenge handlers

### DIFF
--- a/pkg/cmd/util/tokencmd/negotiator_gssapi.go
+++ b/pkg/cmd/util/tokencmd/negotiator_gssapi.go
@@ -49,6 +49,11 @@ func NewGSSAPINegotiator(principalName string) Negotiater {
 	return &gssapiNegotiator{principalName: principalName}
 }
 
+func (g *gssapiNegotiator) Load() error {
+	_, err := g.loadLib()
+	return err
+}
+
 func (g *gssapiNegotiator) InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error) {
 	lib, err := g.loadLib()
 	if err != nil {

--- a/pkg/cmd/util/tokencmd/negotiator_gssapi_unsupported.go
+++ b/pkg/cmd/util/tokencmd/negotiator_gssapi_unsupported.go
@@ -14,6 +14,9 @@ func NewGSSAPINegotiator(principalName string) Negotiater {
 	return &gssapiUnsupported{}
 }
 
+func (g *gssapiUnsupported) Load() error {
+	return errors.New("GSSAPI support is not enabled")
+}
 func (g *gssapiUnsupported) InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error) {
 	return nil, errors.New("GSSAPI support is not enabled")
 }


### PR DESCRIPTION
If a server sends a Negotiate challenge, and `oc` includes gssapi support, it attempts to load the gssapi shared library, then make gssapi InitSecContext calls to handle the negotiate challenge. 

Error messages coming back from InitSecContext are worth presenting to the user, but if gssapi libraries are not even present on the user's machine, displaying a dlopen error for a library is not likely to be useful.

This PR tests if the library can be loaded as part of deciding whether the client can even handle a negotiate challenge, and if it can't, skips the gssapi handler