### PR TITLE
Adds a flag to allow skipping config writes when creating a project

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -444,6 +444,7 @@ _oc_new-project()
 
     flags+=("--description=")
     flags+=("--display-name=")
+    flags+=("--skip-config-write")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -4762,6 +4762,7 @@ _openshift_cli_new-project()
 
     flags+=("--description=")
     flags+=("--display-name=")
+    flags+=("--skip-config-write")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -605,6 +605,7 @@ _oc_new-project()
 
     flags+=("--description=")
     flags+=("--display-name=")
+    flags+=("--skip-config-write")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/contrib/completions/zsh/openshift
+++ b/contrib/completions/zsh/openshift
@@ -4923,6 +4923,7 @@ _openshift_cli_new-project()
 
     flags+=("--description=")
     flags+=("--display-name=")
+    flags+=("--skip-config-write")
     flags+=("--api-version=")
     flags+=("--as=")
     flags+=("--certificate-authority=")

--- a/docs/man/man1/oc-new-project.1
+++ b/docs/man/man1/oc-new-project.1
@@ -32,6 +32,10 @@ After your project is created it will become the default project in your config.
 \fB\-\-display\-name\fP=""
     Project display name
 
+.PP
+\fB\-\-skip\-config\-write\fP=false
+    If true, the project will not be set as a cluster entry in kubeconfig after being created
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/docs/man/man1/openshift-cli-new-project.1
+++ b/docs/man/man1/openshift-cli-new-project.1
@@ -32,6 +32,10 @@ After your project is created it will become the default project in your config.
 \fB\-\-display\-name\fP=""
     Project display name
 
+.PP
+\fB\-\-skip\-config\-write\fP=false
+    If true, the project will not be set as a cluster entry in kubeconfig after being created
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -21,7 +21,10 @@ type NewProjectOptions struct {
 	DisplayName string
 	Description string
 
-	Name string
+	Name   string
+	Server string
+
+	SkipConfigWrite bool
 
 	Client client.Interface
 
@@ -73,6 +76,7 @@ func NewCmdRequestProject(baseName, name, ocLoginName, ocProjectName string, f *
 
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "Project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "Project description")
+	cmd.Flags().BoolVar(&options.SkipConfigWrite, "skip-config-write", false, "If true, the project will not be set as a cluster entry in kubeconfig after being created")
 
 	return cmd
 }
@@ -86,10 +90,18 @@ func (o *NewProjectOptions) complete(cmd *cobra.Command, f *clientcmd.Factory) e
 
 	o.ProjectName = args[0]
 
-	o.ProjectOptions = &ProjectOptions{}
-	o.ProjectOptions.PathOptions = cliconfig.NewPathOptions(cmd)
-	if err := o.ProjectOptions.Complete(f, []string{""}, o.Out); err != nil {
-		return err
+	if !o.SkipConfigWrite {
+		o.ProjectOptions = &ProjectOptions{}
+		o.ProjectOptions.PathOptions = cliconfig.NewPathOptions(cmd)
+		if err := o.ProjectOptions.Complete(f, []string{""}, o.Out); err != nil {
+			return err
+		}
+	} else {
+		clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+		o.Server = clientConfig.Host
 	}
 
 	return nil
@@ -121,15 +133,22 @@ func (o *NewProjectOptions) Run() error {
 		if err := o.ProjectOptions.RunProject(); err != nil {
 			return err
 		}
-	}
 
-	fmt.Fprintf(o.Out, `
+		fmt.Fprintf(o.Out, `
 You can add applications to this project with the 'new-app' command. For example, try:
 
     %[1]s new-app centos/ruby-22-centos7~https://github.com/openshift/ruby-ex.git
 
 to build a new example application in Ruby.
 `, o.Name)
+	} else {
+		fmt.Fprintf(o.Out, `Project %[2]q created on server %[3]q.
+
+To switch to this project and start adding applications, use:
+
+    %[1]s project %[2]s
+`, o.Name, o.ProjectName, o.Server)
+	}
 
 	return nil
 }

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -355,4 +355,3 @@ echo "patch: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_end
-

--- a/test/cmd/projects.sh
+++ b/test/cmd/projects.sh
@@ -17,5 +17,11 @@ os::cmd::expect_success_and_text 'oc projects' 'You are not a member of any proj
 # add a project and expect text for a single project
 os::cmd::expect_success_and_text 'oc new-project test4; sleep 2; oc projects' 'You have one project on this server: "test4".'
 os::cmd::expect_success_and_text 'oc new-project test5; sleep 2; oc projects' 'You have access'
+# test --skip-config-write
+os::cmd::expect_success_and_text 'oc new-project test6 --skip-config-write' 'To switch to this project and start adding applications, use'
+os::cmd::expect_failure 'oc config view | grep "namespace: test6"'
+os::cmd::expect_success 'sleep 2; oc projects | grep test6'
+os::cmd::expect_success_and_text 'oc project test6' 'Now using project "test6"'
+os::cmd::expect_success 'oc config view | grep "namespace: test6"'
 echo 'projects command ok'
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/9979.

By using the `--skip-config-write` flag to skip the kubeconfig load and write, `oc new-project` will only call the REST API to create the project and exit. The command runs much faster, which is useful when creating multiple projects in a batch.