### PR TITLE
go-binddata can not found when GOPATH is a list of directories

### DIFF
--- a/hack/gen-bootstrap-bindata.sh
+++ b/hack/gen-bootstrap-bindata.sh
@@ -17,7 +17,7 @@ pushd vendor/github.com/jteeuwen/go-bindata > /dev/null
 popd > /dev/null
 
 pushd "${OS_ROOT}" > /dev/null
-  "${GOPATH}/bin/go-bindata" -nocompress -nometadata -prefix "bootstrap" -pkg "bootstrap" \
+  "$(os::util::find-go-binary go-bindata)" -nocompress -nometadata -prefix "bootstrap" -pkg "bootstrap" \
                                    -o "${OUTPUT_PARENT}/pkg/bootstrap/bindata.go" -ignore "README.md" \
                                    ${EXAMPLES}/image-streams/... \
                                    ${EXAMPLES}/db-templates/... \

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -108,3 +108,23 @@ function os::util::format_seconds() {
 	printf '%02dh %02dm %02ds' "${hours}" "${minutes}" "${seconds}"
 }
 readonly -f os::util::format_seconds
+
+# os::util::find-go-binary locates a go install binary in GOPATH directories
+# Globals:
+#  - 1: GOPATH
+# Arguments:
+#  - 1: the go-binary to find
+# Return:
+#  None
+function os::util::find-go-binary() {
+  local binary_name="$1"
+
+  IFS=":"
+  for part in $GOPATH; do
+    if [[ -f "$part/bin/$binary_name" && -x "${part}/bin/${binary_name}" ]]; then
+      echo $part/bin/$binary_name
+      break
+    fi
+  done
+}
+readonly -f os::util::find-go-binary

--- a/hack/vendor-console.sh
+++ b/hack/vendor-console.sh
@@ -50,8 +50,8 @@ pushd "${OS_ROOT}" > /dev/null
   # Put each component in its own go package for compilation performance
   # Strip off the dist folder from each package to flatten the resulting directory structure
   # Force timestamps to unify, and mode to 493 (0755)
-  "${GOPATH}/bin/go-bindata" -nocompress -nometadata -prefix "${CONSOLE_REPO_PATH}/dist"      -pkg "assets" -o "pkg/assets/bindata.go"      "${CONSOLE_REPO_PATH}/dist/..."
-  "${GOPATH}/bin/go-bindata" -nocompress -nometadata -prefix "${CONSOLE_REPO_PATH}/dist.java" -pkg "java"   -o "pkg/assets/java/bindata.go" "${CONSOLE_REPO_PATH}/dist.java/..."
+  "$(os::util::find-go-binary go-bindata)" -nocompress -nometadata -prefix "${CONSOLE_REPO_PATH}/dist"      -pkg "assets" -o "pkg/assets/bindata.go"      "${CONSOLE_REPO_PATH}/dist/..."
+  "$(os::util::find-go-binary go-bindata)" -nocompress -nometadata -prefix "${CONSOLE_REPO_PATH}/dist.java" -pkg "java"   -o "pkg/assets/java/bindata.go" "${CONSOLE_REPO_PATH}/dist.java/..."
 
   if [[ -n "${COMMIT:+x}" ]]; then
     if [[ -n "$(git status --porcelain)" ]]; then


### PR DESCRIPTION
when run `$ make verify`, there are some erros:

```
===== Verifying Generated Bootstrap Bindata =====
Generating bootstrap bindata...
FAILURE: Generation of fresh bindata failed:
/root/go/src/github.com/openshift/origin/hack/gen-bootstrap-bindata.sh: line 20: **/root/go:/home/test/bin/go-bindata**: No such file or directory
[ERROR] PID 18518: hack/gen-bootstrap-bindata.sh:20: `"${GOPATH}/bin/go-bindata" -nocompress -nometadata -prefix "bootstrap" -pkg "bootstrap" -o "${OUTPUT_PARENT}/pkg/bootstrap/bindata.go" -ignore "README.md" ${EXAMPLES}/image-streams/... ${EXAMPLES}/db-templates/... ${EXAMPLES}/jenkins/pipeline/... ${EXAMPLES}/quickstarts/...` exited with status 1.
[INFO]          Stack Trace:
[INFO]            1: hack/gen-bootstrap-bindata.sh:20: `"${GOPATH}/bin/go-bindata" -nocompress -nometadata -prefix "bootstrap" -pkg "bootstrap" -o "${OUTPUT_PARENT}/pkg/bootstrap/bindata.go" -ignore "README.md" ${EXAMPLES}/image-streams/... ${EXAMPLES}/db-templates/... ${EXAMPLES}/jenkins/pipeline/... ${EXAMPLES}/quickstarts/...`
[INFO]   Exiting with code 1.
make: *** [verify] Error 1            
```

I found the 'go-bindata' directory is incorrect, because my GOPATH is a list of directories.
I think we can make our script more generic when there is not only one directory for GOPATH.
When run 'go install' command, the binaries will be installed in first directory of GOPATH by default, so I add one line code that can get first GOPATH directory. It looks like work well after my testing.

```
===== Verifying Generated Bootstrap Bindata =====
Generating bootstrap bindata...
Diffing current bootstrap bindata against freshly generated bindata
SUCCESS: Generated bootstrap bindata up to date.
```

@stevekuznetsov PTAL, thanks!
