### PR TITLE
Display original cmd and stderr in extended test

### DIFF
--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -276,6 +276,12 @@ func (c *CLI) printCmd() string {
 	return strings.Join(c.finalArgs, " ")
 }
 
+type ExitError struct {
+	Cmd    string
+	StdErr string
+	*exec.ExitError
+}
+
 // Output executes the command and return the output as string
 func (c *CLI) Output() (string, error) {
 	if c.verbose {
@@ -292,7 +298,7 @@ func (c *CLI) Output() (string, error) {
 		return trimmed, nil
 	case *exec.ExitError:
 		e2e.Logf("Error running %v:\n%s", cmd, trimmed)
-		return trimmed, err
+		return trimmed, &ExitError{ExitError: err.(*exec.ExitError), Cmd: c.execPath + " " + strings.Join(c.finalArgs, " "), StdErr: trimmed}
 	default:
 		FatalErr(fmt.Errorf("unable to execute %q: %v", c.execPath, err))
 		// unreachable code


### PR DESCRIPTION
Currently, when a command execution in extended test fail, you will see something like this:

```
        <*exec.ExitError | 0xc820d49f80>: {
            ProcessState: {
                pid: 4354,
                status: 256,
                rusage: {
                    Utime: {Sec: 0, Usec: 120189},
                    Stime: {Sec: 0, Usec: 20722},
                    Maxrss: 28188,
                    Ixrss: 0,
                    Idrss: 0,
                    Isrss: 0,
                    Minflt: 6714,
                    Majflt: 0,
                    Nswap: 0,
                    Inblock: 0,
                    Oublock: 0,
                    Msgsnd: 0,
                    Msgrcv: 0,
                    Nsignals: 0,
                    Nvcsw: 2160,
                    Nivcsw: 15,
                },
            },
            Stderr: nil,
        }
```

which is not very informative. This PR will add the original command + the trimmed standard error. 