### PR TITLE
Fixed a bug in jUnit output from os::cmd::try_until_text

### DIFF
--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -608,7 +608,6 @@ function os::cmd::internal::run_until_text() {
 		junit_log+=( "FAILURE after ${time_elapsed}s: ${description//$'\n'/;}: the command timed out" )
 
 		os::text::print_red "$(os::cmd::internal::print_try_until_results)"
-		os::test::junit::declare_test_end
 		return_code=1
 	fi
 


### PR DESCRIPTION
Previously, when os::cmd::try_until_text failed, it would
emit a jUnit test end marker too early, before the test
output was written to the jUnit log file. This woul cause
malformed jUnit output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@deads2k PTAL