### PR TITLE
example : add docker image tag parameters

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -112,6 +112,9 @@ This section covers how to perform all the steps of building, deploying, and upd
 
         $ ./pullimages.sh
 
+    Note: the tag of pre-pull the Docker images should be consistent with openshift version. The default result after running this script is pulling latest version of docker images. When you need to pull specially tag, just run like this: 
+        
+        $ ./pullimages.sh v1.2.1
 
 2. Launch an all-in-one `openshift` instance
 

--- a/examples/sample-app/pullimages.sh
+++ b/examples/sample-app/pullimages.sh
@@ -1,6 +1,19 @@
 #!/bin/sh
-docker pull openshift/origin-docker-registry
+# Pull the Docker images used in this sample
+#
+# Args:
+#   TAG: image tag, the tag should be consistent with openshift version
+#
+# Example:
+#   ./pullimage.sh 
+#   ./pullimage.sh TAG
+
+if [ $# -ne 0 ];then
+    tag=$1
+    echo "using image tag: $tag"
+fi
+
+docker pull openshift/origin-docker-registry:$tag
 #docker pull openshift/origin-docker-builder
-docker pull openshift/origin-sti-builder
-docker pull openshift/origin-deployer
-docker pull openshift/origin-pod
+docker pull openshift/origin-sti-builder:$tag
+docker pull openshift/origin-deployer:$tag  


### PR DESCRIPTION
our pullimage.sh should be add dockerimage tag, like **openshift/origin-sti-builder:v1.3.0-alpha.2**.
when I run:

**$./pullimages.sh
$oadm registry -n default --config=openshift.local.config/master/admin.kubeconfig
$oc describe service docker-registry --config=openshift.local.config/master/admin.kubeconfig**

The endpoint of docker-registry service is none, when I check the log, I found the openshift is pulling docker image using tag v1.3.0-alpha.2.  I check my openshift version is v1.3.0-alpha.2, but the default result of runing  './pullimages.sh' is geting the latest tag image.  It was not match with the openshift version.  So I think we should add method to pull specifically tag image and add description for it.

