### PR TITLE
Replace the tab with 4 spaces in cli.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -725,7 +725,7 @@ The subcommands are:
 |`set-credentials` | Sets a user entry in kubeconfig.                                   |
 |`unset`           | Unset an individual value in a kubeconfig file.                    |
 |`use-context`     | Set the current-context in a kubeconfig file.                      |
-|`view`	           | Display merged kubeconfig settings or a specified kubeconfig file. |
+|`view`            | Display merged kubeconfig settings or a specified kubeconfig file. |
 
 The following example changes the config context to use:
 


### PR DESCRIPTION
Spaces, it is aligned to view code with any editor, including the web
page view (such as in the GitHub code). When use tabs, the view on the
page is chaos, and it is terrible to mix tabs and spaces.