### PR TITLE
update hardcoded "oc" cmd suggestion in cmd output

### DIFF
--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -67,7 +67,7 @@ func NewCmdStatus(name, baseCLIName, fullName string, f *clientcmd.Factory, out 
 		Long:    fmt.Sprintf(statusLong, baseCLIName),
 		Example: fmt.Sprintf(statusExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
-			err := opts.Complete(f, cmd, args, out)
+			err := opts.Complete(f, cmd, baseCLIName, args, out)
 			kcmdutil.CheckErr(err)
 
 			if err := opts.Validate(); err != nil {
@@ -87,7 +87,7 @@ func NewCmdStatus(name, baseCLIName, fullName string, f *clientcmd.Factory, out 
 }
 
 // Complete completes the options for the Openshift cli status command.
-func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseCLIName string, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "no arguments should be provided")
 	}
@@ -116,11 +116,17 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args 
 		o.namespace = namespace
 	}
 
+	if baseCLIName == "" {
+		baseCLIName = "oc"
+	}
+
 	o.describer = &describe.ProjectStatusDescriber{
 		K:       kclient,
 		C:       client,
 		Server:  config.Host,
 		Suggest: o.verbose,
+
+		CommandBaseName: baseCLIName,
 
 		// TODO: Remove these and reference them inside the markers using constants.
 		LogsCommandName:             o.logsCommandName,

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -52,6 +52,9 @@ type ProjectStatusDescriber struct {
 	Server  string
 	Suggest bool
 
+	// root command used when calling this command
+	CommandBaseName string
+
 	LogsCommandName             string
 	SecurityPolicyCommandFormat string
 	SetProbeCommandName         string
@@ -311,20 +314,20 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 
 		switch {
 		case !d.Suggest && len(errorMarkers) > 0 && len(warningMarkers) > 0:
-			fmt.Fprintf(out, "%s and %s identified, use 'oc status -v' to see details.\n", errors, warnings)
+			fmt.Fprintf(out, "%s and %s identified, use '%[3]s status -v' to see details.\n", errors, warnings, d.CommandBaseName)
 
 		case !d.Suggest && len(errorMarkers) > 0 && errorSuggestions > 0:
-			fmt.Fprintf(out, "%s identified, use 'oc status -v' to see details.\n", errors)
+			fmt.Fprintf(out, "%s identified, use '%[2]s status -v' to see details.\n", errors, d.CommandBaseName)
 
 		case !d.Suggest && len(warningMarkers) > 0:
-			fmt.Fprintf(out, "%s identified, use 'oc status -v' to see details.\n", warnings)
+			fmt.Fprintf(out, "%s identified, use '%[2]s status -v' to see details.\n", warnings, d.CommandBaseName)
 
 		case (len(services) == 0) && (len(standaloneDCs) == 0) && (len(standaloneImages) == 0):
 			fmt.Fprintln(out, "You have no services, deployment configs, or build configs.")
-			fmt.Fprintln(out, "Run 'oc new-app' to create an application.")
+			fmt.Fprintf(out, "Run '%[1]s new-app' to create an application.\n", d.CommandBaseName)
 
 		default:
-			fmt.Fprintln(out, "View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.")
+			fmt.Fprintf(out, "View details with '%[1]s describe <resource>/<name>' or list everything with '%[1]s get all'.\n", d.CommandBaseName)
 		}
 
 		return nil

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -347,7 +347,7 @@ func TestProjectStatus(t *testing.T) {
 			o.Add(obj)
 		}
 		oc, kc := testclient.NewFixtureClients(o)
-		d := ProjectStatusDescriber{C: oc, K: kc, Server: "https://example.com:8443", Suggest: true, LogsCommandName: "oc logs -p", SecurityPolicyCommandFormat: "policycommand %s %s"}
+		d := ProjectStatusDescriber{C: oc, K: kc, Server: "https://example.com:8443", Suggest: true, CommandBaseName: "oc", LogsCommandName: "oc logs -p", SecurityPolicyCommandFormat: "policycommand %s %s"}
 		out, err := d.Describe("example", "")
 		if !test.ErrFn(err) {
 			t.Errorf("%s: unexpected error: %v", k, err)

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -76,6 +76,8 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/basicresources/status"
 os::cmd::expect_success_and_text 'openshift cli status -h' 'openshift cli describe buildConfig'
 os::cmd::expect_success_and_text 'oc status -h' 'oc describe buildConfig'
+os::cmd::expect_success_and_text 'oc status' 'oc new-app'
+os::cmd::expect_success_and_text 'openshift cli status' 'openshift cli new-app'
 echo "status help output: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
`oc` status command output contains suggestions for `oc` commands with `oc`
hardcoded rather than using the current root command (e.g. `openshift cli status` or `atomic-enterprise cli status`)

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1256274#c1 and https://bugzilla.redhat.com/show_bug.cgi?id=1256274#c3