### PR TITLE
CARRY: Fix edge case in QoS calculation where request=0 and limit !=0

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/qos/util/qos.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/qos/util/qos.go
@@ -40,10 +40,11 @@ func isResourceGuaranteed(container *api.Container, resource api.ResourceName) b
 
 // isResourceBestEffort returns true if the container's resource requirements are best-effort.
 func isResourceBestEffort(container *api.Container, resource api.ResourceName) bool {
-	// A container resource is best-effort if its request is unspecified or 0.
+	// A container resource is best-effort if its request is unspecified or 0 and it has no limit or a limit with value of 0.
 	// If a request is specified, then the user expects some kind of resource guarantee.
 	req, hasReq := container.Resources.Requests[resource]
-	return !hasReq || req.Value() == 0
+	limit, hasLimit := container.Resources.Limits[resource]
+	return (!hasReq || req.Value() == 0) && (!hasLimit || limit.Value() == 0)
 }
 
 // GetQos returns a mapping of resource name to QoS class of a container


### PR DESCRIPTION
In Kubernetes 1.2, a pod's QoS was per resource.  It had a bug when determining if a pod was BestEffort for a particular resource.  If a pod explicitly set a request of 0 with a limit of X, the pod was classified as BestEffort when it should have been Burstable for that resource.

This is fixed in Kubernetes 1.3 when QoS became pod-level instead of resource level.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1357475

/cc @liggitt @ncdc 

