### PR TITLE
Enabling multiline parameter injection for templates

### DIFF
--- a/pkg/cmd/util/env.go
+++ b/pkg/cmd/util/env.go
@@ -41,7 +41,7 @@ func GetEnv(key string) (string, bool) {
 
 type Environment map[string]string
 
-var argumentEnvironment = regexp.MustCompile("^([\\w\\-_]+)\\=(.*)$")
+var argumentEnvironment = regexp.MustCompile("(?ms)^([\\w\\-_]+)\\=(.*)$")
 
 func IsEnvironmentArgument(s string) bool {
 	return argumentEnvironment.MatchString(s)


### PR DESCRIPTION
Fixes #9863 
Parameter regexp changed to allow multiline values. As @Miciah points out in #9863, multi-line values must be quoted.

```
oc new-app --dry-run --template=guestbook-example -p="\"PARM1=a
b
c
\",PARM2=5"
```