### PR TITLE
fix a path format error

### DIFF
--- a/hack/update-generated-docs.sh
+++ b/hack/update-generated-docs.sh
@@ -36,8 +36,8 @@ if [[ -z "$genman" ]]; then
 fi
 
 OUTPUT_DIR_REL=${1:-""}
-OUTPUT_DIR="${OS_ROOT}/${OUTPUT_DIR_REL}/docs/generated"
-MAN_OUTPUT_DIR="${OS_ROOT}/${OUTPUT_DIR_REL}/docs/man/man1"
+OUTPUT_DIR="${OS_ROOT}/${OUTPUT_DIR_REL}docs/generated"
+MAN_OUTPUT_DIR="${OS_ROOT}/${OUTPUT_DIR_REL}docs/man/man1"
 
 mkdir -p "${OUTPUT_DIR}" || echo $? > /dev/null
 mkdir -p "${MAN_OUTPUT_DIR}" || echo $? > /dev/null


### PR DESCRIPTION
Execution `hack/update-generated-docs.sh`, prints as follow:
```
++ Building go targets for linux/amd64: tools/gendocs tools/genman
++ Placing binaries
/home/zte/workspace/miaoyq/openshiftcode/origin/hack/build-go.sh took 237 seconds
Assets generated in /home/zte/workspace/miaoyq/openshiftcode/origin//docs/generated
Assets generated in /home/zte/workspace/miaoyq/openshiftcode/origin//docs/man/man1
```
There are two `/` between `origin` and `docs`.
