### PR TITLE
Use client interface for DCReaper

### DIFF
--- a/pkg/deploy/cmd/reaper.go
+++ b/pkg/deploy/cmd/reaper.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewDeploymentConfigReaper returns a new reaper for deploymentConfigs
-func NewDeploymentConfigReaper(oc *client.Client, kc *kclient.Client) kubectl.Reaper {
+func NewDeploymentConfigReaper(oc client.Interface, kc kclient.Interface) kubectl.Reaper {
 	return &DeploymentConfigReaper{oc: oc, kc: kc, pollInterval: kubectl.Interval, timeout: kubectl.Timeout}
 }
 


### PR DESCRIPTION
This PR aims at aligning the openshift DeploymentConfig Reaper method signature to the [kubernetes ReplicationController Reaper](https://github.com/openshift/origin/blob/v1.3.0-alpha.2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/stop.go#L91) already using a client interface.

The goal is not only to be consistent with k8s but also to enable unit testing of the DCReaper through fake clients, which is not possible as of today.

@sdminonne , @kargakis : FYI