### PR TITLE
Use default scrub pod template for NFS recycler

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -223,7 +223,7 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, na
 	nfsConfig := volume.VolumeConfig{
 		RecyclerMinimumTimeout:   int(config.PersistentVolumeRecyclerConfiguration.MinimumTimeoutNFS),
 		RecyclerTimeoutIncrement: int(config.PersistentVolumeRecyclerConfiguration.IncrementTimeoutNFS),
-		RecyclerPodTemplate:      volume.NewPersistentVolumeRecyclerPodTemplate(),
+		RecyclerPodTemplate:      defaultScrubPod,
 	}
 	if err := kctrlmgr.AttemptToLoadRecycler(config.PersistentVolumeRecyclerConfiguration.PodTemplateFilePathNFS, &nfsConfig); err != nil {
 		glog.Fatalf("Could not create NFS recycler pod from file %s: %+v", config.PersistentVolumeRecyclerConfiguration.PodTemplateFilePathNFS, err)


### PR DESCRIPTION
Pretty sure the change from defaultScrubPod to the plain upstream pod template was unintentional, this reverts the one line. The important thing here for fixing #10230 is that ServiceAccountName gets set.

fixes #10230