### PR TITLE
Use a consistent process for the official release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ update: build
 #
 # Example:
 #   make test-unit
-#   make test-unit WHAT=pkg/build GOFLAGS=-v
+#   make test-unit WHAT=pkg/build TESTFLAGS=-v
 test-unit:
 	TEST_KUBE=true GOTEST_FLAGS="$(TESTFLAGS)" hack/test-go.sh $(WHAT) $(TESTS)
 .PHONY: test-unit
@@ -141,7 +141,7 @@ test-tools:
 # Run assets tests.
 #
 # Example:
-#   make test-assets  
+#   make test-assets
 test-assets:
 ifeq ($(TEST_ASSETS),true)
 	hack/test-assets.sh
@@ -175,7 +175,7 @@ clean:
 	rm -rf $(OUT_DIR)
 .PHONY: clean
 
-# Build an official release of OpenShift, including the official images.
+# Build a release of OpenShift for linux/amd64 and the images that depend on it.
 #
 # Example:
 #   make release
@@ -194,22 +194,26 @@ release-binaries: clean
 	hack/extract-release.sh
 .PHONY: release-binaries
 
-# Release the integrated components for OpenShift, logging and metrics.
+# Release the integrated components for OpenShift, origin, logging, and metrics.
+# The current tag in the Origin release (the tag that points to HEAD) is used to
+# clone and build each component. Components must have a hack/release.sh script
+# which must accept env var OS_TAG as the tag to build. Each component should push
+# its own images. See hack/release.sh and hack/push-release.sh for an example of
+# the appropriate behavior.
+#
+# Prerequisites:
+# * you must be logged into the remote registry with the appropriate
+#   credentials to push.
+# * all repositories must have a Git tag equal to the current repositories tag of
+#   HEAD
+#
+# TODO: consider making hack/release.sh be a make target (make official-release).
 #
 # Example:
 #   make release-components
 release-components: clean
 	hack/release-components.sh
 .PHONY: release-components
-
-# Perform an official release. Requires HEAD of the repository to have a matching
-# tag. Will push images that are tagged tagged with the latest release commit.
-#
-# Example:
-#   make perform-official-release
-perform-official-release: | release-binaries release-components
-	OS_PUSH_ALWAYS="1" OS_PUSH_TAG="HEAD" OS_PUSH_LOCAL="1" hack/push-release.sh
-.PHONY: perform-official-release
 
 # Build the cross compiled release binaries
 #

--- a/hack/release-components.sh
+++ b/hack/release-components.sh
@@ -18,7 +18,7 @@ if [[ -z "${tag}" ]]; then
     echo "error: Specify OS_TAG or ensure the current git HEAD is tagged."
     exit 1
   fi
-  tag=":$( git tag --points-at HEAD )"
+  tag="$( git tag --points-at HEAD )"
 fi
 
 # release_component is the standard release pattern for subcomponents
@@ -28,11 +28,15 @@ function release_component() {
   mkdir -p "_output/components"
   (
     pushd _output/components/
-    git clone --recursive "$2" "$1" -b "${tag}"
+    git clone --recursive "$2" "$1"
+    pushd "$1"
+    git checkout "${tag}"
     OS_TAG="${tag}" hack/release.sh
   )
   local ENDTIME=$(date +%s); echo "--- $1 took $(($ENDTIME - $STARTTIME)) seconds ---"
+  rm -rf "_output/components/$1"
 }
 
 release_component logging https://github.com/openshift/origin-aggregated-logging
 release_component metrics https://github.com/openshift/origin-metrics
+release_component origin https://github.com/openshift/origin

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -12,19 +12,15 @@ source "${OS_ROOT}/hack/lib/init.sh"
 # Go to the top of the tree.
 cd "${OS_ROOT}"
 
-if [[ -z "${OS_TAG}" ]]; then
-  echo "You must specify the OS_TAG variable as the name of the tag to create, e.g. 'v1.0.1'."
-  exit 1
-fi
-tag="${OS_TAG}"
-
-if [[ "$(git name-rev --name-only --tags HEAD)" != "${tag}^0" ]]; then
-  if git rev-parse -q --short "${tag}" &>/dev/null; then
-    echo "Tag ${tag} already exists"
+tag="${OS_TAG:-}"
+if [[ -z "${tag}" ]]; then
+  if [[ "$( git tag --points-at HEAD | wc -l )" -ne 1 ]]; then
+    os::log::error "Specify OS_TAG or ensure the current git HEAD is tagged."
     exit 1
-  else
-    git tag "${tag}" -a -m "${tag}" HEAD
   fi
+  tag="$( git tag --points-at HEAD )"
+elif [[ "$( git rev-parse "${tag}" )" != "$( git rev-parse HEAD )" ]]; then
+  os::log::warning "You are running a version of hack/release.sh that does not match OS_TAG - images may not be build correctly"
 fi
 
 function removeimage() {
@@ -38,12 +34,13 @@ function removeimage() {
   done
 }
 
+# Ensure that the build is using the latest public base images
 removeimage openshift/origin-base openshift/origin-release openshift/origin-haproxy-router-base
 docker pull openshift/origin-base
 docker pull openshift/origin-release
 docker pull openshift/origin-haproxy-router-base
 
-hack/build-release.sh
+OS_GIT_COMMIT="${tag}" hack/build-release.sh
 hack/build-images.sh
 OS_PUSH_TAG="${tag}" OS_TAG="" OS_PUSH_LOCAL="1" hack/push-release.sh
 
@@ -51,5 +48,4 @@ echo
 echo "Pushed ${tag} to DockerHub"
 echo "1. Push tag to GitHub with: git push origin --tags # (ensure you have no extra tags in your environment)"
 echo "2. Create a new release on the releases page and upload the built binaries in _output/local/releases"
-echo "   Note: you should untar the Windows binary and recompress it as a zip"
 echo "3. Send an email"


### PR DESCRIPTION
All components are now built using hack/release.sh

[test]