### PR TITLE
cluster up: use shared volumes in mac and windows

### DIFF
--- a/pkg/bootstrap/docker/host/host.go
+++ b/pkg/bootstrap/docker/host/host.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	docker "github.com/fsouza/go-dockerclient"
@@ -54,6 +55,12 @@ func NewHostHelper(client *docker.Client, image, volumesDir, configDir, dataDir 
 
 // CanUseNsenterMounter returns true if the Docker host machine can execute findmnt through nsenter
 func (h *HostHelper) CanUseNsenterMounter() (bool, error) {
+	// For now, use a shared mount on Windows/Mac
+	// Eventually it also needs to be used on Linux, but nsenter
+	// is still needed for Docker 1.9
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		return false, nil
+	}
 	rc, err := h.runner().
 		Image(h.image).
 		DiscardContainer().


### PR DESCRIPTION
Starting the latest version of origin is not working on the latest version of Docker for Mac (1.12) because it tries to use the nsenter mounter (findmnt is available on the Docker vm). In Kube 1.3 and later secrets are no longer written with the nsenter writer, causing them to not be visible in the host of Docker > 1.10.

Eventually the nsenter mounter will go away, but for now it's needed for Docker 1.9 support on Linux.