### PR TITLE
UPSTREAM: 30162: return err on `oc run --image` with invalid value

### DIFF
--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/run"
+# This test validates the value of --image for oc run
+os::cmd::expect_success_and_text 'oc run newdcforimage --image=validimagevalue' 'deploymentconfig "newdcforimage" created'
+os::cmd::expect_failure_and_text 'oc run newdcforimage2 --image="InvalidImageValue0192"' 'error: Invalid image name "InvalidImageValue0192": invalid reference format'
+echo "oc run: ok"
+os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
@@ -23,6 +23,9 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/docker/distribution/reference"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -132,6 +135,13 @@ func Run(f *cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr i
 	// Let kubectl run follow rules for `--`, see #13004 issue
 	if len(args) == 0 || argsLenAtDash == 0 {
 		return cmdutil.UsageError(cmd, "NAME is required for run")
+	}
+
+	// validate image name
+	imageName := cmdutil.GetFlagString(cmd, "image")
+	validImageRef := reference.ReferenceRegexp.MatchString(imageName)
+	if !validImageRef {
+		return fmt.Errorf("Invalid image name %q: %v", imageName, reference.ErrReferenceInvalidFormat)
 	}
 
 	interactive := cmdutil.GetFlagBool(cmd, "stdin")


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1258354
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/30162

When running `oc run <buildconfigname> --image="Invalid$$%ImageValue%%__"`, a deploymentconfig is successfully created with an image name that is not a valid value for an image reference.

This patch validates that the image name is a valid image reference, and returns an error before creating a deployment config if an invalid value is passed.

`$ oc run test --image="Invalid__%imagename"`
```
error: Invalid image name "Invalid__%imagename": invalid reference format
```

cc @fabianofranz 