### PR TITLE
Allows filtering templates by namespace in new-app

### DIFF
--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -189,7 +189,7 @@ func TestBuildTemplates(t *testing.T) {
 			if !match.IsTemplate() {
 				t.Errorf("%s: Expected template match, got: %v", n, match)
 			}
-			if c.templateName != match.Name {
+			if fmt.Sprintf("%s/%s", c.namespace, c.templateName) != match.Name {
 				t.Errorf("%s: Expected template name %q, got: %q", n, c.templateName, match.Name)
 			}
 			if len(parms) != len(c.parms) {

--- a/pkg/generate/app/templatelookup_test.go
+++ b/pkg/generate/app/templatelookup_test.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/client/testclient"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+)
+
+func testTemplateClient(templates *templateapi.TemplateList) client.Interface {
+	fake := &testclient.Fake{}
+	fake.AddReactor("list", "templates", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		if len(action.GetNamespace()) > 0 {
+			matchingTemplates := &templateapi.TemplateList{
+				Items: []templateapi.Template{},
+			}
+			for _, template := range templates.Items {
+				if template.Namespace == action.GetNamespace() {
+					matchingTemplates.Items = append(matchingTemplates.Items, template)
+				}
+			}
+			return true, matchingTemplates, nil
+		} else {
+			return true, templates, nil
+		}
+	})
+	return fake
+}
+
+func TestTemplateSearcher(t *testing.T) {
+	testData := map[string][]string{
+		"openshift":   {"nodejs-mongodb-example", "rails-postgresql-example", "jenkins-ephemeral", "my-jenkins"},
+		"mynamespace": {"my-jenkins"},
+	}
+
+	tests := []struct {
+		value           string
+		expectedMatches int
+		expectedErr     bool
+	}{
+		{
+			value:           "jenkins",
+			expectedMatches: 3,
+		},
+		{
+			value:           "my-jenkins",
+			expectedMatches: 2,
+		},
+		{
+			value:           "jenkins-ephemeral",
+			expectedMatches: 1,
+		},
+		{
+			value:           "openshift/my-jenkins",
+			expectedMatches: 1,
+		},
+		{
+			value:           "openshift/jenkins",
+			expectedMatches: 2,
+		},
+		{
+			value:           "foobar",
+			expectedMatches: 0,
+		},
+		{
+			value:           "openshift/foobar",
+			expectedMatches: 0,
+		},
+		{
+			value:           "mynamespace/jenkins-ephemeral",
+			expectedMatches: 0,
+		},
+		{
+			value:           "mynamespace/jenkins-ephemeral",
+			expectedMatches: 0,
+		},
+		{
+			value:       "foo/bar/zee",
+			expectedErr: true,
+		},
+	}
+
+	templates := fakeTemplates(testData)
+	client := testTemplateClient(templates)
+	searcher := &TemplateSearcher{
+		Client:     client,
+		Namespaces: []string{"openshift", "mynamespace"},
+	}
+	for _, test := range tests {
+		searchResults, errs := searcher.Search(false, test.value)
+		if errs != nil && !test.expectedErr {
+			t.Errorf("unexpected errors: %v", errs)
+		}
+		if len(searchResults) != test.expectedMatches {
+			t.Errorf("Expected %v search matches for %q, got %v", test.expectedMatches, test.value, len(searchResults))
+		}
+	}
+}
+
+func fakeTemplates(testData map[string][]string) *templateapi.TemplateList {
+	templates := &templateapi.TemplateList{
+		Items: []templateapi.Template{},
+	}
+	for namespace, templateNames := range testData {
+		for _, templateName := range templateNames {
+			template := &templateapi.Template{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      templateName,
+					Namespace: namespace,
+				},
+			}
+			templates.Items = append(templates.Items, *template)
+		}
+	}
+	return templates
+}

--- a/pkg/template/helper.go
+++ b/pkg/template/helper.go
@@ -1,0 +1,44 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TemplateReference points to a stored template
+type TemplateReference struct {
+	Namespace string
+	Name      string
+}
+
+// ParseTemplateReference parses the reference to a template into a
+// TemplateReference.
+func ParseTemplateReference(s string) (TemplateReference, error) {
+	var ref TemplateReference
+	parts := strings.Split(s, "/")
+	switch len(parts) {
+	case 2:
+		// namespace/name
+		ref.Namespace = parts[0]
+		ref.Name = parts[1]
+		break
+	case 1:
+		// name
+		ref.Name = parts[0]
+		break
+	default:
+		return ref, fmt.Errorf("the template reference must be either the template name or namespace and template name separated by slashes")
+	}
+	return ref, nil
+}
+
+func (r TemplateReference) HasNamespace() bool {
+	return len(r.Namespace) > 0
+}
+
+func (r TemplateReference) String() string {
+	if r.HasNamespace() {
+		return fmt.Sprintf("%s/%s", r.Namespace, r.Name)
+	}
+	return r.Name
+}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1248362

This allows the use of the `namespace/templatename` form when specifying templates in `new-app` (it was already supported for image streams, but templates was lacking the support). 

So for example if you have templates with the exact same name "jenkins" in both "mynamespace" and "openshift", you can be explicit about which one you want to use with

```
oc new-app --template=openshift/jenkins ...
oc new-app --template=mynamespace/jenkins -n wheretocreateit ...
```

