### PR TITLE
Remove allocated IP addresses from app-scenarios test data

### DIFF
--- a/pkg/api/graph/test/README.md
+++ b/pkg/api/graph/test/README.md
@@ -1,0 +1,5 @@
+The test data in this folder is used to test the graph API
+
+The test files should contain data as it was returned from the API, and is used to mock API responses
+
+It is not expected to be able to be loaded into the API, since it contains generated values, like allocated service portalIP

--- a/pkg/api/graph/test/k8s-lonely-pod.json
+++ b/pkg/api/graph/test/k8s-lonely-pod.json
@@ -1,0 +1,43 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "lonely-pod",
+        "creationTimestamp": null,
+        "labels": {
+          "name": "lonely-pod"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "lonely-pod",
+            "image": "openshift/hello-openshift",
+            "ports": [
+              {
+                "containerPort": 8080,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "IfNotPresent",
+            "capabilities": {},
+            "securityContext": {
+              "capabilities": {},
+              "privileged": false
+            }
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
+      },
+      "status": {}
+    }
+  ]
+}

--- a/pkg/api/graph/test/k8s-service-with-nothing.json
+++ b/pkg/api/graph/test/k8s-service-with-nothing.json
@@ -1,0 +1,37 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "empty-service",
+        "creationTimestamp": null,
+        "labels": {
+          "template": "empty-service"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 8080,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "empty-service"
+        },
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/pkg/api/graph/test/k8s-unserviced-rc.json
+++ b/pkg/api/graph/test/k8s-unserviced-rc.json
@@ -1,0 +1,175 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "database-rc-1",
+        "creationTimestamp": null,
+        "labels": {
+          "template": "ruby-helloworld-sample"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "name": "database",
+          "deconflict": "database.rc"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "database",
+              "template": "ruby-helloworld-sample",
+              "deconflict": "database.rc"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "ruby-helloworld-database",
+                "image": "mysql",
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "rQHfVnTo"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "root"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend-rc-1",
+        "creationTimestamp": null,
+        "labels": {
+          "template": "ruby-helloworld-sample"
+        }
+      },
+      "spec": {
+        "replicas": 3,
+        "selector": {
+          "name": "frontend",
+          "deconflict": "frontend.rc"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "frontend",
+              "template": "ruby-helloworld-sample",
+              "deconflict": "frontend.rc"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "ruby-helloworld",
+                "image": "openshift/ruby-hello-world",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ADMIN_USERNAME",
+                    "value": "admin6TM"
+                  },
+                  {
+                    "name": "ADMIN_PASSWORD",
+                    "value": "xImx1tHR"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "rQHfVnTo"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "root"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "database-rc",
+        "creationTimestamp": null,
+        "labels": {
+          "template": "ruby-helloworld-sample"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 5434,
+            "targetPort": 3306,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "database"
+        },
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/pkg/api/graph/test/new-project-deployed-app.yaml
+++ b/pkg/api/graph/test/new-project-deployed-app.yaml
@@ -1,0 +1,553 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      name: ruby-sample-build
+      template: application-template-stibuild
+    name: ruby-sample-build
+    namespace: example
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: origin-ruby-sample:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/openshift/ruby-hello-world.git
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+        incremental: true
+      type: Source
+    triggers:
+    - github:
+        secret: secret101
+      type: github
+    - generic:
+        secret: secret101
+      type: generic
+    - imageChange:
+        lastTriggeredImageID: centos/ruby-22-centos7:latest
+      type: imageChange
+  status:
+    lastVersion: 1
+- apiVersion: v1
+  kind: Build
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:18Z
+    labels:
+      buildconfig: ruby-sample-build
+      name: ruby-sample-build
+      template: application-template-stibuild
+    name: ruby-sample-build-1
+    namespace: example
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: origin-ruby-sample:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/openshift/ruby-hello-world.git
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7:latest
+        incremental: true
+      type: Source
+  status:
+    completionTimestamp: 2015-04-07T04:13:01Z
+    config:
+      kind: BuildConfig
+      name: ruby-sample-build
+
+    phase: Complete
+    startTimestamp: 2015-04-07T04:12:21Z
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    annotations:
+      openshift.io/deployment-config.name: database
+      openshift.io/deployment.phase: Running
+      openshift.io/deployment-config.latest-version: "2"
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"database","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/database","uid":"4725b5d3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"271","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ConfigChange"}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"database"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld-database","image":"centos/mysql-56-centos7","ports":[{"containerPort":3306,"protocol":"TCP"}],"env":[{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"database","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ConfigChange"}]}}'
+      pod: deploy-database-19m1he
+    creationTimestamp: 2015-04-07T04:12:18Z
+    labels:
+      template: application-template-stibuild
+    name: database-2
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      deployment: database-2
+      deploymentconfig: database
+      name: database
+    template:
+      metadata:
+        annotations:
+          openshift.io/deployment.name: database-2
+          openshift.io/deployment-config.name: database
+          openshift.io/deployment-config.latest-version: "2"
+        creationTimestamp: null
+        labels:
+          deployment: database-2
+          deploymentconfig: database
+          name: database
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: centos/mysql-56-centos7
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld-database
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    replicas: 2
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    annotations:
+      openshift.io/deployment-config.name: database
+      openshift.io/deployment.phase: Complete
+      openshift.io/deployment-config.latest-version: "1"
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"database","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/database","uid":"4725b5d3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"271","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ConfigChange"}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"database"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld-database","image":"centos/mysql-56-centos7","ports":[{"containerPort":3306,"protocol":"TCP"}],"env":[{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"database","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ConfigChange"}]}}'
+      pod: deploy-database-19m1he
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: database-1
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      deployment: database-1
+      deploymentconfig: database
+      name: database
+    template:
+      metadata:
+        annotations:
+          openshift.io/deployment.name: database-1
+          openshift.io/deployment-config.name: database
+          openshift.io/deployment-config.latest-version: "1"
+        creationTimestamp: null
+        labels:
+          deployment: database-1
+          deploymentconfig: database
+          name: database
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: centos/mysql-56-centos7
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld-database
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    replicas: 1
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: database
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      name: database
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          name: database
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: centos/mysql-56-centos7
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld-database
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    test: true
+    triggers:
+    - type: ConfigChange
+  status:
+    details:
+      causes:
+      - type: ConfigChange
+    latestVersion: 1
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    annotations:
+      openshift.io/deployment-config.name: frontend
+      openshift.io/deployment.phase: Failed
+      openshift.io/deployment-config.latest-version: "2"
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageStreamTag","name":"origin-ruby-sample:latest"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
+      openshift.io/deployment.status-reason: unable to contact server
+      pod: deploy-frontend-17mza9
+    creationTimestamp: 2015-04-07T04:12:53Z
+    labels:
+      template: application-template-stibuild
+    name: frontend-2
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      deployment: frontend-2
+      deploymentconfig: frontend
+      name: frontend
+    template:
+      metadata:
+        annotations:
+          openshift.io/deployment.name: frontend-2
+          openshift.io/deployment-config.name: frontend
+          openshift.io/deployment-config.latest-version: "2"
+        creationTimestamp: null
+        labels:
+          deployment: frontend-2
+          deploymentconfig: frontend
+          name: frontend
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: ADMIN_USERNAME
+            value: adminNPX
+          - name: ADMIN_PASSWORD
+            value: 7q1IdEao
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: 172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    replicas: 0
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    annotations:
+      openshift.io/deployment-config.name: frontend
+      openshift.io/deployment.phase: Complete
+      openshift.io/deployment-config.latest-version: "1"
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageStreamTag","name":"origin-ruby-sample:latest"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
+      pod: deploy-frontend-17mza9
+    creationTimestamp: 2015-04-07T04:12:53Z
+    labels:
+      template: application-template-stibuild
+    name: frontend-1
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      deployment: frontend-1
+      deploymentconfig: frontend
+      name: frontend
+    template:
+      metadata:
+        annotations:
+          openshift.io/deployment.name: frontend-1
+          openshift.io/deployment-config.name: frontend
+          openshift.io/deployment-config.latest-version: "1"
+        creationTimestamp: null
+        labels:
+          deployment: frontend-1
+          deploymentconfig: frontend
+          name: frontend
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: ADMIN_USERNAME
+            value: adminNPX
+          - name: ADMIN_PASSWORD
+            value: 7q1IdEao
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: 172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    replicas: 1
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: frontend
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      name: frontend
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          name: frontend
+          template: application-template-stibuild
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: ADMIN_USERNAME
+            value: adminNPX
+          - name: ADMIN_PASSWORD
+            value: 7q1IdEao
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: 172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ruby-helloworld
+        from:
+          kind: ImageStreamTag
+          name: origin-ruby-sample:latest
+        lastTriggeredImage: 172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58
+      type: ImageChange
+  status:
+    details:
+      causes:
+      - imageTrigger:
+          from:
+            kind: DockerImage
+            name: 172.30.17.139:5000/test/origin-ruby-sample:latest
+        type: ImageChange
+    latestVersion: 3
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: database
+    namespace: example
+  spec:
+    portalIP: 172.30.17.240
+    ports:
+    - nodePort: 0
+      port: 5434
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      name: database
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: database-external
+    namespace: example
+  spec:
+    portalIP: 172.30.17.241
+    ports:
+    - nodePort: 31000
+      port: 5434
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      name: database
+    sessionAffinity: None
+    type: NodePort
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: frontend
+    namespace: example
+  spec:
+    portalIP: 172.30.17.154
+    ports:
+    - nodePort: 0
+      port: 5432
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: frontend
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      openshift.io/host.generated: "true"
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: frontend
+    namespace: example
+    resourceVersion: "393"
+  spec:
+    host: frontend-example.router.default.svc.cluster.local
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: frontend
+  status:
+    ingress:
+    - routerName: default
+      host: frontend-example.router.default.svc.cluster.local
+    - routerName: other
+      host: www.test.com
+      conditions:
+      - type: Admitted
+        status: "False"
+        reason: HostAlreadyClaimed
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      openshift.io/host.generated: "true"
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: other
+    namespace: example
+    resourceVersion: "393"
+  spec:
+    host: www.test.com
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: frontend
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      type: Edge
+  status:
+    ingress:
+    - routerName: other
+      host: www.test.com
+      conditions:
+      - type: Admitted
+        status: "True"
+kind: List
+metadata:
+  resourceVersion: "592"

--- a/pkg/api/graph/test/new-project-no-build.yaml
+++ b/pkg/api/graph/test/new-project-no-build.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-2
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sinatra-example-2:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/mfojtik/sinatra-example-2
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+      type: Source
+    triggers:
+    - github:
+        secret: u5gRhTXiOJpOHxKSI1M6
+      type: github
+    - generic:
+        secret: IDO5sRS52tsUq5hczU6o
+      type: generic
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-2
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: sinatra-example-2
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: sinatra-example-2
+      spec:
+        containers:
+        - capabilities: {}
+          image: library/sinatra-example-2:latest
+          imagePullPolicy: Always
+          name: sinatra-example-2
+          ports:
+          - containerPort: 8080
+            name: s-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - sinatra-example-2
+        from:
+          kind: ImageStreamTag
+          name: sinatra-example-2:latest
+        lastTriggeredImage: ""
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: 2015-04-06T21:18:56Z
+    name: sinatra-example-2
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-2
+  spec:
+    portalIP: 172.30.17.48
+    ports:
+    - nodePort: 0
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: sinatra-example-2
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata:
+  resourceVersion: "116"

--- a/pkg/api/graph/test/new-project-one-build.yaml
+++ b/pkg/api/graph/test/new-project-one-build.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-1
+    namespace: example
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sinatra-example-1:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/mfojtik/sinatra-example-1
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+      type: Source
+    triggers:
+    - github:
+        secret: u5gRhTXiOJpOHxKSI1M6
+      type: github
+    - generic:
+        secret: IDO5sRS52tsUq5hczU6o
+      type: generic
+  status:
+    lastVersion: 1
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: 2015-04-06T21:18:56Z
+    name: sinatra-example-1
+    namespace: example
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: Build
+  metadata:
+    creationTimestamp: 2015-04-06T21:18:56Z
+    labels:
+      buildconfig: sinatra-example-1
+    name: sinatra-example-1-1
+    namespace: example
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sinatra-example-1:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/mfojtik/sinatra-example-1
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+      type: Source
+  status:
+    phase: Running
+    startTimestamp: 2015-04-06T21:19:03Z
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-1
+    namespace: example
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: sinatra-example-1
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: sinatra-example-1
+      spec:
+        containers:
+        - capabilities: {}
+          image: library/sinatra-example-1:latest
+          imagePullPolicy: Always
+          name: sinatra-example-1
+          ports:
+          - containerPort: 8080
+            name: s-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - sinatra-example-1
+        from:
+          kind: ImageStreamTag
+          name: sinatra-example-1:latest
+        lastTriggeredImage: ""
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-example-1
+    namespace: example
+  spec:
+    portalIP: 172.30.17.47
+    ports:
+    - nodePort: 0
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: sinatra-example-1
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata: {}

--- a/pkg/api/graph/test/new-project-two-deployment-configs.yaml
+++ b/pkg/api/graph/test/new-project-two-deployment-configs.yaml
@@ -1,0 +1,187 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-app-example
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sinatra-app-example:latest
+    resources: {}
+    source:
+      git:
+        uri: git://github.com/mfojtik/sinatra-app-example
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+      type: Source
+    triggers:
+    - github:
+        secret: u5gRhTXiOJpOHxKSI1M6
+      type: github
+    - generic:
+        secret: IDO5sRS52tsUq5hczU6o
+      type: generic
+  status:
+    lastVersion: 1
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: 2015-04-06T21:18:56Z
+    name: sinatra-app-example
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: Build
+  metadata:
+    creationTimestamp: 2015-04-06T21:18:56Z
+    labels:
+      buildconfig: sinatra-app-example
+    name: sinatra-app-example-1
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: sinatra-app-example:latest
+    resources: {}
+    revision:
+      git:
+        author:
+          email: someguy@outhere.com
+          name: Roy Programmer
+        commit: 7a4f354721b0c9717e46f2e132b269b495d43e2b
+        committer: {}
+        message: Prepare v1 Template types
+      type: git
+    source:
+      git:
+        uri: git://github.com/mfojtik/sinatra-app-example
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: DockerImage
+          name: centos/ruby-22-centos7
+      type: Source
+  status:
+    phase: Running
+    startTimestamp: 2015-04-06T21:19:03Z
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-app-example-a
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: sinatra-app-example
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: sinatra-app-example
+      spec:
+        containers:
+        - capabilities: {}
+          image: library/sinatra-app-example:latest
+          imagePullPolicy: Always
+          name: sinatra-app-example
+          ports:
+          - containerPort: 8080
+            name: s-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - sinatra-app-example
+        from:
+          kind: ImageStreamTag
+          name: sinatra-app-example:latest
+        lastTriggeredImage: ""
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-app-example-b
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: sinatra-app-example
+    strategy:
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: sinatra-app-example
+      spec:
+        containers:
+        - capabilities: {}
+          image: library/sinatra-app-example:latest
+          imagePullPolicy: Always
+          name: sinatra-app-example
+          ports:
+          - containerPort: 8080
+            name: s-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - sinatra-app-example
+        from:
+          kind: ImageStreamTag
+          name: sinatra-app-example:latest
+        lastTriggeredImage: ""
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-04-06T21:02:00Z
+    name: sinatra-app-example
+  spec:
+    portalIP: 172.30.17.49
+    ports:
+    - nodePort: 0
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: sinatra-app-example
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata: {}

--- a/pkg/api/graph/test/petset.yaml
+++ b/pkg/api/graph/test/petset.yaml
@@ -1,0 +1,496 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1alpha1
+  kind: PetSet
+  metadata:
+    creationTimestamp: 2016-07-21T15:53:09Z
+    generation: 3
+    labels:
+      app: mysql
+    name: mysql
+    namespace: default
+    resourceVersion: "6790"
+    selfLink: /apis/apps/v1alpha1/namespaces/default/petsets/mysql
+    uid: 3900c985-4f5b-11e6-b8a1-080027242396
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: mysql
+    serviceName: galera
+    template:
+      metadata:
+        annotations:
+          pod.alpha.kubernetes.io/init-containers: '[{"name":"install","image":"gcr.io/google_containers/galera-install:0.1","args":["--work-dir=/work-dir"],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"Always"},{"name":"bootstrap","image":"debian:jessie","command":["/work-dir/peer-finder"],"args":["-on-start=\"/work-dir/on-start.sh\"","-service=galera"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"}}}],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}]'
+          pod.alpha.kubernetes.io/initialized: "true"
+        creationTimestamp: null
+        labels:
+          app: mysql
+      spec:
+        containers:
+        - args:
+          - --defaults-file=/etc/mysql/my-galera.cnf
+          - --user=root
+          image: erkules/galera:basic
+          imagePullPolicy: IfNotPresent
+          name: mysql
+          ports:
+          - containerPort: 3306
+            name: mysql
+            protocol: TCP
+          - containerPort: 4444
+            name: sst
+            protocol: TCP
+          - containerPort: 4567
+            name: replication
+            protocol: TCP
+          - containerPort: 4568
+            name: ist
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - mysql -u root -e 'show databases;'
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/
+            name: datadir
+          - mountPath: /etc/mysql
+            name: config
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - emptyDir: {}
+          name: config
+        - emptyDir: {}
+          name: workdir
+    volumeClaimTemplates:
+    - metadata:
+        annotations:
+          volume.alpha.kubernetes.io/storage-class: anything
+        creationTimestamp: null
+        name: datadir
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+      status:
+        phase: Pending
+  status:
+    replicas: 3
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    creationTimestamp: 2016-07-21T15:53:09Z
+    labels:
+      app: mysql
+    name: galera
+    namespace: default
+    resourceVersion: "343"
+    selfLink: /api/v1/namespaces/default/services/galera
+    uid: 38fb3915-4f5b-11e6-b8a1-080027242396
+  spec:
+    clusterIP: None
+    portalIP: None
+    ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      app: mysql
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: |
+        {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"PetSet","namespace":"default","name":"mysql","uid":"3900c985-4f5b-11e6-b8a1-080027242396","apiVersion":"apps","resourceVersion":"6784"}}
+      openshift.io/scc: anyuid
+      pod.alpha.kubernetes.io/init-container-statuses: '[{"name":"install","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T02:41:12Z","finishedAt":"2016-07-27T02:41:12Z","containerID":"docker://5c727d8732899605fcfe3eecbeeb02576f18f5b989496073340427a8d2134622"}},"lastState":{},"ready":true,"restartCount":0,"image":"gcr.io/google_containers/galera-install:0.1","imageID":"docker://sha256:56ef857005d0ce479f2db0e4ee0ece05e0766ebfa7e79e27e1513915262a18ec","containerID":"docker://5c727d8732899605fcfe3eecbeeb02576f18f5b989496073340427a8d2134622"},{"name":"bootstrap","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T02:41:14Z","finishedAt":"2016-07-27T02:41:15Z","containerID":"docker://ab4ca0b3b6ec4860cd55c615534e1e2b11f4c3a33746783aab145919feb2446e"}},"lastState":{},"ready":true,"restartCount":0,"image":"debian:jessie","imageID":"docker://sha256:1b088884749bd93867ddb48ff404d4bbff09a17af8d95bc863efa5d133f87b78","containerID":"docker://ab4ca0b3b6ec4860cd55c615534e1e2b11f4c3a33746783aab145919feb2446e"}]'
+      pod.alpha.kubernetes.io/init-containers: '[{"name":"install","image":"gcr.io/google_containers/galera-install:0.1","args":["--work-dir=/work-dir"],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"Always"},{"name":"bootstrap","image":"debian:jessie","command":["/work-dir/peer-finder"],"args":["-on-start=\"/work-dir/on-start.sh\"","-service=galera"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"}}}],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}]'
+      pod.alpha.kubernetes.io/initialized: "true"
+      pod.beta.kubernetes.io/hostname: mysql-0
+      pod.beta.kubernetes.io/subdomain: galera
+    creationTimestamp: 2016-07-27T02:41:09Z
+    generateName: mysql-
+    labels:
+      app: mysql
+    name: mysql-0
+    namespace: default
+    resourceVersion: "7191"
+    selfLink: /api/v1/namespaces/default/pods/mysql-0
+    uid: 92e49e79-53a3-11e6-b45a-080027242396
+  spec:
+    containers:
+    - args:
+      - --defaults-file=/etc/mysql/my-galera.cnf
+      - --user=root
+      image: erkules/galera:basic
+      imagePullPolicy: IfNotPresent
+      name: mysql
+      ports:
+      - containerPort: 3306
+        name: mysql
+        protocol: TCP
+      - containerPort: 4444
+        name: sst
+        protocol: TCP
+      - containerPort: 4567
+        name: replication
+        protocol: TCP
+      - containerPort: 4568
+        name: ist
+        protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+          - sh
+          - -c
+          - mysql -u root -e 'show databases;'
+        failureThreshold: 3
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+      resources: {}
+      securityContext:
+        capabilities:
+          drop:
+          - MKNOD
+          - SYS_CHROOT
+        privileged: false
+        seLinuxOptions:
+          level: s0:c5,c0
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/lib/
+        name: datadir
+      - mountPath: /etc/mysql
+        name: config
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-au2xq
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: localhost.localdomain
+    imagePullSecrets:
+    - name: default-dockercfg-pzhsj
+    nodeName: localhost.localdomain
+    restartPolicy: Always
+    securityContext:
+      seLinuxOptions:
+        level: s0:c5,c0
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    volumes:
+    - name: datadir
+      persistentVolumeClaim:
+        claimName: datadir-mysql-0
+    - emptyDir: {}
+      name: config
+    - emptyDir: {}
+      name: workdir
+    - name: default-token-au2xq
+      secret:
+        secretName: default-token-au2xq
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T02:41:15Z
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T03:00:47Z
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T02:41:09Z
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://f2406b0f697c525df44b64aec6b1f6024ab88d9df80256426247dc6e9a92cb30
+      image: erkules/galera:basic
+      imageID: docker://sha256:b4780e247a38c12612f539ce1ac8e0988e1781d56fddf719c80fb8d4d7b8bbde
+      lastState: {}
+      name: mysql
+      ready: true
+      restartCount: 0
+      state:
+        running:
+          startedAt: 2016-07-27T02:41:16Z
+    hostIP: 10.0.2.15
+    phase: Running
+    podIP: 172.17.0.2
+    startTime: 2016-07-27T02:41:09Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: |
+        {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"PetSet","namespace":"default","name":"mysql","uid":"3900c985-4f5b-11e6-b8a1-080027242396","apiVersion":"apps","resourceVersion":"6790"}}
+      openshift.io/scc: anyuid
+      pod.alpha.kubernetes.io/init-container-statuses: '[{"name":"install","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T02:41:42Z","finishedAt":"2016-07-27T02:41:42Z","containerID":"docker://2538c65f65557955c02745ef4021181cf322c8dc0db62144dd1e1f8ea9f7fa54"}},"lastState":{},"ready":true,"restartCount":0,"image":"gcr.io/google_containers/galera-install:0.1","imageID":"docker://sha256:56ef857005d0ce479f2db0e4ee0ece05e0766ebfa7e79e27e1513915262a18ec","containerID":"docker://2538c65f65557955c02745ef4021181cf322c8dc0db62144dd1e1f8ea9f7fa54"},{"name":"bootstrap","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T02:41:44Z","finishedAt":"2016-07-27T02:41:45Z","containerID":"docker://4df7188d37033c182e675d45179941766bd1e6a013469038f43fa3fecc2cc06d"}},"lastState":{},"ready":true,"restartCount":0,"image":"debian:jessie","imageID":"docker://sha256:1b088884749bd93867ddb48ff404d4bbff09a17af8d95bc863efa5d133f87b78","containerID":"docker://4df7188d37033c182e675d45179941766bd1e6a013469038f43fa3fecc2cc06d"}]'
+      pod.alpha.kubernetes.io/init-containers: '[{"name":"install","image":"gcr.io/google_containers/galera-install:0.1","args":["--work-dir=/work-dir"],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"Always"},{"name":"bootstrap","image":"debian:jessie","command":["/work-dir/peer-finder"],"args":["-on-start=\"/work-dir/on-start.sh\"","-service=galera"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"}}}],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}]'
+      pod.alpha.kubernetes.io/initialized: "true"
+      pod.beta.kubernetes.io/hostname: mysql-1
+      pod.beta.kubernetes.io/subdomain: galera
+    creationTimestamp: 2016-07-27T02:41:39Z
+    generateName: mysql-
+    labels:
+      app: mysql
+    name: mysql-1
+    namespace: default
+    resourceVersion: "7195"
+    selfLink: /api/v1/namespaces/default/pods/mysql-1
+    uid: a4da4725-53a3-11e6-b45a-080027242396
+  spec:
+    containers:
+    - args:
+      - --defaults-file=/etc/mysql/my-galera.cnf
+      - --user=root
+      image: erkules/galera:basic
+      imagePullPolicy: IfNotPresent
+      name: mysql
+      ports:
+      - containerPort: 3306
+        name: mysql
+        protocol: TCP
+      - containerPort: 4444
+        name: sst
+        protocol: TCP
+      - containerPort: 4567
+        name: replication
+        protocol: TCP
+      - containerPort: 4568
+        name: ist
+        protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+          - sh
+          - -c
+          - mysql -u root -e 'show databases;'
+        failureThreshold: 3
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+      resources: {}
+      securityContext:
+        capabilities:
+          drop:
+          - MKNOD
+          - SYS_CHROOT
+        privileged: false
+        seLinuxOptions:
+          level: s0:c5,c0
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/lib/
+        name: datadir
+      - mountPath: /etc/mysql
+        name: config
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-au2xq
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: localhost.localdomain
+    imagePullSecrets:
+    - name: default-dockercfg-pzhsj
+    nodeName: localhost.localdomain
+    restartPolicy: Always
+    securityContext:
+      seLinuxOptions:
+        level: s0:c5,c0
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    volumes:
+    - name: datadir
+      persistentVolumeClaim:
+        claimName: datadir-mysql-1
+    - emptyDir: {}
+      name: config
+    - emptyDir: {}
+      name: workdir
+    - name: default-token-au2xq
+      secret:
+        secretName: default-token-au2xq
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T02:41:46Z
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T03:00:58Z
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T02:41:39Z
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://be1d5be42ab23d1db23f4552141e9068e2385ba19c3e84596e047eb6d2762d1c
+      image: erkules/galera:basic
+      imageID: docker://sha256:b4780e247a38c12612f539ce1ac8e0988e1781d56fddf719c80fb8d4d7b8bbde
+      lastState:
+        terminated:
+          containerID: docker://9a662fa5b74a962fa362c6a5d632fe3642b12fefde36c8158ab1a50d8fa4e33e
+          exitCode: 1
+          finishedAt: 2016-07-27T02:51:40Z
+          reason: Error
+          startedAt: 2016-07-27T02:51:05Z
+      name: mysql
+      ready: true
+      restartCount: 7
+      state:
+        running:
+          startedAt: 2016-07-27T03:00:39Z
+    hostIP: 10.0.2.15
+    phase: Running
+    podIP: 172.17.0.3
+    startTime: 2016-07-27T02:41:39Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: |
+        {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"PetSet","namespace":"default","name":"mysql","uid":"3900c985-4f5b-11e6-b8a1-080027242396","apiVersion":"apps","resourceVersion":"6790"}}
+      openshift.io/scc: anyuid
+      pod.alpha.kubernetes.io/init-container-statuses: '[{"name":"install","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T03:01:01Z","finishedAt":"2016-07-27T03:01:01Z","containerID":"docker://af008b4ce59d36695fbabf40ae2f7431b51441eb2e9c6962378937c06ac69a35"}},"lastState":{},"ready":true,"restartCount":0,"image":"gcr.io/google_containers/galera-install:0.1","imageID":"docker://sha256:56ef857005d0ce479f2db0e4ee0ece05e0766ebfa7e79e27e1513915262a18ec","containerID":"docker://af008b4ce59d36695fbabf40ae2f7431b51441eb2e9c6962378937c06ac69a35"},{"name":"bootstrap","state":{"terminated":{"exitCode":0,"reason":"Completed","startedAt":"2016-07-27T03:01:02Z","finishedAt":"2016-07-27T03:01:03Z","containerID":"docker://ee97005854130335b54a65429865956260b7729e51e6363ab05e63d5c7c9ee48"}},"lastState":{},"ready":true,"restartCount":0,"image":"debian:jessie","imageID":"docker://sha256:1b088884749bd93867ddb48ff404d4bbff09a17af8d95bc863efa5d133f87b78","containerID":"docker://ee97005854130335b54a65429865956260b7729e51e6363ab05e63d5c7c9ee48"}]'
+      pod.alpha.kubernetes.io/init-containers: '[{"name":"install","image":"gcr.io/google_containers/galera-install:0.1","args":["--work-dir=/work-dir"],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"Always"},{"name":"bootstrap","image":"debian:jessie","command":["/work-dir/peer-finder"],"args":["-on-start=\"/work-dir/on-start.sh\"","-service=galera"],"env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"}}}],"resources":{},"volumeMounts":[{"name":"workdir","mountPath":"/work-dir"},{"name":"config","mountPath":"/etc/mysql"},{"name":"default-token-au2xq","readOnly":true,"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"}],"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}]'
+      pod.alpha.kubernetes.io/initialized: "true"
+      pod.beta.kubernetes.io/hostname: mysql-2
+      pod.beta.kubernetes.io/subdomain: galera
+    creationTimestamp: 2016-07-27T03:00:58Z
+    generateName: mysql-
+    labels:
+      app: mysql
+    name: mysql-2
+    namespace: default
+    resourceVersion: "7226"
+    selfLink: /api/v1/namespaces/default/pods/mysql-2
+    uid: 57e618f1-53a6-11e6-b215-080027242396
+  spec:
+    containers:
+    - args:
+      - --defaults-file=/etc/mysql/my-galera.cnf
+      - --user=root
+      image: erkules/galera:basic
+      imagePullPolicy: IfNotPresent
+      name: mysql
+      ports:
+      - containerPort: 3306
+        name: mysql
+        protocol: TCP
+      - containerPort: 4444
+        name: sst
+        protocol: TCP
+      - containerPort: 4567
+        name: replication
+        protocol: TCP
+      - containerPort: 4568
+        name: ist
+        protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+          - sh
+          - -c
+          - mysql -u root -e 'show databases;'
+        failureThreshold: 3
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+      resources: {}
+      securityContext:
+        capabilities:
+          drop:
+          - MKNOD
+          - SYS_CHROOT
+        privileged: false
+        seLinuxOptions:
+          level: s0:c5,c0
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/lib/
+        name: datadir
+      - mountPath: /etc/mysql
+        name: config
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-au2xq
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: localhost.localdomain
+    imagePullSecrets:
+    - name: default-dockercfg-pzhsj
+    nodeName: localhost.localdomain
+    restartPolicy: Always
+    securityContext:
+      seLinuxOptions:
+        level: s0:c5,c0
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    volumes:
+    - name: datadir
+      persistentVolumeClaim:
+        claimName: datadir-mysql-2
+    - emptyDir: {}
+      name: config
+    - emptyDir: {}
+      name: workdir
+    - name: default-token-au2xq
+      secret:
+        secretName: default-token-au2xq
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T03:01:03Z
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T03:01:28Z
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: 2016-07-27T03:00:58Z
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - containerID: docker://82b774855cdb5d12d98e7bc34f4f9d4e88e757e9cc2da1593e2e2f66e3241e5f
+      image: erkules/galera:basic
+      imageID: docker://sha256:b4780e247a38c12612f539ce1ac8e0988e1781d56fddf719c80fb8d4d7b8bbde
+      lastState: {}
+      name: mysql
+      ready: true
+      restartCount: 0
+      state:
+        running:
+          startedAt: 2016-07-27T03:01:04Z
+    hostIP: 10.0.2.15
+    phase: Running
+    podIP: 172.17.0.4
+    startTime: 2016-07-27T03:00:58Z
+kind: List
+metadata: {}

--- a/pkg/api/graph/test/simple-deployment.yaml
+++ b/pkg/api/graph/test/simple-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: simple-deployment
+spec:
+  replicas: 1
+  selector:
+    name: simple-deployment
+  strategy:
+    type: Rolling
+    rollingParams:
+  template:
+    metadata:
+      labels:
+        name: simple-deployment
+    spec:
+      containers:
+      - image: "docker.io/openshift/deployment-example:v1"
+        imagePullPolicy: IfNotPresent
+        name: myapp
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+  triggers:
+  - type: ConfigChange

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -24,7 +24,7 @@ func mustParseTime(t string) time.Time {
 
 func TestProjectStatus(t *testing.T) {
 	testCases := map[string]struct {
-		Path     string
+		File     string
 		Extra    []runtime.Object
 		ErrFn    func(error) bool
 		Contains []string
@@ -52,7 +52,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"empty service": {
-			Path: "../../../../test/testdata/app-scenarios/k8s-service-with-nothing.json",
+			File: "k8s-service-with-nothing.json",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -67,7 +67,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"service with RC": {
-			Path: "../../../../test/testdata/app-scenarios/k8s-unserviced-rc.json",
+			File: "k8s-unserviced-rc.json",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -83,7 +83,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"rc with unmountable and missing secrets": {
-			Path: "../../../../pkg/api/graph/test/bad_secret_with_just_rc.yaml",
+			File: "bad_secret_with_just_rc.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -98,7 +98,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"dueling rcs": {
-			Path: "../../../../pkg/api/graph/test/dueling-rcs.yaml",
+			File: "dueling-rcs.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "dueling-rc", Namespace: ""},
@@ -111,7 +111,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"service with pod": {
-			Path: "../../../../pkg/api/graph/test/service-with-pod.yaml",
+			File: "service-with-pod.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -126,7 +126,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"standalone rc": {
-			Path: "../../../../pkg/api/graph/test/bare-rc.yaml",
+			File: "bare-rc.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -140,7 +140,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"unstarted build": {
-			Path: "../../../../test/testdata/app-scenarios/new-project-no-build.yaml",
+			File: "new-project-no-build.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -159,7 +159,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"unpushable build": {
-			Path: "../../../../pkg/api/graph/test/unpushable-build.yaml",
+			File: "unpushable-build.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -171,7 +171,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"bare-bc-can-push": {
-			Path: "../../../../pkg/api/graph/test/bare-bc-can-push.yaml",
+			File: "bare-bc-can-push.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -187,7 +187,7 @@ func TestProjectStatus(t *testing.T) {
 			Time: mustParseTime("2015-12-17T20:36:15Z"),
 		},
 		"cyclical build": {
-			Path: "../../../../pkg/api/graph/test/circular.yaml",
+			File: "circular.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -201,7 +201,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"running build": {
-			Path: "../../../../test/testdata/app-scenarios/new-project-one-build.yaml",
+			File: "new-project-one-build.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -220,7 +220,7 @@ func TestProjectStatus(t *testing.T) {
 			Time: mustParseTime("2015-04-06T21:20:03Z"),
 		},
 		"a/b test DeploymentConfig": {
-			Path: "../../../../test/testdata/app-scenarios/new-project-two-deployment-configs.yaml",
+			File: "new-project-two-deployment-configs.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -240,7 +240,7 @@ func TestProjectStatus(t *testing.T) {
 			Time: mustParseTime("2015-04-06T21:20:03Z"),
 		},
 		"with real deployments": {
-			Path: "../../../../test/testdata/app-scenarios/new-project-deployed-app.yaml",
+			File: "new-project-deployed-app.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -271,7 +271,7 @@ func TestProjectStatus(t *testing.T) {
 			Time: mustParseTime("2015-04-07T04:12:25Z"),
 		},
 		"with pet sets": {
-			Path: "../../../../test/testdata/app-scenarios/petset.yaml",
+			File: "petset.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -287,7 +287,7 @@ func TestProjectStatus(t *testing.T) {
 			Time: mustParseTime("2015-04-07T04:12:25Z"),
 		},
 		"restarting pod": {
-			Path: "../../../api/graph/test/restarting-pod.yaml",
+			File: "restarting-pod.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -302,7 +302,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"cross namespace reference": {
-			Path: "../../../api/graph/test/different-project-image-deployment.yaml",
+			File: "different-project-image-deployment.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -316,7 +316,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"monopod": {
-			Path: "../../../../test/testdata/app-scenarios/k8s-lonely-pod.json",
+			File: "k8s-lonely-pod.json",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -330,7 +330,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 		},
 		"deploys single pod": {
-			Path: "../../../../test/testdata/simple-deployment.yaml",
+			File: "simple-deployment.yaml",
 			Extra: []runtime.Object{
 				&projectapi.Project{
 					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
@@ -354,8 +354,9 @@ func TestProjectStatus(t *testing.T) {
 			return time.Now()
 		}
 		o := ktestclient.NewObjects(kapi.Scheme, kapi.Codecs.UniversalDecoder())
-		if len(test.Path) > 0 {
-			if err := ktestclient.AddObjectsFromPath(test.Path, o, kapi.Codecs.UniversalDecoder()); err != nil {
+		if len(test.File) > 0 {
+			// Load data from a folder dedicated to mock data, which is never loaded into the API during tests
+			if err := ktestclient.AddObjectsFromPath("../../../../pkg/api/graph/test/"+test.File, o, kapi.Codecs.UniversalDecoder()); err != nil {
 				t.Errorf("%s: unexpected error: %v", k, err)
 			}
 		}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -345,6 +345,8 @@ echo "ex build-chain: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/admin/complex-scenarios"
+# Make sure no one commits data with allocated values that could flake
+os::cmd::expect_failure 'grep -r "portalIP.*172" test/testdata/app-scenarios'
 os::cmd::expect_success 'oadm new-project example --admin="createuser"'
 os::cmd::expect_success 'oc project example'
 os::cmd::try_until_success 'oc get serviceaccount default'

--- a/test/testdata/app-scenarios/README.md
+++ b/test/testdata/app-scenarios/README.md
@@ -1,0 +1,4 @@
+All files in the folder are loaded into the API during tests, so they should:
+* Not create resources that duel with each other
+* Not include allocated values that could flake (like service portalIP addresses)
+* Pay attention to creation order (for example, create pods first, then petsets, so the create doesn't race with the petset controller)

--- a/test/testdata/app-scenarios/new-project-deployed-app.yaml
+++ b/test/testdata/app-scenarios/new-project-deployed-app.yaml
@@ -438,7 +438,6 @@ items:
     name: database
     namespace: example
   spec:
-    portalIP: 172.30.17.240
     ports:
     - nodePort: 0
       port: 5434
@@ -459,7 +458,6 @@ items:
     name: database-external
     namespace: example
   spec:
-    portalIP: 172.30.17.241
     ports:
     - nodePort: 31000
       port: 5434
@@ -480,7 +478,6 @@ items:
     name: frontend
     namespace: example
   spec:
-    portalIP: 172.30.17.154
     ports:
     - nodePort: 0
       port: 5432

--- a/test/testdata/app-scenarios/new-project-no-build.yaml
+++ b/test/testdata/app-scenarios/new-project-no-build.yaml
@@ -90,7 +90,6 @@ items:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-example-2
   spec:
-    portalIP: 172.30.17.48
     ports:
     - nodePort: 0
       port: 8080

--- a/test/testdata/app-scenarios/new-project-one-build.yaml
+++ b/test/testdata/app-scenarios/new-project-one-build.yaml
@@ -121,7 +121,6 @@ items:
     name: sinatra-example-1
     namespace: example
   spec:
-    portalIP: 172.30.17.47
     ports:
     - nodePort: 0
       port: 8080

--- a/test/testdata/app-scenarios/new-project-two-deployment-configs.yaml
+++ b/test/testdata/app-scenarios/new-project-two-deployment-configs.yaml
@@ -171,7 +171,6 @@ items:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-app-example
   spec:
-    portalIP: 172.30.17.49
     ports:
     - nodePort: 0
       port: 8080


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/10008, part 2

Copies test data with allocated info into the graph test data package for mocking

Removes allocated IPs from files in app-scenarios, adds a test to prevent future additions