### PR TITLE
BuildSource: mark secrets field as omitempty

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -20051,8 +20051,7 @@
     "id": "v1.BuildSource",
     "description": "BuildSource is the SCM used for the build.",
     "required": [
-     "type",
-     "secrets"
+     "type"
     ],
     "properties": {
      "type": {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -252,7 +252,7 @@ type BuildSource struct {
 
 	// secrets represents a list of secrets and their destinations that will
 	// be used only for the build.
-	Secrets []SecretBuildSource `json:"secrets" protobuf:"bytes,8,rep,name=secrets"`
+	Secrets []SecretBuildSource `json:"secrets,omitempty" protobuf:"bytes,8,rep,name=secrets"`
 }
 
 // ImageSource describes an image that is used as source for the build


### PR DESCRIPTION
Prior this change `secrets` field was always serialized and was shown in build logs and available to `assemble` scripts as part of `BUILD` variable. I don't see a reason why we need to serialize it and print as `"secrets":null`.

PTAL @bparees 