### PR TITLE
respect scopes in list/watch projects

### DIFF
--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -16,7 +16,7 @@ import (
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 )
 
-func newTestWatcher(user string, groups []string, namespaces ...*kapi.Namespace) (*userProjectWatcher, *fakeAuthCache) {
+func newTestWatcher(username string, groups []string, namespaces ...*kapi.Namespace) (*userProjectWatcher, *fakeAuthCache) {
 	objects := []runtime.Object{}
 	for i := range namespaces {
 		objects = append(objects, namespaces[i])
@@ -27,7 +27,7 @@ func newTestWatcher(user string, groups []string, namespaces ...*kapi.Namespace)
 	projectCache.Run()
 	fakeAuthCache := &fakeAuthCache{}
 
-	return NewUserProjectWatcher(user, groups, projectCache, fakeAuthCache, false), fakeAuthCache
+	return NewUserProjectWatcher(&user.DefaultInfo{Name: username, Groups: groups}, sets.NewString("*"), projectCache, fakeAuthCache, false), fakeAuthCache
 }
 
 type fakeAuthCache struct {

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -40,7 +40,9 @@ os::cmd::expect_success_and_text "oc get user/~ --token='${whoamitoken}'" "${use
 os::cmd::expect_failure_and_text "oc get pods --token='${whoamitoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
 
 listprojecttoken="$(oc process -f "${OS_ROOT}/test/testdata/authentication/scoped-token-template.yaml" TOKEN_PREFIX=listproject SCOPE=user:list-projects USER_NAME="${username}" USER_UID="${useruid}" | oc create -f - -o name | awk -F/ '{print $2}')"
-os::cmd::expect_success_and_text "oc get projects --token='${listprojecttoken}'" "${project}"
+# this token doesn't have rights to see any projects even though it can hit the list endpoint, so an empty list is correct
+# we'll add another scope that allows listing all known projects even if this token has no other powers in them.
+os::cmd::expect_success_and_not_text "oc get projects --token='${listprojecttoken}'" "${project}"
 os::cmd::expect_failure_and_text "oc get user/~ --token='${listprojecttoken}'" 'prevent this action; User "scoped-user" cannot get users at the cluster scope'
 os::cmd::expect_failure_and_text "oc get pods --token='${listprojecttoken}' -n '${project}'" "prevent this action; User \"scoped-user\" cannot list pods in project \"${project}\""
 

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -1,12 +1,15 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	policy "github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -234,7 +237,6 @@ func TestProjectWatch(t *testing.T) {
 
 	case <-time.After(3 * time.Second):
 	}
-
 }
 
 func waitForDelete(projectName string, w watch.Interface, t *testing.T) {
@@ -266,4 +268,173 @@ func waitForAdd(projectName string, w watch.Interface, t *testing.T) {
 			t.Fatalf("timeout: %v", projectName)
 		}
 	}
+}
+func waitForOnlyAdd(projectName string, w watch.Interface, t *testing.T) {
+	select {
+	case event := <-w.ResultChan():
+		project := event.Object.(*projectapi.Project)
+		t.Logf("got %#v %#v", event, project)
+		if event.Type == watch.Added && project.Name == projectName {
+			return
+		}
+		t.Errorf("got unexpected project %v", project.Name)
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("timeout: %v", projectName)
+	}
+}
+func waitForOnlyDelete(projectName string, w watch.Interface, t *testing.T) {
+	select {
+	case event := <-w.ResultChan():
+		project := event.Object.(*projectapi.Project)
+		t.Logf("got %#v %#v", event, project)
+		if event.Type == watch.Deleted && project.Name == projectName {
+			return
+		}
+		t.Errorf("got unexpected project %v", project.Name)
+
+	case <-time.After(30 * time.Second):
+		t.Fatalf("timeout: %v", projectName)
+	}
+}
+
+func TestScopedProjectAccess(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fullBobClient, _, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "bob")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	oneTwoBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
+		scope.UserListProject,
+		scope.ClusterRoleIndicator + "view:one",
+		scope.ClusterRoleIndicator + "view:two",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	twoThreeBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
+		scope.UserListProject,
+		scope.ClusterRoleIndicator + "view:two",
+		scope.ClusterRoleIndicator + "view:three",
+	})
+
+	allBobClient, _, _, err := testutil.GetScopedClientForUser(clusterAdminClient, *clusterAdminClientConfig, "bob", []string{
+		scope.UserListProject,
+		scope.ClusterRoleIndicator + "view:*",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	oneTwoWatch, err := oneTwoBobClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	twoThreeWatch, err := twoThreeBobClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	allWatch, err := allBobClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "one", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyAdd("one", allWatch, t)
+	waitForOnlyAdd("one", oneTwoWatch, t)
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "two", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyAdd("two", allWatch, t)
+	waitForOnlyAdd("two", oneTwoWatch, t)
+	waitForOnlyAdd("two", twoThreeWatch, t)
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "three", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyAdd("three", allWatch, t)
+	waitForOnlyAdd("three", twoThreeWatch, t)
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "four", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyAdd("four", allWatch, t)
+
+	oneTwoProjects, err := oneTwoBobClient.Projects().List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := hasExactlyTheseProjects(oneTwoProjects, sets.NewString("one", "two")); err != nil {
+		t.Error(err)
+	}
+	twoThreeProjects, err := twoThreeBobClient.Projects().List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := hasExactlyTheseProjects(twoThreeProjects, sets.NewString("two", "three")); err != nil {
+		t.Error(err)
+	}
+	allProjects, err := allBobClient.Projects().List(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := hasExactlyTheseProjects(allProjects, sets.NewString("one", "two", "three", "four")); err != nil {
+		t.Error(err)
+	}
+
+	if err := fullBobClient.Projects().Delete("four"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyDelete("four", allWatch, t)
+
+	if err := fullBobClient.Projects().Delete("three"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyDelete("three", allWatch, t)
+	waitForOnlyDelete("three", twoThreeWatch, t)
+
+	if err := fullBobClient.Projects().Delete("two"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyDelete("two", allWatch, t)
+	waitForOnlyDelete("two", oneTwoWatch, t)
+	waitForOnlyDelete("two", twoThreeWatch, t)
+
+	if err := fullBobClient.Projects().Delete("one"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitForOnlyDelete("one", allWatch, t)
+	waitForOnlyDelete("one", oneTwoWatch, t)
+}
+
+func hasExactlyTheseProjects(list *projectapi.ProjectList, projects sets.String) error {
+	if len(list.Items) != len(projects) {
+		return fmt.Errorf("expected %v, got %v", projects, list.Items)
+	}
+	for _, project := range list.Items {
+		if !projects.Has(project.Name) {
+			return fmt.Errorf("expected %v, got %v", projects, list.Items)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Updates the project cache to filter the project list with respect to scopes.

In a follow-on piece of work, this will make it possible to let an SA get list of projects it can access with the token its given or the list of all projects available depending on which scope the user selects.  

@openshift/api-review 
@sosiouxme you've asked for this, so did stef, and I needed it for my demo.