### PR TITLE
UPSTREAM: 29291: Redundant labels in Prometheus metrics

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/golang/glog"
@@ -109,18 +108,7 @@ func (cc *cadvisorClient) exportHTTP(port uint) error {
 		return err
 	}
 
-	re := regexp.MustCompile(`^k8s_(?P<kubernetes_container_name>[^_\.]+)[^_]+_(?P<kubernetes_pod_name>[^_]+)_(?P<kubernetes_namespace>[^_]+)`)
-	reCaptureNames := re.SubexpNames()
-	cadvisorhttp.RegisterPrometheusHandler(mux, cc, "/metrics", func(name string) map[string]string {
-		extraLabels := map[string]string{}
-		matches := re.FindStringSubmatch(name)
-		for i, match := range matches {
-			if len(reCaptureNames[i]) > 0 {
-				extraLabels[re.SubexpNames()[i]] = match
-			}
-		}
-		return extraLabels
-	})
+	cadvisorhttp.RegisterPrometheusHandler(mux, cc, "/metrics", nil)
 
 	// Only start the http server if port > 0
 	if port > 0 {


### PR DESCRIPTION
Merged upstream PR 29291 removes redundant labels in Prometheus metrics.

Fixes #9958