### PR TITLE
support for defaulting s2i incremental field at the cluster level

### DIFF
--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -83,6 +83,15 @@ func (a *buildDefaults) applyBuildDefaults(build *buildapi.Build) {
 		addDefaultEnvVar(envVar, buildEnv)
 	}
 
+	sourceDefaults := a.defaultsConfig.SourceStrategyDefaults
+	sourceStrategy := build.Spec.Strategy.SourceStrategy
+	if sourceDefaults != nil && sourceDefaults.Incremental != nil && *sourceDefaults.Incremental &&
+		sourceStrategy != nil && sourceStrategy.Incremental == nil {
+		glog.V(5).Infof("Setting source strategy Incremental to true in build %s/%s", build.Namespace, build.Name)
+		t := true
+		build.Spec.Strategy.SourceStrategy.Incremental = &t
+	}
+
 	// Apply git proxy defaults
 	if build.Spec.Source.Git == nil {
 		return

--- a/pkg/build/admission/defaults/api/types.go
+++ b/pkg/build/admission/defaults/api/types.go
@@ -18,4 +18,17 @@ type BuildDefaultsConfig struct {
 	// Env is a set of default environment variables that will be applied to the
 	// build if the specified variables do not exist on the build
 	Env []kapi.EnvVar
+
+	// SourceStrategyDefaults are default values that apply to builds using the
+	// source strategy.
+	SourceStrategyDefaults *SourceStrategyDefaultsConfig
+}
+
+// SourceStrategyDefaultsConfig contains values that apply to builds using the
+// source strategy.
+type SourceStrategyDefaultsConfig struct {
+
+	// Incremental indicates if s2i build strategies should perform an incremental
+	// build or not
+	Incremental *bool
 }

--- a/pkg/build/admission/defaults/api/v1/swagger_doc.go
+++ b/pkg/build/admission/defaults/api/v1/swagger_doc.go
@@ -10,8 +10,18 @@ var map_BuildDefaultsConfig = map[string]string{
 	"gitHTTPProxy":  "GitHTTPProxy is the location of the HTTPProxy for Git source",
 	"gitHTTPSProxy": "GitHTTPSProxy is the location of the HTTPSProxy for Git source",
 	"env":           "Env is a set of default environment variables that will be applied to the build if the specified variables do not exist on the build",
+	"sourceStrategyDefaults": "SourceStrategyDefaults are default values that apply to builds using the source strategy.",
 }
 
 func (BuildDefaultsConfig) SwaggerDoc() map[string]string {
 	return map_BuildDefaultsConfig
+}
+
+var map_SourceStrategyDefaultsConfig = map[string]string{
+	"":            "SourceStrategyDefaultsConfig contains values that apply to builds using the source strategy.",
+	"incremental": "Incremental indicates if s2i build strategies should perform an incremental build or not",
+}
+
+func (SourceStrategyDefaultsConfig) SwaggerDoc() map[string]string {
+	return map_SourceStrategyDefaultsConfig
 }

--- a/pkg/build/admission/defaults/api/v1/types.go
+++ b/pkg/build/admission/defaults/api/v1/types.go
@@ -10,12 +10,25 @@ type BuildDefaultsConfig struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// GitHTTPProxy is the location of the HTTPProxy for Git source
-	GitHTTPProxy string `json:"gitHTTPProxy,omitempty",description:"location of the git http proxy"`
+	GitHTTPProxy string `json:"gitHTTPProxy,omitempty"`
 
 	// GitHTTPSProxy is the location of the HTTPSProxy for Git source
-	GitHTTPSProxy string `json:"gitHTTPSProxy,omitempty",description:"location of the git https proxy"`
+	GitHTTPSProxy string `json:"gitHTTPSProxy,omitempty"`
 
 	// Env is a set of default environment variables that will be applied to the
 	// build if the specified variables do not exist on the build
-	Env []kapi.EnvVar `json:"env,omitempty",description:"default environment variable values to add to builds"`
+	Env []kapi.EnvVar `json:"env,omitempty"`
+
+	// SourceStrategyDefaults are default values that apply to builds using the
+	// source strategy.
+	SourceStrategyDefaults *SourceStrategyDefaultsConfig `json:"sourceStrategyDefaults,omitempty"`
+}
+
+// SourceStrategyDefaultsConfig contains values that apply to builds using the
+// source strategy.
+type SourceStrategyDefaultsConfig struct {
+
+	// Incremental indicates if s2i build strategies should perform an incremental
+	// build or not
+	Incremental *bool `json:"incremental,omitempty"`
 }

--- a/pkg/build/admission/overrides/api/v1/types.go
+++ b/pkg/build/admission/overrides/api/v1/types.go
@@ -9,5 +9,5 @@ type BuildOverridesConfig struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// ForcePull indicates whether the build strategy should always be set to ForcePull=true
-	ForcePull bool `json:"forcePull",description:"if true, will always set ForcePull to true on builds"`
+	ForcePull bool `json:"forcePull"`
 }

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -906,7 +906,13 @@ func DeepCopy_api_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildSt
 		out.Env = nil
 	}
 	out.Scripts = in.Scripts
-	out.Incremental = in.Incremental
+	if in.Incremental != nil {
+		in, out := in.Incremental, &out.Incremental
+		*out = new(bool)
+		**out = *in
+	} else {
+		out.Incremental = nil
+	}
 	out.ForcePull = in.ForcePull
 	return nil
 }

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -512,7 +512,7 @@ type SourceBuildStrategy struct {
 	Scripts string
 
 	// Incremental flag forces the Source build to do incremental builds if true.
-	Incremental bool
+	Incremental *bool
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool

--- a/pkg/build/api/v1/deep_copy_generated.go
+++ b/pkg/build/api/v1/deep_copy_generated.go
@@ -888,7 +888,13 @@ func DeepCopy_v1_SourceBuildStrategy(in SourceBuildStrategy, out *SourceBuildStr
 		out.Env = nil
 	}
 	out.Scripts = in.Scripts
-	out.Incremental = in.Incremental
+	if in.Incremental != nil {
+		in, out := in.Incremental, &out.Incremental
+		*out = new(bool)
+		**out = *in
+	} else {
+		out.Incremental = nil
+	}
 	out.ForcePull = in.ForcePull
 	return nil
 }

--- a/pkg/build/api/v1/generated.pb.go
+++ b/pkg/build/api/v1/generated.pb.go
@@ -1937,14 +1937,16 @@ func (m *SourceBuildStrategy) MarshalTo(data []byte) (int, error) {
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Scripts)))
 	i += copy(data[i:], m.Scripts)
-	data[i] = 0x28
-	i++
-	if m.Incremental {
-		data[i] = 1
-	} else {
-		data[i] = 0
+	if m.Incremental != nil {
+		data[i] = 0x28
+		i++
+		if *m.Incremental {
+			data[i] = 1
+		} else {
+			data[i] = 0
+		}
+		i++
 	}
-	i++
 	data[i] = 0x30
 	i++
 	if m.ForcePull {
@@ -2687,7 +2689,9 @@ func (m *SourceBuildStrategy) Size() (n int) {
 	}
 	l = len(m.Scripts)
 	n += 1 + l + sovGenerated(uint64(l))
-	n += 2
+	if m.Incremental != nil {
+		n += 2
+	}
 	n += 2
 	return n
 }
@@ -8487,7 +8491,8 @@ func (m *SourceBuildStrategy) Unmarshal(data []byte) error {
 					break
 				}
 			}
-			m.Incremental = bool(v != 0)
+			b := bool(v != 0)
+			m.Incremental = &b
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ForcePull", wireType)

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -475,7 +475,7 @@ type SourceBuildStrategy struct {
 	Scripts string `json:"scripts,omitempty" protobuf:"bytes,4,opt,name=scripts"`
 
 	// incremental flag forces the Source build to do incremental builds if true.
-	Incremental bool `json:"incremental,omitempty" protobuf:"varint,5,opt,name=incremental"`
+	Incremental *bool `json:"incremental,omitempty" protobuf:"varint,5,opt,name=incremental"`
 
 	// forcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty" protobuf:"varint,6,opt,name=forcePull"`

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -166,6 +166,10 @@ func (s *S2IBuilder) Build() error {
 			scriptDownloadProxyConfig.HTTPSProxy)
 	}
 
+	var incremental bool
+	if s.build.Spec.Strategy.SourceStrategy.Incremental != nil {
+		incremental = *s.build.Spec.Strategy.SourceStrategy.Incremental
+	}
 	config := &s2iapi.Config{
 		WorkingDir:     buildDir,
 		DockerConfig:   &s2iapi.DockerConfig{Endpoint: s.dockerSocket},
@@ -175,7 +179,7 @@ func (s *S2IBuilder) Build() error {
 		ScriptsURL: s.build.Spec.Strategy.SourceStrategy.Scripts,
 
 		BuilderImage:       s.build.Spec.Strategy.SourceStrategy.From.Name,
-		Incremental:        s.build.Spec.Strategy.SourceStrategy.Incremental,
+		Incremental:        incremental,
 		IncrementalFromTag: pushTag,
 
 		Environment:       buildEnvVars(s.build),

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -67,6 +67,7 @@ func newTestS2IBuilder(config testS2IBuilderConfig) *S2IBuilder {
 }
 
 func makeBuild() *api.Build {
+	t := true
 	return &api.Build{
 		Spec: api.BuildSpec{
 			CommonSpec: api.CommonSpec{
@@ -80,7 +81,7 @@ func makeBuild() *api.Build {
 							Kind: "DockerImage",
 							Name: "test/builder:latest",
 						},
-						Incremental: true,
+						Incremental: &t,
 					}},
 				Output: api.BuildOutput{
 					To: &kapi.ObjectReference{

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -301,7 +301,7 @@ func describeSourceStrategy(s *buildapi.SourceBuildStrategy, out *tabwriter.Writ
 	if s.PullSecret != nil {
 		formatString(out, "Pull Secret Name", s.PullSecret.Name)
 	}
-	if s.Incremental {
+	if s.Incremental != nil && *s.Incremental {
 		formatString(out, "Incremental Build", "yes")
 	}
 	if s.ForcePull {


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/10005

@csrwng ptal
@openshift/api-review ptal

i'm torn about making this a top level field in the override struct since this field is specific to s2i builds.  So if team-api thinks it would be better to create an s2i struct and embed the field there, i'd be open to that... it just feels like overkill right now, but it this could get ugly if we add a lot more override fields that are unique to one strategy or another.
