### PR TITLE
add db template for mariadb

### DIFF
--- a/examples/db-templates/mariadb-ephemeral-template.json
+++ b/examples/db-templates/mariadb-ephemeral-template.json
@@ -2,11 +2,11 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "mysql-persistent",
+    "name": "mariadb-ephemeral",
     "annotations": {
-      "description": "MySQL database service, with persistent storage.  Scaling to more than one replica is not supported.  You must have persistent volumes available in your cluster to use this template.",
-      "iconClass": "icon-mysql-database",
-      "tags": "database,mysql"
+      "description": "MariaDB database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+      "iconClass": "icon-mariadb",
+      "tags": "database,mariadb"
     }
   },
   "objects": [
@@ -19,29 +19,12 @@
       "spec": {
         "ports": [
           {
-            "name": "mysql",
+            "name": "mariadb",
             "port": 3306
           }
         ],
         "selector": {
           "name": "${DATABASE_SERVICE_NAME}"
-        }
-      }
-    },
-    {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "${DATABASE_SERVICE_NAME}"
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "${VOLUME_CAPACITY}"
-          }
         }
       }
     },
@@ -61,11 +44,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "mysql"
+                "mariadb"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mariadb:10.1",
                 "namespace": "${NAMESPACE}"
               }
             }
@@ -87,7 +70,7 @@
           "spec": {
             "containers": [
               {
-                "name": "mysql",
+                "name": "mariadb",
                 "image": " ",
                 "ports": [
                   {
@@ -140,8 +123,8 @@
             "volumes": [
               {
                 "name": "${DATABASE_SERVICE_NAME}-data",
-                "persistentVolumeClaim": {
-                  "claimName": "${DATABASE_SERVICE_NAME}"
+                "emptyDir": {
+                  "medium": ""
                 }
               }
             ]
@@ -168,13 +151,13 @@
       "name": "DATABASE_SERVICE_NAME",
       "displayName": "Database Service Name",
       "description": "The name of the OpenShift Service exposed for the database.",
-      "value": "mysql",
+      "value": "mariadb",
       "required": true
     },
     {
       "name": "MYSQL_USER",
       "displayName": "MySQL User",
-      "description": "Username for MySQL user that will be used for accessing the database.",
+      "description": "Username for MariaDB user that will be used for accessing the database.",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
       "required": true
@@ -182,7 +165,7 @@
     {
       "name": "MYSQL_PASSWORD",
       "displayName": "MySQL Password",
-      "description": "Password for the MySQL user.",
+      "description": "Password for the MariaDB user.",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
       "required": true
@@ -190,19 +173,12 @@
     {
       "name": "MYSQL_DATABASE",
       "displayName": "MySQL Database Name",
-      "description": "Name of the MySQL database accessed.",
+      "description": "Name of the MariaDB database accessed.",
       "value": "sampledb",
-      "required": true
-    },
-    {
-      "name": "VOLUME_CAPACITY",
-      "displayName": "Volume Capacity",
-      "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
-      "value": "1Gi",
       "required": true
     }
   ],
   "labels": {
-    "template": "mysql-persistent-template"
+    "template": "mariadb-persistent-template"
   }
 }

--- a/examples/db-templates/mariadb-persistent-template.json
+++ b/examples/db-templates/mariadb-persistent-template.json
@@ -2,11 +2,11 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "mysql-persistent",
+    "name": "mariadb-persistent",
     "annotations": {
-      "description": "MySQL database service, with persistent storage.  Scaling to more than one replica is not supported.  You must have persistent volumes available in your cluster to use this template.",
-      "iconClass": "icon-mysql-database",
-      "tags": "database,mysql"
+      "description": "MariaDB database service, with persistent storage.  Scaling to more than one replica is not supported.  You must have persistent volumes available in your cluster to use this template.",
+      "iconClass": "icon-mariadb",
+      "tags": "database,mariadb"
     }
   },
   "objects": [
@@ -19,7 +19,7 @@
       "spec": {
         "ports": [
           {
-            "name": "mysql",
+            "name": "mariadb",
             "port": 3306
           }
         ],
@@ -61,11 +61,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "mysql"
+                "mariadb"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mariadb:10.1",
                 "namespace": "${NAMESPACE}"
               }
             }
@@ -87,7 +87,7 @@
           "spec": {
             "containers": [
               {
-                "name": "mysql",
+                "name": "mariadb",
                 "image": " ",
                 "ports": [
                   {
@@ -168,13 +168,13 @@
       "name": "DATABASE_SERVICE_NAME",
       "displayName": "Database Service Name",
       "description": "The name of the OpenShift Service exposed for the database.",
-      "value": "mysql",
+      "value": "mariadb",
       "required": true
     },
     {
       "name": "MYSQL_USER",
       "displayName": "MySQL User",
-      "description": "Username for MySQL user that will be used for accessing the database.",
+      "description": "Username for MariaDB user that will be used for accessing the database.",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
       "required": true
@@ -182,7 +182,7 @@
     {
       "name": "MYSQL_PASSWORD",
       "displayName": "MySQL Password",
-      "description": "Password for the MySQL user.",
+      "description": "Password for the MariaDB user.",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
       "required": true
@@ -190,7 +190,7 @@
     {
       "name": "MYSQL_DATABASE",
       "displayName": "MySQL Database Name",
-      "description": "Name of the MySQL database accessed.",
+      "description": "Name of the MariaDB database accessed.",
       "value": "sampledb",
       "required": true
     },
@@ -203,6 +203,6 @@
     }
   ],
   "labels": {
-    "template": "mysql-persistent-template"
+    "template": "mariadb-persistent-template"
   }
 }

--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -60,7 +60,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:latest",
+                "name": "mongodb:3.2",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -77,7 +77,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:latest",
+                "name": "mongodb:3.2",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -3,7 +3,6 @@
   "apiVersion": "v1",
   "metadata": {
     "name": "mysql-ephemeral",
-    "creationTimestamp": null,
     "annotations": {
       "description": "MySQL database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
       "iconClass": "icon-mysql-database",
@@ -60,7 +59,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:latest",
+                "name": "mysql:5.6",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -122,10 +121,10 @@
                   }
                 ],
                 "resources": {
-		    "limits": {
-			"memory": "${MEMORY_LIMIT}"
-		    }
-		},
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -60,7 +60,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:latest",
+                "name": "postgresql:9.4",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -121,10 +121,10 @@
                   }
                 ],
                 "resources": {
-		    "limits": {
-			"memory": "${MEMORY_LIMIT}"
-		    }
-		},
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -77,7 +77,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:latest",
+                "name": "postgresql:9.4",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -100,9 +100,11 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"mysql-persistent-template":      &templateapi.Template{},
 			"postgresql-persistent-template": &templateapi.Template{},
 			"mongodb-persistent-template":    &templateapi.Template{},
+			"mariadb-persistent-template":    &templateapi.Template{},
 			"mysql-ephemeral-template":       &templateapi.Template{},
 			"postgresql-ephemeral-template":  &templateapi.Template{},
 			"mongodb-ephemeral-template":     &templateapi.Template{},
+			"mariadb-ephemeral-template":     &templateapi.Template{},
 		},
 		"../test/extended/testdata/ldap": {
 			"ldapserver-buildconfig":         &buildapi.BuildConfig{},

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -2,6 +2,8 @@
 // sources:
 // examples/image-streams/image-streams-centos7.json
 // examples/image-streams/image-streams-rhel7.json
+// examples/db-templates/mariadb-ephemeral-template.json
+// examples/db-templates/mariadb-persistent-template.json
 // examples/db-templates/mongodb-ephemeral-template.json
 // examples/db-templates/mongodb-persistent-template.json
 // examples/db-templates/mysql-ephemeral-template.json
@@ -1308,6 +1310,432 @@ func examplesImageStreamsImageStreamsRhel7Json() (*asset, error) {
 	return a, nil
 }
 
+var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mariadb-ephemeral",
+    "annotations": {
+      "description": "MariaDB database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+      "iconClass": "icon-mariadb",
+      "tags": "database,mariadb"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${DATABASE_SERVICE_NAME}"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "mariadb",
+            "port": 3306
+          }
+        ],
+        "selector": {
+          "name": "${DATABASE_SERVICE_NAME}"
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${DATABASE_SERVICE_NAME}"
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate"
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "mariadb"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "mariadb:10.1",
+                "namespace": "${NAMESPACE}"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${DATABASE_SERVICE_NAME}"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "${DATABASE_SERVICE_NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 3306
+                  }
+                ],
+                "readinessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 5,
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c",
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                  }
+                },
+                "livenessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 30,
+                  "tcpSocket": {
+                    "port": 3306
+                  }
+                },
+                "env": [
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "${MYSQL_USER}"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "${MYSQL_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "${DATABASE_SERVICE_NAME}-data",
+                    "mountPath": "/var/lib/mysql/data"
+                  }
+                ],
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "${DATABASE_SERVICE_NAME}-data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "512Mi",
+      "required": true
+    },
+    {
+      "name": "NAMESPACE",
+      "displayName": "Namespace",
+      "description": "The OpenShift Namespace where the ImageStream resides.",
+      "value": "openshift"
+    },
+    {
+      "name": "DATABASE_SERVICE_NAME",
+      "displayName": "Database Service Name",
+      "description": "The name of the OpenShift Service exposed for the database.",
+      "value": "mariadb",
+      "required": true
+    },
+    {
+      "name": "MYSQL_USER",
+      "displayName": "MySQL User",
+      "description": "Username for MariaDB user that will be used for accessing the database.",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{3}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_PASSWORD",
+      "displayName": "MySQL Password",
+      "description": "Password for the MariaDB user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_DATABASE",
+      "displayName": "MySQL Database Name",
+      "description": "Name of the MariaDB database accessed.",
+      "value": "sampledb",
+      "required": true
+    }
+  ],
+  "labels": {
+    "template": "mariadb-persistent-template"
+  }
+}
+`)
+
+func examplesDbTemplatesMariadbEphemeralTemplateJsonBytes() ([]byte, error) {
+	return _examplesDbTemplatesMariadbEphemeralTemplateJson, nil
+}
+
+func examplesDbTemplatesMariadbEphemeralTemplateJson() (*asset, error) {
+	bytes, err := examplesDbTemplatesMariadbEphemeralTemplateJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "examples/db-templates/mariadb-ephemeral-template.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info:  info}
+	return a, nil
+}
+
+var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mariadb-persistent",
+    "annotations": {
+      "description": "MariaDB database service, with persistent storage.  Scaling to more than one replica is not supported.  You must have persistent volumes available in your cluster to use this template.",
+      "iconClass": "icon-mariadb",
+      "tags": "database,mariadb"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${DATABASE_SERVICE_NAME}"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "mariadb",
+            "port": 3306
+          }
+        ],
+        "selector": {
+          "name": "${DATABASE_SERVICE_NAME}"
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${DATABASE_SERVICE_NAME}"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${VOLUME_CAPACITY}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${DATABASE_SERVICE_NAME}"
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate"
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "mariadb"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "mariadb:10.1",
+                "namespace": "${NAMESPACE}"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${DATABASE_SERVICE_NAME}"
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "name": "${DATABASE_SERVICE_NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mariadb",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 3306
+                  }
+                ],
+                "readinessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 5,
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c",
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                  }
+                },
+                "livenessProbe": {
+                  "timeoutSeconds": 1,
+                  "initialDelaySeconds": 30,
+                  "tcpSocket": {
+                    "port": 3306
+                  }
+                },
+                "env": [
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "${MYSQL_USER}"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "${MYSQL_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "${DATABASE_SERVICE_NAME}-data",
+                    "mountPath": "/var/lib/mysql/data"
+                  }
+                ],
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "${DATABASE_SERVICE_NAME}-data",
+                "persistentVolumeClaim": {
+                  "claimName": "${DATABASE_SERVICE_NAME}"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "512Mi",
+      "required": true
+    },
+    {
+      "name": "NAMESPACE",
+      "displayName": "Namespace",
+      "description": "The OpenShift Namespace where the ImageStream resides.",
+      "value": "openshift"
+    },
+    {
+      "name": "DATABASE_SERVICE_NAME",
+      "displayName": "Database Service Name",
+      "description": "The name of the OpenShift Service exposed for the database.",
+      "value": "mariadb",
+      "required": true
+    },
+    {
+      "name": "MYSQL_USER",
+      "displayName": "MySQL User",
+      "description": "Username for MariaDB user that will be used for accessing the database.",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{3}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_PASSWORD",
+      "displayName": "MySQL Password",
+      "description": "Password for the MariaDB user.",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_DATABASE",
+      "displayName": "MySQL Database Name",
+      "description": "Name of the MariaDB database accessed.",
+      "value": "sampledb",
+      "required": true
+    },
+    {
+      "name": "VOLUME_CAPACITY",
+      "displayName": "Volume Capacity",
+      "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+      "value": "1Gi",
+      "required": true
+    }
+  ],
+  "labels": {
+    "template": "mariadb-persistent-template"
+  }
+}
+`)
+
+func examplesDbTemplatesMariadbPersistentTemplateJsonBytes() ([]byte, error) {
+	return _examplesDbTemplatesMariadbPersistentTemplateJson, nil
+}
+
+func examplesDbTemplatesMariadbPersistentTemplateJson() (*asset, error) {
+	bytes, err := examplesDbTemplatesMariadbPersistentTemplateJsonBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "examples/db-templates/mariadb-persistent-template.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info:  info}
+	return a, nil
+}
+
 var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
   "kind": "Template",
   "apiVersion": "v1",
@@ -1370,7 +1798,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:latest",
+                "name": "mongodb:3.2",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -1622,7 +2050,7 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:latest",
+                "name": "mongodb:3.2",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -1807,7 +2235,6 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
   "apiVersion": "v1",
   "metadata": {
     "name": "mysql-ephemeral",
-    "creationTimestamp": null,
     "annotations": {
       "description": "MySQL database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
       "iconClass": "icon-mysql-database",
@@ -1864,7 +2291,7 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:latest",
+                "name": "mysql:5.6",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -1926,10 +2353,10 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                   }
                 ],
                 "resources": {
-		    "limits": {
-			"memory": "${MEMORY_LIMIT}"
-		    }
-		},
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -2093,7 +2520,7 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:latest",
+                "name": "mysql:5.6",
                 "namespace": "${NAMESPACE}"
               }
             }
@@ -2313,7 +2740,7 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:latest",
+                "name": "postgresql:9.4",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -2374,10 +2801,10 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
                   }
                 ],
                 "resources": {
-		    "limits": {
-			"memory": "${MEMORY_LIMIT}"
-		    }
-		},
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -2553,7 +2980,7 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:latest",
+                "name": "postgresql:9.4",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -6073,6 +6500,8 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"examples/image-streams/image-streams-centos7.json": examplesImageStreamsImageStreamsCentos7Json,
 	"examples/image-streams/image-streams-rhel7.json": examplesImageStreamsImageStreamsRhel7Json,
+	"examples/db-templates/mariadb-ephemeral-template.json": examplesDbTemplatesMariadbEphemeralTemplateJson,
+	"examples/db-templates/mariadb-persistent-template.json": examplesDbTemplatesMariadbPersistentTemplateJson,
 	"examples/db-templates/mongodb-ephemeral-template.json": examplesDbTemplatesMongodbEphemeralTemplateJson,
 	"examples/db-templates/mongodb-persistent-template.json": examplesDbTemplatesMongodbPersistentTemplateJson,
 	"examples/db-templates/mysql-ephemeral-template.json": examplesDbTemplatesMysqlEphemeralTemplateJson,
@@ -6130,6 +6559,10 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"examples": &bintree{nil, map[string]*bintree{
 		"db-templates": &bintree{nil, map[string]*bintree{
+			"mariadb-ephemeral-template.json": &bintree{examplesDbTemplatesMariadbEphemeralTemplateJson, map[string]*bintree{
+			}},
+			"mariadb-persistent-template.json": &bintree{examplesDbTemplatesMariadbPersistentTemplateJson, map[string]*bintree{
+			}},
 			"mongodb-ephemeral-template.json": &bintree{examplesDbTemplatesMongodbEphemeralTemplateJson, map[string]*bintree{
 			}},
 			"mongodb-persistent-template.json": &bintree{examplesDbTemplatesMongodbPersistentTemplateJson, map[string]*bintree{

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -87,6 +87,7 @@ var (
 	}
 	templateLocations = map[string]string{
 		"mongodb":            "examples/db-templates/mongodb-ephemeral-template.json",
+		"mariadb":            "examples/db-templates/mariadb-ephemeral-template.json",
 		"mysql":              "examples/db-templates/mysql-ephemeral-template.json",
 		"postgresql":         "examples/db-templates/postgresql-ephemeral-template.json",
 		"cakephp quickstart": "examples/quickstarts/cakephp-mysql.json",

--- a/test/extended/images/mariadb_ephemeral.go
+++ b/test/extended/images/mariadb_ephemeral.go
@@ -1,0 +1,41 @@
+package images
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[images][mariadb][Slow] openshift mariadb image", func() {
+	defer g.GinkgoRecover()
+	var (
+		templatePath = exutil.FixturePath("..", "..", "examples", "db-templates", "mariadb-ephemeral-template.json")
+		oc           = exutil.NewCLI("mariadb-create", exutil.KubeConfigPath())
+	)
+	g.Describe("Creating from a template", func() {
+		g.It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
+			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+			g.By(fmt.Sprintf("calling oc process -f %q", templatePath))
+			configFile, err := oc.Run("process").Args("-f", templatePath).OutputToFile("config.json")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %q", configFile))
+			err = oc.Run("create").Args("-f", configFile).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
+			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
+			err = exutil.WaitForADeploymentToComplete(oc.KubeREST().ReplicationControllers(oc.Namespace()), "mariadb", oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting the mariadb service get endpoints")
+			err = oc.KubeFramework().WaitForAnEndpoint("mariadb")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+	})
+
+})


### PR DESCRIPTION
introduces a template for mariadb, also updates the db templates to use an explicit imagestream tag instead of latest.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1358431
