### PR TITLE
Add scope representing full user permissions, default token requests with unspecified scope

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -33,6 +33,7 @@ import (
 	image "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/docker10"
 	"github.com/openshift/origin/pkg/image/api/dockerpre012"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	quotaapi "github.com/openshift/origin/pkg/quota/api"
 	quotaapiv1 "github.com/openshift/origin/pkg/quota/api/v1"
 	route "github.com/openshift/origin/pkg/route/api"
@@ -416,6 +417,12 @@ func fuzzInternalObject(t *testing.T, forVersion unversioned.GroupVersion, item 
 			c.FuzzNoCustom(j)
 			j.Spec.Template.Spec.InitContainers = nil
 			j.Status.Template.Spec.InitContainers = nil
+		},
+		func(j *oauthapi.OAuthClientAuthorization, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			if len(j.Scopes) == 0 {
+				j.Scopes = append(j.Scopes, "user:full")
+			}
 		},
 
 		func(j *runtime.Object, c fuzz.Continue) {

--- a/pkg/auth/oauth/handlers/authenticator.go
+++ b/pkg/auth/oauth/handlers/authenticator.go
@@ -26,7 +26,7 @@ func NewAuthorizeAuthenticator(request authenticator.Request, handler Authentica
 // HandleAuthorize implements osinserver.AuthorizeHandler to ensure the AuthorizeRequest is authenticated.
 // If the request is authenticated, UserData and Authorized are set and false is returned.
 // If the request is not authenticated, the auth handler is called and the request is not authorized
-func (h *AuthorizeAuthenticator) HandleAuthorize(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+func (h *AuthorizeAuthenticator) HandleAuthorize(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 	info, ok, err := h.request.AuthenticateRequest(ar.HttpRequest)
 	if err != nil {
 		glog.V(4).Infof("OAuth authentication error: %v", err)

--- a/pkg/auth/oauth/registry/registry_test.go
+++ b/pkg/auth/oauth/registry/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RangelReale/osin"
 	"github.com/RangelReale/osincli"
 	kapi "k8s.io/kubernetes/pkg/api"
 	apierrs "k8s.io/kubernetes/pkg/api/errors"
@@ -25,6 +26,8 @@ import (
 )
 
 type testHandlers struct {
+	AuthorizeHandler osinserver.AuthorizeHandler
+
 	User         user.Info
 	Authenticate bool
 	Err          error
@@ -32,6 +35,11 @@ type testHandlers struct {
 	AuthErr      error
 	GrantNeed    bool
 	GrantErr     error
+
+	HandleAuthorizeReq     *osin.AuthorizeRequest
+	HandleAuthorizeResp    *osin.Response
+	HandleAuthorizeHandled bool
+	HandleAuthorizeErr     error
 
 	AuthNeedHandled bool
 	AuthNeedErr     error
@@ -41,6 +49,13 @@ type testHandlers struct {
 	GrantNeedErr     error
 
 	HandledErr error
+}
+
+func (h *testHandlers) HandleAuthorize(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (handled bool, err error) {
+	h.HandleAuthorizeReq = ar
+	h.HandleAuthorizeResp = resp
+	h.HandleAuthorizeHandled, h.HandleAuthorizeErr = h.AuthorizeHandler.HandleAuthorize(ar, resp, w)
+	return h.HandleAuthorizeHandled, h.HandleAuthorizeErr
 }
 
 func (h *testHandlers) AuthenticationNeeded(client api.Client, w http.ResponseWriter, req *http.Request) (bool, error) {
@@ -82,9 +97,14 @@ func TestRegistryAndServer(t *testing.T) {
 		Secret:       "secret",
 		RedirectURIs: []string{assertServer.URL + "/assert"},
 	}
-	validClientAuth := &oapi.OAuthClientAuthorization{
-		UserName:   "user",
-		ClientName: "test",
+
+	restrictedClient := &oapi.OAuthClient{
+		ObjectMeta:   kapi.ObjectMeta{Name: "test"},
+		Secret:       "secret",
+		RedirectURIs: []string{assertServer.URL + "/assert"},
+		ScopeRestrictions: []oapi.ScopeRestriction{
+			{ExactValues: []string{"user:info"}},
+		},
 	}
 
 	testCases := map[string]struct {
@@ -98,7 +118,7 @@ func TestRegistryAndServer(t *testing.T) {
 		"needs auth": {
 			Client: validClient,
 			Check: func(h *testHandlers, _ *http.Request) {
-				if !h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil {
+				if !h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || h.HandleAuthorizeReq.Authorized {
 					t.Errorf("expected request to need authentication: %#v", h)
 				}
 			},
@@ -110,8 +130,34 @@ func TestRegistryAndServer(t *testing.T) {
 				Name: "user",
 			},
 			Check: func(h *testHandlers, _ *http.Request) {
-				if h.AuthNeed || !h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil {
+				if h.AuthNeed || !h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || h.HandleAuthorizeReq.Authorized {
 					t.Errorf("expected request to need to grant access: %#v", h)
+				}
+			},
+		},
+		"invalid scope": {
+			Client:      validClient,
+			AuthSuccess: true,
+			AuthUser: &user.DefaultInfo{
+				Name: "user",
+			},
+			Scope: "some-scope",
+			Check: func(h *testHandlers, _ *http.Request) {
+				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || h.HandleAuthorizeReq.Authorized || h.HandleAuthorizeResp.ErrorId != "invalid_scope" {
+					t.Errorf("expected invalid_scope error: %#v, %#v, %#v", h, h.HandleAuthorizeReq, h.HandleAuthorizeResp)
+				}
+			},
+		},
+		"disallowed scope": {
+			Client:      restrictedClient,
+			AuthSuccess: true,
+			AuthUser: &user.DefaultInfo{
+				Name: "user",
+			},
+			Scope: "user:full",
+			Check: func(h *testHandlers, _ *http.Request) {
+				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || h.HandleAuthorizeReq.Authorized || h.HandleAuthorizeResp.ErrorId != "access_denied" {
+					t.Errorf("expected access_denied error: %#v, %#v, %#v", h, h.HandleAuthorizeReq, h.HandleAuthorizeResp)
 				}
 			},
 		},
@@ -124,11 +170,11 @@ func TestRegistryAndServer(t *testing.T) {
 			ClientAuth: &oapi.OAuthClientAuthorization{
 				UserName:   "user",
 				ClientName: "test",
-				Scopes:     []string{"test"},
+				Scopes:     []string{"user:info"},
 			},
-			Scope: "test other",
+			Scope: "user:info user:check-access",
 			Check: func(h *testHandlers, req *http.Request) {
-				if h.AuthNeed || !h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil {
+				if h.AuthNeed || !h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || h.HandleAuthorizeReq.Authorized {
 					t.Errorf("expected request to need to grant access because of uncovered scopes: %#v", h)
 				}
 			},
@@ -142,12 +188,12 @@ func TestRegistryAndServer(t *testing.T) {
 			ClientAuth: &oapi.OAuthClientAuthorization{
 				UserName:   "user",
 				ClientName: "test",
-				Scopes:     []string{"test", "other"},
+				Scopes:     []string{"user:info", "user:check-access"},
 			},
-			Scope: "test other",
+			Scope: "user:info user:check-access",
 			Check: func(h *testHandlers, req *http.Request) {
-				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil {
-					t.Errorf("unexpected flow: %#v", h)
+				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || !h.HandleAuthorizeReq.Authorized || h.HandleAuthorizeResp.ErrorId != "" {
+					t.Errorf("unexpected flow: %#v, %#v, %#v", h, h.HandleAuthorizeReq, h.HandleAuthorizeResp)
 				}
 			},
 		},
@@ -157,10 +203,14 @@ func TestRegistryAndServer(t *testing.T) {
 			AuthUser: &user.DefaultInfo{
 				Name: "user",
 			},
-			ClientAuth: validClientAuth,
+			ClientAuth: &oapi.OAuthClientAuthorization{
+				UserName:   "user",
+				ClientName: "test",
+				Scopes:     []string{"user:full"},
+			},
 			Check: func(h *testHandlers, req *http.Request) {
-				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil {
-					t.Errorf("unexpected flow: %#v", h)
+				if h.AuthNeed || h.GrantNeed || h.AuthErr != nil || h.GrantErr != nil || !h.HandleAuthorizeReq.Authorized || h.HandleAuthorizeResp.ErrorId != "" {
+					t.Errorf("unexpected flow: %#v, %#v, %#v", h, h.HandleAuthorizeReq, h.HandleAuthorizeResp)
 					return
 				}
 				if req == nil {
@@ -193,21 +243,24 @@ func TestRegistryAndServer(t *testing.T) {
 		}
 		storage := registrystorage.New(access, authorize, client, NewUserConversion())
 		config := osinserver.NewDefaultServerConfig()
+
+		h.AuthorizeHandler = osinserver.AuthorizeHandlers{
+			handlers.NewAuthorizeAuthenticator(
+				h,
+				h,
+				h,
+			),
+			handlers.NewGrantCheck(
+				NewClientAuthorizationGrantChecker(grant),
+				h,
+				h,
+			),
+		}
+
 		server := osinserver.New(
 			config,
 			storage,
-			osinserver.AuthorizeHandlers{
-				handlers.NewAuthorizeAuthenticator(
-					h,
-					h,
-					h,
-				),
-				handlers.NewGrantCheck(
-					NewClientAuthorizationGrantChecker(grant),
-					h,
-					h,
-				),
-			},
+			h,
 			osinserver.AccessHandlers{
 				handlers.NewDenyAccessAuthenticator(),
 			},

--- a/pkg/authorization/authorizer/scope/authorizer_test.go
+++ b/pkg/authorization/authorizer/scope/authorizer_test.go
@@ -72,6 +72,18 @@ func TestAuthorize(t *testing.T) {
 			attributes:     defaultauthorizer.DefaultAuthorizationAttributes{Verb: "get", NonResourceURL: true, URL: "/api"},
 			expectedCalled: true,
 		},
+		{
+			name:           "user:full covers any resource",
+			user:           &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:full"}}},
+			attributes:     defaultauthorizer.DefaultAuthorizationAttributes{Verb: "update", Resource: "users", ResourceName: "harold"},
+			expectedCalled: true,
+		},
+		{
+			name:           "user:full covers any non-resource",
+			user:           &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:full"}}},
+			attributes:     defaultauthorizer.DefaultAuthorizationAttributes{Verb: "post", NonResourceURL: true, URL: "/foo/bar/baz"},
+			expectedCalled: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -33,28 +33,28 @@ func TestUserEvaluator(t *testing.T) {
 		},
 		{
 			name:     "info",
-			scopes:   []string{UserIndicator + UserInfo},
+			scopes:   []string{UserInfo},
 			numRules: 2,
 		},
 		{
 			name:     "one-error",
-			scopes:   []string{UserIndicator, UserIndicator + UserInfo},
+			scopes:   []string{UserIndicator, UserInfo},
 			err:      "unrecognized scope",
 			numRules: 2,
 		},
 		{
 			name:     "access",
-			scopes:   []string{UserIndicator + UserAccessCheck},
+			scopes:   []string{UserAccessCheck},
 			numRules: 3,
 		},
 		{
 			name:     "both",
-			scopes:   []string{UserIndicator + UserInfo, UserIndicator + UserAccessCheck},
+			scopes:   []string{UserInfo, UserAccessCheck},
 			numRules: 4,
 		},
 		{
 			name:     "list-projects",
-			scopes:   []string{UserIndicator + UserListProject},
+			scopes:   []string{UserListProject},
 			numRules: 2,
 		},
 	}

--- a/pkg/client/oauthclientauthorization.go
+++ b/pkg/client/oauthclientauthorization.go
@@ -15,6 +15,7 @@ type OAuthClientAuthorizationInterface interface {
 	Create(obj *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error)
 	List(opts kapi.ListOptions) (*oauthapi.OAuthClientAuthorizationList, error)
 	Get(name string) (*oauthapi.OAuthClientAuthorization, error)
+	Update(obj *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error)
 	Delete(name string) error
 	Watch(opts kapi.ListOptions) (watch.Interface, error)
 }
@@ -32,6 +33,12 @@ func newOAuthClientAuthorizations(c *Client) *oauthClientAuthorizations {
 func (c *oauthClientAuthorizations) Create(obj *oauthapi.OAuthClientAuthorization) (result *oauthapi.OAuthClientAuthorization, err error) {
 	result = &oauthapi.OAuthClientAuthorization{}
 	err = c.r.Post().Resource("oAuthClientAuthorizations").Body(obj).Do().Into(result)
+	return
+}
+
+func (c *oauthClientAuthorizations) Update(obj *oauthapi.OAuthClientAuthorization) (result *oauthapi.OAuthClientAuthorization, err error) {
+	result = &oauthapi.OAuthClientAuthorization{}
+	err = c.r.Put().Resource("oAuthClientAuthorizations").Name(obj.Name).Body(obj).Do().Into(result)
 	return
 }
 

--- a/pkg/client/testclient/fake_oauthclientauthorization.go
+++ b/pkg/client/testclient/fake_oauthclientauthorization.go
@@ -39,6 +39,15 @@ func (c *FakeOAuthClientAuthorization) Create(inObj *oauthapi.OAuthClientAuthori
 	return obj.(*oauthapi.OAuthClientAuthorization), err
 }
 
+func (c *FakeOAuthClientAuthorization) Update(inObj *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootUpdateAction("oauthClientAuthorizations", inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*oauthapi.OAuthClientAuthorization), err
+}
+
 func (c *FakeOAuthClientAuthorization) Delete(name string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("oauthClientAuthorizations", name), &oauthapi.OAuthClientAuthorization{})
 	return err

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -370,14 +370,14 @@ func (c *AuthConfig) getGrantHandler(mux cmdutil.Mux, auth authenticator.Request
 func (c *AuthConfig) getAuthenticationFinalizer() osinserver.AuthorizeHandler {
 	if c.SessionAuth != nil {
 		// The session needs to know the authorize flow is done so it can invalidate the session
-		return osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+		return osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 			_ = c.SessionAuth.InvalidateAuthentication(w, ar.HttpRequest)
 			return false, nil
 		})
 	}
 
 	// Otherwise return a no-op finalizer
-	return osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+	return osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 		return false, nil
 	})
 }

--- a/pkg/oauth/server/osinserver/osinserver.go
+++ b/pkg/oauth/server/osinserver/osinserver.go
@@ -82,7 +82,7 @@ func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 
 		} else {
 
-			handled, err := s.authorize.HandleAuthorize(ar, w)
+			handled, err := s.authorize.HandleAuthorize(ar, resp, w)
 			if err != nil {
 				s.errorHandler.HandleError(err, w, r)
 				return

--- a/pkg/oauth/server/osinserver/osinserver_test.go
+++ b/pkg/oauth/server/osinserver/osinserver_test.go
@@ -22,7 +22,7 @@ func TestClientCredentialFlow(t *testing.T) {
 	oauthServer := New(
 		NewDefaultServerConfig(),
 		storage,
-		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 			ar.Authorized = true
 			return false, nil
 		}),
@@ -65,7 +65,7 @@ func TestAuthorizeStartFlow(t *testing.T) {
 	oauthServer := New(
 		NewDefaultServerConfig(),
 		storage,
-		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 			ar.Authorized = true
 			return false, nil
 		}),

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
@@ -83,7 +83,7 @@ func (a *saOAuthClientAdapter) GetClient(ctx kapi.Context, name string) (*oautha
 
 func getScopeRestrictionsFor(namespace, name string) []oauthapi.ScopeRestriction {
 	return []oauthapi.ScopeRestriction{
-		{ExactValues: []string{scopeauthorizer.UserIndicator + scopeauthorizer.UserInfo, scopeauthorizer.UserIndicator + scopeauthorizer.UserAccessCheck}},
+		{ExactValues: []string{scopeauthorizer.UserInfo, scopeauthorizer.UserAccessCheck}},
 		{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{RoleNames: []string{"*"}, Namespaces: []string{namespace}, AllowEscalation: true}},
 	}
 }

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -82,7 +82,7 @@ func TestNodeAuth(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
 		ClientName: origin.OpenShiftCLIClientID,
 		ExpiresIn:  200,
-		Scopes:     []string{scope.UserIndicator + scope.UserInfo},
+		Scopes:     []string{scope.UserInfo},
 		UserName:   bobUser.Name,
 		UserUID:    string(bobUser.UID),
 	}

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -86,7 +86,7 @@ func TestOAuthStorage(t *testing.T) {
 	oauthServer := osinserver.New(
 		osinserver.NewDefaultServerConfig(),
 		storage,
-		osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
+		osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, resp *osin.Response, w http.ResponseWriter) (bool, error) {
 			ar.UserData = "test"
 			ar.Authorized = true
 			return false, nil

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -58,7 +58,7 @@ func TestScopedTokens(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
 		ClientName: origin.OpenShiftCLIClientID,
 		ExpiresIn:  200,
-		Scopes:     []string{scope.UserIndicator + scope.UserInfo},
+		Scopes:     []string{scope.UserInfo},
 		UserName:   userName,
 		UserUID:    string(haroldUser.UID),
 	}

--- a/test/util/html/form.go
+++ b/test/util/html/form.go
@@ -1,0 +1,119 @@
+package html
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+func visit(n *html.Node, visitor func(*html.Node)) {
+	visitor(n)
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		visit(c, visitor)
+	}
+}
+
+func GetElementsByTagName(root *html.Node, tagName string) []*html.Node {
+	elements := []*html.Node{}
+	visit(root, func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == tagName {
+			elements = append(elements, n)
+		}
+	})
+	return elements
+}
+
+func GetAttr(element *html.Node, attrName string) (string, bool) {
+	for _, attr := range element.Attr {
+		if attr.Key == attrName {
+			return attr.Val, true
+		}
+	}
+	return "", false
+}
+
+// NewRequestFromForm builds a request that simulates submitting the given form. It honors:
+// Form method (defaults to GET)
+// Form action (defaults to currentURL if missing, or currentURL's scheme/host if server-relative)
+// <input name="..." value="..."> values (only the first type="submit" input's value is included)
+func NewRequestFromForm(form *html.Node, currentURL *url.URL) (*http.Request, error) {
+	var (
+		reqMethod string
+		reqURL    *url.URL
+		reqBody   io.Reader
+		reqHeader http.Header = http.Header{}
+		err       error
+	)
+
+	// Method defaults to GET if empty
+	if method, _ := GetAttr(form, "method"); len(method) > 0 {
+		reqMethod = strings.ToUpper(method)
+	} else {
+		reqMethod = "GET"
+	}
+
+	// URL defaults to current URL if empty
+	if action, _ := GetAttr(form, "action"); len(action) > 0 {
+		reqURL, err = url.Parse(action)
+		if err != nil {
+			return nil, err
+		}
+		if reqURL.Scheme == "" {
+			reqURL.Scheme = currentURL.Scheme
+		}
+		if reqURL.Host == "" {
+			reqURL.Host = currentURL.Host
+		}
+	} else {
+		reqURL, err = url.Parse(currentURL.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	formData := url.Values{}
+	if reqMethod == "GET" {
+		// Start with any existing query params when we're submitting via GET
+		formData = reqURL.Query()
+	}
+	addedSubmit := false
+	for _, input := range GetElementsByTagName(form, "input") {
+		if name, ok := GetAttr(input, "name"); ok {
+			if value, ok := GetAttr(input, "value"); ok {
+				// Check if this is a submit input
+				if inputType, _ := GetAttr(input, "type"); inputType == "submit" {
+					// Only add the value of the first one.
+					// We're simulating submitting the form.
+					if addedSubmit {
+						continue
+					}
+					// Remember we've added a submit input
+					addedSubmit = true
+				}
+				formData.Add(name, value)
+			}
+		}
+	}
+
+	switch reqMethod {
+	case "GET":
+		reqURL.RawQuery = formData.Encode()
+	case "POST":
+		reqHeader.Set("Content-Type", "application/x-www-form-urlencoded")
+		reqBody = strings.NewReader(formData.Encode())
+	default:
+		return nil, fmt.Errorf("unknown method: %s", reqMethod)
+	}
+
+	req, err := http.NewRequest(reqMethod, reqURL.String(), reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = reqHeader
+	return req, nil
+
+}

--- a/test/util/html/form_test.go
+++ b/test/util/html/form_test.go
@@ -1,0 +1,131 @@
+package html
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+const (
+	sampleGetForm = `
+<html>
+<body>
+    <form id="1">
+        <input id="i1-1" name="a" value="av">
+        <input id="i1-2" type="submit" name="sa" value="sav">
+        <input id="i1-3" type="submit" name="sb" value="sbv">
+    </form>
+    <form id="2">
+        <input id="i2-1" name="c" value="cv">
+        <input id="i2-2" type="submit" name="sc" value="scv">
+        <input id="i2-3" type="submit" name="sd" value="sdv">
+    </form>
+</body>
+</html>
+`
+
+	samplePostForm = `
+<html>
+<body>
+    <form id="1" action="/test" method="post">
+        <input id="i1-1" name="a" value="av">
+        <input id="i1-2" type="submit" name="sa" value="sav">
+        <input id="i1-3" type="submit" name="sb" value="sbv">
+    </form>
+    <form id="2">
+        <input id="i2-1" name="c" value="cv">
+        <input id="i2-2" type="submit" name="sc" value="scv">
+        <input id="i2-3" type="submit" name="sd" value="sdv">
+    </form>
+</body>
+</html>
+`
+)
+
+func TestGetElementsByTagName(t *testing.T) {
+	tests := []struct {
+		Data        string
+		TagName     string
+		ExpectedIds []string
+	}{
+		{
+			Data:        sampleGetForm,
+			TagName:     `form`,
+			ExpectedIds: []string{"1", "2"},
+		},
+		{
+			Data:        sampleGetForm,
+			TagName:     `input`,
+			ExpectedIds: []string{"i1-1", "i1-2", "i1-3", "i2-1", "i2-2", "i2-3"},
+		},
+	}
+
+	for i, tc := range tests {
+		root, err := html.Parse(strings.NewReader(tc.Data))
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+			continue
+		}
+		elements := GetElementsByTagName(root, tc.TagName)
+		ids := []string{}
+		for _, e := range elements {
+			id, _ := GetAttr(e, "id")
+			ids = append(ids, id)
+		}
+		if !reflect.DeepEqual(tc.ExpectedIds, ids) {
+			t.Errorf("%d: expected %#v, got %#v", i, tc.ExpectedIds, ids)
+			continue
+		}
+	}
+}
+
+func TestNewRequestFromForm(t *testing.T) {
+
+	currentURL, _ := url.Parse("https://localhost:1234")
+
+	relativeGetReq, _ := http.NewRequest("GET", "https://localhost:1234?a=av&sa=sav", nil)
+
+	relativePostReq, _ := http.NewRequest("POST", "https://localhost:1234/test", strings.NewReader(url.Values{
+		"a":  []string{"av"},
+		"sa": []string{"sav"},
+	}.Encode()))
+	relativePostReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	tests := []struct {
+		Data            string
+		CurrentURL      *url.URL
+		ExpectedRequest *http.Request
+	}{
+		{
+			Data:            sampleGetForm,
+			CurrentURL:      currentURL,
+			ExpectedRequest: relativeGetReq,
+		},
+		{
+			Data:            samplePostForm,
+			CurrentURL:      currentURL,
+			ExpectedRequest: relativePostReq,
+		},
+	}
+
+	for i, tc := range tests {
+		root, err := html.Parse(strings.NewReader(tc.Data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		forms := GetElementsByTagName(root, "form")
+		req, err := NewRequestFromForm(forms[0], tc.CurrentURL)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(tc.ExpectedRequest, req) {
+			t.Errorf("%d: expected\n%#v\ngot\n%#v", i, tc.ExpectedRequest, req)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1359035

Default token authorization requests that do not specify a scope to a `user:full` scope which includes all of the user's powers.

- [ ] doc PR for new scope