### PR TITLE
Handle container terminated but pod still running in conditions

### DIFF
--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -344,6 +344,7 @@ func (o *DebugOptions) Debug() error {
 			return err
 		}
 		fmt.Fprintf(o.Attach.Err, "Waiting for pod to start ...\n")
+
 		switch containerRunningEvent, err := watch.Until(o.Timeout, w, kclient.PodContainerRunning(o.Attach.ContainerName)); {
 		// api didn't error right away but the pod wasn't even created
 		case kapierrors.IsNotFound(err):
@@ -352,8 +353,8 @@ func (o *DebugOptions) Debug() error {
 				msg += fmt.Sprintf(" on node %q", o.NodeName)
 			}
 			return fmt.Errorf(msg)
-		// switch to logging output
-		case err == kclient.ErrPodCompleted, !o.Attach.Stdin:
+			// switch to logging output
+		case err == kclient.ErrPodCompleted, err == kclient.ErrContainerTerminated, !o.Attach.Stdin:
 			_, err := kcmd.LogsOptions{
 				Object: pod,
 				Options: &kapi.PodLogOptions{


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1360626
Upstream https://github.com/kubernetes/kubernetes/pull/29952

Sometimes when you have a pod with more than one container, and the container runs and terminates really fast, `PodContainerRunning` can go into a state where the pod indicates it's still running, but the container is already terminated so `oc debug` never returns until it times out. 

Handle that condition by returning `ErrContainerTerminated` when it happens.