### PR TITLE
allow project-admin access to some resource quota objects

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -57,6 +57,7 @@ const (
 	AdminRoleName           = "admin"
 	EditRoleName            = "edit"
 	ViewRoleName            = "view"
+	QuotaManagerRoleName    = "quota-manager"
 	SelfProvisionerRoleName = "self-provisioner"
 	BasicUserRoleName       = "basic-user"
 	StatusCheckerRoleName   = "cluster-status"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -215,6 +215,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 				authorizationapi.NewRule("impersonate").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),
 
+				// project level roles are allowed to modify some resourcequota documents by default to constrain their projects.  They cannot touch all of them
+				// because allowing that would prevent a cluster-admin from constraining projects
+				authorizationapi.NewRule("get", "create", "update", "patch", "delete").Groups(kapiGroup).Resources("resourcequotas").Names(
+					"project-quota-01", "project-quota-02", "project-quota-03", "project-quota-04", "project-quota-05",
+					"project-quota-06", "project-quota-07", "project-quota-08", "project-quota-09", "project-quota-10").RuleOrDie(),
+
 				authorizationapi.NewRule(readWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
@@ -346,6 +352,23 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
 			},
 		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: QuotaManagerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotas").RuleOrDie(),
+				// project level roles are allowed to modify some resourcequota documents by default to constrain their projects.  They cannot touch all of them
+				// because allowing that would prevent a cluster-admin from constraining projects
+				authorizationapi.NewRule("get", "create", "update", "patch", "delete").Groups(kapiGroup).Resources("resourcequotas").Names(
+					"project-quota-01", "project-quota-02", "project-quota-03", "project-quota-04", "project-quota-05",
+					"project-quota-06", "project-quota-07", "project-quota-08", "project-quota-09", "project-quota-10").RuleOrDie(),
+
+				// should should be able to see projects you can control quota in.
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
+			},
+		},
+
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name: BasicUserRoleName,
@@ -616,6 +639,13 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: RegistryAdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("resourcequotas").RuleOrDie(),
+				// project level roles are allowed to modify some resourcequota documents by default to constrain their projects.  They cannot touch all of them
+				// because allowing that would prevent a cluster-admin from constraining projects
+				authorizationapi.NewRule("get", "create", "update", "patch", "delete").Groups(kapiGroup).Resources("resourcequotas").Names(
+					"project-quota-01", "project-quota-02", "project-quota-03", "project-quota-04", "project-quota-05",
+					"project-quota-06", "project-quota-07", "project-quota-08", "project-quota-09", "project-quota-10").RuleOrDie(),
+
 				authorizationapi.NewRule(readWrite...).Groups(imageGroup).Resources("imagestreamimages", "imagestreammappings", "imagestreams", "imagestreams/secrets", "imagestreamtags").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreamimports").RuleOrDie(),
 				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams/layers").RuleOrDie(),

--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -103,6 +103,7 @@ func TestCovers(t *testing.T) {
 	var registryAdmin *authorizationapi.ClusterRole
 	var registryEditor *authorizationapi.ClusterRole
 	var registryViewer *authorizationapi.ClusterRole
+	var quotaManager *authorizationapi.ClusterRole
 
 	for i := range allRoles {
 		role := allRoles[i]
@@ -119,6 +120,8 @@ func TestCovers(t *testing.T) {
 			registryEditor = &role
 		case bootstrappolicy.RegistryViewerRoleName:
 			registryViewer = &role
+		case bootstrappolicy.QuotaManagerRoleName:
+			quotaManager = &role
 		}
 	}
 
@@ -138,6 +141,13 @@ func TestCovers(t *testing.T) {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(registryAdmin.Rules, registryViewer.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+
+	if covers, miss := rulevalidation.Covers(admin.Rules, quotaManager.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+	if covers, miss := rulevalidation.Covers(registryAdmin.Rules, quotaManager.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -451,6 +451,28 @@ items:
     verbs:
     - impersonate
   - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resourceNames:
+    - project-quota-01
+    - project-quota-02
+    - project-quota-03
+    - project-quota-04
+    - project-quota-05
+    - project-quota-06
+    - project-quota-07
+    - project-quota-08
+    - project-quota-09
+    - project-quota-10
+    resources:
+    - resourcequotas
+    verbs:
+    - create
+    - delete
+    - get
+    - patch
+    - update
+  - apiGroups:
     - autoscaling
     attributeRestrictions: null
     resources:
@@ -1246,6 +1268,50 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: quota-manager
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotas
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resourceNames:
+    - project-quota-01
+    - project-quota-02
+    - project-quota-03
+    - project-quota-04
+    - project-quota-05
+    - project-quota-06
+    - project-quota-07
+    - project-quota-08
+    - project-quota-09
+    - project-quota-10
+    resources:
+    - resourcequotas
+    verbs:
+    - create
+    - delete
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - namespaces
+    verbs:
+    - get
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: basic-user
   rules:
   - apiGroups:
@@ -1906,6 +1972,37 @@ items:
     creationTimestamp: null
     name: registry-admin
   rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - resourcequotas
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resourceNames:
+    - project-quota-01
+    - project-quota-02
+    - project-quota-03
+    - project-quota-04
+    - project-quota-05
+    - project-quota-06
+    - project-quota-07
+    - project-quota-08
+    - project-quota-09
+    - project-quota-10
+    resources:
+    - resourcequotas
+    verbs:
+    - create
+    - delete
+    - get
+    - patch
+    - update
   - apiGroups:
     - ""
     attributeRestrictions: null


### PR DESCRIPTION
project-admins need to be able to modify some resourcequota objects to be able to constrain their own projects, but they can't be allowed to modify all of them or a cluster-admin wouldn't be able to limit usage per-project.

I have chosen 10 special names "project-quota-01" through "project-quota-10".

@adellape Where do I go to add release notes about this change.  Any cluster-admin who has chosen one of those names as a resourcequota object that they are using, should create a copy of the resourcequota under a non-special name and delete the existing one (in that order!).  I'd say that chances are slim.

@liggitt names as we discussed.
@smarterclayton kind of breaking change, see release note question above.
@derekwaynecarr ten seems like enough to me, care to argue for more?
@abhgupta you asked about this.