### PR TITLE
Check upper bound of watch port range for IP Failover configuration

### DIFF
--- a/pkg/ipfailover/keepalived/plugin.go
+++ b/pkg/ipfailover/keepalived/plugin.go
@@ -38,11 +38,12 @@ func NewIPFailoverConfiguratorPlugin(name string, f *clientcmd.Factory, options 
 // GetWatchPort gets the port to monitor for the IP Failover configuration.
 func (p *KeepalivedPlugin) GetWatchPort() (int, error) {
 	port := p.Options.WatchPort
-	if port < 1 {
+	if port < 1 || port > 65535 {
+		glog.V(4).Infof("Warning: KeepAlived IP Failover config: %q - WatchPort: %d invalid, will default to %d", p.Name, port, ipfailover.DefaultWatchPort)
 		port = ipfailover.DefaultWatchPort
 	}
 
-	glog.V(4).Infof("KeepAlived IP Failover config: %q - WatchPort: %+v", p.Name, port)
+	glog.V(4).Infof("KeepAlived IP Failover config: %q - WatchPort: %d", p.Name, port)
 
 	return port, nil
 }

--- a/pkg/ipfailover/keepalived/plugin_test.go
+++ b/pkg/ipfailover/keepalived/plugin_test.go
@@ -112,6 +112,11 @@ func TestPluginGetWatchPort(t *testing.T) {
 			Expected:  9999,
 		},
 		{
+			Name:      "service2",
+			WatchPort: 65535,
+			Expected:  65535,
+		},
+		{
 			Name:      "invalid-port",
 			WatchPort: -12345,
 			Expected:  80,
@@ -119,6 +124,11 @@ func TestPluginGetWatchPort(t *testing.T) {
 		{
 			Name:      "invalid-port-2",
 			WatchPort: -1,
+			Expected:  80,
+		},
+		{
+			Name:      "invalid-port-3",
+			WatchPort: 65536,
 			Expected:  80,
 		},
 		{


### PR DESCRIPTION
We should check the upper bound of watch port range for IP Failover configuration.

Question: Should we return error instead of giving a default port when users configure an invalid value? IMO, we can set default value when users don't specify `--watch-port`. But if users give an invalid value, we'd better exit and prompt user to configure again.
