### PR TITLE
Image progress: recognize additional already pushed status

### DIFF
--- a/pkg/util/docker/dockerfile/builder/imageprogress/progress.go
+++ b/pkg/util/docker/dockerfile/builder/imageprogress/progress.go
@@ -60,7 +60,7 @@ func layerStatusFromDockerString(dockerStatus string) layerStatus {
 		return statusDownloading
 	case "Extracting", "Verifying Checksum", "Download complete":
 		return statusExtracting
-	case "Pull complete", "Already exists", "Pushed":
+	case "Pull complete", "Already exists", "Pushed", "Layer already exists":
 		return statusComplete
 	default:
 		return statusPending


### PR DESCRIPTION
Newer versions of Docker use "Layer already exists" instead of "Already exists" as status. Recognize that as complete.