### PR TITLE
update the output of Deploying a private docker registry

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -145,8 +145,12 @@ This section covers how to perform all the steps of building, deploying, and upd
 4. Deploy a private docker registry within OpenShift with the certs necessary for access to master:
 
         $ oadm registry -n default --config=openshift.local.config/master/admin.kubeconfig
-          DeploymentConfig "docker-registry" created
-          Service "docker-registry" created
+        --> Creating registry registry ...
+            serviceaccount "registry" created
+            clusterrolebinding "registry-registry-role" created
+            deploymentconfig "docker-registry" created
+            service "docker-registry" created
+        --> Success  
 
     Note that the private Docker registry is using ephemeral storage,
     so when it is stopped, the image will be lost. An external volume


### PR DESCRIPTION
I think we should upstate the output of "$ oadm registry -n default --config=openshift.local.config/master/admin.kubeconfig".

**current version output:**

 --> Creating registry registry ...
         serviceaccount "registry" created
         clusterrolebinding "registry-registry-role" created
         deploymentconfig "docker-registry" created
         service "docker-registry" created
--> Success 
