### PR TITLE
Recognize gzipped empty layer when marking parents in oadm top images

### DIFF
--- a/pkg/cmd/admin/top/graph.go
+++ b/pkg/cmd/admin/top/graph.go
@@ -21,6 +21,9 @@ const (
 	HistoricImageStreamImageEdgeKind = "HistoricImageStreamImage"
 	PodImageEdgeKind                 = "PodImage"
 	ParentImageEdgeKind              = "ParentImage"
+
+	// digest.DigestSha256EmptyTar is empty layer digest, whereas this is gzipped digest of empty layer
+	digestSHA256GzippedEmptyTar = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
 )
 
 func getImageNodes(nodes []gonum.Node) []*imagegraph.ImageNode {
@@ -50,7 +53,7 @@ func addImagesToGraph(g graph.Graph, images *imageapi.ImageList) {
 			layer := image.DockerImageLayers[i]
 			layerNode := imagegraph.EnsureImageLayerNode(g, layer.Name)
 			edgeKind := ImageLayerEdgeKind
-			if !topLayerAdded && layer.Name != digest.DigestSha256EmptyTar {
+			if !topLayerAdded && layer.Name != digest.DigestSha256EmptyTar && layer.Name != digestSHA256GzippedEmptyTar {
 				edgeKind = ImageTopLayerEdgeKind
 				topLayerAdded = true
 			}

--- a/pkg/cmd/admin/top/images_test.go
+++ b/pkg/cmd/admin/top/images_test.go
@@ -5,6 +5,8 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 
+	"github.com/docker/distribution/digest"
+
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -201,6 +203,82 @@ func TestImagesTop(t *testing.T) {
 						ObjectMeta: kapi.ObjectMeta{Name: "image2"},
 						DockerImageLayers: []imageapi.ImageLayer{
 							{Name: "layer1"},
+							{Name: "layer2"},
+						},
+						DockerImageManifest: "non empty metadata",
+					},
+				},
+			},
+			streams: &imageapi.ImageStreamList{},
+			pods:    &kapi.PodList{},
+			expected: []Info{
+				imageInfo{
+					Image:           "image1",
+					ImageStreamTags: []string{},
+					Metadata:        true,
+					Parents:         []string{},
+					Usage:           []string{},
+				},
+				imageInfo{
+					Image:           "image2",
+					ImageStreamTags: []string{},
+					Metadata:        true,
+					Parents:         []string{"image1"},
+					Usage:           []string{},
+				},
+			},
+		},
+		"image parents with empty layer": {
+			images: &imageapi.ImageList{
+				Items: []imageapi.Image{
+					{
+						ObjectMeta:          kapi.ObjectMeta{Name: "image1"},
+						DockerImageLayers:   []imageapi.ImageLayer{{Name: "layer1"}},
+						DockerImageManifest: "non empty metadata",
+					},
+					{
+						ObjectMeta: kapi.ObjectMeta{Name: "image2"},
+						DockerImageLayers: []imageapi.ImageLayer{
+							{Name: "layer1"},
+							{Name: digest.DigestSha256EmptyTar},
+							{Name: "layer2"},
+						},
+						DockerImageManifest: "non empty metadata",
+					},
+				},
+			},
+			streams: &imageapi.ImageStreamList{},
+			pods:    &kapi.PodList{},
+			expected: []Info{
+				imageInfo{
+					Image:           "image1",
+					ImageStreamTags: []string{},
+					Metadata:        true,
+					Parents:         []string{},
+					Usage:           []string{},
+				},
+				imageInfo{
+					Image:           "image2",
+					ImageStreamTags: []string{},
+					Metadata:        true,
+					Parents:         []string{"image1"},
+					Usage:           []string{},
+				},
+			},
+		},
+		"image parents with gzipped empty layer": {
+			images: &imageapi.ImageList{
+				Items: []imageapi.Image{
+					{
+						ObjectMeta:          kapi.ObjectMeta{Name: "image1"},
+						DockerImageLayers:   []imageapi.ImageLayer{{Name: "layer1"}},
+						DockerImageManifest: "non empty metadata",
+					},
+					{
+						ObjectMeta: kapi.ObjectMeta{Name: "image2"},
+						DockerImageLayers: []imageapi.ImageLayer{
+							{Name: "layer1"},
+							{Name: digestSHA256GzippedEmptyTar},
 							{Name: "layer2"},
 						},
 						DockerImageManifest: "non empty metadata",


### PR DESCRIPTION
It looks like there are two possible checksums for empty layers:

1. [empty layer](https://github.com/docker/distribution/blob/024a9ed6c7d265ad7f74dd2bb04721eb903ff098/digest/digest.go#L13)
2. [gzipped empty layer](https://github.com/docker/distribution/blob/024a9ed6c7d265ad7f74dd2bb04721eb903ff098/manifest/schema1/config_builder.go#L30)

This PR adds the latter to the mechanism marking parents.

@miminar || @legionus ptal