### PR TITLE
UPSTREAM: 29694: Add API for StorageClasses

### DIFF
--- a/vendor/k8s.io/kubernetes/api/swagger-spec/extensions_v1beta1.json
+++ b/vendor/k8s.io/kubernetes/api/swagger-spec/extensions_v1beta1.json
@@ -6477,6 +6477,561 @@
     ]
    },
    {
+    "path": "/apis/extensions/v1beta1/storageclasses",
+    "description": "API at /apis/extensions/v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.StorageClassList",
+      "method": "GET",
+      "summary": "list or watch objects of kind StorageClass",
+      "nickname": "listStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.StorageClassList"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta1.StorageClass",
+      "method": "POST",
+      "summary": "create a StorageClass",
+      "nickname": "createStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.StorageClass",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.StorageClass"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of StorageClass",
+      "nickname": "deletecollectionStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/apis/extensions/v1beta1/watch/storageclasses",
+    "description": "API at /apis/extensions/v1beta1",
+    "operations": [
+     {
+      "type": "*versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of StorageClass",
+      "nickname": "watchStorageClassList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "*versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/apis/extensions/v1beta1/storageclasses/{name}",
+    "description": "API at /apis/extensions/v1beta1",
+    "operations": [
+     {
+      "type": "v1beta1.StorageClass",
+      "method": "GET",
+      "summary": "read the specified StorageClass",
+      "nickname": "readStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the StorageClass",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.StorageClass"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta1.StorageClass",
+      "method": "PUT",
+      "summary": "replace the specified StorageClass",
+      "nickname": "replaceStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.StorageClass",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the StorageClass",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.StorageClass"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta1.StorageClass",
+      "method": "PATCH",
+      "summary": "partially update the specified StorageClass",
+      "nickname": "patchStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the StorageClass",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.StorageClass"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete a StorageClass",
+      "nickname": "deleteStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the StorageClass",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/apis/extensions/v1beta1/watch/storageclasses/{name}",
+    "description": "API at /apis/extensions/v1beta1",
+    "operations": [
+     {
+      "type": "*versioned.Event",
+      "method": "GET",
+      "summary": "watch changes to an object of kind StorageClass",
+      "nickname": "watchStorageClass",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the StorageClass",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "*versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/apis/extensions/v1beta1/thirdpartyresources",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
@@ -9585,6 +10140,63 @@
       "type": "integer",
       "format": "int64",
       "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+     }
+    }
+   },
+   "v1beta1.StorageClassList": {
+    "id": "v1beta1.StorageClassList",
+    "description": "StorageClassList is a collection of storage classes.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "unversioned.ListMeta",
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.StorageClass"
+      },
+      "description": "Items is the list of StorageClasses"
+     }
+    }
+   },
+   "v1beta1.StorageClass": {
+    "id": "v1beta1.StorageClass",
+    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "required": [
+     "provisioner"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "provisioner": {
+      "type": "string",
+      "description": "Provisioner indicates the type of the provisioner."
+     },
+     "parameters": {
+      "type": "object",
+      "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class."
      }
     }
    },

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
@@ -79,6 +79,8 @@ func init() {
 		DeepCopy_extensions_Scale,
 		DeepCopy_extensions_ScaleSpec,
 		DeepCopy_extensions_ScaleStatus,
+		DeepCopy_extensions_StorageClass,
+		DeepCopy_extensions_StorageClassList,
 		DeepCopy_extensions_SupplementalGroupsStrategyOptions,
 		DeepCopy_extensions_ThirdPartyResource,
 		DeepCopy_extensions_ThirdPartyResourceData,
@@ -856,6 +858,47 @@ func DeepCopy_extensions_ScaleStatus(in ScaleStatus, out *ScaleStatus, c *conver
 		}
 	} else {
 		out.Selector = nil
+	}
+	return nil
+}
+
+func DeepCopy_extensions_StorageClass(in StorageClass, out *StorageClass, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := api.DeepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	out.Provisioner = in.Provisioner
+	if in.Parameters != nil {
+		in, out := in.Parameters, &out.Parameters
+		*out = make(map[string]string)
+		for key, val := range in {
+			(*out)[key] = val
+		}
+	} else {
+		out.Parameters = nil
+	}
+	return nil
+}
+
+func DeepCopy_extensions_StorageClassList(in StorageClassList, out *StorageClassList, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := unversioned.DeepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := in.Items, &out.Items
+		*out = make([]StorageClass, len(in))
+		for i := range in {
+			if err := DeepCopy_extensions_StorageClass(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
 	}
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/install/install.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/install/install.go
@@ -94,6 +94,7 @@ func newRESTMapper(externalVersions []unversioned.GroupVersion) meta.RESTMapper 
 	rootScoped := sets.NewString(
 		"PodSecurityPolicy",
 		"ThirdPartyResource",
+		"StorageClass",
 	)
 
 	ignoredKinds := sets.NewString()

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/register.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/register.go
@@ -75,5 +75,7 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&PodSecurityPolicyList{},
 		&NetworkPolicy{},
 		&NetworkPolicyList{},
+		&StorageClass{},
+		&StorageClassList{},
 	)
 }

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/types.go
@@ -896,3 +896,41 @@ type NetworkPolicyList struct {
 
 	Items []NetworkPolicy `json:"items"`
 }
+
+// +genclient=true
+// +nonNamespaced=true
+
+// StorageClass describes a named "class" of storage offered in a cluster.
+// Different classes might map to quality-of-service levels, or to backup policies,
+// or to arbitrary policies determined by the cluster administrators.  Kubernetes
+// itself is unopinionated about what classes represent.  This concept is sometimes
+// called "profiles" in other storage systems.
+// The name of a StorageClass object is significant, and is how users can request a particular class.
+type StorageClass struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata,omitempty"`
+
+	// provisioner is the driver expected to handle this StorageClass.
+	// This is an optionally-prefixed name, like a label key.
+	// For example: "kubernetes.io/gce-pd" or "kubernetes.io/aws-ebs".
+	// This value may not be empty.
+	Provisioner string `json:"provisioner"`
+
+	// parameters holds parameters for the provisioner.
+	// These values are opaque to the  system and are passed directly
+	// to the provisioner.  The only validation done on keys is that they are
+	// not empty.  The maximum number of parameters is
+	// 512, with a cumulative max size of 256K
+	Parameters map[string]string `json:"parameters,omitempty"`
+}
+
+// StorageClassList is a collection of storage classes.
+type StorageClassList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	// Items is the list of StorageClasses
+	Items []StorageClass `json:"items"`
+}

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -152,6 +152,10 @@ func init() {
 		Convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec,
 		Convert_v1beta1_ScaleStatus_To_extensions_ScaleStatus,
 		Convert_extensions_ScaleStatus_To_v1beta1_ScaleStatus,
+		Convert_v1beta1_StorageClass_To_extensions_StorageClass,
+		Convert_extensions_StorageClass_To_v1beta1_StorageClass,
+		Convert_v1beta1_StorageClassList_To_extensions_StorageClassList,
+		Convert_extensions_StorageClassList_To_v1beta1_StorageClassList,
 		Convert_v1beta1_SupplementalGroupsStrategyOptions_To_extensions_SupplementalGroupsStrategyOptions,
 		Convert_extensions_SupplementalGroupsStrategyOptions_To_v1beta1_SupplementalGroupsStrategyOptions,
 		Convert_v1beta1_ThirdPartyResource_To_extensions_ThirdPartyResource,
@@ -2236,6 +2240,90 @@ func autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleS
 
 func Convert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in *extensions.ScaleSpec, out *ScaleSpec, s conversion.Scope) error {
 	return autoConvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec(in, out, s)
+}
+
+func autoConvert_v1beta1_StorageClass_To_extensions_StorageClass(in *StorageClass, out *extensions.StorageClass, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
+		return err
+	}
+	out.Provisioner = in.Provisioner
+	out.Parameters = in.Parameters
+	return nil
+}
+
+func Convert_v1beta1_StorageClass_To_extensions_StorageClass(in *StorageClass, out *extensions.StorageClass, s conversion.Scope) error {
+	return autoConvert_v1beta1_StorageClass_To_extensions_StorageClass(in, out, s)
+}
+
+func autoConvert_extensions_StorageClass_To_v1beta1_StorageClass(in *extensions.StorageClass, out *StorageClass, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ObjectMeta, &out.ObjectMeta, 0); err != nil {
+		return err
+	}
+	out.Provisioner = in.Provisioner
+	out.Parameters = in.Parameters
+	return nil
+}
+
+func Convert_extensions_StorageClass_To_v1beta1_StorageClass(in *extensions.StorageClass, out *StorageClass, s conversion.Scope) error {
+	return autoConvert_extensions_StorageClass_To_v1beta1_StorageClass(in, out, s)
+}
+
+func autoConvert_v1beta1_StorageClassList_To_extensions_StorageClassList(in *StorageClassList, out *extensions.StorageClassList, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]extensions.StorageClass, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_StorageClass_To_extensions_StorageClass(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func Convert_v1beta1_StorageClassList_To_extensions_StorageClassList(in *StorageClassList, out *extensions.StorageClassList, s conversion.Scope) error {
+	return autoConvert_v1beta1_StorageClassList_To_extensions_StorageClassList(in, out, s)
+}
+
+func autoConvert_extensions_StorageClassList_To_v1beta1_StorageClassList(in *extensions.StorageClassList, out *StorageClassList, s conversion.Scope) error {
+	if err := api.Convert_unversioned_TypeMeta_To_unversioned_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := api.Convert_unversioned_ListMeta_To_unversioned_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]StorageClass, len(*in))
+		for i := range *in {
+			if err := Convert_extensions_StorageClass_To_v1beta1_StorageClass(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func Convert_extensions_StorageClassList_To_v1beta1_StorageClassList(in *extensions.StorageClassList, out *StorageClassList, s conversion.Scope) error {
+	return autoConvert_extensions_StorageClassList_To_v1beta1_StorageClassList(in, out, s)
 }
 
 func autoConvert_v1beta1_SupplementalGroupsStrategyOptions_To_extensions_SupplementalGroupsStrategyOptions(in *SupplementalGroupsStrategyOptions, out *extensions.SupplementalGroupsStrategyOptions, s conversion.Scope) error {

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -94,6 +94,8 @@ func init() {
 		DeepCopy_v1beta1_Scale,
 		DeepCopy_v1beta1_ScaleSpec,
 		DeepCopy_v1beta1_ScaleStatus,
+		DeepCopy_v1beta1_StorageClass,
+		DeepCopy_v1beta1_StorageClassList,
 		DeepCopy_v1beta1_SubresourceReference,
 		DeepCopy_v1beta1_SupplementalGroupsStrategyOptions,
 		DeepCopy_v1beta1_ThirdPartyResource,
@@ -1188,6 +1190,47 @@ func DeepCopy_v1beta1_ScaleStatus(in ScaleStatus, out *ScaleStatus, c *conversio
 		out.Selector = nil
 	}
 	out.TargetSelector = in.TargetSelector
+	return nil
+}
+
+func DeepCopy_v1beta1_StorageClass(in StorageClass, out *StorageClass, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := v1.DeepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+		return err
+	}
+	out.Provisioner = in.Provisioner
+	if in.Parameters != nil {
+		in, out := in.Parameters, &out.Parameters
+		*out = make(map[string]string)
+		for key, val := range in {
+			(*out)[key] = val
+		}
+	} else {
+		out.Parameters = nil
+	}
+	return nil
+}
+
+func DeepCopy_v1beta1_StorageClassList(in StorageClassList, out *StorageClassList, c *conversion.Cloner) error {
+	if err := unversioned.DeepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
+		return err
+	}
+	if err := unversioned.DeepCopy_unversioned_ListMeta(in.ListMeta, &out.ListMeta, c); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		in, out := in.Items, &out.Items
+		*out = make([]StorageClass, len(in))
+		for i := range in {
+			if err := DeepCopy_v1beta1_StorageClass(in[i], &(*out)[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/generated.pb.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/generated.pb.go
@@ -88,6 +88,8 @@ limitations under the License.
 		Scale
 		ScaleSpec
 		ScaleStatus
+		StorageClass
+		StorageClassList
 		SubresourceReference
 		SupplementalGroupsStrategyOptions
 		ThirdPartyResource
@@ -365,6 +367,14 @@ func (m *ScaleStatus) Reset()         { *m = ScaleStatus{} }
 func (m *ScaleStatus) String() string { return proto.CompactTextString(m) }
 func (*ScaleStatus) ProtoMessage()    {}
 
+func (m *StorageClass) Reset()         { *m = StorageClass{} }
+func (m *StorageClass) String() string { return proto.CompactTextString(m) }
+func (*StorageClass) ProtoMessage()    {}
+
+func (m *StorageClassList) Reset()         { *m = StorageClassList{} }
+func (m *StorageClassList) String() string { return proto.CompactTextString(m) }
+func (*StorageClassList) ProtoMessage()    {}
+
 func (m *SubresourceReference) Reset()         { *m = SubresourceReference{} }
 func (m *SubresourceReference) String() string { return proto.CompactTextString(m) }
 func (*SubresourceReference) ProtoMessage()    {}
@@ -453,6 +463,8 @@ func init() {
 	proto.RegisterType((*Scale)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.Scale")
 	proto.RegisterType((*ScaleSpec)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.ScaleSpec")
 	proto.RegisterType((*ScaleStatus)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.ScaleStatus")
+	proto.RegisterType((*StorageClass)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.StorageClass")
+	proto.RegisterType((*StorageClassList)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.StorageClassList")
 	proto.RegisterType((*SubresourceReference)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.SubresourceReference")
 	proto.RegisterType((*SupplementalGroupsStrategyOptions)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.SupplementalGroupsStrategyOptions")
 	proto.RegisterType((*ThirdPartyResource)(nil), "k8s.io.kubernetes.pkg.apis.extensions.v1beta1.ThirdPartyResource")
@@ -2895,6 +2907,91 @@ func (m *ScaleStatus) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *StorageClass) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *StorageClass) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
+	n72, err := m.ObjectMeta.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n72
+	data[i] = 0x12
+	i++
+	i = encodeVarintGenerated(data, i, uint64(len(m.Provisioner)))
+	i += copy(data[i:], m.Provisioner)
+	if len(m.Parameters) > 0 {
+		for k := range m.Parameters {
+			data[i] = 0x1a
+			i++
+			v := m.Parameters[k]
+			mapSize := 1 + len(k) + sovGenerated(uint64(len(k))) + 1 + len(v) + sovGenerated(uint64(len(v)))
+			i = encodeVarintGenerated(data, i, uint64(mapSize))
+			data[i] = 0xa
+			i++
+			i = encodeVarintGenerated(data, i, uint64(len(k)))
+			i += copy(data[i:], k)
+			data[i] = 0x12
+			i++
+			i = encodeVarintGenerated(data, i, uint64(len(v)))
+			i += copy(data[i:], v)
+		}
+	}
+	return i, nil
+}
+
+func (m *StorageClassList) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *StorageClassList) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	data[i] = 0xa
+	i++
+	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
+	n73, err := m.ListMeta.MarshalTo(data[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n73
+	if len(m.Items) > 0 {
+		for _, msg := range m.Items {
+			data[i] = 0x12
+			i++
+			i = encodeVarintGenerated(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
 func (m *SubresourceReference) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -2981,11 +3078,11 @@ func (m *ThirdPartyResource) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n72, err := m.ObjectMeta.MarshalTo(data[i:])
+	n74, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n72
+	i += n74
 	data[i] = 0x12
 	i++
 	i = encodeVarintGenerated(data, i, uint64(len(m.Description)))
@@ -3023,11 +3120,11 @@ func (m *ThirdPartyResourceData) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ObjectMeta.Size()))
-	n73, err := m.ObjectMeta.MarshalTo(data[i:])
+	n75, err := m.ObjectMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n73
+	i += n75
 	if m.Data != nil {
 		data[i] = 0x12
 		i++
@@ -3055,11 +3152,11 @@ func (m *ThirdPartyResourceDataList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n74, err := m.ListMeta.MarshalTo(data[i:])
+	n76, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n74
+	i += n76
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -3093,11 +3190,11 @@ func (m *ThirdPartyResourceList) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	i = encodeVarintGenerated(data, i, uint64(m.ListMeta.Size()))
-	n75, err := m.ListMeta.MarshalTo(data[i:])
+	n77, err := m.ListMeta.MarshalTo(data[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n75
+	i += n77
 	if len(m.Items) > 0 {
 		for _, msg := range m.Items {
 			data[i] = 0x12
@@ -3995,6 +4092,38 @@ func (m *ScaleStatus) Size() (n int) {
 	}
 	l = len(m.TargetSelector)
 	n += 1 + l + sovGenerated(uint64(l))
+	return n
+}
+
+func (m *StorageClass) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ObjectMeta.Size()
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.Provisioner)
+	n += 1 + l + sovGenerated(uint64(l))
+	if len(m.Parameters) > 0 {
+		for k, v := range m.Parameters {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovGenerated(uint64(len(k))) + 1 + len(v) + sovGenerated(uint64(len(v)))
+			n += mapEntrySize + 1 + sovGenerated(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *StorageClassList) Size() (n int) {
+	var l int
+	_ = l
+	l = m.ListMeta.Size()
+	n += 1 + l + sovGenerated(uint64(l))
+	if len(m.Items) > 0 {
+		for _, e := range m.Items {
+			l = e.Size()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -12128,6 +12257,337 @@ func (m *ScaleStatus) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.TargetSelector = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StorageClass) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StorageClass: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StorageClass: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ObjectMeta", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ObjectMeta.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Provisioner", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Provisioner = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Parameters", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var keykey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				keykey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var stringLenmapkey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLenmapkey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLenmapkey := int(stringLenmapkey)
+			if intStringLenmapkey < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postStringIndexmapkey := iNdEx + intStringLenmapkey
+			if postStringIndexmapkey > l {
+				return io.ErrUnexpectedEOF
+			}
+			mapkey := string(data[iNdEx:postStringIndexmapkey])
+			iNdEx = postStringIndexmapkey
+			var valuekey uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				valuekey |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			var stringLenmapvalue uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLenmapvalue |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLenmapvalue := int(stringLenmapvalue)
+			if intStringLenmapvalue < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+			if postStringIndexmapvalue > l {
+				return io.ErrUnexpectedEOF
+			}
+			mapvalue := string(data[iNdEx:postStringIndexmapvalue])
+			iNdEx = postStringIndexmapvalue
+			if m.Parameters == nil {
+				m.Parameters = make(map[string]string)
+			}
+			m.Parameters[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenerated(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StorageClassList) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenerated
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StorageClassList: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StorageClassList: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ListMeta", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.ListMeta.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Items", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Items = append(m.Items, StorageClass{})
+			if err := m.Items[len(m.Items)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/generated.proto
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/generated.proto
@@ -942,6 +942,34 @@ message ScaleStatus {
   optional string targetSelector = 3;
 }
 
+// StorageClass describes the parameters for a class of storage for
+// which PersistentVolumes can be dynamically provisioned.
+// 
+// StorageClasses are non-namespaced; the name of the storage class
+// according to etcd is in ObjectMeta.Name.
+message StorageClass {
+  // Standard object's metadata.
+  // More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+  optional k8s.io.kubernetes.pkg.api.v1.ObjectMeta metadata = 1;
+
+  // Provisioner indicates the type of the provisioner.
+  optional string provisioner = 2;
+
+  // Parameters holds the parameters for the provisioner that should
+  // create volumes of this storage class.
+  map<string, string> parameters = 3;
+}
+
+// StorageClassList is a collection of storage classes.
+message StorageClassList {
+  // Standard list metadata
+  // More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+  optional k8s.io.kubernetes.pkg.api.unversioned.ListMeta metadata = 1;
+
+  // Items is the list of StorageClasses
+  repeated StorageClass items = 2;
+}
+
 // SubresourceReference contains enough information to let you inspect or modify the referred subresource.
 message SubresourceReference {
   // Kind of the referent; More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/register.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/register.go
@@ -63,6 +63,8 @@ func addKnownTypes(scheme *runtime.Scheme) {
 		&PodSecurityPolicyList{},
 		&NetworkPolicy{},
 		&NetworkPolicyList{},
+		&StorageClass{},
+		&StorageClassList{},
 	)
 	// Add the watch version that applies
 	versionedwatch.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
@@ -1193,3 +1193,36 @@ type NetworkPolicyList struct {
 	// Items is a list of schema objects.
 	Items []NetworkPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
+
+// +genclient=true
+// +nonNamespaced=true
+
+// StorageClass describes the parameters for a class of storage for
+// which PersistentVolumes can be dynamically provisioned.
+//
+// StorageClasses are non-namespaced; the name of the storage class
+// according to etcd is in ObjectMeta.Name.
+type StorageClass struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	v1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Provisioner indicates the type of the provisioner.
+	Provisioner string `json:"provisioner" protobuf:"bytes,2,opt,name=provisioner"`
+
+	// Parameters holds the parameters for the provisioner that should
+	// create volumes of this storage class.
+	Parameters map[string]string `json:"parameters,omitempty" protobuf:"bytes,3,rep,name=parameters"`
+}
+
+// StorageClassList is a collection of storage classes.
+type StorageClassList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	unversioned.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Items is the list of StorageClasses
+	Items []StorageClass `json:"items" protobuf:"bytes,2,rep,name=items"`
+}

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -674,6 +674,27 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 	return map_ScaleStatus
 }
 
+var map_StorageClass = map[string]string{
+	"":            "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+	"metadata":    "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+	"provisioner": "Provisioner indicates the type of the provisioner.",
+	"parameters":  "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
+}
+
+func (StorageClass) SwaggerDoc() map[string]string {
+	return map_StorageClass
+}
+
+var map_StorageClassList = map[string]string{
+	"":         "StorageClassList is a collection of storage classes.",
+	"metadata": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+	"items":    "Items is the list of StorageClasses",
+}
+
+func (StorageClassList) SwaggerDoc() map[string]string {
+	return map_StorageClassList
+}
+
 var map_SubresourceReference = map[string]string{
 	"":            "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
 	"kind":        "Kind of the referent; More info: http://releases.k8s.io/release-1.3/docs/devel/api-conventions.md#types-kinds",

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/validation/validation.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/validation/validation.go
@@ -744,3 +744,65 @@ func ValidateNetworkPolicyUpdate(update, old *extensions.NetworkPolicy) field.Er
 	}
 	return allErrs
 }
+
+// ValidateStorageClass validates a StorageClass.
+func ValidateStorageClass(storageClass *extensions.StorageClass) field.ErrorList {
+	allErrs := apivalidation.ValidateObjectMeta(&storageClass.ObjectMeta, false, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	allErrs = append(allErrs, validateProvisioner(storageClass.Provisioner, field.NewPath("provisioner"))...)
+	allErrs = append(allErrs, validateParameters(storageClass.Parameters, field.NewPath("parameters"))...)
+
+	return allErrs
+}
+
+// ValidateStorageClassUpdate tests if an update to StorageClass is valid.
+func ValidateStorageClassUpdate(storageClass, oldStorageClass *extensions.StorageClass) field.ErrorList {
+	allErrs := apivalidation.ValidateObjectMetaUpdate(&storageClass.ObjectMeta, &oldStorageClass.ObjectMeta, field.NewPath("metadata"))
+	if !reflect.DeepEqual(oldStorageClass.Parameters, storageClass.Parameters) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("parameters"), "updates to parameters are forbidden."))
+	}
+
+	if strings.Compare(storageClass.Provisioner, oldStorageClass.Provisioner) != 0 {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("provisioner"), "updates to provisioner are forbidden."))
+	}
+	return allErrs
+}
+
+// validateProvisioner tests if provisioner is a valid qualified name.
+func validateProvisioner(provisioner string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(provisioner) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, provisioner))
+	}
+	if len(provisioner) > 0 {
+		for _, msg := range validation.IsQualifiedName(strings.ToLower(provisioner)) {
+			allErrs = append(allErrs, field.Invalid(fldPath, provisioner, msg))
+		}
+	}
+	return allErrs
+}
+
+const maxProvisionerParameterSize = 256 * (1 << 10) // 256 kB
+const maxProvisionerParameterLen = 512
+
+// validateParameters tests that keys are qualified names and that provisionerParameter are < 256kB.
+func validateParameters(params map[string]string, fldPath *field.Path) field.ErrorList {
+	var totalSize int64
+	allErrs := field.ErrorList{}
+
+	if len(params) > maxProvisionerParameterLen {
+		allErrs = append(allErrs, field.TooLong(fldPath, "Provisioner Parameters exceeded max allowed", maxProvisionerParameterLen))
+		return allErrs
+	}
+
+	for k, v := range params {
+		if len(k) < 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath, k, "field can not be empty."))
+		}
+		totalSize += (int64)(len(k)) + (int64)(len(v))
+	}
+
+	if totalSize > maxProvisionerParameterSize {
+		allErrs = append(allErrs, field.TooLong(fldPath, "", maxProvisionerParameterSize))
+	}
+	return allErrs
+}

--- a/vendor/k8s.io/kubernetes/pkg/apis/extensions/validation/validation_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/extensions/validation/validation_test.go
@@ -1929,3 +1929,80 @@ func newBool(val bool) *bool {
 	*p = val
 	return p
 }
+
+func TestValidateStorageClass(t *testing.T) {
+	successCases := []extensions.StorageClass{
+		{
+			// empty parameters
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/foo-provisioner",
+			Parameters:  map[string]string{},
+		},
+		{
+			// nil parameters
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/foo-provisioner",
+		},
+		{
+			// some parameters
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/foo-provisioner",
+			Parameters: map[string]string{
+				"kubernetes.io/foo-parameter": "free/form/string",
+				"foo-parameter":               "free-form-string",
+				"foo-parameter2":              "{\"embedded\": \"json\", \"with\": {\"structures\":\"inside\"}}",
+			},
+		},
+	}
+
+	// Success cases are expected to pass validation.
+	for k, v := range successCases {
+		if errs := ValidateStorageClass(&v); len(errs) != 0 {
+			t.Errorf("Expected success for %d, got %v", k, errs)
+		}
+	}
+
+	// generate a map longer than maxProvisionerParameterSize
+	longParameters := make(map[string]string)
+	totalSize := 0
+	for totalSize < maxProvisionerParameterSize {
+		k := fmt.Sprintf("param/%d", totalSize)
+		v := fmt.Sprintf("value-%d", totalSize)
+		longParameters[k] = v
+		totalSize = totalSize + len(k) + len(v)
+	}
+
+	errorCases := map[string]extensions.StorageClass{
+		"namespace is present": {
+			ObjectMeta:  api.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Provisioner: "kubernetes.io/foo-provisioner",
+		},
+		"invalid provisioner": {
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/invalid/provisioner",
+		},
+		"invalid empty parameter name": {
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/foo",
+			Parameters: map[string]string{
+				"": "value",
+			},
+		},
+		"provisioner: Required value": {
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "",
+		},
+		"too long parameters": {
+			ObjectMeta:  api.ObjectMeta{Name: "foo"},
+			Provisioner: "kubernetes.io/foo",
+			Parameters:  longParameters,
+		},
+	}
+
+	// Error cases are not expected to pass validation.
+	for testName, storageClass := range errorCases {
+		if errs := ValidateStorageClass(&storageClass); len(errs) == 0 {
+			t.Errorf("Expected failure for test: %s", testName)
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/extensions_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/extensions_client.go
@@ -30,6 +30,7 @@ type ExtensionsInterface interface {
 	PodSecurityPoliciesGetter
 	ReplicaSetsGetter
 	ScalesGetter
+	StorageClassesGetter
 	ThirdPartyResourcesGetter
 }
 
@@ -60,6 +61,10 @@ func (c *ExtensionsClient) ReplicaSets(namespace string) ReplicaSetInterface {
 
 func (c *ExtensionsClient) Scales(namespace string) ScaleInterface {
 	return newScales(c, namespace)
+}
+
+func (c *ExtensionsClient) StorageClasses() StorageClassInterface {
+	return newStorageClasses(c)
 }
 
 func (c *ExtensionsClient) ThirdPartyResources() ThirdPartyResourceInterface {

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_extensions_client.go
@@ -50,6 +50,10 @@ func (c *FakeExtensions) Scales(namespace string) unversioned.ScaleInterface {
 	return &FakeScales{c, namespace}
 }
 
+func (c *FakeExtensions) StorageClasses() unversioned.StorageClassInterface {
+	return &FakeStorageClasses{c}
+}
+
 func (c *FakeExtensions) ThirdPartyResources() unversioned.ThirdPartyResourceInterface {
 	return &FakeThirdPartyResources{c}
 }

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_storageclass.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/fake/fake_storageclass.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeStorageClasses implements StorageClassInterface
+type FakeStorageClasses struct {
+	Fake *FakeExtensions
+}
+
+var storageclassesResource = unversioned.GroupVersionResource{Group: "extensions", Version: "", Resource: "storageclasses"}
+
+func (c *FakeStorageClasses) Create(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction(storageclassesResource, storageClass), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Update(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction(storageclassesResource, storageClass), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction(storageclassesResource, name), &extensions.StorageClass{})
+	return err
+}
+
+func (c *FakeStorageClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.StorageClassList{})
+	return err
+}
+
+func (c *FakeStorageClasses) Get(name string) (result *extensions.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction(storageclassesResource, name), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) List(opts api.ListOptions) (result *extensions.StorageClassList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction(storageclassesResource, opts), &extensions.StorageClassList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &extensions.StorageClassList{}
+	for _, item := range obj.(*extensions.StorageClassList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *FakeStorageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction(storageclassesResource, opts))
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/storageclass.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned/storageclass.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// StorageClassesGetter has a method to return a StorageClassInterface.
+// A group's client should implement this interface.
+type StorageClassesGetter interface {
+	StorageClasses() StorageClassInterface
+}
+
+// StorageClassInterface has methods to work with StorageClass resources.
+type StorageClassInterface interface {
+	Create(*extensions.StorageClass) (*extensions.StorageClass, error)
+	Update(*extensions.StorageClass) (*extensions.StorageClass, error)
+	Delete(name string, options *api.DeleteOptions) error
+	DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error
+	Get(name string) (*extensions.StorageClass, error)
+	List(opts api.ListOptions) (*extensions.StorageClassList, error)
+	Watch(opts api.ListOptions) (watch.Interface, error)
+	StorageClassExpansion
+}
+
+// storageClasses implements StorageClassInterface
+type storageClasses struct {
+	client *ExtensionsClient
+}
+
+// newStorageClasses returns a StorageClasses
+func newStorageClasses(c *ExtensionsClient) *storageClasses {
+	return &storageClasses{
+		client: c,
+	}
+}
+
+// Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *storageClasses) Create(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Post().
+		Resource("storageclasses").
+		Body(storageClass).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *storageClasses) Update(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Put().
+		Resource("storageclasses").
+		Name(storageClass.Name).
+		Body(storageClass).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
+func (c *storageClasses) Delete(name string, options *api.DeleteOptions) error {
+	return c.client.Delete().
+		Resource("storageclasses").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *storageClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	return c.client.Delete().
+		Resource("storageclasses").
+		VersionedParams(&listOptions, api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
+func (c *storageClasses) Get(name string) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) List(opts api.ListOptions) (result *extensions.StorageClassList, err error) {
+	result = &extensions.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *storageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Resource("storageclasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/extensions_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/extensions_client.go
@@ -33,6 +33,7 @@ type ExtensionsInterface interface {
 	PodSecurityPoliciesGetter
 	ReplicaSetsGetter
 	ScalesGetter
+	StorageClassesGetter
 	ThirdPartyResourcesGetter
 }
 
@@ -71,6 +72,10 @@ func (c *ExtensionsClient) ReplicaSets(namespace string) ReplicaSetInterface {
 
 func (c *ExtensionsClient) Scales(namespace string) ScaleInterface {
 	return newScales(c, namespace)
+}
+
+func (c *ExtensionsClient) StorageClasses() StorageClassInterface {
+	return newStorageClasses(c)
 }
 
 func (c *ExtensionsClient) ThirdPartyResources() ThirdPartyResourceInterface {

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_extensions_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_extensions_client.go
@@ -58,6 +58,10 @@ func (c *FakeExtensions) Scales(namespace string) v1beta1.ScaleInterface {
 	return &FakeScales{c, namespace}
 }
 
+func (c *FakeExtensions) StorageClasses() v1beta1.StorageClassInterface {
+	return &FakeStorageClasses{c}
+}
+
 func (c *FakeExtensions) ThirdPartyResources() v1beta1.ThirdPartyResourceInterface {
 	return &FakeThirdPartyResources{c}
 }

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_storageclass.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/fake/fake_storageclass.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeStorageClasses implements StorageClassInterface
+type FakeStorageClasses struct {
+	Fake *FakeExtensions
+}
+
+var storageclassesResource = unversioned.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "storageclasses"}
+
+func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootCreateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewRootDeleteAction(storageclassesResource, name), &v1beta1.StorageClass{})
+	return err
+}
+
+func (c *FakeStorageClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	action := core.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.StorageClassList{})
+	return err
+}
+
+func (c *FakeStorageClasses) Get(name string) (result *v1beta1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootGetAction(storageclassesResource, name), &v1beta1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) List(opts api.ListOptions) (result *v1beta1.StorageClassList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootListAction(storageclassesResource, opts), &v1beta1.StorageClassList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label := opts.LabelSelector
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.StorageClassList{}
+	for _, item := range obj.(*v1beta1.StorageClassList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *FakeStorageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewRootWatchAction(storageclassesResource, opts))
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/generated_expansion.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/generated_expansion.go
@@ -29,3 +29,5 @@ type ThirdPartyResourceExpansion interface{}
 type ReplicaSetExpansion interface{}
 
 type PodSecurityPolicyExpansion interface{}
+
+type StorageClassExpansion interface{}

--- a/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/storageclass.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/clientset_generated/release_1_3/typed/extensions/v1beta1/storageclass.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	api "k8s.io/kubernetes/pkg/api"
+	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// StorageClassesGetter has a method to return a StorageClassInterface.
+// A group's client should implement this interface.
+type StorageClassesGetter interface {
+	StorageClasses() StorageClassInterface
+}
+
+// StorageClassInterface has methods to work with StorageClass resources.
+type StorageClassInterface interface {
+	Create(*v1beta1.StorageClass) (*v1beta1.StorageClass, error)
+	Update(*v1beta1.StorageClass) (*v1beta1.StorageClass, error)
+	Delete(name string, options *api.DeleteOptions) error
+	DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error
+	Get(name string) (*v1beta1.StorageClass, error)
+	List(opts api.ListOptions) (*v1beta1.StorageClassList, error)
+	Watch(opts api.ListOptions) (watch.Interface, error)
+	StorageClassExpansion
+}
+
+// storageClasses implements StorageClassInterface
+type storageClasses struct {
+	client *ExtensionsClient
+}
+
+// newStorageClasses returns a StorageClasses
+func newStorageClasses(c *ExtensionsClient) *storageClasses {
+	return &storageClasses{
+		client: c,
+	}
+}
+
+// Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	result = &v1beta1.StorageClass{}
+	err = c.client.Post().
+		Resource("storageclasses").
+		Body(storageClass).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *storageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	result = &v1beta1.StorageClass{}
+	err = c.client.Put().
+		Resource("storageclasses").
+		Name(storageClass.Name).
+		Body(storageClass).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
+func (c *storageClasses) Delete(name string, options *api.DeleteOptions) error {
+	return c.client.Delete().
+		Resource("storageclasses").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *storageClasses) DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error {
+	return c.client.Delete().
+		Resource("storageclasses").
+		VersionedParams(&listOptions, api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
+func (c *storageClasses) Get(name string) (result *v1beta1.StorageClass, err error) {
+	result = &v1beta1.StorageClass{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) List(opts api.ListOptions) (result *v1beta1.StorageClassList, err error) {
+	result = &v1beta1.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *storageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Resource("storageclasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/extensions.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/extensions.go
@@ -37,6 +37,7 @@ type ExtensionsInterface interface {
 	ThirdPartyResourceNamespacer
 	ReplicaSetsNamespacer
 	PodSecurityPoliciesInterface
+	StorageClassesInterface
 }
 
 // ExtensionsClient is used to interact with experimental Kubernetes features.
@@ -80,6 +81,10 @@ func (c *ExtensionsClient) ThirdPartyResources() ThirdPartyResourceInterface {
 
 func (c *ExtensionsClient) ReplicaSets(namespace string) ReplicaSetInterface {
 	return newReplicaSets(c, namespace)
+}
+
+func (c *ExtensionsClient) StorageClasses() StorageClassInterface {
+	return newStorageClasses(c)
 }
 
 // NewExtensions creates a new ExtensionsClient for the given config. This client

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/storageclasses.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/storageclasses.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type StorageClassesInterface interface {
+	StorageClasses() StorageClassInterface
+}
+
+// StorageClassInterface has methods to work with StorageClass resources.
+type StorageClassInterface interface {
+	List(opts api.ListOptions) (*extensions.StorageClassList, error)
+	Get(name string) (*extensions.StorageClass, error)
+	Create(storageClass *extensions.StorageClass) (*extensions.StorageClass, error)
+	Update(storageClass *extensions.StorageClass) (*extensions.StorageClass, error)
+	Delete(name string) error
+	Watch(opts api.ListOptions) (watch.Interface, error)
+}
+
+// storageClasses implements StorageClassInterface
+type storageClasses struct {
+	client *ExtensionsClient
+}
+
+func newStorageClasses(c *ExtensionsClient) *storageClasses {
+	return &storageClasses{c}
+}
+
+func (c *storageClasses) List(opts api.ListOptions) (result *extensions.StorageClassList, err error) {
+	result = &extensions.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *storageClasses) Get(name string) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Get().Resource("storageClasses").Name(name).Do().Into(result)
+	return
+}
+
+func (c *storageClasses) Create(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Post().Resource("storageClasses").Body(storageClass).Do().Into(result)
+	return
+}
+
+func (c *storageClasses) Update(storageClass *extensions.StorageClass) (result *extensions.StorageClass, err error) {
+	result = &extensions.StorageClass{}
+	err = c.client.Put().Resource("storageClasses").Name(storageClass.Name).Body(storageClass).Do().Into(result)
+	return
+}
+
+func (c *storageClasses) Delete(name string) error {
+	return c.client.Delete().Resource("storageClasses").Name(name).Do().Error()
+}
+
+func (c *storageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Resource("storageClasses").
+		VersionedParams(&opts, api.ParameterCodec).
+		Watch()
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/storageclasses_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/storageclasses_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient/simple"
+)
+
+func getStorageClassResourceName() string {
+	return "storageclasses"
+}
+
+func TestListStorageClasses(t *testing.T) {
+	c := &simple.Client{
+		Request: simple.Request{
+			Method: "GET",
+			Path:   testapi.Extensions.ResourcePath(getStorageClassResourceName(), "", ""),
+		},
+		Response: simple.Response{StatusCode: 200,
+			Body: &extensions.StorageClassList{
+				Items: []extensions.StorageClass{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Provisioner: "aaa",
+					},
+				},
+			},
+		},
+	}
+	receivedSCList, err := c.Setup(t).Extensions().StorageClasses().List(api.ListOptions{})
+	c.Validate(t, receivedSCList, err)
+}
+
+func TestGetStorageClass(t *testing.T) {
+	c := &simple.Client{
+		Request: simple.Request{Method: "GET", Path: testapi.Extensions.ResourcePath(getStorageClassResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &extensions.StorageClass{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Provisioner: "aaa",
+			},
+		},
+	}
+	receivedSC, err := c.Setup(t).Extensions().StorageClasses().Get("foo")
+	c.Validate(t, receivedSC, err)
+}
+
+func TestGetStorageClassWithNoName(t *testing.T) {
+	c := &simple.Client{Error: true}
+	receivedSC, err := c.Setup(t).Extensions().StorageClasses().Get("")
+	if (err != nil) && (err.Error() != simple.NameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", simple.NameRequiredError, err)
+	}
+
+	c.Validate(t, receivedSC, err)
+}
+
+func TestUpdateStorageClass(t *testing.T) {
+	requestSC := &extensions.StorageClass{
+		ObjectMeta:  api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+		Provisioner: "aaa",
+	}
+	c := &simple.Client{
+		Request: simple.Request{Method: "PUT", Path: testapi.Extensions.ResourcePath(getStorageClassResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &extensions.StorageClass{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Provisioner: "aaa",
+			},
+		},
+	}
+	receivedSC, err := c.Setup(t).Extensions().StorageClasses().Update(requestSC)
+	c.Validate(t, receivedSC, err)
+}
+
+func TestDeleteStorageClass(t *testing.T) {
+	c := &simple.Client{
+		Request:  simple.Request{Method: "DELETE", Path: testapi.Extensions.ResourcePath(getStorageClassResourceName(), "", "foo"), Query: simple.BuildQueryValues(nil)},
+		Response: simple.Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Extensions().StorageClasses().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestCreateStorageClass(t *testing.T) {
+	requestSC := &extensions.StorageClass{
+		ObjectMeta:  api.ObjectMeta{Name: "foo"},
+		Provisioner: "aaa",
+	}
+	c := &simple.Client{
+		Request: simple.Request{Method: "POST", Path: testapi.Extensions.ResourcePath(getStorageClassResourceName(), "", ""), Body: requestSC, Query: simple.BuildQueryValues(nil)},
+		Response: simple.Response{
+			StatusCode: 200,
+			Body: &extensions.StorageClass{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Provisioner: "aaa",
+			},
+		},
+	}
+	receivedSC, err := c.Setup(t).Extensions().StorageClasses().Create(requestSC)
+	c.Validate(t, receivedSC, err)
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_storage_classes.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_storage_classes.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	kclientlib "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeStorageClasses implements StorageClassInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeStorageClasses struct {
+	Fake *FakeExperimental
+}
+
+// Ensure statically that FakeStorageClasses implements StorageClassInterface.
+var _ kclientlib.StorageClassInterface = &FakeStorageClasses{}
+
+func (c *FakeStorageClasses) Get(name string) (*extensions.StorageClass, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("storageclasses", "", name), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) List(opts api.ListOptions) (*extensions.StorageClassList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("storageclasses", "", opts), &extensions.StorageClassList{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClassList), err
+}
+
+func (c *FakeStorageClasses) Create(np *extensions.StorageClass) (*extensions.StorageClass, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("storageclasses", "", np), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Update(np *extensions.StorageClass) (*extensions.StorageClass, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("storageclasses", "", np), &extensions.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("storageclasses", "", name), &extensions.StorageClass{})
+	return err
+}
+
+func (c *FakeStorageClasses) Watch(opts api.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("storageclasses", "", opts))
+}

--- a/vendor/k8s.io/kubernetes/pkg/client/unversioned/testclient/testclient.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/unversioned/testclient/testclient.go
@@ -410,6 +410,10 @@ func (c *FakeExperimental) NetworkPolicies(namespace string) client.NetworkPolic
 	return &FakeNetworkPolicies{Fake: c, Namespace: namespace}
 }
 
+func (c *FakeExperimental) StorageClasses() client.StorageClassInterface {
+	return &FakeStorageClasses{Fake: c}
+}
+
 func NewSimpleFakeRbac(objects ...runtime.Object) *FakeRbac {
 	return &FakeRbac{Fake: NewSimpleFake(objects...)}
 }

--- a/vendor/k8s.io/kubernetes/pkg/master/master.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/master.go
@@ -99,6 +99,7 @@ import (
 	serviceetcd "k8s.io/kubernetes/pkg/registry/service/etcd"
 	ipallocator "k8s.io/kubernetes/pkg/registry/service/ipallocator"
 	serviceaccountetcd "k8s.io/kubernetes/pkg/registry/serviceaccount/etcd"
+	storageclassetcd "k8s.io/kubernetes/pkg/registry/storageclass/etcd"
 	thirdpartyresourceetcd "k8s.io/kubernetes/pkg/registry/thirdpartyresource/etcd"
 	"k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata"
 	thirdpartyresourcedataetcd "k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata/etcd"
@@ -947,6 +948,10 @@ func (m *Master) getExtensionResources(c *Config) map[string]rest.Storage {
 	if c.APIResourceConfigSource.ResourceEnabled(version.WithResource("networkpolicies")) {
 		storage["networkpolicies"] = networkPolicyStorage
 	}
+	storageClassStorage := storageclassetcd.NewREST(restOptions("storageclasses"))
+	if c.APIResourceConfigSource.ResourceEnabled(version.WithResource("storageclasses")) {
+		storage["storageclasses"] = storageClassStorage
+	}
 
 	return storage
 }
@@ -1117,6 +1122,7 @@ func DefaultAPIResourceConfigSource() *genericapiserver.ResourceConfig {
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("jobs"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("thirdpartyresources"),
+		extensionsapiv1beta1.SchemeGroupVersion.WithResource("storageclasses"),
 	)
 
 	return ret

--- a/vendor/k8s.io/kubernetes/pkg/registry/storageclass/doc.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storageclass/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors All rights reserved.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
-
-type DaemonSetExpansion interface{}
-
-type HorizontalPodAutoscalerExpansion interface{}
-
-type IngressExpansion interface{}
-
-type JobExpansion interface{}
-
-type PodSecurityPolicyExpansion interface{}
-
-type ThirdPartyResourceExpansion interface{}
-
-type ReplicaSetExpansion interface{}
-
-type StorageClassExpansion interface{}
+// Package storageClass provides Registry interface and its REST
+// implementation for storing storageclass api objects.
+package storageclass

--- a/vendor/k8s.io/kubernetes/pkg/registry/storageclass/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storageclass/etcd/etcd.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/registry/storageclass"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type REST struct {
+	*registry.Store
+}
+
+// NewREST returns a RESTStorage object that will work against persistent volumes.
+func NewREST(opts generic.RESTOptions) *REST {
+	prefix := "/storageclasses"
+
+	newListFunc := func() runtime.Object { return &extensions.StorageClassList{} }
+	storageInterface := opts.Decorator(
+		opts.Storage,
+		100,
+		&extensions.StorageClass{},
+		prefix,
+		storageclass.Strategy,
+		newListFunc,
+	)
+
+	store := &registry.Store{
+		NewFunc:     func() runtime.Object { return &extensions.StorageClass{} },
+		NewListFunc: newListFunc,
+		KeyRootFunc: func(ctx api.Context) string {
+			return prefix
+		},
+		KeyFunc: func(ctx api.Context, name string) (string, error) {
+			return registry.NoNamespaceKeyFunc(ctx, prefix, name)
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*extensions.StorageClass).Name, nil
+		},
+		PredicateFunc:           storageclass.MatchStorageClasses,
+		QualifiedResource:       api.Resource("storageclasses"),
+		DeleteCollectionWorkers: opts.DeleteCollectionWorkers,
+
+		CreateStrategy:      storageclass.Strategy,
+		UpdateStrategy:      storageclass.Strategy,
+		DeleteStrategy:      storageclass.Strategy,
+		ReturnDeletedObject: true,
+
+		Storage: storageInterface,
+	}
+
+	return &REST{store}
+}

--- a/vendor/k8s.io/kubernetes/pkg/registry/storageclass/etcd/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storageclass/etcd/etcd_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+	"k8s.io/kubernetes/pkg/runtime"
+	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
+)
+
+func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, extensions.GroupName)
+	restOptions := generic.RESTOptions{Storage: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
+	storageClassStorage := NewREST(restOptions)
+	return storageClassStorage, server
+}
+
+func validNewStorageClass(name string) *extensions.StorageClass {
+	return &extensions.StorageClass{
+		ObjectMeta: api.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: "kubernetes.io/aws-ebs",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+	}
+}
+
+func validChangedStorageClass() *extensions.StorageClass {
+	return validNewStorageClass("foo")
+}
+
+func TestCreate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	storageClass := validNewStorageClass("foo")
+	storageClass.ObjectMeta = api.ObjectMeta{GenerateName: "foo"}
+	test.TestCreate(
+		// valid
+		storageClass,
+		// invalid
+		&extensions.StorageClass{
+			ObjectMeta: api.ObjectMeta{Name: "*BadName!"},
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestUpdate(
+		// valid
+		validNewStorageClass("foo"),
+		// updateFunc
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*extensions.StorageClass)
+			object.Parameters = map[string]string{"foo": "bar"}
+			return object
+		},
+		//invalid update
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*extensions.StorageClass)
+			object.Parameters = map[string]string{"faz": "bar"}
+			return object
+		},
+	)
+
+}
+
+func TestDelete(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope().ReturnDeletedObject()
+	test.TestDelete(validNewStorageClass("foo"))
+}
+
+func TestGet(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestGet(validNewStorageClass("foo"))
+}
+
+func TestList(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestList(validNewStorageClass("foo"))
+}
+
+func TestWatch(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestWatch(
+		validNewStorageClass("foo"),
+		// matching labels
+		[]labels.Set{},
+		// not matching labels
+		[]labels.Set{
+			{"foo": "bar"},
+		},
+		// matching fields
+		[]fields.Set{
+			{"metadata.name": "foo"},
+		},
+		// not matching fields
+		[]fields.Set{
+			{"metadata.name": "bar"},
+		},
+	)
+}

--- a/vendor/k8s.io/kubernetes/pkg/registry/storageclass/strategy.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storageclass/strategy.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/apis/extensions/validation"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/registry/generic"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/validation/field"
+)
+
+// storageClassStrategy implements behavior for StorageClass objects
+type storageClassStrategy struct {
+	runtime.ObjectTyper
+	api.NameGenerator
+}
+
+// Strategy is the default logic that applies when creating and updating
+// StorageClass objects via the REST API.
+var Strategy = storageClassStrategy{api.Scheme, api.SimpleNameGenerator}
+
+func (storageClassStrategy) NamespaceScoped() bool {
+	return false
+}
+
+// ResetBeforeCreate clears the Status field which is not allowed to be set by end users on creation.
+func (storageClassStrategy) PrepareForCreate(obj runtime.Object) {
+	_ = obj.(*extensions.StorageClass)
+}
+
+func (storageClassStrategy) Validate(ctx api.Context, obj runtime.Object) field.ErrorList {
+	storageClass := obj.(*extensions.StorageClass)
+	return validation.ValidateStorageClass(storageClass)
+}
+
+// Canonicalize normalizes the object after validation.
+func (storageClassStrategy) Canonicalize(obj runtime.Object) {
+}
+
+func (storageClassStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// PrepareForUpdate sets the Status fields which is not allowed to be set by an end user updating a PV
+func (storageClassStrategy) PrepareForUpdate(obj, old runtime.Object) {
+	_ = obj.(*extensions.StorageClass)
+	_ = old.(*extensions.StorageClass)
+}
+
+func (storageClassStrategy) ValidateUpdate(ctx api.Context, obj, old runtime.Object) field.ErrorList {
+	errorList := validation.ValidateStorageClass(obj.(*extensions.StorageClass))
+	return append(errorList, validation.ValidateStorageClassUpdate(obj.(*extensions.StorageClass), old.(*extensions.StorageClass))...)
+}
+
+func (storageClassStrategy) AllowUnconditionalUpdate() bool {
+	return true
+}
+
+// MatchStorageClass returns a generic matcher for a given label and field selector.
+func MatchStorageClasses(label labels.Selector, field fields.Selector) generic.Matcher {
+	return &generic.SelectionPredicate{
+		Label: label,
+		Field: field,
+		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			cls, ok := obj.(*extensions.StorageClass)
+			if !ok {
+				return nil, nil, fmt.Errorf("given object is not of type StorageClass")
+			}
+
+			return labels.Set(cls.ObjectMeta.Labels), StorageClassToSelectableFields(cls), nil
+		},
+	}
+}
+
+// StorageClassToSelectableFields returns a label set that represents the object
+func StorageClassToSelectableFields(storageClass *extensions.StorageClass) fields.Set {
+	return generic.ObjectMetaFieldsSet(storageClass.ObjectMeta, false)
+}

--- a/vendor/k8s.io/kubernetes/pkg/registry/storageclass/strategy_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storageclass/strategy_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+func TestStorageClassStrategy(t *testing.T) {
+	ctx := api.NewDefaultContext()
+	if Strategy.NamespaceScoped() {
+		t.Errorf("StorageClass must not be namespace scoped")
+	}
+	if Strategy.AllowCreateOnUpdate() {
+		t.Errorf("StorageClass should not allow create on update")
+	}
+
+	storageClass := &extensions.StorageClass{
+		ObjectMeta: api.ObjectMeta{
+			Name: "valid-class",
+		},
+		Provisioner: "kubernetes.io/aws-ebs",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	Strategy.PrepareForCreate(storageClass)
+
+	errs := Strategy.Validate(ctx, storageClass)
+	if len(errs) != 0 {
+		t.Errorf("unexpected error validating %v", errs)
+	}
+
+	newStorageClass := &extensions.StorageClass{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "valid-class-2",
+			ResourceVersion: "4",
+		},
+		Provisioner: "kubernetes.io/aws-ebs",
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	Strategy.PrepareForUpdate(newStorageClass, storageClass)
+
+	errs = Strategy.ValidateUpdate(ctx, newStorageClass, storageClass)
+	if len(errs) == 0 {
+		t.Errorf("Expected a validation error")
+	}
+}

--- a/vendor/k8s.io/kubernetes/test/integration/storageclasses/storage_classes_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/storageclasses/storage_classes_test.go
@@ -1,0 +1,101 @@
+// +build integration,!no-etcd
+
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclasses
+
+// This file contains tests for the storage classes API resource.
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const provisionerPluginName = "kubernetes.io/mock-provisioner"
+
+// TestStorageClasses tests apiserver-side behavior of creation of storage class objects and their use by pvcs.
+func TestStorageClasses(t *testing.T) {
+	_, s := framework.RunAMaster(nil)
+	defer s.Close()
+
+	client := client.NewOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Default.GroupVersion()}})
+
+	ns := framework.CreateTestingNamespace("storageclass", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	DoTestStorageClasses(t, client, ns)
+}
+
+// DoTestStorageClasses tests storage classes for one api version.
+func DoTestStorageClasses(t *testing.T, client *client.Client, ns *api.Namespace) {
+	// Make a storage class object.
+	s := extensions.StorageClass{
+		TypeMeta: unversioned.TypeMeta{
+			Kind: "StorageClass",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name: "gold",
+		},
+		Provisioner: provisionerPluginName,
+	}
+
+	if _, err := client.Extensions().StorageClasses().Create(&s); err != nil {
+		t.Errorf("unable to create test storage class: %v", err)
+	}
+	defer deleteStorageClassOrErrorf(t, client, s.Namespace, s.Name)
+
+	// Template for pvcs that specify a storage class
+	pvc := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "XXX",
+			Namespace: ns.Name,
+			Annotations: map[string]string{
+				"volume.beta.kubernetes.io/storage-class": "gold",
+			},
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			Resources:   api.ResourceRequirements{Requests: api.ResourceList{api.ResourceName(api.ResourceStorage): resource.MustParse("1G")}},
+			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
+		},
+	}
+
+	pvc.ObjectMeta.Name = "uses-storageclass"
+	if _, err := client.PersistentVolumeClaims(ns.Name).Create(pvc); err != nil {
+		t.Errorf("Failed to create pvc: %v", err)
+	}
+	defer deletePersistentVolumeClaimOrErrorf(t, client, ns.Name, pvc.Name)
+}
+
+func deleteStorageClassOrErrorf(t *testing.T, c *client.Client, ns, name string) {
+	if err := c.Extensions().StorageClasses().Delete(name); err != nil {
+		t.Errorf("unable to delete storage class %v: %v", name, err)
+	}
+}
+
+func deletePersistentVolumeClaimOrErrorf(t *testing.T, c *client.Client, ns, name string) {
+	if err := c.PersistentVolumeClaims(ns).Delete(name); err != nil {
+		t.Errorf("unable to delete persistent volume claim %v: %v", name, err)
+	}
+}


### PR DESCRIPTION
This is the first part of dynamic provisioning for OpenShift 3.3.

This patch has been accepted upstream and has been ported back to Kubernetes 1.3. It contains just new API for StorageClasses + generated files and related hand-written registration of the API to server.

`kubectl` changes and logic in volume controller will follow in a separate PR as it has not been merged to Kubernetes yet.

cc: @pmorie @childsb