### PR TITLE
allow git_ssl_no_verify env variable in build pods

### DIFF
--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -25,7 +25,7 @@ const (
 	sourceSecretMountPath          = "/var/run/secrets/openshift.io/source"
 )
 
-var whitelistEnvVarNames = []string{"BUILD_LOGLEVEL"}
+var whitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY"}
 
 // FatalError is an error which can't be retried.
 type FatalError string


### PR DESCRIPTION
This will allow users to control whether our git clone does ssl verification or not, by setting a buildconfig env variable.

@liggitt ptal, i don't think there are any security risks (other than the ones users are signing themselves up for if they set this) to letting users control this env variable within our privileged builder pod, but a sanity check would be good.
