### PR TITLE
Add V(5) logging back to pkg/util/ovs and pkg/util/ipcmd

### DIFF
--- a/pkg/util/ipcmd/ipcmd.go
+++ b/pkg/util/ipcmd/ipcmd.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/util/exec"
 )
 
@@ -39,8 +41,12 @@ func (tx *Transaction) exec(args []string) (string, error) {
 		return "", tx.err
 	}
 
+	glog.V(5).Infof("Executing: %s %s", ipcmdPath, strings.Join(args, " "))
 	var output []byte
 	output, tx.err = tx.execer.Command(ipcmdPath, args...).CombinedOutput()
+	if tx.err != nil {
+		glog.V(5).Infof("Error executing %s: %s", ipcmdPath, string(output))
+	}
 	return string(output), tx.err
 }
 

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/util/exec"
 )
 
@@ -32,8 +34,12 @@ func (tx *Transaction) exec(cmd string, args ...string) (string, error) {
 		return "", tx.err
 	}
 
+	glog.V(5).Infof("Executing: %s %s", cmdpath, strings.Join(args, " "))
 	var output []byte
 	output, tx.err = tx.execer.Command(cmdpath, args...).CombinedOutput()
+	if tx.err != nil {
+		glog.V(5).Infof("Error executing %s: %s", cmdpath, string(output))
+	}
 	return string(output), tx.err
 }
 


### PR DESCRIPTION
They used to get logging via the old openshift-sdn pkg/exec, but kexec doesn't log anything.

@openshift/networking PTAL