### PR TITLE
oc rsync: allow multiple include or exclude patterns

### DIFF
--- a/docs/man/man1/oc-rsync.1
+++ b/docs/man/man1/oc-rsync.1
@@ -38,11 +38,11 @@ for the copy.
     Delete files not present in source
 
 .PP
-\fB\-\-exclude\fP=""
+\fB\-\-exclude\fP=[]
     rsync \- exclude files matching specified pattern
 
 .PP
-\fB\-\-include\fP=""
+\fB\-\-include\fP=[]
     rsync \- include files matching specified pattern
 
 .PP

--- a/docs/man/man1/openshift-cli-rsync.1
+++ b/docs/man/man1/openshift-cli-rsync.1
@@ -38,11 +38,11 @@ for the copy.
     Delete files not present in source
 
 .PP
-\fB\-\-exclude\fP=""
+\fB\-\-exclude\fP=[]
     rsync \- exclude files matching specified pattern
 
 .PP
-\fB\-\-include\fP=""
+\fB\-\-include\fP=[]
     rsync \- include files matching specified pattern
 
 .PP

--- a/pkg/cmd/cli/cmd/rsync/rsync.go
+++ b/pkg/cmd/cli/cmd/rsync/rsync.go
@@ -77,8 +77,8 @@ type RsyncOptions struct {
 	Delete        bool
 	Watch         bool
 
-	RsyncInclude  string
-	RsyncExclude  string
+	RsyncInclude  []string
+	RsyncExclude  []string
 	RsyncProgress bool
 	RsyncNoPerms  bool
 
@@ -113,8 +113,8 @@ func NewCmdRsync(name, parent string, f *clientcmd.Factory, out, errOut io.Write
 	// Flags for rsync options, Must match rsync flag names
 	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", false, "Suppress non-error messages")
 	cmd.Flags().BoolVar(&o.Delete, "delete", false, "Delete files not present in source")
-	cmd.Flags().StringVar(&o.RsyncExclude, "exclude", "", "rsync - exclude files matching specified pattern")
-	cmd.Flags().StringVar(&o.RsyncInclude, "include", "", "rsync - include files matching specified pattern")
+	cmd.Flags().StringSliceVar(&o.RsyncExclude, "exclude", nil, "rsync - exclude files matching specified pattern")
+	cmd.Flags().StringSliceVar(&o.RsyncInclude, "include", nil, "rsync - include files matching specified pattern")
 	cmd.Flags().BoolVar(&o.RsyncProgress, "progress", false, "rsync - show progress during transfer")
 	cmd.Flags().BoolVar(&o.RsyncNoPerms, "no-perms", false, "rsync - do not transfer permissions")
 	cmd.Flags().BoolVarP(&o.Watch, "watch", "w", false, "Watch directory for changes and resync automatically")

--- a/pkg/cmd/cli/cmd/rsync/util.go
+++ b/pkg/cmd/cli/cmd/rsync/util.go
@@ -89,10 +89,14 @@ func rsyncFlagsFromOptions(o *RsyncOptions) []string {
 		flags = append(flags, "--delete")
 	}
 	if len(o.RsyncInclude) > 0 {
-		flags = append(flags, fmt.Sprintf("--include=%s", o.RsyncInclude))
+		for _, include := range o.RsyncInclude {
+			flags = append(flags, fmt.Sprintf("--include=%s", include))
+		}
 	}
 	if len(o.RsyncExclude) > 0 {
-		flags = append(flags, fmt.Sprintf("--exclude=%s", o.RsyncExclude))
+		for _, exclude := range o.RsyncExclude {
+			flags = append(flags, fmt.Sprintf("--exclude=%s", exclude))
+		}
 	}
 	if o.RsyncProgress {
 		flags = append(flags, "--progress")


### PR DESCRIPTION
Allows multiple --include/--exclude flags to be specified, or a comma-separated list of patterns
Fixes #8185