### PR TITLE
wait for imagestream tags to be imported before running tests

### DIFF
--- a/test/extended/images/s2i_python.go
+++ b/test/extended/images/s2i_python.go
@@ -27,9 +27,10 @@ var _ = g.Describe("[images][python][Slow] hot deploy for openshift python image
 		g.It(fmt.Sprintf("should work with hot deploy"), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-			exutil.CheckOpenShiftNamespaceImageStreams(oc)
+			err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
 			g.By(fmt.Sprintf("calling oc new-app %s", djangoRepository))
-			err := oc.Run("new-app").Args(djangoRepository, "--strategy=source").Execute()
+			err = oc.Run("new-app").Args(djangoRepository, "--strategy=source").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")

--- a/test/extended/images/sample_repos.go
+++ b/test/extended/images/sample_repos.go
@@ -40,9 +40,10 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 			g.It(fmt.Sprintf("should build a "+c.repoName+" image and run it in a pod"), func() {
 				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-				exutil.CheckOpenShiftNamespaceImageStreams(oc)
+				err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
+				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By(fmt.Sprintf("calling oc new-app with the " + c.repoName + " example template"))
-				err := oc.Run("new-app").Args("-f", c.templateURL).Execute()
+				err = oc.Run("new-app").Args("-f", c.templateURL).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				// all the templates automatically start a build.


### PR DESCRIPTION
based on this test failure:
```
STEP: calling oc new-app https://github.com/openshift/django-ex.git
Jul 18 17:45:38.871: INFO: Running 'oc new-app --namespace=extended-test-s2i-python-sua2q-xd4zt --config=/tmp/openshift/extended-test-s2i-python-sua2q-xd4zt-user.kubeconfig https://github.com/openshift/django-ex.git --strategy=source'
--> Found Docker image 7fd24fb (10 days old) from Docker Hub for "python"
```

in which we found the python image instead of the python imagestream, i think there are cases where we are starting the tests before the imagestream is imported, which results in new-app finding/using the wrong thing.  This might explain the "missing imagestreams" scenarios that @gabemontero was seeing as well.  (ie the imagestreams weren't missing, just the tags weren't present) but I don't remember exactly what he was seeing in those cases.

i'm also not sure when we do the import relative to when we execute the tests (I would hope we're not importing before each test, i think we share the openshift server+imagestreams through out the run) but that only makes this failure more baffling since there are other python-related tests that passed on the run:
https://ci.openshift.redhat.com/jenkins/job/test_pr_origin_extended/324/consoleFull
