### PR TITLE
Fix BZ1361024

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -232,7 +232,7 @@ backend be_edge_http_{{$cfgIdx}}
       {{ end }}
     {{ end }}
 
-{{ if index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections" }}
+{{ if matchPattern "true|TRUE" (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections") }}
   stick-table type ip size 100k expire 30s store conn_cur,conn_rate(3s),http_req_rate(10s)
   tcp-request content track-sc2 src
   {{ if (isInteger (index $cfg.Annotations "haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp")) }} 


### PR DESCRIPTION
by forcing haproxy.router.openshift.io/rate-limit-connections to only
apply the rate limits when set to "true" or "TRUE" allows the user to
check configurations by temporarily turning off the rate limits without
changing the rest of the configurations