### PR TITLE
Bug 1355721 - The value of skipcommit cannot be shown correctly when set router loglevel=4

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -654,7 +654,7 @@ func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
 // commit/reload should be skipped.
 func (r *templateRouter) SetSkipCommit(skipCommit bool) {
 	if r.skipCommit != skipCommit {
-		glog.V(4).Infof("Updating skip commit to: %s", skipCommit)
+		glog.V(4).Infof("Updating skip commit to: %t", skipCommit)
 		r.skipCommit = skipCommit
 	}
 }


### PR DESCRIPTION
fix the bug: https://bugzilla.redhat.com/show_bug.cgi?id=1355721