### PR TITLE
make oc login kubeconfig permission error clearer

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -303,6 +303,10 @@ os::cmd::expect_success "oc login --server=${KUBERNETES_MASTER} --certificate-au
 # this shouldn't fail but instead output "Dry run enabled - no modifications will be made. Add --confirm to remove images"
 os::cmd::expect_success 'oadm prune images'
 
+# make sure we handle invalid config file destination
+os::cmd::expect_failure_and_text "oc login '${KUBERNETES_MASTER}' -u test -p test --config=/src --insecure-skip-tls-verify" 'KUBECONFIG is set to a file that cannot be created or modified'
+echo "login warnings: ok"
+
 # log in and set project to use from now on
 VERBOSE=true os::cmd::expect_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything"
 VERBOSE=true os::cmd::expect_success 'oc get projects'

--- a/pkg/cmd/cli/cmd/errors/login.go
+++ b/pkg/cmd/cli/cmd/errors/login.go
@@ -1,0 +1,53 @@
+package errors
+
+import (
+	"runtime"
+
+	"github.com/openshift/origin/pkg/cmd/errors"
+)
+
+const (
+	KubeConfigFileSolutionWindows = `
+Make sure that the value of the --config flag passed contains a valid path:
+   --config=c:\path\to\valid\file
+`
+	KubeConfigFileSolutionUnix = `
+Make sure that the value of the --config flag passed contains a valid path:
+   --config=/path/to/valid/file
+`
+	KubeConfigSolutionUnix = `
+You can unset the KUBECONFIG variable to use the default location for it:
+   unset KUBECONFIG
+
+Or you can set its value to a file that can be written to:
+   export KUBECONFIG=/path/to/file
+`
+
+	KubeConfigSolutionWindows = `
+You can clear the KUBECONFIG variable to use the default location for it:
+   set KUBECONFIG=
+
+Or you can set its value to a file that can be written to:
+   set KUBECONFIG=c:\path\to\file`
+)
+
+// ErrKubeConfigNotWriteable is returned when the file pointed to by KUBECONFIG cannot be created or written to
+// if isExplicitFile flag is true, the path to .kubeconfig was set using a --config=... flag
+func ErrKubeConfigNotWriteable(file string, isExplicitFile bool, err error) error {
+	return errors.NewError("KUBECONFIG is set to a file that cannot be created or modified: %s", file).WithCause(err).WithSolution(kubeConfigSolution(isExplicitFile))
+}
+
+func kubeConfigSolution(isExplicitFile bool) string {
+	switch runtime.GOOS {
+	case "windows":
+		if isExplicitFile {
+			return KubeConfigFileSolutionWindows
+		}
+		return KubeConfigSolutionWindows
+	default:
+		if isExplicitFile {
+			return KubeConfigFileSolutionUnix
+		}
+		return KubeConfigSolutionUnix
+	}
+}

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -18,7 +18,9 @@ import (
 	"k8s.io/kubernetes/pkg/util/term"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/errors"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
+	cmderr "github.com/openshift/origin/pkg/cmd/errors"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
@@ -394,7 +396,13 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 	}
 
 	if err := kclientcmd.ModifyConfig(o.PathOptions, *configToWrite, true); err != nil {
-		return false, err
+		if !os.IsPermission(err) {
+			return false, err
+		}
+
+		out := &bytes.Buffer{}
+		cmderr.PrintError(errors.ErrKubeConfigNotWriteable(o.PathOptions.GetDefaultFilename(), o.PathOptions.IsExplicitFile(), err), out)
+		return false, fmt.Errorf("%v", out)
 	}
 
 	created := false

--- a/pkg/cmd/errors/errors.go
+++ b/pkg/cmd/errors/errors.go
@@ -1,0 +1,80 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"runtime/debug"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/cmd/util/prefixwriter"
+)
+
+type Error interface {
+	error
+	WithCause(error) Error
+	WithSolution(string) Error
+	WithDetails(string) Error
+}
+
+func NewError(msg string, args ...interface{}) Error {
+	return &internalError{
+		msg: fmt.Sprintf(msg, args...),
+	}
+}
+
+type internalError struct {
+	msg      string
+	cause    error
+	solution string
+	details  string
+}
+
+func (e *internalError) Error() string {
+	return e.msg
+}
+
+func (e *internalError) Cause() error {
+	return e.cause
+}
+
+func (e *internalError) Solution() string {
+	return e.solution
+}
+
+func (e *internalError) Details() string {
+	return e.details
+}
+
+func (e *internalError) WithCause(err error) Error {
+	e.cause = err
+	return e
+}
+
+func (e *internalError) WithDetails(details string) Error {
+	e.details = details
+	return e
+}
+
+func (e *internalError) WithSolution(solution string) Error {
+	e.solution = fmt.Sprintf(solution)
+	return e
+}
+
+func LogError(err error) {
+	if err == nil {
+		return
+	}
+	glog.V(1).Infof("Unexpected error: %v", err)
+	if glog.V(5) {
+		debug.PrintStack()
+	}
+}
+
+func PrintLog(out io.Writer, title string, content []byte) {
+	fmt.Fprintf(out, "%s:\n", title)
+	w := prefixwriter.New("  ", out)
+	w.Write(bytes.TrimSpace(content))
+	fmt.Fprintf(out, "\n")
+}

--- a/pkg/cmd/errors/printer.go
+++ b/pkg/cmd/errors/printer.go
@@ -1,0 +1,31 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+type hasCause interface {
+	Cause() error
+}
+
+type hasDetails interface {
+	Details() string
+}
+
+type hasSolution interface {
+	Solution() string
+}
+
+func PrintError(err error, out io.Writer) {
+	fmt.Fprintf(out, "%v\n", err)
+	if d, ok := err.(hasDetails); ok && len(d.Details()) > 0 {
+		fmt.Fprintf(out, "%s\n", d.Details())
+	}
+	if c, ok := err.(hasCause); ok && c.Cause() != nil {
+		fmt.Fprintf(out, "%v\n", c.Cause())
+	}
+	if s, ok := err.(hasSolution); ok && len(s.Solution()) > 0 {
+		fmt.Fprintf(out, "%s", s.Solution())
+	}
+}


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1332131

When logging in with a `$KUBECONFIG` variable, or `--config` flag pointing to a location that denies write access, `oc login` prints a non-specific error at the bottom of its output:

`export KUBECONFIG=/src`
`oc login  --token=<my_token> --insecure-skip-tls-verify`
```
Logged into "https://localhost:8443" as "test" using the token provided.

You have one project on this server: "test-project"

Using project "test-project".
error: open /src.lock: permission denied
```

This updates the error to be more clear as to what has happened:

`oc login -u test -p test --insecure-skip-tls-verify`
```
Login successful.

You have one project on this server: "myproject"

Using project "myproject".
error: KUBECONFIG is set to a file that cannot be created or modified: /src
Solution:

You can unset the KUBECONFIG variable to use the default location for it:
   unset KUBECONFIG

Or you can set its value to a file that can be written to:
   export KUBECONFIG=/path/to/file

Caused By:
  open /src.lock: permission denied
```

Same output, but using a `--config` flag:

`oc login -u test -p test --insecure-skip-tls-verify --config=/src`
```
Login successful.

You have one project on this server: "myproject"

Using project "myproject".
error: KUBECONFIG is set to a file that cannot be created or modified: /src
Solution:

Make sure that the value of the --config flag passed contains a valid path:
        --config=/path/to/valid/file

Caused By:
  open /src.lock: permission denied
```