### PR TITLE
Make root oc cmd dynamic in all command output

### DIFF
--- a/docs/man/man1/openshift-cli-status.1
+++ b/docs/man/man1/openshift-cli-status.1
@@ -18,8 +18,8 @@ Show a high level overview of the current project
 .PP
 This command will show services, deployment configs, build configurations, and active deployments.
 If you have any misconfigured components information about them will be shown. For more information
-about individual items, use the describe command (e.g. oc describe buildConfig,
-oc describe deploymentConfig, oc describe service).
+about individual items, use the describe command (e.g. openshift cli describe buildConfig,
+openshift cli describe deploymentConfig, openshift cli describe service).
 
 .PP
 You can specify an output format of "\-o dot" to have this command output the generated status

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -96,7 +96,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				loginCmd,
 				cmd.NewCmdRequestProject(fullName, "new-project", fullName+" login", fullName+" project", f, out),
 				cmd.NewCmdNewApplication(fullName, f, out),
-				cmd.NewCmdStatus(cmd.StatusRecommendedName, fullName+" "+cmd.StatusRecommendedName, f, out),
+				cmd.NewCmdStatus(cmd.StatusRecommendedName, fullName, fullName+" "+cmd.StatusRecommendedName, f, out),
 				cmd.NewCmdProject(fullName+" project", f, out),
 				cmd.NewCmdProjects(fullName, f, out),
 				cmd.NewCmdExplain(fullName, f, out),

--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -41,7 +41,7 @@ func NewCmdImportImage(fullName string, f *clientcmd.Factory, out io.Writer) *co
 		Example:    fmt.Sprintf(importImageExample, fullName),
 		SuggestFor: []string{"image"},
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(opts.Complete(f, cmd, args, out))
+			kcmdutil.CheckErr(opts.Complete(f, cmd, args, fullName, out))
 			kcmdutil.CheckErr(opts.Validate(cmd))
 			kcmdutil.CheckErr(opts.Run())
 		},
@@ -68,6 +68,8 @@ type ImportImageOptions struct {
 	Tag       string
 	Target    string
 
+	CommandName string
+
 	// helpers
 	out      io.Writer
 	osClient client.Interface
@@ -76,7 +78,9 @@ type ImportImageOptions struct {
 
 // Complete turns a partially defined ImportImageOptions into a solvent structure
 // which can be validated and used for aa import.
-func (o *ImportImageOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *ImportImageOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, commandName string, out io.Writer) error {
+	o.CommandName = commandName
+
 	if len(args) > 0 {
 		o.Target = args[0]
 	}
@@ -186,7 +190,7 @@ func (o *ImportImageOptions) Run() error {
 		if _, ok := err.(importError); ok {
 			return err
 		}
-		return fmt.Errorf("unable to determine if the import completed successfully - please run 'oc describe -n %s imagestream/%s' to see if the tags were updated as expected: %v", stream.Namespace, stream.Name, err)
+		return fmt.Errorf("unable to determine if the import completed successfully - please run '%s describe -n %s imagestream/%s' to see if the tags were updated as expected: %v", o.CommandName, stream.Namespace, stream.Name, err)
 	}
 
 	fmt.Fprint(o.out, "The import completed successfully.\n\n")

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -55,7 +55,7 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out 
 		Long:    loginLong,
 		Example: fmt.Sprintf(loginExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.Complete(f, cmd, args); err != nil {
+			if err := options.Complete(f, cmd, args, fullName); err != nil {
 				kcmdutil.CheckErr(err)
 			}
 
@@ -91,7 +91,7 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out 
 	return cmds
 }
 
-func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string, commandName string) error {
 	kubeconfig, err := f.OpenShiftClientConfig.RawConfig()
 	o.StartingKubeConfig = &kubeconfig
 	if err != nil {
@@ -100,6 +100,11 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 		}
 		// build a valid object to use if we failed on a non-existent file
 		o.StartingKubeConfig = kclientcmdapi.NewConfig()
+	}
+
+	o.CommandName = commandName
+	if o.CommandName == "" {
+		o.CommandName = "oc"
 	}
 
 	addr := flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default()
@@ -190,7 +195,7 @@ func RunLogin(cmd *cobra.Command, options *LoginOptions) error {
 	}
 
 	if newFileCreated {
-		fmt.Fprintln(options.Out, "Welcome! See 'oc help' to get started.")
+		fmt.Fprintf(options.Out, "Welcome! See '%s help' to get started.\n", options.CommandName)
 	}
 	return nil
 }

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -58,6 +58,8 @@ type LoginOptions struct {
 	Token string
 
 	PathOptions *kclientcmd.PathOptions
+
+	CommandName string
 }
 
 // Gather all required information in a comprehensive order.
@@ -311,9 +313,9 @@ func (o *LoginOptions) gatherProjectInfo() error {
 	case 0:
 		fmt.Fprintf(o.Out, `You don't have any projects. You can try to create a new project, by running
 
-    oc new-project <projectname>
+    %s new-project <projectname>
 
-`)
+`, o.CommandName)
 		o.Project = ""
 
 	case 1:
@@ -342,7 +344,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 		}
 		o.Project = current.Name
 
-		fmt.Fprintf(o.Out, "You have access to the following projects and can switch between them with 'oc project <projectname>':\n\n")
+		fmt.Fprintf(o.Out, "You have access to the following projects and can switch between them with '%s project <projectname>':\n\n", o.CommandName)
 		for _, p := range projects.List() {
 			if o.Project == p {
 				fmt.Fprintf(o.Out, "  * %s\n", p)

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -293,9 +293,9 @@ func (o *NewAppOptions) Run() error {
 				}
 			}
 			if triggered {
-				fmt.Fprintf(out, "%sBuild scheduled, use 'oc logs -f bc/%s' to track its progress.\n", indent, t.Name)
+				fmt.Fprintf(out, "%[1]sBuild scheduled, use '%[3]s logs -f bc/%[2]s' to track its progress.\n", indent, t.Name, o.CommandName)
 			} else {
-				fmt.Fprintf(out, "%sUse 'oc start-build %s' to start a build.\n", indent, t.Name)
+				fmt.Fprintf(out, "%[1]sUse '%[3]s start-build %[2]s' to start a build.\n", indent, t.Name, o.CommandName)
 			}
 		case *imageapi.ImageStream:
 			if len(t.Status.DockerImageRepository) == 0 {
@@ -649,7 +649,7 @@ func transformError(err error, commandName, commandPath string, groups errorGrou
 					heredoc.Docf(`
 						The argument %[1]q could apply to the following Docker images, OpenShift image streams, or templates:
 
-						%[2]sTo view a full list of matches, use 'oc new-app -S %[1]s'`, t.Value, buf.String(),
+						%[2]sTo view a full list of matches, use '%[3]s new-app -S %[1]s'`, t.Value, buf.String(), commandName,
 					),
 					t,
 					t.Errs...,
@@ -746,7 +746,7 @@ func printHumanReadableQueryResult(r *newcmd.QueryResult, out io.Writer, command
 	sort.Sort(newapp.ScoredComponentMatches(dockerImages))
 
 	if len(templates) > 0 {
-		fmt.Fprintln(out, "Templates (oc new-app --template=<template>)")
+		fmt.Fprintf(out, "Templates (%s new-app --template=<template>)\n", commandName)
 		fmt.Fprintln(out, "-----")
 		for _, match := range templates {
 			template := match.Template
@@ -762,7 +762,7 @@ func printHumanReadableQueryResult(r *newcmd.QueryResult, out io.Writer, command
 	}
 
 	if len(imageStreams) > 0 {
-		fmt.Fprintln(out, "Image streams (oc new-app --image-stream=<image-stream> [--code=<source>])")
+		fmt.Fprintf(out, "Image streams (%s new-app --image-stream=<image-stream> [--code=<source>])\n", commandName)
 		fmt.Fprintln(out, "-----")
 		for _, match := range imageStreams {
 			imageStream := match.ImageStream
@@ -790,7 +790,7 @@ func printHumanReadableQueryResult(r *newcmd.QueryResult, out io.Writer, command
 	}
 
 	if len(dockerImages) > 0 {
-		fmt.Fprintln(out, "Docker images (oc new-app --docker-image=<docker-image> [--code=<source>])")
+		fmt.Fprintf(out, "Docker images (%s new-app --docker-image=<docker-image> [--code=<source>])\n", commandName)
 		fmt.Fprintln(out, "-----")
 		for _, match := range dockerImages {
 			image := match.Image

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -25,6 +25,9 @@ type ProjectsOptions struct {
 	Out          io.Writer
 	PathOptions  *kclientcmd.PathOptions
 
+	// internal strings
+	CommandName string
+
 	DisplayShort bool
 }
 
@@ -64,7 +67,7 @@ func NewCmdProjects(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
 
-			if err := options.Complete(f, args, out); err != nil {
+			if err := options.Complete(f, args, fullName, out); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
 			}
 
@@ -78,10 +81,12 @@ func NewCmdProjects(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	return cmd
 }
 
-func (o *ProjectsOptions) Complete(f *clientcmd.Factory, args []string, out io.Writer) error {
+func (o *ProjectsOptions) Complete(f *clientcmd.Factory, args []string, commandName string, out io.Writer) error {
 	if len(args) > 0 {
 		return fmt.Errorf("no arguments should be passed")
 	}
+
+	o.CommandName = commandName
 
 	var err error
 	o.Config, err = f.OpenShiftClientConfig.RawConfig()
@@ -142,7 +147,7 @@ func (o ProjectsOptions) RunProjects() error {
 			asterisk := ""
 			count := 0
 			if !o.DisplayShort {
-				msg += "You have access to the following projects and can switch between them with 'oc project <projectname>':\n"
+				msg += fmt.Sprintf("You have access to the following projects and can switch between them with '%s project <projectname>':\n", o.CommandName)
 			}
 
 			sort.Sort(SortByProjectName(projects))

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -25,8 +25,8 @@ Show a high level overview of the current project
 
 This command will show services, deployment configs, build configurations, and active deployments.
 If you have any misconfigured components information about them will be shown. For more information
-about individual items, use the describe command (e.g. oc describe buildConfig,
-oc describe deploymentConfig, oc describe service).
+about individual items, use the describe command (e.g. %[1]s describe buildConfig,
+%[1]s describe deploymentConfig, %[1]s describe service).
 
 You can specify an output format of "-o dot" to have this command output the generated status
 graph in DOT format that is suitable for use by the "dot" command.`
@@ -57,13 +57,14 @@ type StatusOptions struct {
 }
 
 // NewCmdStatus implements the OpenShift cli status command.
-func NewCmdStatus(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+// baseCLIName is the path from root cmd to the parent of this cmd.
+func NewCmdStatus(name, baseCLIName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	opts := &StatusOptions{}
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s [-o dot | -v ]", StatusRecommendedName),
 		Short:   "Show an overview of the current project",
-		Long:    statusLong,
+		Long:    fmt.Sprintf(statusLong, baseCLIName),
 		Example: fmt.Sprintf(statusExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(f, cmd, args, out)

--- a/pkg/deploy/cmd/rollback.go
+++ b/pkg/deploy/cmd/rollback.go
@@ -30,7 +30,7 @@ func (r *DeploymentConfigRollbacker) Rollback(namespace, name string, updatedAnn
 		return "", fmt.Errorf("passed object is not a deployment config: %#v", obj)
 	}
 	if config.Spec.Paused {
-		return "", fmt.Errorf("cannot rollback a paused config; resume it first with 'oc rollout resume dc/%s' and try again", config.Name)
+		return "", fmt.Errorf("cannot rollback a paused config; resume it first with '%[2]s rollout resume dc/%[1]s' and try again", config.Name, name)
 	}
 
 	rollback := &deployapi.DeploymentConfigRollback{

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -69,6 +69,12 @@ os::cmd::expect_success_and_text 'openshift cli get dc --loglevel=7  2>&1 | grep
 echo "version reporting: ok"
 os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/basicresources/status"
+os::cmd::expect_success_and_text 'openshift cli status -h' 'openshift cli describe buildConfig'
+os::cmd::expect_success_and_text 'oc status -h' 'oc describe buildConfig'
+echo "status help output: ok"
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_start "cmd/basicresources/explain"
 os::cmd::expect_success_and_text 'oc types' 'Deployment Configuration'
 os::cmd::expect_failure_and_text 'oc get' 'deploymentconfig'


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1256274

Suggestions to use the "oc" command are hardcoded into some commands (and their help output). This updates the help output and other instances in those commands to be dynamic.

###### Before
```
$ openshift cli login -u test -p test
You have access to the following projects and can switch between them with 'oc project <projectname>':
```
###### After
```
$ openshift cli login -u test -p test
You have access to the following projects and can switch between them with 'openshift cli project <projectname>':
```
