### PR TITLE
Delete EgressNetworkPolicy objects on namespace deletion

### DIFF
--- a/pkg/project/controller/controller.go
+++ b/pkg/project/controller/controller.go
@@ -65,6 +65,10 @@ func deleteAllContent(client osclient.Interface, namespace string) (err error) {
 	if err != nil {
 		return err
 	}
+	err = deleteEgressNetworkPolicies(client, namespace)
+	if err != nil {
+		return err
+	}
 	err = deleteImageStreams(client, namespace)
 	if err != nil {
 		return err
@@ -187,6 +191,20 @@ func deleteImageStreams(client osclient.Interface, ns string) error {
 	}
 	for i := range items.Items {
 		err := client.ImageStreams(ns).Delete(items.Items[i].Name)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteEgressNetworkPolicies(client osclient.Interface, ns string) error {
+	items, err := client.EgressNetworkPolicies(ns).List(kapi.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.EgressNetworkPolicies(ns).Delete(items.Items[i].Name)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}

--- a/pkg/project/controller/controller_test.go
+++ b/pkg/project/controller/controller_test.go
@@ -52,6 +52,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 		ktestclient.NewListAction("builds", "", kapi.ListOptions{}),
 		ktestclient.NewListAction("namespace", "", kapi.ListOptions{}),
 		ktestclient.NewListAction("deploymentconfig", "", kapi.ListOptions{}),
+		ktestclient.NewListAction("egressnetworkpolicy", "", kapi.ListOptions{}),
 	}
 	kubeActionSet := []core.Action{}
 	originActionSet := []ktestclient.Action{}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1363659

It seems like `pkg/project/controller/controller_test.go` should auto-generate its list of expected cleanup actions based on the set of registered OpenShift-specific resource types that specify NamespaceScoped true (so that this would have been caught when EgressNetworkPolicy was added), but I'm not sure how to do that...