### PR TITLE
Fixes docker call in CONTRIBUTING documentation

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -76,7 +76,7 @@ export OS_OUTPUT_GOPATH=1
 
 6.  Next, assuming you have not changed the kubernetes/openshift service subnet configuration from the default value of 172.30.0.0/16, you need to instruct the Docker daemon to trust any Docker registry on the 172.30.0.0/16 subnet.  If you are running Docker as a service via `systemd`, add the `--insecure-registry 172.30.0.0/16` argument to the options value in `/etc/sysconfig/docker` and restart the Docker daemon.  Otherwise, add "--insecure-registry 172.30.0.0/16" to the Docker daemon invocation, eg:
 
-        $ docker -d --insecure-registry 172.30.0.0/16
+        $ docker daemon --insecure-registry 172.30.0.0/16
 
 7.  Then, the OpenShift firewalld rules are also a work in progress. For now it is easiest to disable firewalld altogether:
 


### PR DESCRIPTION
In order to run docker as a daemon, the command is now `docker daemon`
instead of `docker -d`

This has been confirmed on RHEL, Fedora 23, and Mac

@danmcp ptal?

Fixes #10165 