### PR TITLE
Make bootstrap policy setup more robust

### DIFF
--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -1,13 +1,16 @@
 package policybased
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
 
 	oapi "github.com/openshift/origin/pkg/api"
@@ -63,7 +66,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runt
 
 func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 	policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
-	if err != nil && kapierrors.IsNotFound(err) {
+	if kapierrors.IsNotFound(err) {
 		return nil, kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
 	}
 	if err != nil {
@@ -80,24 +83,27 @@ func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, err
 
 // Delete(ctx api.Context, name string) (runtime.Object, error)
 func (m *VirtualStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
-	policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
-	if err != nil && kapierrors.IsNotFound(err) {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
-	}
-	if err != nil {
+	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
+		policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
+		if kapierrors.IsNotFound(err) {
+			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+		}
+		if err != nil {
+			return err
+		}
+
+		if _, exists := policy.Roles[name]; !exists {
+			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+		}
+
+		delete(policy.Roles, name)
+		policy.LastModified = unversioned.Now()
+
+		return m.PolicyStorage.UpdatePolicy(ctx, policy)
+	}); err != nil {
 		return nil, err
 	}
 
-	if _, exists := policy.Roles[name]; !exists {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
-	}
-
-	delete(policy.Roles, name)
-	policy.LastModified = unversioned.Now()
-
-	if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
-		return nil, err
-	}
 	return &unversioned.Status{Status: unversioned.StatusSuccess}, nil
 }
 
@@ -110,6 +116,13 @@ func (m *VirtualStorage) CreateRoleWithEscalation(ctx kapi.Context, obj *authori
 }
 
 func (m *VirtualStorage) createRole(ctx kapi.Context, obj runtime.Object, allowEscalation bool) (*authorizationapi.Role, error) {
+	// Copy object before passing to BeforeCreate, since it mutates
+	objCopy, err := kapi.Scheme.DeepCopy(obj)
+	if err != nil {
+		return nil, err
+	}
+	obj = objCopy.(runtime.Object)
+
 	if err := rest.BeforeCreate(m.CreateStrategy, ctx, obj); err != nil {
 		return nil, err
 	}
@@ -121,19 +134,21 @@ func (m *VirtualStorage) createRole(ctx kapi.Context, obj runtime.Object, allowE
 		}
 	}
 
-	policy, err := m.EnsurePolicy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if _, exists := policy.Roles[role.Name]; exists {
-		return nil, kapierrors.NewAlreadyExists(authorizationapi.Resource("role"), role.Name)
-	}
+	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
+		policy, err := m.EnsurePolicy(ctx)
+		if err != nil {
+			return err
+		}
+		if _, exists := policy.Roles[role.Name]; exists {
+			return kapierrors.NewAlreadyExists(authorizationapi.Resource("role"), role.Name)
+		}
 
-	role.ResourceVersion = policy.ResourceVersion
-	policy.Roles[role.Name] = role
-	policy.LastModified = unversioned.Now()
+		role.ResourceVersion = policy.ResourceVersion
+		policy.Roles[role.Name] = role
+		policy.LastModified = unversioned.Now()
 
-	if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
+		return m.PolicyStorage.UpdatePolicy(ctx, policy)
+	}); err != nil {
 		return nil, err
 	}
 
@@ -148,57 +163,78 @@ func (m *VirtualStorage) UpdateRoleWithEscalation(ctx kapi.Context, obj *authori
 }
 
 func (m *VirtualStorage) updateRole(ctx kapi.Context, name string, objInfo rest.UpdatedObjectInfo, allowEscalation bool) (*authorizationapi.Role, bool, error) {
-	old, err := m.Get(ctx, name)
-	if err != nil {
-		return nil, false, err
-	}
+	var updatedRole *authorizationapi.Role
+	var roleConflicted = false
 
-	obj, err := objInfo.UpdatedObject(ctx, old)
-	if err != nil {
-		return nil, false, err
-	}
-
-	role, ok := obj.(*authorizationapi.Role)
-	if !ok {
-		return nil, false, kapierrors.NewBadRequest(fmt.Sprintf("obj is not a role: %#v", obj))
-	}
-
-	if err := rest.BeforeUpdate(m.UpdateStrategy, ctx, obj, old); err != nil {
-		return nil, false, err
-	}
-
-	if !allowEscalation {
-		if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
-			return nil, false, err
+	// Retry if the policy update hits a conflict
+	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
+		policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
+		if kapierrors.IsNotFound(err) {
+			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
 		}
-	}
+		if err != nil {
+			return err
+		}
 
-	policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
-	if err != nil && kapierrors.IsNotFound(err) {
-		return nil, false, kapierrors.NewNotFound(authorizationapi.Resource("role"), role.Name)
-	}
-	if err != nil {
+		oldRole, exists := policy.Roles[name]
+		if !exists {
+			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+		}
+
+		obj, err := objInfo.UpdatedObject(ctx, oldRole)
+		if err != nil {
+			return err
+		}
+
+		role, ok := obj.(*authorizationapi.Role)
+		if !ok {
+			return kapierrors.NewBadRequest(fmt.Sprintf("obj is not a role: %#v", obj))
+		}
+
+		if len(role.ResourceVersion) == 0 && m.UpdateStrategy.AllowUnconditionalUpdate() {
+			role.ResourceVersion = oldRole.ResourceVersion
+		}
+
+		if err := rest.BeforeUpdate(m.UpdateStrategy, ctx, obj, oldRole); err != nil {
+			return err
+		}
+
+		if !allowEscalation {
+			if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
+				return err
+			}
+		}
+
+		// conflict detection
+		if role.ResourceVersion != oldRole.ResourceVersion {
+			// mark as a conflict err, but return an untyped error to escape the retry
+			roleConflicted = true
+			return errors.New(registry.OptimisticLockErrorMsg)
+		}
+		// non-mutating change
+		if kapi.Semantic.DeepEqual(oldRole, role) {
+			updatedRole = role
+			return nil
+		}
+
+		role.ResourceVersion = policy.ResourceVersion
+		policy.Roles[role.Name] = role
+		policy.LastModified = unversioned.Now()
+
+		if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
+			return err
+		}
+		updatedRole = role
+		return nil
+	}); err != nil {
+		if roleConflicted {
+			// construct the typed conflict error
+			return nil, false, kapierrors.NewConflict(authorizationapi.Resource("name"), name, err)
+		}
 		return nil, false, err
 	}
 
-	oldRole, exists := policy.Roles[role.Name]
-	if !exists {
-		return nil, false, kapierrors.NewNotFound(authorizationapi.Resource("role"), role.Name)
-	}
-
-	// non-mutating change
-	if kapi.Semantic.DeepEqual(oldRole, role) {
-		return role, false, nil
-	}
-
-	role.ResourceVersion = policy.ResourceVersion
-	policy.Roles[role.Name] = role
-	policy.LastModified = unversioned.Now()
-
-	if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
-		return nil, false, err
-	}
-	return role, false, nil
+	return updatedRole, false, nil
 }
 
 // EnsurePolicy returns the policy object for the specified namespace.  If one does not exist, it is created for you.  Permission to
@@ -213,7 +249,10 @@ func (m *VirtualStorage) EnsurePolicy(ctx kapi.Context) (*authorizationapi.Polic
 		// if we have no policy, go ahead and make one.  creating one here collapses code paths below.  We only take this hit once
 		policy = NewEmptyPolicy(kapi.NamespaceValue(ctx))
 		if err := m.PolicyStorage.CreatePolicy(ctx, policy); err != nil {
-			return nil, err
+			// Tolerate the policy having been created in the meantime
+			if !kapierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
 		}
 
 		policy, err = m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)

--- a/pkg/authorization/registry/role/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage_test.go
@@ -138,6 +138,80 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUnconditionalUpdate(t *testing.T) {
+	storage := makeLocalTestStorage()
+	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})
+	realizedRoleObj, err := storage.Create(ctx, &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+		Rules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString(authorizationapi.VerbAll)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	realizedRole := realizedRoleObj.(*authorizationapi.Role)
+
+	role := &authorizationapi.Role{
+		ObjectMeta: realizedRole.ObjectMeta,
+		Rules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("list", "update")},
+		},
+	}
+	role.ResourceVersion = ""
+
+	obj, created, err := storage.Update(ctx, role.Name, rest.DefaultUpdatedObjectInfo(role, kapi.Scheme))
+	if err != nil || created {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	switch actual := obj.(type) {
+	case *unversioned.Status:
+		t.Errorf("Unexpected operation error: %v", obj)
+
+	case *authorizationapi.Role:
+		if realizedRole.ResourceVersion == actual.ResourceVersion {
+			t.Errorf("Expected change to role binding. Expected: %s, Got: %s", realizedRole.ResourceVersion, actual.ResourceVersion)
+		}
+		role.ResourceVersion = actual.ResourceVersion
+		if !reflect.DeepEqual(role, obj) {
+			t.Errorf("Updated role does not match input role. %s", diff.ObjectReflectDiff(role, obj))
+		}
+	default:
+		t.Errorf("Unexpected result type: %v", obj)
+	}
+}
+
+func TestConflictingUpdate(t *testing.T) {
+	storage := makeLocalTestStorage()
+	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})
+	realizedRoleObj, err := storage.Create(ctx, &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+		Rules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString(authorizationapi.VerbAll)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	realizedRole := realizedRoleObj.(*authorizationapi.Role)
+
+	role := &authorizationapi.Role{
+		ObjectMeta: realizedRole.ObjectMeta,
+		Rules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("list", "update")},
+		},
+	}
+	role.ResourceVersion += "1"
+
+	_, _, err = storage.Update(ctx, role.Name, rest.DefaultUpdatedObjectInfo(role, kapi.Scheme))
+	if err == nil || !kapierrors.IsConflict(err) {
+		t.Errorf("Expected conflict error, got: %#v", err)
+	}
+}
+
 func TestUpdateNoOp(t *testing.T) {
 	storage := makeLocalTestStorage()
 	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})

--- a/pkg/authorization/registry/role/strategy.go
+++ b/pkg/authorization/registry/role/strategy.go
@@ -35,7 +35,7 @@ func (s strategy) AllowCreateOnUpdate() bool {
 }
 
 func (strategy) AllowUnconditionalUpdate() bool {
-	return false
+	return true
 }
 
 func (s strategy) GenerateName(base string) string {

--- a/pkg/authorization/registry/rolebinding/strategy.go
+++ b/pkg/authorization/registry/rolebinding/strategy.go
@@ -36,7 +36,7 @@ func (s strategy) AllowCreateOnUpdate() bool {
 }
 
 func (strategy) AllowUnconditionalUpdate() bool {
-	return false
+	return true
 }
 
 func (s strategy) GenerateName(base string) string {

--- a/pkg/cmd/admin/policy/modify_roles.go
+++ b/pkg/cmd/admin/policy/modify_roles.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -338,6 +339,10 @@ subjectCheck:
 	} else {
 		roleBinding.Name = getUniqueName(o.RoleName, roleBindingNames)
 		err = o.RoleBindingAccessor.CreateRoleBinding(roleBinding)
+		// If the rolebinding was created in the meantime, rerun
+		if kapierrors.IsAlreadyExists(err) {
+			return o.AddRole()
+		}
 	}
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
@@ -235,18 +235,20 @@ func (o *ReconcileClusterRoleBindingsOptions) ChangedClusterRoleBindings() ([]*a
 
 // ReplaceChangedRoleBindings will reconcile all the changed system role bindings back to the recommended bootstrap policy
 func (o *ReconcileClusterRoleBindingsOptions) ReplaceChangedRoleBindings(changedRoleBindings []*authorizationapi.ClusterRoleBinding) error {
+	errs := []error{}
 	for i := range changedRoleBindings {
 		roleBinding, err := o.RoleBindingClient.Get(changedRoleBindings[i].Name)
 		if err != nil && !kapierrors.IsNotFound(err) {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 
 		if kapierrors.IsNotFound(err) {
 			createdRoleBinding, err := o.RoleBindingClient.Create(changedRoleBindings[i])
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
-
 			fmt.Fprintf(o.Out, "clusterrolebinding/%s\n", createdRoleBinding.Name)
 			continue
 		}
@@ -259,11 +261,13 @@ func (o *ReconcileClusterRoleBindingsOptions) ReplaceChangedRoleBindings(changed
 			// TODO: for extra credit, determine whether the right to delete/create this rolebinding for the current user came from this rolebinding before deleting it
 			err := o.RoleBindingClient.Delete(roleBinding.Name)
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 			createdRoleBinding, err := o.RoleBindingClient.Create(changedRoleBindings[i])
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 			fmt.Fprintf(o.Out, "clusterrolebinding/%s\n", createdRoleBinding.Name)
 			continue
@@ -272,13 +276,14 @@ func (o *ReconcileClusterRoleBindingsOptions) ReplaceChangedRoleBindings(changed
 		roleBinding.Subjects = changedRoleBindings[i].Subjects
 		updatedRoleBinding, err := o.RoleBindingClient.Update(roleBinding)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 
 		fmt.Fprintf(o.Out, "clusterrolebinding/%s\n", updatedRoleBinding.Name)
 	}
 
-	return nil
+	return kutilerrors.NewAggregate(errs)
 }
 
 func computeUpdatedBinding(expected authorizationapi.ClusterRoleBinding, actual authorizationapi.ClusterRoleBinding, excludeSubjects []kapi.ObjectReference, union bool) (*authorizationapi.ClusterRoleBinding, bool) {

--- a/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
@@ -159,6 +159,11 @@ func (o *ReconcileClusterRoleBindingsOptions) RunReconcileClusterRoleBindings(cm
 		return fetchErr
 	}
 
+	errs := []error{}
+	if fetchErr != nil {
+		errs = append(errs, fetchErr)
+	}
+
 	if (len(o.Output) != 0) && !o.Confirmed {
 		list := &kapi.List{}
 		for _, item := range changedClusterRoleBindings {
@@ -167,13 +172,15 @@ func (o *ReconcileClusterRoleBindingsOptions) RunReconcileClusterRoleBindings(cm
 		mapper, _ := f.Object(false)
 		fn := cmdutil.VersionedPrintObject(f.PrintObject, cmd, mapper, o.Out)
 		if err := fn(list); err != nil {
-			return kutilerrors.NewAggregate([]error{fetchErr, err})
+			errs = append(errs, err)
+			return kutilerrors.NewAggregate(errs)
 		}
 	}
 
 	if o.Confirmed {
 		if err := o.ReplaceChangedRoleBindings(changedClusterRoleBindings); err != nil {
-			return kutilerrors.NewAggregate([]error{fetchErr, err})
+			errs = append(errs, err)
+			return kutilerrors.NewAggregate(errs)
 		}
 	}
 


### PR DESCRIPTION
Makes the virtual storage for role/rolebinding act more like real objects:
* Tolerate AlreadyExists errors when lazily creating empty Policy/PolicyBinding objects
* Allow unconditional updates of roles/rolebindings (empty ResourceVersion)
* Detect resourceVersion conflicts on updates on roles/rolebindings
* Retry on underlying policy/policyBinding conflicts
* Avoid mutating the original object passed into Create calls

Makes the reconcile and bootstrap operations aggregate errors and continue

Makes the AddRole() role-modification operation tolerate a race where the computed rolebinding name already exists when the operation tries to create it

Makes the bootstrap policy overwrite avoid unnecessary deletes/recreates:
1. Attempt create
2. If an AlreadyExists error is returned, attempt an unconditional update
3. If any error is returned from the update, fall back to delete/recreate (current behavior)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1359900
Fixes #8781