### PR TITLE
allow SA oauth clients to list projects

### DIFF
--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -53,8 +53,8 @@ func TestUserEvaluator(t *testing.T) {
 			numRules: 4,
 		},
 		{
-			name:     "list-projects",
-			scopes:   []string{UserListProject},
+			name:     "list--scoped-projects",
+			scopes:   []string{UserListScopedProjects},
 			numRules: 2,
 		},
 	}

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
@@ -83,7 +83,12 @@ func (a *saOAuthClientAdapter) GetClient(ctx kapi.Context, name string) (*oautha
 
 func getScopeRestrictionsFor(namespace, name string) []oauthapi.ScopeRestriction {
 	return []oauthapi.ScopeRestriction{
-		{ExactValues: []string{scopeauthorizer.UserInfo, scopeauthorizer.UserAccessCheck}},
+		{ExactValues: []string{
+			scopeauthorizer.UserInfo,
+			scopeauthorizer.UserAccessCheck,
+			scopeauthorizer.UserListScopedProjects,
+			scopeauthorizer.UserListAllProjects,
+		}},
 		{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{RoleNames: []string{"*"}, Namespaces: []string{namespace}, AllowEscalation: true}},
 	}
 }

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -32,12 +32,15 @@ whoamitoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-tok
 os::cmd::expect_success_and_text "oc get user/~ --token='${whoamitoken}'" "${username}"
 os::cmd::expect_failure_and_text "oc get pods --token='${whoamitoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
 
-listprojecttoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=listproject SCOPE=user:list-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
+listprojecttoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=listproject SCOPE=user:list-scoped-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
 # this token doesn't have rights to see any projects even though it can hit the list endpoint, so an empty list is correct
 # we'll add another scope that allows listing all known projects even if this token has no other powers in them.
 os::cmd::expect_success_and_not_text "oc get projects --token='${listprojecttoken}'" "${project}"
 os::cmd::expect_failure_and_text "oc get user/~ --token='${listprojecttoken}'" 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
 os::cmd::expect_failure_and_text "oc get pods --token='${listprojecttoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
+
+listprojecttoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=listallprojects SCOPE=user:list-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
+os::cmd::expect_success_and_text "oc get projects --token='${listprojecttoken}'" "${project}"
 
 adminnonescalatingpowerstoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=admin SCOPE=role:admin:* USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
 os::cmd::expect_failure_and_text "oc get user/~ --token='${adminnonescalatingpowerstoken}'" 'prevent this action; User "scoped-user" cannot get users at the cluster scope'

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -321,7 +321,7 @@ func TestScopedProjectAccess(t *testing.T) {
 	}
 
 	oneTwoBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
-		scope.UserListProject,
+		scope.UserListScopedProjects,
 		scope.ClusterRoleIndicator + "view:one",
 		scope.ClusterRoleIndicator + "view:two",
 	})
@@ -330,13 +330,13 @@ func TestScopedProjectAccess(t *testing.T) {
 	}
 
 	twoThreeBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
-		scope.UserListProject,
+		scope.UserListScopedProjects,
 		scope.ClusterRoleIndicator + "view:two",
 		scope.ClusterRoleIndicator + "view:three",
 	})
 
 	allBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
-		scope.UserListProject,
+		scope.UserListScopedProjects,
 		scope.ClusterRoleIndicator + "view:*",
 	})
 	if err != nil {


### PR DESCRIPTION
Allows an SA being used as an oauth client to list the available projects for this user.    This also adds `user:list-all-projects` so that we have one scope for "list projects this token can see based on other permissions" and another for "list all projects this user can see regard of the other permissions on this token"

@liggitt @smarterclayton I'm unsure about this, but in my quest to run a personal webconsole I found it was the first request.  Running a personal version of a normally cross namespace thing doesn't seem immediately unreasonable.