### PR TITLE
Use pod name instead of id in oc delete example

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1223,8 +1223,8 @@ Delete one or more resources
   # Delete pods and services with label name=myLabel.
   oc delete pods,services -l name=myLabel
 
-  # Delete a pod with ID 1234-56-7890-234234-456456.
-  oc delete pod 1234-56-7890-234234-456456
+  # Delete a pod with name node-1-vsjnm.
+  oc delete pod node-1-vsjnm
 
   # Delete all resources associated with a running app, includes
   # buildconfig,deploymentconfig,service,imagestream,route and pod,

--- a/docs/man/man1/oc-delete.1
+++ b/docs/man/man1/oc-delete.1
@@ -154,8 +154,8 @@ will be lost along with the rest of the resource.
   # Delete pods and services with label name=myLabel.
   oc delete pods,services \-l name=myLabel
 
-  # Delete a pod with ID 1234\-56\-7890\-234234\-456456.
-  oc delete pod 1234\-56\-7890\-234234\-456456
+  # Delete a pod with name node\-1\-vsjnm.
+  oc delete pod node\-1\-vsjnm
 
   # Delete all resources associated with a running app, includes
   # buildconfig,deploymentconfig,service,imagestream,route and pod,

--- a/docs/man/man1/openshift-cli-delete.1
+++ b/docs/man/man1/openshift-cli-delete.1
@@ -154,8 +154,8 @@ will be lost along with the rest of the resource.
   # Delete pods and services with label name=myLabel.
   openshift cli delete pods,services \-l name=myLabel
 
-  # Delete a pod with ID 1234\-56\-7890\-234234\-456456.
-  openshift cli delete pod 1234\-56\-7890\-234234\-456456
+  # Delete a pod with name node\-1\-vsjnm.
+  openshift cli delete pod node\-1\-vsjnm
 
   # Delete all resources associated with a running app, includes
   # buildconfig,deploymentconfig,service,imagestream,route and pod,

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -127,8 +127,8 @@ will be lost along with the rest of the resource.`
   # Delete pods and services with label name=myLabel.
   %[1]s delete pods,services -l name=myLabel
 
-  # Delete a pod with ID 1234-56-7890-234234-456456.
-  %[1]s delete pod 1234-56-7890-234234-456456
+  # Delete a pod with name node-1-vsjnm.
+  %[1]s delete pod node-1-vsjnm
 
   # Delete all resources associated with a running app, includes
   # buildconfig,deploymentconfig,service,imagestream,route and pod,


### PR DESCRIPTION
Updates `oc delete -h` example for deleting pods from using a pod UID to using its name instead.

##### Before
```
Examples:
  # Delete a pod with ID 1234-56-7890-234234-456456.
  oc delete pod 1234-56-7890-234234-456456
``` 

##### After
```
Examples:
  # Delete a pod with name node-1-vsjnm.
  oc delete pod node-1-vsjnm
```

Fixes #9897
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1342914