### PR TITLE
handle forbidden server errs on older versions

### DIFF
--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -118,7 +118,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 	root.AddCommand(cli.NewCmdKubectl("kube", out))
 	root.AddCommand(newExperimentalCommand("ex", name+" ex"))
 	root.AddCommand(newCompletionCommand("completion", name+" completion"))
-	root.AddCommand(cmd.NewCmdVersion(name, f, out, cmd.VersionOptions{PrintEtcdVersion: true}))
+	root.AddCommand(cmd.NewCmdVersion(name, f, out, cmd.VersionOptions{PrintEtcdVersion: true, IsServer: true}))
 
 	// infra commands are those that are bundled with the binary but not displayed to end users
 	// directly


### PR DESCRIPTION
Older server versions do not support the `/version/openshift` endpoint. This updates error handling on `pkg/cmd/cli/cmd/version.go` to give a better output:

##### Before on an older server image
```
oc v1.3.0-alpha.2+75fce88
kubernetes v1.3.0+57fb9ac
features: Basic-Auth
error: unexpected end of JSON input
```

**The error at the end changed from** `error: unexpected end of JSON input` **to** `Error from server: User "<user>" cannot "get" on "/version/openshift"` when issuing command from a non-admin account.

##### After on the same image
```
oc v1.3.0-alpha.0+efda5a8-dirty
kubernetes v1.3.0+57fb9ac
features: Basic-Auth

Server https://10.13.137.149:8443
OpenShift unknown
Kubernetes v1.2.0-36-g4a3f9c5
```

"Unauthorized" users would no longer receive the error about not being able to make a "get" request to the version endpoint (this error would be ignored) as by default ["that rule is in the system:discovery role, which is granted to all users by default"](https://github.com/openshift/origin/issues/10081#issuecomment-235893420)

fixes #10082 and #10081 

cc @fabianofranz @deads2k @liggitt @stevekuznetsov 