### PR TITLE
Enable deployments

### DIFF
--- a/pkg/api/install/install.go
+++ b/pkg/api/install/install.go
@@ -49,6 +49,8 @@ import (
 	routev1 "github.com/openshift/origin/pkg/route/api/v1"
 	templatev1 "github.com/openshift/origin/pkg/template/api/v1"
 	userv1 "github.com/openshift/origin/pkg/user/api/v1"
+
+	"github.com/openshift/origin/pkg/api/upstreamconversions"
 )
 
 func init() {
@@ -518,4 +520,6 @@ func init() {
 		}
 		return false, nil
 	})
+
+	upstreamconversions.AddToScheme(kapi.Scheme)
 }

--- a/pkg/api/upstreamconversions/conversions.go
+++ b/pkg/api/upstreamconversions/conversions.go
@@ -1,0 +1,36 @@
+package upstreamconversions
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
+	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func AddToScheme(scheme *runtime.Scheme) {
+	addConversionFuncs(scheme)
+}
+
+func addConversionFuncs(scheme *runtime.Scheme) {
+	if err := scheme.AddConversionFuncs(
+		Convert_v1beta1_ReplicaSet_to_api_ReplicationController,
+	); err != nil {
+		panic(err)
+	}
+}
+
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *extensionsv1beta1.ReplicaSet, out *kapi.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensionsapi.ReplicaSet{}
+	if err := extensionsv1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &kapiv1.ReplicationController{}
+	if err := kapiv1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return kapiv1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}

--- a/pkg/api/upstreamconversions/conversions.go
+++ b/pkg/api/upstreamconversions/conversions.go
@@ -1,12 +1,23 @@
 package upstreamconversions
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
 	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapiv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 )
 
 func AddToScheme(scheme *runtime.Scheme) {
@@ -16,6 +27,16 @@ func AddToScheme(scheme *runtime.Scheme) {
 func addConversionFuncs(scheme *runtime.Scheme) {
 	if err := scheme.AddConversionFuncs(
 		Convert_v1beta1_ReplicaSet_to_api_ReplicationController,
+
+		Convert_api_DeploymentConfig_To_v1beta1_Deployment,
+		Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec,
+		Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus,
+		Convert_v1_DeploymentConfig_To_extensions_Deployment,
+
+		Convert_extensions_Deployment_To_v1_DeploymentConfig,
+		Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec,
+		Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus,
+		Convert_v1beta1_Deployment_to_api_DeploymentConfig,
 	); err != nil {
 		panic(err)
 	}
@@ -33,4 +54,361 @@ func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *extensionsv1bet
 	}
 
 	return kapiv1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}
+
+func Convert_v1beta1_Deployment_to_api_DeploymentConfig(in *extensionsv1beta1.Deployment, out *deployapi.DeploymentConfig, s conversion.Scope) error {
+	intermediate1 := &extensionsapi.Deployment{}
+	if err := extensionsv1beta1.Convert_v1beta1_Deployment_To_extensions_Deployment(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &deployapiv1.DeploymentConfig{}
+	if err := Convert_extensions_Deployment_To_v1_DeploymentConfig(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	if err := deployapiv1.Convert_v1_DeploymentConfig_To_api_DeploymentConfig(intermediate2, out, s); err != nil {
+		return err
+	}
+
+	if out.Annotations == nil {
+		out.Annotations = make(map[string]string)
+	}
+	if _, exists := out.Annotations[kapi.OriginalKindAnnotationName]; !exists {
+		out.Annotations[kapi.OriginalKindAnnotationName] = "Deployment.extensions"
+	}
+
+	return nil
+}
+
+func Convert_v1_DeploymentConfig_To_extensions_Deployment(in *deployapiv1.DeploymentConfig, out *extensionsapi.Deployment, s conversion.Scope) error {
+	intermediate1 := &deployapi.DeploymentConfig{}
+	if err := deployapiv1.Convert_v1_DeploymentConfig_To_api_DeploymentConfig(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &extensionsv1beta1.Deployment{}
+	if err := Convert_api_DeploymentConfig_To_v1beta1_Deployment(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	if err := extensionsv1beta1.Convert_v1beta1_Deployment_To_extensions_Deployment(intermediate2, out, s); err != nil {
+		return err
+	}
+
+	if out.Annotations == nil {
+		out.Annotations = make(map[string]string)
+	}
+	if _, exists := out.Annotations[kapi.OriginalKindAnnotationName]; !exists {
+		out.Annotations[kapi.OriginalKindAnnotationName] = "DeploymentConfig."
+	}
+
+	return nil
+}
+
+//  d._internal -> dc.v1
+func Convert_extensions_Deployment_To_v1_DeploymentConfig(in *extensionsapi.Deployment, out *deployapiv1.DeploymentConfig, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensionsapi.Deployment))(in)
+	}
+	if err := kapi.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := kapiv1.Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+
+	if in.Annotations == nil {
+		out.Annotations = map[string]string{}
+	}
+
+	if err := Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec(&in.Spec, &out.Spec, s); err != nil {
+		if err := errorsToNonConvertible(err, &out.Annotations); err != nil {
+			return err
+		}
+	}
+
+	if err := Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus(&in.Status, &out.Status, s); err != nil {
+		if err := errorsToNonConvertible(err, &out.Annotations); err != nil {
+			return err
+		}
+	}
+
+	// Restore all stored non-convertible fields
+	if in.ObjectMeta.Annotations != nil {
+		restoreNonConvertible("status.latestVersion", in.ObjectMeta.Annotations, &out.Status.LatestVersion)
+		restoreNonConvertible("status.details", in.ObjectMeta.Annotations, &out.Status.Details)
+		restoreNonConvertible("spec.test", in.ObjectMeta.Annotations, &out.Spec.Test)
+		prefix := "spec.strategy."
+		restoreNonConvertible("spec.strategy.resources", in.ObjectMeta.Annotations, &out.Spec.Strategy.Resources)
+		restoreNonConvertible("spec.strategy.annotations", in.ObjectMeta.Annotations, &out.Spec.Strategy.Annotations)
+		restoreNonConvertible("spec.strategy.labels", in.ObjectMeta.Annotations, &out.Spec.Strategy.Labels)
+		restoreNonConvertible("spec.strategy.triggers", in.ObjectMeta.Annotations, &out.Spec.Triggers)
+
+		if out.Spec.Strategy.RollingParams != nil {
+			prefix = "spec.strategy.rollingParams."
+			out.Spec.Strategy.RollingParams.UpdatePeriodSeconds = new(int64)
+			restoreNonConvertible(prefix+"updatePeriodSeconds", in.ObjectMeta.Annotations, out.Spec.Strategy.RollingParams.UpdatePeriodSeconds)
+			out.Spec.Strategy.RollingParams.IntervalSeconds = new(int64)
+			restoreNonConvertible(prefix+"intervalSeconds", in.ObjectMeta.Annotations, out.Spec.Strategy.RollingParams.IntervalSeconds)
+			out.Spec.Strategy.RollingParams.TimeoutSeconds = new(int64)
+			restoreNonConvertible(prefix+"timeoutSeconds", in.ObjectMeta.Annotations, out.Spec.Strategy.RollingParams.TimeoutSeconds)
+
+			if _, exists := in.ObjectMeta.Annotations[kapi.NonConvertibleAnnotationPrefix+"/"+prefix+"updatePercent"]; exists {
+				out.Spec.Strategy.RollingParams.UpdatePercent = new(int32)
+				restoreNonConvertible(prefix+"updatePercent", in.ObjectMeta.Annotations, out.Spec.Strategy.RollingParams.UpdatePercent)
+			}
+
+			intermediate := deployapiv1.LifecycleHook{}
+			restoreNonConvertible(prefix+"pre", in.ObjectMeta.Annotations, &intermediate)
+			out.Spec.Strategy.RollingParams.Pre = &intermediate
+
+			intermediate = deployapiv1.LifecycleHook{}
+			restoreNonConvertible(prefix+"post", in.ObjectMeta.Annotations, &intermediate)
+			out.Spec.Strategy.RollingParams.Post = &intermediate
+		}
+
+		if out.Spec.Strategy.RecreateParams != nil {
+			intermediate := deployapiv1.RecreateDeploymentStrategyParams{}
+			restoreNonConvertible("spec.strategy.recreateParams", in.ObjectMeta.Annotations, &intermediate)
+			*out.Spec.Strategy.RecreateParams = intermediate
+		}
+
+	}
+
+	return nil
+}
+
+//  dc._internal -> d.v1beta1
+func Convert_api_DeploymentConfig_To_v1beta1_Deployment(in *deployapi.DeploymentConfig, out *extensionsv1beta1.Deployment, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentConfig))(in)
+	}
+	if err := kapi.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := kapiv1.Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+
+	if in.Annotations == nil {
+		out.Annotations = map[string]string{}
+	}
+
+	if err := Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec(&in.Spec, &out.Spec, s); err != nil {
+		if err := errorsToNonConvertible(err, &out.Annotations); err != nil {
+			return err
+		}
+	}
+
+	if err := Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus(&in.Status, &out.Status, s); err != nil {
+		if err := errorsToNonConvertible(err, &out.Annotations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Convert_extensions_DeploymentSpec_To_v1_DeploymentConfigSpec(in *extensionsapi.DeploymentSpec, out *deployapiv1.DeploymentConfigSpec, s conversion.Scope) error {
+	out.Replicas = in.Replicas
+	out.MinReadySeconds = in.MinReadySeconds
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
+	out.Paused = in.Paused
+
+	nonConvertibleFields := field.ErrorList{}
+
+	if in.Selector != nil {
+		if err := kapi.Convert_unversioned_LabelSelector_to_map(in.Selector, &out.Selector, s); err != nil {
+			addNonConvertible("spec.labelSelector", in.Selector, &nonConvertibleFields)
+		}
+	}
+
+	switch in.Strategy.Type {
+	case extensionsapi.RecreateDeploymentStrategyType:
+		out.Strategy.Type = deployapiv1.DeploymentStrategyTypeRecreate
+		out.Strategy.RecreateParams = &deployapiv1.RecreateDeploymentStrategyParams{}
+	case extensionsapi.RollingUpdateDeploymentStrategyType:
+		out.Strategy.Type = deployapiv1.DeploymentStrategyTypeRolling
+		out.Strategy.RollingParams = &deployapiv1.RollingDeploymentStrategyParams{
+			MaxSurge:       &in.Strategy.RollingUpdate.MaxSurge,
+			MaxUnavailable: &in.Strategy.RollingUpdate.MaxUnavailable,
+		}
+	}
+
+	out.Template = &kapiv1.PodTemplateSpec{}
+	if err := s.Convert(&in.Template, out.Template, 0); err != nil {
+		return err
+	}
+
+	return nonConvertibleFields.ToAggregate()
+}
+
+func Convert_api_DeploymentConfigSpec_To_v1beta1_DeploymentSpec(in *deployapi.DeploymentConfigSpec, out *extensionsv1beta1.DeploymentSpec, s conversion.Scope) error {
+	out.Replicas = &in.Replicas
+	out.MinReadySeconds = in.MinReadySeconds
+	out.RevisionHistoryLimit = in.RevisionHistoryLimit
+	out.Paused = in.Paused
+	// TODO: Set this based on annotation
+	out.RollbackTo = &extensionsv1beta1.RollbackConfig{}
+
+	nonConvertibleFields := field.ErrorList{}
+
+	if in.Test == true {
+		addNonConvertible("spec.test", true, &nonConvertibleFields)
+	}
+
+	if in.Selector != nil {
+		out.Selector = &extensionsv1beta1.LabelSelector{}
+		intermediate := &unversioned.LabelSelector{}
+		if err := kapi.Convert_map_to_unversioned_LabelSelector(&in.Selector, intermediate, s); err != nil {
+			return err
+		}
+		if err := s.Convert(intermediate, out.Selector, 0); err != nil {
+			return err
+		}
+	}
+
+	switch in.Strategy.Type {
+	case deployapi.DeploymentStrategyTypeRolling:
+		out.Strategy.Type = extensionsv1beta1.RollingUpdateDeploymentStrategyType
+		if in.Strategy.RollingParams != nil {
+			out.Strategy.RollingUpdate = &extensionsv1beta1.RollingUpdateDeployment{}
+			// first fields we know how to convert
+			out.Strategy.RollingUpdate.MaxSurge = &intstr.IntOrString{}
+			s.Convert(&in.Strategy.RollingParams.MaxSurge, out.Strategy.RollingUpdate.MaxSurge, 0)
+
+			out.Strategy.RollingUpdate.MaxUnavailable = &intstr.IntOrString{}
+			s.Convert(&in.Strategy.RollingParams.MaxUnavailable, out.Strategy.RollingUpdate.MaxUnavailable, 0)
+
+			prefix := "spec.strategy.rollingParams."
+			addNonConvertible(prefix+"updatePeriodSeconds", in.Strategy.RollingParams.UpdatePeriodSeconds, &nonConvertibleFields)
+			addNonConvertible(prefix+"intervalSeconds", in.Strategy.RollingParams.IntervalSeconds, &nonConvertibleFields)
+			addNonConvertible(prefix+"timeoutSeconds", in.Strategy.RollingParams.TimeoutSeconds, &nonConvertibleFields)
+			if in.Strategy.RollingParams.UpdatePercent != nil {
+				addNonConvertible(prefix+"updatePercent", in.Strategy.RollingParams.UpdatePercent, &nonConvertibleFields)
+			}
+			addNonConvertible(prefix+"pre", in.Strategy.RollingParams.Pre, &nonConvertibleFields)
+			addNonConvertible(prefix+"post", in.Strategy.RollingParams.Post, &nonConvertibleFields)
+		} else {
+			in.Strategy.RollingParams = &deployapi.RollingDeploymentStrategyParams{}
+		}
+	case deployapi.DeploymentStrategyTypeRecreate:
+		out.Strategy.Type = extensionsv1beta1.RecreateDeploymentStrategyType
+		if in.Strategy.RecreateParams != nil {
+			addNonConvertible("spec.strategy.recreateParams", in.Strategy.RecreateParams, &nonConvertibleFields)
+		} else {
+			in.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{}
+		}
+	}
+
+	addNonConvertible("spec.strategy.resources", in.Strategy.Resources, &nonConvertibleFields)
+	if in.Strategy.Annotations != nil {
+		addNonConvertible("spec.strategy.annotations", in.Strategy.Annotations, &nonConvertibleFields)
+	}
+	if in.Strategy.Labels != nil {
+		addNonConvertible("spec.strategy.labels", in.Strategy.Labels, &nonConvertibleFields)
+	}
+
+	if len(in.Triggers) > 0 {
+		addNonConvertible("spec.strategy.triggers", in.Triggers, &nonConvertibleFields)
+	}
+
+	if in.Template != nil {
+		out.Template = kapiv1.PodTemplateSpec{}
+		if err := s.Convert(in.Template, &out.Template, 0); err != nil {
+			return err
+		}
+	}
+
+	return nonConvertibleFields.ToAggregate()
+}
+
+func Convert_extensions_DeploymentStatus_To_v1_DeploymentConfigStatus(in *extensionsapi.DeploymentStatus, out *deployapiv1.DeploymentConfigStatus, s conversion.Scope) error {
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
+	return nil
+}
+
+func Convert_api_DeploymentConfigStatus_To_v1beta1_DeploymentStatus(in *deployapi.DeploymentConfigStatus, out *extensionsv1beta1.DeploymentStatus, s conversion.Scope) error {
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
+
+	nonConvertibleFields := field.ErrorList{}
+	nonConvertibleFields = append(nonConvertibleFields,
+		field.Invalid(field.NewPath("status.latestVersion"), in.LatestVersion, "cannot convert"),
+	)
+
+	if in.Details != nil {
+		nonConvertibleFields = append(nonConvertibleFields,
+			field.Invalid(field.NewPath("status.details"), *in.Details, "cannot convert"),
+		)
+	}
+
+	return nonConvertibleFields.ToAggregate()
+}
+
+func setOriginalKind(in runtime.Object, out map[string]string) map[string]string {
+	if out == nil {
+		out = map[string]string{}
+	}
+	if _, exists := out[kapi.OriginalKindAnnotationName]; !exists {
+		gvk := in.GetObjectKind().GroupVersionKind()
+		out[kapi.OriginalKindAnnotationName] = gvk.Kind + "." + gvk.Group
+	}
+	return out
+}
+
+func addNonConvertible(fieldName string, in interface{}, out *field.ErrorList) {
+	switch reflect.ValueOf(in).Type().Kind() {
+	case reflect.Map, reflect.Ptr, reflect.Slice:
+		if reflect.ValueOf(in).IsNil() {
+			return
+		}
+	}
+	*out = append(*out, field.Invalid(field.NewPath(fieldName), in, "cannot convert"))
+}
+
+// TODO this needs to return an error before merge
+func restoreNonConvertible(name string, annotations map[string]string, out interface{}) {
+	v, ok := annotations[kapi.NonConvertibleAnnotationPrefix+"/"+name]
+	if ok && len(v) > 0 {
+		if err := json.Unmarshal([]byte(v), &out); err != nil {
+			fmt.Printf("ERROR: failed to decode %q non-convertible field to %#+v: %v", name, out, err)
+		}
+	} else {
+		fmt.Printf("WARNING: requested field not found (%q)\n", name)
+	}
+}
+
+// errorsToNonConvertible converts the errors.Aggregate into
+// non-convertible field annotations. It returns error when the error in
+// aggregate is not a field error.
+func errorsToNonConvertible(err error, out *map[string]string) error {
+	if out == nil {
+		out = &map[string]string{}
+	}
+	newMap := *out
+	if fieldErrs, ok := err.(errors.Aggregate); ok {
+		for _, e := range fieldErrs.Errors() {
+			fieldErr, ok := e.(*field.Error)
+			if !ok {
+				return err
+			}
+			// encode the original value as JSON
+			b, err := json.Marshal(fieldErr.BadValue)
+			if err != nil {
+				return err
+			}
+			newMap[kapi.NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = string(b)
+		}
+		*out = newMap
+		return nil
+	}
+	return err
 }

--- a/pkg/api/upstreamconversions/conversions_test.go
+++ b/pkg/api/upstreamconversions/conversions_test.go
@@ -1,0 +1,216 @@
+package upstreamconversions
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/google/gofuzz"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapiv1 "github.com/openshift/origin/pkg/deploy/api/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/diff"
+)
+
+func TestDeploymentRoundtrip(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		// Deployment
+		var (
+			in                 = &extensions.Deployment{}
+			out                = &extensions.Deployment{}
+			deploymentExternal = &extensionsv1beta1.Deployment{}
+		)
+
+		// DeploymentConfig
+		var (
+			configInternal = &deployapi.DeploymentConfig{}
+			configExternal = &deployapiv1.DeploymentConfig{}
+		)
+
+		// Add Convert_v1beta1_Deployment_to_api_DeploymentConfig to scheme
+		AddToScheme(kapi.Scheme)
+
+		extGroup := testapi.Extensions
+		fuzzInternalObject(t, extGroup.InternalGroupVersion(), in, rand.Int63(),
+			func(p *kapi.PodTemplateSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(p)
+				c.Fuzz(&p.Spec)
+				p.Annotations = map[string]string{}
+				p.Spec.InitContainers = []kapi.Container{}
+			},
+			func(s *unversioned.LabelSelector, c fuzz.Continue) {
+				s.MatchLabels = map[string]string{"foo": "bar"}
+			},
+			// the rollbackTo is not supported in deployment config
+			func(r *extensions.RollbackConfig, c fuzz.Continue) {},
+		)
+
+		mustBeEqualDiff := func(in interface{}, out interface{}) {
+			if !reflect.DeepEqual(in, out) {
+				t.Fatalf("objects are different:\nA:\t%#v\nB:\t%#v\n\nDiff:\n%s\n\n%s", in, out, diff.ObjectDiff(in, out), diff.ObjectGoPrintSideBySide(out, in))
+			}
+		}
+
+		if err := kapi.Scheme.Convert(in, deploymentExternal, nil); err != nil {
+			t.Fatalf("d.internal -> d.v1beta1: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(deploymentExternal, configInternal, nil); err != nil {
+			t.Fatalf("d.v1beta1 -> dc.internal: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(configInternal, configExternal, nil); err != nil {
+			t.Fatalf("dc.internal -> dc.v1: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(configExternal, out, nil); err != nil {
+			t.Fatalf("dc.v1 -> d.internal: unexpected error: %v", err)
+		}
+
+		mustBeEqualDiff(in.Status, out.Status)
+		mustBeEqualDiff(in.Spec, out.Spec)
+	}
+}
+
+func TestDeploymentConfigRoundtrip(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		// DeploymentConfig
+		var (
+			in             = &deployapi.DeploymentConfig{}
+			out            = &deployapi.DeploymentConfig{}
+			configExternal = &deployapiv1.DeploymentConfig{}
+		)
+
+		// Deployment
+		var (
+			deploymentInternal = &extensions.Deployment{}
+			deploymentExternal = &extensionsv1beta1.Deployment{}
+		)
+
+		// Add Convert_v1beta1_Deployment_to_api_DeploymentConfig to scheme
+		AddToScheme(kapi.Scheme)
+
+		extGroup := testapi.Extensions
+		fuzzInternalObject(t, extGroup.InternalGroupVersion(), in, rand.Int63(),
+			func(p *kapi.PodTemplateSpec, c fuzz.Continue) {
+				c.FuzzNoCustom(p)
+				c.Fuzz(&p.Spec)
+				p.Annotations = map[string]string{}
+				p.Spec.InitContainers = []kapi.Container{}
+			},
+			func(s *unversioned.LabelSelector, c fuzz.Continue) {
+				s.MatchLabels = map[string]string{"foo": "bar"}
+			},
+			// the rollbackTo is not supported in deployment config
+			func(r *extensions.RollbackConfig, c fuzz.Continue) {},
+			// custom deployment strategy is not supported in upstream
+			func(p *deployapi.CustomDeploymentStrategyParams, c fuzz.Continue) {},
+			func(p *deployapi.RecreateDeploymentStrategyParams, c fuzz.Continue) {
+				c.FuzzNoCustom(p)
+				v := int64(60)
+				p.TimeoutSeconds = &v
+			},
+			func(p *deployapi.RollingDeploymentStrategyParams, c fuzz.Continue) {
+				c.FuzzNoCustom(p)
+				timeoutVal := int64(60)
+				p.TimeoutSeconds = &timeoutVal
+				p.UpdatePercent = nil
+			},
+			func(h *deployapi.ExecNewPodHook, c fuzz.Continue) {
+				c.FuzzNoCustom(h)
+				h.ContainerName = "foo"
+			},
+			func(h *deployapi.LifecycleHook, c fuzz.Continue) {
+				c.FuzzNoCustom(h)
+				h.FailurePolicy = deployapi.LifecycleHookFailurePolicyAbort
+				for i := range h.TagImages {
+					h.TagImages[i].ContainerName = "foo"
+				}
+			},
+			func(d *deployapi.DeploymentConfig, c fuzz.Continue) {
+				c.FuzzNoCustom(d)
+				strategies := []deployapi.DeploymentStrategyType{
+					deployapi.DeploymentStrategyTypeRolling,
+					deployapi.DeploymentStrategyTypeRecreate,
+				}
+				d.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{
+					{
+						Type: deployapi.DeploymentTriggerOnConfigChange,
+					},
+				}
+				d.Spec.Strategy.Type = strategies[rand.Intn(len(strategies))]
+				d.Spec.Strategy.CustomParams = nil
+				switch d.Spec.Strategy.Type {
+				case deployapi.DeploymentStrategyTypeRolling:
+					d.Spec.Strategy.RecreateParams = nil
+					d.Spec.Strategy.RollingParams = &deployapi.RollingDeploymentStrategyParams{}
+					c.Fuzz(d.Spec.Strategy.RollingParams)
+				case deployapi.DeploymentStrategyTypeRecreate:
+					d.Spec.Strategy.RollingParams = nil
+					d.Spec.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{}
+					c.Fuzz(d.Spec.Strategy.RecreateParams)
+				}
+			},
+		)
+
+		mustBeEqualDiff := func(input interface{}, output interface{}) {
+			if !reflect.DeepEqual(input, output) {
+				t.Fatalf("objects are different:\nA:\t%#v\nB:\t%#v\n\nDiff:\n%s\n\n%s",
+					input, output, diff.ObjectDiff(input, output), diff.ObjectGoPrintSideBySide(input, output))
+			}
+		}
+
+		if err := kapi.Scheme.Convert(in, configExternal, nil); err != nil {
+			t.Fatalf("dc.internal -> dc.v1beta1: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(configExternal, deploymentInternal, nil); err != nil {
+			t.Fatalf("dc.v1 -> d.internal: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(deploymentInternal, deploymentExternal, nil); err != nil {
+			t.Fatalf("d.internal -> d.v1: unexpected error: %v", err)
+		}
+
+		if err := kapi.Scheme.Convert(deploymentExternal, out, nil); err != nil {
+			t.Fatalf("d.v1 -> dc.internal: unexpected error: %v", err)
+		}
+
+		if out.ObjectMeta.Annotations[kapi.OriginalKindAnnotationName] != "DeploymentConfig." {
+			t.Errorf("expected original-kind annotations to be set to v1.DeploymentConfig, got %v", out.ObjectMeta.Annotations[kapi.OriginalKindAnnotationName])
+		}
+
+		// TODO: The resources are properly restored, but the format is changed from
+		// DecimalExponent to DecimalSI. We should investigate why is that
+		// happening.
+		out.Spec.Strategy.Resources = in.Spec.Strategy.Resources
+
+		mustBeEqualDiff(in.Status, out.Status)
+		mustBeEqualDiff(in.Spec, out.Spec)
+	}
+}
+
+func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item runtime.Object, seed int64, funcs ...interface{}) runtime.Object {
+	f := apitesting.FuzzerFor(t, forVersion, rand.NewSource(seed))
+	if len(funcs) > 0 {
+		f.Funcs(funcs...).Fuzz(item)
+	} else {
+		f.Fuzz(item)
+	}
+
+	j, err := meta.TypeAccessor(item)
+	if err != nil {
+		t.Fatalf("Unexpected error %v for %#v", err, item)
+	}
+	j.SetKind("")
+	j.SetAPIVersion("")
+
+	return item
+}

--- a/pkg/cmd/admin/migrate/migrator.go
+++ b/pkg/cmd/admin/migrate/migrator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -127,6 +128,16 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 			if len(o.ToKey) > 0 && o.ToKey <= key {
 				return false, nil
 			}
+
+			// check to see if this is the native type.  The annotation tells us.
+			metadata, err := meta.Accessor(info.Object)
+			if err != nil {
+				return false, err
+			}
+			if _, exists := metadata.GetAnnotations()[kapi.OriginalKindAnnotationName]; exists {
+				return false, nil
+			}
+
 			return true, nil
 		}
 	}

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -19,6 +19,9 @@ const (
 	InfraReplicationControllerServiceAccountName = "replication-controller"
 	ReplicationControllerRoleName                = "system:replication-controller"
 
+	InfraReplicaSetControllerServiceAccountName = "replicaset-controller"
+	ReplicaSetControllerRoleName                = "system:replicaset-controller"
+
 	InfraDeploymentControllerServiceAccountName = "deployment-controller"
 	DeploymentControllerRoleName                = "system:deployment-controller"
 
@@ -216,6 +219,38 @@ func init() {
 					Resources: sets.NewString("pods"),
 				},
 				// ReplicationManager.podControl.recorder
+				{
+					Verbs:     sets.NewString("create", "update", "patch"),
+					Resources: sets.NewString("events"),
+				},
+			},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = InfraSAs.addServiceAccount(
+		InfraReplicaSetControllerServiceAccountName,
+		authorizationapi.ClusterRole{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ReplicaSetControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("get", "list", "watch", "update"),
+					Resources: sets.NewString("replicasets"),
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("replicasets/status"),
+				},
+				{
+					Verbs:     sets.NewString("list", "watch", "create", "delete"),
+					Resources: sets.NewString("pods"),
+				},
 				{
 					Verbs:     sets.NewString("create", "update", "patch"),
 					Resources: sets.NewString("events"),

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -22,6 +22,9 @@ const (
 	InfraReplicaSetControllerServiceAccountName = "replicaset-controller"
 	ReplicaSetControllerRoleName                = "system:replicaset-controller"
 
+	InfraDeploymentConfigControllerServiceAccountName = "deploymentconfig-controller"
+	DeploymentConfigControllerRoleName                = "system:deploymentconfig-controller"
+
 	InfraDeploymentControllerServiceAccountName = "deployment-controller"
 	DeploymentControllerRoleName                = "system:deployment-controller"
 
@@ -152,10 +155,10 @@ func init() {
 	}
 
 	err = InfraSAs.addServiceAccount(
-		InfraDeploymentControllerServiceAccountName,
+		InfraDeploymentConfigControllerServiceAccountName,
 		authorizationapi.ClusterRole{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: DeploymentControllerRoleName,
+				Name: DeploymentConfigControllerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
 				// DeploymentControllerFactory.deploymentLW
@@ -175,6 +178,45 @@ func init() {
 				},
 				// DeploymentController.recorder (EventBroadcaster)
 				{
+					Verbs:     sets.NewString("create", "update", "patch"),
+					Resources: sets.NewString("events"),
+				},
+			},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = InfraSAs.addServiceAccount(
+		InfraDeploymentControllerServiceAccountName,
+		authorizationapi.ClusterRole{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: DeploymentControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("get", "list", "watch", "update"),
+					Resources: sets.NewString("deployments"),
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("deployments/status"),
+				},
+				{
+					APIGroups: []string{"extensions"},
+					Verbs:     sets.NewString("list", "watch", "get", "create", "update", "delete"),
+					Resources: sets.NewString("replicasets"),
+				},
+				{
+					APIGroups: []string{""},
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("pods"),
+				},
+				{
+					APIGroups: []string{""},
 					Verbs:     sets.NewString("create", "update", "patch"),
 					Resources: sets.NewString("events"),
 				},

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -218,7 +218,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
+					"replicasets", "replicasets/scale", "deployments", "deployments/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -271,7 +272,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
+					"replicasets", "replicasets/scale", "deployments", "deployments/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
@@ -316,7 +318,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicasets", "replicasets/scale").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicasets", "replicasets/scale",
+					"deployments", "deployments/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -218,7 +218,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(authzGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -271,7 +271,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
@@ -316,7 +316,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicasets", "replicasets/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	clientadapter "k8s.io/kubernetes/pkg/client/unversioned/adapters/internalclientset"
+	"k8s.io/kubernetes/pkg/controller/deployment"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -246,6 +247,14 @@ func (c *MasterConfig) RunReplicaSetController(client *client.Client) {
 		int(c.ControllerManager.LookupCacheSizeForRC),
 	)
 	go controller.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
+}
+
+func (c *MasterConfig) RunDeploymentController(client *client.Client) {
+	controller := deployment.NewDeploymentController(
+		clientadapter.FromUnversionedClient(client),
+		kctrlmgr.ResyncPeriod(c.ControllerManager),
+	)
+	go controller.Run(int(c.ControllerManager.ConcurrentDeploymentSyncs), utilwait.NeverStop)
 }
 
 // RunJobController starts the Kubernetes job controller sync loop

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -96,6 +96,7 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) ([]string, error
 			Storage:                 storage,
 			Decorator:               generic.UndecoratedStorage,
 			DeleteCollectionWorkers: 0,
+			ResourcePrefix:          c.Master.StorageFactory.ResourcePrefix(kapi.Resource("endpoints")),
 		})
 
 		endpointRegistry := endpoint.NewRegistry(endpointsStorage)

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -39,7 +39,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/persistentvolume"
 	podautoscalercontroller "k8s.io/kubernetes/pkg/controller/podautoscaler"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
-	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
+	replicasetcontroller "k8s.io/kubernetes/pkg/controller/replicaset"
 	servicecontroller "k8s.io/kubernetes/pkg/controller/service"
 	volumecontroller "k8s.io/kubernetes/pkg/controller/volume"
 
@@ -237,16 +237,14 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, na
 	return allPlugins
 }
 
-// RunReplicationController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunReplicationController(client *client.Client) {
-	controllerManager := replicationcontroller.NewReplicationManager(
-		c.Informers.Pods().Informer(),
+func (c *MasterConfig) RunReplicaSetController(client *client.Client) {
+	controller := replicasetcontroller.NewReplicaSetController(
 		clientadapter.FromUnversionedClient(client),
 		kctrlmgr.ResyncPeriod(c.ControllerManager),
-		replicationcontroller.BurstReplicas,
+		replicasetcontroller.BurstReplicas,
 		int(c.ControllerManager.LookupCacheSizeForRC),
 	)
-	go controllerManager.Run(int(c.ControllerManager.ConcurrentRCSyncs), utilwait.NeverStop)
+	go controller.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
 }
 
 // RunJobController starts the Kubernetes job controller sync loop

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -179,6 +179,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	// the order here is important, it defines which version will be used for storage
 	storageFactory.AddCohabitatingResources(extensions.Resource("jobs"), batch.Resource("jobs"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("horizontalpodautoscalers"), autoscaling.Resource("horizontalpodautoscalers"))
+	storageFactory.AddCohabitatingResources(kapi.Resource("replicationcontrollers"), kapi.Resource("replicationControllers" /*typoed with camel-case upstream*/), extensions.Resource("replicasets"))
 
 	// Preserve previous behavior of using the first non-loopback address
 	// TODO: Deprecate this behavior and just require a valid value to be passed in

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -40,6 +40,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/controller/shared"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // MasterConfig defines the required values to start a Kubernetes master
@@ -180,6 +181,10 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	storageFactory.AddCohabitatingResources(extensions.Resource("jobs"), batch.Resource("jobs"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("horizontalpodautoscalers"), autoscaling.Resource("horizontalpodautoscalers"))
 	storageFactory.AddCohabitatingResources(kapi.Resource("replicationcontrollers"), kapi.Resource("replicationControllers" /*typoed with camel-case upstream*/), extensions.Resource("replicasets"))
+	storageFactory.AddCohabitatingResources(deployapi.Resource("deploymentconfigs"), extensions.Resource("deployments"))
+	storageFactory.IgnoreCohabitingStorageVersion(extensions.Resource("deployments"))
+	storageFactory.SetEtcdPrefix(extensions.Resource("deployments"), options.EtcdStorageConfig.OpenShiftStoragePrefix)
+	storageFactory.SetEtcdPrefix(deployapi.Resource("deploymentconfigs"), options.EtcdStorageConfig.OpenShiftStoragePrefix)
 
 	// Preserve previous behavior of using the first non-loopback address
 	// TODO: Deprecate this behavior and just require a valid value to be passed in

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -847,7 +847,7 @@ func (c *MasterConfig) DeploymentConfigScaleClient() *kclient.Client {
 
 // DeploymentControllerClients returns the deployment controller client objects
 func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient.Client) {
-	_, osClient, kClient, err := c.GetServiceAccountClients(bootstrappolicy.InfraDeploymentControllerServiceAccountName)
+	_, osClient, kClient, err := c.GetServiceAccountClients(bootstrappolicy.InfraDeploymentConfigControllerServiceAccountName)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -539,7 +539,7 @@ func newServiceAccountTokenGetter(options configapi.MasterConfig, client newetcd
 		// When we're running in-process, go straight to etcd (using the KubernetesStorageVersion/KubernetesStoragePrefix, since service accounts are kubernetes objects)
 		codec := kapi.Codecs.LegacyCodec(unversioned.GroupVersion{Group: kapi.GroupName, Version: options.EtcdStorageConfig.KubernetesStorageVersion})
 		ketcdHelper := etcdstorage.NewEtcdStorage(client, codec, options.EtcdStorageConfig.KubernetesStoragePrefix, false, genericapiserveroptions.DefaultDeserializationCacheSize)
-		tokenGetter = sacontroller.NewGetterFromStorageInterface(ketcdHelper)
+		tokenGetter = sacontroller.NewGetterFromStorageInterface(ketcdHelper, "serviceaccounts", "secrets")
 	}
 	return tokenGetter, nil
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -561,6 +561,10 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
+		_, _, deploymentClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraDeploymentControllerServiceAccountName)
+		if err != nil {
+			glog.Fatalf("Could not get client for deployment controller: %v", err)
+		}
 		_, _, jobClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraJobControllerServiceAccountName)
 		if err != nil {
 			glog.Fatalf("Could not get client for job controller: %v", err)
@@ -606,6 +610,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunNodeController()
 		kc.RunScheduler()
 		kc.RunReplicaSetController(rsClient)
+		kc.RunDeploymentController(deploymentClient)
 
 		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -557,7 +557,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunSecurityAllocationController()
 
 	if kc != nil {
-		_, _, rcClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicationControllerServiceAccountName)
+		_, _, rsClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicaSetControllerServiceAccountName)
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
@@ -605,7 +605,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		// no special order
 		kc.RunNodeController()
 		kc.RunScheduler()
-		kc.RunReplicationController(rcClient)
+		kc.RunReplicaSetController(rsClient)
 
 		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
 

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -226,6 +226,10 @@ func (c *DeploymentConfigController) deletePod(obj interface{}) {
 }
 
 func (c *DeploymentConfigController) enqueueDeploymentConfig(dc *deployapi.DeploymentConfig) {
+	if originalKind, exists := dc.Annotations[kapi.OriginalKindAnnotationName]; exists && originalKind != "DeploymentConfig." {
+		return
+	}
+
 	key, err := kcontroller.KeyFunc(dc)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %#v: %v", dc, err)

--- a/pkg/deploy/controller/generictrigger/factory.go
+++ b/pkg/deploy/controller/generictrigger/factory.go
@@ -131,6 +131,10 @@ func (c *DeploymentTriggerController) updateImageStream(old, cur interface{}) {
 }
 
 func (c *DeploymentTriggerController) enqueueDeploymentConfig(dc *deployapi.DeploymentConfig) {
+	if originalKind, exists := dc.Annotations[kapi.OriginalKindAnnotationName]; exists && originalKind != "DeploymentConfig." {
+		return
+	}
+
 	key, err := kcontroller.KeyFunc(dc)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %+v: %v", dc, err)

--- a/pkg/deploy/controller/imagechange/factory.go
+++ b/pkg/deploy/controller/imagechange/factory.go
@@ -52,7 +52,12 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 			configs := []*deployapi.DeploymentConfig{}
 			objs := store.List()
 			for _, obj := range objs {
-				configs = append(configs, obj.(*deployapi.DeploymentConfig))
+				dc := obj.(*deployapi.DeploymentConfig)
+				if originalKind, exists := dc.Annotations[kapi.OriginalKindAnnotationName]; exists && originalKind != "DeploymentConfig." {
+					continue
+				}
+
+				configs = append(configs, dc)
 			}
 			return configs, nil
 		},

--- a/test/cmd/cohabitation.sh
+++ b/test/cmd/cohabitation.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/cohabitation"
+
+# integration tests ensure that the go client can list and watch and ensure that etcd is correct
+# this test ensures that the bytes coming back from the API have the correct type
+
+os::cmd::expect_success 'oadm policy add-role-to-user admin cohabiting-user -n cmd-cohabitation'
+os::cmd::try_until_text 'oadm policy who-can create replicationcontrollers' 'cohabiting-user'
+os::cmd::expect_success 'oc login -u cohabiting-user -p asdf'
+accesstoken=$(oc whoami -t)
+os::cmd::expect_success 'oc login -u system:admin'
+
+os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replication.yaml -n cmd-cohabitation'
+os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replicaset/frontend.yaml -n cmd-cohabitation'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers" '"kind": "ReplicationControllerList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers" '"kind": "ReplicaSetList"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets" '"kind": "ReplicaSetList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets" '"kind": "ReplicationControllerList"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/frontend" '"kind": "ReplicationController"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/frontend" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/frontend" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/frontend" '"kind": "ReplicationController"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/nginx" '"kind": "ReplicationController"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers/nginx" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/nginx" '"kind": "ReplicaSet"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets/nginx" '"kind": "ReplicationController"'
+
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers?watch=true" '"kind":"ReplicationController"'
+os::cmd::expect_failure_and_not_text "curl --max-time 1 -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers?watch=true" '"kind":"ReplicaSet"'
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicaSet"'
+os::cmd::expect_failure_and_not_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicationController"'
+
+
+echo "cohabitation: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/cohabitation.sh
+++ b/test/cmd/cohabitation.sh
@@ -13,12 +13,14 @@ os::test::junit::declare_suite_start "cmd/cohabitation"
 
 # integration tests ensure that the go client can list and watch and ensure that etcd is correct
 # this test ensures that the bytes coming back from the API have the correct type
-
 os::cmd::expect_success 'oadm policy add-role-to-user admin cohabiting-user -n cmd-cohabitation'
 os::cmd::try_until_text 'oadm policy who-can create replicationcontrollers' 'cohabiting-user'
 os::cmd::expect_success 'oc login -u cohabiting-user -p asdf'
 accesstoken=$(oc whoami -t)
 os::cmd::expect_success 'oc login -u system:admin'
+
+
+os::test::junit::declare_suite_start "cmd/cohabitation/rc-rs"
 
 os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replication.yaml -n cmd-cohabitation'
 os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/replicaset/frontend.yaml -n cmd-cohabitation'
@@ -42,6 +44,51 @@ os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer
 os::cmd::expect_failure_and_not_text "curl --max-time 1 -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/namespaces/cmd-cohabitation/replicationcontrollers?watch=true" '"kind":"ReplicaSet"'
 os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicaSet"'
 os::cmd::expect_failure_and_not_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/replicasets?watch=true" '"kind":"ReplicationController"'
+
+os::cmd::expect_success 'oc scale rc/nginx --replicas=1'
+os::cmd::expect_success 'oc scale rc/frontend --replicas=1'
+os::cmd::expect_success 'oc scale rs/nginx --replicas=1'
+os::cmd::expect_success 'oc scale rs/frontend --replicas=1'
+
+echo "rs<>rs: ok"
+os::test::junit::declare_suite_end
+
+
+
+os::test::junit::declare_suite_start "cmd/cohabitation/d-dc"
+
+os::cmd::expect_success 'oc create -f test/extended/testdata/deployment-simple.yaml -n cmd-cohabitation'
+os::cmd::expect_success 'oc create -f vendor/k8s.io/kubernetes/docs/user-guide/deployment.yaml -n cmd-cohabitation'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs" '"kind": "DeploymentConfigList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs" '"kind": "DeploymentList"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments" '"kind": "DeploymentList"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments" '"kind": "DeploymentConfigList"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs/deployment-simple" '"kind": "DeploymentConfig"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs/deployment-simple" '"kind": "Deployment"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments/deployment-simple" '"kind": "Deployment"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments/deployment-simple" '"kind": "DeploymentConfig"'
+
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs/nginx-deployment" '"kind": "DeploymentConfig"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs/nginx-deployment" '"kind": "Deployment"'
+os::cmd::expect_success_and_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments/nginx-deployment" '"kind": "Deployment"'
+os::cmd::expect_success_and_not_text "curl -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments/nginx-deployment" '"kind": "DeploymentConfig"'
+
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs?watch=true" '"kind":"DeploymentConfig"'
+os::cmd::expect_failure_and_not_text "curl --max-time 1 -k -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-cohabitation/deploymentconfigs?watch=true" '"kind":"Deployment"'
+os::cmd::expect_failure_and_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments?watch=true" '"kind":"Deployment"'
+os::cmd::expect_failure_and_not_text "curl -k --max-time 1 -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/apis/extensions/v1beta1/namespaces/cmd-cohabitation/deployments?watch=true" '"kind":"DeploymentConfig"'
+
+os::cmd::expect_success 'oc scale dc/deployment-simple --replicas=1'
+os::cmd::expect_failure_and_text 'oc scale dc/nginx-deployment --replicas=1' "wrong native type, no cross type updates allowed"
+os::cmd::expect_success 'oc scale deployment/nginx-deployment --replicas=1'
+os::cmd::expect_failure_and_text 'oc scale deployment/deployment-simple --replicas=1' "wrong native type, no cross type updates allowed"
+os::cmd::expect_success 'oc rollout pause deployment/nginx-deployment'
+os::cmd::expect_failure_and_text 'oc rollout pause deployment/deployment-simple' "wrong native type, no cross type updates allowed"
+
+echo "d<>dc: ok"
+os::test::junit::declare_suite_end
 
 
 echo "cohabitation: ok"

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -143,17 +143,6 @@ readonly EXCLUDED_TESTS=(
   kube-ui                 # Not installed by default
   "^Kubernetes Dashboard"  # Not installed by default (also probbaly slow image pull)
 
-	# deployments are not yet enabled
-  "Deployment deployment"
-  "Deployment paused deployment"
-  "paused deployment should be ignored by the controller"
-  "deployment should create new pods"
-	"should create an rc or deployment from an image"
-	"should create a deployment from an image"
-  "RollingUpdateDeployment should scale up and down in the right order"
-  "RollingUpdateDeployment should delete old pods and create new ones"
-  "RecreateDeployment should delete old pods and create new ones"
-
   "\[Feature:Federation\]"   # Not enabled yet
   "\[Feature:PodAffinity\]"  # Not enabled yet
   Ingress                    # Not enabled yet

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -181,7 +181,6 @@ readonly EXCLUDED_TESTS=(
   "should support exec through an HTTP proxy" # doesn't work because it requires a) static binary b) linux c) kubectl, https://github.com/openshift/origin/issues/7097
   "NFS"                      # no permissions https://github.com/openshift/origin/pull/6884
   "\[Feature:Example\]"      # may need to pre-pull images
-  "should serve a basic image on each replica with a public image" # is failing to create pods, the test is broken
   "ResourceQuota and capture the life of a secret" # https://github.com/openshift/origin/issue/9414
   "NodeProblemDetector"        # requires a non-master node to run on
 

--- a/test/integration/cohabitation_dc_d_test.go
+++ b/test/integration/cohabitation_dc_d_test.go
@@ -1,0 +1,234 @@
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/watch"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+func TestDCDCohabitation(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	projectName := "dc-d-cohabitation"
+	username := "some-user"
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, username); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	oclient, kclient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, username)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err := testutil.GetFixture("../../test/extended/testdata/deployment-simple.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dc := obj.(*deployapi.DeploymentConfig)
+	if _, err := oclient.DeploymentConfigs(projectName).Create(dc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err = testutil.GetFixture("../../vendor/k8s.io/kubernetes/docs/user-guide/deployment.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d := obj.(*extensionsapi.Deployment)
+	if _, err := kclient.Extensions().Deployments(projectName).Create(d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// wait until we have two RCs.  this ensures that controllers have run and tried to create things.
+	// if our types were ever going to be stored wrong, this is where it would happen
+	rcWatch, err := kclient.ReplicationControllers(projectName).Watch(kapi.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	numAdds := 0
+	watch.Until(30*time.Second, rcWatch, func(event watch.Event) (bool, error) {
+		if event.Type == watch.Added {
+			numAdds = numAdds + 1
+		}
+		if numAdds >= 2 {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	// make sure we get back both from each list endpoint
+	/////////////////////////////////////////////////////////////////////////////////
+	dcList, err := oclient.DeploymentConfigs(projectName).List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend := false
+	foundNginx := false
+	for _, dc := range dcList.Items {
+		if dc.Name == "nginx-deployment" {
+			foundNginx = true
+		}
+		if dc.Name == "deployment-simple" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing dc: %#v", dcList)
+	}
+
+	dList, err := kclient.Extensions().Deployments(projectName).List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for _, d := range dList.Items {
+		if d.Name == "nginx-deployment" {
+			foundNginx = true
+		}
+		if d.Name == "deployment-simple" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing d: %#v", dList)
+	}
+	/////////////////////////////////////////////////////////////////////////////////
+
+	// make sure we serialize in the correct format
+	/////////////////////////////////////////////////////////////////////////////////
+	etcdClient := testutil.NewEtcdClient()
+	etcdControlled, err := etcdClient.Get("/openshift.io/deploymentconfigs/"+projectName, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, node := range etcdControlled.Node.Nodes {
+		obj := fakeObject{}
+		if err := json.Unmarshal([]byte(node.Value), &obj); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		switch obj.Metadata.Name {
+		case "deployment-simple":
+			if obj.Kind != "DeploymentConfig" || obj.APIVersion != "v1" {
+				t.Errorf("wrong serialization: %v", node.Value)
+			}
+
+		case "nginx-deployment":
+			if obj.Kind != "Deployment" || obj.APIVersion != "extensions/v1beta1" {
+				t.Errorf("wrong serialization: %v", node.Value)
+			}
+
+		default:
+			t.Errorf("unexpected deployment: %v", node.Value)
+		}
+
+		for key := range obj.Metadata.Annotations {
+			if key == kapi.OriginalKindAnnotationName {
+				t.Errorf("wrong serialization: %v", node.Value)
+			}
+			if strings.HasPrefix(key, kapi.NonConvertibleAnnotationPrefix) {
+				t.Errorf("wrong serialization: %v", node.Value)
+			}
+		}
+	}
+	/////////////////////////////////////////////////////////////////////////////////
+
+	// make the lists return each object in the correct format
+	/////////////////////////////////////////////////////////////////////////////////
+	dcWatch, err := oclient.DeploymentConfigs(projectName).Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-dcWatch.ResultChan()
+		dc := obj.Object.(*deployapi.DeploymentConfig)
+		if dc.Name == "nginx-deployment" {
+			foundNginx = true
+		}
+		if dc.Name == "deployment-simple" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing dc: %v %v", foundFrontend, foundNginx)
+	}
+
+	dWatch, err := kclient.Extensions().Deployments(projectName).Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-dWatch.ResultChan()
+		d := obj.Object.(*extensionsapi.Deployment)
+		if d.Name == "nginx-deployment" {
+			foundNginx = true
+		}
+		if d.Name == "deployment-simple" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing d: %v %v", foundFrontend, foundNginx)
+	}
+	/////////////////////////////////////////////////////////////////////////////////
+
+	// make the gets have the correct annotations and that updates across types are rejected
+	/////////////////////////////////////////////////////////////////////////////////
+	dAsDC, err := oclient.DeploymentConfigs(projectName).Get("nginx-deployment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := oclient.DeploymentConfigs(projectName).Update(dAsDC); err == nil || !strings.Contains(err.Error(), "wrong native type, no cross type updates allowed") {
+		t.Errorf("wrong error: %v", err)
+	}
+	if _, err := clusterAdminClient.DeploymentConfigs(projectName).UpdateStatus(dAsDC); err == nil || !strings.Contains(err.Error(), "wrong native type, no cross type updates allowed") {
+		t.Errorf("wrong error: %v", err)
+	}
+	if dAsDC.Annotations[kapi.OriginalKindAnnotationName] != "Deployment.extensions" {
+		t.Errorf("missing annotation: %v", dAsDC.Annotations)
+	}
+
+	dcAsD, err := kclient.Extensions().Deployments(projectName).Get("deployment-simple")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := kclient.Extensions().Deployments(projectName).Update(dcAsD); err == nil || !strings.Contains(err.Error(), "wrong native type, no cross type updates allowed") {
+		t.Errorf("wrong error: %v", err)
+	}
+	if _, err := clusterAdminKubeClient.Extensions().Deployments(projectName).UpdateStatus(dcAsD); err == nil || !strings.Contains(err.Error(), "wrong native type, no cross type updates allowed") {
+		t.Errorf("wrong error: %v", err)
+	}
+	if dcAsD.Annotations[kapi.OriginalKindAnnotationName] != "DeploymentConfig." {
+		t.Errorf("missing annotation: %v", dcAsD.Annotations)
+	}
+	/////////////////////////////////////////////////////////////////////////////////
+
+}

--- a/test/integration/cohabitation_rc_rs_test.go
+++ b/test/integration/cohabitation_rc_rs_test.go
@@ -1,0 +1,143 @@
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	extensionsapi "k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+type fakeObject struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+}
+
+func TestRCRSCohabitation(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err := testutil.GetFixture("../../vendor/k8s.io/kubernetes/docs/user-guide/replication.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rc := obj.(*kapi.ReplicationController)
+	if _, err := clusterAdminKubeClient.ReplicationControllers("default").Create(rc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, err = testutil.GetFixture("../../vendor/k8s.io/kubernetes/docs/user-guide/replicaset/frontend.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rs := obj.(*extensionsapi.ReplicaSet)
+	if _, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").Create(rs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// make sure we get back both from each endpoint
+	rcList, err := clusterAdminKubeClient.ReplicationControllers("default").List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend := false
+	foundNginx := false
+	for _, rc := range rcList.Items {
+		if rc.Name == "nginx" {
+			foundNginx = true
+		}
+		if rc.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rc: %#v", rcList)
+	}
+
+	rsList, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for _, rs := range rsList.Items {
+		if rs.Name == "nginx" {
+			foundNginx = true
+		}
+		if rs.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rs: %#v", rsList)
+	}
+
+	etcdClient := testutil.NewEtcdClient()
+	etcdControllers, err := etcdClient.Get("/kubernetes.io/controllers/default", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedEtcdEncoding := fakeObject{Kind: "ReplicationController", APIVersion: "v1"}
+	for _, node := range etcdControllers.Node.Nodes {
+		obj := fakeObject{}
+		if err := json.Unmarshal([]byte(node.Value), &obj); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if obj != expectedEtcdEncoding {
+			t.Errorf("expected %v, got %v", expectedEtcdEncoding, obj)
+		}
+	}
+
+	rcWatch, err := clusterAdminKubeClient.ReplicationControllers("default").Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-rcWatch.ResultChan()
+		rc := obj.Object.(*kapi.ReplicationController)
+		if rc.Name == "nginx" {
+			foundNginx = true
+		}
+		if rc.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rc: %v %v", foundFrontend, foundNginx)
+	}
+
+	rsWatch, err := clusterAdminKubeClient.Extensions().ReplicaSets("default").Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundFrontend = false
+	foundNginx = false
+	for i := 0; i < 2; i++ {
+		obj := <-rsWatch.ResultChan()
+		rs := obj.Object.(*extensionsapi.ReplicaSet)
+		if rs.Name == "nginx" {
+			foundNginx = true
+		}
+		if rs.Name == "frontend" {
+			foundFrontend = true
+		}
+	}
+	if !foundFrontend || !foundNginx {
+		t.Errorf("missing rs: %v %v", foundFrontend, foundNginx)
+	}
+
+}

--- a/test/integration/cohabitation_rc_rs_test.go
+++ b/test/integration/cohabitation_rc_rs_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -14,8 +12,14 @@ import (
 )
 
 type fakeObject struct {
-	Kind       string `json:"kind"`
-	APIVersion string `json:"apiVersion"`
+	Kind       string       `json:"kind"`
+	APIVersion string       `json:"apiVersion"`
+	Metadata   fakeMetadata `json:"metadata"`
+}
+
+type fakeMetadata struct {
+	Name        string            `json:"name"`
+	Annotations map[string]string `json:"annotations"`
 }
 
 func TestRCRSCohabitation(t *testing.T) {
@@ -89,14 +93,13 @@ func TestRCRSCohabitation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectedEtcdEncoding := fakeObject{Kind: "ReplicationController", APIVersion: "v1"}
 	for _, node := range etcdControllers.Node.Nodes {
 		obj := fakeObject{}
 		if err := json.Unmarshal([]byte(node.Value), &obj); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if obj != expectedEtcdEncoding {
-			t.Errorf("expected %v, got %v", expectedEtcdEncoding, obj)
+		if obj.Kind != "ReplicationController" || obj.APIVersion != "v1" {
+			t.Errorf("wrong serialization: %v", node.Value)
 		}
 	}
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -485,6 +485,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     - replicationcontrollers/scale
     verbs:
     - create
@@ -842,6 +844,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     - replicationcontrollers/scale
     verbs:
     - create
@@ -1106,6 +1110,8 @@ items:
     resources:
     - horizontalpodautoscalers
     - jobs
+    - replicasets
+    - replicasets/scale
     verbs:
     - get
     - list
@@ -2710,6 +2716,48 @@ items:
     - create
     - delete
     - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:replicaset-controller
+  rules:
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets/status
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - list
+    - watch
   - apiGroups:
     - ""
     attributeRestrictions: null

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -483,6 +483,8 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
+    - deployments
+    - deployments/scale
     - horizontalpodautoscalers
     - jobs
     - replicasets
@@ -842,6 +844,8 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
+    - deployments
+    - deployments/scale
     - horizontalpodautoscalers
     - jobs
     - replicasets
@@ -1108,6 +1112,8 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
+    - deployments
+    - deployments/scale
     - horizontalpodautoscalers
     - jobs
     - replicasets
@@ -2270,6 +2276,59 @@ items:
   metadata:
     creationTimestamp: null
     name: system:deployment-controller
+  rules:
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - deployments/status
+    verbs:
+    - update
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:deploymentconfig-controller
   rules:
   - apiGroups:
     - ""

--- a/test/util/helpers.go
+++ b/test/util/helpers.go
@@ -42,3 +42,19 @@ func GetImageFixture(filename string) (*imageapi.Image, error) {
 	}
 	return obj.(*imageapi.Image), nil
 }
+
+func GetFixture(filename string) (runtime.Object, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := kyaml.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := runtime.Decode(kapi.Codecs.UniversalDecoder(), jsonData)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/apiserver/authenticator"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -182,7 +183,7 @@ func Run(s *options.APIServer) error {
 		if err != nil {
 			glog.Fatalf("Unable to get serviceaccounts storage: %v", err)
 		}
-		serviceAccountGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storage)
+		serviceAccountGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storage, storageFactory.ResourcePrefix(api.Resource("serviceaccounts")), storageFactory.ResourcePrefix(api.Resource("secrets")))
 	}
 
 	authenticator, err := authenticator.New(authenticator.AuthenticatorConfig{
@@ -227,11 +228,11 @@ func Run(s *options.APIServer) error {
 
 	if modeEnabled(apiserver.ModeRBAC) {
 		mustGetRESTOptions := func(resource string) generic.RESTOptions {
-			s, err := storageFactory.New(api.Resource(resource))
+			s, err := storageFactory.New(rbac.Resource(resource))
 			if err != nil {
 				glog.Fatalf("Unable to get %s storage: %v", resource, err)
 			}
-			return generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage}
+			return generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: storageFactory.ResourcePrefix(rbac.Resource(resource))}
 		}
 
 		// For initial bootstrapping go directly to etcd to avoid privillege escalation check.

--- a/vendor/k8s.io/kubernetes/pkg/api/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/conversion.go
@@ -171,7 +171,9 @@ func Convert_resource_Quantity_To_resource_Quantity(in *resource.Quantity, out *
 }
 
 func Convert_map_to_unversioned_LabelSelector(in *map[string]string, out *unversioned.LabelSelector, s conversion.Scope) error {
-	out = new(unversioned.LabelSelector)
+	if out == nil {
+		return nil
+	}
 	for labelKey, labelValue := range *in {
 		utillabels.AddLabelToSelector(out, labelKey, labelValue)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/api/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/helpers.go
@@ -50,6 +50,23 @@ func (c *ConversionError) Error() string {
 	)
 }
 
+const (
+	// annotation key prefix used to identify non-convertible json paths.
+	NonConvertibleAnnotationPrefix = "non-convertible.kubernetes.io"
+	// annotation key name used to identiffy original kind.
+	OriginalKindAnnotationName = "original-kind.kubernetes.io"
+)
+
+func NonConvertibleFields(annotations map[string]string) []string {
+	nonConvertibleKeys := []string{}
+	for key := range annotations {
+		if strings.HasPrefix(key, NonConvertibleAnnotationPrefix) {
+			nonConvertibleKeys = append(nonConvertibleKeys, key)
+		}
+	}
+	return nonConvertibleKeys
+}
+
 // Semantic can do semantic deep equality checks for api objects.
 // Example: api.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
 var Semantic = conversion.EqualitiesOrDie(

--- a/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/serialization_test.go
@@ -38,8 +38,12 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/serializer/streaming"
+	"k8s.io/kubernetes/pkg/runtime/serializer/versioning"
 	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
@@ -145,6 +149,61 @@ func roundTripSame(t *testing.T, group testapi.TestGroup, item runtime.Object, e
 		for _, codec := range codecs {
 			roundTrip(t, codec, item)
 		}
+	}
+}
+
+func Convert_v1beta1_ReplicaSet_to_api_ReplicationController(in *v1beta1.ReplicaSet, out *api.ReplicationController, s conversion.Scope) error {
+	intermediate1 := &extensions.ReplicaSet{}
+	if err := v1beta1.Convert_v1beta1_ReplicaSet_To_extensions_ReplicaSet(in, intermediate1, s); err != nil {
+		return err
+	}
+
+	intermediate2 := &v1.ReplicationController{}
+	if err := v1.Convert_extensions_ReplicaSet_to_v1_ReplicationController(intermediate1, intermediate2, s); err != nil {
+		return err
+	}
+
+	return v1.Convert_v1_ReplicationController_To_api_ReplicationController(intermediate2, out, s)
+}
+
+func TestSetControllerConversion(t *testing.T) {
+	if err := api.Scheme.AddConversionFuncs(Convert_v1beta1_ReplicaSet_to_api_ReplicationController); err != nil {
+		t.Fatal(err)
+	}
+
+	rs := &extensions.ReplicaSet{}
+	rc := &api.ReplicationController{}
+
+	extGroup := testapi.Extensions
+	defaultGroup := testapi.Default
+
+	fuzzInternalObject(t, extGroup.InternalGroupVersion(), rs, rand.Int63())
+
+	t.Logf("rs._internal.extensions -> rs.v1beta1.extensions")
+	data, err := runtime.Encode(extGroup.Codec(), rs)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	decoder := api.Codecs.UniversalDecoder(*extGroup.GroupVersion(), *defaultGroup.GroupVersion())
+	if err := versioning.EnableCrossGroupDecoding(decoder, extGroup.GroupVersion().Group, defaultGroup.GroupVersion().Group); err != nil {
+		t.Fatalf("unexpected error while enabling cross-group decoding: %v", err)
+	}
+
+	t.Logf("rs.v1beta1.extensions -> rc._internal")
+	if err := runtime.DecodeInto(decoder, data, rc); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
+	}
+
+	t.Logf("rc._internal -> rc.v1")
+	data, err = runtime.Encode(defaultGroup.Codec(), rc)
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+
+	t.Logf("rc.v1 -> rs._internal.extensions")
+	if err := runtime.DecodeInto(decoder, data, rs); err != nil {
+		t.Fatalf("unexpected decoding error: %v", err)
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers.go
@@ -64,6 +64,35 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 	return selector, nil
 }
 
+// LabelSelectorAsMap converts the LabelSelector api type into a map of strings, ie. the
+// original structure of a label selector. Operators that cannot be converted into plain
+// labels (Exists, DoesNotExist, NotIn, and In with more than one value) will result in
+// an error.
+func LabelSelectorAsMap(ps *LabelSelector) (map[string]string, error) {
+	if ps == nil {
+		return nil, nil
+	}
+	selector := map[string]string{}
+	for k, v := range ps.MatchLabels {
+		selector[k] = v
+	}
+	for _, expr := range ps.MatchExpressions {
+		switch expr.Operator {
+		case LabelSelectorOpIn:
+			if len(expr.Values) != 1 {
+				return selector, fmt.Errorf("operator %q without a single value cannot be converted into the old label selector format", expr.Operator)
+			}
+			// Should we do anything in case this will override a previous key-value pair?
+			selector[expr.Key] = expr.Values[0]
+		case LabelSelectorOpNotIn, LabelSelectorOpExists, LabelSelectorOpDoesNotExist:
+			return selector, fmt.Errorf("operator %q cannot be converted into the old label selector format", expr.Operator)
+		default:
+			return selector, fmt.Errorf("%q is not a valid selector operator", expr.Operator)
+		}
+	}
+	return selector, nil
+}
+
 // ParseToLabelSelector parses a string representing a selector into a LabelSelector object.
 // Note: This function should be kept in sync with the parser in pkg/labels/selector.go
 func ParseToLabelSelector(selector string) (*LabelSelector, error) {

--- a/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/unversioned/helpers_test.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/labels"
@@ -75,6 +76,76 @@ func TestLabelSelectorAsSelector(t *testing.T) {
 		}
 		if err != nil && !tc.expectErr {
 			t.Errorf("[%v]did not expect error but got: %v", i, err)
+		}
+		if !reflect.DeepEqual(out, tc.out) {
+			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
+		}
+	}
+}
+
+func TestLabelSelectorAsMap(t *testing.T) {
+	matchLabels := map[string]string{"foo": "bar"}
+	matchExpressions := func(operator LabelSelectorOperator, values []string) []LabelSelectorRequirement {
+		return []LabelSelectorRequirement{{
+			Key:      "baz",
+			Operator: operator,
+			Values:   values,
+		}}
+	}
+
+	tests := []struct {
+		in        *LabelSelector
+		out       map[string]string
+		errString string
+	}{
+		{in: nil, out: nil},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels},
+			out: map[string]string{"foo": "bar"},
+		},
+		{
+			in:  &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"foo": "bar", "baz": "norf"},
+		},
+		{
+			in:  &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf"})},
+			out: map[string]string{"baz": "norf"},
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpIn, []string{"norf", "qux"})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "without a single value cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpNotIn, []string{"norf", "qux"})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchLabels: matchLabels, MatchExpressions: matchExpressions(LabelSelectorOpExists, []string{})},
+			out:       map[string]string{"foo": "bar"},
+			errString: "cannot be converted",
+		},
+		{
+			in:        &LabelSelector{MatchExpressions: matchExpressions(LabelSelectorOpDoesNotExist, []string{})},
+			out:       map[string]string{},
+			errString: "cannot be converted",
+		},
+	}
+
+	for i, tc := range tests {
+		out, err := LabelSelectorAsMap(tc.in)
+		if err == nil && len(tc.errString) > 0 {
+			t.Errorf("[%v]expected error but got none.", i)
+			continue
+		}
+		if err != nil && len(tc.errString) == 0 {
+			t.Errorf("[%v]did not expect error but got: %v", i, err)
+			continue
+		}
+		if err != nil && len(tc.errString) > 0 && !strings.Contains(err.Error(), tc.errString) {
+			t.Errorf("[%v]expected error with %q but got: %v", i, tc.errString, err)
+			continue
 		}
 		if !reflect.DeepEqual(out, tc.out) {
 			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -34,9 +34,6 @@ const (
 
 	// Value used to identify mirror pods from pre-v1.1 kubelet.
 	mirrorAnnotationValue_1_0 = "mirror"
-
-	// annotation key prefix used to identify non-convertible json paths.
-	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) {
@@ -279,7 +276,7 @@ func Convert_extensions_ReplicaSet_to_v1_ReplicationController(in *extensions.Re
 		if out.Annotations == nil {
 			out.Annotations = make(map[string]string)
 		}
-		out.Annotations[NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
+		out.Annotations[api.NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
 	}
 	if err := Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -19,10 +19,13 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
 )
 
 const (
@@ -31,6 +34,9 @@ const (
 
 	// Value used to identify mirror pods from pre-v1.1 kubelet.
 	mirrorAnnotationValue_1_0 = "mirror"
+
+	// annotation key prefix used to identify non-convertible json paths.
+	NonConvertibleAnnotationPrefix = "kubernetes.io/non-convertible"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) {
@@ -45,6 +51,12 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec,
 		Convert_v1_ServiceSpec_To_api_ServiceSpec,
 		Convert_v1_ResourceList_To_api_ResourceList,
+		Convert_v1_ReplicationController_to_extensions_ReplicaSet,
+		Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec,
+		Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus,
+		Convert_extensions_ReplicaSet_to_v1_ReplicationController,
+		Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec,
+		Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus,
 
 		Convert_api_VolumeSource_To_v1_VolumeSource,
 		Convert_v1_VolumeSource_To_api_VolumeSource,
@@ -204,17 +216,107 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 	}
 }
 
+func Convert_v1_ReplicationController_to_extensions_ReplicaSet(in *ReplicationController, out *extensions.ReplicaSet, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationController))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerSpec_to_extensions_ReplicaSetSpec(in *ReplicationControllerSpec, out *extensions.ReplicaSetSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerSpec))(in)
+	}
+	out.Replicas = *in.Replicas
+	if in.Selector != nil {
+		api.Convert_map_to_unversioned_LabelSelector(&in.Selector, out.Selector, s)
+	}
+	if in.Template != nil {
+		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, &out.Template, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Convert_v1_ReplicationControllerStatus_to_extensions_ReplicaSetStatus(in *ReplicationControllerStatus, out *extensions.ReplicaSetStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*ReplicationControllerStatus))(in)
+	}
+	out.Replicas = in.Replicas
+	out.FullyLabeledReplicas = in.FullyLabeledReplicas
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
+func Convert_extensions_ReplicaSet_to_v1_ReplicationController(in *extensions.ReplicaSet, out *ReplicationController, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSet))(in)
+	}
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, s); err != nil {
+		fieldErr, ok := err.(*field.Error)
+		if !ok {
+			return err
+		}
+		if out.Annotations == nil {
+			out.Annotations = make(map[string]string)
+		}
+		out.Annotations[NonConvertibleAnnotationPrefix+"/"+fieldErr.Field] = reflect.ValueOf(fieldErr.BadValue).String()
+	}
+	if err := Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Convert_extensions_ReplicaSetSpec_to_v1_ReplicationControllerSpec(in *extensions.ReplicaSetSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetSpec))(in)
+	}
+	out.Replicas = new(int32)
+	*out.Replicas = in.Replicas
+	var invalidErr error
+	if in.Selector != nil {
+		invalidErr = api.Convert_unversioned_LabelSelector_to_map(in.Selector, &out.Selector, s)
+	}
+	out.Template = new(PodTemplateSpec)
+	if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, out.Template, s); err != nil {
+		return err
+	}
+	return invalidErr
+}
+
+func Convert_extensions_ReplicaSetStatus_to_v1_ReplicationControllerStatus(in *extensions.ReplicaSetStatus, out *ReplicationControllerStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.ReplicaSetStatus))(in)
+	}
+	out.Replicas = int32(in.Replicas)
+	out.FullyLabeledReplicas = int32(in.FullyLabeledReplicas)
+	out.ObservedGeneration = in.ObservedGeneration
+	return nil
+}
+
 func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *api.ReplicationControllerSpec, out *ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = &in.Replicas
 	out.Selector = in.Selector
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(ObjectReference)
-	//	if err := Convert_api_ObjectReference_To_v1_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(PodTemplateSpec)
 		if err := Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
@@ -229,15 +331,6 @@ func Convert_api_ReplicationControllerSpec_To_v1_ReplicationControllerSpec(in *a
 func Convert_v1_ReplicationControllerSpec_To_api_ReplicationControllerSpec(in *ReplicationControllerSpec, out *api.ReplicationControllerSpec, s conversion.Scope) error {
 	out.Replicas = *in.Replicas
 	out.Selector = in.Selector
-
-	//if in.TemplateRef != nil {
-	//	out.TemplateRef = new(api.ObjectReference)
-	//	if err := Convert_v1_ObjectReference_To_api_ObjectReference(in.TemplateRef, out.TemplateRef, s); err != nil {
-	//		return err
-	//	}
-	//} else {
-	//	out.TemplateRef = nil
-	//}
 	if in.Template != nil {
 		out.Template = new(api.PodTemplateSpec)
 		if err := Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/controller/deployment/deployment_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/deployment/deployment_controller.go
@@ -370,6 +370,10 @@ func (dc *DeploymentController) deletePod(obj interface{}) {
 }
 
 func (dc *DeploymentController) enqueueDeployment(deployment *extensions.Deployment) {
+	if originalKind, exists := deployment.Annotations[api.OriginalKindAnnotationName]; exists && originalKind != "Deployment.extensions" {
+		return
+	}
+
 	key, err := controller.KeyFunc(deployment)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %+v: %v", deployment, err)

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
@@ -69,9 +69,9 @@ func (r *registryGetter) GetSecret(namespace, name string) (*api.Secret, error) 
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(s storage.Interface) serviceaccount.ServiceAccountTokenGetter {
+func NewGetterFromStorageInterface(s storage.Interface, saPrefix, secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
 	return NewGetterFromRegistries(
-		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
-		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage})),
+		serviceaccountregistry.NewRegistry(serviceaccountetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix})),
+		secret.NewRegistry(secretetcd.NewREST(generic.RESTOptions{Storage: s, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix})),
 	)
 }

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -19,6 +19,7 @@ package genericapiserver
 import (
 	"fmt"
 	"mime"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -36,6 +37,12 @@ type StorageFactory interface {
 	// New finds the storage destination for the given group and resource. It will
 	// return an error if the group has no storage destination configured.
 	New(groupResource unversioned.GroupResource) (storage.Interface, error)
+
+	// ResourcePrefix returns the overridden resource prefix for the GroupResource
+	// This allows for cohabitation of resources with different native types and provides
+	// centralized control over the shape of etcd directories
+	ResourcePrefix(groupResource unversioned.GroupResource) string
+
 	// Backends gets all backends for all registered storage destinations.
 	// Used for getting all instances for health validations.
 	Backends() []string
@@ -77,8 +84,12 @@ type groupResourceOverrides struct {
 	// etcdLocation contains the list of "special" locations that are used for particular GroupResources
 	// These are merged on top of the StorageConfig when requesting the storage.Interface for a given GroupResource
 	etcdLocation []string
-	// etcdPrefix contains the list of "special" prefixes for a GroupResource.  Resource=* means for the entire group
+	// etcdPrefix contains the list of "special" prefixes for a GroupResource.
 	etcdPrefix string
+	// etcdResourcePrefix is the location to use to store a particular type under the `etcdPrefix` location
+	// If empty, the default mapping is used.  If the default mapping doesn't contain an entry, it will use
+	// the ToLowered name of the resource, not including the group.
+	etcdResourcePrefix string
 	// mediaType is the desired serializer to choose. If empty, the default is chosen.
 	mediaType string
 	// serializer contains the list of "special" serializers for a GroupResource.  Resource=* means for the entire group
@@ -124,6 +135,12 @@ func (s *DefaultStorageFactory) SetEtcdLocation(groupResource unversioned.GroupR
 func (s *DefaultStorageFactory) SetEtcdPrefix(groupResource unversioned.GroupResource, prefix string) {
 	overrides := s.Overrides[groupResource]
 	overrides.etcdPrefix = prefix
+	s.Overrides[groupResource] = overrides
+}
+
+func (s *DefaultStorageFactory) SetResourceEtcdPrefix(groupResource unversioned.GroupResource, prefix string) {
+	overrides := s.Overrides[groupResource]
+	overrides.etcdResourcePrefix = prefix
 	s.Overrides[groupResource] = overrides
 }
 
@@ -277,4 +294,31 @@ func NewStorageCodec(storageMediaType string, ns runtime.StorageSerializer, stor
 	encoder := ns.EncoderForVersion(s, runtime.NewMultiGroupVersioner(storageVersion, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
 	decoder := ns.DecoderToVersion(ds, runtime.NewMultiGroupVersioner(memoryVersion, unversioned.GroupKind{Group: memoryVersion.Group}, unversioned.GroupKind{Group: storageVersion.Group}))
 	return runtime.NewCodec(encoder, decoder), nil
+}
+
+var specialDefaultResourcePrefixes = map[unversioned.GroupResource]string{
+	unversioned.GroupResource{Group: "", Resource: "replicationControllers"}: "controllers",
+	unversioned.GroupResource{Group: "", Resource: "replicationcontrollers"}: "controllers",
+	unversioned.GroupResource{Group: "", Resource: "endpoints"}:              "services/endpoints",
+	unversioned.GroupResource{Group: "", Resource: "nodes"}:                  "minions",
+	unversioned.GroupResource{Group: "", Resource: "services"}:               "services/specs",
+}
+
+func (s *DefaultStorageFactory) ResourcePrefix(groupResource unversioned.GroupResource) string {
+	chosenStorageResource := s.getStorageGroupResource(groupResource)
+	groupOverride := s.Overrides[getAllResourcesAlias(chosenStorageResource)]
+	exactResourceOverride := s.Overrides[chosenStorageResource]
+
+	etcdResourcePrefix := specialDefaultResourcePrefixes[chosenStorageResource]
+	if len(groupOverride.etcdResourcePrefix) > 0 {
+		etcdResourcePrefix = groupOverride.etcdResourcePrefix
+	}
+	if len(exactResourceOverride.etcdResourcePrefix) > 0 {
+		etcdResourcePrefix = exactResourceOverride.etcdResourcePrefix
+	}
+	if len(etcdResourcePrefix) == 0 {
+		etcdResourcePrefix = strings.ToLower(chosenStorageResource.Resource)
+	}
+
+	return etcdResourcePrefix
 }

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -306,9 +306,13 @@ func NewStorageCodec(storageMediaType string, ns runtime.StorageSerializer,
 	case storageEncodingResource == unversioned.GroupResource{Group: "", Resource: "replicationControllers"},
 		storageEncodingResource == unversioned.GroupResource{Group: "", Resource: "replicationcontrollers"}:
 		encoder = ns.EncoderForVersion(s, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
-
 	case storageEncodingResource == unversioned.GroupResource{Group: "extensions", Resource: "replicasets"}:
 		encoder = ns.EncoderForVersion(s, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
+
+	case storageEncodingResource == unversioned.GroupResource{Group: "", Resource: "deploymentconfigs"}:
+		encoder = ns.EncoderForVersion(s, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "", Version: "v1", Kind: "DeploymentConfig"}, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
+	case storageEncodingResource == unversioned.GroupResource{Group: "extensions", Resource: "deployments"}:
+		encoder = ns.EncoderForVersion(s, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
 
 	default:
 		encoder = ns.EncoderForVersion(s, runtime.NewMultiGroupVersioner(storageVersion, unversioned.GroupKind{Group: storageVersion.Group}, unversioned.GroupKind{Group: memoryVersion.Group}))
@@ -325,9 +329,13 @@ func NewStorageCodec(storageMediaType string, ns runtime.StorageSerializer,
 	case memoryEncodingResource == unversioned.GroupResource{Group: "", Resource: "replicationControllers"},
 		memoryEncodingResource == unversioned.GroupResource{Group: "", Resource: "replicationcontrollers"}:
 		decoder = ns.DecoderToVersion(ds, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "", Version: runtime.APIVersionInternal, Kind: "ReplicationController"}, decodeableGroupKinds...))
-
 	case memoryEncodingResource == unversioned.GroupResource{Group: "extensions", Resource: "replicasets"}:
 		decoder = ns.DecoderToVersion(ds, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "extensions", Version: runtime.APIVersionInternal, Kind: "ReplicaSet"}, decodeableGroupKinds...))
+
+	case memoryEncodingResource == unversioned.GroupResource{Group: "", Resource: "deploymentconfigs"}:
+		decoder = ns.DecoderToVersion(ds, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "", Version: runtime.APIVersionInternal, Kind: "DeploymentConfig"}, decodeableGroupKinds...))
+	case memoryEncodingResource == unversioned.GroupResource{Group: "extensions", Resource: "deployments"}:
+		decoder = ns.DecoderToVersion(ds, runtime.NewMultiGroupKinder(unversioned.GroupVersionKind{Group: "extensions", Version: runtime.APIVersionInternal, Kind: "Deployment"}, decodeableGroupKinds...))
 
 	default:
 		decoder = ns.DecoderToVersion(ds, runtime.NewMultiGroupVersioner(memoryVersion, decodeableGroupKinds...))

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory.go
@@ -87,6 +87,11 @@ type groupResourceOverrides struct {
 	// of exposing one set of concepts.  autoscaling.HPA and extensions.HPA as a for instance
 	// The order of the slice matters!  It is the priority order of lookup for finding a storage location
 	cohabitatingResources []unversioned.GroupResource
+
+	// ignoreCohabitatingStorageVersion controls whether or not a cohabitating resource attempts to serialize into the same
+	// groupVersion as all other cohabitators.  If not, it uses the groupVersion assigned to itself instead of the one being
+	// used by the first enabled cohabitator.
+	ignoreCohabitatingStorageVersion bool
 }
 
 var _ StorageFactory = &DefaultStorageFactory{}
@@ -134,6 +139,16 @@ func (s *DefaultStorageFactory) AddCohabitatingResources(groupResources ...unver
 	for _, groupResource := range groupResources {
 		overrides := s.Overrides[groupResource]
 		overrides.cohabitatingResources = groupResources
+		s.Overrides[groupResource] = overrides
+	}
+}
+
+// IgnoreCohabitingStorageVersion indicates that the cohabitating resource should serialize using its own groupVersion, not the "shared" groupVersion
+// of all cohabitators.  Useful during resource migration/parity cases
+func (s *DefaultStorageFactory) IgnoreCohabitingStorageVersion(groupResources ...unversioned.GroupResource) {
+	for _, groupResource := range groupResources {
+		overrides := s.Overrides[groupResource]
+		overrides.ignoreCohabitatingStorageVersion = true
 		s.Overrides[groupResource] = overrides
 	}
 }
@@ -198,7 +213,12 @@ func (s *DefaultStorageFactory) New(groupResource unversioned.GroupResource) (st
 		config.ServerList = overriddenEtcdLocations
 	}
 
-	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(chosenStorageResource)
+	storageEncodingResource := chosenStorageResource
+	if s.Overrides[groupResource].ignoreCohabitatingStorageVersion {
+		storageEncodingResource = groupResource
+	}
+
+	storageEncodingVersion, err := s.ResourceEncodingConfig.StorageEncodingFor(storageEncodingResource)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/storage_factory_test.go
@@ -87,3 +87,91 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	}
 }
+
+func TestCohabitingSerializationVersion(t *testing.T) {
+	defaultConfig := storagebackend.Config{
+		Prefix:     options.DefaultEtcdPathPrefix,
+		ServerList: []string{"http://127.0.0.1"},
+	}
+
+	testCases := []struct {
+		name              string
+		factory           func() *DefaultStorageFactory
+		requestedResource unversioned.GroupResource
+
+		expectedResource unversioned.GroupResource
+	}{
+		{
+			name: "request first",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("one"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "request second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("one"),
+		},
+		{
+			name: "ignore second",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("two"),
+			expectedResource:  api.Resource("two"),
+		},
+		{
+			name: "ignore second, request third",
+			factory: func() *DefaultStorageFactory {
+				resourceConfig := NewResourceConfig()
+				f := NewDefaultStorageFactory(defaultConfig, "", api.Codecs, NewDefaultResourceEncodingConfig(), resourceConfig)
+				resourceConfig.EnableVersions(api.SchemeGroupVersion)
+				f.AddCohabitatingResources(api.Resource("one"), api.Resource("two"), api.Resource("three"))
+				f.IgnoreCohabitingStorageVersion(api.Resource("two"))
+				return f
+			},
+			requestedResource: api.Resource("three"),
+			expectedResource:  api.Resource("one"),
+		},
+	}
+
+	for _, tc := range testCases {
+		factory := tc.factory()
+		testEncodingConfig := &testDefaultResourceEncodingConfig{ResourceEncodingConfig: factory.ResourceEncodingConfig}
+		factory.ResourceEncodingConfig = testEncodingConfig
+
+		factory.New(tc.requestedResource)
+
+		if e, a := tc.expectedResource, testEncodingConfig.requestedResource; e != a {
+			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+type testDefaultResourceEncodingConfig struct {
+	ResourceEncodingConfig
+	requestedResource unversioned.GroupResource
+}
+
+func (o *testDefaultResourceEncodingConfig) StorageEncodingFor(resource unversioned.GroupResource) (unversioned.GroupVersion, error) {
+	o.requestedResource = resource
+	return api.SchemeGroupVersion, nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/master/master.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/master.go
@@ -872,6 +872,7 @@ func (m *Master) GetRESTOptionsOrDie(c *Config, resource unversioned.GroupResour
 		Storage:                 storage,
 		Decorator:               m.StorageDecorator(),
 		DeleteCollectionWorkers: m.deleteCollectionWorkers,
+		ResourcePrefix:          c.StorageFactory.ResourcePrefix(resource),
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/clusterrole/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/clusterrole/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterroles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/clusterrolebinding/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/clusterrolebinding/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/clusterrolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.ClusterRoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/configmap/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/configmap/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/configmaps"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ConfigMapList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/controller/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/controller/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/controllers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ReplicationControllerList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/daemonset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/daemonset/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/daemonsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DaemonSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
@@ -61,7 +61,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *RollbackREST) {
-	prefix := "/deployments"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.DeploymentList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	storeerr "k8s.io/kubernetes/pkg/api/errors/storage"
+	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
@@ -106,6 +107,29 @@ func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *RollbackREST) {
 	return &REST{store}, &StatusREST{store: &statusStore}, &RollbackREST{store: store}
 }
 
+type forceDCOnUpdate struct {
+	rest.UpdatedObjectInfo
+}
+
+// UpdatedObject satisfies the UpdatedObjectInfo interface.
+// It returns a copy of the held obj, passed through any configured transformers.
+func (i forceDCOnUpdate) UpdatedObject(ctx api.Context, oldObj runtime.Object) (runtime.Object, error) {
+	accessor, err := meta.Accessor(oldObj)
+	if err != nil {
+		return nil, err
+	}
+	originalKind, exists := accessor.GetAnnotations()[api.OriginalKindAnnotationName]
+	if !exists || originalKind == "Deployment.extensions" {
+		return i.UpdatedObjectInfo.UpdatedObject(ctx, oldObj)
+	}
+
+	return nil, fmt.Errorf("wrong native type, no cross type updates allowed: %v", originalKind)
+}
+
+func (r *REST) Update(ctx api.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
+	return r.Store.Update(ctx, name, forceDCOnUpdate{objInfo})
+}
+
 // StatusREST implements the REST endpoint for changing the status of a deployment
 type StatusREST struct {
 	store *registry.Store
@@ -122,7 +146,7 @@ func (r *StatusREST) Get(ctx api.Context, name string) (runtime.Object, error) {
 
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo)
+	return r.store.Update(ctx, name, forceDCOnUpdate{objInfo})
 }
 
 // RollbackREST implements the REST endpoint for initiating the rollback of a deployment
@@ -173,6 +197,9 @@ func (r *RollbackREST) setDeploymentRollback(ctx api.Context, deploymentID strin
 		if !ok {
 			return nil, fmt.Errorf("unexpected object: %#v", obj)
 		}
+		if originalKind, exists := d.Annotations[api.OriginalKindAnnotationName]; exists && originalKind == "Deployment.extensions" {
+			return nil, fmt.Errorf("wrong native type, no cross type updates allowed: %v", originalKind)
+		}
 		if d.Annotations == nil {
 			d.Annotations = make(map[string]string)
 		}
@@ -214,6 +241,9 @@ func (r *ScaleREST) Update(ctx api.Context, name string, objInfo rest.UpdatedObj
 	deployment, err := r.registry.GetDeployment(ctx, name)
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("deployments/scale"), name)
+	}
+	if originalKind, exists := deployment.Annotations[api.OriginalKindAnnotationName]; exists && originalKind == "Deployment.extensions" {
+		return nil, false, fmt.Errorf("wrong native type, no cross type updates allowed: %v", originalKind)
 	}
 
 	oldScale, err := scaleFromDeployment(deployment)

--- a/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/deployment/etcd/etcd_test.go
@@ -41,7 +41,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*DeploymentStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "deployments"}
 	deploymentStorage := NewStorage(restOptions)
 	return &deploymentStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/endpoint/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/endpoint/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/services/endpoints"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.EndpointsList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/event/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/event/etcd/etcd.go
@@ -32,7 +32,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against events.
 func NewREST(opts generic.RESTOptions, ttl uint64) *REST {
-	prefix := "/events"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here - switching on Cacher
 	// for events will lead to too high memory consumption.

--- a/vendor/k8s.io/kubernetes/pkg/registry/experimental/controller/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/experimental/controller/etcd/etcd_test.go
@@ -32,7 +32,7 @@ import (
 
 func newStorage(t *testing.T) (*ScaleREST, *etcdtesting.EtcdTestServer, storage.Interface) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "controllers"}
 	return NewStorage(restOptions).Scale, server, etcdStorage
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/generic/options.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/generic/options.go
@@ -25,4 +25,6 @@ type RESTOptions struct {
 	Storage                 pkgstorage.Interface
 	Decorator               StorageDecorator
 	DeleteCollectionWorkers int
+
+	ResourcePrefix string
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/horizontalpodautoscalers"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/ingress/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/ingress/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/ingress"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.IngressList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/job/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/job/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/jobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.JobList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/limitrange/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/limitrange/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/limitranges"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.LimitRangeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd.go
@@ -52,7 +52,7 @@ type FinalizeREST struct {
 
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST, *FinalizeREST) {
-	prefix := "/namespaces"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NamespaceList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/namespace/etcd/etcd_test.go
@@ -31,7 +31,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
 	namespaceStorage, _, _ := NewREST(restOptions)
 	return namespaceStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/networkpolicy/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/networkpolicy/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/networkpolicies"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensionsapi.NetworkPolicyList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/node/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/node/etcd/etcd.go
@@ -66,7 +66,7 @@ func (r *StatusREST) Update(ctx api.Context, name string, objInfo rest.UpdatedOb
 
 // NewREST returns a RESTStorage object that will work against nodes.
 func NewStorage(opts generic.RESTOptions, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper) NodeStorage {
-	prefix := "/minions"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.NodeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/persistentvolume/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumes"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/persistentvolumeclaims"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PersistentVolumeClaimList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/petsets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &appsapi.PetSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/petset/etcd/etcd_test.go
@@ -33,7 +33,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, apps.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "petsets"}
 	petSetStorage, statusStorage := NewREST(restOptions)
 	return petSetStorage, statusStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewStorage returns a RESTStorage object that will work against pods.
 func NewStorage(opts generic.RESTOptions, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper) PodStorage {
-	prefix := "/pods"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/poddisruptionbudgets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/poddisruptionbudget/etcd/etcd_test.go
@@ -34,7 +34,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, policy.GroupName)
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "poddisruptionbudgets"}
 	podDisruptionBudgetStorage, statusStorage := NewREST(restOptions)
 	return podDisruptionBudgetStorage, statusStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/podsecuritypolicy/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/podsecuritypolicy/etcd/etcd.go
@@ -32,22 +32,22 @@ type REST struct {
 	*registry.Store
 }
 
-const Prefix = "/podsecuritypolicies"
-
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(opts generic.RESTOptions) *REST {
+	prefix := "/" + opts.ResourcePrefix
+
 	newListFunc := func() runtime.Object { return &extensions.PodSecurityPolicyList{} }
 	storageInterface := opts.Decorator(
-		opts.Storage, 100, &extensions.PodSecurityPolicy{}, Prefix, podsecuritypolicy.Strategy, newListFunc)
+		opts.Storage, 100, &extensions.PodSecurityPolicy{}, prefix, podsecuritypolicy.Strategy, newListFunc)
 
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &extensions.PodSecurityPolicy{} },
 		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
-			return Prefix
+			return prefix
 		},
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, Prefix, name)
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*extensions.PodSecurityPolicy).Name, nil

--- a/vendor/k8s.io/kubernetes/pkg/registry/podtemplate/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/podtemplate/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/podtemplates"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.PodTemplateList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd.go
@@ -59,7 +59,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/replicasets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &extensions.ReplicaSetList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/replicaset/etcd/etcd_test.go
@@ -38,7 +38,7 @@ const defaultReplicas = 100
 
 func newStorage(t *testing.T) (*ReplicaSetStorage, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "extensions")
-	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "replicasets"}
 	replicaSetStorage := NewStorage(restOptions)
 	return &replicaSetStorage, server
 }

--- a/vendor/k8s.io/kubernetes/pkg/registry/resourcequota/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/resourcequota/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/resourcequotas"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ResourceQuotaList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/role/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/role/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/roles"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/rolebinding/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rolebinding/etcd/etcd.go
@@ -35,7 +35,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/rolebindings"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &rbac.RoleBindingList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/scheduledjob/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/scheduledjob/etcd/etcd.go
@@ -36,7 +36,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against ScheduledJobs.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/scheduledjobs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &batch.ScheduledJobList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/secret/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/secret/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/secrets"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.SecretList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/service/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/service/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(opts generic.RESTOptions) (*REST, *StatusREST) {
-	prefix := "/services/specs"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/serviceaccount/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/serviceaccount/etcd/etcd.go
@@ -33,7 +33,7 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/serviceaccounts"
+	prefix := "/" + opts.ResourcePrefix
 
 	newListFunc := func() runtime.Object { return &api.ServiceAccountList{} }
 	storageInterface := opts.Decorator(

--- a/vendor/k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd/etcd.go
@@ -34,7 +34,7 @@ type REST struct {
 
 // NewREST returns a registry which will store ThirdPartyResource in the given helper
 func NewREST(opts generic.RESTOptions) *REST {
-	prefix := "/thirdpartyresources"
+	prefix := "/" + opts.ResourcePrefix
 
 	// We explicitly do NOT do any decoration here yet.
 	storageInterface := opts.Storage

--- a/vendor/k8s.io/kubernetes/pkg/runtime/interfaces.go
+++ b/vendor/k8s.io/kubernetes/pkg/runtime/interfaces.go
@@ -39,6 +39,14 @@ type GroupVersioner interface {
 	PrefersGroup() (string, bool)
 }
 
+// GroupVersionerKinder conveys information about a desired target version for objects being converted.
+type GroupVersionerKinder interface {
+	GroupVersioner
+	// KindForGroupKind returns the desired GroupVersionKind for a given GroupKind, or false if no version
+	// is preferred. The kind on the GroupKind is optional, and implementers may choose to ignore it.
+	KindForGroupKind(group unversioned.GroupKind) (unversioned.GroupVersionKind, bool)
+}
+
 // Encoders write objects to a serialized form
 type Encoder interface {
 	// Encode writes an object to a stream. Implementations may return errors if the versions are

--- a/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
@@ -507,7 +507,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 					{"role=master"},
 					{"Status:", "Running"},
 					{"IP:"},
-					{"Controllers:", "ReplicationController/redis-master"},
+					{"Controllers:", "ReplicaSet/redis-master"},
 					{"Image:", redisImage},
 					{"State:", "Running"},
 					{"QoS Tier:", "BestEffort"},


### PR DESCRIPTION
Enables deployments upstream.  DCs and Ds cohabitate in etcd, but are stored in their native versions.  This doesn't attempt to make any subresources work properly and explicitly disallows updates to resources from a different native version.  Clients can corrupt this by removing the annotation, but they're only hurting themselves.

@mfojtik if you want to play