### PR TITLE
Handled working dir changes in Bash relative path util

### DIFF
--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -289,13 +289,7 @@ function os::cmd::internal::determine_caller() {
 	done
 
 	local caller_file="${BASH_SOURCE[${call_depth}]}"
-	if which realpath >&/dev/null; then
-		# if the caller has `realpath`, we can use it to make our file names cleaner by
-		# trimming the absolute file path up to `...openshift/origin/` and showing only
-		# the relative path from the Origin root directory
-		caller_file="$( realpath "${caller_file}" )"
-		caller_file="${caller_file//*openshift\/origin\/}"
-	fi
+    caller_file="$( os::util::repository_relative_path "${caller_file}" )"
 	local caller_line="${BASH_LINENO[${call_depth}-1]}"
 	echo "${caller_file}:${caller_line}"
 }

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -42,7 +42,7 @@ readonly -f os::util::describe_return_code
 # Arguments:
 #  None
 # Returns:
-#  - export OS_DESCRIBE_RETURN_CODE 
+#  - export OS_DESCRIBE_RETURN_CODE
 #  - export OS_SCRIPT_START_TIME
 function os::util::install_describe_return_code() {
 	export OS_DESCRIBE_RETURN_CODE="true"
@@ -50,6 +50,18 @@ function os::util::install_describe_return_code() {
 	os::util::trap::init_exit
 }
 readonly -f os::util::install_describe_return_code
+
+# OS_ORIGINAL_WD is the original working directory the script sourcing this utility file was called
+# from. This is an important directory as if $0 is a relative path, we cannot use the following path
+# utility without knowing from where $0 is relative.
+if [[ -z "${OS_ORIGINAL_WD:-}" ]]; then
+	# since this could be sourced in a context where the utilities are already loaded,
+	# we want to ensure that this is re-entrant, so we only set $OS_ORIGINAL_WD if it
+	# is not set already
+	OS_ORIGINAL_WD="$( pwd )"
+	readonly OS_ORIGINAL_WD
+	export OS_ORIGINAL_WD
+fi
 
 # os::util::repository_relative_path returns the relative path from the $OS_ROOT directory to the
 # given file, if the file is inside of the $OS_ROOT directory. If the file is outside of $OS_ROOT,
@@ -65,10 +77,12 @@ function os::util::repository_relative_path() {
 	local filename=$1
 
 	if which realpath >/dev/null 2>&1; then
+		pushd "${OS_ORIGINAL_WD}" >/dev/null 2>&1
 		local trim_path
-        trim_path="$( realpath "${OS_ROOT}" )/"
+		trim_path="$( realpath "${OS_ROOT}" )/"
 		filename="$( realpath "${filename}" )"
 		filename="${filename##*${trim_path}}"
+		popd >/dev/null 2>&1
 	fi
 
 	echo "${filename}"


### PR DESCRIPTION
The `os::util::repository_relative_path` utility attempts to print
the relative path from the repo root to a file in the repo. To
accomplish this, it utilizes `realpath` and is therefore dependent
on the working directory to be able to resolve relative paths. If
a script changes the current working directory, the utility breaks.
With this change, the working directory at the time of sourcing
the utility is recorded and used to make the function is robust to
that behavior.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/openshift/origin/issues/10041

@Miciah PTAL
@enj FYI