### PR TITLE
delete unuseful variable definition and update other doc

### DIFF
--- a/examples/db-templates/README.md
+++ b/examples/db-templates/README.md
@@ -38,35 +38,11 @@ Replace `/path/to/template.json` with an appropriate path, that can be either a
 local path or an URL. Example:
 
     $ oc new-app https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json
-    --> Deploying template mongodb-ephemeral for "https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json"
-     With parameters:
-      DATABASE_SERVICE_NAME=mongodb
-      MONGODB_USER=userJNX # generated
-      MONGODB_PASSWORD=tnEDilMVrgjp5AI2 # generated
-      MONGODB_DATABASE=sampledb
-      MONGODB_ADMIN_PASSWORD=8bYEs8OlNYhVyMBs # generated
-    --> Creating resources ...
-    Service "mongodb" created
-    DeploymentConfig "mongodb" created
-    --> Success
-    Run 'oc status' to view your app.
 
 The parameters listed in the output above can be tweaked by specifying values in
 the command line with the `-p` option:
 
     $ oc new-app examples/db-templates/mongodb-ephemeral-template.json -p DATABASE_SERVICE_NAME=mydb -p MONGODB_USER=default
-    --> Deploying template mongodb-ephemeral for "examples/db-templates/mongodb-ephemeral-template.json"
-         With parameters:
-          DATABASE_SERVICE_NAME=mydb
-          MONGODB_USER=default
-          MONGODB_PASSWORD=RPvMbWlQFOevSowQ # generated
-          MONGODB_DATABASE=sampledb
-          MONGODB_ADMIN_PASSWORD=K7tIjDxDHHYCvFrJ # generated
-    --> Creating resources ...
-        Service "mydb" created
-        DeploymentConfig "mydb" created
-    --> Success
-        Run 'oc status' to view your app.
 
 Note that the persistent template requires an existing persistent volume,
 otherwise the deployment won't ever succeed.

--- a/examples/privileged-pod-pvc/README.md
+++ b/examples/privileged-pod-pvc/README.md
@@ -56,7 +56,7 @@ _**As admin:**_
 
 ```bash
 $ oc create -f gluster-endpoints.yaml
-$ oc create -f gluster-service.yaml
+$ oc create -f gluster-endpoints-service.yaml
 $ oc create -f gluster-pv.yaml
 ```
 ###Make the volume available within the user project
@@ -68,7 +68,7 @@ Create the PersistentVolumeClaim
 
 Create the privileged pod
 
-`$ oc create -f gluster-priv-pod.yaml`
+`$ oc create -f gluster-nginx-priv-pod.yaml`
 
 
 ##Confirm the Setup was Successful

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -2,7 +2,6 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-GO_VERSION=($(go version))
 echo "Detected go version: $(go version)"
 
 go get github.com/tools/godep


### PR DESCRIPTION
In this shell GO_VERSION is not used, author may want to get 'go version' output parameters in future by using  ($(GO_VERSION)),  but currently I think $GO_VERSION can use like this.