### PR TITLE
Moved completions tests from hack/test-cmd.sh into test/cmd/completions.sh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -319,27 +319,6 @@ os::cmd::expect_success "oc get services --config='${MASTER_CONFIG_DIR}/admin.ku
 # test config files from env vars
 os::cmd::expect_success "KUBECONFIG='${MASTER_CONFIG_DIR}/admin.kubeconfig' oc get services"
 
-# test completion command help
-os::cmd::expect_success_and_text "oc completion -h" "prints shell code"
-os::cmd::expect_success_and_text "openshift completion -h" "prints shell code"
-os::cmd::expect_success_and_text "oadm completion -h" "prints shell code"
-# test completion command output
-os::cmd::expect_failure_and_text "oc completion" "Shell not specified."
-os::cmd::expect_success "oc completion bash"
-os::cmd::expect_success "oc completion zsh"
-os::cmd::expect_failure_and_text "oc completion test_shell" 'Unsupported shell type "test_shell"'
-# test completion command for openshift
-os::cmd::expect_failure_and_text "openshift completion" "Shell not specified."
-os::cmd::expect_success "openshift completion bash"
-os::cmd::expect_success "openshift completion zsh"
-os::cmd::expect_failure_and_text "openshift completion test_shell" 'Unsupported shell type "test_shell"'
-# test completion command for oadm
-os::cmd::expect_failure_and_text "oadm completion" "Shell not specified."
-os::cmd::expect_success "oadm completion bash"
-os::cmd::expect_success "oadm completion zsh"
-os::cmd::expect_failure_and_text "oadm completion test_shell" 'Unsupported shell type "test_shell"'
-echo "oc completion: ok"
-
 # test config files in the home directory
 mkdir -p ${HOME}/.kube
 cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.kube/config

--- a/test/cmd/completions.sh
+++ b/test/cmd/completions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/completions"
+# This test validates basic resource retrieval and command interaction
+
+# test completion command help
+os::cmd::expect_success_and_text "oc completion -h" "prints shell code"
+os::cmd::expect_success_and_text "openshift completion -h" "prints shell code"
+os::cmd::expect_success_and_text "oadm completion -h" "prints shell code"
+# test completion command output
+os::cmd::expect_failure_and_text "oc completion" "Shell not specified."
+os::cmd::expect_success "oc completion bash"
+os::cmd::expect_success "oc completion zsh"
+os::cmd::expect_failure_and_text "oc completion test_shell" 'Unsupported shell type "test_shell"'
+# test completion command for openshift
+os::cmd::expect_failure_and_text "openshift completion" "Shell not specified."
+os::cmd::expect_success "openshift completion bash"
+os::cmd::expect_success "openshift completion zsh"
+os::cmd::expect_failure_and_text "openshift completion test_shell" 'Unsupported shell type "test_shell"'
+# test completion command for oadm
+os::cmd::expect_failure_and_text "oadm completion" "Shell not specified."
+os::cmd::expect_success "oadm completion bash"
+os::cmd::expect_success "oadm completion zsh"
+os::cmd::expect_failure_and_text "oadm completion test_shell" 'Unsupported shell type "test_shell"'
+echo "oc completion: ok"
+
+os::test::junit::declare_suite_end


### PR DESCRIPTION
These tests did not require any special environment and therefore it did
not make sense to run them as part of every start-up for test-cmd, even
when the user provided some other subset of tests to run.

@liggitt PTAL, clean move

@juanvallejo FYI