### PR TITLE
update FAQ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ FAQ
     for building applications in containers.  Our goal is to do most of that work upstream, with
     integration and final packaging occurring in Origin.
 
-    You can run the core Kubernetes server components with `openshift start kube`, use `kubectl` via
+    You can run the core Kubernetes server components with `openshift start kubernetes`, use `kubectl` via
     `openshift kube`, and the Origin release zips include versions of `kubectl`, `kubelet`,
     `kube-apiserver`, and other core components. You can see the version of Kubernetes included with
     Origin via `openshift version`.


### PR DESCRIPTION
 I try to run"openshift start kube" described in README.md FAQ, the output is "no arguments are supported for start ".  then I run "openshift start --help":

Available Commands:
  master      Launch a master
  node        Launch a node
  network     Launch node network
  etcd        Launch etcd server
  **kubernetes**  Kubernetes server components 

I think we should update our description "You can run the core Kubernetes server components with openshift start kube" to "openshift start kubernetes"