### PR TITLE
Preventing build from inheriting master log level

### DIFF
--- a/pkg/build/admission/buildpodutil.go
+++ b/pkg/build/admission/buildpodutil.go
@@ -56,10 +56,49 @@ func SetBuild(a admission.Attributes, build *buildapi.Build, groupVersion unvers
 	if err != nil {
 		return err
 	}
+
 	err = setBuildInPod(build, pod, groupVersion)
 	if err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("unable to set build in pod: %v", err))
 	}
+
+	return nil
+}
+
+// SetBuildLogLevel extracts BUILD_LOGLEVEL from the Build environment
+// and feeds it as an argument to the Pod's entrypoint. The BUILD_LOGLEVEL
+// environment variable may have been set in multiple ways: a default value,
+// by a BuildConfig, or by the BuildDefaults admission plugin. In this method
+// we finally act on the value by injecting it into the Pod.
+func SetBuildLogLevel(attributes admission.Attributes, build *buildapi.Build) error {
+	pod, err := GetPod(attributes)
+	if err != nil {
+		return err
+	}
+
+	var envs []kapi.EnvVar
+
+	// Check whether the build strategy supports --loglevel parameter.
+	switch {
+	case build.Spec.Strategy.DockerStrategy != nil:
+		envs = build.Spec.Strategy.DockerStrategy.Env
+	case build.Spec.Strategy.SourceStrategy != nil:
+		envs = build.Spec.Strategy.SourceStrategy.Env
+	default:
+		// The build strategy does not support --loglevel
+		return nil
+	}
+
+	buildLogLevel := "0" // The ultimate default for the build pod's loglevel if no actor sets BUILD_LOGLEVEL in the Build
+	for i := range envs {
+		env := envs[i]
+		if env.Name == "BUILD_LOGLEVEL" {
+			buildLogLevel = env.Value
+			break
+		}
+	}
+	c := &pod.Spec.Containers[0]
+	c.Args = append(c.Args, "--loglevel="+buildLogLevel)
 	return nil
 }
 

--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -72,6 +72,11 @@ func (a *buildDefaults) Admit(attributes admission.Attributes) error {
 
 	a.applyBuildDefaults(build)
 
+	err = buildadmission.SetBuildLogLevel(attributes, build)
+	if err != nil {
+		return err
+	}
+
 	return buildadmission.SetBuild(attributes, build, version)
 }
 

--- a/pkg/build/admission/testutil/build.go
+++ b/pkg/build/admission/testutil/build.go
@@ -9,19 +9,30 @@ type TestBuild buildapi.Build
 func Build() *TestBuild {
 	b := (*TestBuild)(&buildapi.Build{})
 	b.Name = "TestBuild"
-	b.Spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
+	b.WithDockerStrategy()
 	b.Spec.Source.Git = &buildapi.GitBuildSource{
 		URI: "http://test.build/source",
 	}
 	return b
 }
 
+// clearStrategy nil all strategies in the Spec since it is a
+// common pattern to detect strategy by testing for non-nil.
+func (b *TestBuild) clearStrategy() {
+	b.Spec.Strategy.DockerStrategy = nil
+	b.Spec.Strategy.SourceStrategy = nil
+	b.Spec.Strategy.CustomStrategy = nil
+	b.Spec.Strategy.JenkinsPipelineStrategy = nil
+}
+
 func (b *TestBuild) WithDockerStrategy() *TestBuild {
+	b.clearStrategy()
 	b.Spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
 	return b
 }
 
 func (b *TestBuild) WithSourceStrategy() *TestBuild {
+	b.clearStrategy()
 	strategy := &buildapi.SourceBuildStrategy{}
 	strategy.From.Name = "builder/image"
 	strategy.From.Kind = "DockerImage"
@@ -30,6 +41,7 @@ func (b *TestBuild) WithSourceStrategy() *TestBuild {
 }
 
 func (b *TestBuild) WithCustomStrategy() *TestBuild {
+	b.clearStrategy()
 	strategy := &buildapi.CustomBuildStrategy{}
 	strategy.From.Name = "builder/image"
 	strategy.From.Kind = "DockerImage"

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -215,7 +215,7 @@ func RunDockerBuild(out io.Writer) error {
 	return runBuild(out, dockerBuilder{})
 }
 
-// RunSTIBuild creates a STI builder and runs its build
-func RunSTIBuild(out io.Writer) error {
+// RunS2IBuild creates a S2I builder and runs its build
+func RunS2IBuild(out io.Writer) error {
 	return runBuild(out, s2iBuilder{})
 }

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
 // DockerBuildStrategy creates a Docker build using a Docker builder image.
@@ -32,7 +31,6 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 
 	containerEnv := []kapi.EnvVar{
 		{Name: "BUILD", Value: string(data)},
-		{Name: "BUILD_LOGLEVEL", Value: fmt.Sprintf("%d", cmdutil.GetLogLevel())},
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)
@@ -55,7 +53,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 					Name:  "docker-build",
 					Image: bs.Image,
 					Env:   containerEnv,
-					Args:  []string{"--loglevel=" + getContainerVerbosity(containerEnv)},
+					Args:  []string{},
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 					SecurityContext: &kapi.SecurityContext{
 						Privileged: &privileged,

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
 // SourceBuildStrategy creates STI(source to image) builds
@@ -43,7 +42,6 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 
 	containerEnv := []kapi.EnvVar{
 		{Name: "BUILD", Value: string(data)},
-		{Name: "BUILD_LOGLEVEL", Value: fmt.Sprintf("%d", cmdutil.GetLogLevel())},
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)
@@ -82,7 +80,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 					SecurityContext: &kapi.SecurityContext{
 						Privileged: &privileged,
 					},
-					Args: []string{"--loglevel=" + getContainerVerbosity(containerEnv)},
+					Args: []string{},
 				},
 			},
 			RestartPolicy: kapi.RestartPolicyNever,

--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	stiBuilderLong = `
+	s2iBuilderLong = `
 Perform a Source-to-Image build
 
 This command executes a Source-to-Image build using arguments passed via the environment.
@@ -25,14 +25,14 @@ This command executes a Docker build using arguments passed via the environment.
 It expects to be run inside of a container.`
 )
 
-// NewCommandSTIBuilder provides a CLI handler for STI build type
-func NewCommandSTIBuilder(name string) *cobra.Command {
+// NewCommandS2IBuilder provides a CLI handler for S2I build type
+func NewCommandS2IBuilder(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Run a Source-to-Image build",
-		Long:  stiBuilderLong,
+		Long:  s2iBuilderLong,
 		Run: func(c *cobra.Command, args []string) {
-			err := cmd.RunSTIBuild(c.Out())
+			err := cmd.RunS2IBuild(c.Out())
 			kcmdutil.CheckErr(err)
 		},
 	}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -63,7 +63,7 @@ func CommandFor(basename string) *cobra.Command {
 	case "openshift-recycle":
 		cmd = recycle.NewCommandRecycle(basename, out)
 	case "openshift-sti-build":
-		cmd = builder.NewCommandSTIBuilder(basename)
+		cmd = builder.NewCommandS2IBuilder(basename)
 	case "openshift-docker-build":
 		cmd = builder.NewCommandDockerBuilder(basename)
 	case "oc", "osc":
@@ -131,7 +131,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 		irouter.NewCommandF5Router("f5-router"),
 		deployer.NewCommandDeployer("deploy"),
 		recycle.NewCommandRecycle("recycle", out),
-		builder.NewCommandSTIBuilder("sti-build"),
+		builder.NewCommandS2IBuilder("sti-build"),
 		builder.NewCommandDockerBuilder("docker-build"),
 		diagnostics.NewCommandPodDiagnostics("diagnostic-pod", out),
 	)

--- a/test/extended/builds/s2i_extended_build.go
+++ b/test/extended/builds/s2i_extended_build.go
@@ -53,7 +53,7 @@ var _ = g.Describe("[builds][Slow] s2i extended build", func() {
 			})
 
 			g.By("running the build")
-			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			out, err := oc.Run("start-build").Args("--build-loglevel=5", buildConfigName).Output()
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
 			}
@@ -95,7 +95,7 @@ var _ = g.Describe("[builds][Slow] s2i extended build", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("running the build")
-			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			out, err := oc.Run("start-build").Args("--build-loglevel=5", buildConfigName).Output()
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
 			}
@@ -137,7 +137,7 @@ var _ = g.Describe("[builds][Slow] s2i extended build", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("running the build")
-			out, err := oc.Run("start-build").Args(buildConfigName).Output()
+			out, err := oc.Run("start-build").Args("--build-loglevel=5", buildConfigName).Output()
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "\nstart-build output:\n%s\n", out)
 			}

--- a/test/extended/testdata/build-secrets/test-docker-build.json
+++ b/test/extended/testdata/build-secrets/test-docker-build.json
@@ -1,47 +1,50 @@
 {
-  "kind":"BuildConfig",
-  "apiVersion":"v1",
-  "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "name": "test"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Binary",
-      "binary": {
-      },
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Binary",
+      "binary": {},
       "secrets": [
         {
-          "secret": { "name": "testsecret" },
+          "secret": {
+            "name": "testsecret"
+          },
           "destinationDir": "secret-dir"
         },
         {
-          "secret": { "name": "testsecret2" }
+          "secret": {
+            "name": "testsecret2"
+          }
         }
       ]
     },
-    "strategy":{
-      "type":"Docker",
-      "env": [
-        {
-          "name": "BUILD_LOGLEVEL",
-          "value": "5"
-        }
-      ],
-      "dockerStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
-        }
+    "strategy": {
+      "type": "Docker",
+      "dockerStrategy": {
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-22-centos7"
+        },
+        "env": [
+          {
+            "name": "BUILD_LOGLEVEL",
+            "value": "5"
+          }
+        ]
       }
     },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "test:latest"
       }
     }
   }

--- a/test/extended/testdata/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/build-secrets/test-s2i-build.json
@@ -11,8 +11,7 @@
     "triggers": [],
     "source": {
       "type": "Binary",
-      "binary": {
-      },
+      "binary": {},
       "secrets": [
         {
           "secret": {
@@ -29,17 +28,17 @@
     },
     "strategy": {
       "type": "Source",
-      "env": [
-        {
-          "name": "BUILD_LOGLEVEL",
-          "value": "5"
-        }
-      ],
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
           "name": "centos/ruby-22-centos7"
-        }
+        },
+        "env": [
+          {
+            "name": "BUILD_LOGLEVEL",
+            "value": "5"
+          }
+        ]
       }
     },
     "output": {

--- a/test/extended/testdata/forcepull-setup.json
+++ b/test/extended/testdata/forcepull-setup.json
@@ -1,58 +1,56 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
-    "metadata": {},
-    "items": [
-	{
-    
-	    "kind": "ImageStream",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "forcepull-extended-test-builder",
-		"creationTimestamp": null
-	    },
-	    "spec": {},
-	    "status": {
-		"dockerImageRepository": ""
-	    }
-    
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "forcepull-bldr",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "forcepull-bldr"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/gabemontero/forcepull-extended-test-builder.git"
-		    }
+	"kind": "List",
+	"apiVersion": "v1",
+	"metadata": {},
+	"items": [
+		{
+			"kind": "ImageStream",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "forcepull-extended-test-builder",
+				"creationTimestamp": null
+			},
+			"spec": {},
+			"status": {
+				"dockerImageRepository": ""
+			}
 		},
-		"strategy": {
-		    "type": "Docker",
-		    "dockerStrategy": {
-			"env": [
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			]
-		    }
-		},
-		"output":{
-		    "to":{
-			"kind":"ImageStreamTag",
-			"name":"forcepull-extended-test-builder:latest"
-		    }
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "forcepull-bldr",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "forcepull-bldr"
+				}
+			},
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/gabemontero/forcepull-extended-test-builder.git"
+					}
+				},
+				"strategy": {
+					"type": "Docker",
+					"dockerStrategy": {
+						"env": [
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						]
+					}
+				},
+				"output": {
+					"to": {
+						"kind": "ImageStreamTag",
+						"name": "forcepull-extended-test-builder:latest"
+					}
+				}
+			}
 		}
-	    }
-	}
-    ]
+	]
 }

--- a/test/extended/testdata/forcepull-test.json
+++ b/test/extended/testdata/forcepull-test.json
@@ -1,234 +1,233 @@
 {
-    "kind": "List",
-    "apiVersion": "v1",
-    "metadata": {},
-    "items": [
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-fc",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-fc"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
-		},
-		"strategy": {
-		    "type": "Custom",
-		    "customStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+	"kind": "List",
+	"apiVersion": "v1",
+	"metadata": {},
+	"items": [
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-fc",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-fc"
+				}
 			},
-			"env": [
-			    {
-				"name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
-				"value": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
-			    },
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"exposeDockerSocket": true,
-			"forcePull":false
-		    }
-		}
-	    }
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-fd",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-fd"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Custom",
+					"customStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+								"value": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+							},
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"exposeDockerSocket": true,
+						"forcePull": false
+					}
+				}
+			}
 		},
-		"strategy": {
-		    "type": "Docker",
-		    "dockerStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-fd",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-fd"
+				}
 			},
-			"env": [
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"forcePull": false
-		    }
-		}
-	    }
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-fs",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-fs"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Docker",
+					"dockerStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"forcePull": false
+					}
+				}
+			}
 		},
-		"strategy": {
-		    "type": "Source",
-		    "sourceStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-fs",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-fs"
+				}
 			},
-			"env": [
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"forcePull": false
-		    }
-		}
-	    }
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-tc",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-tc"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Source",
+					"sourceStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"forcePull": false
+					}
+				}
+			}
 		},
-		"strategy": {
-		    "type": "Custom",
-		    "customStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-tc",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-tc"
+				}
 			},
-			"env": [
-			    {
-				"name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
-				"value": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
-			    },
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"exposeDockerSocket": true,
-			"forcePull":true
-		    }
-		}
-	    }
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-td",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-td"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Custom",
+					"customStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+								"value": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+							},
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"exposeDockerSocket": true,
+						"forcePull": true
+					}
+				}
+			}
 		},
-		"strategy": {
-		    "type": "Docker",
-		    "dockerStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-td",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-td"
+				}
 			},
-			"env": [
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"forcePull": true
-		    }
-		}
-	    }
-	},
-	{
-	    "kind": "BuildConfig",
-	    "apiVersion": "v1",
-	    "metadata": {
-		"name": "ruby-sample-build-ts",
-		"creationTimestamp": null,
-		"labels": {
-		    "name": "ruby-sample-build-ts"
-		}
-	    },
-	    "spec": {
-		"triggers": [],
-		"source": {
-		    "type": "Git",
-		    "git": {
-			"uri": "https://github.com/openshift/ruby-hello-world.git"
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Docker",
+					"dockerStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"forcePull": true
+					}
+				}
+			}
 		},
-		"strategy": {
-		    "type": "Source",
-		    "sourceStrategy": {
-			"from": {
-			    "kind": "DockerImage",
-			    "name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+		{
+			"kind": "BuildConfig",
+			"apiVersion": "v1",
+			"metadata": {
+				"name": "ruby-sample-build-ts",
+				"creationTimestamp": null,
+				"labels": {
+					"name": "ruby-sample-build-ts"
+				}
 			},
-			"env": [
-			    {
-				"name": "BUILD_LOGLEVEL",
-				"value": "5" 
-			    }
-			],
-			"forcePull": true
-		    }
+			"spec": {
+				"triggers": [],
+				"source": {
+					"type": "Git",
+					"git": {
+						"uri": "https://github.com/openshift/ruby-hello-world.git"
+					}
+				},
+				"strategy": {
+					"type": "Source",
+					"sourceStrategy": {
+						"from": {
+							"kind": "DockerImage",
+							"name": "SERVICE_REGISTRY_IP/forcepull-extended-test-builder"
+						},
+						"env": [
+							{
+								"name": "BUILD_LOGLEVEL",
+								"value": "5"
+							}
+						],
+						"forcePull": true
+					}
+				}
+			}
 		}
-	    }
-	}	
-
-    ]
+	]
 }

--- a/test/extended/testdata/incremental-auth-build.json
+++ b/test/extended/testdata/incremental-auth-build.json
@@ -39,13 +39,13 @@
         },
         "strategy": {
           "type": "Source",
-          "env": [
-            {
-              "name": "BUILD_LOGLEVEL",
-              "value": "5"
-            }
-          ],
           "sourceStrategy": {
+            "env": [
+              {
+                "name": "BUILD_LOGLEVEL",
+                "value": "5"
+              }
+            ],
             "from": {
               "kind": "DockerImage",
               "name": "centos/ruby-22-centos7:latest"
@@ -83,13 +83,13 @@
         },
         "strategy": {
           "type": "Source",
-          "env": [
-            {
-              "name": "BUILD_LOGLEVEL",
-              "value": "5"
-            }
-          ],
           "sourceStrategy": {
+            "env": [
+              {
+                "name": "BUILD_LOGLEVEL",
+                "value": "5"
+              }
+            ],
             "from": {
               "kind": "ImageStreamTag",
               "name": "internal-image:latest"
@@ -105,10 +105,8 @@
         }
       }
     }
-
   ],
-  "parameters": [
-  ],
+  "parameters": [],
   "labels": {
     "template": "application-template-stibuild"
   }

--- a/test/extended/testdata/test-build.json
+++ b/test/extended/testdata/test-build.json
@@ -40,7 +40,48 @@
           "sourceStrategy": {
             "env": [
               { "name": "FOO", "value": "test" },
-              { "name": "BAR", "value": "test" }
+              { "name": "BAR", "value": "test" },
+              { "name": "BUILD_LOGLEVEL", "value": "5" }
+            ],
+            "from": {
+              "kind": "DockerImage",
+              "name": "centos/ruby-22-centos7"
+            }
+          }
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sample-verbose-build",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "imageChange",
+            "imageChange": {}
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          }
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "env": [
+              { "name": "FOO", "value": "test" },
+              { "name": "BAR", "value": "test" },
+              { "name": "BUILD_LOGLEVEL", "value": "5" }
             ],
             "from": {
               "kind": "DockerImage",
@@ -77,7 +118,8 @@
           "dockerStrategy": {
             "env": [
               { "name": "FOO", "value": "test" },
-              { "name": "BAR", "value": "test" }
+              { "name": "BAR", "value": "test" },
+              { "name": "BUILD_LOGLEVEL", "value": "5" }
             ],
             "from": {
               "kind": "DockerImage",

--- a/test/extended/testdata/test-docker-no-outputname.json
+++ b/test/extended/testdata/test-docker-no-outputname.json
@@ -1,32 +1,32 @@
 {
-  "kind":"BuildConfig",
-  "apiVersion":"v1",
-  "metadata":{
-    "name":"test-docker",
-    "labels":{
-      "name":"test-docker"
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test-docker",
+    "labels": {
+      "name": "test-docker"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Git",
-      "git":{
-        "uri":"https://github.com/openshift/ruby-hello-world"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Git",
+      "git": {
+        "uri": "https://github.com/openshift/ruby-hello-world"
       }
     },
-    "strategy":{
-      "type":"Docker",
-      "env": [
-        {
-          "name": "BUILD_LOGLEVEL",
-          "value": "5"
-        }
-      ],
-      "dockerStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
+    "strategy": {
+      "type": "Docker",
+      "dockerStrategy": {
+        "env": [
+          {
+            "name": "BUILD_LOGLEVEL",
+            "value": "5"
+          }
+        ],
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-22-centos7"
         }
       }
     }

--- a/test/extended/testdata/test-s2i-build.json
+++ b/test/extended/testdata/test-s2i-build.json
@@ -1,40 +1,40 @@
 {
-  "kind":"BuildConfig",
-  "apiVersion":"v1",
-  "metadata":{
-    "name":"test",
-    "labels":{
-      "name":"test"
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test",
+    "labels": {
+      "name": "test"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Git",
-      "git":{
-        "uri":"https://github.com/openshift/origin"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Git",
+      "git": {
+        "uri": "https://github.com/openshift/origin"
       },
-      "contextDir":"test/extended/testdata/test-build-app"
+      "contextDir": "test/extended/testdata/test-build-app"
     },
-    "strategy":{
-      "type":"Source",
-      "env": [
-        {
-          "name": "BUILD_LOGLEVEL",
-          "value": "5"
-        }
-      ],
-      "sourceStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
+    "strategy": {
+      "type": "Source",
+      "sourceStrategy": {
+        "env": [
+          {
+            "name": "BUILD_LOGLEVEL",
+            "value": "5"
+          }
+        ],
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-22-centos7"
         }
       }
     },
-    "output":{
-      "to":{
-        "kind":"ImageStreamTag",
-        "name":"test:latest"
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "test:latest"
       }
     }
   }

--- a/test/extended/testdata/test-s2i-no-outputname.json
+++ b/test/extended/testdata/test-s2i-no-outputname.json
@@ -1,32 +1,32 @@
 {
-"kind":"BuildConfig",
-  "apiVersion":"v1",
-  "metadata":{
-    "name":"test-sti",
-    "labels":{
-      "name":"test-sti"
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test-sti",
+    "labels": {
+      "name": "test-sti"
     }
   },
-  "spec":{
-    "triggers":[],
-    "source":{
-      "type":"Git",
-      "git":{
-        "uri":"https://github.com/openshift/ruby-hello-world"
+  "spec": {
+    "triggers": [],
+    "source": {
+      "type": "Git",
+      "git": {
+        "uri": "https://github.com/openshift/ruby-hello-world"
       }
     },
-    "strategy":{
-      "type":"Source",
-      "env": [
-        {
-          "name": "BUILD_LOGLEVEL",
-          "value": "5"
-        }
-      ],
-      "sourceStrategy":{
-        "from":{
-          "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
+    "strategy": {
+      "type": "Source",
+      "sourceStrategy": {
+        "env": [
+          {
+            "name": "BUILD_LOGLEVEL",
+            "value": "5"
+          }
+        ],
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-22-centos7"
         }
       }
     }


### PR DESCRIPTION
Fixes #8738 
This implementation:
- Prevents builds from inheriting the logging level of the master
- Does not break any existing use of BuildDefaults (and does not change how proxy information is managed)
- Ultimate default for builder is --loglevel=1 . This can be overridden multiple ways. In order of decreasing precedence: 
  - Specifying --build-loglevel on start-build (except on binary builds, which has always been the case since the function relies on env variables)
  - BUILD_LOGLEVEL in buildconfig
  - BuildDefaults/env/BUILD_LOGLEVEL variable in master-config.

Example master-config entry:
```
kubernetesMasterConfig:
  admissionConfig:
    pluginConfig:
      BuildDefaults:
        configuration:
          apiVersion: v1
          kind: BuildDefaultsConfig
          env:
          - name: "BUILD_LOGLEVEL"
            value: "5"
```
