### PR TITLE
Bug 1281735 - remove the internal docker registry information from imagestream

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -640,7 +640,9 @@ func (d *ImageStreamDescriber) Describe(namespace, name string, settings kctl.De
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
-		formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
+		if len(imageStream.Spec.DockerImageRepository) > 0 {
+			formatString(out, "Imported From", imageStream.Spec.DockerImageRepository)
+		}
 		formatImageStreamTags(out, imageStream)
 		return nil
 	})

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -34,7 +34,7 @@ var (
 	imageColumns            = []string{"NAME", "DOCKER REF"}
 	imageStreamTagColumns   = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
 	imageStreamImageColumns = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
-	imageStreamColumns      = []string{"NAME", "DOCKER REPO", "TAGS", "UPDATED"}
+	imageStreamColumns      = []string{"NAME", "TAGS", "UPDATED"}
 	projectColumns          = []string{"NAME", "DISPLAY NAME", "STATUS"}
 	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "TERMINATION", "LABELS"}
 	deploymentConfigColumns = []string{"NAME", "REVISION", "DESIRED", "CURRENT", "TRIGGERED BY"}
@@ -434,11 +434,7 @@ func printImageStream(stream *imageapi.ImageStream, w io.Writer, opts kctl.Print
 			return err
 		}
 	}
-	repo := stream.Spec.DockerImageRepository
-	if len(repo) == 0 {
-		repo = stream.Status.DockerImageRepository
-	}
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", name, repo, tags, latestTime); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s", name, tags, latestTime); err != nil {
 		return err
 	}
 	if err := appendItemLabels(stream.Labels, w, opts.ColumnLabels, opts.ShowLabels); err != nil {


### PR DESCRIPTION
Fixes #5927 and https://bugzilla.redhat.com/show_bug.cgi?id=1281735.

@mfojtik ptal