### PR TITLE
Skip the '-' character in scratch builds for Docker 1.9.1

### DIFF
--- a/pkg/util/docker/dockerfile/builder/client.go
+++ b/pkg/util/docker/dockerfile/builder/client.go
@@ -306,7 +306,7 @@ func (e *ClientExecutor) CreateScratchImage() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name := fmt.Sprintf("scratch-%s", random)
+	name := fmt.Sprintf("scratch%s", random)
 
 	buf := &bytes.Buffer{}
 	w := tar.NewWriter(buf)


### PR DESCRIPTION
Some versions don't allow image names with dashes.

[test]

Fixes #9269