### PR TITLE
The docker-builder url is not found

### DIFF
--- a/docs/builds.md
+++ b/docs/builds.md
@@ -81,7 +81,7 @@ Source-to-images (s2i) is a tool for building reproducible Docker images. It pro
 ### Custom Builds
 
 The custom build strategy is very similar to *Docker build* strategy, but users might
-customize the builder image that will be used for build execution. The *Docker build* uses [openshift/docker-builder](https://registry.hub.docker.com/u/openshift/docker-builder/) image by default. Using your own builder image allows you to customize your build process.
+customize the builder image that will be used for build execution. The *Docker build* uses [openshift/origin-docker-builder](https://hub.docker.com/r/openshift/origin-docker-builder/) image by default. Using your own builder image allows you to customize your build process.
 
 An example JSON of a custom build strategy:
 


### PR DESCRIPTION
“https://registry.hub.docker.com/u/openshift/docker-builder/” is not found
"https://hub.docker.com/r/openshift/origin-docker-builder/" is correct.
![not](https://cloud.githubusercontent.com/assets/20062886/17469083/74f1ad32-5d60-11e6-9192-aec715d9a3d4.PNG)
![new](https://cloud.githubusercontent.com/assets/20062886/17469084/75022a18-5d60-11e6-83fe-412ad7144097.PNG)
