### PR TITLE
Update oc annotate to allow use of --resource-version flag with single rsrc

### DIFF
--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -106,6 +106,8 @@ os::cmd::try_until_success 'oc label pod/hello-openshift acustom=label' # can ra
 os::cmd::expect_success_and_text 'oc describe pod/hello-openshift' 'acustom=label'
 os::cmd::try_until_success 'oc annotate pod/hello-openshift foo=bar' # can race against scheduling and status updates
 os::cmd::expect_success_and_text 'oc get -o yaml pod/hello-openshift' 'foo: bar'
+os::cmd::expect_failure_and_not_text 'oc annotate pod hello-openshift description="test" --resource-version=123' 'may only be used with a single resource'
+os::cmd::expect_failure_and_text 'oc annotate pod hello-openshift hello-openshift description="test" --resource-version=123' 'may only be used with a single resource'
 os::cmd::expect_success 'oc delete pods -l acustom=label --grace-period=0'
 os::cmd::expect_failure 'oc get pod/hello-openshift'
 echo "label: ok"

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/annotate.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/annotate.go
@@ -190,11 +190,6 @@ func (o AnnotateOptions) Validate(args []string) error {
 		return err
 	}
 
-	// only apply resource version locking on a single resource
-	if len(o.resources) > 1 && len(o.resourceVersion) > 0 {
-		return fmt.Errorf("--resource-version may only be used with a single resource")
-	}
-
 	return nil
 }
 
@@ -203,6 +198,17 @@ func (o AnnotateOptions) RunAnnotate() error {
 	r := o.builder.Do()
 	if err := r.Err(); err != nil {
 		return err
+	}
+
+	var singularResource bool
+	r.IntoSingular(&singularResource)
+
+	// only apply resource version locking on a single resource.
+	// we must perform this check after o.builder.Do() as
+	// []o.resources can not not accurately return the proper number
+	// of resources when they are not passed in "resource/name" format.
+	if !singularResource && len(o.resourceVersion) > 0 {
+		return fmt.Errorf("--resource-version may only be used with a single resource")
 	}
 
 	return r.Visit(func(info *resource.Info, err error) error {


### PR DESCRIPTION
fixes #9908
Upstream: https://github.com/kubernetes/kubernetes/pull/29319
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1257853

When using annotate with a `--resource-version` on a resource, such as `oc annotate pod <pod_name> --resource-version=1820 description='myannotation'`, the command fails with the error: `error: --resource-version may only be used with a single resource`.

Upon printing the output of `resources` that the annotate command receives from cli args, it prints: `Resources:[pod <pod_name>]`. In other words, it treats the name of the resource as a second resource. This PR addresses this issue by using the resource builder Singular flag to determine if only a single resource was passed.
