### PR TITLE
new-app: accept template on stdin

### DIFF
--- a/pkg/generate/app/templatelookup.go
+++ b/pkg/generate/app/templatelookup.go
@@ -138,6 +138,13 @@ func (r *TemplateFileSearcher) Search(precise bool, terms ...string) (ComponentM
 			}
 		}
 
+		if list, isList := obj.(*kapi.List); isList && !isSingular {
+			if len(list.Items) == 1 {
+				obj = list.Items[0]
+				isSingular = true
+			}
+		}
+
 		if !isSingular {
 			errs = append(errs, fmt.Errorf("there is more than one object in %q", term))
 			continue

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -70,6 +70,9 @@ os::cmd::expect_success_and_text 'oc new-app -f test/testdata/template-with-app-
 # verify the existing app label on an object is overridden by new-app
 os::cmd::expect_success_and_not_text 'oc new-app -f test/testdata/template-with-app-label.json -o yaml' 'app: myapp'
 
+# verify that a template can be passed in stdin
+os::cmd::expect_success 'cat examples/sample-app/application-template-stibuild.json | oc new-app -o yaml -f -'
+
 # check search
 os::cmd::expect_success_and_text 'oc new-app --search mysql' "Tags:\s+5.5, 5.6, latest"
 os::cmd::expect_success_and_text 'oc new-app --search ruby-helloworld-sample' 'ruby-helloworld-sample'


### PR DESCRIPTION
new-app should not throw an error when passing a template on stdin
it currently breaks because isSingle is returned as false by the builder, even though there is only a single object in the list.

Fixes https://github.com/openshift/origin/issues/8555