### PR TITLE
example: add pulling origin-pod

### DIFF
--- a/examples/sample-app/pullimages.sh
+++ b/examples/sample-app/pullimages.sh
@@ -3,3 +3,4 @@ docker pull openshift/origin-docker-registry
 #docker pull openshift/origin-docker-builder
 docker pull openshift/origin-sti-builder
 docker pull openshift/origin-deployer
+docker pull openshift/origin-pod


### PR DESCRIPTION
When I do that as described in the example, after running ./pullimages.sh. I see the docker images have been download in my host. Now I want to run openshift test in my another computer, I'd like to say this computer is not online,  I have to load all images(tar) from previously computer(online) to local(not online), after  running '**openshift start**' and '**oadm registry -n default --config=openshift.local.config/master/admin.kubeconfig**'.
I found that the endpoints of docker-registry service is none. 
there are some errors in log like this:
**ERRO[2139] Handler for GET /images/openshift/origin-pod:v1.3.0-alpha.2/json returned error: No such image: openshift/origin-pod:v1.3.0-alpha.2**
I think openshift need 'openshift/origin-pod' image to be download. 
the description of this action may be in other documents, in order to better guide, we should update the script. 