### PR TITLE
Build pod controller: Always set pod name annotation on build

### DIFF
--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -452,7 +452,5 @@ func setBuildPodNameAnnotation(build *buildapi.Build, podName string) {
 	if build.Annotations == nil {
 		build.Annotations = map[string]string{}
 	}
-	if _, hasAnnotation := build.Annotations[buildapi.BuildPodNameAnnotation]; !hasAnnotation {
-		build.Annotations[buildapi.BuildPodNameAnnotation] = podName
-	}
+	build.Annotations[buildapi.BuildPodNameAnnotation] = podName
 }


### PR DESCRIPTION
When cloning a build, the build pod name annotation is not getting updated on the cloned build because one from the cloned build exists.