### PR TITLE
dump etcd on test integration failures

### DIFF
--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -189,6 +189,7 @@ func setupAdmissionPluginTestConfig(t *testing.T, value string) string {
 }
 
 func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
@@ -204,6 +205,7 @@ func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin1configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
@@ -222,6 +224,7 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
@@ -241,6 +244,7 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
@@ -256,6 +260,7 @@ func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin2configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
@@ -274,6 +279,7 @@ func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
@@ -294,6 +300,8 @@ func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
 
 func TestAlwaysPullImagesOn(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -343,6 +351,8 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 
 func TestAlwaysPullImagesOff(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, kubeConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)

--- a/test/integration/api_paths_test.go
+++ b/test/integration/api_paths_test.go
@@ -20,6 +20,8 @@ import (
 
 func TestRootAPIPaths(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	masterConfig, adminConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error starting test master: %v", err)

--- a/test/integration/audit_test.go
+++ b/test/integration/audit_test.go
@@ -36,6 +36,7 @@ func setupAuditTest(t *testing.T) (*kclient.Client, *client.Client) {
 
 func TestBasicFunctionalityWithAudit(t *testing.T) {
 	kubeClient, _ := setupAuditTest(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	if _, err := kubeClient.Pods(kapi.NamespaceDefault).Watch(kapi.ListOptions{}); err != nil {
 		t.Errorf("Unexpected error watching pods: %v", err)

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -35,6 +35,8 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 	idp.MappingMethod = "claim"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -30,6 +30,8 @@ import (
 
 func TestClusterReaderCoverage(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -114,6 +116,8 @@ func TestClusterReaderCoverage(t *testing.T) {
 
 func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -185,6 +189,8 @@ func waitForProject(t *testing.T, client client.Interface, projectName string, d
 
 func TestAuthorizationResolution(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -373,7 +379,7 @@ func (test localResourceAccessReviewTest) run(t *testing.T) {
 
 func TestAuthorizationResourceAccessReview(t *testing.T) {
 	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t, "TestAuthorizationResourceAccessReview")
+	defer testutil.DumpEtcdOnFailure(t)
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -567,6 +573,7 @@ func (test subjectAccessReviewTest) run(t *testing.T) {
 
 func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
@@ -695,6 +702,8 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 
 func TestAuthorizationSubjectAccessReview(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -979,6 +988,8 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 // this is needed to support old docker registry images
 func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1106,6 +1117,8 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 // this is needed to support old who-can client
 func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -23,6 +23,8 @@ import (
 
 func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -79,6 +81,8 @@ func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T
 
 func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,6 +125,8 @@ func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
 
 func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -180,6 +186,8 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 
 func TestSelfSubjectAccessReviewsNonExistingNamespace(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, false)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
@@ -74,6 +75,7 @@ func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
 }
 
 func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, true)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -81,6 +81,7 @@ func mockBuild() *buildapi.Build {
 // TestConcurrentBuildControllers tests the transition of a build from new to pending. Ensures that only a single New -> Pending
 // transition happens and that only a single pod is created during a set period of time.
 func TestConcurrentBuildControllers(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	// Start a master with multiple BuildControllers
 	osClient, kClient := setupBuildControllerTest(controllerCount{BuildControllers: 5}, t)
 
@@ -161,6 +162,7 @@ type buildControllerPodTest struct {
 
 // TestConcurrentBuildPodControllers tests the lifecycle of a build pod when running multiple controllers.
 func TestConcurrentBuildPodControllers(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	// Start a master with multiple BuildPodControllers
 	osClient, kClient := setupBuildControllerTest(controllerCount{BuildPodControllers: 5}, t)
 
@@ -309,6 +311,7 @@ func TestConcurrentBuildPodControllers(t *testing.T) {
 }
 
 func TestConcurrentBuildImageChangeTriggerControllers(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	// Start a master with multiple ImageChangeTrigger controllers
 	osClient, _ := setupBuildControllerTest(controllerCount{ImageChangeControllers: 5}, t)
 	tag := "latest"
@@ -322,21 +325,25 @@ func TestConcurrentBuildImageChangeTriggerControllers(t *testing.T) {
 }
 
 func TestBuildDeleteController(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	runBuildDeleteTest(t, osClient, kClient)
 }
 
 func TestBuildRunningPodDeleteController(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	runBuildRunningPodDeleteTest(t, osClient, kClient)
 }
 
 func TestBuildCompletePodDeleteController(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	runBuildCompletePodDeleteTest(t, osClient, kClient)
 }
 
 func TestConcurrentBuildConfigControllers(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	osClient, kClient := setupBuildControllerTest(controllerCount{ConfigChangeControllers: 5}, t)
 	runBuildConfigChangeControllerTest(t, osClient, kClient)
 }

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -26,6 +26,7 @@ import (
 var buildPodAdmissionTestTimeout time.Duration = 10 * time.Second
 
 func TestBuildDefaultGitHTTPProxy(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	httpProxy := "http://my.test.proxy:12345"
 	oclient, kclient := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPProxy: httpProxy,
@@ -37,6 +38,7 @@ func TestBuildDefaultGitHTTPProxy(t *testing.T) {
 }
 
 func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	httpsProxy := "https://my.test.proxy:12345"
 	oclient, kclient := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPSProxy: httpsProxy,
@@ -48,6 +50,7 @@ func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
 }
 
 func TestBuildDefaultEnvironment(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	env := []kapi.EnvVar{
 		{
 			Name:  "VAR1",
@@ -68,6 +71,7 @@ func TestBuildDefaultEnvironment(t *testing.T) {
 }
 
 func TestBuildOverrideForcePull(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	oclient, kclient := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})
@@ -78,6 +82,7 @@ func TestBuildOverrideForcePull(t *testing.T) {
 }
 
 func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	oclient, kclient := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestCLIGetToken(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestClusterQuota(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestClusterResourceOverridePluginWithNoLimits(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	config := &overrideapi.ClusterResourceOverrideConfig{
 		LimitCPUToMemoryPercent:     100,
 		CPURequestToLimitPercent:    50,
@@ -45,6 +46,7 @@ func TestClusterResourceOverridePluginWithNoLimits(t *testing.T) {
 }
 
 func TestClusterResourceOverridePluginWithLimits(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	config := &overrideapi.ClusterResourceOverrideConfig{
 		LimitCPUToMemoryPercent:     100,
 		CPURequestToLimitPercent:    50,

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -19,6 +19,7 @@ func TestDeployScale(t *testing.T) {
 	const namespace = "test-deploy-scale"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -26,6 +26,7 @@ func TestTriggers_manual(t *testing.T) {
 	const namespace = "test-triggers-manual"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
@@ -103,6 +104,7 @@ func TestTriggers_manual(t *testing.T) {
 // will start a new deployment when an image change happens.
 func TestTriggers_imageChange(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -208,6 +210,7 @@ waitForNewConfig:
 // trigger will have its image updated without starting a new deployment.
 func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -353,6 +356,7 @@ out:
 // will start a new deployment iff all images are resolved.
 func TestTriggers_MultipleICTs(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -508,6 +512,7 @@ func TestTriggers_configChange(t *testing.T) {
 	const namespace = "test-triggers-configchange"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/diag_nodes_test.go
+++ b/test/integration/diag_nodes_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestDiagNodeConditions(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, nodeConfig, clientFile, err := testserver.StartTestAllInOne()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestDiscoveryGroupVersions(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error starting test master: %v", err)

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestDNS(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clientFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -55,6 +55,7 @@ func testOne(t *testing.T, client *kclient.Client, namespace, addrType string, s
 
 func TestEndpointAdmission(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -21,6 +21,7 @@ func TestExtensionsAPIDeletion(t *testing.T) {
 	const projName = "ext-deletion-proj"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -19,6 +19,7 @@ func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 	const projName = "ext-disabled-batch-enabled-proj"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -147,6 +148,7 @@ func TestExtensionsAPIDisabled(t *testing.T) {
 	const projName = "ext-disabled-proj"
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/external_kube_test.go
+++ b/test/integration/external_kube_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestExternalKube(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// Start one OpenShift master as "cluster1" to play the external kube server
 	cluster1MasterConfig, cluster1AdminConfigFile, err := testserver.StartTestMasterAPI()
 	if err != nil {

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestBasicUserBasedGroupManipulation(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -107,6 +108,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 
 func TestBasicGroupManipulation(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -177,6 +179,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 
 func TestGroupCommands(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -21,6 +21,7 @@ const (
 )
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -30,6 +31,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -39,6 +41,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -48,6 +51,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -57,6 +61,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -66,6 +71,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	projectAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -364,6 +370,7 @@ func runTest(t *testing.T, testname string, projectAdminClient *client.Client, i
 }
 
 func TestMultipleImageChangeBuildTriggers(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	mockImageStream := func(name, tag string) *imageapi.ImageStream {
 		return &imageapi.ImageStream{
 			ObjectMeta: kapi.ObjectMeta{Name: name},

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestImageStreamImport(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -197,6 +198,7 @@ func TestImageStreamImportOfV1ImageFromV2Repository(t *testing.T) {
 	}
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	// start regular HTTP servers
 	requireAuth := false
@@ -318,6 +320,7 @@ func TestImageStreamImportOfV1ImageFromV2Repository(t *testing.T) {
 
 func TestImageStreamImportAuthenticated(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, true, &count))
@@ -484,6 +487,7 @@ func TestImageStreamImportAuthenticated(t *testing.T) {
 // repository.
 func TestImageStreamImportTagsFromRepository(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, false, &count))
@@ -584,6 +588,7 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 // error occurs writes the error only once (instead of every interval)
 func TestImageStreamImportScheduled(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	written := make(chan struct{}, 1)
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/integration/imagestream_admission_test.go
+++ b/test/integration/imagestream_admission_test.go
@@ -21,6 +21,7 @@ import (
 const limitRangeName = "limits"
 
 func TestImageStreamTagsAdmission(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kClient, client := setupImageStreamAdmissionTest(t)
 
 	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest, imagetest.MiscImageDigest} {
@@ -216,6 +217,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 }
 
 func TestImageStreamAdmitSpecUpdate(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kClient, client := setupImageStreamAdmissionTest(t)
 
 	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest} {
@@ -354,6 +356,7 @@ func TestImageStreamAdmitSpecUpdate(t *testing.T) {
 }
 
 func TestImageStreamAdmitStatusUpdate(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kClient, client := setupImageStreamAdmissionTest(t)
 	images := []*imageapi.Image{}
 

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestImageStreamList(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -49,6 +50,7 @@ func mockImageStream() *imageapi.ImageStream {
 
 func TestImageStreamCreate(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -96,6 +98,7 @@ func TestImageStreamCreate(t *testing.T) {
 
 func TestImageStreamMappingCreate(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -283,6 +286,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 
 func TestImageStreamTagLifecycleHook(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestLeaderLeaseAcquire(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	client := testutil.NewEtcdClient()
 
 	key := "/random/key"
@@ -52,6 +53,7 @@ func TestLeaderLeaseAcquire(t *testing.T) {
 
 func TestLeaderLeaseWait(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	client := testutil.NewEtcdClient()
 	key := "/random/key"
 
@@ -93,6 +95,7 @@ func TestLeaderLeaseWait(t *testing.T) {
 
 func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	client := testutil.NewEtcdClient()
 	key := "/random/key"
 
@@ -124,6 +127,7 @@ func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 
 func TestLeaderLeaseReacquire(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	client := testutil.NewEtcdClient()
 	key := "/random/key"
 

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestLogin(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	clientcmd.DefaultCluster = clientcmdapi.Cluster{Server: ""}
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestNamespaceLifecycleAdmission(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -28,6 +28,7 @@ type testRequest struct {
 
 func TestNodeAuth(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// Server config
 	masterConfig, nodeConfig, adminKubeConfigFile, err := testserver.StartTestAllInOne()
 	if err != nil {

--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -309,6 +309,7 @@ func TestOAuthBasicAuthPassword(t *testing.T) {
 
 	// Build master config
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -40,6 +40,7 @@ func TestOAuthCertFallback(t *testing.T) {
 	)
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_disabled_test.go
+++ b/test/integration/oauth_disabled_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestOAuthDisabled(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -24,6 +24,7 @@ func TestOAuthHTPasswd(t *testing.T) {
 	defer os.Remove(htpasswdFile.Name())
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -82,6 +82,7 @@ func TestOAuthLDAP(t *testing.T) {
 	defer ldapServer.Stop()
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -69,6 +69,7 @@ func TestOAuthOIDC(t *testing.T) {
 
 	// Get master config
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -46,6 +46,7 @@ func TestOAuthRequestHeader(t *testing.T) {
 
 	// Get master config
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -55,6 +55,7 @@ func (u *testUser) ConvertFromAccessToken(*api.OAuthAccessToken) (interface{}, e
 
 func TestOAuthStorage(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/patch_test.go
+++ b/test/integration/patch_test.go
@@ -24,6 +24,7 @@ import (
 func TestPatchConflicts(t *testing.T) {
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -23,17 +23,20 @@ import (
 )
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameClusterAdmin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	oclient, kclient := setupClusterAdminPodNodeConstraintsTest(t, &pluginapi.PodNodeConstraintsConfig{})
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, cluster admin", kclient, oclient, "nodename.example.com", nil, false)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameNonAdmin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{}
 	oclient, kclient := setupUserPodNodeConstraintsTest(t, config, "derples")
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, regular user", kclient, oclient, "nodename.example.com", nil, true)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorClusterAdmin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}
@@ -42,6 +45,7 @@ func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorClusterAdmin(t *testing
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorNonAdmin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestPolicyCommands(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/project_reqlimit_test.go
+++ b/test/integration/project_reqlimit_test.go
@@ -125,6 +125,7 @@ func projectRequestLimitUsers() map[string]labels.Set {
 }
 
 func TestProjectRequestLimitMultiLevelConfig(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitMultiLevelConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -140,6 +141,7 @@ func TestProjectRequestLimitMultiLevelConfig(t *testing.T) {
 }
 
 func TestProjectRequestLimitEmptyConfig(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitEmptyConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -155,6 +157,7 @@ func TestProjectRequestLimitEmptyConfig(t *testing.T) {
 }
 
 func TestProjectRequestLimitSingleConfig(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitSingleDefaultConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -172,6 +175,7 @@ func TestProjectRequestLimitSingleConfig(t *testing.T) {
 // we had a bug where this failed on ` uenxpected error: metadata.name: Invalid value: "system:admin": may not contain ":"`
 // make sure we never have that bug again and that project limits for them work
 func TestProjectRequestLimitAsSystemAdmin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	_, oclient, _ := setupProjectRequestLimitTest(t, projectRequestLimitSingleDefaultConfig())
 
 	if _, err := oclient.ProjectRequests().Create(&projectapi.ProjectRequest{

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -20,6 +20,7 @@ import (
 // TestProjectIsNamespace verifies that a project is a namespace, and a namespace is a project
 func TestProjectIsNamespace(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -86,6 +87,7 @@ func TestProjectIsNamespace(t *testing.T) {
 // TestProjectMustExist verifies that content cannot be added in a project that does not exist
 func TestProjectMustExist(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -156,6 +158,7 @@ func TestProjectMustExist(t *testing.T) {
 
 func TestProjectWatch(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/root_redirect_test.go
+++ b/test/integration/root_redirect_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestRootRedirect(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, _, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -29,6 +29,7 @@ import (
 // processed.  Reload should similarly suppressed on subsequent
 // resyncs.
 func TestRouterReloadSuppressionOnSync(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	stressRouter(
 		t,
 		// Allow the test to be configured to enable experimentation

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -46,6 +46,7 @@ func testPodDuration(t *testing.T, name string, kclient kclient.Interface, pod *
 }
 
 func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsLimit: &secs,
@@ -58,6 +59,7 @@ func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
 }
 
 func TestRunOnceDurationAdmissionPluginProjectLimit(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsLimit: &secs,

--- a/test/integration/sa_oauthclient_test.go
+++ b/test/integration/sa_oauthclient_test.go
@@ -35,6 +35,7 @@ import (
 
 func TestSAAsOAuthClient(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestPodUpdateSCCEnforcement(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestScopedTokens(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -100,6 +101,7 @@ func TestScopedTokens(t *testing.T) {
 
 func TestScopedImpersonation(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -144,6 +146,7 @@ func TestScopedImpersonation(t *testing.T) {
 
 func TestScopeEscalations(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -224,6 +227,7 @@ func TestScopeEscalations(t *testing.T) {
 
 func TestTokensWithIllegalScopes(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestServiceAccountAuthorization(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	saNamespace := api.NamespaceDefault
 	saName := serviceaccountadmission.DefaultServiceAccountName
 	saUsername := serviceaccount.MakeUsername(saNamespace, saName)
@@ -248,6 +249,7 @@ func TestAutomaticCreationOfPullSecrets(t *testing.T) {
 	saName := serviceaccountadmission.DefaultServiceAccountName
 
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -305,6 +307,7 @@ func getServiceAccountPullSecret(client *kclient.Client, ns, name string) (strin
 
 func TestEnforcingServiceAccount(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
 	if err != nil {

--- a/test/integration/shortcut_expansion_test.go
+++ b/test/integration/shortcut_expansion_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestCachingDiscoveryClient(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, originKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -30,6 +30,7 @@ const (
 
 func TestSNI(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	// Create tempfiles with certs and keys we're going to use
 	certNames := map[string]string{}
 	for certName, certContents := range sniCerts {

--- a/test/integration/storage_versions_test.go
+++ b/test/integration/storage_versions_test.go
@@ -33,6 +33,7 @@ import (
 // }
 
 func TestStorageVersionsUnified(t *testing.T) {
+	defer testutil.DumpEtcdOnFailure(t)
 	runStorageTest(t, "unified",
 		extensions_v1beta1.SchemeGroupVersion,
 		extensions_v1beta1.SchemeGroupVersion,

--- a/test/integration/template_test.go
+++ b/test/integration/template_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestTemplate(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, path, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,6 +120,7 @@ func walkJSONFiles(inDir string, fn func(name, path string, data []byte)) error 
 
 func TestTemplateTransformationFromConfig(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestUnprivilegedNewProject(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -92,6 +93,7 @@ func TestUnprivilegedNewProject(t *testing.T) {
 }
 func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	namespace := "foo"
 	templateName := "bar"
 
@@ -187,6 +189,7 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 
 func TestUnprivilegedNewProjectDenied(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -67,6 +67,7 @@ func makeMapping(user, identity string) *api.UserIdentityMapping {
 
 func TestUserInitialization(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -72,6 +72,7 @@ func signedManifest(name string) ([]byte, digest.Digest, error) {
 
 func TestV2RegistryGetTags(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -85,6 +85,7 @@ func tryAccessURL(t *testing.T, url string, expectedStatus int, expectedRedirect
 
 func TestAccessOriginWebConsole(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -112,6 +113,7 @@ func TestAccessOriginWebConsole(t *testing.T) {
 
 func TestAccessDisabledWebConsole(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -150,6 +152,7 @@ func TestAccessDisabledWebConsole(t *testing.T) {
 
 func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -55,6 +55,7 @@ func TestWebConsoleExtensions(t *testing.T) {
 
 	// Build master config.
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("Failed creating master configuration: %v", err)

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestWebhookGitHubPushWithImage(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -123,6 +124,7 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 
 func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -223,6 +225,7 @@ func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 
 func TestWebhookGitHubPing(t *testing.T) {
 	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unable to start master: %v", err)

--- a/test/util/etcd.go
+++ b/test/util/etcd.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	goruntime "runtime"
+	"strings"
 	"testing"
 
 	"github.com/coreos/pkg/capnslog"
@@ -84,10 +86,15 @@ func withEtcdKey(f func(string)) {
 	f(prefix)
 }
 
-func DumpEtcdOnFailure(t *testing.T, name string) {
+func DumpEtcdOnFailure(t *testing.T) {
 	if !t.Failed() {
 		return
 	}
+
+	pc := make([]uintptr, 10)
+	goruntime.Callers(2, pc)
+	f := goruntime.FuncForPC(pc[0])
+	name := f.Name()[strings.LastIndex(f.Name(), "Test"):]
 
 	client := NewEtcdClient()
 	etcdResponse, err := client.RawGet("/", false, true)


### PR DESCRIPTION
Dumps etcd contents when an integration test fails.  Wow that tedious.

@enj ptal.