### PR TITLE
Handle local source as binary when git is not available

### DIFF
--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -259,7 +259,7 @@ func (r *SourceRepository) RemoteURL() (*url.URL, bool, error) {
 	case "file":
 		gitRepo := git.NewRepository()
 		remote, ok, err := gitRepo.GetOriginURL(r.url.Path)
-		if err != nil {
+		if err != nil && err != git.ErrGitNotAvailable {
 			return nil, false, err
 		}
 		if !ok {


### PR DESCRIPTION
If new-app cannot determine the origin url of a local directory because git is not present, it should treat the directory as if it had no origin remote.