### PR TITLE
Return nil directly instead of err when err is nil

### DIFF
--- a/pkg/sdn/plugin/registry.go
+++ b/pkg/sdn/plugin/registry.go
@@ -147,7 +147,7 @@ func (registry *Registry) UpdateClusterNetwork(ni *NetworkInfo) error {
 		return err
 	}
 	log.Infof("Updated ClusterNetwork %s", clusterNetworkToString(updatedNetwork))
-	return err
+	return nil
 }
 
 func (registry *Registry) CreateClusterNetwork(ni *NetworkInfo) error {
@@ -164,7 +164,7 @@ func (registry *Registry) CreateClusterNetwork(ni *NetworkInfo) error {
 		return err
 	}
 	log.Infof("Created ClusterNetwork %s", clusterNetworkToString(updatedNetwork))
-	return err
+	return nil
 }
 
 func validateClusterNetwork(network string, hostSubnetLength uint32, serviceNetwork string, pluginName string) (*NetworkInfo, error) {


### PR DESCRIPTION
When the value of `err` is nil, return nil directly instead of err to avoid confusion.