### PR TITLE
make build API validation compile

### DIFF
--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -665,7 +665,7 @@ func validateRuntimeImage(sourceStrategy *buildapi.SourceBuildStrategy, fldPath 
 		return append(allErrs, field.Required(fldPath, "name"))
 	}
 
-	if sourceStrategy.Incremental {
+	if sourceStrategy.Incremental != nil && *sourceStrategy.Incremental {
 		return append(allErrs, field.Invalid(fldPath, sourceStrategy.Incremental, "incremental cannot be set to true with extended builds"))
 	}
 	return


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/10311

I'm getting 
```
# github.com/openshift/origin/pkg/build/api/validation
pkg/build/api/validation/validation.go:668: non-bool sourceStrategy.Incremental (type *bool) used as if condition
[ERROR] PID 3057: hack/common.sh:325: `GOOS=${platform%/*} GOARCH=${platform##*/} go install "${goflags[@]:+${goflags[@]}}" "${platform_goflags[@]:+${platform_goflags[@]}}" -ldflags "${version_ldflags}" "${nonstatics[@]}"` exited with status 2.
[INFO] 		Stack Trace: 
[INFO] 		  1: hack/common.sh:325: `GOOS=${platform%/*} GOARCH=${platform##*/} go install "${goflags[@]:+${goflags[@]}}" "${platform_goflags[@]:+${platform_goflags[@]}}" -ldflags "${version_ldflags}" "${nonstatics[@]}"`
[INFO] 		  2: hack/common.sh:264: os::build::internal::build_binaries
[INFO] 		  3: hack/build-go.sh:31: os::build::build_binaries
[INFO]   Exiting with code 2.
[ERROR] PID 3029: hack/common.sh:261: `local -a binaries=("$@")` exited with status 2.
[INFO] 		Stack Trace: 
[INFO] 		  1: hack/common.sh:261: `local -a binaries=("$@")`
[INFO] 		  2: hack/build-go.sh:31: os::build::build_binaries
[INFO]   Exiting with code 2.
```
in my jobs and locally.  See https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_origin_check/4762/console

@bparees @liggitt 

[test]