### PR TITLE
Login as admin before dumping all objects in e2e tests

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -33,13 +33,13 @@ function cleanup()
 	set +e
 	dump_container_logs
 
-	# pull information out of the server log so that we can get failure management in jenkins to highlight it and 
+	# pull information out of the server log so that we can get failure management in jenkins to highlight it and
 	# really have it smack people in their logs.  This is a severe correctness problem
     grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/container-origin.log
 
 
 	echo "[INFO] Dumping all resources to ${LOG_DIR}/export_all.json"
-	if [[ -n "${ADMIN_KUBECONFIG:-}" ]]; then
+		oc login -u system:admin -n default --config=${ADMIN_KUBECONFIG}
 		oc export all --all-namespaces --raw -o json --config=${ADMIN_KUBECONFIG} > ${LOG_DIR}/export_all.json
 	fi
 


### PR DESCRIPTION
I've noticed this line earlier today in the [failure logs](https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_origin_integration/4306/consoleFull):

```
[INFO] Dumping container logs to /tmp/openshift/test-end-to-end-docker//logs
[INFO] Dumping all resources to /tmp/openshift/test-end-to-end-docker//logs/export_all.json
Error from server: User "e2e-user" cannot list all buildconfigs in the cluster
[INFO] Dumping etcd contents to /tmp/openshift/test-end-to-end-docker//artifacts/etcd_dump.json
```

I've noticed that in [hack/util.sh#cleanup_openshift](https://github.com/openshift/origin/blob/9ac692312a7e62c62ecb0cebb1581a138fd63d66/hack/util.sh#L569) we first log in as admin. Did exactly the same here. @stevekuznetsov ptal