### PR TITLE
check that destination exists before attempting to extract secrets / configmaps to it

### DIFF
--- a/pkg/cmd/cli/cmd/extract.go
+++ b/pkg/cmd/cli/cmd/extract.go
@@ -102,6 +102,10 @@ func (o *ExtractOptions) Complete(f *clientcmd.Factory, in io.Reader, out io.Wri
 }
 
 func (o *ExtractOptions) Validate() error {
+	// determine if output location is valid before continuing
+	if _, err := os.Stat(o.TargetDirectory); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -44,6 +44,7 @@ os::cmd::expect_failure_and_text "oc extract secret/dockercfg secret/dockercfg -
 os::cmd::expect_success_and_text "oc extract secret/dockercfg secret/dockercfg --to '${workingdir}' --confirm" '.dockercfg'
 os::cmd::expect_success_and_text "oc extract secret/dockercfg --to '${workingdir}' --confirm" '.dockercfg'
 os::cmd::expect_success "oc extract secret/dockercfg --to '${workingdir}' --confirm | xargs rm"
+os::cmd::expect_failure_and_text "oc extract secret/dockercfg --to missing-dir" "stat missing-dir: no such file or directory"
 
 # attach secrets to service account
 # single secret with prefix


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1360652

Simplify output user sees by failing command (if destination provided by `--to` does not exist) before looping through each secret / configmap and attempting to write to destination.

##### Before
```
# oc extract secret/test-secret configmap/special-config --to=/not-exist
error: data-1: open /not-exist/data-1: no such file or directory
error: data-2: open /not-exist/data-2: no such file or directory

error: special.how: open /not-exist/special.how: no such file or directory
error: special.type: open /not-exist/special.type: no such file or directory
```

##### After
```
# oc extract secret/test-secret configmap/special-config --to=/not-exist
error: stat not-exist: no such file or directory
```