### PR TITLE
[POC] don't admit pods that use images with images.openshift.io/deny-execut…

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -317,6 +317,7 @@ var (
 		"LimitPodHardAntiAffinityTopology",
 		"SCCExecRestrictions",
 		"PersistentVolumeLabel",
+		"ImageBlacklist",
 		// NOTE: quotaadmission and ClusterResourceQuota must be the last 2 plugins.
 		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		quotaadmission.PluginName,
@@ -349,6 +350,7 @@ var (
 		"LimitPodHardAntiAffinityTopology",
 		"SCCExecRestrictions",
 		"PersistentVolumeLabel",
+		"ImageBlacklist",
 		// NOTE: quotaadmission and ClusterResourceQuota must be the last 2 plugins.
 		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		quotaadmission.PluginName,

--- a/pkg/cmd/server/start/admission.go
+++ b/pkg/cmd/server/start/admission.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/build/admission/overrides"
 	_ "github.com/openshift/origin/pkg/build/admission/strategyrestrictions"
 	_ "github.com/openshift/origin/pkg/image/admission"
+	_ "github.com/openshift/origin/pkg/image/admission/restricted"
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/project/admission/requestlimit"
@@ -42,6 +43,7 @@ var (
 func init() {
 	defaultOffPlugins.Insert("AlwaysPullImages")
 	defaultOnPlugins.Insert("ClusterResourceQuota")
+	defaultOnPlugins.Insert("ImageBlacklist")
 	admission.PluginEnabledFn = IsAdmissionPluginActivated
 }
 

--- a/pkg/image/admission/restricted/restricted_images.go
+++ b/pkg/image/admission/restricted/restricted_images.go
@@ -1,0 +1,196 @@
+package clusterresourcequota
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	oclient "github.com/openshift/origin/pkg/client"
+	ocache "github.com/openshift/origin/pkg/client/cache"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	"github.com/openshift/origin/pkg/controller/shared"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func init() {
+	admission.RegisterPlugin("ImageBlacklist",
+		func(client clientset.Interface, config io.Reader) (admission.Interface, error) {
+			return NewImageBlacklister()
+		})
+}
+
+// imageBlacklistAdmission implements an admission controller that can enforce imageStream constraints
+type imageBlacklistAdmission struct {
+	*admission.Handler
+
+	// these are used to create the accessor
+	imageStreamLister *ocache.StoreToImageStreamLister
+	imageStreamSynced func() bool
+
+	imagesClient oclient.ImagesInterfacer
+
+	internalRegistryNames sets.String
+	blacklistAnnotation   string
+}
+
+var _ oadmission.WantsInformers = &imageBlacklistAdmission{}
+var _ oadmission.WantsOpenshiftClient = &imageBlacklistAdmission{}
+var _ oadmission.Validator = &imageBlacklistAdmission{}
+
+const (
+	timeToWaitForCacheSync = 10 * time.Second
+)
+
+func NewImageBlacklister() (admission.Interface, error) {
+	return &imageBlacklistAdmission{
+		Handler:               admission.NewHandler(admission.Create, admission.Update),
+		internalRegistryNames: sets.NewString("registry.default.svc", "172.30.106.197"),
+		blacklistAnnotation:   "images.openshift.io/deny-execution",
+	}, nil
+}
+
+// Admit makes admission decisions while enforcing imageStream
+func (q *imageBlacklistAdmission) Admit(a admission.Attributes) (err error) {
+	if a.GetResource().GroupResource() != kapi.Resource("pods") {
+		return nil
+	}
+	// ignore all operations that correspond to sub-resource actions
+	if len(a.GetSubresource()) != 0 {
+		return nil
+	}
+
+	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {
+		return admission.NewForbidden(a, errors.New("caches not synchronized"))
+	}
+
+	imageRefs, err := getPullSpecsToCheck(a)
+	if err != nil {
+		return err
+	}
+
+	for _, imageRef := range imageRefs {
+		imageDigest := imageRef.ID
+		// if the pull spec wasn't an ID, then pull the latest ID from the imagestream
+		if len(imageDigest) == 0 {
+			if !q.internalRegistryNames.Has(imageRef.Registry) {
+				continue
+			}
+
+			imageStream, err := q.imageStreamLister.ImageStreams(imageRef.Namespace).Get(imageRef.Name)
+			if kapierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return admission.NewForbidden(a, err)
+			}
+			tagName := "latest"
+			if len(imageRef.Tag) > 0 {
+				tagName = imageRef.Tag
+			}
+			tag, exists := imageStream.Status.Tags[tagName]
+			if !exists {
+				continue
+			}
+			if len(tag.Items) == 0 {
+				continue
+			}
+			imageDigest = tag.Items[0].Image
+		}
+
+		image, err := q.imagesClient.Images().Get(imageDigest)
+		if kapierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+		if image.Annotations[q.blacklistAnnotation] == "true" {
+			return admission.NewForbidden(a, fmt.Errorf("image %v has been marked as disallowed", imageRef))
+		}
+	}
+
+	return nil
+}
+
+// getPullSpecsToCheck finds the pull specs we need to check
+// for creates, we need to check every pull spec
+// for updates, we only need to check the differences
+func getPullSpecsToCheck(a admission.Attributes) ([]imageapi.DockerImageReference, error) {
+	pod, ok := a.GetObject().(*kapi.Pod)
+	if !ok {
+		return nil, admission.NewForbidden(a, fmt.Errorf("expected pod, got %T", a.GetObject()))
+	}
+
+	pullSpecs := sets.String{}
+	for _, container := range pod.Spec.InitContainers {
+		pullSpecs.Insert(container.Image)
+	}
+	for _, container := range pod.Spec.Containers {
+		pullSpecs.Insert(container.Image)
+	}
+
+	// for updates, we only want the diff
+	if a.GetOperation() == admission.Update {
+		oldPod, ok := a.GetOldObject().(*kapi.Pod)
+		if !ok {
+			return nil, admission.NewForbidden(a, fmt.Errorf("expected pod, got %T", a.GetObject()))
+		}
+		for _, container := range oldPod.Spec.InitContainers {
+			pullSpecs.Delete(container.Image)
+		}
+		for _, container := range oldPod.Spec.Containers {
+			pullSpecs.Delete(container.Image)
+		}
+	}
+
+	ret := []imageapi.DockerImageReference{}
+	for pullSpec := range pullSpecs {
+		dockerImageRef, err := imageapi.ParseDockerImageReference(pullSpec)
+		if err != nil {
+			return nil, admission.NewForbidden(a, err)
+		}
+		ret = append(ret, dockerImageRef)
+	}
+
+	return ret, nil
+}
+
+func (q *imageBlacklistAdmission) waitForSyncedStore(timeout <-chan time.Time) bool {
+	for !q.imageStreamSynced() {
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-timeout:
+			return q.imageStreamSynced()
+		}
+	}
+
+	return true
+}
+
+func (q *imageBlacklistAdmission) SetInformers(informers shared.InformerFactory) {
+	q.imageStreamLister = informers.ImageStreams().Lister()
+	q.imageStreamSynced = informers.ImageStreams().Informer().HasSynced
+}
+
+func (q *imageBlacklistAdmission) SetOpenshiftClient(client oclient.Interface) {
+	q.imagesClient = client
+}
+
+func (q *imageBlacklistAdmission) Validate() error {
+	if q.imageStreamLister == nil {
+		return errors.New("missing imageStreamLister")
+	}
+	if q.imagesClient == nil {
+		return errors.New("missing imagesClient")
+	}
+
+	return nil
+}


### PR DESCRIPTION
…ion=true

Less powerful alternative to https://github.com/openshift/origin/pull/10114.  If you try to create a pod with an image pull spec that uses a digest we've marked in our `images` as `"images.openshift.io/deny-execution" = "true"`, you're rejected.  If you create a pod with an image pull spec that uses an imagestreamtag that *currently* points to an image with the same annotation, you're rejected.

This is only point in time.  If the tag is repointed after admission, the pod will continue to live.  Also, you'd obviously have to lock down the registries that a node can pull images from.  If we wanted to pursue this, we could create another admission plugin that prevents create or update for tags that point to denied images.  That closes the hole significantly since you can't swap the tag out from underneath.

@smarterclayton 