### PR TITLE
Add builds/status and buildconfigs/status subresource

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -1198,6 +1198,171 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/buildconfigs/{name}/status",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.BuildConfig",
+      "method": "GET",
+      "summary": "read status of the specified BuildConfig",
+      "nickname": "readNamespacedBuildConfigStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the BuildConfig",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.BuildConfig"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.BuildConfig",
+      "method": "PUT",
+      "summary": "replace status of the specified BuildConfig",
+      "nickname": "replaceNamespacedBuildConfigStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.BuildConfig",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the BuildConfig",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.BuildConfig"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.BuildConfig",
+      "method": "PATCH",
+      "summary": "partially update status of the specified BuildConfig",
+      "nickname": "patchNamespacedBuildConfigStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the BuildConfig",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.BuildConfig"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/namespaces/{namespace}/buildconfigs/{name}/webhooks",
     "description": "OpenShift REST API, version v1",
     "operations": [
@@ -2181,6 +2346,53 @@
     "operations": [
      {
       "type": "v1.Build",
+      "method": "GET",
+      "summary": "read details of the specified Build",
+      "nickname": "readNamespacedBuildDetails",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Build",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Build"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Build",
       "method": "PUT",
       "summary": "replace details of the specified Build",
       "nickname": "replaceNamespacedBuildDetails",
@@ -2232,6 +2444,63 @@
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.Build",
+      "method": "PATCH",
+      "summary": "partially update details of the specified Build",
+      "nickname": "patchNamespacedBuildDetails",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Build",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Build"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -2365,6 +2634,171 @@
       ],
       "consumes": [
        "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/namespaces/{namespace}/builds/{name}/status",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.Build",
+      "method": "GET",
+      "summary": "read status of the specified Build",
+      "nickname": "readNamespacedBuildStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Build",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Build"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Build",
+      "method": "PUT",
+      "summary": "replace status of the specified Build",
+      "nickname": "replaceNamespacedBuildStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.Build",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Build",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Build"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Build",
+      "method": "PATCH",
+      "summary": "partially update status of the specified Build",
+      "nickname": "patchNamespacedBuildStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Build",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Build"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]

--- a/pkg/build/admission/strategyrestrictions/admission.go
+++ b/pkg/build/admission/strategyrestrictions/admission.go
@@ -46,6 +46,11 @@ func (a *buildByStrategy) Admit(attr admission.Attributes) error {
 	if resource := attr.GetResource().GroupResource(); resource != buildsResource && resource != buildConfigsResource {
 		return nil
 	}
+	// Explicitly exclude the builds/status and buildconfigs/status subresource because they
+	// cannot be used to change the build type
+	if attr.GetSubresource() == "status" {
+		return nil
+	}
 	// Explicitly exclude the builds/details subresource because it's only
 	// updating commit info and cannot change build type.
 	if attr.GetResource().GroupResource() == buildsResource && attr.GetSubresource() == "details" {

--- a/pkg/build/admission/strategyrestrictions/admission_test.go
+++ b/pkg/build/admission/strategyrestrictions/admission_test.go
@@ -43,6 +43,15 @@ func TestBuildAdmission(t *testing.T) {
 			expectAccept:     true,
 		},
 		{
+			name:           "allowed build status",
+			object:         testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
+			kind:           buildapi.Kind("Build"),
+			resource:       buildsResource,
+			subResource:    "status",
+			reviewResponse: reviewResponse(false, "cannot create buildconfig of type source"),
+			expectAccept:   true,
+		},
+		{
 			name:             "allowed source build clone",
 			object:           testBuildRequest("buildname"),
 			responseObject:   testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
@@ -90,6 +99,15 @@ func TestBuildAdmission(t *testing.T) {
 			reviewResponse:   reviewResponse(true, ""),
 			expectAccept:     true,
 			expectedResource: authorizationapi.DockerBuildResource,
+		},
+		{
+			name:           "allowed build config status",
+			object:         testBuildConfig(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
+			kind:           buildapi.Kind("BuildConfig"),
+			resource:       buildConfigsResource,
+			subResource:    "status",
+			reviewResponse: reviewResponse(false, "cannot create buildconfig of type source"),
+			expectAccept:   true,
 		},
 		{
 			name:             "allowed build config instantiate",

--- a/pkg/build/api/deep_copy_generated.go
+++ b/pkg/build/api/deep_copy_generated.go
@@ -415,6 +415,7 @@ func DeepCopy_api_BuildSpec(in BuildSpec, out *BuildSpec, c *conversion.Cloner) 
 	if err := DeepCopy_api_CommonSpec(in.CommonSpec, &out.CommonSpec, c); err != nil {
 		return err
 	}
+	out.Cancelled = in.Cancelled
 	if in.TriggeredBy != nil {
 		in, out := in.TriggeredBy, &out.TriggeredBy
 		*out = make([]BuildTriggerCause, len(in))
@@ -431,7 +432,6 @@ func DeepCopy_api_BuildSpec(in BuildSpec, out *BuildSpec, c *conversion.Cloner) 
 
 func DeepCopy_api_BuildStatus(in BuildStatus, out *BuildStatus, c *conversion.Cloner) error {
 	out.Phase = in.Phase
-	out.Cancelled = in.Cancelled
 	out.Reason = in.Reason
 	out.Message = in.Message
 	if in.StartTimestamp != nil {

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -67,6 +67,10 @@ type Build struct {
 type BuildSpec struct {
 	CommonSpec
 
+	// Cancelled describes if a cancel event was triggered for the build.
+	// +genconversion=false
+	Cancelled bool
+
 	// TriggeredBy describes which triggers started the most recent update to the
 	// build configuration and contains information about those triggers.
 	TriggeredBy []BuildTriggerCause
@@ -166,9 +170,6 @@ type ImageChangeCause struct {
 type BuildStatus struct {
 	// Phase is the point in the build lifecycle.
 	Phase BuildPhase
-
-	// Cancelled describes if a cancel event was triggered for the build.
-	Cancelled bool
 
 	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
 	Reason StatusReason

--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -10,6 +10,22 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
+func Convert_api_Build_To_v1_Build(in *newer.Build, out *Build, s conversion.Scope) error {
+	if err := autoConvert_api_Build_To_v1_Build(in, out, s); err != nil {
+		return err
+	}
+	out.Status.Cancelled = in.Spec.Cancelled
+	return nil
+}
+
+func Convert_v1_Build_To_api_Build(in *Build, out *newer.Build, s conversion.Scope) error {
+	if err := autoConvert_v1_Build_To_api_Build(in, out, s); err != nil {
+		return err
+	}
+	out.Spec.Cancelled = in.Status.Cancelled
+	return nil
+}
+
 func Convert_v1_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *newer.BuildConfig, s conversion.Scope) error {
 	if err := autoConvert_v1_BuildConfig_To_api_BuildConfig(in, out, s); err != nil {
 		return err
@@ -170,6 +186,8 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_api_BuildSource_To_v1_BuildSource,
 		Convert_v1_BuildStrategy_To_api_BuildStrategy,
 		Convert_api_BuildStrategy_To_v1_BuildStrategy,
+		Convert_api_Build_To_v1_Build,
+		Convert_v1_Build_To_api_Build,
 	)
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Build",

--- a/pkg/build/api/v1/conversion_generated.go
+++ b/pkg/build/api/v1/conversion_generated.go
@@ -172,10 +172,6 @@ func autoConvert_v1_Build_To_api_Build(in *Build, out *build_api.Build, s conver
 	return nil
 }
 
-func Convert_v1_Build_To_api_Build(in *Build, out *build_api.Build, s conversion.Scope) error {
-	return autoConvert_v1_Build_To_api_Build(in, out, s)
-}
-
 func autoConvert_api_Build_To_v1_Build(in *build_api.Build, out *Build, s conversion.Scope) error {
 	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
@@ -190,10 +186,6 @@ func autoConvert_api_Build_To_v1_Build(in *build_api.Build, out *Build, s conver
 		return err
 	}
 	return nil
-}
-
-func Convert_api_Build_To_v1_Build(in *build_api.Build, out *Build, s conversion.Scope) error {
-	return autoConvert_api_Build_To_v1_Build(in, out, s)
 }
 
 func autoConvert_v1_BuildConfig_To_api_BuildConfig(in *BuildConfig, out *build_api.BuildConfig, s conversion.Scope) error {
@@ -838,7 +830,6 @@ func Convert_api_BuildSpec_To_v1_BuildSpec(in *build_api.BuildSpec, out *BuildSp
 
 func autoConvert_v1_BuildStatus_To_api_BuildStatus(in *BuildStatus, out *build_api.BuildStatus, s conversion.Scope) error {
 	out.Phase = build_api.BuildPhase(in.Phase)
-	out.Cancelled = in.Cancelled
 	out.Reason = build_api.StatusReason(in.Reason)
 	out.Message = in.Message
 	out.StartTimestamp = in.StartTimestamp
@@ -863,7 +854,6 @@ func Convert_v1_BuildStatus_To_api_BuildStatus(in *BuildStatus, out *build_api.B
 
 func autoConvert_api_BuildStatus_To_v1_BuildStatus(in *build_api.BuildStatus, out *BuildStatus, s conversion.Scope) error {
 	out.Phase = BuildPhase(in.Phase)
-	out.Cancelled = in.Cancelled
 	out.Reason = StatusReason(in.Reason)
 	out.Message = in.Message
 	out.StartTimestamp = in.StartTimestamp

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -127,6 +127,7 @@ type BuildStatus struct {
 	Phase BuildPhase `json:"phase" protobuf:"bytes,1,opt,name=phase,casttype=BuildPhase"`
 
 	// cancelled describes if a cancel event was triggered for the build.
+	// +genconversion=false
 	Cancelled bool `json:"cancelled,omitempty" protobuf:"varint,2,opt,name=cancelled"`
 
 	// reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -13,8 +13,8 @@ import (
 	_ "github.com/openshift/origin/pkg/build/api/install"
 )
 
-func TestBuildValidationSuccess(t *testing.T) {
-	build := &buildapi.Build{
+func testBuild() *buildapi.Build {
+	return &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{
@@ -39,8 +39,63 @@ func TestBuildValidationSuccess(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
+}
+
+func TestBuildValidationSuccess(t *testing.T) {
+	build := testBuild()
 	if result := ValidateBuild(build); len(result) > 0 {
 		t.Errorf("Unexpected validation error returned %v", result)
+	}
+}
+
+func TestValidateBuildDetailsUpdate(t *testing.T) {
+	older := testBuild()
+	newer := testBuild()
+
+	// Ensure that revision update is not allowed when already set
+	older.Spec.CommonSpec.Revision = &buildapi.SourceRevision{}
+	newer.Spec.CommonSpec.Revision = &buildapi.SourceRevision{}
+	errs := ValidateBuildDetailsUpdate(newer, older)
+	if len(errs) == 0 {
+		t.Errorf("no error returned when a revision already exists")
+	}
+
+	// Ensure that an update is not allowed with null revision
+	older.Spec.CommonSpec.Revision = nil
+	newer.Spec.CommonSpec.Revision = nil
+	errs = ValidateBuildDetailsUpdate(newer, older)
+	if len(errs) == 0 {
+		t.Errorf("no error returned when newer doesn't include a revision")
+	}
+
+	// Ensure that a valid update is allowed
+	older.Spec.CommonSpec.Revision = nil
+	newer.Spec.CommonSpec.Revision = &buildapi.SourceRevision{}
+	errs = ValidateBuildDetailsUpdate(newer, older)
+	if len(errs) != 0 {
+		t.Errorf("expected no error, got: %v", errs)
+	}
+}
+
+func TestValidateBuildStatusUpdate(t *testing.T) {
+	older := testBuild()
+	newer := testBuild()
+
+	// Ensure that a change to the cancelled flag is not allowed through a status update
+	older.Status.Cancelled = false
+	newer.Status.Cancelled = true
+	errs := ValidateBuildStatusUpdate(newer, older)
+	if len(errs) == 0 {
+		t.Errorf("no error returned when changing cancelled flag on build status update")
+	}
+
+	// Ensure that a valid status update is allowed
+	older.Status.Cancelled = false
+	newer.Status.Cancelled = false
+	newer.Status.Phase = buildapi.BuildPhaseComplete
+	errs = ValidateBuildStatusUpdate(newer, older)
+	if len(errs) > 0 {
+		t.Errorf("expected no error, got: %v", errs)
 	}
 }
 
@@ -2508,6 +2563,259 @@ func TestDiffBuildSpec(t *testing.T) {
 		}
 		if diff != test.expected {
 			t.Errorf("%s: expected: %s, got: %s", test.name, test.expected, diff)
+		}
+	}
+}
+
+func TestBuildStatusUpdateValidation(t *testing.T) {
+	testBC := func() *buildapi.BuildConfig {
+		obj := &buildapi.BuildConfig{}
+		obj.Name = "buildconfig"
+		obj.Namespace = "test"
+		obj.Spec.CommonSpec.Source.Git = &buildapi.GitBuildSource{
+			URI: "https://github.com/test/source.git",
+		}
+		return obj
+	}
+	addGeneric := func(bc *buildapi.BuildConfig, secret string, allowEnv bool) {
+		bc.Spec.Triggers = append(bc.Spec.Triggers, buildapi.BuildTriggerPolicy{
+			Type: buildapi.GenericWebHookBuildTriggerType,
+			GenericWebHook: &buildapi.WebHookTrigger{
+				Secret:   secret,
+				AllowEnv: allowEnv,
+			},
+		})
+	}
+	addGithub := func(bc *buildapi.BuildConfig, secret string, allowEnv bool) {
+		bc.Spec.Triggers = append(bc.Spec.Triggers, buildapi.BuildTriggerPolicy{
+			Type: buildapi.GitHubWebHookBuildTriggerType,
+			GitHubWebHook: &buildapi.WebHookTrigger{
+				Secret:   secret,
+				AllowEnv: allowEnv,
+			},
+		})
+	}
+	addImage := func(bc *buildapi.BuildConfig, from *kapi.ObjectReference, lastTriggeredID string) {
+		bc.Spec.Triggers = append(bc.Spec.Triggers, buildapi.BuildTriggerPolicy{
+			Type: buildapi.ImageChangeBuildTriggerType,
+			ImageChange: &buildapi.ImageChangeTrigger{
+				From:                 from,
+				LastTriggeredImageID: lastTriggeredID,
+			},
+		})
+	}
+	image := func(kind string, namespace string, name string) *kapi.ObjectReference {
+		return &kapi.ObjectReference{
+			Name:      name,
+			Namespace: namespace,
+			Kind:      kind,
+		}
+	}
+	tests := []struct {
+		name            string
+		older           func() *buildapi.BuildConfig
+		newer           func() *buildapi.BuildConfig
+		expectError     bool
+		expectErrorType field.ErrorType
+		expectErrorPath string
+	}{
+		{
+			name: "valid bc with same triggers",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "githubsecret", true)
+				addImage(bc, image("ImageStreamTag", "", "test:tag"), "")
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "githubsecret", true)
+				addImage(bc, image("ImageStreamTag", "", "test:tag"), "")
+				return bc
+			},
+		},
+		{
+			name: "invalid with different trigger length",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "secret2", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid with different trigger type",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addImage(bc, image("ImageStreamTag", "", "test:tag"), "")
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, null generic",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				bc.Spec.Triggers[0].GenericWebHook = nil
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, null github",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", false)
+				bc.Spec.Triggers[1].GitHubWebHook = nil
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, null image",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", false)
+				addImage(bc, image("ImageStreamTag", "", "test:tag"), "")
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", false)
+				addImage(bc, image("ImageStreamTag", "", "test:tag"), "")
+				bc.Spec.Triggers[2].ImageChange = nil
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, different generic",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret2", false)
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, different github",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", false)
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", true)
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "invalid same trigger type, different image ref",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", true)
+				addImage(bc, image("ImageStreamTag", "test", "image1:latest"), "")
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", true)
+				addImage(bc, image("ImageStreamTag", "test", "image2:latest"), "")
+				return bc
+			},
+			expectError:     true,
+			expectErrorType: field.ErrorTypeInvalid,
+			expectErrorPath: "spec",
+		},
+		{
+			name: "valid same image trigger type, different lastTriggeredID",
+			older: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", true)
+				addImage(bc, image("ImageStreamTag", "test", "image1:latest"), "original_last_triggered")
+				return bc
+			},
+			newer: func() *buildapi.BuildConfig {
+				bc := testBC()
+				addGeneric(bc, "testsecret", false)
+				addGithub(bc, "testsecret2", true)
+				addImage(bc, image("ImageStreamTag", "test", "image1:latest"), "new_last_triggered")
+				return bc
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result := ValidateBuildConfigStatusUpdate(test.older(), test.newer())
+		if len(result) > 0 && !test.expectError {
+			t.Errorf("%s: did not expect an error. Got: %v", test.name, result)
+			continue
+		}
+		if test.expectError {
+			if len(result) == 0 {
+				t.Errorf("%s: expected an error but did not get any.", test.name)
+				continue
+			}
+			if result[0].Type != test.expectErrorType {
+				t.Errorf("%s: expected error of type %s. Got %s", test.name, test.expectErrorType, result[0].Type)
+			}
+			if result[0].Field != test.expectErrorPath {
+				t.Errorf("%s: expected error field %s. Got %s", test.name, test.expectErrorPath, result[0].Field)
+			}
 		}
 	}
 }

--- a/pkg/build/client/clients.go
+++ b/pkg/build/client/clients.go
@@ -11,6 +11,10 @@ type BuildStatusUpdater interface {
 	UpdateStatus(namespace string, build *buildapi.Build) error
 }
 
+type BuildUpdater interface {
+	Update(namespace string, build *buildapi.Build) error
+}
+
 // BuildLister provides methods for listing the Builds.
 type BuildLister interface {
 	List(namespace string, opts kapi.ListOptions) (*buildapi.BuildList, error)
@@ -27,6 +31,12 @@ func NewOSClientBuildClient(client osclient.Interface) *OSClientBuildClient {
 }
 
 // Update updates builds using the OpenShift client.
+func (c OSClientBuildClient) Update(namespace string, build *buildapi.Build) error {
+	_, e := c.Client.Builds(namespace).Update(build)
+	return e
+}
+
+// UpdateStatus updates build status using the OpenShift client.
 func (c OSClientBuildClient) UpdateStatus(namespace string, build *buildapi.Build) error {
 	_, e := c.Client.Builds(namespace).UpdateStatus(build)
 	return e

--- a/pkg/build/client/clients.go
+++ b/pkg/build/client/clients.go
@@ -6,40 +6,9 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
-// BuildConfigGetter provides methods for getting BuildConfigs
-type BuildConfigGetter interface {
-	Get(namespace, name string) (*buildapi.BuildConfig, error)
-}
-
-// BuildConfigUpdater provides methods for updating BuildConfigs
-type BuildConfigUpdater interface {
-	Update(buildConfig *buildapi.BuildConfig) error
-}
-
-// OSClientBuildConfigClient delegates get and update operations to the OpenShift client interface
-type OSClientBuildConfigClient struct {
-	Client osclient.Interface
-}
-
-// NewOSClientBuildConfigClient creates a new build config client that uses an openshift client to create and get BuildConfigs
-func NewOSClientBuildConfigClient(client osclient.Interface) *OSClientBuildConfigClient {
-	return &OSClientBuildConfigClient{Client: client}
-}
-
-// Get returns a BuildConfig using the OpenShift client.
-func (c OSClientBuildConfigClient) Get(namespace, name string) (*buildapi.BuildConfig, error) {
-	return c.Client.BuildConfigs(namespace).Get(name)
-}
-
-// Update updates a BuildConfig using the OpenShift client.
-func (c OSClientBuildConfigClient) Update(buildConfig *buildapi.BuildConfig) error {
-	_, err := c.Client.BuildConfigs(buildConfig.Namespace).Update(buildConfig)
-	return err
-}
-
-// BuildUpdater provides methods for updating existing Builds.
-type BuildUpdater interface {
-	Update(namespace string, build *buildapi.Build) error
+// BuildStatusUpdater provides methods for updating the status of Builds.
+type BuildStatusUpdater interface {
+	UpdateStatus(namespace string, build *buildapi.Build) error
 }
 
 // BuildLister provides methods for listing the Builds.
@@ -58,8 +27,8 @@ func NewOSClientBuildClient(client osclient.Interface) *OSClientBuildClient {
 }
 
 // Update updates builds using the OpenShift client.
-func (c OSClientBuildClient) Update(namespace string, build *buildapi.Build) error {
-	_, e := c.Client.Builds(namespace).Update(build)
+func (c OSClientBuildClient) UpdateStatus(namespace string, build *buildapi.Build) error {
+	_, e := c.Client.Builds(namespace).UpdateStatus(build)
 	return e
 }
 

--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -22,13 +22,13 @@ import (
 
 // BuildController watches build resources and manages their state
 type BuildController struct {
-	BuildUpdater      buildclient.BuildUpdater
-	BuildLister       buildclient.BuildLister
-	PodManager        podManager
-	BuildStrategy     BuildStrategy
-	ImageStreamClient imageStreamClient
-	Recorder          record.EventRecorder
-	RunPolicies       []policy.RunPolicy
+	BuildStatusUpdater buildclient.BuildStatusUpdater
+	BuildLister        buildclient.BuildLister
+	PodManager         podManager
+	BuildStrategy      BuildStrategy
+	ImageStreamClient  imageStreamClient
+	Recorder           record.EventRecorder
+	RunPolicies        []policy.RunPolicy
 }
 
 // BuildStrategy knows how to create a pod spec for a pod which can execute a build.
@@ -72,7 +72,7 @@ func (bc *BuildController) CancelBuild(build *buildapi.Build) error {
 	build.Status.Message = ""
 	now := unversioned.Now()
 	build.Status.CompletionTimestamp = &now
-	if err := bc.BuildUpdater.Update(build.Namespace, build); err != nil {
+	if err := bc.BuildStatusUpdater.UpdateStatus(build.Namespace, build); err != nil {
 		return fmt.Errorf("Failed to update build %s/%s: %v", build.Namespace, build.Name, err)
 	}
 
@@ -125,7 +125,7 @@ func (bc *BuildController) HandleBuild(build *buildapi.Build) error {
 		return err
 	}
 
-	if err := bc.BuildUpdater.Update(build.Namespace, build); err != nil {
+	if err := bc.BuildStatusUpdater.UpdateStatus(build.Namespace, build); err != nil {
 		// This is not a retryable error because the build has been created.  The worst case
 		// outcome of not updating the buildconfig is that we might rerun a build for the
 		// same "new" imageid change in the future, which is better than guaranteeing we
@@ -262,10 +262,10 @@ func (bc *BuildController) resolveOutputDockerImageReference(build *buildapi.Bui
 
 // BuildPodController watches pods running builds and manages the build state
 type BuildPodController struct {
-	BuildStore   cache.Store
-	BuildUpdater buildclient.BuildUpdater
-	SecretClient kclient.SecretsNamespacer
-	PodManager   podManager
+	BuildStore         cache.Store
+	BuildStatusUpdater buildclient.BuildStatusUpdater
+	SecretClient       kclient.SecretsNamespacer
+	PodManager         podManager
 }
 
 // HandlePod updates the state of the build based on the pod state
@@ -340,7 +340,7 @@ func (bc *BuildPodController) HandlePod(pod *kapi.Pod) error {
 			now := unversioned.Now()
 			build.Status.StartTimestamp = &now
 		}
-		if err := bc.BuildUpdater.Update(build.Namespace, build); err != nil {
+		if err := bc.BuildStatusUpdater.UpdateStatus(build.Namespace, build); err != nil {
 			return fmt.Errorf("failed to update build %s/%s: %v", build.Namespace, build.Name, err)
 		}
 		glog.V(4).Infof("Build %s/%s status was updated %s -> %s", build.Namespace, build.Name, build.Status.Phase, nextStatus)
@@ -355,8 +355,8 @@ func isBuildCancellable(build *buildapi.Build) bool {
 
 // BuildPodDeleteController watches pods running builds and updates the build if the pod is deleted
 type BuildPodDeleteController struct {
-	BuildStore   cache.Store
-	BuildUpdater buildclient.BuildUpdater
+	BuildStore         cache.Store
+	BuildStatusUpdater buildclient.BuildStatusUpdater
 }
 
 // HandleBuildPodDeletion sets the status of a build to error if the build pod has been deleted
@@ -392,8 +392,8 @@ func (bc *BuildPodDeleteController) HandleBuildPodDeletion(pod *kapi.Pod) error 
 		build.Status.Message = "The pod for this build was deleted before the build completed."
 		now := unversioned.Now()
 		build.Status.CompletionTimestamp = &now
-		if err := bc.BuildUpdater.Update(build.Namespace, build); err != nil {
-			return fmt.Errorf("Failed to update build %s/%s: %v", build.Namespace, build.Name, err)
+		if err := bc.BuildStatusUpdater.UpdateStatus(build.Namespace, build); err != nil {
+			return fmt.Errorf("Failed to update build status %s/%s: %v", build.Namespace, build.Name, err)
 		}
 	}
 	return nil

--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -103,7 +103,7 @@ func (bc *BuildController) HandleBuild(build *buildapi.Build) error {
 	}
 
 	// A cancelling event was triggered for the build, delete its pod and update build status.
-	if build.Status.Cancelled && build.Status.Phase != buildapi.BuildPhaseCancelled {
+	if build.Spec.Cancelled && build.Status.Phase != buildapi.BuildPhaseCancelled {
 		glog.V(5).Infof("Marking build %s/%s as cancelled", build.Namespace, build.Name)
 		if err := bc.CancelBuild(build); err != nil {
 			build.Status.Reason = buildapi.StatusReasonCancelBuildFailed
@@ -140,7 +140,7 @@ func (bc *BuildController) HandleBuild(build *buildapi.Build) error {
 // build.Message.
 func (bc *BuildController) nextBuildPhase(build *buildapi.Build) error {
 	// If a cancelling event was triggered for the build, update build status.
-	if build.Status.Cancelled {
+	if build.Spec.Cancelled {
 		glog.V(4).Infof("Cancelling build %s/%s.", build.Namespace, build.Name)
 		build.Status.Phase = buildapi.BuildPhaseCancelled
 		build.Status.Reason = ""
@@ -374,7 +374,7 @@ func (bc *BuildPodDeleteController) HandleBuildPodDeletion(pod *kapi.Pod) error 
 	build := obj.(*buildapi.Build)
 
 	// If build was cancelled, we'll leave HandleBuild to update the build
-	if build.Status.Cancelled {
+	if build.Spec.Cancelled {
 		glog.V(4).Infof("Cancelation for build was already triggered, ignoring")
 		return nil
 	}

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -23,6 +23,12 @@ func (okc *okBuildStatusUpdater) UpdateStatus(namespace string, build *buildapi.
 	return nil
 }
 
+type okBuildUpdater struct{}
+
+func (okc *okBuildUpdater) Update(namespace string, build *buildapi.Build) error {
+	return nil
+}
+
 type okBuildLister struct{}
 
 func (okc *okBuildLister) List(namespace string, opts kapi.ListOptions) (*buildapi.BuildList, error) {
@@ -158,7 +164,7 @@ func mockBuildController() *BuildController {
 		BuildStrategy:      &okStrategy{},
 		ImageStreamClient:  &okImageStreamClient{},
 		Recorder:           &record.FakeRecorder{},
-		RunPolicies:        policy.GetAllRunPolicies(&okBuildLister{}, &okBuildStatusUpdater{}),
+		RunPolicies:        policy.GetAllRunPolicies(&okBuildLister{}, &okBuildUpdater{}, &okBuildStatusUpdater{}),
 	}
 }
 

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -62,6 +62,7 @@ func limitedLogAndRetry(buildupdater buildclient.BuildStatusUpdater, maxTimeout 
 type BuildControllerFactory struct {
 	OSClient            osclient.Interface
 	KubeClient          kclient.Interface
+	BuildUpdater        buildclient.BuildUpdater
 	BuildStatusUpdater  buildclient.BuildStatusUpdater
 	BuildLister         buildclient.BuildLister
 	DockerBuildStrategy *strategy.DockerBuildStrategy
@@ -85,7 +86,7 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 		BuildLister:        factory.BuildLister,
 		ImageStreamClient:  client,
 		PodManager:         client,
-		RunPolicies:        policy.GetAllRunPolicies(factory.BuildLister, factory.BuildStatusUpdater),
+		RunPolicies:        policy.GetAllRunPolicies(factory.BuildLister, factory.BuildUpdater, factory.BuildStatusUpdater),
 		BuildStrategy: &typeBasedFactoryStrategy{
 			DockerBuildStrategy: factory.DockerBuildStrategy,
 			SourceBuildStrategy: factory.SourceBuildStrategy,

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -33,7 +33,7 @@ import (
 const maxRetries = 60
 
 // limitedLogAndRetry stops retrying after maxTimeout, failing the build.
-func limitedLogAndRetry(buildupdater buildclient.BuildUpdater, maxTimeout time.Duration) controller.RetryFunc {
+func limitedLogAndRetry(buildupdater buildclient.BuildStatusUpdater, maxTimeout time.Duration) controller.RetryFunc {
 	return func(obj interface{}, err error, retries controller.Retry) bool {
 		isFatal := strategy.IsFatal(err)
 		build := obj.(*buildapi.Build)
@@ -50,7 +50,7 @@ func limitedLogAndRetry(buildupdater buildclient.BuildUpdater, maxTimeout time.D
 		build.Status.CompletionTimestamp = &now
 		glog.V(3).Infof("Giving up retrying Build %s/%s: %v", build.Namespace, build.Name, err)
 		utilruntime.HandleError(err)
-		if err := buildupdater.Update(build.Namespace, build); err != nil {
+		if err := buildupdater.UpdateStatus(build.Namespace, build); err != nil {
 			// retry update, but only on error other than NotFound
 			return !kerrors.IsNotFound(err)
 		}
@@ -62,7 +62,7 @@ func limitedLogAndRetry(buildupdater buildclient.BuildUpdater, maxTimeout time.D
 type BuildControllerFactory struct {
 	OSClient            osclient.Interface
 	KubeClient          kclient.Interface
-	BuildUpdater        buildclient.BuildUpdater
+	BuildStatusUpdater  buildclient.BuildStatusUpdater
 	BuildLister         buildclient.BuildLister
 	DockerBuildStrategy *strategy.DockerBuildStrategy
 	SourceBuildStrategy *strategy.SourceBuildStrategy
@@ -81,11 +81,11 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 
 	client := ControllerClient{factory.KubeClient, factory.OSClient}
 	buildController := &buildcontroller.BuildController{
-		BuildUpdater:      factory.BuildUpdater,
-		BuildLister:       factory.BuildLister,
-		ImageStreamClient: client,
-		PodManager:        client,
-		RunPolicies:       policy.GetAllRunPolicies(factory.BuildLister, factory.BuildUpdater),
+		BuildStatusUpdater: factory.BuildStatusUpdater,
+		BuildLister:        factory.BuildLister,
+		ImageStreamClient:  client,
+		PodManager:         client,
+		RunPolicies:        policy.GetAllRunPolicies(factory.BuildLister, factory.BuildStatusUpdater),
 		BuildStrategy: &typeBasedFactoryStrategy{
 			DockerBuildStrategy: factory.DockerBuildStrategy,
 			SourceBuildStrategy: factory.SourceBuildStrategy,
@@ -99,7 +99,7 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			limitedLogAndRetry(factory.BuildUpdater, 30*time.Minute),
+			limitedLogAndRetry(factory.BuildStatusUpdater, 30*time.Minute),
 			flowcontrol.NewTokenBucketRateLimiter(1, 10)),
 		Handle: func(obj interface{}) error {
 			build := obj.(*buildapi.Build)
@@ -112,7 +112,7 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 						build.Status.Reason = buildapi.StatusReasonError
 					}
 					build.Status.Message = msg
-					if err := buildController.BuildUpdater.Update(build.Namespace, build); err != nil {
+					if err := buildController.BuildStatusUpdater.UpdateStatus(build.Namespace, build); err != nil {
 						glog.V(2).Infof("Failed to update status message of Build %s/%s: %v", build.Namespace, build.Name, err)
 					}
 					buildController.Recorder.Eventf(build, kapi.EventTypeWarning, "HandleBuildError", "Build has error: %v", err)
@@ -154,9 +154,9 @@ func (factory *BuildControllerFactory) CreateDeleteController() controller.Runna
 
 // BuildPodControllerFactory construct BuildPodController objects
 type BuildPodControllerFactory struct {
-	OSClient     osclient.Interface
-	KubeClient   kclient.Interface
-	BuildUpdater buildclient.BuildUpdater
+	OSClient           osclient.Interface
+	KubeClient         kclient.Interface
+	BuildStatusUpdater buildclient.BuildStatusUpdater
 	// Stop may be set to allow controllers created by this factory to be terminated.
 	Stop <-chan struct{}
 
@@ -195,10 +195,10 @@ func (factory *BuildPodControllerFactory) Create() controller.RunnableController
 
 	client := ControllerClient{factory.KubeClient, factory.OSClient}
 	buildPodController := &buildcontroller.BuildPodController{
-		BuildStore:   factory.buildStore,
-		BuildUpdater: factory.BuildUpdater,
-		SecretClient: factory.KubeClient,
-		PodManager:   client,
+		BuildStore:         factory.buildStore,
+		BuildStatusUpdater: factory.BuildStatusUpdater,
+		SecretClient:       factory.KubeClient,
+		PodManager:         client,
 	}
 
 	return &controller.RetryController{
@@ -246,8 +246,8 @@ func (factory *BuildPodControllerFactory) CreateDeleteController() controller.Ru
 	cache.NewReflector(&buildPodDeleteLW{client, queue}, &kapi.Pod{}, queue, 5*time.Minute).RunUntil(factory.Stop)
 
 	buildPodDeleteController := &buildcontroller.BuildPodDeleteController{
-		BuildStore:   factory.buildStore,
-		BuildUpdater: factory.BuildUpdater,
+		BuildStore:         factory.buildStore,
+		BuildStatusUpdater: factory.BuildStatusUpdater,
 	}
 
 	return &controller.RetryController{

--- a/pkg/build/controller/factory/factory_test.go
+++ b/pkg/build/controller/factory/factory_test.go
@@ -14,17 +14,17 @@ import (
 	controller "github.com/openshift/origin/pkg/controller"
 )
 
-type buildUpdater struct {
+type buildStatusUpdater struct {
 	Build *buildapi.Build
 }
 
-func (b *buildUpdater) Update(namespace string, build *buildapi.Build) error {
+func (b *buildStatusUpdater) UpdateStatus(namespace string, build *buildapi.Build) error {
 	b.Build = build
 	return nil
 }
 
 func TestLimitedLogAndRetryFinish(t *testing.T) {
-	updater := &buildUpdater{}
+	updater := &buildStatusUpdater{}
 	err := errors.New("funky error")
 
 	now := unversioned.Now()
@@ -50,7 +50,7 @@ func TestLimitedLogAndRetryFinish(t *testing.T) {
 }
 
 func TestLimitedLogAndRetryProcessing(t *testing.T) {
-	updater := &buildUpdater{}
+	updater := &buildStatusUpdater{}
 	err := errors.New("funky error")
 
 	now := unversioned.Now()

--- a/pkg/build/controller/image_change_controller_test.go
+++ b/pkg/build/controller/image_change_controller_test.go
@@ -391,7 +391,7 @@ func mockBuildConfigInstantiator(buildcfg *buildapi.BuildConfig, imageStream *im
 			GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
 				return buildcfg, nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return instantiator.buildConfigUpdater.Update(buildConfig)
 			},
 			CreateBuildFunc: func(ctx kapi.Context, build *buildapi.Build) error {

--- a/pkg/build/controller/policy/parallel.go
+++ b/pkg/build/controller/policy/parallel.go
@@ -12,8 +12,8 @@ import (
 // order as they were created and using this policy might cause unpredictable
 // behavior.
 type ParallelPolicy struct {
-	BuildLister  buildclient.BuildLister
-	BuildUpdater buildclient.BuildUpdater
+	BuildLister        buildclient.BuildLister
+	BuildStatusUpdater buildclient.BuildStatusUpdater
 }
 
 // IsRunnable implements the RunPolicy interface. The parallel builds are run as soon
@@ -28,5 +28,5 @@ func (s *ParallelPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
 
 // OnComplete implements the RunPolicy interface.
 func (s *ParallelPolicy) OnComplete(build *buildapi.Build) error {
-	return handleComplete(s.BuildLister, s.BuildUpdater, build)
+	return handleComplete(s.BuildLister, s.BuildStatusUpdater, build)
 }

--- a/pkg/build/controller/policy/parallel_test.go
+++ b/pkg/build/controller/policy/parallel_test.go
@@ -13,7 +13,7 @@ func TestParallelIsRunnableNewBuilds(t *testing.T) {
 		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	policy := ParallelPolicy{BuildLister: client, BuildStatusUpdater: client}
 	for _, build := range allNewBuilds {
 		runnable, err := policy.IsRunnable(&build)
 		if err != nil {
@@ -32,7 +32,7 @@ func TestParallelIsRunnableMixedBuilds(t *testing.T) {
 		addBuild("build-5", "sample-bc", buildapi.BuildPhasePending, buildapi.BuildRunPolicyParallel),
 	}
 	client := newTestClient(mixedBuilds)
-	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	policy := ParallelPolicy{BuildLister: client, BuildStatusUpdater: client}
 	for _, build := range mixedBuilds {
 		runnable, err := policy.IsRunnable(&build)
 		if err != nil {
@@ -51,7 +51,7 @@ func TestParallelIsRunnableWithSerialRunning(t *testing.T) {
 		addBuild("build-9", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicyParallel),
 	}
 	client := newTestClient(mixedBuilds)
-	policy := ParallelPolicy{BuildLister: client, BuildUpdater: client}
+	policy := ParallelPolicy{BuildLister: client, BuildStatusUpdater: client}
 	for _, build := range mixedBuilds {
 		runnable, err := policy.IsRunnable(&build)
 		if err != nil {

--- a/pkg/build/controller/policy/policy.go
+++ b/pkg/build/controller/policy/policy.go
@@ -25,11 +25,11 @@ type RunPolicy interface {
 }
 
 // GetAllRunPolicies returns a set of all run policies.
-func GetAllRunPolicies(lister buildclient.BuildLister, updater buildclient.BuildStatusUpdater) []RunPolicy {
+func GetAllRunPolicies(lister buildclient.BuildLister, updater buildclient.BuildUpdater, statusUpdater buildclient.BuildStatusUpdater) []RunPolicy {
 	return []RunPolicy{
-		&ParallelPolicy{BuildLister: lister, BuildStatusUpdater: updater},
-		&SerialPolicy{BuildLister: lister, BuildStatusUpdater: updater},
-		&SerialLatestOnlyPolicy{BuildLister: lister, BuildStatusUpdater: updater},
+		&ParallelPolicy{BuildLister: lister, BuildStatusUpdater: statusUpdater},
+		&SerialPolicy{BuildLister: lister, BuildStatusUpdater: statusUpdater},
+		&SerialLatestOnlyPolicy{BuildLister: lister, BuildUpdater: updater},
 	}
 }
 

--- a/pkg/build/controller/policy/policy_test.go
+++ b/pkg/build/controller/policy/policy_test.go
@@ -24,7 +24,7 @@ func (f *fakeBuildClient) List(namespace string, opts kapi.ListOptions) (*builda
 	return f.builds, nil
 }
 
-func (f *fakeBuildClient) Update(namespace string, build *buildapi.Build) error {
+func (f *fakeBuildClient) UpdateStatus(namespace string, build *buildapi.Build) error {
 	// Make sure every update fails at least once with conflict to ensure build updates are
 	// retried.
 	if f.updateErrCount == 0 {

--- a/pkg/build/controller/policy/policy_test.go
+++ b/pkg/build/controller/policy/policy_test.go
@@ -25,6 +25,10 @@ func (f *fakeBuildClient) List(namespace string, opts kapi.ListOptions) (*builda
 }
 
 func (f *fakeBuildClient) UpdateStatus(namespace string, build *buildapi.Build) error {
+	return f.Update(namespace, build)
+}
+
+func (f *fakeBuildClient) Update(namespace string, build *buildapi.Build) error {
 	// Make sure every update fails at least once with conflict to ensure build updates are
 	// retried.
 	if f.updateErrCount == 0 {
@@ -67,7 +71,7 @@ func TestForBuild(t *testing.T) {
 		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
 	}
 	client := newTestClient(builds)
-	policies := GetAllRunPolicies(client, client)
+	policies := GetAllRunPolicies(client, client, client)
 
 	if policy := ForBuild(&builds[0], policies); policy != nil {
 		if _, ok := policy.(*ParallelPolicy); !ok {

--- a/pkg/build/controller/policy/serial.go
+++ b/pkg/build/controller/policy/serial.go
@@ -12,8 +12,8 @@ import (
 // created. This will produce consistent results, but block the build execution until the
 // previous builds are complete.
 type SerialPolicy struct {
-	BuildLister  buildclient.BuildLister
-	BuildUpdater buildclient.BuildUpdater
+	BuildLister        buildclient.BuildLister
+	BuildStatusUpdater buildclient.BuildStatusUpdater
 }
 
 // IsRunnable implements the RunPolicy interface.
@@ -31,5 +31,5 @@ func (s *SerialPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
 
 // OnComplete implements the RunPolicy interface.
 func (s *SerialPolicy) OnComplete(build *buildapi.Build) error {
-	return handleComplete(s.BuildLister, s.BuildUpdater, build)
+	return handleComplete(s.BuildLister, s.BuildStatusUpdater, build)
 }

--- a/pkg/build/controller/policy/serial_latest_only.go
+++ b/pkg/build/controller/policy/serial_latest_only.go
@@ -22,6 +22,7 @@ import (
 // expect that every commit is built.
 type SerialLatestOnlyPolicy struct {
 	BuildStatusUpdater buildclient.BuildStatusUpdater
+	BuildUpdater       buildclient.BuildUpdater
 	BuildLister        buildclient.BuildLister
 }
 
@@ -79,8 +80,8 @@ func (s *SerialLatestOnlyPolicy) cancelPreviousBuilds(build *buildapi.Build) []e
 	var result = []error{}
 	for _, b := range builds.Items {
 		err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
-			b.Status.Cancelled = true
-			err := s.BuildStatusUpdater.UpdateStatus(b.Namespace, &b)
+			b.Spec.Cancelled = true
+			err := s.BuildUpdater.Update(b.Namespace, &b)
 			if err != nil && errors.IsConflict(err) {
 				glog.V(5).Infof("Error cancelling build %s/%s: %v (will retry)", b.Namespace, b.Name, err)
 				return false, nil

--- a/pkg/build/controller/policy/serial_latest_only_test.go
+++ b/pkg/build/controller/policy/serial_latest_only_test.go
@@ -14,7 +14,7 @@ func TestSerialLatestOnlyIsRunnableNewBuilds(t *testing.T) {
 		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
 	runnableBuilds := []string{
 		"build-1",
 	}
@@ -58,7 +58,7 @@ func TestSerialLatestOnlyIsRunnableMixed(t *testing.T) {
 		addBuild("build-4", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
 	for _, build := range allNewBuilds {
 		runnable, err := policy.IsRunnable(&build)
 		if err != nil {
@@ -96,7 +96,7 @@ func TestSerialLatestOnlyIsRunnableBuildsWithErrors(t *testing.T) {
 	builds[1].ObjectMeta.Annotations = map[string]string{}
 
 	client := newTestClient(builds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
 
 	ok, err := policy.IsRunnable(&builds[0])
 	if !ok || err != nil {

--- a/pkg/build/controller/policy/serial_latest_only_test.go
+++ b/pkg/build/controller/policy/serial_latest_only_test.go
@@ -14,7 +14,7 @@ func TestSerialLatestOnlyIsRunnableNewBuilds(t *testing.T) {
 		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
 	runnableBuilds := []string{
 		"build-1",
 	}
@@ -45,7 +45,7 @@ func TestSerialLatestOnlyIsRunnableNewBuilds(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !builds.Items[1].Status.Cancelled {
+	if !builds.Items[1].Spec.Cancelled {
 		t.Errorf("expected build-2 to be cancelled")
 	}
 }
@@ -58,7 +58,7 @@ func TestSerialLatestOnlyIsRunnableMixed(t *testing.T) {
 		addBuild("build-4", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerialLatestOnly),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
 	for _, build := range allNewBuilds {
 		runnable, err := policy.IsRunnable(&build)
 		if err != nil {
@@ -72,13 +72,13 @@ func TestSerialLatestOnlyIsRunnableMixed(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if builds.Items[0].Status.Cancelled {
+	if builds.Items[0].Spec.Cancelled {
 		t.Errorf("expected build-1 is complete and should not be cancelled")
 	}
-	if builds.Items[2].Status.Cancelled {
+	if builds.Items[2].Spec.Cancelled {
 		t.Errorf("expected build-3 is running and should not be cancelled")
 	}
-	if builds.Items[3].Status.Cancelled {
+	if builds.Items[3].Spec.Cancelled {
 		t.Errorf("expected build-4 will run next and should not be cancelled")
 	}
 }
@@ -96,7 +96,7 @@ func TestSerialLatestOnlyIsRunnableBuildsWithErrors(t *testing.T) {
 	builds[1].ObjectMeta.Annotations = map[string]string{}
 
 	client := newTestClient(builds)
-	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildStatusUpdater: client}
+	policy := SerialLatestOnlyPolicy{BuildLister: client, BuildUpdater: client}
 
 	ok, err := policy.IsRunnable(&builds[0])
 	if !ok || err != nil {

--- a/pkg/build/controller/policy/serial_test.go
+++ b/pkg/build/controller/policy/serial_test.go
@@ -13,7 +13,7 @@ func TestSerialIsRunnableNewBuilds(t *testing.T) {
 		addBuild("build-3", "sample-bc", buildapi.BuildPhaseNew, buildapi.BuildRunPolicySerial),
 	}
 	client := newTestClient(allNewBuilds)
-	policy := SerialPolicy{BuildLister: client, BuildUpdater: client}
+	policy := SerialPolicy{BuildLister: client, BuildStatusUpdater: client}
 	runnableBuilds := []string{
 		"build-1",
 	}

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -712,9 +712,11 @@ func generateBuildFromBuild(build *buildapi.Build, buildConfig *buildapi.BuildCo
 	}
 	// TODO remove/update this when we support cloning binary builds
 	newBuild.Spec.Source.Binary = nil
+	newBuild.Spec.Cancelled = false
 	if newBuild.Annotations == nil {
 		newBuild.Annotations = make(map[string]string)
 	}
+	delete(newBuild.Annotations, buildapi.BuildPodNameAnnotation)
 	newBuild.Annotations[buildapi.BuildCloneAnnotation] = build.Name
 	if buildConfig != nil {
 		newBuild.Annotations[buildapi.BuildNumberAnnotation] = strconv.FormatInt(buildConfig.Status.LastVersion, 10)

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -54,7 +54,7 @@ type BuildGenerator struct {
 // GeneratorClient is the API client used by the generator
 type GeneratorClient interface {
 	GetBuildConfig(ctx kapi.Context, name string) (*buildapi.BuildConfig, error)
-	UpdateBuildConfig(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error
+	UpdateBuildConfigStatus(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error
 	GetBuild(ctx kapi.Context, name string) (*buildapi.Build, error)
 	CreateBuild(ctx kapi.Context, build *buildapi.Build) error
 	GetImageStream(ctx kapi.Context, name string) (*imageapi.ImageStream, error)
@@ -64,13 +64,13 @@ type GeneratorClient interface {
 
 // Client is an implementation of the GeneratorClient interface
 type Client struct {
-	GetBuildConfigFunc      func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error)
-	UpdateBuildConfigFunc   func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error
-	GetBuildFunc            func(ctx kapi.Context, name string) (*buildapi.Build, error)
-	CreateBuildFunc         func(ctx kapi.Context, build *buildapi.Build) error
-	GetImageStreamFunc      func(ctx kapi.Context, name string) (*imageapi.ImageStream, error)
-	GetImageStreamImageFunc func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error)
-	GetImageStreamTagFunc   func(ctx kapi.Context, name string) (*imageapi.ImageStreamTag, error)
+	GetBuildConfigFunc          func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error)
+	UpdateBuildConfigStatusFunc func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error
+	GetBuildFunc                func(ctx kapi.Context, name string) (*buildapi.Build, error)
+	CreateBuildFunc             func(ctx kapi.Context, build *buildapi.Build) error
+	GetImageStreamFunc          func(ctx kapi.Context, name string) (*imageapi.ImageStream, error)
+	GetImageStreamImageFunc     func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error)
+	GetImageStreamTagFunc       func(ctx kapi.Context, name string) (*imageapi.ImageStreamTag, error)
 }
 
 // GetBuildConfig retrieves a named build config
@@ -78,9 +78,9 @@ func (c Client) GetBuildConfig(ctx kapi.Context, name string) (*buildapi.BuildCo
 	return c.GetBuildConfigFunc(ctx, name)
 }
 
-// UpdateBuildConfig updates a named build config
-func (c Client) UpdateBuildConfig(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
-	return c.UpdateBuildConfigFunc(ctx, buildConfig)
+// UpdateBuildConfigStatus updates the status of a named build config
+func (c Client) UpdateBuildConfigStatus(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+	return c.UpdateBuildConfigStatusFunc(ctx, buildConfig)
 }
 
 // GetBuild retrieves a build
@@ -253,8 +253,8 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 
 	// need to update the BuildConfig because LastVersion and possibly
 	// LastTriggeredImageID changed
-	if err := g.Client.UpdateBuildConfig(ctx, bc); err != nil {
-		glog.V(4).Infof("Failed to update BuildConfig %s/%s so no Build will be created", bc.Namespace, bc.Name)
+	if err := g.Client.UpdateBuildConfigStatus(ctx, bc); err != nil {
+		glog.V(4).Infof("Failed to update status for BuildConfig %s/%s so no Build will be created", bc.Namespace, bc.Name)
 		return nil, err
 	}
 
@@ -352,8 +352,8 @@ func (g *BuildGenerator) Clone(ctx kapi.Context, request *buildapi.BuildRequest)
 
 	// need to update the BuildConfig because LastVersion changed
 	if buildConfig != nil {
-		if err := g.Client.UpdateBuildConfig(ctx, buildConfig); err != nil {
-			glog.V(4).Infof("Failed to update BuildConfig %s/%s so no Build will be created", buildConfig.Namespace, buildConfig.Name)
+		if err := g.Client.UpdateBuildConfigStatus(ctx, buildConfig); err != nil {
+			glog.V(4).Infof("Failed to update status for BuildConfig %s/%s so no Build will be created", buildConfig.Namespace, buildConfig.Name)
 			return nil, err
 		}
 	}

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -69,7 +69,7 @@ func TestInstantiateBinary(t *testing.T) {
 
 // TODO(agoldste): I'm not sure the intent of this test. Using the previous logic for
 // the generator, which would try to update the build config before creating
-// the build, I can see why the UpdateBuildConfigFunc is set up to return an
+// the build, I can see why the UpdateBuildConfigStatusFunc is set up to return an
 // error, but nothing is checking the value of instantiationCalls. We could
 // update this test to fail sooner, when the build is created, but that's
 // already handled by TestCreateBuildCreateError. We may just want to delete
@@ -88,7 +88,7 @@ func TestInstantiateRetry(t *testing.T) {
 			GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
 				return mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput()), nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				instantiationCalls++
 				return fmt.Errorf("update-error")
 			},
@@ -364,7 +364,7 @@ func TestInstantiateWithImageTrigger(t *testing.T) {
 			func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
 				return bc, nil
 			}
-		client.UpdateBuildConfigFunc =
+		client.UpdateBuildConfigStatusFunc =
 			func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				bc = buildConfig
 				return nil
@@ -862,7 +862,7 @@ func TestGenerateBuildWithImageTagForSourceStrategyImageRepository(t *testing.T)
 				}, nil
 			},
 
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return nil
 			},
 		}}
@@ -939,7 +939,7 @@ func TestGenerateBuildWithImageTagForDockerStrategyImageRepository(t *testing.T)
 					},
 				}, nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return nil
 			},
 		}}
@@ -1016,7 +1016,7 @@ func TestGenerateBuildWithImageTagForCustomStrategyImageRepository(t *testing.T)
 					},
 				}, nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return nil
 			},
 		}}
@@ -1525,7 +1525,7 @@ func mockBuildGenerator() *BuildGenerator {
 			GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
 				return mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput()), nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return nil
 			},
 			CreateBuildFunc: func(ctx kapi.Context, build *buildapi.Build) error {

--- a/pkg/build/registry/build/etcd/etcd_test.go
+++ b/pkg/build/registry/build/etcd/etcd_test.go
@@ -17,7 +17,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	storage, _, err := NewREST(restoptions.NewSimpleGetter(etcdStorage))
+	storage, _, _, err := NewREST(restoptions.NewSimpleGetter(etcdStorage))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/build/registry/build/strategy_test.go
+++ b/pkg/build/registry/build/strategy_test.go
@@ -18,28 +18,7 @@ func TestBuildStrategy(t *testing.T) {
 	if Strategy.AllowCreateOnUpdate() {
 		t.Errorf("Build should not allow create on update")
 	}
-	build := &buildapi.Build{
-		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
-		Spec: buildapi.BuildSpec{
-			CommonSpec: buildapi.CommonSpec{
-				Source: buildapi.BuildSource{
-					Git: &buildapi.GitBuildSource{
-						URI: "http://github.com/my/repository",
-					},
-					ContextDir: "context",
-				},
-				Strategy: buildapi.BuildStrategy{
-					DockerStrategy: &buildapi.DockerBuildStrategy{},
-				},
-				Output: buildapi.BuildOutput{
-					To: &kapi.ObjectReference{
-						Kind: "DockerImage",
-						Name: "repository/data",
-					},
-				},
-			},
-		},
-	}
+	build := testBuild()
 	Strategy.PrepareForCreate(build)
 	if len(build.Status.Phase) == 0 || build.Status.Phase != buildapi.BuildPhaseNew {
 		t.Errorf("Build phase is not New")
@@ -61,8 +40,8 @@ func TestBuildStrategy(t *testing.T) {
 	}
 }
 
-func TestBuildDecorator(t *testing.T) {
-	build := &buildapi.Build{
+func testBuild() *buildapi.Build {
+	return &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{
@@ -87,6 +66,10 @@ func TestBuildDecorator(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
+}
+
+func TestBuildDecorator(t *testing.T) {
+	build := testBuild()
 	now := unversioned.Now()
 	startTime := unversioned.NewTime(now.Time.Add(-1 * time.Minute))
 	build.Status.StartTimestamp = &startTime
@@ -96,5 +79,48 @@ func TestBuildDecorator(t *testing.T) {
 	}
 	if build.Status.Duration <= 0 {
 		t.Errorf("Build duration should be greater than zero")
+	}
+}
+
+func TestBuildStatusUpdate(t *testing.T) {
+	original := testBuild()
+
+	tests := []struct {
+		updated  func() *buildapi.Build
+		validate func(bc *buildapi.Build)
+	}{
+		{
+			// Ensure spec is not changed
+			updated: func() *buildapi.Build {
+				b := testBuild()
+				b.Spec.CommonSpec.Source.Git.URI = "https://github.com/different/repo"
+				return b
+			},
+			validate: func(b *buildapi.Build) {
+				if b.Spec.CommonSpec.Source.Git.URI != original.Spec.CommonSpec.Source.Git.URI {
+					t.Errorf("unexpected change to source URI. Got: %s, Expected: %s",
+						b.Spec.CommonSpec.Source.Git.URI,
+						original.Spec.CommonSpec.Source.Git.URI)
+				}
+			},
+		},
+		{
+			// Ensure status is updated
+			updated: func() *buildapi.Build {
+				b := testBuild()
+				b.Status.Phase = buildapi.BuildPhasePending
+				return b
+			},
+			validate: func(b *buildapi.Build) {
+				if b.Status.Phase != buildapi.BuildPhasePending {
+					t.Errorf("expected status.phase to be updated to %s, got: %s", buildapi.BuildPhasePending, b.Status.Phase)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		newBuild := test.updated()
+		StatusStrategy.PrepareForUpdate(newBuild, original)
+		test.validate(newBuild)
 	}
 }

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -13,12 +14,18 @@ import (
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
+// REST implements the REST endpoint for a BuildConfig
 type REST struct {
 	*registry.Store
 }
 
+// StatusREST implements the REST endpoint for the BuildConfig status
+type StatusREST struct {
+	store *registry.Store
+}
+
 // NewStorage returns a RESTStorage object that will work against nodes.
-func NewREST(optsGetter restoptions.Getter) (*REST, error) {
+func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 	prefix := "/buildconfigs"
 
 	store := &registry.Store{
@@ -45,8 +52,26 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	}
 
 	if err := restoptions.ApplyOptions(optsGetter, store, prefix); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &REST{store}, nil
+	statusStore := *store
+	statusStore.UpdateStrategy = buildconfig.StatusStrategy
+
+	return &REST{store}, &StatusREST{store: &statusStore}, nil
+}
+
+// New creates a new pod resource
+func (r *StatusREST) New() runtime.Object {
+	return &api.BuildConfig{}
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	return r.store.Get(ctx, name)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx kapi.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo)
 }

--- a/pkg/build/registry/buildconfig/etcd/etcd_test.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd_test.go
@@ -17,7 +17,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-	storage, err := NewREST(restoptions.NewSimpleGetter(etcdStorage))
+	storage, _, err := NewREST(restoptions.NewSimpleGetter(etcdStorage))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -8,15 +8,8 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
-func TestBuildConfigStrategy(t *testing.T) {
-	ctx := kapi.NewDefaultContext()
-	if !Strategy.NamespaceScoped() {
-		t.Errorf("BuildConfig is namespace scoped")
-	}
-	if Strategy.AllowCreateOnUpdate() {
-		t.Errorf("BuildConfig should not allow create on update")
-	}
-	buildConfig := &buildapi.BuildConfig{
+func testBC() *buildapi.BuildConfig {
+	return &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
 			RunPolicy: buildapi.BuildRunPolicySerial,
@@ -24,6 +17,14 @@ func TestBuildConfigStrategy(t *testing.T) {
 				{
 					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
 					Type:          buildapi.GitHubWebHookBuildTriggerType,
+				},
+				{
+					ImageChange: &buildapi.ImageChangeTrigger{
+						From: &kapi.ObjectReference{
+							Kind: "ImageStreamTag",
+							Name: "testimage:latest",
+						},
+					},
 				},
 				{
 					Type: "unknown",
@@ -51,41 +52,20 @@ func TestBuildConfigStrategy(t *testing.T) {
 			LastVersion: 10,
 		},
 	}
-	newBC := &buildapi.BuildConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
-		Spec: buildapi.BuildConfigSpec{
-			RunPolicy: buildapi.BuildRunPolicySerial,
-			Triggers: []buildapi.BuildTriggerPolicy{
-				{
-					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
-					Type:          buildapi.GitHubWebHookBuildTriggerType,
-				},
-				{
-					Type: "unknown",
-				},
-			},
-			CommonSpec: buildapi.CommonSpec{
-				Source: buildapi.BuildSource{
-					Git: &buildapi.GitBuildSource{
-						URI: "http://github.com/my/repository",
-					},
-					ContextDir: "context",
-				},
-				Strategy: buildapi.BuildStrategy{
-					DockerStrategy: &buildapi.DockerBuildStrategy{},
-				},
-				Output: buildapi.BuildOutput{
-					To: &kapi.ObjectReference{
-						Kind: "DockerImage",
-						Name: "repository/data",
-					},
-				},
-			},
-		},
-		Status: buildapi.BuildConfigStatus{
-			LastVersion: 9,
-		},
+}
+
+func TestBuildConfigStrategy(t *testing.T) {
+	ctx := kapi.NewDefaultContext()
+	if !Strategy.NamespaceScoped() {
+		t.Errorf("BuildConfig is namespace scoped")
 	}
+	if Strategy.AllowCreateOnUpdate() {
+		t.Errorf("BuildConfig should not allow create on update")
+	}
+	buildConfig := testBC()
+	newBC := testBC()
+
+	// Ensure PrepareForCreate and Validation work
 	Strategy.PrepareForCreate(buildConfig)
 	errs := Strategy.Validate(ctx, buildConfig)
 	if len(errs) != 0 {
@@ -116,5 +96,62 @@ func TestBuildConfigStrategy(t *testing.T) {
 	errs = Strategy.Validate(ctx, invalidBuildConfig)
 	if len(errs) == 0 {
 		t.Errorf("Expected error validating")
+	}
+}
+
+func TestBuildConfigStatusUpdate(t *testing.T) {
+	original := testBC()
+
+	tests := []struct {
+		updated  func() *buildapi.BuildConfig
+		validate func(bc *buildapi.BuildConfig)
+	}{
+		{
+			// Ensure spec is not changed
+			updated: func() *buildapi.BuildConfig {
+				bc := testBC()
+				bc.Spec.CommonSpec.Source.Git.URI = "https://github.com/different/repo"
+				return bc
+			},
+			validate: func(bc *buildapi.BuildConfig) {
+				if bc.Spec.CommonSpec.Source.Git.URI != original.Spec.CommonSpec.Source.Git.URI {
+					t.Errorf("unexpected change to source URI. Got: %s, Expected: %s",
+						bc.Spec.CommonSpec.Source.Git.URI,
+						original.Spec.CommonSpec.Source.Git.URI)
+				}
+			},
+		},
+		{
+			// Ensure status is updated
+			updated: func() *buildapi.BuildConfig {
+				bc := testBC()
+				bc.Status.LastVersion = 100
+				return bc
+			},
+			validate: func(bc *buildapi.BuildConfig) {
+				if bc.Status.LastVersion != 100 {
+					t.Errorf("expected status to be updated to %d, got: %d", 100, bc.Status.LastVersion)
+				}
+			},
+		},
+		{
+			// Ensure that trigger is updated
+			updated: func() *buildapi.BuildConfig {
+				bc := testBC()
+				bc.Spec.Triggers[1].ImageChange.LastTriggeredImageID = "last_triggered_image_id"
+				return bc
+			},
+			validate: func(bc *buildapi.BuildConfig) {
+				if bc.Spec.Triggers[1].ImageChange.LastTriggeredImageID != "last_triggered_image_id" {
+					t.Errorf("expected an update to LastTriggeredImageID. Got: %s",
+						bc.Spec.Triggers[1].ImageChange.LastTriggeredImageID)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		newBC := test.updated()
+		StatusStrategy.PrepareForUpdate(newBC, original)
+		test.validate(newBC)
 	}
 }

--- a/pkg/build/registry/buildconfiginstantiate/rest_test.go
+++ b/pkg/build/registry/buildconfiginstantiate/rest_test.go
@@ -28,7 +28,7 @@ func TestCreateInstantiate(t *testing.T) {
 			GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
 				return mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput()), nil
 			},
-			UpdateBuildConfigFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
+			UpdateBuildConfigStatusFunc: func(ctx kapi.Context, buildConfig *buildapi.BuildConfig) error {
 				return nil
 			},
 			CreateBuildFunc: func(ctx kapi.Context, build *buildapi.Build) error {

--- a/pkg/client/buildconfigs.go
+++ b/pkg/client/buildconfigs.go
@@ -33,6 +33,7 @@ type BuildConfigInterface interface {
 	InstantiateBinary(request *buildapi.BinaryBuildRequestOptions, r io.Reader) (result *buildapi.Build, err error)
 
 	WebHookURL(name string, trigger *buildapi.BuildTriggerPolicy) (*url.URL, error)
+	UpdateStatus(build *buildapi.BuildConfig) (*buildapi.BuildConfig, error)
 }
 
 // buildConfigs implements BuildConfigsNamespacer interface
@@ -92,6 +93,13 @@ func (c *buildConfigs) Create(build *buildapi.BuildConfig) (result *buildapi.Bui
 func (c *buildConfigs) Update(build *buildapi.BuildConfig) (result *buildapi.BuildConfig, err error) {
 	result = &buildapi.BuildConfig{}
 	err = c.r.Put().Namespace(c.ns).Resource("buildConfigs").Name(build.Name).Body(build).Do().Into(result)
+	return
+}
+
+// UpdateStatus updates the buildconfig status on the server. Returns the server's representation of the buildconfig and error if one occurs.
+func (c *buildConfigs) UpdateStatus(build *buildapi.BuildConfig) (result *buildapi.BuildConfig, err error) {
+	result = &buildapi.BuildConfig{}
+	err = c.r.Put().Namespace(c.ns).Resource("buildConfigs").Name(build.Name).SubResource("status").Body(build).Do().Into(result)
 	return
 }
 

--- a/pkg/client/builds.go
+++ b/pkg/client/builds.go
@@ -22,6 +22,7 @@ type BuildInterface interface {
 	Watch(opts kapi.ListOptions) (watch.Interface, error)
 	Clone(request *buildapi.BuildRequest) (*buildapi.Build, error)
 	UpdateDetails(build *buildapi.Build) (*buildapi.Build, error)
+	UpdateStatus(build *buildapi.Build) (*buildapi.Build, error)
 }
 
 // builds implements BuildsNamespacer interface
@@ -100,5 +101,12 @@ func (c *builds) Clone(request *buildapi.BuildRequest) (result *buildapi.Build, 
 func (c *builds) UpdateDetails(build *buildapi.Build) (result *buildapi.Build, err error) {
 	result = &buildapi.Build{}
 	err = c.r.Put().Namespace(c.ns).Resource("builds").Name(build.Name).SubResource("details").Body(build).Do().Into(result)
+	return
+}
+
+// UpdateStatus updates the build status for a given build.
+func (c *builds) UpdateStatus(build *buildapi.Build) (result *buildapi.Build, err error) {
+	result = &buildapi.Build{}
+	err = c.r.Put().Namespace(c.ns).Resource("builds").Name(build.Name).SubResource("status").Body(build).Do().Into(result)
 	return
 }

--- a/pkg/client/testclient/fake_buildconfigs.go
+++ b/pkg/client/testclient/fake_buildconfigs.go
@@ -97,3 +97,12 @@ func (c *FakeBuildConfigs) InstantiateBinary(request *buildapi.BinaryBuildReques
 
 	return obj.(*buildapi.Build), err
 }
+
+func (c *FakeBuildConfigs) UpdateStatus(inObj *buildapi.BuildConfig) (*buildapi.BuildConfig, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewUpdateAction("buildconfigs/status", c.Namespace, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*buildapi.BuildConfig), err
+}

--- a/pkg/client/testclient/fake_builds.go
+++ b/pkg/client/testclient/fake_builds.go
@@ -79,3 +79,12 @@ func (c *FakeBuilds) UpdateDetails(inObj *buildapi.Build) (*buildapi.Build, erro
 
 	return obj.(*buildapi.Build), err
 }
+
+func (c *FakeBuilds) UpdateStatus(inObj *buildapi.Build) (*buildapi.Build, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewUpdateAction("builds/status", c.Namespace, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*buildapi.Build), err
+}

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -193,7 +193,7 @@ func (o *CancelBuildOptions) Run() error {
 		go func(build *buildapi.Build) {
 			defer wg.Done()
 			err := wait.Poll(500*time.Millisecond, 30*time.Second, func() (bool, error) {
-				build.Status.Cancelled = true
+				build.Spec.Cancelled = true
 				_, err := o.BuildClient.Update(build)
 				switch {
 				case err == nil:

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -120,11 +120,13 @@ func init() {
 					Verbs:     sets.NewString("get", "list", "watch"),
 					Resources: sets.NewString("builds"),
 				},
+				// TODO: Remove permission to update builds when no longer a compatibility issue
 				// BuildController.BuildUpdater (OSClientBuildClient)
 				{
 					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("builds"),
+					Resources: sets.NewString("builds", "builds/status"),
 				},
+				// TODO: Remove permission to create virtual build strategy types when no longer a compatibility issue
 				// Create permission on virtual build type resources allows builds of those types to be updated
 				{
 					Verbs:     sets.NewString("create"),

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -240,10 +240,10 @@ func (c *MasterConfig) RunBuildController(informers shared.InformerFactory) {
 
 	osclient, kclient := c.BuildControllerClients()
 	factory := buildcontrollerfactory.BuildControllerFactory{
-		KubeClient:   kclient,
-		OSClient:     osclient,
-		BuildUpdater: buildclient.NewOSClientBuildClient(osclient),
-		BuildLister:  buildclient.NewOSClientBuildClient(osclient),
+		KubeClient:         kclient,
+		OSClient:           osclient,
+		BuildStatusUpdater: buildclient.NewOSClientBuildClient(osclient),
+		BuildLister:        buildclient.NewOSClientBuildClient(osclient),
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
 			Image: dockerImage,
 			// TODO: this will be set to --storage-version (the internal schema we use)
@@ -271,9 +271,9 @@ func (c *MasterConfig) RunBuildController(informers shared.InformerFactory) {
 func (c *MasterConfig) RunBuildPodController() {
 	osclient, kclient := c.BuildPodControllerClients()
 	factory := buildcontrollerfactory.BuildPodControllerFactory{
-		OSClient:     osclient,
-		KubeClient:   kclient,
-		BuildUpdater: buildclient.NewOSClientBuildClient(osclient),
+		OSClient:           osclient,
+		KubeClient:         kclient,
+		BuildStatusUpdater: buildclient.NewOSClientBuildClient(osclient),
 	}
 	controller := factory.Create()
 	controller.Run()

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -242,6 +242,7 @@ func (c *MasterConfig) RunBuildController(informers shared.InformerFactory) {
 	factory := buildcontrollerfactory.BuildControllerFactory{
 		KubeClient:         kclient,
 		OSClient:           osclient,
+		BuildUpdater:       buildclient.NewOSClientBuildClient(osclient),
 		BuildStatusUpdater: buildclient.NewOSClientBuildClient(osclient),
 		BuildLister:        buildclient.NewOSClientBuildClient(osclient),
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -102,6 +102,8 @@ func TestClusterReaderCoverage(t *testing.T) {
 		imageapi.Resource("imagestreamimports"), imageapi.Resource("imagestreammappings"),
 		extensionsapi.Resource("deployments/rollback"),
 		kapi.Resource("pods/attach"), kapi.Resource("namespaces/finalize"),
+		kapi.Resource("builds/status"),
+		kapi.Resource("buildconfigs/status"),
 	}
 	for _, resource := range nonreadingResources {
 		delete(allResources, resource)

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -764,7 +764,7 @@ func runBuildCompletePodDeleteTest(t *testing.T, clusterAdminClient *client.Clie
 	}
 
 	newBuild.Status.Phase = buildapi.BuildPhaseComplete
-	clusterAdminClient.Builds(testutil.Namespace()).Update(newBuild)
+	clusterAdminClient.Builds(testutil.Namespace()).UpdateStatus(newBuild)
 	event = waitForWatch(t, "build updated to complete", buildWatch)
 	if e, a := watchapi.Modified, event.Type; e != a {
 		t.Fatalf("expected watch event type %s, got %s", e, a)

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2182,6 +2182,7 @@ items:
     attributeRestrictions: null
     resources:
     - builds
+    - builds/status
     verbs:
     - update
   - apiGroups:


### PR DESCRIPTION
Introduces 2 new subresources for builds and buildconfigs
- builds/status
- buildconfigs/status

For builds, any modifications to the build.Status struct should now be done through the builds/status subresource, with the exception of the build.Status.Cancelled flag. That flag can still be modified through the regular builds resource. Modifications to the build.Spec can only be done through the builds resource.

For buildConfigs, modifications to the buildconfig.Status struct are now only allowed through the buildconfigs/status subresource. Modifications to the buildconfig.Spec struct are only allowed through the buildconfigs resource with the exception of changes to the buildconfig.Spec.Triggers[x].ImageChange.LastImageID field. That field can be modified through the buildconfigs/status subresource.

The intent of these changes is to separate the use cases for regular updates vs status updates. In general, only the system (controllers, API server) should be allowed to change the status of an object. And only users should be allowed to change the Spec of the object. In the case of builds, a build should generally be immutable from a regular user's perspective. The exception to this is the cancel operation.

The build controller service account no longer needs to have create permission on the builds/source, builds/docker, builds/custom subresources because it only needs to do builds/status updates.

Fixes https://github.com/openshift/origin/issues/6886
