### PR TITLE
Fix openshift/origin-release:golang-1.4 image

### DIFF
--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -28,5 +28,6 @@ WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \
       io.k8s.description="This is the standard release image for OpenShift Origin and contains the necessary build tools to build the platform."
 
-# Expect the working directory to be populated with the repo source
-CMD hack/build-cross.sh
+# Expect a tar with the source of OpenShift Origin (and /os-version-defs in the root)
+# This image is for OpenShift versions v1.2.0 and earlier.
+CMD bsdtar mxzf - && hack/build-cross.sh


### PR DESCRIPTION
Restore expectation/processing of source archive tarball on stdin.

@smarterclayton @stevekuznetsov 