### PR TITLE
Add Dockerfile.centos7 and .cccp.yml files to origin 1.2

### DIFF
--- a/images/base/.cccp.yml
+++ b/images/base/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-base

--- a/images/base/Dockerfile.centos7
+++ b/images/base/Dockerfile.centos7
@@ -1,0 +1,13 @@
+#
+# This is the base image from which all OpenShift Origin images inherit. Only packages
+# common to all downstream images should be here.
+#
+# The standard name for this image is openshift/origin-base
+#
+FROM centos:centos7
+
+RUN INSTALL_PKGS="which git tar wget hostname sysvinit-tools util-linux bsdtar centos-release-openshift-origin \
+        socat ethtool device-mapper iptables e2fsprogs xfsprogs" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all

--- a/images/builder/docker/custom-docker-builder/.cccp.yml
+++ b/images/builder/docker/custom-docker-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-custom-docker-builder

--- a/images/builder/docker/custom-docker-builder/Dockerfile.centos7
+++ b/images/builder/docker/custom-docker-builder/Dockerfile.centos7
@@ -1,0 +1,25 @@
+# This image is intended for testing purposes, it has the same behavior as
+# the origin-docker-builder image, but does so as a custom image so it can
+# be used with Custom build strategies.  It expects a set of
+# environment variables to parameterize the build:
+#
+#   OUTPUT_REGISTRY - the Docker registry URL to push this image to
+#   OUTPUT_IMAGE - the name to tag the image with
+#   SOURCE_URI - a URI to fetch the build context from
+#   SOURCE_REF - a reference to pass to Git for which commit to use (optional)
+#
+# This image expects to have the Docker socket bind-mounted into the container.
+# If "/root/.dockercfg" is bind mounted in, it will use that as authorization 
+# to a Docker registry.
+#
+# The standard name for this image is openshift/origin-custom-docker-builder
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="gettext automake make docker" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+ENV HOME /root
+ADD ./build.sh /tmp/build.sh
+CMD ["/tmp/build.sh"]

--- a/images/builder/docker/docker-builder/.cccp.yml
+++ b/images/builder/docker/docker-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-docker-builder

--- a/images/builder/docker/sti-builder/.cccp.yml
+++ b/images/builder/docker/sti-builder/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-sti-builder

--- a/images/deployer/.cccp.yml
+++ b/images/deployer/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-deployer

--- a/images/dind/Dockerfile.centos7
+++ b/images/dind/Dockerfile.centos7
@@ -1,0 +1,51 @@
+#
+# This image is used for running a host of an openshift dev cluster.
+#
+# The standard name for this image is openshift/dind
+#
+
+FROM centos:centos7
+
+## Configure systemd to run in a container
+ENV container=docker
+
+RUN systemctl mask systemd-remount-fs.service dev-hugepages.mount \
+  sys-fs-fuse-connections.mount systemd-logind.service getty.target \
+  console-getty.service dnf-makecache.service lvm2-lvmetad.service \
+  systemd-udevd.service systemd-udev-hwdb-update.service \
+  systemd-udev-trigger.service docker-storage-setup.service
+RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; \
+  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+
+VOLUME ["/run", "/tmp"]
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="git golang mercurial tar make \
+      hostname bind-utils iproute iputils which procps-ng openssh-server \
+      docker openvswitch bridge-utils ethtool iptables-services" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V --nofiles $INSTALL_PKGS && \
+    yum clean all
+
+
+# sshd should be enabled as needed
+RUN systemctl disable sshd.service
+
+## Configure dind
+ENV DIND_COMMIT 81aa1b507f51901eafcfaad70a656da376cf937d
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" \
+  -o /usr/local/bin/dind && chmod +x /usr/local/bin/dind
+RUN mkdir -p /etc/systemd/system/docker.service.d
+COPY dind.conf /etc/systemd/system/docker.service.d/
+
+RUN systemctl enable docker
+
+VOLUME /var/lib/docker
+
+CMD ["/usr/sbin/init"]

--- a/images/dockerregistry/.cccp.yml
+++ b/images/dockerregistry/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-docker-registry

--- a/images/dockerregistry/Dockerfile.centos7
+++ b/images/dockerregistry/Dockerfile.centos7
@@ -1,0 +1,22 @@
+#
+# This is the integrated OpenShift Origin Docker registry. It is configured to
+# publish metadata to OpenShift to provide automatic management of images on push.
+#
+# The standard name for this image is openshift/origin-docker-registry
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="tree findutils origin-dockerregistry" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# The registry doesn't require a privileged user.
+USER 1001
+
+EXPOSE 5000
+VOLUME /registry
+ENV REGISTRY_CONFIGURATION_PATH /config.yml
+CMD DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} /dockerregistry ${REGISTRY_CONFIGURATION_PATH}
+
+ADD config.yml $REGISTRY_CONFIGURATION_PATH

--- a/images/ipfailover/keepalived/.cccp.yml
+++ b/images/ipfailover/keepalived/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-keepalived-ipfailover

--- a/images/node/.cccp.yml
+++ b/images/node/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: node

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -1,0 +1,40 @@
+#
+# This is an OpenShift Origin node image with integrated OpenvSwitch SDN
+# If you do not require OVS SDN you should just use the origin image
+#
+# The standard name for this image is openshift/node
+#
+
+FROM openshift/origin
+
+# Based on work by: Peter Schiffer <pschiffe@redhat.com>
+MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
+
+# We need to install openvswitch for the client portions, the daemons are expected
+# to run in another container
+
+RUN INSTALL_PKGS="origin-sdn-ovs libmnl libnetfilter_conntrack openvswitch \
+    libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
+    binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
+    ceph-common iscsi-initiator-utils" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+RUN mkdir -p \
+    /usr/lib/systemd/system/origin-node.service.d \
+    /usr/lib/systemd/system/docker.service.d
+
+# All of the following are placed in images/node by hack/build-images.sh
+# They won't exist in the git checkout
+ADD scripts/* /usr/local/bin/
+RUN chmod +x /usr/local/bin/* /usr/bin/openshift-*
+
+VOLUME [ "/etc/origin/node", "/var/lib/origin" ]
+WORKDIR /var/lib/origin
+
+ENV HOME /root
+ENV OPENSHIFT_CONTAINERIZED true
+ENV KUBECONFIG /etc/origin/node/node.kubeconfig
+ENTRYPOINT []
+CMD [ "/usr/local/bin/origin-node-run.sh" ]

--- a/images/openldap/.cccp.yml
+++ b/images/openldap/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: oco-openldap

--- a/images/openvswitch/.cccp.yml
+++ b/images/openvswitch/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: openvswitch

--- a/images/openvswitch/Dockerfile.centos7
+++ b/images/openvswitch/Dockerfile.centos7
@@ -1,0 +1,26 @@
+#
+# This is an openvswitch image meant to enable OpenShift OVS based SDN
+#
+# The standard name for this image is openshift/openvswitch
+#
+
+FROM centos:centos7
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="openvswitch" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+ADD  scripts/* /usr/local/bin/
+RUN chmod +x /usr/local/bin/*
+VOLUME [ "/etc/openswitch" ]
+
+ENV HOME /root
+ENTRYPOINT [ "/usr/local/bin/ovs-run.sh" ]

--- a/images/origin/.cccp.yml
+++ b/images/origin/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin

--- a/images/origin/Dockerfile.centos7
+++ b/images/origin/Dockerfile.centos7
@@ -1,0 +1,27 @@
+#
+# This is the official OpenShift Origin image. It has as its entrypoint the OpenShift
+# all-in-one binary.
+#
+# While this image can be used for a simple node it does not support OVS based
+# SDN or storage plugins required for EBS, GCE, Gluster, Ceph, or iSCSI volume
+# management. For those features please use 'openshift/node' 
+#
+# The standard name for this image is openshift/origin
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+RUN mkdir -p /var/lib/origin
+
+RUN setcap 'cap_net_bind_service=ep' /usr/bin/openshift
+
+ENV HOME /root
+ENV OPENSHIFT_CONTAINERIZED true
+ENV KUBECONFIG /var/lib/origin/openshift.local.config/master/admin.kubeconfig
+WORKDIR /var/lib/origin
+EXPOSE 8443 53
+ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/pod/.cccp.yml
+++ b/images/pod/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-pod

--- a/images/pod/Dockerfile.centos7
+++ b/images/pod/Dockerfile.centos7
@@ -1,0 +1,25 @@
+#
+# This is the official OpenShift Origin pod infrastructure image. It will stay running
+# until terminated by a signal and is the heart of each running pod. It holds on to
+# the network and IPC namespaces as containers come and go during the lifetime of the
+# pod.
+#
+# The standard name for this image is openshift/origin-pod
+#
+FROM centos:centos7
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="origin-pod" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+RUN ln -s /usr/bin/pod /pod
+
+ENTRYPOINT ["/pod"]

--- a/images/recycler/.cccp.yml
+++ b/images/recycler/.cccp.yml
@@ -1,0 +1,2 @@
+job-id: origin-recycler
+

--- a/images/recycler/Dockerfile.centos7
+++ b/images/recycler/Dockerfile.centos7
@@ -1,0 +1,20 @@
+#
+# This is the default OpenShift Origin persistent volume recycler image.
+#
+# The standard name for this image is openshift/origin-recycler
+#
+FROM centos:centos7
+
+## Install origin repo
+RUN INSTALL_PKGS="centos-release-openshift-origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+## Install packages
+RUN INSTALL_PKGS="origin-recycle" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+ENTRYPOINT ["/usr/bin/recycle"]

--- a/images/release/.cccp.yml
+++ b/images/release/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-release

--- a/images/router/egress/.cccp.yml
+++ b/images/router/egress/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-egress-router

--- a/images/router/egress/Dockerfile.centos7
+++ b/images/router/egress/Dockerfile.centos7
@@ -1,0 +1,15 @@
+#
+# This is the egress router for OpenShift Origin
+#
+# The standard name for this image is openshift/origin-egress-router
+
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="iproute" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+ADD egress-router.sh /bin/egress-router.sh
+
+ENTRYPOINT /bin/egress-router.sh

--- a/images/router/f5/.cccp.yml
+++ b/images/router/f5/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-f5-router

--- a/images/router/haproxy-base/.cccp.yml
+++ b/images/router/haproxy-base/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-haproxy-router-base

--- a/images/router/haproxy/.cccp.yml
+++ b/images/router/haproxy/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-haproxy-router

--- a/images/router/haproxy/Dockerfile.centos7
+++ b/images/router/haproxy/Dockerfile.centos7
@@ -1,0 +1,29 @@
+#
+# This is the HAProxy router for OpenShift Origin.
+#
+# The standard name for this image is openshift/origin-haproxy-router
+#
+FROM openshift/origin-haproxy-router-base
+
+RUN INSTALL_PKGS="origin" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+ADD conf/ /var/lib/haproxy/conf/
+ADD reload-haproxy /var/lib/haproxy/reload-haproxy
+
+#
+# Note: /var is changed to 777 to allow access when running this container as a non-root uid
+#       this is temporary and should be removed when the container is switch to an empty-dir
+#       with gid support.
+# Note2: cap_net_bind_service must be granted to haproxy to allow a non-root uid to bind to low ports
+#
+RUN chmod -R 777 /var && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy
+WORKDIR /var/lib/haproxy/conf
+
+EXPOSE 80
+ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router"]

--- a/images/simple-authenticated-registry/.cccp.yml
+++ b/images/simple-authenticated-registry/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: oco-simple-authenticated-registry


### PR DESCRIPTION
These files should not interfere with any non-CentOS work.
They make it possible to build OpenShift Origin 1.2 images in CentOS's enviroment.