### PR TITLE
properly check for running app pod

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -26,7 +26,7 @@ function wait_for_app() {
   DB_IP=$(oc get -n "$1" --output-version=v1 --template="{{ .spec.portalIP }}" service database)
 
   echo "[INFO] Waiting for frontend pod to start"
-  os::cmd::try_until_text "oc get -n $1 pods" 'frontend.+Running' "$(( 2 * TIME_MIN ))"
+  os::cmd::try_until_text "oc get -n $1 pods -l name=frontend" 'Running' "$(( 2 * TIME_MIN ))"
   os::cmd::expect_success "oc logs dc/frontend -n $1"
 
   echo "[INFO] Waiting for frontend service to start"


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/10145

@stevekuznetsov ptal.  previously we weren't filtering the pods correctly so we'd see the deployment pod running and think that meant the app pod was running, which cut into our 2 minute timeout when we started looking for the actual service to be running.  I'm not 100% confident this is the whole issue, but let's give it a shot and if the problem recurs i'll dig in further.
