### PR TITLE
Removed namespace assumptions from test-cmd test cases

### DIFF
--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -9,6 +9,8 @@ source "${OS_ROOT}/hack/lib/init.sh"
 os::log::stacktrace::install
 trap os::test::junit::reconcile_output EXIT
 
+project="$( oc project -q )"
+
 os::test::junit::declare_suite_start "cmd/authentication"
 
 os::test::junit::declare_suite_start "cmd/authentication/scopedtokens"
@@ -19,39 +21,39 @@ os::cmd::expect_success 'oc login -u scoped-user -p asdf'
 os::cmd::expect_success 'oc login -u system:admin'
 username="$(oc get user/scoped-user -o jsonpath='{.metadata.name}')"
 useruid="$(oc get user/scoped-user -o jsonpath='{.metadata.uid}')"
-os::cmd::expect_success_and_text "oc policy can-i --list -n cmd-authentication --as=scoped-user" 'get.*pods'
+os::cmd::expect_success_and_text "oc policy can-i --list -n '${project}' --as=scoped-user" 'get.*pods'
 
 whoamitoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=whoami SCOPE=user:info USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
 os::cmd::expect_success_and_text "oc get user/~ --token='${whoamitoken}'" "${username}"
-os::cmd::expect_failure_and_text "oc get pods --token='${whoamitoken}' -n cmd-authentication" 'prevent this action; User "scoped-user" cannot list pods in project "cmd-authentication"'
+os::cmd::expect_failure_and_text "oc get pods --token='${whoamitoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
 
 listprojecttoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=listproject SCOPE=user:list-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
-os::cmd::expect_success_and_text "oc get projects --token='${listprojecttoken}'" 'cmd-authentication'
+os::cmd::expect_success_and_text "oc get projects --token='${listprojecttoken}'" "${project}"
 os::cmd::expect_failure_and_text "oc get user/~ --token='${listprojecttoken}'" 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
-os::cmd::expect_failure_and_text "oc get pods --token='${listprojecttoken}' -n cmd-authentication" 'prevent this action; User "scoped-user" cannot list pods in project "cmd-authentication"'
+os::cmd::expect_failure_and_text "oc get pods --token='${listprojecttoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
 
 adminnonescalatingpowerstoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=admin SCOPE=role:admin:* USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
 os::cmd::expect_failure_and_text "oc get user/~ --token='${adminnonescalatingpowerstoken}'" 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
-os::cmd::expect_failure_and_text "oc get secrets --token='${adminnonescalatingpowerstoken}' -n cmd-authentication" 'prevent this action; User "scoped-user" cannot list secrets in project "cmd-authentication"'
-os::cmd::expect_success_and_text "oc get projects/cmd-authentication --token='${adminnonescalatingpowerstoken}' -n cmd-authentication" 'cmd-authentication'
+os::cmd::expect_failure_and_text "oc get secrets --token='${adminnonescalatingpowerstoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list secrets in project \"${project}\""
+os::cmd::expect_success_and_text "oc get 'projects/${project}' --token='${adminnonescalatingpowerstoken}' -n '${project}'" "${project}"
 
 allescalatingpowerstoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=clusteradmin SCOPE='role:cluster-admin:*:!' USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
 os::cmd::expect_success_and_text "oc get user/~ --token='${allescalatingpowerstoken}'" "${username}"
-os::cmd::expect_success "oc get secrets --token='${allescalatingpowerstoken}' -n cmd-authentication"
+os::cmd::expect_success "oc get secrets --token='${allescalatingpowerstoken}' -n '${project}'"
 # scopes allow it, but authorization doesn't
 os::cmd::expect_failure_and_text "oc get secrets --token='${allescalatingpowerstoken}' -n default" 'cannot list secrets in project'
-os::cmd::expect_success_and_text "oc get projects --token='${allescalatingpowerstoken}'" 'cmd-authentication'
-os::cmd::expect_success_and_text "oc policy can-i --list --token='${allescalatingpowerstoken}' -n cmd-authentication" 'get.*pods'
+os::cmd::expect_success_and_text "oc get projects --token='${allescalatingpowerstoken}'" "${project}"
+os::cmd::expect_success_and_text "oc policy can-i --list --token='${allescalatingpowerstoken}' -n '${project}'" 'get.*pods'
 
 accesstoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=access SCOPE=user:check-access USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
-os::cmd::expect_success_and_text "curl -k -XPOST -H 'Content-Type: application/json' -H 'Authorization: Bearer ${accesstoken}' ${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/cmd-authentication/localsubjectaccessreviews -d @${OS_ROOT}/test/testdata/authentication/localsubjectaccessreview.json" '"kind": "SubjectAccessReviewResponse"'
-os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication --ignore-scopes" 'yes'
-os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication" 'no'
-os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n cmd-authentication" 'no'
-os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n cmd-authentication --ignore-scopes" 'yes'
-os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n cmd-authentication --scopes='role:admin:*'" 'yes'
-os::cmd::expect_success_and_text "oc policy can-i --list --token='${accesstoken}' -n cmd-authentication --scopes='role:admin:*'" 'get.*pods'
-os::cmd::expect_success_and_not_text "oc policy can-i --list --token='${accesstoken}' -n cmd-authentication" 'get.*pods'
+os::cmd::expect_success_and_text "curl -k -XPOST -H 'Content-Type: application/json' -H 'Authorization: Bearer ${accesstoken}' '${API_SCHEME}://${API_HOST}:${API_PORT}/oapi/v1/namespaces/${project}/localsubjectaccessreviews' -d @${OS_ROOT}/test/testdata/authentication/localsubjectaccessreview.json" '"kind": "SubjectAccessReviewResponse"'
+os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n '${project}' --ignore-scopes" 'yes'
+os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n '${project}'" 'no'
+os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n '${project}'" 'no'
+os::cmd::expect_success_and_text "oc policy can-i create subjectaccessreviews --token='${accesstoken}' -n '${project}' --ignore-scopes" 'yes'
+os::cmd::expect_success_and_text "oc policy can-i create pods --token='${accesstoken}' -n '${project}' --scopes='role:admin:*'" 'yes'
+os::cmd::expect_success_and_text "oc policy can-i --list --token='${accesstoken}' -n '${project}' --scopes='role:admin:*'" 'get.*pods'
+os::cmd::expect_success_and_not_text "oc policy can-i --list --token='${accesstoken}' -n '${project}'" 'get.*pods'
 
 
 os::test::junit::declare_suite_end

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -9,6 +9,8 @@ source "${OS_ROOT}/hack/lib/init.sh"
 os::log::stacktrace::install
 trap os::test::junit::reconcile_output EXIT
 
+project="$( oc project -q )"
+
 os::test::junit::declare_suite_start "cmd/policy"
 # This test validates user level policy
 os::cmd::expect_success_and_text 'oc whoami --as deads' "deads"
@@ -26,7 +28,7 @@ os::cmd::expect_success 'oc new-project foo'
 os::cmd::expect_failure 'oc whoami --as=system:admin'
 os::cmd::expect_success_and_text 'oc whoami --as=system:serviceaccount:foo:default' "system:serviceaccount:foo:default"
 os::cmd::expect_failure 'oc whoami --as=system:serviceaccount:another:default'
-os::cmd::expect_success 'oc login -u system:admin -n cmd-policy'
+os::cmd::expect_success "oc login -u system:admin -n '${project}'"
 os::cmd::expect_success 'oc delete project foo'
 
 

--- a/test/extended/testdata/roles/policy-roles.yaml
+++ b/test/extended/testdata/roles/policy-roles.yaml
@@ -1,68 +1,75 @@
+kind: Template
 apiVersion: v1
-items:
-- apiVersion: v1
-  kind: Role
-  metadata:
-    creationTimestamp: null
-    name: basic-user
-  rules:
-  - apiGroups: null
-    attributeRestrictions: null
-    resourceNames:
-    - "~"
-    resources:
-    - users
-    verbs:
-    - get
-  - apiGroups: null
-    attributeRestrictions: null
-    resources:
-    - projectrequests
-    verbs:
-    - list
-  - apiGroups: null
-    attributeRestrictions: null
-    resources:
-    - clusterroles
-    verbs:
-    - get
-    - list
-  - apiGroups: null
-    attributeRestrictions: null
-    resources:
-    - projects
-    verbs:
-    - list
-  - apiGroups: null
-    attributeRestrictions:
-      apiVersion: v1
-      kind: IsPersonalSubjectAccessReview
-    resources:
-    - localsubjectaccessreviews
-    - subjectaccessreviews
-    verbs:
-    - create
-- apiVersion: v1
-  groupNames:
-  - system:authenticated
-  kind: PolicyBinding
-  metadata:
-    name: "cmd-admin:default"
-  policyRef:
-    namespace: cmd-admin
-- apiVersion: v1
-  groupNames:
-  - system:authenticated
-  kind: RoleBinding
-  metadata:
-    creationTimestamp: null
-    name: basic-users
-  roleRef:
-    name: basic-user
-    namespace: cmd-admin
-  subjects:
-  - kind: SystemGroup
-    name: system:authenticated
-  userNames: null
-kind: List
-metadata: {}
+metadata:
+  name: "policy-roles-template"
+labels:
+  createdBy: "policy-roles-template"
+parameters:
+  - description: "The namespace to create roles in."
+    name: NAMESPACE
+    required: true
+objects:
+  - apiVersion: v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      name: basic-user
+    rules:
+    - apiGroups: null
+      attributeRestrictions: null
+      resourceNames:
+      - "~"
+      resources:
+      - users
+      verbs:
+      - get
+    - apiGroups: null
+      attributeRestrictions: null
+      resources:
+      - projectrequests
+      verbs:
+      - list
+    - apiGroups: null
+      attributeRestrictions: null
+      resources:
+      - clusterroles
+      verbs:
+      - get
+      - list
+    - apiGroups: null
+      attributeRestrictions: null
+      resources:
+      - projects
+      verbs:
+      - list
+    - apiGroups: null
+      attributeRestrictions:
+        apiVersion: v1
+        kind: IsPersonalSubjectAccessReview
+      resources:
+      - localsubjectaccessreviews
+      - subjectaccessreviews
+      verbs:
+      - create
+  - apiVersion: v1
+    groupNames:
+    - system:authenticated
+    kind: PolicyBinding
+    metadata:
+      name: "${NAMESPACE}:default"
+    policyRef:
+      namespace: ${NAMESPACE}
+  - apiVersion: v1
+    groupNames:
+    - system:authenticated
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: basic-users
+    roleRef:
+      name: basic-user
+      namespace: ${NAMESPACE}
+    subjects:
+    - kind: SystemGroup
+      name: system:authenticated
+    userNames: null


### PR DESCRIPTION
A number of test-cmd test cases were making assumptions
about the namespace that they would be executing in. As
we support running the the tests outside of the script
launcher in hack/test-cmd.sh, tests cannot assume their
namespaces. This commit refactors the tests to determine
their namespace with `oc project -q` and thereby make
the tests less fragile.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@liggitt @deads2k @smarterclayton