### PR TITLE
Support scheduler config options so custom schedulers can be used

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -974,8 +974,10 @@ type KubernetesMasterConfig struct {
 	ServicesNodePortRange string
 	// StaticNodeNames is the list of nodes that are statically known
 	StaticNodeNames []string
+
 	// SchedulerConfigFile points to a file that describes how to set up the scheduler. If empty, you get the default scheduling rules.
 	SchedulerConfigFile string
+
 	// PodEvictionTimeout controls grace period for deleting pods on failed nodes.
 	// It takes valid time duration string. If empty, you get the default pod eviction timeout.
 	PodEvictionTimeout string
@@ -995,6 +997,10 @@ type KubernetesMasterConfig struct {
 	// the server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalid
 	// configurations.
 	ControllerArguments ExtendedArguments
+	// SchedulerArguments are key value pairs that will be passed directly to the Kube scheduler that match the scheduler's
+	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not
+	// start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.
+	SchedulerArguments ExtendedArguments
 }
 
 type CertInfo struct {

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -353,6 +353,7 @@ var map_KubernetesMasterConfig = map[string]string{
 	"admissionConfig":          "AdmissionConfig contains admission control plugin configuration.",
 	"apiServerArguments":       "APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers's command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.",
 	"controllerArguments":      "ControllerArguments are key value pairs that will be passed directly to the Kube controller manager that match the controller manager's command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.",
+	"schedulerArguments":       "SchedulerArguments are key value pairs that will be passed directly to the Kube scheduler that match the scheduler's command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.",
 }
 
 func (KubernetesMasterConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -970,8 +970,10 @@ type KubernetesMasterConfig struct {
 	ServicesNodePortRange string `json:"servicesNodePortRange"`
 	// StaticNodeNames is the list of nodes that are statically known
 	StaticNodeNames []string `json:"staticNodeNames"`
+
 	// SchedulerConfigFile points to a file that describes how to set up the scheduler. If empty, you get the default scheduling rules.
 	SchedulerConfigFile string `json:"schedulerConfigFile"`
+
 	// PodEvictionTimeout controls grace period for deleting pods on failed nodes.
 	// It takes valid time duration string. If empty, you get the default pod eviction timeout.
 	PodEvictionTimeout string `json:"podEvictionTimeout"`
@@ -990,6 +992,10 @@ type KubernetesMasterConfig struct {
 	// the server will not start. These values may override other settings in KubernetesMasterConfig which may cause invalid
 	// configurations.
 	ControllerArguments ExtendedArguments `json:"controllerArguments"`
+	// SchedulerArguments are key value pairs that will be passed directly to the Kube scheduler that match the scheduler's
+	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not
+	// start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.
+	SchedulerArguments ExtendedArguments `json:"schedulerArguments"`
 }
 
 // CertInfo relates a certificate with a private key

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -184,6 +184,7 @@ kubernetesMasterConfig:
   proxyClientInfo:
     certFile: ""
     keyFile: ""
+  schedulerArguments: null
   schedulerConfigFile: ""
   servicesNodePortRange: ""
   servicesSubnet: ""

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -356,9 +356,9 @@ func (c *MasterConfig) createSchedulerConfig() (*scheduler.Config, error) {
 	var configData []byte
 
 	// TODO make the rate limiter configurable
-	configFactory := factory.NewConfigFactory(c.KubeClient, kapi.DefaultSchedulerName, kapi.DefaultHardPodAffinitySymmetricWeight, kapi.DefaultFailureDomains)
+	configFactory := factory.NewConfigFactory(c.KubeClient, c.SchedulerServer.SchedulerName, int(c.SchedulerServer.HardPodAffinitySymmetricWeight), c.SchedulerServer.FailureDomains)
 	if _, err := os.Stat(c.Options.SchedulerConfigFile); err == nil {
-		configData, err = ioutil.ReadFile(c.Options.SchedulerConfigFile)
+		configData, err = ioutil.ReadFile(c.SchedulerServer.PolicyConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read scheduler config: %v", err)
 		}

--- a/pkg/cmd/server/kubernetes/master_config_test.go
+++ b/pkg/cmd/server/kubernetes/master_config_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 	utilconfig "k8s.io/kubernetes/pkg/util/config"
 	"k8s.io/kubernetes/pkg/util/diff"
+	scheduleroptions "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
@@ -135,6 +136,43 @@ func TestCMServerDefaults(t *testing.T) {
 				LeaseDuration: unversioned.Duration{Duration: 15 * time.Second},
 				RenewDeadline: unversioned.Duration{Duration: 10 * time.Second},
 				RetryPeriod:   unversioned.Duration{Duration: 2 * time.Second},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(defaults, expectedDefaults) {
+		t.Logf("expected defaults, actual defaults: \n%s", diff.ObjectReflectDiff(expectedDefaults, defaults))
+		t.Errorf("Got different defaults than expected, adjust in BuildKubernetesMasterConfig and update expectedDefaults")
+	}
+}
+
+func TestSchedulerServerDefaults(t *testing.T) {
+	defaults := scheduleroptions.NewSchedulerServer()
+
+	// This is a snapshot of the default config
+	// If the default changes (new fields are added, or default values change), we want to know
+	// Once we've reacted to the changes appropriately in BuildKubernetesMasterConfig(), update this expected default to match the new upstream defaults
+	expectedDefaults := &scheduleroptions.SchedulerServer{
+		KubeSchedulerConfiguration: componentconfig.KubeSchedulerConfiguration{
+			Port:                           10251, // disabled
+			Address:                        "0.0.0.0",
+			AlgorithmProvider:              "DefaultProvider",
+			ContentType:                    "application/vnd.kubernetes.protobuf",
+			KubeAPIQPS:                     50,
+			KubeAPIBurst:                   100,
+			SchedulerName:                  "default-scheduler",
+			HardPodAffinitySymmetricWeight: 1,
+			FailureDomains:                 "kubernetes.io/hostname,failure-domain.beta.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region",
+			LeaderElection: componentconfig.LeaderElectionConfiguration{
+				LeaseDuration: unversioned.Duration{
+					Duration: 15 * time.Second,
+				},
+				RenewDeadline: unversioned.Duration{
+					Duration: 10 * time.Second,
+				},
+				RetryPeriod: unversioned.Duration{
+					Duration: 2 * time.Second,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Will allow us to be consistent with upstream on this.

@ncdc