### PR TITLE
enable RS with cohabitation

### DIFF
--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -49,6 +49,8 @@ import (
 	routev1 "github.com/openshift/origin/pkg/route/api/v1"
 	templatev1 "github.com/openshift/origin/pkg/template/api/v1"
 	userv1 "github.com/openshift/origin/pkg/user/api/v1"
+
+	"github.com/openshift/origin/pkg/api/upstreamconversions"
 )
 
 func init() {
@@ -518,4 +520,6 @@ func init() {
 		}
 		return false, nil
 	})
+
+	upstreamconversions.AddToScheme(kapi.Scheme)
 }

--- a/pkg/api/upstreamconversions/conversions.go
+++ b/pkg/api/upstreamconversions/conversions.go
@@ -1,0 +1,36 @@
+package upstreamconversions
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
+	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func AddToScheme(scheme *runtime.Scheme) {
+	addConversionFuncs(scheme)
+}
+
+func addConversionFuncs(scheme *runtime.Scheme) {
+	if err := scheme.AddConversionFuncs(
+		Convert_v1beta1_ReplicaSet_to_api_ReplicationController,
+	); err != nil {
+		panic(err)
+	}
+}
+
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *extensionsv1beta1.ReplicaSet, out *kapi.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensionsapi.ReplicaSet{}
+	if err := extensionsv1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &kapiv1.ReplicationController{}
+	if err := kapiv1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return kapiv1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -19,6 +19,9 @@ const (
 	InfraReplicationControllerServiceAccountName = "replication-controller"
 	ReplicationControllerRoleName                = "system:replication-controller"
 
+	InfraReplicaSetControllerServiceAccountName = "replicaset-controller"
+	ReplicaSetControllerRoleName                = "system:replicaset-controller"
+
 	InfraDeploymentControllerServiceAccountName = "deployment-controller"
 	DeploymentControllerRoleName                = "system:deployment-controller"
 
@@ -216,6 +219,38 @@ func init() {
 					Resources: sets.NewString("pods"),
 				},
 				// ReplicationManager.podControl.recorder
+				{
+					Verbs:     sets.NewString("create", "update", "patch"),
+					Resources: sets.NewString("events"),
+				},
+			},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = InfraSAs.addServiceAccount(
+		InfraReplicaSetControllerServiceAccountName,
+		authorizationapi.ClusterRole{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ReplicaSetControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("get", "list", "watch", "update"),
+					Resources: sets.NewString("replicasets"),
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("replicasets/status"),
+				},
+				{
+					Verbs:     sets.NewString("list", "watch", "create", "delete"),
+					Resources: sets.NewString("pods"),
+				},
 				{
 					Verbs:     sets.NewString("create", "update", "patch"),
 					Resources: sets.NewString("events"),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -218,7 +218,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -271,7 +271,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
@@ -316,7 +316,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -96,6 +96,7 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) ([]string, error
 			Storage:                 storage,
 			Decorator:               generic.UndecoratedStorage,
 			DeleteCollectionWorkers: 0,
+			ResourcePrefix:          c.Master.StorageFactory.ResourcePrefix(kapi.Resource("endpoints")),
 		})
 
 		endpointRegistry := endpoint.NewRegistry(endpointsStorage)

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -39,7 +39,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/persistentvolume"
 	podautoscalercontroller "k8s.io/kubernetes/pkg/controller/podautoscaler"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
-	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
+	replicasetcontroller "k8s.io/kubernetes/pkg/controller/replicaset"
 	servicecontroller "k8s.io/kubernetes/pkg/controller/service"
 	volumecontroller "k8s.io/kubernetes/pkg/controller/volume"
 
@@ -237,16 +237,14 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, na
 	return allPlugins
 }
 
-// RunReplicationController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunReplicationController(client *client.Client) {
-	controllerManager := replicationcontroller.NewReplicationManager(
-		c.Informers.Pods().Informer(),
+func (c *MasterConfig) RunReplicaSetController(client *client.Client) {
+	controller := replicasetcontroller.NewReplicaSetController(
 		clientadapter.FromUnversionedClient(client),
 		kctrlmgr.ResyncPeriod(c.ControllerManager),
-		replicationcontroller.BurstReplicas,
+		replicasetcontroller.BurstReplicas,
 		int(c.ControllerManager.LookupCacheSizeForRC),
 	)
-	go controllerManager.Run(int(c.ControllerManager.ConcurrentRCSyncs), utilwait.NeverStop)
+	go controller.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
 }
 
 // RunJobController starts the Kubernetes job controller sync loop

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -179,6 +179,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	// the order here is important, it defines which version will be used for storage
 	storageFactory.AddCohabitatingResources(extensions.Resource("jobs"), batch.Resource("jobs"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("horizontalpodautoscalers"), autoscaling.Resource("horizontalpodautoscalers"))
+	storageFactory.AddCohabitatingResources(kapi.Resource("replicationcontrollers"), kapi.Resource("replicationControllers" /*typoed with camel-case upstream*/), extensions.Resource("replicasets"))
 
 	// Preserve previous behavior of using the first non-loopback address
 	// TODO: Deprecate this behavior and just require a valid value to be passed in

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -539,7 +539,7 @@ func newServiceAccountTokenGetter(options configapi.MasterConfig, client newetcd
 		// When we're running in-process, go straight to etcd (using the KubernetesStorageVersion/KubernetesStoragePrefix, since service accounts are kubernetes objects)
 		codec := kapi.Codecs.LegacyCodec(unversioned.GroupVersion{Group: kapi.GroupName, Version: options.EtcdStorageConfig.KubernetesStorageVersion})
 		ketcdHelper := etcdstorage.NewEtcdStorage(client, codec, options.EtcdStorageConfig.KubernetesStoragePrefix, false, genericapiserveroptions.DefaultDeserializationCacheSize)
-		tokenGetter = sacontroller.NewGetterFromStorageInterface(ketcdHelper)
+		tokenGetter = sacontroller.NewGetterFromStorageInterface(ketcdHelper, "serviceaccounts", "secrets")
 	}
 	return tokenGetter, nil
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -557,7 +557,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunSecurityAllocationController()
 
 	if kc != nil {
-		_, _, rcClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicationControllerServiceAccountName)
+		_, _, rsClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicaSetControllerServiceAccountName)
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
@@ -605,7 +605,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		// no special order
 		kc.RunNodeController()
 		kc.RunScheduler()
-		kc.RunReplicationController(rcClient)
+		kc.RunReplicaSetController(rsClient)
 
 		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
 

--- a/test/cmd/cohabitation.sh
+++ b/test/cmd/cohabitation.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/cohabitation"
+
+# integration tests ensure that the go client can list and watch and ensure that etcd is correct
+# this test ensures that the bytes coming back from the API have the correct type
+
+os::cmd::expect_success 'oadm policy add-role-to-user admin cohabiting-user -n cmd-cohabitation'
+os::cmd::try_until_text 'oadm policy who-can create replicationcontrollers' 'cohabiting-user'
+os::cmd::expect_success 'oc login -u cohabiting-user -p asdf'
+accesstoken=$(oc whoami -t)
+os::cmd::expect_success 'oc login -u system:admin'
+
+os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replication.yaml -n cmd-cohabitation'
+os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replicaset/frontend.yaml -n cmd-cohabitation'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers" '"kind": "ReplicationControllerList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers" '"kind": "ReplicaSetList"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets" '"kind": "ReplicaSetList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets" '"kind": "ReplicationControllerList"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/frontend" '"kind": "ReplicationController"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/frontend" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/frontend" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/frontend" '"kind": "ReplicationController"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/nginx" '"kind": "ReplicationController"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/nginx" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/nginx" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/nginx" '"kind": "ReplicationController"'
+
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers?watch=true" '"kind":"ReplicationController"'
+os::cmd::expect_failure_and_not_text "curl --max-time 1 -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers?watch=true" '"kind":"ReplicaSet"'
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicaSet"'
+os::cmd::expect_failure_and_not_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicationController"'
+
+
+echo "cohabitation: ok"
+os::test::junit::declare_suite_end

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -181,7 +181,6 @@ readonly EXCLUDED_TESTS=(
   "should support exec through an HTTP proxy" # doesn't work because it requires a) static binary b) linux c) kubectl, https://github.com/openshift/origin/issues/7097
   "NFS"                      # no permissions https://github.com/openshift/origin/pull/6884
   "\[Feature:Example\]"      # may need to pre-pull images
-  "should serve a basic image on each replica with a public image" # is failing to create pods, the test is broken
   "ResourceQuota and capture the life of a secret" # https://github.com/openshift/origin/issue/9414
   "NodeProblemDetector"        # requires a non-master node to run on
 

--- a/test/integration/cohabitation_rc_rs_test.go
+++ b/test/integration/cohabitation_rc_rs_test.go
@@ -1,0 +1,143 @@
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+type fakeObject struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+}
+
+func TestRCRSCohabitation(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err := testutil.GetFixture("../../vendor/k8s.io/kubernetes/docs/user-guide/replication.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rc := obj.(*kapi.ReplicationController)
+	if _, err := clusterAdminKubeClient.ReplicationControllers("default").Create(rc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err = testutil.GetFixture("../../vendor/k8s.io/kubernetes/docs/user-guide/replicaset/frontend.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rs := obj.(*extensionsapi.ReplicaSet)
+	if _, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").Create(rs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// make sure we get back both from each endpoint
+	rcList, err := clusterAdminKubeClient.ReplicationControllers("default").List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend := false
+	foundNginx := false
+	for _, rc := range rcList.Items {
+		if rc.Name == "nginx" {
+			foundNginx = true
+		}
+		if rc.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rc: %#v", rcList)
+	}
+
+	rsList, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for _, rs := range rsList.Items {
+		if rs.Name == "nginx" {
+			foundNginx = true
+		}
+		if rs.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rs: %#v", rsList)
+	}
+
+	etcdClient := testutil.NewEtcdClient()
+	etcdControllers, err := etcdClient.Get("/kubernetes.io/controllers/default", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedEtcdEncoding := fakeObject{Kind: "ReplicationController", APIVersion: "v1"}
+	for _, node := range etcdControllers.Node.Nodes {
+		obj := fakeObject{}
+		if err := json.Unmarshal([]byte(node.Value), &obj); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if obj != expectedEtcdEncoding {
+			t.Errorf("expected %v, got %v", expectedEtcdEncoding, obj)
+		}
+	}
+
+	rcWatch, err := clusterAdminKubeClient.ReplicationControllers("default").Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-rcWatch.ResultChan()
+		rc := obj.Object.(*kapi.ReplicationController)
+		if rc.Name == "nginx" {
+			foundNginx = true
+		}
+		if rc.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rc: %v %v", foundFrontend, foundNginx)
+	}
+
+	rsWatch, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-rsWatch.ResultChan()
+		rs := obj.Object.(*extensionsapi.ReplicaSet)
+		if rs.Name == "nginx" {
+			foundNginx = true
+		}
+		if rs.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rs: %v %v", foundFrontend, foundNginx)
+	}
+
+}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -485,6 +485,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     - replicationcontrollers/scale
     verbs:
     - create
@@ -842,6 +844,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     - replicationcontrollers/scale
     verbs:
     - create
@@ -1106,6 +1110,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     verbs:
     - get
     - list
@@ -2710,6 +2716,48 @@ items:
     - create
     - delete
     - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:replicaset-controller
+  rules:
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets/status
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - list
+    - watch
   - apiGroups:
     - ""
     attributeRestrictions: null

--- a/test/util/helpers.go
+++ b/test/util/helpers.go
@@ -42,3 +42,19 @@ func GetImageFixture(filename string) (*imageapi.Image, error) {
 	}
 	return obj.(*imageapi.Image), nil
 }
+
+func GetFixture(filename string) (runtime.Object, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := kyaml.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := runtime.Decode(kapi.Codecs.UniversalDecoder(), jsonData)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/apiserver/authenticator"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -182,7 +183,7 @@ func Run(s *options.APIServer) error {
 		if err != nil {
 			glog.Fatalf("Unable to get serviceaccounts storage: %v", err)
 		}
-		serviceAccountGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storage)
+		serviceAccountGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storage, storageFactory.ResourcePrefix(api.Resource("serviceaccounts")), storageFactory.ResourcePrefix(api.Resource("secrets")))
 	}
 
 	authenticator, err := authenticator.New(authenticator.AuthenticatorConfig{
@@ -227,11 +228,11 @@ func Run(s *options.APIServer) error {
 
 	if modeEnabled(apiserver.ModeRBAC) {
 		mustGetRESTOptions := func(resource string) generic.RESTOptions {
-			s, err := storageFactory.New(api.Resource(resource))
+			s, err := storageFactory.New(rbac.Resource(resource))
 			if err != nil {
 				glog.Fatalf("Unable to get %s storage: %v", resource, err)
 			}
-			return generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage}
+			return generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: storageFactory.ResourcePrefix(rbac.Resource(resource))}
 		}
 
 		// For initial bootstrapping go directly to etcd to avoid privillege escalation check.

--- a/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
@@ -38,8 +38,12 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
+	"k8s.io/kubernetes/pkg/runtime/serializer/versioning"
 	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
@@ -145,6 +149,61 @@ func roundTripSame(t *testing.T, group testapi.TestGroup, item runtime.Object, e
 		for _, codec := range codecs {
 			roundTrip(t, codec, item)
 		}
+	}
+}
+
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *v1beta1.ReplicaSet, out *api.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensions.ReplicaSet{}
+	if err := v1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &v1.ReplicationController{}
+	if err := v1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return v1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}
+
+func TestSetControllerConversion(t *testing.T) {
+	if err := api.Scheme.AddConversionFuncs(Convert_v1beta1_ReplicaSet_to_api_ReplicationController); err != nil {
+		t.Fatal(err)
+	}
+
+	rs := &extensions.ReplicaSet{}
+	rc := &api.ReplicationController{}
+
+	extGroup := testapi.Extensions
+	defaultGroup := testapi.Default
+
+	fuzzInternalObject(t, extGroup.InternalGroupVersion(), rs, rand.Int63())
+
+	t.Logf("rs._internal.extensions -> rs.v1beta1.extensions")
+	data, err := runtime.Encode(extGroup.Codec(), rs)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	decoder := api.Codecs.UniversalDecoder(*extGroup.GroupVersion(), *defaultGroup.GroupVersion())
+	if err := versioning.EnableCrossGroupDecoding(decoder, extGroup.GroupVersion().Group, defaultGroup.GroupVersion().Group); err != nil {
+		t.Fatalf("unexpected error while enabling cross-group decoding: %v", err)
+	}
+
+	t.Logf("rs.v1beta1.extensions -> rc._internal")
+	if err := runtime.DecodeInto(decoder, data, rc); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
+	}
+
+	t.Logf("rc._internal -> rc.v1")
+	data, err = runtime.Encode(defaultGroup.Codec(), rc)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	t.Logf("rc.v1 -> rs._internal.extensions")
+	if err := runtime.DecodeInto(decoder, data, rs); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
@@ -64,6 +64,35 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 	return selector, nil
 }
 
+// LabelSelectorAsMap converts the LabelSelector api type into a map of strings, ie. the
+// original structure of a label selector. Operators that cannot be converted into plain
+// labels (Exists, DoesNotExist, NotIn, and In with more than one value) will result in
+// an error.
+func LabelSelectorAsMap(ps *LabelSelector) (map[string]string, error) {
+	if ps == nil {
+		return nil, nil
+	}
+	selector := map[string]string{}
+	for k, v := range ps.MatchLabels {
+		selector[k] = v
+	}
+	for _, expr := range ps.MatchExpressions {
+		switch expr.Operator {
+		case LabelSelectorOpIn:
+			if len(expr.Values) != 1 {
+				return selector, fmt.Errorf("operator %q without a single value cannot be converted into the old label selector format", expr.Operator)
+			}
+			// Should we do anything in case this will override a previous key-value pair?
+			selector[expr.Key] = expr.Values[0]
+		case LabelSelectorOpNotIn, LabelSelectorOpExists, LabelSelectorOpDoesNotExist:
+			return selector, fmt.Errorf("operator %q cannot be converted into the old label selector format", expr.Operator)
+		default:
+			return selector, fmt.Errorf("%q is not a valid selector operator", expr.Operator)
+		}
+	}
+	return selector, nil
+}
+
 // ParseToLabelSelector parses a string representing a selector into a LabelSelector object.
 // Note: This function should be kept in sync with the parser in pkg/labels/selector.go
 func ParseToLabelSelector(selector string) (*LabelSelector, error) {

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/labels"
@@ -75,6 +76,76 @@ func TestLabelSelectorAsSelector(t *testing.T) {
 		}
 		if err != nil && !tc.expectErr {
 			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(out, tc.out) {
+			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
+		}
+	}
+}
+
+func TestLabelSelectorAsMap(t *testing.T) {
+	matchLabels := map[string]string{"foo": "bar"}
+	matchExpressions := func(operator LabelSelectorOperator, values []string) []LabelSelectorRequirement {
+		return []LabelSelectorRequirement{{
+			Key:      "baz",
+			Operator: operator,
+			Values:   values,
+		}}
+	}
+
+	tests := []struct {
+		in        *LabelSelector
+		out       map[string]string
+		errString string
+	}{
+		{in: nil, out: nil},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels},
+			out: map[string]string{"foo": "bar"},
+		},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"foo": "bar", "baz": "norf"},
+		},
+		{
+			in:  &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"baz": "norf"},
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf", "qux"})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "without a single value cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpNotIn, []string{"norf", "qux"})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpExists, []string{})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpDoesNotExist, []string{})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+	}
+
+	for i, tc := range tests {
+		out, err := LabelSelectorAsMap(tc.in)
+		if err == nil && len(tc.errString) > 0 {
+			t.Errorf("[%v]expected error but got none.", i)
+			continue
+		}
+		if err != nil && len(tc.errString) == 0 {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+			continue
+		}
+		if err != nil && len(tc.errString) > 0 && !strings.Contains(err.Error(), tc.errString) {
+			t.Errorf("[%v]expected error with %q but got: %v", i, tc.errString, err)
+			continue
 		}
 		if !reflect.DeepEqual(out, tc.out) {
 			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -19,10 +19,13 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
 )
 
 const (
@@ -31,6 +34,9 @@ const (
 
 	// Value used to identify mirror pods from pre-v1.1 kubelet.
 	mirrorAnnotationValue_1_0 = "mirror"
+
+	// annotation key prefix used to identify non-convertible json paths.
+	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) {
@@ -45,6 +51,12 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
 		Convert_v1_ServiceSpec_To_api_ServiceSpec,
 		Convert_v1_ResourceList_To_api_ResourceList,
+		Convert_v1_ReplicationController_to_extensions_ReplicaSet,
+		Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec,
+		Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus,
+		Convert_extensions_ReplicaSet_to_v1_ReplicationController,
+		Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec,
+		Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus,
 
 		Convert_api_VolumeSource_To_v1_VolumeSource,
 		Convert_v1_VolumeSource_To_api_VolumeSource,
@@ -204,17 +216,107 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 }
 
+func Convert_v1_ReplicationController_to_extensions_ReplicaSet(in *ReplicationController, out *extensions.ReplicaSet, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationController))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(in *ReplicationControllerSpec, out *extensions.ReplicaSetSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerSpec))(in)
+	}
+	out.Replicas = *in.Replicas
+	if in.Selector != nil {
+		api.Convert_map_to_unversioned_LabelSelector(&in.Selector, out.Selector, s)
+	}
+	if in.Template != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, &out.Template, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(in *ReplicationControllerStatus, out *extensions.ReplicaSetStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerStatus))(in)
+	}
+	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
+func Convert_extensions_ReplicaSet_to_v1_ReplicationController(in *extensions.ReplicaSet, out *ReplicationController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSet))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		fieldErr, ok := err.(*field.Error)
+		if !ok {
+			return err
+		}
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
+	}
+	if err := Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(in *extensions.ReplicaSetSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetSpec))(in)
+	}
+	out.Replicas = new(int32)
+	*out.Replicas = in.Replicas
+	var invalidErr error
+	if in.Selector != nil {
+		invalidErr = api.Convert_unversioned_LabelSelector_to_map(in.Selector, &out.Selector, s)
+	}
+	out.Template = new(PodTemplateSpec)
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, out.Template, s); err != nil {
+		return err
+	}
+	return invalidErr
+}
+
+func Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(in *extensions.ReplicaSetStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetStatus))(in)
+	}
+	out.Replicas = int32(in.Replicas)
+	out.FullyLabeledReplicas = int32(in.FullyLabeledReplicas)
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
 func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = &in.Replicas
 	out.Selector = in.Selector
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(ObjectReference)
-	//	if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
@@ -229,15 +331,6 @@ func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 func Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = *in.Replicas
 	out.Selector = in.Selector
-
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(api.ObjectReference)
-	//	if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
 		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
@@ -69,9 +69,9 @@ func (r *registryGetter) GetSecret(namespace, name string) (*api.Secret, error) 
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(s storage.Interface) serviceaccount.ServiceAccountTokenGetter {
+func NewGetterFromStorageInterface(s storage.Interface, saPrefix, secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
 	return NewGetterFromRegistries(
-		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
-		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
+		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix})),
+		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix})),
 	)
 }

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -19,6 +19,7 @@ package genericapiserver
 import (
 	"fmt"
 	"mime"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -36,6 +37,12 @@ type StorageFactory interface {
 	// New finds the storage destination for the given group and resource. It will
 	// return an error if the group has no storage destination configured.
 	New(groupResource unversioned.GroupResource) (storage.Interface, error)
+
+	// ResourcePrefix returns the overridden resource prefix for the GroupResource
+	// This allows for cohabitation of resources with different native types and provides
+	// centralized control over the shape of etcd directories
+	ResourcePrefix(groupResource unversioned.GroupResource) string
+
 	// Backends gets all backends for all registered storage destinations.
 	// Used for getting all instances for health validations.
 	Backends() []string
@@ -77,8 +84,12 @@ type groupResourceOverrides struct {
 	// etcdLocation contains the list of "special" locations that are used for particular GroupResources
 	// These are merged on top of the StorageConfig when requesting the storage.Interface for a given GroupResource
 	etcdLocation []string
-	// etcdPrefix contains the list of "special" prefixes for a GroupResource.  Resource=* means for the entire group
+	// etcdPrefix contains the list of "special" prefixes for a GroupResource.
 	etcdPrefix string
+	// etcdResourcePrefix is the location to use to store a particular type under the `etcdPrefix` location
+	// If empty, the default mapping is used.  If the default mapping doesn't contain an entry, it will use
+	// the ToLowered name of the resource, not including the group.
+	etcdResourcePrefix string
 	// mediaType is the desired serializer to choose. If empty, the default is chosen.
 	mediaType string
 	// serializer contains the list of "special" serializers for a GroupResource.  Resource=* means for the entire group
@@ -124,6 +135,12 @@ func (s *DefaultStorageFactory) SetEtcdLocation(groupResource unversioned.GroupR
 func (s *DefaultStorageFactory) SetEtcdPrefix(groupResource unversioned.GroupResource, prefix string) {
 	overrides := s.Overrides[groupResource]
 	overrides.etcdPrefix = prefix
+	s.Overrides[groupResource] = overrides
+}
+
+func (s *DefaultStorageFactory) SetResourceEtcdPrefix(groupResource unversioned.GroupResource, prefix string) {
+	overrides := s.Overrides[groupResource]
+	overrides.etcdResourcePrefix = prefix
 	s.Overrides[groupResource] = overrides
 }
 
@@ -277,4 +294,31 @@ func NewStorageCodec(storageMediaType string, ns runtime.StorageSerializer, stor
 	encoder := ns.EncoderForVersion(s, runtime.NewMultiGroupVersioner(storageVersion, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
 	decoder := ns.DecoderToVersion(ds, runtime.NewMultiGroupVersioner(memoryVersion, unversioned.GroupKind{Group: memoryVersion.Group}, unversioned.GroupKind{Group: storageVersion.Group}))
 	return runtime.NewCodec(encoder, decoder), nil
+}
+
+var specialDefaultResourcePrefixes = map[unversioned.GroupResource]string{
+	unversioned.GroupResource{Group: "", Resource: "replicationControllers"}: "controllers",
+	unversioned.GroupResource{Group: "", Resource: "replicationcontrollers"}: "controllers",
+	unversioned.GroupResource{Group: "", Resource: "endpoints"}:              "services/endpoints",
+	unversioned.GroupResource{Group: "", Resource: "nodes"}:                  "minions",
+	unversioned.GroupResource{Group: "", Resource: "services"}:               "services/specs",
+}
+
+func (s *DefaultStorageFactory) ResourcePrefix(groupResource unversioned.GroupResource) string {
+	chosenStorageResource := s.getStorageGroupResource(groupResource)
+	groupOverride := s.Overrides[getAllResourcesAlias(chosenStorageResource)]
+	exactResourceOverride := s.Overrides[chosenStorageResource]
+
+	etcdResourcePrefix := specialDefaultResourcePrefixes[chosenStorageResource]
+	if len(groupOverride.etcdResourcePrefix) > 0 {
+		etcdResourcePrefix = groupOverride.etcdResourcePrefix
+	}
+	if len(exactResourceOverride.etcdResourcePrefix) > 0 {
+		etcdResourcePrefix = exactResourceOverride.etcdResourcePrefix
+	}
+	if len(etcdResourcePrefix) == 0 {
+		etcdResourcePrefix = strings.ToLower(chosenStorageResource.Resource)
+	}
+
+	return etcdResourcePrefix
 }

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -87,6 +87,11 @@ type groupResourceOverrides struct {
 	// of exposing one set of concepts.  autoscaling.HPA and extensions.HPA as a for instance
 	// The order of the slice matters!  It is the priority order of lookup for finding a storage location
 	cohabitatingResources []unversioned.GroupResource
+
+	// ignoreCohabitatingStorageVersion controls whether or not a cohabitating resource attempts to serialize into the same
+	// groupVersion as all other cohabitators.  If not, it uses the groupVersion assigned to itself instead of the one being
+	// used by the first enabled cohabitator.
+	ignoreCohabitatingStorageVersion bool
 }
 
 var _ StorageFactory = &DefaultStorageFactory{}
@@ -134,6 +139,16 @@ func (s *DefaultStorageFactory) AddCohabitatingResources(groupResources ...unver
 	for _, groupResource := range groupResources {
 		overrides := s.Overrides[groupResource]
 		overrides.cohabitatingResources = groupResources
+		s.Overrides[groupResource] = overrides
+	}
+}
+
+// IgnoreCohabitingStorageVersion indicates that the cohabitating resource should serialize using its own groupVersion, not the "shared" groupVersion
+// of all cohabitators.  Useful during resource migration/parity cases
+func (s *DefaultStorageFactory) IgnoreCohabitingStorageVersion(groupResources ...unversioned.GroupResource) {
+	for _, groupResource := range groupResources {
+		overrides := s.Overrides[groupResource]
+		overrides.ignoreCohabitatingStorageVersion = true
 		s.Overrides[groupResource] = overrides
 	}
 }
@@ -198,7 +213,12 @@ func (s *DefaultStorageFactory) New(groupResource unversioned.GroupResource) (st
 		config.ServerList = overriddenEtcdLocations
 	}
 
-	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(chosenStorageResource)
+	storageEncodingResource := chosenStorageResource
+	if s.Overrides[groupResource].ignoreCohabitatingStorageVersion {
+		storageEncodingResource = groupResource
+	}
+
+	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(storageEncodingResource)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
@@ -87,3 +87,91 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	}
 }
+
+func TestCohabitingSerializationVersion(t *testing.T) {
+	defaultConfig := storagebackend.Config{
+		Prefix:     options.DefaultEtcdPathPrefix,
+		ServerList: []string{"http://127.0.0.1"},
+	}
+
+	testCases := []struct {
+		name              string
+		factory           func() *DefaultStorageFactory
+		requestedResource unversioned.GroupResource
+
+		expectedResource unversioned.GroupResource
+	}{
+		{
+			name: "request first",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("one"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "request second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "ignore second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("two"),
+		},
+		{
+			name: "ignore second, request third",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("three"),
+			expectedResource:  api.Resource("one"),
+		},
+	}
+
+	for _, tc := range testCases {
+		factory := tc.factory()
+		testEncodingConfig := &testDefaultResourceEncodingConfig{ResourceEncodingConfig: factory.ResourceEncodingConfig}
+		factory.ResourceEncodingConfig = testEncodingConfig
+
+		factory.New(tc.requestedResource)
+
+		if e, a := tc.expectedResource, testEncodingConfig.requestedResource; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+type testDefaultResourceEncodingConfig struct {
+	ResourceEncodingConfig
+	requestedResource unversioned.GroupResource
+}
+
+func (o *testDefaultResourceEncodingConfig) StorageEncodingFor(resource unversioned.GroupResource) (unversioned.GroupVersion, error) {
+	o.requestedResource = resource
+	return api.SchemeGroupVersion, nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/master/master.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/master.go
@@ -872,6 +872,7 @@ func (m *Master) GetRESTOptionsOrDie(c *Config, resource unversioned.GroupResour
 		Storage:                 storage,
 		Decorator:               m.StorageDecorator(),
 		DeleteCollectionWorkers: m.deleteCollectionWorkers,
+		ResourcePrefix:          c.StorageFactory.ResourcePrefix(resource),
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/clusterrole/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/clusterrole/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterroles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/clusterrolebinding/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/clusterrolebinding/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterrolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/configmap/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/configmap/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/configmaps"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ConfigMapList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/controller/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/controller/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/controllers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ReplicationControllerList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/daemonset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/daemonset/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/daemonsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DaemonSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
@@ -61,7 +61,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *RollbackREST) {
-	prefix := "/deployments"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DeploymentList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd_test.go
@@ -41,7 +41,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*DeploymentStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "deployments"}
 	deploymentStorage := NewStorage(restOptions)
 	return &deploymentStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/endpoint/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/endpoint/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/services/endpoints"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.EndpointsList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/event/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/event/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against events.
 func NewREST(opts generic.RESTOptions, ttl uint64) *REST {
-	prefix := "/events"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here - switching on Cacher
 	// for events will lead to too high memory consumption.

--- a/vendor/k8s.io/kubernetes/pkg/registry/experimental/controller/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/experimental/controller/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 
 func newStorage(t *testing.T) (*ScaleREST, *etcdtesting.EtcdTestServer, storage.Interface) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "controllers"}
 	return NewStorage(restOptions).Scale, server, etcdStorage
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/generic/options.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/generic/options.go
@@ -25,4 +25,6 @@ type RESTOptions struct {
 	Storage                 pkgstorage.Interface
 	Decorator               StorageDecorator
 	DeleteCollectionWorkers int
+
+	ResourcePrefix string
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/horizontalpodautoscalers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/ingress/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/ingress/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/ingress"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.IngressList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/job/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/job/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/jobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.JobList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/limitrange/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/limitrange/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/limitranges"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.LimitRangeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd.go
@@ -52,7 +52,7 @@ type FinalizeREST struct {
 
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *FinalizeREST) {
-	prefix := "/namespaces"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NamespaceList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd_test.go
@@ -31,7 +31,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
 	namespaceStorage, _, _ := NewREST(restOptions)
 	return namespaceStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/networkpolicy/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/networkpolicy/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/networkpolicies"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensionsapi.NetworkPolicyList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/node/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/node/etcd/etcd.go
@@ -66,7 +66,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 
 // NewREST returns a RESTStorage object that will work against nodes.
 func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper) NodeStorage {
-	prefix := "/minions"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/persistentvolume/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumes"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumeclaims"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeClaimList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/petsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &appsapi.PetSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd_test.go
@@ -33,7 +33,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, apps.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "petsets"}
 	petSetStorage, statusStorage := NewREST(restOptions)
 	return petSetStorage, statusStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against pods.
 func NewStorage(opts generic.RESTOptions, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper) PodStorage {
-	prefix := "/pods"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/poddisruptionbudgets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
@@ -34,7 +34,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, policy.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "poddisruptionbudgets"}
 	podDisruptionBudgetStorage, statusStorage := NewREST(restOptions)
 	return podDisruptionBudgetStorage, statusStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/podsecuritypolicy/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/podsecuritypolicy/etcd/etcd.go
@@ -32,22 +32,22 @@ type REST struct {
 	*registry.Store
 }
 
-const Prefix = "/podsecuritypolicies"
-
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(opts generic.RESTOptions) *REST {
+	prefix := "/" + opts.ResourcePrefix
+
 	newListFunc := func() runtime.Object { return &extensions.PodSecurityPolicyList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, 100, &extensions.PodSecurityPolicy{}, Prefix, podsecuritypolicy.Strategy, newListFunc)
+		opts.Storage, 100, &extensions.PodSecurityPolicy{}, prefix, podsecuritypolicy.Strategy, newListFunc)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &extensions.PodSecurityPolicy{} },
 		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
-			return Prefix
+			return prefix
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, Prefix, name)
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*extensions.PodSecurityPolicy).Name, nil

--- a/vendor/k8s.io/kubernetes/pkg/registry/podtemplate/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/podtemplate/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/podtemplates"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodTemplateList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/replicasets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.ReplicaSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd_test.go
@@ -38,7 +38,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*ReplicaSetStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "replicasets"}
 	replicaSetStorage := NewStorage(restOptions)
 	return &replicaSetStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/resourcequota/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/resourcequota/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/resourcequotas"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ResourceQuotaList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/role/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/role/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/roles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/rolebinding/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rolebinding/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/rolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/scheduledjob/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/scheduledjob/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ScheduledJobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/scheduledjobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.ScheduledJobList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/secret/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/secret/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/secrets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.SecretList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/service/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/service/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/services/specs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/serviceaccount/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/serviceaccount/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/serviceaccounts"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceAccountList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a registry which will store ThirdPartyResource in the given helper
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/thirdpartyresources"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here yet.
 	storageInterface := opts.Storage

--- a/vendor/k8s.io/kubernetes/pkg/runtime/interfaces.go
+++ b/vendor/k8s.io/kubernetes/pkg/runtime/interfaces.go
@@ -39,6 +39,14 @@ type GroupVersioner interface {
 	PrefersGroup() (string, bool)
 }
 
+// GroupVersionerKinder conveys information about a desired target version for objects being converted.
+type GroupVersionerKinder interface {
+	GroupVersioner
+	// KindForGroupKind returns the desired GroupVersionKind for a given GroupKind, or false if no version
+	// is preferred. The kind on the GroupKind is optional, and implementers may choose to ignore it.
+	KindForGroupKind(group unversioned.GroupKind) (unversioned.GroupVersionKind, bool)
+}
+
 // Encoders write objects to a serialized form
 type Encoder interface {
 	// Encode writes an object to a stream. Implementations may return errors if the versions are

--- a/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
@@ -507,7 +507,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 					{"role=master"},
 					{"Status:", "Running"},
 					{"IP:"},
-					{"Controllers:", "ReplicationController/redis-master"},
+					{"Controllers:", "ReplicaSet/redis-master"},
 					{"Image:", redisImage},
 					{"State:", "Running"},
 					{"QoS Tier:", "BestEffort"},


### PR DESCRIPTION
Mostly working, though rather hacked.  I've had to leave RCs writing as RCs and RSs as RSs because otherwise the watch cache doesn't think it can convert.  Even with that, the watch cache is unhappy for cross group types.

I've had to register RS under the RC name in the scheme to trick the GroupVersioner to accept it for conversion.

All that said, I have functional RSs at this point and only the RS controller running.

@mfojtik @smarterclayton 