### PR TITLE
Moved shared init code into hack/lib/init.sh

### DIFF
--- a/contrib/vagrant/provision-config.sh
+++ b/contrib/vagrant/provision-config.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-# Set a useful format for xtrace output
-# export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-
-OS_ROOT=$(
-  unset CDPATH
-  origin_root=$(dirname "${BASH_SOURCE}")/../..
-  cd "${origin_root}"
-  pwd
-)
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 source ${OS_ROOT}/contrib/vagrant/provision-util.sh
 
 # Passed as arguments to provisioning script

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -4,18 +4,8 @@
 #
 # Set OS_IMAGE_PUSH=true to push images to a registry
 #
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 oc="$(os::build::find-binary oc ${OS_ROOT})"
 if [[ -z "${oc}" ]]; then

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 
 # Build all cross compile targets and the base binaries
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 platforms=( "${OS_CROSS_COMPILE_PLATFORMS[@]}" )
 if [[ -n "${OS_ONLY_BUILD_PLATFORMS-}" ]]; then

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 
 # This script sets up a go workspace locally and builds all go components.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # only works on Linux for now, all other platforms must build binaries themselves
 if [[ -z "$@" ]]; then

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -6,19 +6,9 @@
 # NOTE:  you only need to run this script if your code changes are part of
 # any images OpenShift runs internally such as origin-sti-builder, origin-docker-builder,
 # origin-deployer, etc.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 source "${OS_ROOT}/contrib/node/install-sdn.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
 
 if [[ "${OS_RELEASE:-}" == "n" ]]; then
   # Use local binaries

--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -2,20 +2,14 @@
 
 # This script build the sources in openshift/origin-release image using
 # the Fedora environment and Go compiler.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-function absolute_path() { 
+function absolute_path() {
   pushd . > /dev/null
   [ -d "$1" ] && cd "$1" && dirs -l +0
   popd > /dev/null
 }
 
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 origin_path="src/github.com/openshift/origin"
 
 # TODO: Remove this check and fix the docker command instead after the

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -4,18 +4,8 @@
 # image to be built prior to executing this command via hack/build-base-images.sh.
 
 # NOTE:   only committed code is built.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 context="${OS_ROOT}/_output/buildenv-context"
 

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
 
 # See HACKING.md for usage
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 repo="${UPSTREAM_REPO:-k8s.io/kubernetes}"
 package="${UPSTREAM_PACKAGE:-pkg/api}"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -3,24 +3,6 @@
 # This script provides common script functions for the hacks
 # Requires OS_ROOT to be set
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-# The root of the build/dist directory
-readonly OS_ROOT=$(
-  unset CDPATH
-  os_root=$(dirname "${BASH_SOURCE}")/..
-
-  cd "${os_root}"
-  os_root=`pwd`
-  if [ -h "${os_root}" ]; then
-    readlink "${os_root}"
-  else
-    pwd
-  fi
-)
-
 readonly OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.6}"
 readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"
 

--- a/hack/copy-kube-artifacts.sh
+++ b/hack/copy-kube-artifacts.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
 # this will allow matching files also in subdirs with **/*.json pattern
 shopt -s globstar
 
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 GODEP_ROOT="${OS_ROOT}/vendor"
 KUBE_ROOT=${1:-""}

--- a/hack/env
+++ b/hack/env
@@ -4,16 +4,6 @@
 # image to be built prior to executing this command via hack/build-base-images.sh.
 
 # NOTE:   only committed code is built.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::environment::run "$@"

--- a/hack/export-certs.sh
+++ b/hack/export-certs.sh
@@ -5,15 +5,7 @@
 #
 #   $ source hack/export-certs.sh ./openshift.local.config/master/admin
 #   $ curl $CURL_ARGS <a protected URL>
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-set -e
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 DEF="${1:-}"
 CERT_DIR="${CERT_DIR:-$DEF}"

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -2,16 +2,7 @@
 
 # This script extracts a valid release tar into _output/releases. It requires hack/build-release.sh
 # to have been executed
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # Copy the release archives release back to the local _output/local/bin/... directories.
 # NOTE: On Mac and Windows you must pass WARN=1 in order to extract the output.

--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -13,10 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-set -o errexit
-set -o nounset
-set -o pipefail
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 #### HACK ####
 # Sometimes godep just can't handle things. This lets use manually put
@@ -58,8 +55,6 @@ pin-godep() {
     "${GODEP}" go install
   popd > /dev/null
 }
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 # build the godep tool
 # Again go get stinks, hence || true

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -13,10 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-set -o errexit
-set -o nounset
-set -o pipefail
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 pin-godep() {
   pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
@@ -24,8 +21,6 @@ pin-godep() {
     "${GODEP}" go install
   popd > /dev/null
 }
-
-ORIGIN_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 # build the godep tool
 # Again go get stinks, hence || true
@@ -43,6 +38,4 @@ REQUIRED_BINS=(
   "./..."
 )
 
-pushd "${ORIGIN_ROOT}" > /dev/null
 "${GODEP}" save -t "${REQUIRED_BINS[@]}"
-popd > /dev/null

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -e
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 etcd_version=$(go run ${OS_ROOT}/tools/godepversion/godepversion.go ${OS_ROOT}/Godeps/Godeps.json github.com/coreos/etcd/etcdserver)
 

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
-
-set -e
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 GO_VERSION=($(go version))
 echo "Detected go version: $(go version)"

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -5,10 +5,33 @@
 # sively `source`s *.sh files in this directory tree. As such, no files should be `source`ed outside
 # of this script to ensure that we do not attempt to overwrite read-only variables.
 
-if [[ -z "${OS_ROOT:-}" ]]; then
-	echo "[ERROR] In order to import OpenShift Bash libraries, \$OS_ROOT must be set."
-	exit 1
-fi
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# os::util::absolute_path returns the absolute path to the directory provided
+function os::util::absolute_path() {
+	local relative_path="$1"
+	local absolute_path
+
+	pushd "${relative_path}" >/dev/null
+	relative_path="$( pwd )"
+	if [[ -h "${relative_path}" ]]; then
+		absolute_path="$( readlink "${relative_path}" )"
+	else
+		absolute_path="${relative_path}"
+	fi
+	popd >/dev/null
+
+	echo "${absolute_path}"
+}
+readonly -f os::util::absolute_path
+
+# find the absolute path to the root of the Origin source tree
+init_source="$( dirname "${BASH_SOURCE}" )/../.."
+OS_ROOT="$( os::util::absolute_path "${init_source}" )"
+export OS_ROOT
+cd "${OS_ROOT}"
 
 library_files=( $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ) )
 # TODO(skuzmets): Move the contents of the following files into respective library files.
@@ -19,4 +42,8 @@ for library_file in "${library_files[@]}"; do
 	source "${library_file}"
 done
 
-unset library_files library_file
+unset library_files library_file init_source
+
+# all of our Bash scripts need to have the stacktrace
+# handler installed to deal with errors
+os::log::stacktrace::install

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -121,8 +121,9 @@ function os::util::find-go-binary() {
 
   IFS=":"
   for part in $GOPATH; do
-    if [[ -f "$part/bin/$binary_name" && -x "${part}/bin/${binary_name}" ]]; then
-      echo $part/bin/$binary_name
+  	local binary="${part}/bin/${binary_name}"
+    if [[ -f "${binary}" && -x "${binary}" ]]; then
+      echo "${binary}"
       break
     fi
   done

--- a/hack/load-etcd-dump.sh
+++ b/hack/load-etcd-dump.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/move-upstream.sh
+++ b/hack/move-upstream.sh
@@ -6,17 +6,7 @@
 #  2. Set TARGET_BRANCH for the new branch to work in
 #  3. In your kube git directory, set the current branch to the level to want to apply patches to
 #  4. Run `hack/move-upstream.sh master...<commit hash you want to start pulling patches from>`
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 repo="${UPSTREAM_REPO:-k8s.io/kubernetes}"
 package="${UPSTREAM_PACKAGE:-pkg/api}"

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -5,17 +5,8 @@
 # Set OS_PUSH_BASE_IMAGES=true to push base images
 # Set OS_PUSH_BASE_REGISTRY to prefix the destination images
 #
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # Allow a release to be repushed with a tag
 tag="${OS_PUSH_TAG:-}"

--- a/hack/pythia.sh
+++ b/hack/pythia.sh
@@ -5,13 +5,7 @@
 
 # Prereq:
 # go get github.com/fzipp/pythia
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # Check for `go` binary and set ${GOPATH}.
 os::build::setup_env

--- a/hack/rebase-describe-bumps.sh
+++ b/hack/rebase-describe-bumps.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 "${OS_ROOT}/hack/build-go.sh" tools/rebasehelpers/godepchecker
 

--- a/hack/release-components.sh
+++ b/hack/release-components.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
 # This script builds and pushes a release to DockerHub.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 tag="${OS_TAG:-}"
 if [[ -z "${tag}" ]]; then

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
 # This script builds and pushes a release to DockerHub.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 tag="${OS_TAG:-}"
 if [[ -z "${tag}" ]]; then

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -2,16 +2,8 @@
 
 # This command checks that the built commands can function together for
 # simple scenarios.  It does not require Docker so it can run in travis.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::util::environment::setup_time_vars
 
 function cleanup()

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -2,14 +2,8 @@
 
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "[INFO] Starting containerized end-to-end test"
 
@@ -33,7 +27,7 @@ function cleanup()
 	set +e
 	dump_container_logs
 
-	# pull information out of the server log so that we can get failure management in jenkins to highlight it and 
+	# pull information out of the server log so that we can get failure management in jenkins to highlight it and
 	# really have it smack people in their logs.  This is a severe correctness problem
     grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/container-origin.log
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -2,13 +2,8 @@
 
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 readonly JQSETPULLPOLICY='(.items[] | select(.kind == "DeploymentConfig") | .spec.template.spec.containers[0].imagePullPolicy) |= "IfNotPresent"'
 
@@ -20,9 +15,6 @@ if [[ "${TEST_END_TO_END:-}" != "direct" ]]; then
 	fi
 	echo "++ Docker is not installed, running end-to-end against local binaries"
 fi
-
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
 
 ensure_iptables_or_die
 

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -19,11 +19,6 @@
 #  - JUNIT_REPORT:        toggles the creation of jUnit XML from the test output and changes this script's output behavior
 #                         to use the 'junitreport' tool for summarizing the tests.
 #  - DLV_DEBUG            toggles running tests using delve debugger
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 function exit_trap() {
     local return_code=$?
 
@@ -42,10 +37,7 @@ function exit_trap() {
 trap exit_trap EXIT
 
 start_time=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-cd "${OS_ROOT}"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::build::setup_env
 os::util::environment::setup_tmpdir_vars "test-go"
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/test-kube-e2e.sh
+++ b/hack/test-kube-e2e.sh
@@ -21,17 +21,7 @@
 #
 # KUBE_ROOT=../kubernetes hack/test-kube-e2e.sh --ginkgo.focus="Network.*intra"
 #
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(
-  unset CDPATH
-  origin_root=$(dirname "${BASH_SOURCE}")/..
-  cd "${origin_root}"
-  pwd
-)
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 KUBE_ROOT=${KUBE_ROOT:-""}
 

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 
 # This script runs all of the test written for our Bash libraries.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 function exit_trap() {
     local return_code=$?
 
     end_time=$(date +%s)
-    
+
     if [[ "${return_code}" -eq "0" ]]; then
         verb="succeeded"
     else
@@ -24,9 +19,7 @@ function exit_trap() {
 trap exit_trap EXIT
 
 start_time=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::util::environment::setup_tmpdir_vars "test-lib"
 
 cd "${OS_ROOT}"

--- a/hack/test-lib/test/junit.sh
+++ b/hack/test-lib/test/junit.sh
@@ -2,15 +2,11 @@
 #
 # This script tests os::test::junit functionality.
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
 function exit_trap() {
     local return_code=$?
 
     end_time=$(date +%s)
-    
+
     if [[ "${return_code}" -eq "0" ]]; then
         verb="succeeded"
     else
@@ -24,9 +20,7 @@ function exit_trap() {
 trap exit_trap EXIT
 
 start_time=$(date +%s)
-OS_ROOT="$( dirname "${BASH_SOURCE}" )"/../../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$( dirname "${BASH_SOURCE}" )/../../lib/init.sh"
 
 # envars used to track these interactions are not propagated out of the subshells used to run these commands
 # therefore each os::cmd call is its own sandbox and complicated scenarios need to play out inside one call

--- a/hack/test-local-registry.sh
+++ b/hack/test-local-registry.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
 # This command runs any exposed integration tests for the developer tools
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::test::junit::declare_suite_start 'tools'
 

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 # This file ensures that the helper functions in util.sh behave as expected
-
-set -o errexit
-set -o nounset
-set -o pipefail
-# set -x
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 BASETMPDIR="${TMPDIR:-/tmp}/openshift/test-tools"
@@ -166,7 +158,7 @@ os::cmd::expect_success_and_text 'echo $(( 1 - 20 ))' '\-19' # we need to escape
 # redirects
 os::cmd::expect_failure_and_text 'grep' '(Usage|usage)'
 
-os::cmd::expect_success_and_not_text 'pwd 1>/dev/null' '.' 
+os::cmd::expect_success_and_not_text 'pwd 1>/dev/null' '.'
 
 os::cmd::expect_failure_and_not_text 'grep 2>/dev/null' '(Usage|usage)'
 
@@ -186,161 +178,161 @@ os::test::junit::declare_suite_start "cmd/util/output"
 
 # expect_code
 output=$(os::cmd::expect_code 'exit 0' '0')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_code 'exit 1' '0') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
 
 output=$(os::cmd::expect_code 'exit 1' '1')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_code 'exit 0' '1') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
 
 output=$(os::cmd::expect_code 'exit 99' '99')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_code 'exit 1' '99') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
 
 # expect_success
 output=$(os::cmd::expect_success 'exit 0')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_success 'exit 1') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
 
 # expect_failure
 output=$(os::cmd::expect_failure 'exit 1')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_failure 'exit 0') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
 
 # expect_code_and_text
 output=$(os::cmd::expect_code_and_text 'echo "hello" && exit 0' '0' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_code_and_text 'echo "hello" && exit 1' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_code_and_text 'echo "goodbye" && exit 0' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_code_and_text 'echo "goodbye" && exit 1' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 # expect_success_and_text
 output=$(os::cmd::expect_success_and_text 'echo "hello" && exit 0' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_success_and_text 'echo "hello" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_success_and_text 'echo "goodbye" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_success_and_text 'echo "goodbye" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 # expect_failure_and_text
 output=$(os::cmd::expect_failure_and_text 'echo "hello" && exit 1' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_failure_and_text 'echo "hello" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_failure_and_text 'echo "goodbye" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_failure_and_text 'echo "goodbye" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'goodbye'
 
 # expect_code_and_not_text
 output=$(os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 0' '0' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 1' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_code_and_not_text 'echo "hello" && exit 0' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_code_and_not_text 'echo "hello" && exit 1' '0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 # expect_success_and_not_text
 output=$(os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 0' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_success_and_not_text 'echo "hello" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_success_and_not_text 'echo "hello" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 # expect_failure_and_not_text
 output=$(os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 1' 'hello')
-echo "${output}" | grep -q 'SUCCESS' 
+echo "${output}" | grep -q 'SUCCESS'
 
 output=$(os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q 'goodbye' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q 'goodbye'
 
 output=$(os::cmd::expect_failure_and_not_text 'echo "hello" && exit 1' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 output=$(os::cmd::expect_failure_and_not_text 'echo "hello" && exit 0' 'hello') || true
-echo "${output}" | grep -q 'FAILURE' 
-echo "${output}" | grep -q 'the command returned the wrong error code' 
-echo "${output}" | grep -q '; the output content test failed' 
-echo "${output}" | grep -q 'hello' 
+echo "${output}" | grep -q 'FAILURE'
+echo "${output}" | grep -q 'the command returned the wrong error code'
+echo "${output}" | grep -q '; the output content test failed'
+echo "${output}" | grep -q 'hello'
 
 echo "output tests: ok"
 os::test::junit::declare_suite_end

--- a/hack/update-external-examples.sh
+++ b/hack/update-external-examples.sh
@@ -4,12 +4,7 @@
 # so they can be included directly in our repository.
 # Feeds off a README.md file with well defined syntax that informs this
 # script how to pull the file down.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # For now the only external examples are in examples/quickstarts.
 QUICKSTARTS_DIR="${OS_ROOT}/examples/quickstarts"

--- a/hack/update-generated-bootstrap-bindata.sh
+++ b/hack/update-generated-bootstrap-bindata.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
 STARTTIME=$(date +%s)
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 EXAMPLES=examples
 OUTPUT_PARENT=${OUTPUT_ROOT:-$OS_ROOT}

--- a/hack/update-generated-clientsets.sh
+++ b/hack/update-generated-clientsets.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
 # This script sets up a go workspace locally and builds all go components.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd ${OS_ROOT}
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # ensure we have the latest compiled binaries
 "${OS_ROOT}/hack/build-go.sh"

--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/update-generated-deep-copies.sh
+++ b/hack/update-generated-deep-copies.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 

--- a/hack/update-generated-docs.sh
+++ b/hack/update-generated-docs.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
 # This script sets up a go workspace locally and builds all go components.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 "${OS_ROOT}/hack/build-go.sh" tools/gendocs tools/genman
 

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-# Go to the top of the tree.
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3.0."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-swagger-descriptions.sh
+++ b/hack/update-generated-swagger-descriptions.sh
@@ -7,15 +7,7 @@
 # This script accepts the following parameters as environment variables:
 #  - VERIFY:  run the script to verify current documentation
 #  - DRY_RUN: print which files would be generated and exit
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # read in envar options
 verify="${VERIFY:-}"

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
 # Script to create latest swagger spec.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup()
 {

--- a/hack/update-swagger-docs.sh
+++ b/hack/update-swagger-docs.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
 # Script to generate docs from the latest swagger spec.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 pushd "${OS_ROOT}/hack/swagger-doc" > /dev/null
 gradle gendocs --info

--- a/hack/vendor-console.sh
+++ b/hack/vendor-console.sh
@@ -8,13 +8,7 @@
 #                        directory will be used.
 #   - CONSOLE_REPO_PATH: specifies a directory path to look for the web console repo.  If not set it is assumed to be
 #                        a sibling to this repository.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 CONSOLE_REPO_PATH=${CONSOLE_REPO_PATH:-$OS_ROOT/../origin-web-console}
 if [[ ! -d "$CONSOLE_REPO_PATH" ]]; then

--- a/hack/verify-generated-bootstrap-bindata.sh
+++ b/hack/verify-generated-bootstrap-bindata.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Bootstrap Bindata ====="
 

--- a/hack/verify-generated-clientsets.sh
+++ b/hack/verify-generated-clientsets.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
 echo "===== Verifying Generated Client sets ====="
 output=$(VERIFY=true ${OS_ROOT}/hack/update-generated-clientsets.sh 2>&1)
 

--- a/hack/verify-generated-completions.sh
+++ b/hack/verify-generated-completions.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Completions ====="
 

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Conversions ====="
 

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Deep Copies ====="
 

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Docs ====="
 

--- a/hack/verify-generated-protobuf.sh
+++ b/hack/verify-generated-protobuf.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 APIROOTS=${APIROOTS:-pkg}
 _tmp="${OS_ROOT}/_output/diff"

--- a/hack/verify-generated-swagger-descriptions.sh
+++ b/hack/verify-generated-swagger-descriptions.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 #
 # This script verifies that generated Swagger self-describing documentation is up to date.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying Generated Swagger Descriptions ====="
 

--- a/hack/verify-generated-swagger-spec.sh
+++ b/hack/verify-generated-swagger-spec.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 echo "===== Verifying API Swagger Spec ====="
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
-
-# GoFmt apparently is changing @ head...
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::golang::verify_go_version
-
-cd "${OS_ROOT}"
 
 bad_files=$(find_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-
-set -o errexit
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::golang::verify_go_version
 os::golang::verify_golint_version
-
-cd "${OS_ROOT}"
 
 arg="${1:-""}"
 bad_files=""

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
-
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::golang::verify_go_version
 
-cd "${OS_ROOT}"
 mkdir -p _output/govet
 
 os::build::setup_env

--- a/hack/verify-jsonformat.sh
+++ b/hack/verify-jsonformat.sh
@@ -12,11 +12,7 @@
 # automatically:
 # $ ./hack/verify-jsonformat.sh --format --fix
 #
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 json_files=$(find {api,examples,docs,images,plugins,test} -name "*.json")
 tmp_dir=$(mktemp -d)

--- a/hack/verify-open-ports.sh
+++ b/hack/verify-open-ports.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
 # Script to create latest swagger spec.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
-
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # Open port scanning
 echo "[INFO] Checking open ports ('sudo openshift start' should already be running)"

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 if ! git status &> /dev/null; then
   echo "SKIPPED: Not a Git repository"

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 project="$( oc project -q )"

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/completions.sh
+++ b/test/cmd/completions.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/completions"

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/diagnostics.sh
+++ b/test/cmd/diagnostics.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # This test validates the diagnostics command

--- a/test/cmd/dns.sh
+++ b/test/cmd/dns.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/help"

--- a/test/cmd/images-old-policy.sh
+++ b/test/cmd/images-old-policy.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 project="$( oc project -q )"

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 source "${OS_ROOT}/test/cmd/images_tests.sh"

--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 project="$( oc project -q )"

--- a/test/cmd/printer.sh
+++ b/test/cmd/printer.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Test that resource printer includes resource kind on multiple resources

--- a/test/cmd/process.sh
+++ b/test/cmd/process.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -24,16 +18,16 @@ os::cmd::expect_failure_and_text 'oc process name1 name2' 'template name must be
 # fail to pass a filename or template by name
 os::cmd::expect_failure_and_text 'oc process' 'Must pass a filename or name of stored template'
 # can't ask for parameters and try process the template
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --value=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-value' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters -v someval' '\-\-parameters flag does not process the template, can.t be used with \-\-value' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --labels=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-labels' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters -l someval' '\-\-parameters flag does not process the template, can.t be used with \-\-labels' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --output=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters -o someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --output-version=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output-version' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --raw' '\-\-parameters flag does not process the template, can.t be used with \-\-raw' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters --template=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-template' 
-os::cmd::expect_failure_and_text 'oc process template-name --parameters -t someval' '\-\-parameters flag does not process the template, can.t be used with \-\-template' 
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --value=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-value'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters -v someval' '\-\-parameters flag does not process the template, can.t be used with \-\-value'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --labels=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-labels'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters -l someval' '\-\-parameters flag does not process the template, can.t be used with \-\-labels'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --output=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters -o someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --output-version=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-output-version'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --raw' '\-\-parameters flag does not process the template, can.t be used with \-\-raw'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters --template=someval' '\-\-parameters flag does not process the template, can.t be used with \-\-template'
+os::cmd::expect_failure_and_text 'oc process template-name --parameters -t someval' '\-\-parameters flag does not process the template, can.t be used with \-\-template'
 
 # providing a value more than once should fail
 os::cmd::expect_failure_and_text 'oc process template-name key=value key=value' 'provided more than once: key'

--- a/test/cmd/projects.sh
+++ b/test/cmd/projects.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/projects"

--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/quota"

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/triggers.sh
+++ b/test/cmd/triggers.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -2,14 +2,8 @@
 
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
 os::util::environment::setup_time_vars
 trap os::test::junit::reconcile_output EXIT
 
@@ -227,7 +221,7 @@ os::cmd::expect_success 'oc policy add-role-to-user system:image-puller system:a
 os::cmd::try_until_text 'oc policy who-can get imagestreams/layers -n custom' 'system:anonymous'
 os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull"
 os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id"
-# unauthorized pushes return authorization errors, regardless of backing data 
+# unauthorized pushes return authorization errors, regardless of backing data
 os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/missing/image:tag"              "authentication required"
 os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull"    "authentication required"
 os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id" "authentication required"

--- a/test/extended/all.sh
+++ b/test/extended/all.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 #
 # This script will run all test scripts that are in test/extended.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-cd "${OS_ROOT}"
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 test_scripts=`find test/extended -maxdepth 1 -name "*.sh" -not  \( -name "all.sh" \)`
 

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 #
 # This scripts starts the OpenShift server with custom TLS certs, and verifies generated kubeconfig files can be used to talk to it.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::setup_all_server_vars "test-extended-alternate-certs/"
 reset_tmp_dir
@@ -52,8 +44,8 @@ os::cmd::expect_success "openshift start --master=https://localhost:${API_PORT} 
 # Don't try this at home.  We don't have flags for setting etcd ports in the config, but we want deconflicted ones.  Use sed to replace defaults in a completely unsafe way
 os::util::sed "s/:4001$/:${ETCD_PORT}/g" master/master-config.yaml
 os::util::sed "s/:7001$/:${ETCD_PEER_PORT}/g" master/master-config.yaml
-# replace top-level namedCertificates config 
-os::util::sed 's#^  namedCertificates: null#  namedCertificates: [{"certFile":"custom.crt","keyFile":"custom.key","names":["localhost"]}]#' master/master-config.yaml 
+# replace top-level namedCertificates config
+os::util::sed 's#^  namedCertificates: null#  namedCertificates: [{"certFile":"custom.crt","keyFile":"custom.key","names":["localhost"]}]#' master/master-config.yaml
 
 # Start master
 OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master \

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -3,15 +3,7 @@
 # This scripts starts the OpenShift server with a default configuration.
 # The OpenShift Docker registry and router are installed.
 # It will run all tests that are imported into test/extended.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-cd "${OS_ROOT}"
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::setup_all_server_vars "test-extended-alternate-launches/"
 reset_tmp_dir

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -4,17 +4,8 @@
 # No registry or router is setup.
 # It is intended to test cli commands that may require docker and therefore
 # cannot be run under Travis.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 os::util::environment::setup_time_vars
-
-cd "${OS_ROOT}"
 
 os::build::setup_env
 

--- a/test/extended/conformance.sh
+++ b/test/extended/conformance.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 #
 # Runs the conformance extended tests for OpenShift
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 source "${OS_ROOT}/test/extended/setup.sh"
-cd "${OS_ROOT}"
 
 os::test::extended::setup
 os::test::extended::focus "$@"

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -2,14 +2,8 @@
 #
 # Runs all standard extended tests against either an existing cluster (TEST_ONLY=1)
 # or a standard started server.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 source "${OS_ROOT}/test/extended/setup.sh"
-cd "${OS_ROOT}"
 
 os::test::extended::setup
 os::test::extended::focus "$@"

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 #
 # Extended tests for logging in using GSSAPI
-
-set -o errexit
-set -o nounset
-set -o pipefail
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 starttime="$(date +%s)"
 
 project_name='gssapiproxy'
 test_name="test-extended/${project_name}"
-
-OS_ROOT="$(dirname "${BASH_SOURCE}")/../.."
-cd "${OS_ROOT}"
-source hack/lib/init.sh
 
 os::build::setup_env
 
@@ -21,7 +14,6 @@ os::util::environment::setup_time_vars
 os::util::environment::setup_all_server_vars "${test_name}"
 os::util::environment::use_sudo
 
-os::log::stacktrace::install
 os::log::start_system_logger
 
 ensure_iptables_or_die

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -3,17 +3,8 @@
 # This scripts starts the OpenShift server with a default configuration.
 # The OpenShift Docker registry and router are installed.
 # It will run all tests that are imported into test/extended.
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 os::util::environment::setup_time_vars
-
-cd "${OS_ROOT}"
 
 os::build::setup_env
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -2,10 +2,7 @@
 
 # This script runs the networking e2e tests. See CONTRIBUTING.adoc for
 # documentation.
-
-set -o errexit
-set -o nounset
-set -o pipefail
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 if [[ -n "${OPENSHIFT_VERBOSE_OUTPUT:-}" ]]; then
   set -o xtrace
@@ -14,10 +11,6 @@ fi
 
 # Ensure that subshells inherit bash settings (specifically xtrace)
 export SHELLOPTS
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
 
 # These strings filter the available tests.
 #

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -1,4 +1,4 @@
-  #!/bin/bash
+#!/bin/bash
 #
 # This abstracts starting up an extended server.
 
@@ -21,9 +21,6 @@ function os::test::extended::focus {
 #   and then tests are executed.  Tests that depend on fine grained setup should
 #   be done in other contexts.
 function os::test::extended::setup {
-  source "${OS_ROOT}/hack/lib/init.sh"
-  os::log::stacktrace::install
-
   # build binaries
   if [[ -z $(os::build::find-binary ginkgo) ]]; then
     hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
All of our Bash scripts made a number of initialization
steps: setting Bash flags, finding and moving into the
Origin root directory. This commit moves all of those
steps into hack/lib/init.sh in order to cut down on the
amount of boilerplate in our files.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>