### PR TITLE
UPSTREAM: 29306: allow a cohabitator to use its own serialization version

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -87,6 +87,11 @@ type groupResourceOverrides struct {
 	// of exposing one set of concepts.  autoscaling.HPA and extensions.HPA as a for instance
 	// The order of the slice matters!  It is the priority order of lookup for finding a storage location
 	cohabitatingResources []unversioned.GroupResource
+
+	// ignoreCohabitatingStorageVersion controls whether or not a cohabitating resource attempts to serialize into the same
+	// groupVersion as all other cohabitators.  If not, it uses the groupVersion assigned to itself instead of the one being
+	// used by the first enabled cohabitator.
+	ignoreCohabitatingStorageVersion bool
 }
 
 var _ StorageFactory = &DefaultStorageFactory{}
@@ -134,6 +139,16 @@ func (s *DefaultStorageFactory) AddCohabitatingResources(groupResources ...unver
 	for _, groupResource := range groupResources {
 		overrides := s.Overrides[groupResource]
 		overrides.cohabitatingResources = groupResources
+		s.Overrides[groupResource] = overrides
+	}
+}
+
+// IgnoreCohabitingStorageVersion indicates that the cohabitating resource should serialize using its own groupVersion, not the "shared" groupVersion
+// of all cohabitators.  Useful during resource migration/parity cases
+func (s *DefaultStorageFactory) IgnoreCohabitingStorageVersion(groupResources ...unversioned.GroupResource) {
+	for _, groupResource := range groupResources {
+		overrides := s.Overrides[groupResource]
+		overrides.ignoreCohabitatingStorageVersion = true
 		s.Overrides[groupResource] = overrides
 	}
 }
@@ -198,7 +213,12 @@ func (s *DefaultStorageFactory) New(groupResource unversioned.GroupResource) (st
 		config.ServerList = overriddenEtcdLocations
 	}
 
-	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(chosenStorageResource)
+	storageEncodingResource := chosenStorageResource
+	if s.Overrides[groupResource].ignoreCohabitatingStorageVersion {
+		storageEncodingResource = groupResource
+	}
+
+	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(storageEncodingResource)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
@@ -87,3 +87,91 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	}
 }
+
+func TestCohabitingSerializationVersion(t *testing.T) {
+	defaultConfig := storagebackend.Config{
+		Prefix:     options.DefaultEtcdPathPrefix,
+		ServerList: []string{"http://127.0.0.1"},
+	}
+
+	testCases := []struct {
+		name              string
+		factory           func() *DefaultStorageFactory
+		requestedResource unversioned.GroupResource
+
+		expectedResource unversioned.GroupResource
+	}{
+		{
+			name: "request first",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("one"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "request second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "ignore second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("two"),
+		},
+		{
+			name: "ignore second, request third",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("three"),
+			expectedResource:  api.Resource("one"),
+		},
+	}
+
+	for _, tc := range testCases {
+		factory := tc.factory()
+		testEncodingConfig := &testDefaultResourceEncodingConfig{ResourceEncodingConfig: factory.ResourceEncodingConfig}
+		factory.ResourceEncodingConfig = testEncodingConfig
+
+		factory.New(tc.requestedResource)
+
+		if e, a := tc.expectedResource, testEncodingConfig.requestedResource; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+type testDefaultResourceEncodingConfig struct {
+	ResourceEncodingConfig
+	requestedResource unversioned.GroupResource
+}
+
+func (o *testDefaultResourceEncodingConfig) StorageEncodingFor(resource unversioned.GroupResource) (unversioned.GroupVersion, error) {
+	o.requestedResource = resource
+	return api.SchemeGroupVersion, nil
+}


### PR DESCRIPTION
Adds the ability for cohabitors to have different external versions. When we're trying to collapse resources together, but before they have parity, you want to share an etcd directory without serializing the same way. This allows punch through.

D to DC probably needs this.

@kargakis ptal