### PR TITLE
update help output suggestions to display correct cmd format

### DIFF
--- a/pkg/cmd/templates/templater.go
+++ b/pkg/cmd/templates/templater.go
@@ -76,6 +76,7 @@ type FlagExposer interface {
 	ExposeFlags(cmd *cobra.Command, flags ...string) FlagExposer
 }
 
+// ActsAsRootCommand displays command usage using a root command usage template
 func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...CommandGroup) FlagExposer {
 	if cmd == nil {
 		panic("nil root command")
@@ -192,14 +193,25 @@ func (t *templater) optionsCmdFor(c *cobra.Command) string {
 	if !c.Runnable() {
 		return ""
 	}
-	rootCmdStructure := t.parents(c)
-	for i := len(rootCmdStructure) - 1; i >= 0; i-- {
-		cmd := rootCmdStructure[i]
-		if _, _, err := cmd.Find([]string{"options"}); err == nil {
-			return cmd.CommandPath() + " options"
+
+	parentCmdHasOptsArg := false
+	currentCmdHasOptsArg := false
+
+	if t.RootCmd.HasParent() {
+		if _, _, err := t.RootCmd.Parent().Find([]string{"options"}); err == nil {
+			parentCmdHasOptsArg = true
 		}
 	}
-	return ""
+
+	if _, _, err := t.RootCmd.Find([]string{"options"}); err == nil {
+		currentCmdHasOptsArg = true
+	}
+
+	if (parentCmdHasOptsArg && currentCmdHasOptsArg) || !t.RootCmd.HasParent() {
+		return t.RootCmd.CommandPath() + " options"
+	}
+
+	return t.RootCmd.Parent().CommandPath() + " options"
 }
 
 func (t *templater) usageLine(c *cobra.Command) string {

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -49,7 +49,7 @@ Examples:
 {{end}}{{end}}{{ if or $visibleFlags.HasFlags $explicitlyExposedFlags.HasFlags}}
 Options:
 {{ if $visibleFlags.HasFlags}}{{flagsUsages $visibleFlags}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{flagsUsages $explicitlyExposedFlags}}{{end}}{{end}}{{ if .HasSubCommands }}
-Use "{{$rootCmd}} help <command>" for more information about a given command.{{end}}{{ if $optionsCmdFor}}
+Use "{{$rootCmd}} <command> --help" for more information about a given command.{{end}}{{ if $optionsCmdFor}}
 Use "{{$optionsCmdFor}}" for a list of global command-line options (applies to all commands).{{end}}`
 
 	optionsHelpTemplate = ``


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1313198

When displaying help output for commands that invoke the [templates.ActsAsRootCommand](https://github.com/openshift/origin/blob/master/pkg/cmd/templates/templater.go#L79) method, suggested commands are displayed out of order:

`$ oc set -h`
```
Configure application resources

These commands help you make changes to existing application resources.

Usage:
  oc set COMMAND [options]

Replication controllers, deployments, and daemon sets:
  env             Update environment variables on a pod template
  volumes         Update volumes on a pod template
  probe           Update a probe on a pod template
  deployment-hook Update a deployment hook on a deployment config

Manage application flows:
  triggers        Update the triggers on a build or deployment config
  build-hook      Update a build hook on a build config

Use "oc set help <command>" for more information about a given command.
Use "oc options" for a list of global command-line options (applies to all commands).
```

**Use "oc set help <command>"** should be *Use "oc help set <command>"*
When invoking help for sub-commands, such as `oc set triggers -h`, the suggested line for *Use "oc options"...* adds on the immediate parent command:
`Use "oc set options"...`

A suggested solution for this would be to display help output for these commands without calling `templates.ActsAsRootCommand` method, and use a non-root usage template instead:

```
Configure application resources

These commands help you make changes to existing application resources.

Usage:
  oc set COMMAND [options]

Available Commands:
  env             Update environment variables on a pod template
  volumes         Update volumes on a pod template
  probe           Update a probe on a pod template
  deployment-hook Update a deployment hook on a deployment config
  triggers        Update the triggers on a build or deployment config
  build-hook      Update a build hook on a build config

Use "oc help <command>" for more information about a given command.
Use "oc options" for a list of global command-line options (applies to all commands).
```

*Sub-commands* also display the correct usage suggested by the two bottom lines. The only immediate difference is that all available sub-commands are not formatted in groups.

cc @deads2k @fabianofranz @liggitt 

EDIT: The only commands currently affected by this are `oc set -h` and `oadm policy -h`. If we still wish to print available sub-commands for these commands in groups, we could make a function elsewhere that does this