### PR TITLE
Drop cluster-internal endpoint filtering / pod monitoring

### DIFF
--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"fmt"
 	"net"
-	"strings"
-	"sync"
 
 	"github.com/golang/glog"
 
@@ -26,10 +24,8 @@ type proxyFirewallItem struct {
 }
 
 type ovsProxyPlugin struct {
-	registry  *Registry
-	podsByIP  map[string]*kapi.Pod
-	podsMutex sync.Mutex
-	firewall  map[string][]proxyFirewallItem
+	registry *Registry
+	firewall map[string][]proxyFirewallItem
 
 	baseEndpointsHandler pconfig.EndpointsConfigHandler
 }
@@ -42,7 +38,6 @@ func NewProxyPlugin(pluginName string, osClient *osclient.Client, kClient *kclie
 
 	return &ovsProxyPlugin{
 		registry: newRegistry(osClient, kClient),
-		podsByIP: make(map[string]*kapi.Pod),
 		firewall: make(map[string][]proxyFirewallItem),
 	}, nil
 }
@@ -52,12 +47,6 @@ func (proxy *ovsProxyPlugin) Start(baseHandler pconfig.EndpointsConfigHandler) e
 
 	proxy.baseEndpointsHandler = baseHandler
 
-	// Populate pod info map synchronously so that kube proxy can filter endpoints to support isolation
-	pods, err := proxy.registry.GetAllPods()
-	if err != nil {
-		return err
-	}
-
 	policies, err := proxy.registry.GetEgressNetworkPolicies()
 	if err != nil {
 		return fmt.Errorf("Could not get EgressNetworkPolicies: %s", err)
@@ -66,13 +55,7 @@ func (proxy *ovsProxyPlugin) Start(baseHandler pconfig.EndpointsConfigHandler) e
 		proxy.updateNetworkPolicy(policy)
 	}
 
-	for _, pod := range pods {
-		proxy.trackPod(&pod)
-	}
-
-	go utilwait.Forever(proxy.watchPods, 0)
 	go utilwait.Forever(proxy.watchEgressNetworkPolicies, 0)
-
 	return nil
 }
 
@@ -113,74 +96,6 @@ func (proxy *ovsProxyPlugin) updateNetworkPolicy(policy osapi.EgressNetworkPolic
 	}
 }
 
-func (proxy *ovsProxyPlugin) watchPods() {
-	eventQueue := proxy.registry.RunEventQueue(Pods)
-
-	for {
-		eventType, obj, err := eventQueue.Pop()
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("EventQueue failed for pods: %v", err))
-			return
-		}
-		pod := obj.(*kapi.Pod)
-
-		glog.V(5).Infof("Watch %s event for Pod %q", strings.Title(string(eventType)), pod.ObjectMeta.Name)
-		switch eventType {
-		case watch.Added, watch.Modified:
-			proxy.trackPod(pod)
-		case watch.Deleted:
-			proxy.unTrackPod(pod)
-		}
-	}
-}
-
-func (proxy *ovsProxyPlugin) getTrackedPod(ip string) (*kapi.Pod, bool) {
-	proxy.podsMutex.Lock()
-	defer proxy.podsMutex.Unlock()
-
-	pod, ok := proxy.podsByIP[ip]
-	return pod, ok
-}
-
-func (proxy *ovsProxyPlugin) trackPod(pod *kapi.Pod) {
-	if pod.Status.PodIP == "" {
-		return
-	}
-
-	proxy.podsMutex.Lock()
-	defer proxy.podsMutex.Unlock()
-	podInfo, ok := proxy.podsByIP[pod.Status.PodIP]
-
-	if pod.Status.Phase == kapi.PodPending || pod.Status.Phase == kapi.PodRunning {
-		// When a pod hits one of the states where the IP is in use then
-		// we need to add it to our IP -> namespace tracker.  There _should_ be no
-		// other entries for the IP if we caught all of the right messages, so warn
-		// if we see one, but clobber it anyway since the IPAM
-		// should ensure that each IP is uniquely assigned to a pod (when running)
-		if ok && podInfo.UID != pod.UID {
-			glog.Warningf("IP '%s' was marked as used by namespace '%s' (pod '%s')... updating to namespace '%s' (pod '%s')",
-				pod.Status.PodIP, podInfo.Namespace, podInfo.UID, pod.ObjectMeta.Namespace, pod.UID)
-		}
-
-		proxy.podsByIP[pod.Status.PodIP] = pod
-	} else if ok && podInfo.UID == pod.UID {
-		// If the UIDs match, then this pod is moving to a state that indicates it is not running
-		// so we need to remove it from the cache
-		delete(proxy.podsByIP, pod.Status.PodIP)
-	}
-}
-
-func (proxy *ovsProxyPlugin) unTrackPod(pod *kapi.Pod) {
-	proxy.podsMutex.Lock()
-	defer proxy.podsMutex.Unlock()
-
-	// Only delete if the pod ID is the one we are tracking (in case there is a failed or complete
-	// pod lying around that gets deleted while there is a running pod with the same IP)
-	if podInfo, ok := proxy.podsByIP[pod.Status.PodIP]; ok && podInfo.UID == pod.UID {
-		delete(proxy.podsByIP, pod.Status.PodIP)
-	}
-}
-
 func (proxy *ovsProxyPlugin) firewallBlocksIP(namespace string, ip net.IP) bool {
 	for _, item := range proxy.firewall[namespace] {
 		if item.net.Contains(ip) {
@@ -191,6 +106,11 @@ func (proxy *ovsProxyPlugin) firewallBlocksIP(namespace string, ip net.IP) bool 
 }
 
 func (proxy *ovsProxyPlugin) OnEndpointsUpdate(allEndpoints []kapi.Endpoints) {
+	if len(proxy.firewall) == 0 {
+		proxy.baseEndpointsHandler.OnEndpointsUpdate(allEndpoints)
+		return
+	}
+
 	ni, err := proxy.registry.GetNetworkInfo()
 	if err != nil {
 		glog.Warningf("Error fetching network information: %v", err)
@@ -205,20 +125,7 @@ EndpointLoop:
 		for _, ss := range ep.Subsets {
 			for _, addr := range ss.Addresses {
 				IP := net.ParseIP(addr.IP)
-				if ni.ServiceNetwork.Contains(IP) {
-					glog.Warningf("Service '%s' in namespace '%s' has an Endpoint inside the service network (%s)", ep.ObjectMeta.Name, ns, addr.IP)
-					continue EndpointLoop
-				} else if ni.ClusterNetwork.Contains(IP) {
-					podInfo, ok := proxy.getTrackedPod(addr.IP)
-					if !ok {
-						glog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to non-existent pod (%s)", ep.ObjectMeta.Name, ns, addr.IP)
-						continue EndpointLoop
-					}
-					if podInfo.ObjectMeta.Namespace != ns {
-						glog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to pod %s in namespace '%s'", ep.ObjectMeta.Name, ns, addr.IP, podInfo.ObjectMeta.Namespace)
-						continue EndpointLoop
-					}
-				} else {
+				if !ni.ClusterNetwork.Contains(IP) && !ni.ServiceNetwork.Contains(IP) {
 					if proxy.firewallBlocksIP(ns, IP) {
 						glog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to firewalled destination (%s)", ep.ObjectMeta.Name, ns, addr.IP)
 						continue EndpointLoop

--- a/pkg/sdn/plugin/registry.go
+++ b/pkg/sdn/plugin/registry.go
@@ -85,15 +85,6 @@ func (registry *Registry) UpdateSubnet(hs *osapi.HostSubnet) (*osapi.HostSubnet,
 	return registry.oClient.HostSubnets().Update(hs)
 }
 
-func (registry *Registry) GetAllPods() ([]kapi.Pod, error) {
-	podList, err := registry.kClient.Pods(kapi.NamespaceAll).List(kapi.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return podList.Items, nil
-}
-
 func (registry *Registry) GetRunningPods(nodeName, namespace string) ([]kapi.Pod, error) {
 	fieldSelector := fields.Set{"spec.host": nodeName}.AsSelector()
 	opts := kapi.ListOptions{


### PR DESCRIPTION
With #9383 merged, we no longer need to sanity-check cluster-internal service endpoints, so we can drop the pod monitor.

Unfortunately, for the moment at least, we still need to filter out cluster-external endpoints that violate EgressFirewall rules (#9227). Eventually we will hopefully be able to get rid of that. For now, this branch is based on top of the EgressFirewall branch (since otherwise we'd be completely dropping the endpoint filter in this branch, and then bringing it back in the EgressFirewall branch). It can land after that does.

Closes #9255.

@openshift/networking PTAL. Only the last commit is new; the rest is from 9227.