### PR TITLE
Highlight only active deployment in describer

### DIFF
--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -73,6 +73,16 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string, settings kc
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, deploymentConfig.ObjectMeta)
+		var (
+			deploymentsHistory   []kapi.ReplicationController
+			activeDeploymentName string
+		)
+
+		if d.config == nil {
+			if rcs, err := d.kubeClient.ReplicationControllers(namespace).List(kapi.ListOptions{LabelSelector: deployutil.ConfigSelector(deploymentConfig.Name)}); err == nil {
+				deploymentsHistory = rcs.Items
+			}
+		}
 
 		if deploymentConfig.Status.LatestVersion == 0 {
 			formatString(out, "Latest Version", "Not deployed")
@@ -83,34 +93,41 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string, settings kc
 		printDeploymentConfigSpec(d.kubeClient, *deploymentConfig, out)
 		fmt.Fprintln(out)
 
-		deploymentName := deployutil.LatestDeploymentNameForConfig(deploymentConfig)
-		deployment, err := d.kubeClient.ReplicationControllers(namespace).Get(deploymentName)
-		if err != nil {
-			if kerrors.IsNotFound(err) {
-				formatString(out, "Latest Deployment", "<none>")
-			} else {
-				formatString(out, "Latest Deployment", fmt.Sprintf("error: %v", err))
+		latestDeploymentName := deployutil.LatestDeploymentNameForConfig(deploymentConfig)
+		if activeDeployment := deployutil.ActiveDeployment(deploymentConfig, deploymentsHistory); activeDeployment != nil {
+			activeDeploymentName = activeDeployment.Name
+		}
+
+		var deployment *kapi.ReplicationController
+		isNotDeployed := len(deploymentsHistory) == 0
+		for _, item := range deploymentsHistory {
+			if item.Name == latestDeploymentName {
+				deployment = &item
 			}
+		}
+
+		if isNotDeployed {
+			formatString(out, "Latest Deployment", "<none>")
 		} else {
 			header := fmt.Sprintf("Deployment #%d (latest)", deployutil.DeploymentVersionFor(deployment))
-			printDeploymentRc(deployment, d.kubeClient, out, header, true)
+			// Show details if the current deployment is the active one or it is the
+			// initial deployment.
+			printDeploymentRc(deployment, d.kubeClient, out, header, (deployment.Name == activeDeploymentName) || len(deploymentsHistory) == 1)
 		}
+
 		// We don't show the deployment history when running `oc rollback --dry-run`.
-		if d.config == nil {
-			deploymentsHistory, err := d.kubeClient.ReplicationControllers(namespace).List(kapi.ListOptions{LabelSelector: labels.Everything()})
-			if err == nil {
-				sorted := deploymentsHistory.Items
-				sort.Sort(sort.Reverse(rcutils.OverlappingControllers(sorted)))
-				counter := 1
-				for _, item := range sorted {
-					if item.Name != deploymentName && deploymentConfig.Name == deployutil.DeploymentConfigNameFor(&item) {
-						header := fmt.Sprintf("Deployment #%d", deployutil.DeploymentVersionFor(&item))
-						printDeploymentRc(&item, d.kubeClient, out, header, false)
-						counter++
-					}
-					if counter == maxDisplayDeployments {
-						break
-					}
+		if d.config == nil && !isNotDeployed {
+			sorted := deploymentsHistory
+			sort.Sort(sort.Reverse(rcutils.OverlappingControllers(sorted)))
+			counter := 1
+			for _, item := range sorted {
+				if item.Name != latestDeploymentName && deploymentConfig.Name == deployutil.DeploymentConfigNameFor(&item) {
+					header := fmt.Sprintf("Deployment #%d", deployutil.DeploymentVersionFor(&item))
+					printDeploymentRc(&item, d.kubeClient, out, header, item.Name == activeDeploymentName)
+					counter++
+				}
+				if counter == maxDisplayDeployments {
+					break
 				}
 			}
 		}


### PR DESCRIPTION
This PR causes that only the "active" deployment gets highlighted in `oc describe`:

```
Deployment #3: (latest)
	Created:	1 seconds ago
	Status:		Pending
	Replicas:	0 current / 0 desired
Deployment #2:
	Name:		ruby-ex-2
	Created:	53 seconds ago
	Status:		Complete
	Replicas:	1 current / 1 desired
	Selector:	app=ruby-ex,deployment=ruby-ex-2,deploymentconfig=ruby-ex
	Labels:		app=ruby-ex,openshift.io/deployment-config.name=ruby-ex
	Pods Status:	1 Running / 0 Waiting / 0 Succeeded / 0 Failed
Deployment #1:
	Created:	5 minutes ago
	Status:		Complete
	Replicas:	0 current / 0 desired
```

Fixes: https://github.com/openshift/origin/issues/7996