### PR TITLE
Set default image version for 'oc cluster up'

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -208,7 +208,8 @@ To use a different suffix, specify it with `--routing-suffix`.
 
 ## Specifying Images to Use
 
-By default `oc cluster up` uses `openshift/origin:latest` as its OpenShift image and `openshift-origin-${component}:latest` for 
+By default `oc cluster up` uses `openshift/origin:[released-version]` as its OpenShift image (where [released-version]
+corresponds to the release of the `oc` client) and `openshift-origin-${component}:[released-version]` for
 other images created by the OpenShift cluster (registry, router, builders, etc). It is possible to use a different set of 
 images by specifying the version and/or the image prefix.
 

--- a/docs/man/man1/oc-cluster-up.1
+++ b/docs/man/man1/oc-cluster-up.1
@@ -94,7 +94,7 @@ A public hostname can also be specified for the server with the \-\-public\-host
     Use existing configuration if present
 
 .PP
-\fB\-\-version\fP="latest"
+\fB\-\-version\fP=""
     Specify the tag for OpenShift images
 
 

--- a/docs/man/man1/openshift-cli-cluster-up.1
+++ b/docs/man/man1/openshift-cli-cluster-up.1
@@ -94,7 +94,7 @@ A public hostname can also be specified for the server with the \-\-public\-host
     Use existing configuration if present
 
 .PP
-\fB\-\-version\fP="latest"
+\fB\-\-version\fP=""
     Specify the tag for OpenShift images
 
 

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	dockerutil "github.com/openshift/origin/pkg/cmd/util/docker"
+	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
 const (
@@ -121,7 +122,7 @@ func NewCmdUp(name, fullName string, f *osclientcmd.Factory, out io.Writer) *cob
 	}
 	cmd.Flags().BoolVar(&config.ShouldCreateDockerMachine, "create-machine", false, "Create a Docker machine if one doesn't exist")
 	cmd.Flags().StringVar(&config.DockerMachine, "docker-machine", "", "Specify the Docker machine to use")
-	cmd.Flags().StringVar(&config.ImageVersion, "version", "latest", "Specify the tag for OpenShift images")
+	cmd.Flags().StringVar(&config.ImageVersion, "version", "", "Specify the tag for OpenShift images")
 	cmd.Flags().StringVar(&config.Image, "image", "openshift/origin", "Specify the images to use for OpenShift")
 	cmd.Flags().BoolVar(&config.SkipRegistryCheck, "skip-registry-check", false, "Skip Docker daemon registry check")
 	cmd.Flags().StringVar(&config.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
@@ -198,6 +199,10 @@ func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 	c.TaskPrinter = NewTaskPrinter(c.Out)
 	c.originalFactory = f
 	c.command = cmd
+
+	if len(c.ImageVersion) == 0 {
+		c.ImageVersion = defaultImageVersion()
+	}
 
 	c.addTask("Checking OpenShift client", c.CheckOpenShiftClient)
 
@@ -307,6 +312,10 @@ func defaultPortForwarding() bool {
 }
 
 const defaultDockerMachineName = "openshift"
+
+func defaultImageVersion() string {
+	return variable.OverrideVersion.LastSemanticVersion()
+}
 
 // CreateDockerMachine will create a new Docker machine to run OpenShift
 func (c *ClientStartConfig) CreateDockerMachine(out io.Writer) error {


### PR DESCRIPTION
Sets the default value of the --version flag to the last released version that corresponds to the oc client.