### PR TITLE
Cherry-pick scripts create a .make directory that we should ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /examples/sample-app/logs/openshift.log
 /dind-*.rc
 /os-version-defs
+/.make/
 *.swp
 .vimrc
 .vagrant-openshift.json*


### PR DESCRIPTION
If I use the script to cherry-pick code, I get a folder:

`vendor/k8s.io/kubernetes/.make`

that confuses the cherry pick script to merge files it should ignore.

/cc @deads2k 