### PR TITLE
Update client config invalid option errors to be more specific

### DIFF
--- a/test/cmd/config.sh
+++ b/test/cmd/config.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates,secrets --all
+  exit 0
+) &>/dev/null
+
+# check to make sure that "get"ting a resource with no config file present
+# still returns error indicating that no config-file is set
+os::test::junit::declare_suite_start "cmd/configuration"
+os::cmd::expect_success_and_not_text 'oc get bc' 'does not exist'
+(
+  export HOME=/tmp
+  unset KUBECONFIG
+  unset KUBERNETES_MASTER
+  
+  os::cmd::expect_failure_and_text 'oc get bc --user=""' 'Missing or incomplete configuration info'
+  os::cmd::expect_failure_and_text 'oc get bc --context=""' 'Missing or incomplete configuration info'
+  os::cmd::expect_failure_and_text 'oc get bc --cluster=""' 'Missing or incomplete configuration info'
+
+  os::cmd::expect_failure_and_text 'oc get bc --context="test"' 'context "test" does not exist'
+  os::cmd::expect_failure_and_text 'oc get bc --cluster="test"' 'cluster "test" does not exist'
+  os::cmd::expect_failure_and_text 'oc get bc --user="test"' 'auth info "test" does not exist'
+
+  os::cmd::expect_failure_and_text 'oc get bc --config=missing' 'missing: no such file or directory'
+
+  # make sure non-existing --cluster and --user can still be set
+  os::cmd::expect_success_and_text 'oc config set-context new-context-name --cluster=missing-cluster --user=missing-user --namespace=default --config=new-config.yaml' 'context "new-context-name" set'
+  # os::cmd::expect_failure_and_text "env -u KUBECONFIG -u KUBERNETES_MASTER oc get bc --config=new-config.yaml" 'Missing or incomplete configuration info'
+  os::cmd::expect_failure_and_text "oc get bc --config=new-config.yaml" 'Missing or incomplete configuration info'
+)
+echo "config error handling: ok"
+os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config.go
@@ -99,12 +99,28 @@ func (config *DirectClientConfig) RawConfig() (clientcmdapi.Config, error) {
 
 // ClientConfig implements ClientConfig
 func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
-	if err := config.ConfirmUsable(); err != nil {
+	// check that getAuthInfo, getContext, and getCluster do not return an error.
+	// Do this before checking if the curent config is usable in the event that an
+	// AuthInfo, Context, or Cluster config with user-defined names are not found.
+	// This provides a user with the immediate cause for error if one is found
+	configAuthInfo, err := config.getAuthInfo()
+	if err != nil {
 		return nil, err
 	}
 
-	configAuthInfo := config.getAuthInfo()
-	configClusterInfo := config.getCluster()
+	_, err = config.getContext()
+	if err != nil {
+		return nil, err
+	}
+
+	configClusterInfo, err := config.getCluster()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := config.ConfirmUsable(); err != nil {
+		return nil, err
+	}
 
 	clientConfig := &restclient.Config{}
 	clientConfig.Host = configClusterInfo.Server
@@ -126,7 +142,8 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 		//       Our mergo.Merge version is older than this change.
 		var persister restclient.AuthProviderConfigPersister
 		if config.configAccess != nil {
-			persister = PersisterForUser(config.configAccess, config.getAuthInfoName())
+			authInfoName, _ := config.getAuthInfoName()
+			persister = PersisterForUser(config.configAccess, authInfoName)
 		}
 		userAuthPartialConfig, err := getUserIdentificationPartialConfig(configAuthInfo, config.fallbackReader, persister)
 		if err != nil {
@@ -250,7 +267,10 @@ func (config *DirectClientConfig) Namespace() (string, bool, error) {
 		return "", false, err
 	}
 
-	configContext := config.getContext()
+	configContext, err := config.getContext()
+	if err != nil {
+		return "", false, err
+	}
 
 	if len(configContext.Namespace) == 0 {
 		return api.NamespaceDefault, false, nil
@@ -272,8 +292,12 @@ func (config *DirectClientConfig) ConfigAccess() ConfigAccess {
 // but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
 func (config *DirectClientConfig) ConfirmUsable() error {
 	validationErrors := make([]error, 0)
-	validationErrors = append(validationErrors, validateAuthInfo(config.getAuthInfoName(), config.getAuthInfo())...)
-	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
+	authInfoName, _ := config.getAuthInfoName()
+	authInfo, _ := config.getAuthInfo()
+	validationErrors = append(validationErrors, validateAuthInfo(authInfoName, authInfo)...)
+	clusterName, _ := config.getClusterName()
+	cluster, _ := config.getCluster()
+	validationErrors = append(validationErrors, validateClusterInfo(clusterName, cluster)...)
 	// when direct client config is specified, and our only error is that no server is defined, we should
 	// return a standard "no config" error
 	if len(validationErrors) == 1 && validationErrors[0] == ErrEmptyCluster {
@@ -282,65 +306,84 @@ func (config *DirectClientConfig) ConfirmUsable() error {
 	return newErrConfigurationInvalid(validationErrors)
 }
 
-func (config *DirectClientConfig) getContextName() string {
+// getContextName returns the default, or user-set context name, and a boolean that indicates
+// whether the default context name has been overwritten by a user-set flag, or left as its default value
+func (config *DirectClientConfig) getContextName() (string, bool) {
 	if len(config.overrides.CurrentContext) != 0 {
-		return config.overrides.CurrentContext
+		return config.overrides.CurrentContext, true
 	}
 	if len(config.contextName) != 0 {
-		return config.contextName
+		return config.contextName, false
 	}
 
-	return config.config.CurrentContext
+	return config.config.CurrentContext, false
 }
 
-func (config *DirectClientConfig) getAuthInfoName() string {
+// getAuthInfoName returns a string containing the current authinfo name for the current context,
+// and a boolean indicating  whether the default authInfo name is overwritten by a user-set flag, or
+// left as its default value
+func (config *DirectClientConfig) getAuthInfoName() (string, bool) {
 	if len(config.overrides.Context.AuthInfo) != 0 {
-		return config.overrides.Context.AuthInfo
+		return config.overrides.Context.AuthInfo, true
 	}
-	return config.getContext().AuthInfo
+	context, _ := config.getContext()
+	return context.AuthInfo, false
 }
 
-func (config *DirectClientConfig) getClusterName() string {
+// getClusterName returns a string containing the default, or user-set cluster name, and a boolean
+// indicating whether the default clusterName has been overwritten by a user-set flag, or left as
+// its default value
+func (config *DirectClientConfig) getClusterName() (string, bool) {
 	if len(config.overrides.Context.Cluster) != 0 {
-		return config.overrides.Context.Cluster
+		return config.overrides.Context.Cluster, true
 	}
-	return config.getContext().Cluster
+	context, _ := config.getContext()
+	return context.Cluster, false
 }
 
-func (config *DirectClientConfig) getContext() clientcmdapi.Context {
+// getContext returns the clientcmdapi.Context, or an error if a required context is not found.
+func (config *DirectClientConfig) getContext() (clientcmdapi.Context, error) {
 	contexts := config.config.Contexts
-	contextName := config.getContextName()
+	contextName, required := config.getContextName()
 
 	var mergedContext clientcmdapi.Context
 	if configContext, exists := contexts[contextName]; exists {
 		mergo.Merge(&mergedContext, configContext)
+	} else if required {
+		return clientcmdapi.Context{}, fmt.Errorf("context %q does not exist", contextName)
 	}
 	mergo.Merge(&mergedContext, config.overrides.Context)
 
-	return mergedContext
+	return mergedContext, nil
 }
 
-func (config *DirectClientConfig) getAuthInfo() clientcmdapi.AuthInfo {
+// getAuthInfo returns the clientcmdapi.AuthInfo, or an error if a required auth info is not found.
+func (config *DirectClientConfig) getAuthInfo() (clientcmdapi.AuthInfo, error) {
 	authInfos := config.config.AuthInfos
-	authInfoName := config.getAuthInfoName()
+	authInfoName, required := config.getAuthInfoName()
 
 	var mergedAuthInfo clientcmdapi.AuthInfo
 	if configAuthInfo, exists := authInfos[authInfoName]; exists {
 		mergo.Merge(&mergedAuthInfo, configAuthInfo)
+	} else if required {
+		return clientcmdapi.AuthInfo{}, fmt.Errorf("auth info %q does not exist", authInfoName)
 	}
 	mergo.Merge(&mergedAuthInfo, config.overrides.AuthInfo)
 
-	return mergedAuthInfo
+	return mergedAuthInfo, nil
 }
 
-func (config *DirectClientConfig) getCluster() clientcmdapi.Cluster {
+// getCluster returns the clientcmdapi.Cluster, or an error if a required cluster is not found.
+func (config *DirectClientConfig) getCluster() (clientcmdapi.Cluster, error) {
 	clusterInfos := config.config.Clusters
-	clusterInfoName := config.getClusterName()
+	clusterInfoName, required := config.getClusterName()
 
 	var mergedClusterInfo clientcmdapi.Cluster
 	mergo.Merge(&mergedClusterInfo, config.overrides.ClusterDefaults)
 	if configClusterInfo, exists := clusterInfos[clusterInfoName]; exists {
 		mergo.Merge(&mergedClusterInfo, configClusterInfo)
+	} else if required {
+		return clientcmdapi.Cluster{}, fmt.Errorf("cluster %q does not exist", clusterInfoName)
 	}
 	mergo.Merge(&mergedClusterInfo, config.overrides.ClusterInfo)
 	// An override of --insecure-skip-tls-verify=true and no accompanying CA/CA data should clear already-set CA/CA data
@@ -352,7 +395,7 @@ func (config *DirectClientConfig) getCluster() clientcmdapi.Cluster {
 		mergedClusterInfo.CertificateAuthorityData = nil
 	}
 
-	return mergedClusterInfo
+	return mergedClusterInfo, nil
 }
 
 // inClusterClientConfig makes a config that will work from within a kubernetes cluster container environment.

--- a/vendor/k8s.io/kubernetes/test/integration/kubectl/kubectl_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/kubectl/kubectl_test.go
@@ -52,9 +52,7 @@ func TestKubectlValidation(t *testing.T) {
 	cluster.Server = components.ApiServer.URL
 	cluster.InsecureSkipTLSVerify = true
 	overrides := clientcmd.ConfigOverrides{
-		ClusterInfo:    *cluster,
-		Context:        *ctx,
-		CurrentContext: "test",
+		ClusterInfo: *cluster,
 	}
 	cmdConfig := clientcmd.NewNonInteractiveClientConfig(*cfg, "test", &overrides, nil)
 	factory := util.NewFactory(cmdConfig)


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1281333
Upstream: https://github.com/kubernetes/kubernetes/pull/29236

When using kubeconfig / oc option (such as --context, --cluster) with non exist value, the command gives confusing error message: 
`error: No configuration file found, please login or point to an existing file:`

This adds checking for invalid flag values to make the error output more relevant.