### PR TITLE
UPSTREAM: 30313: remove duplicate errors from aggregate error outputs

### DIFF
--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -55,6 +55,11 @@ os::cmd::expect_success 'oc delete all -l app=php'
 os::cmd::expect_failure 'oc get dc/mysql'
 os::cmd::expect_failure 'oc get dc/php'
 
+# ensure non-duplicate invalid label errors show up
+os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'error: ImageStream "nginx" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'DeploymentConfig "nginx" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'Service "nginx" is invalid'
+
 # check if we can create from a stored template
 os::cmd::expect_success 'oc create -f examples/sample-app/application-template-stibuild.json'
 os::cmd::expect_success 'oc get template ruby-helloworld-sample'

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api/errors"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
 
 	"github.com/evanphx/json-patch"
@@ -59,10 +61,10 @@ type debugError interface {
 // souce is the filename or URL to the template file(*.json or *.yaml), or stdin to use to handle the resource.
 func AddSourceToErr(verb string, source string, err error) error {
 	if source != "" {
-		if statusError, ok := err.(errors.APIStatus); ok {
+		if statusError, ok := err.(kerrors.APIStatus); ok {
 			status := statusError.Status()
 			status.Message = fmt.Sprintf("error when %s %q: %v", verb, source, status.Message)
-			return &errors.StatusError{ErrStatus: status}
+			return &kerrors.StatusError{ErrStatus: status}
 		}
 		return fmt.Errorf("error when %s %q: %v", verb, source, err)
 	}
@@ -113,11 +115,12 @@ func checkErr(err error, handleErr func(string)) {
 		return
 	}
 
-	if errors.IsInvalid(err) {
-		details := err.(*errors.StatusError).Status().Details
+	if kerrors.IsInvalid(err) {
+		details := err.(*kerrors.StatusError).Status().Details
 		prefix := fmt.Sprintf("The %s %q is invalid.\n", details.Kind, details.Name)
 		errs := statusCausesToAggrError(details.Causes)
 		handleErr(MultilineError(prefix, errs))
+		return
 	}
 
 	if noMatch, ok := err.(*meta.NoResourceMatchError); ok {
@@ -137,9 +140,11 @@ func checkErr(err error, handleErr func(string)) {
 	// handle multiline errors
 	if clientcmd.IsConfigurationInvalid(err) {
 		handleErr(MultilineError("Error in configuration: ", err))
+		return
 	}
 	if agg, ok := err.(utilerrors.Aggregate); ok && len(agg.Errors()) > 0 {
 		handleErr(MultipleErrors("", agg.Errors()))
+		return
 	}
 
 	msg, ok := StandardErrorMessage(err)
@@ -153,9 +158,16 @@ func checkErr(err error, handleErr func(string)) {
 }
 
 func statusCausesToAggrError(scs []unversioned.StatusCause) utilerrors.Aggregate {
-	errs := make([]error, len(scs))
-	for i, sc := range scs {
-		errs[i] = fmt.Errorf("%s: %s", sc.Field, sc.Message)
+	errs := make([]error, 0, len(scs))
+	errorMsgs := sets.NewString()
+	for _, sc := range scs {
+		// check for duplicate error messages and skip them
+		msg := fmt.Sprintf("%s: %s", sc.Field, sc.Message)
+		if errorMsgs.Has(msg) {
+			continue
+		}
+		errorMsgs.Insert(msg)
+		errs = append(errs, errors.New(msg))
 	}
 	return utilerrors.NewAggregate(errs)
 }
@@ -170,7 +182,7 @@ func StandardErrorMessage(err error) (string, bool) {
 	if debugErr, ok := err.(debugError); ok {
 		glog.V(4).Infof(debugErr.DebugError())
 	}
-	status, isStatus := err.(errors.APIStatus)
+	status, isStatus := err.(kerrors.APIStatus)
 	switch {
 	case isStatus:
 		switch s := status.Status(); {
@@ -179,7 +191,7 @@ func StandardErrorMessage(err error) (string, bool) {
 		default:
 			return fmt.Sprintf("Error from server: %s", err.Error()), true
 		}
-	case errors.IsUnexpectedObjectError(err):
+	case kerrors.IsUnexpectedObjectError(err):
 		return fmt.Sprintf("Server returned an unexpected response: %s", err.Error()), true
 	}
 	switch t := err.(type) {
@@ -498,7 +510,7 @@ func GetThirdPartyGroupVersions(discovery discovery.DiscoveryInterface) ([]unver
 	groupList, err := discovery.ServerGroups()
 	if err != nil {
 		// On forbidden or not found, just return empty lists.
-		if errors.IsForbidden(err) || errors.IsNotFound(err) {
+		if kerrors.IsForbidden(err) || kerrors.IsNotFound(err) {
 			return result, gvks, nil
 		}
 


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1257800
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/30313

Duplicate error messages are sometimes shown when displaying aggregate
errors:

`$ oc label pod/database-1-fn0r7 qwer1345%$$#=self`
```
* metadata.labels: Invalid value: "qwer1345%5602#": name part must match
* the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or
* 'my.name' or '123-abc')
* metadata.labels: Invalid value: "qwer1345%5602#": name part must match
* the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or
* 'my.name' or '123-abc')
* metadata.labels: Invalid value: "qwer1345%5602#": name part must match
* the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or
* 'my.name' or '123-abc')
```

This patch removes any duplicate messages (adjacent or not) that appear
in the final list of errors.

##### Before
`$ oc label pod/database-1-fn0r7 qwer1345%$$#=self`
```
The Pod "database-1-fn0r7" is invalid.

* metadata.labels: Invalid value: "qwer1345%24704#": name part must match the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or 'my.name' or '123-abc')
* metadata.labels: Invalid value: "qwer1345%24704#": name part must match the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or 'my.name' or '123-abc')
* metadata.labels: Invalid value: "qwer1345%24704#": name part must match the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or 'my.name' or '123-abc')
➜  origin git:(jvallejo_remove-duplicate-err-oclabel-ocenv) ✗ oc label pod/database-1-fn0r7 qwer1345%$$#=self
```

##### After
`$ oc label pod/database-1-fn0r7 qwer1345%$$#=self`
```
The Pod "database-1-fn0r7" is invalid.
metadata.labels: Invalid value: "qwer1345%24704#": name part must match the regex ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9] (e.g. 'MyName' or 'my.name' or '123-abc')
```

cc @fabianofranz 