### PR TITLE
[RPMS] Require device-mapper-persistent-data >= 0.6.2

### DIFF
--- a/contrib/tuned/origin-node-host/tuned.conf
+++ b/contrib/tuned/origin-node-host/tuned.conf
@@ -3,6 +3,7 @@
 #
 
 [main]
+summary=Optimize bare metal systems running the OpenShift
 include=throughput-performance
 
 [selinux]

--- a/origin.spec
+++ b/origin.spec
@@ -104,6 +104,7 @@ Requires:       util-linux
 Requires:       socat
 Requires:       nfs-utils
 Requires:       ethtool
+Requires:       device-mapper-persistent-data >= 0.6.2
 Requires(post):   systemd
 Requires(preun):  systemd
 Requires(postun): systemd


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1361579