### PR TITLE
Dump deployment logs in case of test failure

### DIFF
--- a/test/extended/images/postgresql_replica.go
+++ b/test/extended/images/postgresql_replica.go
@@ -93,46 +93,53 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 
 		tableCounter := 0
 		assertReplicationIsWorking := func(masterDeployment, slaveDeployment string, slaveCount int) (exutil.Database, []exutil.Database, exutil.Database) {
+			check := func(err error) {
+				if err != nil {
+					exutil.DumpDeploymentLogs("postgresql-master", oc)
+					exutil.DumpDeploymentLogs("postgresql-slave", oc)
+				}
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
 			tableCounter++
 			table := fmt.Sprintf("table_%0.2d", tableCounter)
 
 			master, slaves, helper := CreatePostgreSQLReplicationHelpers(oc.KubeREST().Pods(oc.Namespace()), masterDeployment, slaveDeployment, fmt.Sprintf("%s-1", postgreSQLHelperName), slaveCount)
 			err := exutil.WaitUntilAllHelpersAreUp(oc, []exutil.Database{master, helper})
 			if err != nil {
+				exutil.DumpDeploymentLogs("postgresql-master", oc)
 				exutil.DumpDeploymentLogs("postgresql-helper", oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
+
 			err = exutil.WaitUntilAllHelpersAreUp(oc, slaves)
-			if err != nil {
-				exutil.DumpDeploymentLogs("postgresql-slave", oc)
-			}
-			o.Expect(err).NotTo(o.HaveOccurred())
+			check(err)
 
 			// Test if we can query as admin
 			oc.KubeFramework().WaitForAnEndpoint("postgresql-master")
 			err = helper.TestRemoteLogin(oc, "postgresql-master")
-			o.Expect(err).NotTo(o.HaveOccurred())
+			check(err)
 
 			// Create a new table with random name
 			_, err = master.Query(oc, fmt.Sprintf("CREATE TABLE %s (col1 VARCHAR(20), col2 VARCHAR(20));", table))
-			o.Expect(err).NotTo(o.HaveOccurred())
+			check(err)
 
 			// Write new data to the table through master
 			_, err = master.Query(oc, fmt.Sprintf("INSERT INTO %s (col1, col2) VALUES ('val1', 'val2');", table))
-			o.Expect(err).NotTo(o.HaveOccurred())
+			check(err)
 
 			// Make sure data is present on master
 			err = exutil.WaitForQueryOutputContains(oc, master, 10*time.Second, false,
 				fmt.Sprintf("SELECT * FROM %s;", table),
 				"col1 | val1\ncol2 | val2")
-			o.Expect(err).NotTo(o.HaveOccurred())
+			check(err)
 
 			// Make sure data was replicated to all slaves
 			for _, slave := range slaves {
 				err = exutil.WaitForQueryOutputContains(oc, slave, 90*time.Second, false,
 					fmt.Sprintf("SELECT * FROM %s;", table),
 					"col1 | val1\ncol2 | val2")
-				o.Expect(err).NotTo(o.HaveOccurred())
+				check(err)
 			}
 
 			return master, slaves, helper

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -145,7 +145,7 @@ func DumpDeploymentLogs(dc string, oc *CLI) {
 					podName := pod.ObjectMeta.Name
 
 					fmt.Fprintf(g.GinkgoWriter, "\n\n dumping logs for pod %s \n\n", podName)
-					depOuput, err := oc.Run("logs").Args("-f", "pod/"+podName).Output()
+					depOuput, err := oc.Run("logs").Args("pod/" + podName).Output()
 					if err == nil {
 						fmt.Fprintf(g.GinkgoWriter, "\n\n  logs for pod %s : %s\n\n", podName, depOuput)
 					} else {


### PR DESCRIPTION
This should help us with debugging extended test flakes for postgres, like #9688.

@bparees PTAL