### PR TITLE
WIP: [DO_NOT_MERGE] Enable upstream deployments

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -16,8 +16,8 @@ const (
 	InfraBuildControllerServiceAccountName = "build-controller"
 	BuildControllerRoleName                = "system:build-controller"
 
-	InfraReplicationControllerServiceAccountName = "replication-controller"
-	ReplicationControllerRoleName                = "system:replication-controller"
+	InfraReplicaSetControllerServiceAccountName = "replica-set-controller"
+	ReplicaSetControllerRoleName                = "system:replica-set-controller"
 
 	InfraDeploymentControllerServiceAccountName = "deployment-controller"
 	DeploymentControllerRoleName                = "system:deployment-controller"
@@ -183,39 +183,41 @@ func init() {
 	}
 
 	err = InfraSAs.addServiceAccount(
-		InfraReplicationControllerServiceAccountName,
+		InfraReplicaSetControllerServiceAccountName,
 		authorizationapi.ClusterRole{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: ReplicationControllerRoleName,
+				Name: ReplicaSetControllerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				// ReplicationManager.rcController.ListWatch
+				// ReplicaSetController.rcController.ListWatch
 				{
+					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("replicationcontrollers"),
+					Resources: sets.NewString("replicasets"),
 				},
-				// ReplicationManager.syncReplicationController() -> updateReplicaCount()
+				// ReplicaSetController.syncReplicaSet() -> updateReplicaCount()
 				{
-					// TODO: audit/remove those, 1.0 controllers needed get, update
+					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("get", "update"),
-					Resources: sets.NewString("replicationcontrollers"),
+					Resources: sets.NewString("replicasets"),
 				},
-				// ReplicationManager.syncReplicationController() -> updateReplicaCount()
+				// ReplicaSetController.syncReplicaSet() -> updateReplicaCount()
 				{
+					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("replicationcontrollers/status"),
+					Resources: sets.NewString("replicasets/status"),
 				},
-				// ReplicationManager.podController.ListWatch
+				// ReplicaSetController.podController.ListWatch
 				{
 					Verbs:     sets.NewString("list", "watch"),
 					Resources: sets.NewString("pods"),
 				},
-				// ReplicationManager.podControl (RealPodControl)
+				// ReplicaSetController.podControl (RealPodControl)
 				{
 					Verbs:     sets.NewString("create", "delete"),
 					Resources: sets.NewString("pods"),
 				},
-				// ReplicationManager.podControl.recorder
+				// ReplicaSetController.podControl.recorder
 				{
 					Verbs:     sets.NewString("create", "update", "patch"),
 					Resources: sets.NewString("events"),

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -157,18 +157,31 @@ func init() {
 			Rules: []authorizationapi.PolicyRule{
 				// DeploymentControllerFactory.deploymentLW
 				{
+					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("replicationcontrollers"),
+					Resources: sets.NewString("replicationcontrollers", "replicasets", "deployments"),
 				},
 				// DeploymentControllerFactory.deploymentClient
 				{
+					APIGroups: []string{extensions.GroupName},
 					Verbs:     sets.NewString("get", "update"),
-					Resources: sets.NewString("replicationcontrollers"),
+					Resources: sets.NewString("replicationcontrollers", "replicasets", "deployments"),
+				},
+				// DeploymentController (upstream) creating RS
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("create", "update", "delete", "watch"),
+					Resources: sets.NewString("replicationcontrollers", "replicasets"),
 				},
 				// DeploymentController.podClient
 				{
 					Verbs:     sets.NewString("get", "list", "create", "watch", "delete", "update"),
 					Resources: sets.NewString("pods"),
+				},
+				{
+					APIGroups: []string{extensions.GroupName},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("deployments/status"),
 				},
 				// DeploymentController.recorder (EventBroadcaster)
 				{

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -119,8 +119,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets", "daemonsets/status", "deployments", "deployments/scale",
 					"deployments/status", "horizontalpodautoscalers", "horizontalpodautoscalers/status", "ingresses", "ingresses/status", "jobs", "jobs/status",
-					"networkpolicies", "podsecuritypolicies", "replicasets", "replicasets/scale", "replicasets/status", "replicationcontrollers",
-					"replicationcontrollers/scale", "thirdpartyresources").RuleOrDie(),
+					"networkpolicies", "podsecuritypolicies", "replicasets", "replicasets/scale", "replicasets/status", "replicationcontrollers/scale", "thirdpartyresources").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(authzGroup).Resources("clusterpolicies", "clusterpolicybindings", "clusterroles", "clusterrolebindings",
 					"policies", "policybindings", "roles", "rolebindings").RuleOrDie(),
@@ -219,7 +218,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
+					"replicasets", "replicasets/status", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -272,8 +272,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets", "replicasets/status").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
@@ -307,18 +307,17 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				Name: ViewRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
-				// TODO add "replicationcontrollers/scale" here
 				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("pods", "replicationcontrollers", "serviceaccounts",
 					"services", "endpoints", "persistentvolumeclaims", "configmaps").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
-					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
+					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log", "replicationcontrollers/scale").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers").RuleOrDie(),
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "daemonsets", "replicasets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("replicasets/status", "replicasets/scale").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
@@ -439,6 +438,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				authorizationapi.NewRule("get", "list").Groups(kapiGroup).Resources("pods", "replicationcontrollers").RuleOrDie(),
+				authorizationapi.NewRule("get", "list").Groups(extensionsGroup).Resources("replicasets").RuleOrDie(),
 				authorizationapi.NewRule("list").Groups(kapiGroup).Resources("limitranges").RuleOrDie(),
 				authorizationapi.NewRule("get", "list").Groups(buildGroup).Resources("buildconfigs", "builds").RuleOrDie(),
 				authorizationapi.NewRule("get", "list").Groups(deployGroup).Resources("deploymentconfigs").RuleOrDie(),
@@ -454,6 +454,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				authorizationapi.NewRule("get", "list", "update").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
+				authorizationapi.NewRule("get", "list", "update").Groups(extensionsGroup).Resources("replicasets").RuleOrDie(),
 				authorizationapi.NewRule("get", "list", "watch", "create").Groups(kapiGroup).Resources("pods").RuleOrDie(),
 				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(kapiGroup).Resources("events").RuleOrDie(),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -219,7 +219,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
-					"replicasets", "replicasets/status", "replicasets/scale").RuleOrDie(),
+					"replicasets", "replicasets/status", "replicasets/scale", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -272,7 +272,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets", "replicasets/status").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
@@ -316,7 +316,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "daemonsets", "replicasets").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "daemonsets", "replicasets", "deployments", "deployments/status", "deployments/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("replicasets/status", "replicasets/scale").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -39,7 +39,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/persistentvolume"
 	podautoscalercontroller "k8s.io/kubernetes/pkg/controller/podautoscaler"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
-	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
+	replicasetcontroller "k8s.io/kubernetes/pkg/controller/replicaset"
 	servicecontroller "k8s.io/kubernetes/pkg/controller/service"
 	volumecontroller "k8s.io/kubernetes/pkg/controller/volume"
 
@@ -237,16 +237,15 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, na
 	return allPlugins
 }
 
-// RunReplicationController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunReplicationController(client *client.Client) {
-	controllerManager := replicationcontroller.NewReplicationManager(
-		c.Informers.Pods().Informer(),
+// RunReplicaSetController starts the Kubernetes replica set controller sync loop
+func (c *MasterConfig) RunReplicaSetController(client *client.Client) {
+	controllerManager := replicasetcontroller.NewReplicaSetController(
 		clientadapter.FromUnversionedClient(client),
 		kctrlmgr.ResyncPeriod(c.ControllerManager),
-		replicationcontroller.BurstReplicas,
-		int(c.ControllerManager.LookupCacheSizeForRC),
+		replicasetcontroller.BurstReplicas,
+		int(c.ControllerManager.LookupCacheSizeForRS),
 	)
-	go controllerManager.Run(int(c.ControllerManager.ConcurrentRCSyncs), utilwait.NeverStop)
+	go controllerManager.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
 }
 
 // RunJobController starts the Kubernetes job controller sync loop

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	clientadapter "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
+	"k8s.io/kubernetes/pkg/controller/deployment"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -246,6 +247,14 @@ func (c *MasterConfig) RunReplicaSetController(client *client.Client) {
 		int(c.ControllerManager.LookupCacheSizeForRS),
 	)
 	go controllerManager.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
+}
+
+func (c *MasterConfig) RunDeploymentController(client *client.Client) {
+	controller := deployment.NewDeploymentController(
+		clientadapter.FromUnversionedClient(client),
+		kctrlmgr.ResyncPeriod(c.ControllerManager),
+	)
+	go controller.Run(int(c.ControllerManager.ConcurrentDeploymentSyncs), utilwait.NeverStop)
 }
 
 // RunJobController starts the Kubernetes job controller sync loop

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -39,6 +39,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/controller/shared"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // MasterConfig defines the required values to start a Kubernetes master
@@ -178,6 +179,10 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	// the order here is important, it defines which version will be used for storage
 	storageFactory.AddCohabitatingResources(extensions.Resource("jobs"), batch.Resource("jobs"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("horizontalpodautoscalers"), autoscaling.Resource("horizontalpodautoscalers"))
+	storageFactory.AddCohabitatingResources(kapi.Resource("replicationcontrollers"), extensions.Resource("replicasets"))
+	storageFactory.AddCohabitatingResources(deployapi.Resource("deploymentconfigs"), extensions.Resource("deployments"))
+
+	storageFactory.IgnoreCohabitingStorageVersion(deployapi.Resource("deploymentconfigs"))
 
 	// Preserve previous behavior of using the first non-loopback address
 	// TODO: Deprecate this behavior and just require a valid value to be passed in

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -561,6 +561,10 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
+		_, _, deploymentClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraDeploymentControllerServiceAccountName)
+		if err != nil {
+			glog.Fatalf("Could not get client for deployment controller: %v", err)
+		}
 		_, _, jobClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraJobControllerServiceAccountName)
 		if err != nil {
 			glog.Fatalf("Could not get client for job controller: %v", err)
@@ -606,6 +610,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunNodeController()
 		kc.RunScheduler()
 		kc.RunReplicaSetController(rsClient)
+		kc.RunDeploymentController(deploymentClient)
 
 		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -557,7 +557,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunSecurityAllocationController()
 
 	if kc != nil {
-		_, _, rcClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicationControllerServiceAccountName)
+		_, _, rsClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicaSetControllerServiceAccountName)
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
@@ -605,7 +605,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		// no special order
 		kc.RunNodeController()
 		kc.RunScheduler()
-		kc.RunReplicationController(rcClient)
+		kc.RunReplicaSetController(rsClient)
 
 		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -22,6 +22,9 @@ const (
 	DeploymentStatusComplete DeploymentStatus = "Complete"
 	// DeploymentStatusFailed means the deployment finished with an error.
 	DeploymentStatusFailed DeploymentStatus = "Failed"
+
+	// TODO: Move this to k8s
+	OriginalKindAnnotation = "k8s.io/original-kind"
 )
 
 // DeploymentStrategy describes how to perform a deployment.

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -6,6 +6,10 @@ import (
 	"reflect"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -132,6 +136,20 @@ func Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategy
 	return nil
 }
 
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *v1beta1.ReplicaSet, out *api.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensions.ReplicaSet{}
+	if err := v1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &v1.ReplicationController{}
+	if err := v1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return v1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}
+
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
 		Convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
@@ -139,6 +157,8 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 
 		Convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
 		Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,
+
+		Convert_v1beta1_ReplicaSet_to_api_ReplicationController,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -150,6 +151,221 @@ func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *v1beta1.Replica
 	return v1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
 }
 
+func originalKindAnnotation(in runtime.Object, out map[string]string) map[string]string {
+	if _, exists := out[newer.OriginalKindAnnotation]; !exists {
+		gvk := in.GetObjectKind().GroupVersionKind()
+		out[newer.OriginalKindAnnotation] = gvk.Version + "." + gvk.Kind
+	}
+	return out
+}
+
+func nonConvertibleField(name string, value interface{}, out *map[string]string) {
+	newMap := *out
+	newMap[api.NonConvertibleAnnotationPrefix+"/"+name] = reflect.ValueOf(value).String()
+	*out = newMap
+}
+
+func Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec(in *extensions.DeploymentSpec, out *DeploymentConfigSpec, annotations *map[string]string, s conversion.Scope) {
+	out.Replicas = in.Replicas
+	out.MinReadySeconds = in.MinReadySeconds
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
+	out.Paused = in.Paused
+
+	if in.Selector != nil {
+		api.Convert_unversioned_LabelSelector_to_map(in.Selector, &out.Selector, s)
+	}
+
+	switch in.Strategy.Type {
+	case extensions.RecreateDeploymentStrategyType:
+		out.Strategy.Type = DeploymentStrategyTypeRecreate
+	case extensions.RollingUpdateDeploymentStrategyType:
+		out.Strategy.Type = DeploymentStrategyTypeRolling
+		out.Strategy.RollingParams = &RollingDeploymentStrategyParams{
+			MaxSurge:       &in.Strategy.RollingUpdate.MaxSurge,
+			MaxUnavailable: &in.Strategy.RollingUpdate.MaxUnavailable,
+		}
+	}
+}
+
+func Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec(in *newer.DeploymentConfigSpec, out *v1beta1.DeploymentSpec, annotations *map[string]string, s conversion.Scope) {
+	out.Replicas = &in.Replicas
+	out.MinReadySeconds = in.MinReadySeconds
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
+	out.Paused = in.Paused
+
+	if in.Test == true {
+		nonConvertibleField("spec.test", true, annotations)
+	}
+
+	immediate := &unversioned.LabelSelector{}
+	api.Convert_map_to_unversioned_LabelSelector(&in.Selector, immediate, s)
+	s.Convert(&immediate, out.Selector, 0)
+
+	switch in.Strategy.Type {
+	case newer.DeploymentStrategyTypeRolling:
+		out.Strategy.Type = v1beta1.RecreateDeploymentStrategyType
+		if in.Strategy.RollingParams.UpdatePeriodSeconds != nil {
+			nonConvertibleField("spec.strategy.updatePeriodSeconds", *in.Strategy.RollingParams.UpdatePeriodSeconds, annotations)
+		}
+		if in.Strategy.RollingParams.IntervalSeconds != nil {
+			nonConvertibleField("spec.strategy.intervalSeconds", *in.Strategy.RollingParams.IntervalSeconds, annotations)
+		}
+		if in.Strategy.RollingParams.TimeoutSeconds != nil {
+			nonConvertibleField("spec.strategy.timeoutSeconds", *in.Strategy.RollingParams.TimeoutSeconds, annotations)
+		}
+		if in.Strategy.RollingParams.MaxSurge.IntValue() > 0 {
+			nonConvertibleField("spec.strategy.maxSurge", in.Strategy.RollingParams.MaxSurge, annotations)
+		}
+		if in.Strategy.RollingParams.UpdatePercent != nil {
+			nonConvertibleField("spec.strategy.UpdatePercent", *in.Strategy.RollingParams.UpdatePercent, annotations)
+		}
+		if in.Strategy.RollingParams.Pre != nil {
+			nonConvertibleField("spec.strategy.pre", *in.Strategy.RollingParams.Pre, annotations)
+		}
+		if in.Strategy.RollingParams.Post != nil {
+			nonConvertibleField("spec.strategy.post", *in.Strategy.RollingParams.Post, annotations)
+		}
+	case newer.DeploymentStrategyTypeRecreate:
+		out.Strategy.Type = v1beta1.RollingUpdateDeploymentStrategyType
+		// Add non-convertible field annotations
+		if in.Strategy.RecreateParams.Pre != nil {
+			nonConvertibleField("spec.strategy.pre", *in.Strategy.RecreateParams.Pre, annotations)
+		}
+		if in.Strategy.RecreateParams.Post != nil {
+			nonConvertibleField("spec.strategy.post", *in.Strategy.RecreateParams.Post, annotations)
+		}
+		if in.Strategy.RecreateParams.Mid != nil {
+			nonConvertibleField("spec.strategy.mid", *in.Strategy.RecreateParams.Mid, annotations)
+		}
+		if in.Strategy.RecreateParams.TimeoutSeconds != nil {
+			nonConvertibleField("spec.strategy.timeoutSeconds", *in.Strategy.RecreateParams.TimeoutSeconds, annotations)
+		}
+	}
+}
+
+func Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus(in *extensions.DeploymentStatus, out *DeploymentConfigStatus, annotations *map[string]string) {
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
+	// TODO: Handle LatestVersion
+}
+
+func Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus(in *newer.DeploymentConfigStatus, out *v1beta1.DeploymentStatus, annotations *map[string]string) {
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
+	nonConvertibleField("status.latestVersion", in.LatestVersion, annotations)
+}
+
+//  d._internal -> dc.v1
+func Convert_extensions_Deployment_To_v1_DeploymentConfig(in *extensions.Deployment, out *DeploymentConfig, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.Deployment))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+
+	Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec(&in.Spec, &out.Spec, &out.ObjectMeta.Annotations, s)
+	Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus(&in.Status, &out.Status, &out.ObjectMeta.Annotations)
+
+	return v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Spec.Template, out.Spec.Template, s)
+}
+
+//  dc._internal -> d.v1beta1
+func Convert_api_DeploymentConfig_To_v1beta1_Deployment(in *newer.DeploymentConfig, out *v1beta1.Deployment, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*newer.DeploymentConfig))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+
+	Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec(&in.Spec, &out.Spec, &out.ObjectMeta.Annotations, s)
+	Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus(&in.Status, &out.Status, &out.ObjectMeta.Annotations)
+
+	return v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Spec.Template, &out.Spec.Template, s)
+}
+
+func Convert_v1_DeploymentConfig_To_extensions_Deployment(in *DeploymentConfig, out *extensions.Deployment, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*DeploymentConfig))(in)
+	}
+
+	immediateSpec := &newer.DeploymentConfigSpec{}
+	immediateExtSpec := &v1beta1.DeploymentSpec{}
+
+	if err := s.Convert(&in.Spec, immediateSpec, 0); err != nil {
+		return err
+	}
+
+	Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec(immediateSpec, immediateExtSpec, &out.ObjectMeta.Annotations, s)
+
+	if err := s.Convert(immediateExtSpec, &out.Spec, 0); err != nil {
+		return err
+	}
+
+	immediateStatus := &newer.DeploymentConfigStatus{}
+	immediateExtStatus := &v1beta1.DeploymentStatus{}
+	if err := s.Convert(&in.Status, immediateStatus, 0); err != nil {
+		return err
+	}
+
+	Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus(immediateStatus, immediateExtStatus, &out.ObjectMeta.Annotations)
+
+	if err := s.Convert(immediateExtStatus, &out.Status, 0); err != nil {
+		return err
+	}
+
+	out.SetAnnotations(originalKindAnnotation(in, out.GetAnnotations()))
+
+	return v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Spec.Template, &out.Spec.Template, s)
+}
+
+func Convert_v1beta1_Deployment_To_api_DeploymentConfig(in *v1beta1.Deployment, out *newer.DeploymentConfig, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1beta1.Deployment))(in)
+	}
+
+	immediateSpec := &extensions.DeploymentSpec{}
+	immediateExtSpec := &DeploymentConfigSpec{}
+	if err := s.Convert(&in.Spec, immediateSpec, 0); err != nil {
+		return err
+	}
+
+	Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec(immediateSpec, immediateExtSpec, &out.ObjectMeta.Annotations, s)
+
+	if err := s.Convert(immediateExtSpec, &out.Spec, 0); err != nil {
+		return err
+	}
+
+	immediateStatus := &extensions.DeploymentStatus{}
+	immediateExtStatus := &DeploymentConfigStatus{}
+	if err := s.Convert(&in.Status, immediateStatus, 0); err != nil {
+		return err
+	}
+
+	Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus(immediateStatus, immediateExtStatus, &out.ObjectMeta.Annotations)
+
+	if err := s.Convert(immediateExtStatus, &out.Status, 0); err != nil {
+		return err
+	}
+
+	out.SetAnnotations(originalKindAnnotation(in, out.GetAnnotations()))
+
+	return v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Spec.Template, out.Spec.Template, s)
+}
+
 func addConversionFuncs(scheme *runtime.Scheme) {
 	err := scheme.AddConversionFuncs(
 		Convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
@@ -159,6 +375,11 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,
 
 		Convert_v1beta1_ReplicaSet_to_api_ReplicationController,
+
+		Convert_api_DeploymentConfig_To_v1beta1_Deployment,
+		Convert_v1_DeploymentConfig_To_extensions_Deployment,
+		Convert_v1beta1_Deployment_To_api_DeploymentConfig,
+		Convert_extensions_Deployment_To_v1_DeploymentConfig,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -132,6 +132,12 @@ func ValidateDeploymentConfigStatus(status deployapi.DeploymentConfigStatus) fie
 
 func ValidateDeploymentConfigUpdate(newConfig *deployapi.DeploymentConfig, oldConfig *deployapi.DeploymentConfig) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&newConfig.ObjectMeta, &oldConfig.ObjectMeta, field.NewPath("metadata"))
+	if kind, ok := oldConfig.GetAnnotations()[deployapi.OriginalKindAnnotation]; ok && kind != "v1.DeploymentConfig" {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("kind"), oldConfig.GetObjectKind().GroupVersionKind().Kind, "updating deployment via deployment config is not supported"),
+		)
+	}
 	allErrs = append(allErrs, ValidateDeploymentConfig(newConfig)...)
 	allErrs = append(allErrs, ValidateDeploymentConfigStatusUpdate(newConfig, oldConfig)...)
 	return allErrs

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -208,7 +208,7 @@ func (c *DeploymentController) getByKey(key string) (*kapi.ReplicationController
 		c.queue.Add(key)
 		return nil, err
 	}
-	if !exists {
+	if !exists && len(key) > 0 {
 		glog.Infof("Replication controller %q has been deleted", key)
 		return nil, nil
 	}

--- a/vendor/k8s.io/kubernetes/pkg/api/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/helpers.go
@@ -50,6 +50,21 @@ func (c *ConversionError) Error() string {
 	)
 }
 
+const (
+	// annotation key prefix used to identify non-convertible json paths.
+	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
+)
+
+func NonConvertibleFields(annotations map[string]string) []string {
+	nonConvertibleKeys := []string{}
+	for key := range annotations {
+		if strings.HasPrefix(key, NonConvertibleAnnotationPrefix) {
+			nonConvertibleKeys = append(nonConvertibleKeys, key)
+		}
+	}
+	return nonConvertibleKeys
+}
+
 // Semantic can do semantic deep equality checks for api objects.
 // Example: api.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
 var Semantic = conversion.EqualitiesOrDie(

--- a/vendor/k8s.io/kubernetes/pkg/api/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/helpers.go
@@ -52,7 +52,7 @@ func (c *ConversionError) Error() string {
 
 const (
 	// annotation key prefix used to identify non-convertible json paths.
-	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
+	NonConvertibleAnnotationPrefix = "non-convertible.kubernetes.io"
 )
 
 func NonConvertibleFields(annotations map[string]string) []string {

--- a/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
@@ -38,8 +38,12 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
+	"k8s.io/kubernetes/pkg/runtime/serializer/versioning"
 	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
@@ -145,6 +149,61 @@ func roundTripSame(t *testing.T, group testapi.TestGroup, item runtime.Object, e
 		for _, codec := range codecs {
 			roundTrip(t, codec, item)
 		}
+	}
+}
+
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *v1beta1.ReplicaSet, out *api.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensions.ReplicaSet{}
+	if err := v1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &v1.ReplicationController{}
+	if err := v1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return v1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}
+
+func TestSetControllerConversion(t *testing.T) {
+	if err := api.Scheme.AddConversionFuncs(Convert_v1beta1_ReplicaSet_to_api_ReplicationController); err != nil {
+		t.Fatal(err)
+	}
+
+	rs := &extensions.ReplicaSet{}
+	rc := &api.ReplicationController{}
+
+	extGroup := testapi.Extensions
+	defaultGroup := testapi.Default
+
+	fuzzInternalObject(t, extGroup.InternalGroupVersion(), rs, rand.Int63())
+
+	t.Logf("rs._internal.extensions -> rs.v1beta1.extensions")
+	data, err := runtime.Encode(extGroup.Codec(), rs)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	decoder := api.Codecs.UniversalDecoder(*extGroup.GroupVersion(), *defaultGroup.GroupVersion())
+	if err := versioning.EnableCrossGroupDecoding(decoder, extGroup.GroupVersion().Group, defaultGroup.GroupVersion().Group); err != nil {
+		t.Fatalf("unexpected error while enabling cross-group decoding: %v", err)
+	}
+
+	t.Logf("rs.v1beta1.extensions -> rc._internal")
+	if err := runtime.DecodeInto(decoder, data, rc); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
+	}
+
+	t.Logf("rc._internal -> rc.v1")
+	data, err = runtime.Encode(defaultGroup.Codec(), rc)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	t.Logf("rc.v1 -> rs._internal.extensions")
+	if err := runtime.DecodeInto(decoder, data, rs); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
@@ -64,6 +64,35 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 	return selector, nil
 }
 
+// LabelSelectorAsMap converts the LabelSelector api type into a map of strings, ie. the
+// original structure of a label selector. Operators that cannot be converted into plain
+// labels (Exists, DoesNotExist, NotIn, and In with more than one value) will result in
+// an error.
+func LabelSelectorAsMap(ps *LabelSelector) (map[string]string, error) {
+	if ps == nil {
+		return nil, nil
+	}
+	selector := map[string]string{}
+	for k, v := range ps.MatchLabels {
+		selector[k] = v
+	}
+	for _, expr := range ps.MatchExpressions {
+		switch expr.Operator {
+		case LabelSelectorOpIn:
+			if len(expr.Values) != 1 {
+				return selector, fmt.Errorf("operator %q without a single value cannot be converted into the old label selector format", expr.Operator)
+			}
+			// Should we do anything in case this will override a previous key-value pair?
+			selector[expr.Key] = expr.Values[0]
+		case LabelSelectorOpNotIn, LabelSelectorOpExists, LabelSelectorOpDoesNotExist:
+			return selector, fmt.Errorf("operator %q cannot be converted into the old label selector format", expr.Operator)
+		default:
+			return selector, fmt.Errorf("%q is not a valid selector operator", expr.Operator)
+		}
+	}
+	return selector, nil
+}
+
 // ParseToLabelSelector parses a string representing a selector into a LabelSelector object.
 // Note: This function should be kept in sync with the parser in pkg/labels/selector.go
 func ParseToLabelSelector(selector string) (*LabelSelector, error) {

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/labels"
@@ -75,6 +76,76 @@ func TestLabelSelectorAsSelector(t *testing.T) {
 		}
 		if err != nil && !tc.expectErr {
 			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(out, tc.out) {
+			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
+		}
+	}
+}
+
+func TestLabelSelectorAsMap(t *testing.T) {
+	matchLabels := map[string]string{"foo": "bar"}
+	matchExpressions := func(operator LabelSelectorOperator, values []string) []LabelSelectorRequirement {
+		return []LabelSelectorRequirement{{
+			Key:      "baz",
+			Operator: operator,
+			Values:   values,
+		}}
+	}
+
+	tests := []struct {
+		in        *LabelSelector
+		out       map[string]string
+		errString string
+	}{
+		{in: nil, out: nil},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels},
+			out: map[string]string{"foo": "bar"},
+		},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"foo": "bar", "baz": "norf"},
+		},
+		{
+			in:  &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"baz": "norf"},
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf", "qux"})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "without a single value cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpNotIn, []string{"norf", "qux"})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpExists, []string{})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpDoesNotExist, []string{})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+	}
+
+	for i, tc := range tests {
+		out, err := LabelSelectorAsMap(tc.in)
+		if err == nil && len(tc.errString) > 0 {
+			t.Errorf("[%v]expected error but got none.", i)
+			continue
+		}
+		if err != nil && len(tc.errString) == 0 {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+			continue
+		}
+		if err != nil && len(tc.errString) > 0 && !strings.Contains(err.Error(), tc.errString) {
+			t.Errorf("[%v]expected error with %q but got: %v", i, tc.errString, err)
+			continue
 		}
 		if !reflect.DeepEqual(out, tc.out) {
 			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -34,9 +34,6 @@ const (
 
 	// Value used to identify mirror pods from pre-v1.1 kubelet.
 	mirrorAnnotationValue_1_0 = "mirror"
-
-	// annotation key prefix used to identify non-convertible json paths.
-	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) {
@@ -279,7 +276,7 @@ func Convert_extensions_ReplicaSet_to_v1_ReplicationController(in *extensions.Re
 		if out.Annotations == nil {
 			out.Annotations = make(map[string]string)
 		}
-		out.Annotations[NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
+		out.Annotations[api.NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
 	}
 	if err := Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -19,10 +19,13 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
 )
 
 const (
@@ -31,6 +34,9 @@ const (
 
 	// Value used to identify mirror pods from pre-v1.1 kubelet.
 	mirrorAnnotationValue_1_0 = "mirror"
+
+	// annotation key prefix used to identify non-convertible json paths.
+	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) {
@@ -45,6 +51,12 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
 		Convert_v1_ServiceSpec_To_api_ServiceSpec,
 		Convert_v1_ResourceList_To_api_ResourceList,
+		Convert_v1_ReplicationController_to_extensions_ReplicaSet,
+		Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec,
+		Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus,
+		Convert_extensions_ReplicaSet_to_v1_ReplicationController,
+		Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec,
+		Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus,
 
 		Convert_api_VolumeSource_To_v1_VolumeSource,
 		Convert_v1_VolumeSource_To_api_VolumeSource,
@@ -204,17 +216,107 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 }
 
+func Convert_v1_ReplicationController_to_extensions_ReplicaSet(in *ReplicationController, out *extensions.ReplicaSet, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationController))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(in *ReplicationControllerSpec, out *extensions.ReplicaSetSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerSpec))(in)
+	}
+	out.Replicas = *in.Replicas
+	if in.Selector != nil {
+		api.Convert_map_to_unversioned_LabelSelector(&in.Selector, out.Selector, s)
+	}
+	if in.Template != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, &out.Template, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(in *ReplicationControllerStatus, out *extensions.ReplicaSetStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerStatus))(in)
+	}
+	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
+func Convert_extensions_ReplicaSet_to_v1_ReplicationController(in *extensions.ReplicaSet, out *ReplicationController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSet))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		fieldErr, ok := err.(*field.Error)
+		if !ok {
+			return err
+		}
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
+	}
+	if err := Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(in *extensions.ReplicaSetSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetSpec))(in)
+	}
+	out.Replicas = new(int32)
+	*out.Replicas = in.Replicas
+	var invalidErr error
+	if in.Selector != nil {
+		invalidErr = api.Convert_unversioned_LabelSelector_to_map(in.Selector, &out.Selector, s)
+	}
+	out.Template = new(PodTemplateSpec)
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, out.Template, s); err != nil {
+		return err
+	}
+	return invalidErr
+}
+
+func Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(in *extensions.ReplicaSetStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetStatus))(in)
+	}
+	out.Replicas = int32(in.Replicas)
+	out.FullyLabeledReplicas = int32(in.FullyLabeledReplicas)
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
 func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = &in.Replicas
 	out.Selector = in.Selector
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(ObjectReference)
-	//	if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
@@ -229,15 +331,6 @@ func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 func Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = *in.Replicas
 	out.Selector = in.Selector
-
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(api.ObjectReference)
-	//	if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
 		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/register.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/register.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
 	versionedwatch "k8s.io/kubernetes/pkg/watch/versioned"
 )
@@ -91,6 +92,10 @@ func addKnownTypes(scheme *runtime.Scheme) {
 
 	// Add common types
 	scheme.AddKnownTypes(SchemeGroupVersion, &unversioned.Status{})
+
+	// Add replica sets
+	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.ReplicaSet{})
+	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.ReplicaSetList{})
 
 	// Add the watch version that applies
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/register.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/register.go
@@ -97,6 +97,10 @@ func addKnownTypes(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.ReplicaSet{})
 	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.ReplicaSetList{})
 
+	// Add deployments
+	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.Deployment{})
+	scheme.AddKnownTypes(SchemeGroupVersion, &extensions.DeploymentList{})
+
 	// Add the watch version that applies
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)
 }

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -87,6 +87,11 @@ type groupResourceOverrides struct {
 	// of exposing one set of concepts.  autoscaling.HPA and extensions.HPA as a for instance
 	// The order of the slice matters!  It is the priority order of lookup for finding a storage location
 	cohabitatingResources []unversioned.GroupResource
+
+	// ignoreCohabitatingStorageVersion controls whether or not a cohabitating resource attempts to serialize into the same
+	// groupVersion as all other cohabitators.  If not, it uses the groupVersion assigned to itself instead of the one being
+	// used by the first enabled cohabitator.
+	ignoreCohabitatingStorageVersion bool
 }
 
 var _ StorageFactory = &DefaultStorageFactory{}
@@ -134,6 +139,16 @@ func (s *DefaultStorageFactory) AddCohabitatingResources(groupResources ...unver
 	for _, groupResource := range groupResources {
 		overrides := s.Overrides[groupResource]
 		overrides.cohabitatingResources = groupResources
+		s.Overrides[groupResource] = overrides
+	}
+}
+
+// IgnoreCohabitingStorageVersion indicates that the cohabitating resource should serialize using its own groupVersion, not the "shared" groupVersion
+// of all cohabitators.  Useful during resource migration/parity cases
+func (s *DefaultStorageFactory) IgnoreCohabitingStorageVersion(groupResources ...unversioned.GroupResource) {
+	for _, groupResource := range groupResources {
+		overrides := s.Overrides[groupResource]
+		overrides.ignoreCohabitatingStorageVersion = true
 		s.Overrides[groupResource] = overrides
 	}
 }
@@ -198,7 +213,12 @@ func (s *DefaultStorageFactory) New(groupResource unversioned.GroupResource) (st
 		config.ServerList = overriddenEtcdLocations
 	}
 
-	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(chosenStorageResource)
+	storageEncodingResource := chosenStorageResource
+	if s.Overrides[groupResource].ignoreCohabitatingStorageVersion {
+		storageEncodingResource = groupResource
+	}
+
+	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(storageEncodingResource)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
@@ -87,3 +87,91 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	}
 }
+
+func TestCohabitingSerializationVersion(t *testing.T) {
+	defaultConfig := storagebackend.Config{
+		Prefix:     options.DefaultEtcdPathPrefix,
+		ServerList: []string{"http://127.0.0.1"},
+	}
+
+	testCases := []struct {
+		name              string
+		factory           func() *DefaultStorageFactory
+		requestedResource unversioned.GroupResource
+
+		expectedResource unversioned.GroupResource
+	}{
+		{
+			name: "request first",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("one"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "request second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "ignore second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("two"),
+		},
+		{
+			name: "ignore second, request third",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("three"),
+			expectedResource:  api.Resource("one"),
+		},
+	}
+
+	for _, tc := range testCases {
+		factory := tc.factory()
+		testEncodingConfig := &testDefaultResourceEncodingConfig{ResourceEncodingConfig: factory.ResourceEncodingConfig}
+		factory.ResourceEncodingConfig = testEncodingConfig
+
+		factory.New(tc.requestedResource)
+
+		if e, a := tc.expectedResource, testEncodingConfig.requestedResource; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+type testDefaultResourceEncodingConfig struct {
+	ResourceEncodingConfig
+	requestedResource unversioned.GroupResource
+}
+
+func (o *testDefaultResourceEncodingConfig) StorageEncodingFor(resource unversioned.GroupResource) (unversioned.GroupVersion, error) {
+	o.requestedResource = resource
+	return api.SchemeGroupVersion, nil
+}


### PR DESCRIPTION
Just a placeholder for the initial work of enabling upstream deployments in origin.

- [x] Enable upstream controller
- [x] Update SA policies to allow controller creating/updating RS
- [ ] Write conversions from D <-> DC
- [ ] Add non-convertible fields as an annotation
- [ ] Add "original-kind" annotation to allow controllers only to serve types they own
- [ ] Cohabitate `Deployment` and `DeploymentConfig`
- [ ] Tests
- [ ] Check the UI impact (does the D show in the UI?, could they be scaled?, etc.)

FYI: This is based on @kargakis PR, it will be squashed once his PR lands.

More info: https://github.com/openshift/origin/pull/9941
ReplicaSet: https://github.com/openshift/origin/pull/8274