### PR TITLE
dockerregistry build in spec should set correct tags for GCS

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -188,7 +188,7 @@ pushd _thirdpartyhacks
 popd
 export GOPATH=$(pwd)/_build:$(pwd)/_thirdpartyhacks:%{buildroot}%{gopath}:%{gopath}
 # Build all linux components we care about
-go install -ldflags "%{ldflags}" %{import_path}/cmd/dockerregistry
+go install -tags include_gcs -ldflags "%{ldflags}" %{import_path}/cmd/dockerregistry
 go install -ldflags "%{ldflags}" -tags=gssapi %{import_path}/cmd/openshift
 go install -ldflags "%{ldflags}" -tags=gssapi %{import_path}/cmd/oc
 go test -c -o _build/bin/extended.test -ldflags "%{ldflags}" %{import_path}/test/extended


### PR DESCRIPTION
@sdodson I don't like not using hack/build-cross.sh from our spec file. It leads to drift, and the eng team should be the one making a fair amount of these build decisions.

It also means we're not shipping what we test.