### PR TITLE
Fix a link for docker machine

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -6,7 +6,7 @@
   - [Windows](#windows)
   - [Linux](#linux)
 - [Administrator Access](#administrator-access)
-- [Docker Machine](#docker-machine-details)
+- [Docker Machine](#docker-machine)
 - [Configuration](#configuration)
 - [Etcd Data](#etcd-data)
 - [Routing](#routing)


### PR DESCRIPTION
Fix a link for docker machine which can be used to access  accurately the content in the document.

AS IS:
Docker Machine (#docker-machine-details)
TO BE:
Docker Machine (#docker-machine)

Please check it.
Thanks!

@mfojtik PTAL