### PR TITLE
cluster up: suggest 'cluster down' message

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -432,7 +432,7 @@ func (c *ClientStartConfig) CheckExistingOpenShiftContainer(out io.Writer) error
 		return errors.NewError("unexpected error while checking OpenShift container state").WithCause(err)
 	}
 	if running {
-		return errors.NewError("OpenShift is already running").WithSolution("To start OpenShift again, stop current %q container.", openShiftContainer)
+		return errors.NewError("OpenShift is already running").WithSolution("To start OpenShift again, stop the current cluster:\n$ %s\n", cmdutil.SiblingCommand(c.command, "down"))
 	}
 	if exists {
 		err = c.DockerHelper().RemoveContainer(openShiftContainer)

--- a/pkg/cmd/cli/cmd/rsync/copyrsync.go
+++ b/pkg/cmd/cli/cmd/rsync/copyrsync.go
@@ -13,6 +13,7 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -33,7 +34,7 @@ var rshExcludeFlags = sets.NewString("delete", "strategy", "quiet", "include", "
 
 func newRsyncStrategy(f *clientcmd.Factory, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
 	// Determine the rsh command to pass to the local rsync command
-	rsh := siblingCommand(c, "rsh")
+	rsh := cmdutil.SiblingCommand(c, "rsh")
 	rshCmd := []string{rsh}
 	// Append all original flags to rsh command
 	c.Flags().Visit(func(flag *pflag.Flag) {

--- a/pkg/cmd/cli/cmd/rsync/util.go
+++ b/pkg/cmd/cli/cmd/rsync/util.go
@@ -3,13 +3,10 @@ package rsync
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/golang/glog"
-	"github.com/spf13/cobra"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 )
 
@@ -39,27 +36,6 @@ func hasLocalRsync() bool {
 		return false
 	}
 	return true
-}
-
-// siblingCommand returns a sibling command to the current command
-func siblingCommand(cmd *cobra.Command, name string) string {
-	c := cmd.Parent()
-	command := []string{}
-	for c != nil {
-		glog.V(5).Infof("Found parent command: %s", c.Name())
-		command = append([]string{c.Name()}, command...)
-		c = c.Parent()
-	}
-	// Replace the root command with what was actually used
-	// in the command line
-	glog.V(4).Infof("Setting root command to: %s", os.Args[0])
-	command[0] = os.Args[0]
-
-	// Append the sibling command
-	command = append(command, name)
-	glog.V(4).Infof("The sibling command is: %s", strings.Join(command, " "))
-
-	return strings.Join(command, " ")
 }
 
 func isExitError(err error) bool {

--- a/pkg/cmd/util/sibling.go
+++ b/pkg/cmd/util/sibling.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// SiblingCommand returns a sibling command to the given command
+func SiblingCommand(cmd *cobra.Command, name string) string {
+	c := cmd.Parent()
+	command := []string{}
+	for c != nil {
+		glog.V(5).Infof("Found parent command: %s", c.Name())
+		command = append([]string{c.Name()}, command...)
+		c = c.Parent()
+	}
+	// Replace the root command with what was actually used
+	// in the command line
+	glog.V(4).Infof("Setting root command to: %s", os.Args[0])
+	command[0] = os.Args[0]
+
+	// Append the sibling command
+	command = append(command, name)
+	glog.V(4).Infof("The sibling command is: %s", strings.Join(command, " "))
+
+	return strings.Join(command, " ")
+}


### PR DESCRIPTION
Now suggests to use 'cluster down' to bring down the cluster when it detects that it's already running. 

Moved the siblingCommand utility from rsync to a more common location so it can be used by 'cluster up' as well. 

Fixes #9438