### PR TITLE
Update oc scale help  to display duration "units" in --timeout usage

### DIFF
--- a/docs/man/man1/oc-replace.1
+++ b/docs/man/man1/oc-replace.1
@@ -62,7 +62,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-timeout\fP=0
-    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object
+    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 .PP
 \fB\-\-validate\fP=false

--- a/docs/man/man1/oc-scale.1
+++ b/docs/man/man1/oc-scale.1
@@ -61,7 +61,7 @@ desired replicas in the configuration template.
 
 .PP
 \fB\-\-timeout\fP=0
-    The length of time to wait before giving up on a scale operation, zero means don't wait.
+    The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/docs/man/man1/openshift-cli-replace.1
+++ b/docs/man/man1/openshift-cli-replace.1
@@ -62,7 +62,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-timeout\fP=0
-    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object
+    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 .PP
 \fB\-\-validate\fP=false

--- a/docs/man/man1/openshift-cli-scale.1
+++ b/docs/man/man1/openshift-cli-scale.1
@@ -61,7 +61,7 @@ desired replicas in the configuration template.
 
 .PP
 \fB\-\-timeout\fP=0
-    The length of time to wait before giving up on a scale operation, zero means don't wait.
+    The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/docs/man/man1/openshift-kube-replace.1
+++ b/docs/man/man1/openshift-kube-replace.1
@@ -68,7 +68,7 @@ Please refer to the models in
 
 .PP
 \fB\-\-timeout\fP=0
-    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object
+    Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 .PP
 \fB\-\-validate\fP=true

--- a/docs/man/man1/openshift-kube-scale.1
+++ b/docs/man/man1/openshift-kube-scale.1
@@ -57,7 +57,7 @@ scale is sent to the server.
 
 .PP
 \fB\-\-timeout\fP=0
-    The length of time to wait before giving up on a scale operation, zero means don't wait.
+    The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/replace.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/replace.go
@@ -81,7 +81,7 @@ func NewCmdReplace(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Bool("force", false, "Delete and re-create the specified resource")
 	cmd.Flags().Bool("cascade", false, "Only relevant during a force replace. If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).")
 	cmd.Flags().Int("grace-period", -1, "Only relevant during a force replace. Period of time in seconds given to the old resource to terminate gracefully. Ignored if negative.")
-	cmd.Flags().Duration("timeout", 0, "Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object")
+	cmd.Flags().Duration("timeout", 0, "Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddRecursiveFlag(cmd, &options.Recursive)
 	cmdutil.AddOutputFlagsForMutation(cmd)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/scale.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/scale.go
@@ -81,7 +81,7 @@ func NewCmdScale(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Int("current-replicas", -1, "Precondition for current size. Requires that the current size of the resource match this value in order to scale.")
 	cmd.Flags().Int("replicas", -1, "The new desired number of replicas. Required.")
 	cmd.MarkFlagRequired("replicas")
-	cmd.Flags().Duration("timeout", 0, "The length of time to wait before giving up on a scale operation, zero means don't wait.")
+	cmd.Flags().Duration("timeout", 0, "The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	cmdutil.AddOutputFlagsForMutation(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1277070

`oc scale` has `--timeout` option, but the help info does not give accepted time units. 

The help info gives default value `0` without a unit, potentially misleading a user into thinking they need to pass the numbered time only.