### PR TITLE
handle authorization evaluation error for SAR

### DIFF
--- a/pkg/authorization/api/deep_copy_generated.go
+++ b/pkg/authorization/api/deep_copy_generated.go
@@ -658,6 +658,7 @@ func DeepCopy_api_SubjectAccessReviewResponse(in SubjectAccessReviewResponse, ou
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -206,6 +206,10 @@ type SubjectAccessReviewResponse struct {
 	Allowed bool
 	// Reason is optional.  It indicates why a request was allowed or denied.
 	Reason string
+	// EvaluationError is an indication that some error occurred during the authorization check.
+	// It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is
+	// most common when a bound role is missing, but enough roles are still present and bound to reason about the request.
+	EvaluationError string
 }
 
 // SubjectAccessReview is an object for requesting information about whether a user or group can perform an action

--- a/pkg/authorization/api/v1/conversion_generated.go
+++ b/pkg/authorization/api/v1/conversion_generated.go
@@ -1101,6 +1101,7 @@ func autoConvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewRespon
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 
@@ -1115,6 +1116,7 @@ func autoConvert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewRespon
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 

--- a/pkg/authorization/api/v1/deep_copy_generated.go
+++ b/pkg/authorization/api/v1/deep_copy_generated.go
@@ -658,6 +658,7 @@ func DeepCopy_v1_SubjectAccessReviewResponse(in SubjectAccessReviewResponse, out
 	out.Namespace = in.Namespace
 	out.Allowed = in.Allowed
 	out.Reason = in.Reason
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 

--- a/pkg/authorization/api/v1/generated.pb.go
+++ b/pkg/authorization/api/v1/generated.pb.go
@@ -1609,6 +1609,10 @@ func (m *SubjectAccessReviewResponse) MarshalTo(data []byte) (int, error) {
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Reason)))
 	i += copy(data[i:], m.Reason)
+	data[i] = 0x22
+	i++
+	i = encodeVarintGenerated(data, i, uint64(len(m.EvaluationError)))
+	i += copy(data[i:], m.EvaluationError)
 	return i, nil
 }
 
@@ -2162,6 +2166,8 @@ func (m *SubjectAccessReviewResponse) Size() (n int) {
 	n += 1 + l + sovGenerated(uint64(l))
 	n += 2
 	l = len(m.Reason)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.EvaluationError)
 	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
@@ -6431,6 +6437,35 @@ func (m *SubjectAccessReviewResponse) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Reason = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EvaluationError", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EvaluationError = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/authorization/api/v1/generated.proto
+++ b/pkg/authorization/api/v1/generated.proto
@@ -409,6 +409,11 @@ message SubjectAccessReviewResponse {
 
   // Reason is optional.  It indicates why a request was allowed or denied.
   optional string reason = 3;
+
+  // EvaluationError is an indication that some error occurred during the authorization check.
+  // It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is
+  // most common when a bound role is missing, but enough roles are still present and bound to reason about the request.
+  optional string evaluationError = 4;
 }
 
 // SubjectRulesReviewStatus is contains the result of a rules check

--- a/pkg/authorization/api/v1/swagger_doc.go
+++ b/pkg/authorization/api/v1/swagger_doc.go
@@ -324,10 +324,11 @@ func (SubjectAccessReview) SwaggerDoc() map[string]string {
 }
 
 var map_SubjectAccessReviewResponse = map[string]string{
-	"":          "SubjectAccessReviewResponse describes whether or not a user or group can perform an action",
-	"namespace": "Namespace is the namespace used for the access review",
-	"allowed":   "Allowed is required.  True if the action would be allowed, false otherwise.",
-	"reason":    "Reason is optional.  It indicates why a request was allowed or denied.",
+	"":                "SubjectAccessReviewResponse describes whether or not a user or group can perform an action",
+	"namespace":       "Namespace is the namespace used for the access review",
+	"allowed":         "Allowed is required.  True if the action would be allowed, false otherwise.",
+	"reason":          "Reason is optional.  It indicates why a request was allowed or denied.",
+	"evaluationError": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is most common when a bound role is missing, but enough roles are still present and bound to reason about the request.",
 }
 
 func (SubjectAccessReviewResponse) SwaggerDoc() map[string]string {

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -193,6 +193,10 @@ type SubjectAccessReviewResponse struct {
 	Allowed bool `json:"allowed" protobuf:"varint,2,opt,name=allowed"`
 	// Reason is optional.  It indicates why a request was allowed or denied.
 	Reason string `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`
+	// EvaluationError is an indication that some error occurred during the authorization check.
+	// It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is
+	// most common when a bound role is missing, but enough roles are still present and bound to reason about the request.
+	EvaluationError string `json:"evaluationError,omitempty" protobuf:"bytes,4,opt,name=evaluationError"`
 }
 
 // OptionalScopes is an array that may also be left nil to distinguish between set and unset.

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -99,14 +99,13 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	requestContext := kapi.WithNamespace(kapi.WithUser(ctx, userToCheck), subjectAccessReview.Action.Namespace)
 	attributes := authorizer.ToDefaultAuthorizationAttributes(subjectAccessReview.Action)
 	allowed, reason, err := r.authorizer.Authorize(requestContext, attributes)
-	if err != nil {
-		return nil, err
-	}
-
 	response := &authorizationapi.SubjectAccessReviewResponse{
 		Namespace: subjectAccessReview.Action.Namespace,
 		Allowed:   allowed,
 		Reason:    reason,
+	}
+	if err != nil {
+		response.EvaluationError = err.Error()
 	}
 
 	return response, nil

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -20,6 +20,7 @@ type subjectAccessTest struct {
 	requestingUser *user.DefaultInfo
 
 	expectedUserInfo *user.DefaultInfo
+	expectedError    string
 }
 
 type testAuthorizer struct {
@@ -76,6 +77,7 @@ func TestDeniedNamespace(t *testing.T) {
 			User:   "foo",
 			Groups: sets.NewString(),
 		},
+		expectedError: "denied initial check",
 	}
 
 	test.runTest(t)
@@ -140,6 +142,11 @@ func TestErrors(t *testing.T) {
 			},
 			User:   "foo",
 			Groups: sets.NewString("first", "second"),
+		},
+		expectedUserInfo: &user.DefaultInfo{
+			Name:   "foo",
+			Groups: []string{"first", "second"},
+			Extra:  map[string][]string{},
 		},
 	}
 
@@ -233,9 +240,10 @@ func (r *subjectAccessTest) runTest(t *testing.T) {
 	storage := REST{r.authorizer}
 
 	expectedResponse := &authorizationapi.SubjectAccessReviewResponse{
-		Namespace: r.reviewRequest.Action.Namespace,
-		Allowed:   r.authorizer.allowed,
-		Reason:    r.authorizer.reason,
+		Namespace:       r.reviewRequest.Action.Namespace,
+		Allowed:         r.authorizer.allowed,
+		Reason:          r.authorizer.reason,
+		EvaluationError: r.authorizer.err,
 	}
 
 	expectedAttributes := authorizer.ToDefaultAuthorizationAttributes(r.reviewRequest.Action)
@@ -246,17 +254,16 @@ func (r *subjectAccessTest) runTest(t *testing.T) {
 	}
 
 	obj, err := storage.Create(ctx, r.reviewRequest)
-	if err != nil && len(r.authorizer.err) == 0 {
+	switch {
+	case err == nil && len(r.expectedError) == 0:
+	case err == nil && len(r.expectedError) != 0:
+		t.Fatalf("missing expected error: %v", r.expectedError)
+	case err != nil && len(r.expectedError) == 0:
 		t.Fatalf("unexpected error: %v", err)
+	case err != nil && len(r.expectedError) == 0 && err.Error() != r.expectedError:
+		t.Fatalf("unexpected error: %v", r.expectedError)
 	}
-	if len(r.authorizer.err) != 0 {
-		if err == nil {
-			t.Fatalf("unexpected non-error: %v", err)
-		}
-		if e, a := r.authorizer.err, err.Error(); e != a {
-			t.Fatalf("expected %v, got %v", e, a)
-		}
-
+	if len(r.expectedError) > 0 {
 		return
 	}
 
@@ -264,10 +271,6 @@ func (r *subjectAccessTest) runTest(t *testing.T) {
 	case *authorizationapi.SubjectAccessReviewResponse:
 		if !reflect.DeepEqual(expectedResponse, obj) {
 			t.Errorf("diff %v", diff.ObjectGoPrintDiff(expectedResponse, obj))
-		}
-	case nil:
-		if len(r.authorizer.err) == 0 {
-			t.Fatal("unexpected nil object")
 		}
 
 	default:

--- a/pkg/cmd/admin/policy/cani.go
+++ b/pkg/cmd/admin/policy/cani.go
@@ -162,7 +162,11 @@ func (o *canIOptions) Run() (bool, error) {
 	if response.Allowed {
 		fmt.Fprintln(o.Out, "yes")
 	} else {
-		fmt.Fprintln(o.Out, "no")
+		fmt.Fprint(o.Out, "no")
+		if len(response.EvaluationError) > 0 {
+			fmt.Fprintf(o.Out, " - %v", response.EvaluationError)
+		}
+		fmt.Fprintln(o.Out)
 	}
 
 	return response.Allowed, nil

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -47,6 +47,8 @@ accesstoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-tok
 os::cmd::expect_success_and_text "curl -k -XPOST -H 'Content-Type: application/json' -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-authentication/localsubjectaccessreviews -d @${OS_ROOT}/test/testdata/authentication/localsubjectaccessreview.json" '"kind": "SubjectAccessReviewResponse"'
 os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication --ignore-scopes" 'yes'
 os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication" 'no'
+os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n cmd-authentication" 'no'
+os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n cmd-authentication --ignore-scopes" 'yes'
 os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication --scopes='role:admin:*'" 'yes'
 os::cmd::expect_success_and_text "oc policy can-i --list --token='${accesstoken}' -n cmd-authentication --scopes='role:admin:*'" 'get.*pods'
 os::cmd::expect_success_and_not_text "oc policy can-i --list --token='${accesstoken}' -n cmd-authentication" 'get.*pods'


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1360241

When authorizing a SAR, we introspect the body to determine whether its a self-SAR.  When running that authorization check on a SAR for a SAR, the content isn't present.  We have an API field for providing the content, but we haven't wired it up.

In addition, `oc policy can-i` isn't likely to have a mechanism to provide that.  Here's where things get interesting.  Turns out the answer is correct.  If you can run a SAR, you get back allowed.  If you can only run a self-SAR, you get back denied.  Adding an EvaluationError makes it a little prettier, but the net result is the same: you're denied.

I see the choices as:
 1. wire the content field, leave `can-i` broken.  This is work/risk for no useability gain.
 1. wire the content field, add wiring for `can-i`. No one would ever do this, because it would be incredibly unwieldy. 
 1. introspect the exact error in `can-i`.  Yuck, don't do that.
 1. wire up an `EvaluationError` field that parallels our actual evaluator.  We really want this anyway to handle remote authorization calls.

@liggitt you're the most likely to object.