### PR TITLE
add back missing integration tests

### DIFF
--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/imagesigning_test.go
+++ b/test/integration/imagesigning_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -1,5 +1,3 @@
-//  +build integration
-
 package integration
 
 import (

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -1,5 +1,3 @@
-//  +build integration
-
 package integration
 
 import (


### PR DESCRIPTION
Integration tests that had build tags were no longer being run.

@smarterclayton @liggitt yell if you don't want these for some reason.  Looks like inflight misses from https://github.com/openshift/origin/pull/9778

[merge]