### PR TITLE
pkg/util/ovs improvements

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -223,15 +223,17 @@ func (plugin *OsdnNode) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesNe
 	if err != nil {
 		return false, err
 	}
-	err = plugin.ovs.AddPort(VXLAN, 1, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`)
+	_ = plugin.ovs.DeletePort(VXLAN)
+	_, err = plugin.ovs.AddPort(VXLAN, 1, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`)
 	if err != nil {
 		return false, err
 	}
-	err = plugin.ovs.AddPort(TUN, 2, "type=internal")
+	_ = plugin.ovs.DeletePort(TUN)
+	_, err = plugin.ovs.AddPort(TUN, 2, "type=internal")
 	if err != nil {
 		return false, err
 	}
-	err = plugin.ovs.AddPort(VOVSBR, 3)
+	_, err = plugin.ovs.AddPort(VOVSBR, 3)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -12,7 +12,6 @@ import (
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/util/ipcmd"
 	"github.com/openshift/origin/pkg/util/netutils"
-	"github.com/openshift/origin/pkg/util/ovs"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
@@ -49,7 +48,7 @@ func getPluginVersion(multitenant bool) []string {
 	return []string{"00", version}
 }
 
-func alreadySetUp(multitenant bool, localSubnetGatewayCIDR, clusterNetworkCIDR string) bool {
+func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR, clusterNetworkCIDR string) bool {
 	var found bool
 
 	exec := kexec.New()
@@ -86,9 +85,7 @@ func alreadySetUp(multitenant bool, localSubnetGatewayCIDR, clusterNetworkCIDR s
 		return false
 	}
 
-	otx := ovs.NewTransaction(exec, BR)
-	flows, err := otx.DumpFlows()
-	otx.EndTransaction()
+	flows, err := plugin.ovs.DumpFlows()
 	if err != nil {
 		return false
 	}
@@ -105,7 +102,7 @@ func alreadySetUp(multitenant bool, localSubnetGatewayCIDR, clusterNetworkCIDR s
 		// OVS note action format hex bytes separated by '.'; first
 		// byte is plugin type (multi-tenant/single-tenant) and second
 		// byte is flow rule version
-		expected := getPluginVersion(multitenant)
+		expected := getPluginVersion(plugin.multitenant)
 		existing := strings.Split(flow[idx+len(VERSION_ACTION):], ".")
 		if len(existing) >= 2 && existing[0] == expected[0] && existing[1] == expected[1] {
 			found = true
@@ -157,7 +154,7 @@ func (plugin *OsdnNode) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesNe
 	glog.V(5).Infof("[SDN setup] node pod subnet %s gateway %s", ipnet.String(), localSubnetGateway)
 
 	gwCIDR := fmt.Sprintf("%s/%d", localSubnetGateway, localSubnetMaskLength)
-	if alreadySetUp(plugin.multitenant, gwCIDR, clusterNetworkCIDR) {
+	if plugin.alreadySetUp(gwCIDR, clusterNetworkCIDR) {
 		glog.V(5).Infof("[SDN setup] no SDN setup required")
 		return false, nil
 	}
@@ -222,12 +219,24 @@ func (plugin *OsdnNode) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesNe
 		return false, err
 	}
 
-	otx := ovs.NewTransaction(exec, BR)
-	otx.AddBridge("fail-mode=secure", "protocols=OpenFlow13")
-	otx.AddPort(VXLAN, 1, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`)
-	otx.AddPort(TUN, 2, "type=internal")
-	otx.AddPort(VOVSBR, 3)
+	err = plugin.ovs.AddBridge("fail-mode=secure", "protocols=OpenFlow13")
+	if err != nil {
+		return false, err
+	}
+	err = plugin.ovs.AddPort(VXLAN, 1, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`)
+	if err != nil {
+		return false, err
+	}
+	err = plugin.ovs.AddPort(TUN, 2, "type=internal")
+	if err != nil {
+		return false, err
+	}
+	err = plugin.ovs.AddPort(VOVSBR, 3)
+	if err != nil {
+		return false, err
+	}
 
+	otx := plugin.ovs.NewTransaction()
 	// Table 0: initial dispatch based on in_port
 	// vxlan0
 	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:1", clusterNetworkCIDR, localSubnetCIDR)
@@ -342,7 +351,7 @@ func (plugin *OsdnNode) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesNe
 	}
 
 	// Table 253: rule version; note action is hex bytes separated by '.'
-	otx = ovs.NewTransaction(exec, BR)
+	otx = plugin.ovs.NewTransaction()
 	pluginVersion := getPluginVersion(plugin.multitenant)
 	otx.AddFlow("%s, %s%s.%s", VERSION_TABLE, VERSION_ACTION, pluginVersion[0], pluginVersion[1])
 	err = otx.EndTransaction()
@@ -444,7 +453,7 @@ func policyNames(policies []*osapi.EgressNetworkPolicy) string {
 }
 
 func (plugin *OsdnNode) updateEgressNetworkPolicy(vnid uint32) error {
-	otx := ovs.NewTransaction(kexec.New(), BR)
+	otx := plugin.ovs.NewTransaction()
 
 	policies := plugin.egressPolicies[vnid]
 	namespaces := plugin.vnids.GetNamespaces(vnid)
@@ -496,7 +505,7 @@ func (plugin *OsdnNode) updateEgressNetworkPolicy(vnid uint32) error {
 
 func (plugin *OsdnNode) AddHostSubnetRules(subnet *osapi.HostSubnet) error {
 	glog.Infof("AddHostSubnetRules for %s", hostSubnetToString(subnet))
-	otx := ovs.NewTransaction(kexec.New(), BR)
+	otx := plugin.ovs.NewTransaction()
 
 	otx.AddFlow("table=1, priority=100, tun_src=%s, actions=goto_table:5", subnet.HostIP)
 	otx.AddFlow("table=8, priority=100, arp, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, subnet.HostIP)
@@ -512,7 +521,7 @@ func (plugin *OsdnNode) AddHostSubnetRules(subnet *osapi.HostSubnet) error {
 func (plugin *OsdnNode) DeleteHostSubnetRules(subnet *osapi.HostSubnet) error {
 	glog.Infof("DeleteHostSubnetRules for %s", hostSubnetToString(subnet))
 
-	otx := ovs.NewTransaction(kexec.New(), BR)
+	otx := plugin.ovs.NewTransaction()
 	otx.DeleteFlows("table=1, tun_src=%s", subnet.HostIP)
 	otx.DeleteFlows("table=8, ip, nw_dst=%s", subnet.Subnet)
 	otx.DeleteFlows("table=8, arp, nw_dst=%s", subnet.Subnet)
@@ -530,7 +539,7 @@ func (plugin *OsdnNode) AddServiceRules(service *kapi.Service, netID uint32) err
 
 	glog.V(5).Infof("AddServiceRules for %v", service)
 
-	otx := ovs.NewTransaction(kexec.New(), BR)
+	otx := plugin.ovs.NewTransaction()
 	for _, port := range service.Spec.Ports {
 		otx.AddFlow(generateAddServiceRule(netID, service.Spec.ClusterIP, port.Protocol, int(port.Port)))
 		err := otx.EndTransaction()
@@ -548,7 +557,7 @@ func (plugin *OsdnNode) DeleteServiceRules(service *kapi.Service) error {
 
 	glog.V(5).Infof("DeleteServiceRules for %v", service)
 
-	otx := ovs.NewTransaction(kexec.New(), BR)
+	otx := plugin.ovs.NewTransaction()
 	for _, port := range service.Spec.Ports {
 		otx.DeleteFlows(generateDeleteServiceRule(service.Spec.ClusterIP, port.Protocol, int(port.Port)))
 		err := otx.EndTransaction()

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -12,6 +12,7 @@ import (
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/plugin/api"
 	"github.com/openshift/origin/pkg/util/netutils"
+	"github.com/openshift/origin/pkg/util/ovs"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
@@ -26,6 +27,7 @@ type OsdnNode struct {
 	multitenant        bool
 	kClient            *kclient.Client
 	osClient           *osclient.Client
+	ovs                *ovs.Interface
 	networkInfo        *NetworkInfo
 	localIP            string
 	localSubnet        *osapi.HostSubnet
@@ -67,10 +69,16 @@ func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient *kclien
 		}
 	}
 
+	ovsif, err := ovs.New(kexec.New(), BR)
+	if err != nil {
+		return nil, err
+	}
+
 	plugin := &OsdnNode{
 		multitenant:        IsOpenShiftMultitenantNetworkPlugin(pluginName),
 		kClient:            kClient,
 		osClient:           osClient,
+		ovs:                ovsif,
 		localIP:            selfIP,
 		hostName:           hostname,
 		vnids:              newNodeVNIDMap(),

--- a/pkg/util/ipcmd/ipcmd_test.go
+++ b/pkg/util/ipcmd/ipcmd_test.go
@@ -2,6 +2,7 @@ package ipcmd
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/util/exec"
@@ -27,19 +28,31 @@ func missingSetup() *exec.FakeExec {
 	}
 }
 
-func addTestResult(fexec *exec.FakeExec, command string, output string, err error) {
+func addTestResult(t *testing.T, fexec *exec.FakeExec, command string, output string, err error) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			func() ([]byte, error) { return []byte(output), err },
 		},
 	}
 	fexec.CommandScript = append(fexec.CommandScript,
-		func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) })
+		func(cmd string, args ...string) exec.Cmd {
+			execCommand := strings.Join(append([]string{cmd}, args...), " ")
+			if execCommand != command {
+				t.Fatalf("Unexpected command: wanted %q got %q", command, execCommand)
+			}
+			return exec.InitFakeCmd(&fcmd, cmd, args...)
+		})
+}
+
+func ensureTestResults(t *testing.T, fexec *exec.FakeExec) {
+	if fexec.CommandCalls != len(fexec.CommandScript) {
+		t.Fatalf("Only used %d of %d expected commands", fexec.CommandCalls, len(fexec.CommandScript))
+	}
 }
 
 func TestGetAddresses(t *testing.T) {
 	fexec := normalSetup()
-	addTestResult(fexec, "/sbin/ip addr show dev lo", `1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
+	addTestResult(t, fexec, "/sbin/ip addr show dev lo", `1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
     inet 127.0.0.1/8 scope host lo
        valid_lft forever preferred_lft forever
@@ -61,8 +74,9 @@ func TestGetAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transaction unexpectedly returned error: %v", err)
 	}
+	ensureTestResults(t, fexec)
 
-	addTestResult(fexec, "/sbin/ip addr show dev eth0", `2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+	addTestResult(t, fexec, "/sbin/ip addr show dev eth0", `2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
     link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff
     inet 192.168.1.10/24 brd 192.168.1.255 scope global dynamic eth0
        valid_lft 81296sec preferred_lft 81296sec
@@ -84,8 +98,9 @@ func TestGetAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transaction unexpectedly returned error: %v", err)
 	}
+	ensureTestResults(t, fexec)
 
-	addTestResult(fexec, "/sbin/ip addr show dev wlan0", "", fmt.Errorf("Device \"%s\" does not exist", "wlan0"))
+	addTestResult(t, fexec, "/sbin/ip addr show dev wlan0", "", fmt.Errorf("Device \"%s\" does not exist", "wlan0"))
 	itx = NewTransaction(fexec, "wlan0")
 	addrs, err = itx.GetAddresses()
 	if err == nil {
@@ -95,6 +110,7 @@ func TestGetAddresses(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Transaction unexpectedly returned no error")
 	}
+	ensureTestResults(t, fexec)
 }
 
 func TestGetRoutes(t *testing.T) {
@@ -104,7 +120,7 @@ func TestGetRoutes(t *testing.T) {
 		l3 = "192.168.1.0/24  proto kernel  scope link  src 192.168.1.15 "
 	)
 	fexec := normalSetup()
-	addTestResult(fexec, "/sbin/ip route show dev wlp3s0", l1+"\n"+l2+"\n"+l3+"\n", nil)
+	addTestResult(t, fexec, "/sbin/ip route show dev wlp3s0", l1+"\n"+l2+"\n"+l3+"\n", nil)
 	itx := NewTransaction(fexec, "wlp3s0")
 	routes, err := itx.GetRoutes()
 	if err != nil {
@@ -126,8 +142,9 @@ func TestGetRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Transaction unexpectedly returned error: %v", err)
 	}
+	ensureTestResults(t, fexec)
 
-	addTestResult(fexec, "/sbin/ip route show dev wlan0", "", fmt.Errorf("Device \"%s\" does not exist", "wlan0"))
+	addTestResult(t, fexec, "/sbin/ip route show dev wlan0", "", fmt.Errorf("Device \"%s\" does not exist", "wlan0"))
 	itx = NewTransaction(fexec, "wlan0")
 	routes, err = itx.GetRoutes()
 	if err == nil {
@@ -137,20 +154,22 @@ func TestGetRoutes(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Transaction unexpectedly returned no error")
 	}
+	ensureTestResults(t, fexec)
 }
 
 func TestErrorHandling(t *testing.T) {
 	fexec := normalSetup()
-	addTestResult(fexec, "/sbin/ip link del dummy0", "", fmt.Errorf("Device \"%s\" does not exist", "dummy0"))
+	addTestResult(t, fexec, "/sbin/ip link del dummy0", "", fmt.Errorf("Device \"%s\" does not exist", "dummy0"))
 	itx := NewTransaction(fexec, "dummy0")
 	itx.DeleteLink()
 	err := itx.EndTransaction()
 	if err == nil {
 		t.Fatalf("Failed to get expected error")
 	}
+	ensureTestResults(t, fexec)
 
-	addTestResult(fexec, "/sbin/ip link del dummy0", "", fmt.Errorf("Device \"%s\" does not exist", "dummy0"))
-	addTestResult(fexec, "/sbin/ip link add dummy0 type dummy", "", nil)
+	addTestResult(t, fexec, "/sbin/ip link del dummy0", "", fmt.Errorf("Device \"%s\" does not exist", "dummy0"))
+	addTestResult(t, fexec, "/sbin/ip link add dummy0 type dummy", "", nil)
 	itx = NewTransaction(fexec, "dummy0")
 	itx.DeleteLink()
 	itx.IgnoreError()
@@ -159,8 +178,9 @@ func TestErrorHandling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpectedly got error after IgnoreError(): %v", err)
 	}
+	ensureTestResults(t, fexec)
 
-	addTestResult(fexec, "/sbin/ip link add dummy0 type dummy", "", fmt.Errorf("RTNETLINK answers: Operation not permitted"))
+	addTestResult(t, fexec, "/sbin/ip link add dummy0 type dummy", "", fmt.Errorf("RTNETLINK answers: Operation not permitted"))
 	// other commands do not get run due to previous error
 	itx = NewTransaction(fexec, "dummy0")
 	itx.AddLink("type", "dummy")
@@ -170,6 +190,7 @@ func TestErrorHandling(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Failed to get expected error")
 	}
+	ensureTestResults(t, fexec)
 }
 
 func TestIPMissing(t *testing.T) {

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -10,81 +10,99 @@ import (
 	"k8s.io/kubernetes/pkg/util/exec"
 )
 
-type Transaction struct {
+const (
+	OVS_OFCTL = "ovs-ofctl"
+	OVS_VSCTL = "ovs-vsctl"
+)
+
+type Interface struct {
 	execer exec.Interface
 	bridge string
-	err    error
 }
 
-// NewTransaction begins a new OVS transaction for a given bridge. If an error
-// occurs at any step in the transaction, it will be recorded until
-// EndTransaction(), and any further calls on the transaction will be ignored.
-func NewTransaction(execer exec.Interface, bridge string) *Transaction {
-	return &Transaction{execer: execer, bridge: bridge}
-}
-
-func (tx *Transaction) exec(cmd string, args ...string) (string, error) {
-	if tx.err != nil {
-		return "", tx.err
+// New returns a new ovs.Interface
+func New(execer exec.Interface, bridge string) (*Interface, error) {
+	if _, err := execer.LookPath(OVS_OFCTL); err != nil {
+		return nil, fmt.Errorf("OVS is not installed")
+	}
+	if _, err := execer.LookPath(OVS_VSCTL); err != nil {
+		return nil, fmt.Errorf("OVS is not installed")
 	}
 
-	cmdpath, err := tx.execer.LookPath(cmd)
+	return &Interface{execer: execer, bridge: bridge}, nil
+}
+
+func (ovsif *Interface) exec(cmd string, args ...string) (string, error) {
+	if cmd == OVS_OFCTL {
+		args = append([]string{"-O", "OpenFlow13"}, args...)
+	}
+	glog.V(5).Infof("Executing: %s %s", cmd, strings.Join(args, " "))
+
+	output, err := ovsif.execer.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		tx.err = fmt.Errorf("OVS is not installed")
-		return "", tx.err
+		glog.V(5).Infof("Error executing %s: %s", cmd, string(output))
 	}
-
-	glog.V(5).Infof("Executing: %s %s", cmdpath, strings.Join(args, " "))
-	var output []byte
-	output, tx.err = tx.execer.Command(cmdpath, args...).CombinedOutput()
-	if tx.err != nil {
-		glog.V(5).Infof("Error executing %s: %s", cmdpath, string(output))
-	}
-	return string(output), tx.err
+	return string(output), err
 }
 
-func (tx *Transaction) vsctlExec(args ...string) (string, error) {
-	return tx.exec("ovs-vsctl", args...)
-}
-
-func (tx *Transaction) ofctlExec(args ...string) (string, error) {
-	args = append([]string{"-O", "OpenFlow13"}, args...)
-	return tx.exec("ovs-ofctl", args...)
-}
-
-// AddBridge creates the bridge associated with the transaction, optionally setting
+// AddBridge creates the bridge associated with the interface, optionally setting
 // properties on it (as with "ovs-vsctl set Bridge ..."). If the bridge already
 // existed, it will be destroyed and recreated.
-func (tx *Transaction) AddBridge(properties ...string) {
-	args := []string{"--if-exists", "del-br", tx.bridge, "--", "add-br", tx.bridge}
+func (ovsif *Interface) AddBridge(properties ...string) error {
+	args := []string{"--if-exists", "del-br", ovsif.bridge, "--", "add-br", ovsif.bridge}
 	if len(properties) > 0 {
-		args = append(args, "--", "set", "Bridge", tx.bridge)
+		args = append(args, "--", "set", "Bridge", ovsif.bridge)
 		args = append(args, properties...)
 	}
-	tx.vsctlExec(args...)
+	_, err := ovsif.exec(OVS_VSCTL, args...)
+	return err
 }
 
-// DeleteBridge deletes the bridge associated with the transaction. (It is an
+// DeleteBridge deletes the bridge associated with the interface. (It is an
 // error if the bridge does not exist.)
-func (tx *Transaction) DeleteBridge() {
-	tx.vsctlExec("del-br", tx.bridge)
+func (ovsif *Interface) DeleteBridge() error {
+	_, err := ovsif.exec(OVS_VSCTL, "del-br", ovsif.bridge)
+	return err
 }
 
 // AddPort adds an interface to the bridge, requesting the indicated port
 // number, and optionally setting properties on it (as with "ovs-vsctl set
 // Interface ...").
-func (tx *Transaction) AddPort(port string, ofport uint, properties ...string) {
-	args := []string{"--if-exists", "del-port", port, "--", "add-port", tx.bridge, port, "--", "set", "Interface", port, fmt.Sprintf("ofport_request=%d", ofport)}
+func (ovsif *Interface) AddPort(port string, ofport uint, properties ...string) error {
+	args := []string{"--if-exists", "del-port", port, "--", "add-port", ovsif.bridge, port, "--", "set", "Interface", port, fmt.Sprintf("ofport_request=%d", ofport)}
 	if len(properties) > 0 {
 		args = append(args, properties...)
 	}
-	tx.vsctlExec(args...)
+	_, err := ovsif.exec(OVS_VSCTL, args...)
+	return err
 }
 
 // DeletePort removes an interface from the bridge. (It is an error if the
 // interface is not currently a bridge port.)
-func (tx *Transaction) DeletePort(port string) {
-	tx.vsctlExec("del-port", port)
+func (ovsif *Interface) DeletePort(port string) error {
+	_, err := ovsif.exec(OVS_VSCTL, "del-port", port)
+	return err
+}
+
+type Transaction struct {
+	ovsif *Interface
+	err   error
+}
+
+func (tx *Transaction) exec(cmd string, args ...string) (string, error) {
+	out := ""
+	if tx.err == nil {
+		out, tx.err = tx.ovsif.exec(cmd, args...)
+	}
+	return out, tx.err
+}
+
+// NewTransaction begins a new OVS transaction. If an error occurs at
+// any step in the transaction, it will be recorded until
+// EndTransaction(), and any further calls on the transaction will be
+// ignored.
+func (ovsif *Interface) NewTransaction() *Transaction {
+	return &Transaction{ovsif: ovsif}
 }
 
 // AddFlow adds a flow to the bridge. The arguments are passed to fmt.Sprintf().
@@ -92,7 +110,7 @@ func (tx *Transaction) AddFlow(flow string, args ...interface{}) {
 	if len(args) > 0 {
 		flow = fmt.Sprintf(flow, args...)
 	}
-	tx.ofctlExec("add-flow", tx.bridge, flow)
+	tx.exec(OVS_OFCTL, "add-flow", tx.ovsif.bridge, flow)
 }
 
 // DeleteFlows deletes all matching flows from the bridge. The arguments are
@@ -101,14 +119,22 @@ func (tx *Transaction) DeleteFlows(flow string, args ...interface{}) {
 	if len(args) > 0 {
 		flow = fmt.Sprintf(flow, args...)
 	}
-	tx.ofctlExec("del-flows", tx.bridge, flow)
+	tx.exec(OVS_OFCTL, "del-flows", tx.ovsif.bridge, flow)
+}
+
+// EndTransaction ends an OVS transaction and returns any error that occurred
+// during the transaction. You should not use the transaction again after
+// calling this function.
+func (tx *Transaction) EndTransaction() error {
+	err := tx.err
+	tx.err = nil
+	return err
 }
 
 // DumpFlows dumps the flow table for the bridge and returns it as an array of
-// strings, one per flow. Since this function has a return value, it also
-// returns an error immediately if an error occurs.
-func (tx *Transaction) DumpFlows() ([]string, error) {
-	out, err := tx.ofctlExec("dump-flows", tx.bridge)
+// strings, one per flow.
+func (ovsif *Interface) DumpFlows() ([]string, error) {
+	out, err := ovsif.exec(OVS_OFCTL, "dump-flows", ovsif.bridge)
 	if err != nil {
 		return nil, err
 	}
@@ -121,13 +147,4 @@ func (tx *Transaction) DumpFlows() ([]string, error) {
 		}
 	}
 	return flows, nil
-}
-
-// EndTransaction ends an OVS transaction and returns any error that occurred
-// during the transaction. You should not use the transaction again after
-// calling this function.
-func (tx *Transaction) EndTransaction() error {
-	err := tx.err
-	tx.err = nil
-	return err
 }


### PR DESCRIPTION
This is partly a proof-of-concept / proposal. A few changes to pkg/ovs:

1. It makes the pkg/ovs `Transaction` type actually transactional (in the sense that either all of the flow modifications in it will take place or none of them will) and atomic, though at the same time, it moves everything except `AddFlow` and `DeleteFlows` out of the transaction type so you have to individually check each call for errors. The latter doesn't hurt too badly. I'm pretty sure we want at least this part.
 - This simplifies some code in the egress firewall setup that previously had to worry about the non-atomicity of flow updates, although it doesn't get rid of all of the vnid-renaming race conditions (in particular, that we change the vnid being applied to traffic coming out of a container before we change the vnid being examined in other rules). That can only be fixed if we move the pod update code from the shell script to the plugin though.
 - (This may also depend on a newer version of OVS than we want to depend on?)
2. It makes it so you can specify input and output ports in flow rules by ifname rather than by number. (ie, `in_port=$vxlan0`). I think I like this part too, although I feel guilty for not using our constants (eg, `"in_port=%s...", VXLAN`). But it seems to me that doing it that way is worse than just hardcoding numbers...
3. It makes it so you can give names to tables and then use those in flows as well (`table=$outgoing, ..., actions=goto_table:$to_vxlan`), which was hopefully going to address @knobunc 's table-renumbering problem. It's hard to give the tables names that are both compact and descriptive though, and I don't like this as much as I hoped (and it doesn't help with ovs-ofctl calls from the shell script either).