### PR TITLE
[WIP] Listen unauthenticated requests on separate port

### DIFF
--- a/images/dockerregistry/Dockerfile
+++ b/images/dockerregistry/Dockerfile
@@ -15,6 +15,7 @@ LABEL io.k8s.display-name="OpenShift Origin Image Registry" \
 # The registry doesn't require a root user.
 USER 1001
 EXPOSE 5000
+EXPOSE 5001
 VOLUME /registry
 ENV REGISTRY_CONFIGURATION_PATH=/config.yml
 

--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -13,6 +13,7 @@ storage:
 auth:
   openshift:
     realm: openshift
+    noauthaddr: :5001
 middleware:
   registry:
     - name: openshift

--- a/pkg/bootstrap/docker/openshift/admin.go
+++ b/pkg/bootstrap/docker/openshift/admin.go
@@ -44,7 +44,7 @@ func (h *Helper) InstallRegistry(kubeClient kclient.Interface, f *clientcmd.Fact
 			Name:           "registry",
 			Type:           "docker-registry",
 			ImageTemplate:  imageTemplate,
-			Ports:          "5000",
+			Ports:          "5000,5001",
 			Replicas:       1,
 			Labels:         "docker-registry=default",
 			Volume:         "/registry",

--- a/pkg/serviceaccounts/controllers/docker_registry_service.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service.go
@@ -245,10 +245,12 @@ func (e *DockerRegistryServiceController) getDockerRegistryLocations() []string 
 
 	hasPortalIP := (len(service.Spec.ClusterIP) > 0) && (net.ParseIP(service.Spec.ClusterIP) != nil)
 	if hasPortalIP && len(service.Spec.Ports) > 0 {
-		return []string{
-			net.JoinHostPort(service.Spec.ClusterIP, fmt.Sprintf("%d", service.Spec.Ports[0].Port)),
-			net.JoinHostPort(fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace), fmt.Sprintf("%d", service.Spec.Ports[0].Port)),
+		var loc []string
+		for _, e := range service.Spec.Ports {
+			loc = append(loc, net.JoinHostPort(service.Spec.ClusterIP, fmt.Sprintf("%d", e.Port)))
+			loc = append(loc, net.JoinHostPort(fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace), fmt.Sprintf("%d", e.Port)))
 		}
+		return loc
 	}
 
 	return []string{}


### PR DESCRIPTION
Following the [trello card](https://trello.com/c/Ev8y3pC4/651-5-support-unauthenticated-docker-pull) I began to explore how to implement anonymous access like `docker.io`.

Before sending any commands, the client checks the API version and authentication is necessary. The client makes it [very easy](https://docs.docker.com/registry/spec/api/#/api-version-check). It sends a request to the url `/v2/`. Client assumes that authorization not required if `200 OK` response is returned. If a `401 Unauthorized` response is returned, the client should take action based on the contents of the “WWW-Authenticate” header.

If you try to `docker login` on the server and he said `200 OK`, the client will not send anything to the server because it is not necessary. That's why we always reply `401 Unauthorized` if the authorization data is not transferred.

At the stage of processing request to `/v2/`, we cannot understand what user will do next. Having just one server we can't process anonymous requests as well as authorized users requests.

So, how `docker.io` do it:

* When you run the command `docker login -u user` client send authorization data to `https://index.docker.io/v1/` which is v1 docker-registry.
* When you try to pull/push something all requests coming to `https://registry-1.docker.io` which is v2 docker-registry.

What can we do:

We can not do anything without a second server. I didn't want to break current behavior so I added a second server on a different port (5001). On it listens goroutine which allows you to perform unauthorized requests. So if you give rights to the `system:anonymous`:

`oc policy add-role-to-user registry-viewer system:anonymous`

We will be able to pull an image anonymously using port 5001.
I see no other way how to implement it.

@pweil- @smarterclayton @mfojtik @deads2k @liggitt @kargakis @soltysh @miminar 