### PR TITLE
change "timeout server" to "timeout tunnel" for pass through routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -289,7 +289,7 @@ backend be_tcp_{{$cfgIdx}}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
-  timeout server  {{$value}}
+  timeout tunnel  {{$value}}
       {{ end }}
     {{ end }}
   hash-type consistent


### PR DESCRIPTION
timeout tunnel overrides both timeout server and timeout client where
applicable. pass through routes are of type TUN within haproxy so
timeout tunnel applies to them. In order to change the timeout for pass
through routes it is required to change the routes backend timeout
tunnel

solves: https://bugzilla.redhat.com/show_bug.cgi?id=1360243