### PR TITLE
cluster up: fix incorrect directory permissions

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper_unix.go
+++ b/pkg/bootstrap/docker/openshift/helper_unix.go
@@ -49,7 +49,7 @@ func KillExistingSocat() error {
 
 func SaveSocatPid(pid int) error {
 	parentDir := filepath.Dir(SocatPidFile)
-	err := os.MkdirAll(parentDir, 0644)
+	err := os.MkdirAll(parentDir, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When starting 'cluster up' on a Mac that requires socat, the directory created for the pid file should have execute permission. Current behavior is broken if the directory already doesn't exist.