### PR TITLE
oc rsync: support arbitrary rsync flags

### DIFF
--- a/pkg/cmd/cli/cmd/rsync/copytar.go
+++ b/pkg/cmd/cli/cmd/rsync/copytar.go
@@ -116,7 +116,7 @@ func (r *tarStrategy) Copy(source, destination *pathSpec, out, errOut io.Writer)
 	glog.V(3).Infof("Copying files with tar")
 
 	if len(r.IgnoredFlags) > 0 {
-		fmt.Fprintf(errOut, "Ignoring the following flags because they only apply to rsync: %s\n", strings.Join(r.IgnoredFlags, ", "))
+		return fmt.Errorf("these flags only apply to rsync: %s\n", strings.Join(r.IgnoredFlags, ", "))
 	}
 
 	if r.Delete {

--- a/pkg/cmd/cli/cmd/rsync/util.go
+++ b/pkg/cmd/cli/cmd/rsync/util.go
@@ -80,6 +80,11 @@ func rsyncFlagsFromOptions(o *RsyncOptions) []string {
 	if o.RsyncNoPerms {
 		flags = append(flags, "--no-perms")
 	}
+	if len(o.RsyncExtraFlags) > 0 {
+		for _, extraFlag := range o.RsyncExtraFlags {
+			flags = append(flags, extraFlag)
+		}
+	}
 	return flags
 }
 
@@ -96,6 +101,11 @@ func rsyncSpecificFlags(o *RsyncOptions) []string {
 	}
 	if o.RsyncNoPerms {
 		flags = append(flags, "--no-perms")
+	}
+	if len(o.RsyncExtraFlags) > 0 {
+		for _, extraFlag := range o.RsyncExtraFlags {
+			flags = append(flags, extraFlag)
+		}
 	}
 	return flags
 }


### PR DESCRIPTION
Allows specifying arbitrary flags for rsync after '--' 
example:
```
oc rsync ./src jenkins-1-wkyfs:/src -- --exclude-from=excludes.txt
```
If using the tar strategy, and rsync flags were specified, the command now fails instead of displaying a warning.

Fixes https://github.com/openshift/origin/issues/8223