### PR TITLE
improve grant page appearance, allow partial scope approval

### DIFF
--- a/pkg/auth/oauth/handlers/grant.go
+++ b/pkg/auth/oauth/handlers/grant.go
@@ -162,7 +162,7 @@ func (g *redirectGrant) GrantNeeded(user user.Info, grant *api.Grant, w http.Res
 	redirectURL.RawQuery = url.Values{
 		"then":         {req.URL.String()},
 		"client_id":    {grant.Client.GetId()},
-		"scopes":       {grant.Scope},
+		"scope":        {grant.Scope},
 		"redirect_uri": {grant.RedirectURI},
 	}.Encode()
 	http.Redirect(w, req, redirectURL.String(), http.StatusFound)

--- a/pkg/auth/oauth/registry/registry_test.go
+++ b/pkg/auth/oauth/registry/registry_test.go
@@ -239,7 +239,7 @@ func TestRegistryAndServer(t *testing.T) {
 			ClientAuthorization: testCase.ClientAuth,
 		}
 		if testCase.ClientAuth == nil {
-			grant.Err = apierrs.NewNotFound(oapi.Resource("OAuthClientAuthorization"), "test:test")
+			grant.GetErr = apierrs.NewNotFound(oapi.Resource("OAuthClientAuthorization"), "test:test")
 		}
 		storage := registrystorage.New(access, authorize, client, NewUserConversion())
 		config := osinserver.NewDefaultServerConfig()

--- a/pkg/auth/server/grant/templates.go
+++ b/pkg/auth/server/grant/templates.go
@@ -1,0 +1,168 @@
+package grant
+
+import "html/template"
+
+var defaultGrantTemplate = template.Must(template.New("defaultGrantForm").Parse(defaultGrantTemplateString))
+
+const defaultGrantTemplateString = `<!DOCTYPE html>
+
+<html>
+
+<head>
+    <title>
+      Authorize 
+      {{ if and .ServiceAccountName .ServiceAccountNamespace }}
+        service account {{ .ServiceAccountName }} in project {{ .ServiceAccountNamespace }}
+      {{ else }}
+        {{ .Values.ClientID }}
+      {{ end }}
+    </title>
+    <style>
+        body    { font-family: sans-serif; line-height: 1.2em; margin: 2em 5%; color: #363636; }
+
+        table         { border-collapse: collapse; margin: 2em 0; width: 100%; max-width: 600px; }
+        table caption { text-align: left; }
+        td            { padding: .5em .25em; vertical-align: top; }
+        tr + tr       { border-top: 1px solid #d1d1d1; }
+
+        h1,h2,h3 { font-weight: normal; line-height: 1.3em; }
+
+        input[type=submit]                      { font-size: 1em;   }
+        input[type=submit] + input[type=submit] { margin-left: 1em; }
+
+        .identifier-highlight { color: #8b8d8f; }
+
+        .scope-title         { font-size: .9em; font-weight: bold; padding-top: .1em; padding-bottom: .25em; }
+        .scope-details       { font-size: .8em; }
+        .redirect-info       { font-size: .8em; margin: 2em 0 2em .25em; }
+        .existing-permission { color: #3f9c35; text-align: center; }
+
+        .muted   { color: #9c9c9c; }
+        .warning { color: #ec7a08; }
+        .error   { color: #cc0000; }
+
+        @media (max-width:481px) {
+          body { margin: .5em; }
+          h1,h2,h3 { margin: 0; padding-bottom: .5em; }
+          table { margin: .5em 0 }
+          input[type=submit] { display: block; width: 100%; margin: 1em 0 !important; }
+          h1 { font-size: 1.5em; }
+          h2 { font-size: 1.3em; }
+          h3 { font-size: 1.1em; }
+        }
+    </style>
+</head>
+
+<!-- Define a subtemplate to use for rendering existing or requested scopes -->
+{{ define "scope" }}
+          <div class="scope-title">{{ .Name }}</div>
+          {{ if .Description }}<div class="scope-details muted"  >{{ .Description }}</div>
+{{ end -}}
+          {{ if .Warning     }}<div class="scope-details warning">{{ .Warning }}</div>
+{{ end -}}
+          {{ if .Error       }}<div class="scope-details error"  >{{ .Error }}</div>
+{{ end -}}
+{{ end }}
+
+<body>
+{{ if .Error }}
+<div class="error">{{ .Error }}</div>
+{{ else }}
+<form action="{{ .Action }}" method="POST">
+  <input type="hidden" name="{{ .Names.Then        }}" value="{{ .Values.Then        }}">
+  <input type="hidden" name="{{ .Names.CSRF        }}" value="{{ .Values.CSRF        }}">
+  <input type="hidden" name="{{ .Names.ClientID    }}" value="{{ .Values.ClientID    }}">
+  <input type="hidden" name="{{ .Names.UserName    }}" value="{{ .Values.UserName    }}">
+  <input type="hidden" name="{{ .Names.RedirectURI }}" value="{{ .Values.RedirectURI }}">
+
+  <h1>Authorize Access</h1>
+
+  <h3>
+    {{ if and .ServiceAccountName .ServiceAccountNamespace }}
+      Service account <span class="identifier-highlight">{{ .ServiceAccountName }}</span> in project <span class="identifier-highlight">{{ .ServiceAccountNamespace }}</span>
+    {{ else }}
+      <span class="identifier-highlight">{{ .Values.ClientID }}</span>
+    {{ end }}
+
+    is requesting
+    
+    {{ if .GrantedScopes }}
+      additional permissions
+    {{ else }}
+      permission
+    {{ end }}
+    
+    to access your account (<span class="identifier-highlight">{{ .Values.UserName }}</span>)
+  </h3>
+
+  <!-- Display scopes that have already been granted -->
+  {{ if .GrantedScopes -}}
+  <table>
+    <caption>Existing access</caption>
+    <colgroup><col><col width="100%"></colgroup>
+    {{ range $i,$scope := .GrantedScopes -}}
+    <tr>
+      <td>
+        <div class="scope-title existing-permission">&#10003;</div>
+        <!-- Add an invisible checkbox to make spacing match the "requested permissions" table -->
+        <input type="checkbox" checked disabled style="visibility:hidden">
+      </td>
+      <td>
+        <div>
+{{ template "scope" . }}
+        </div>
+      </td>
+    </tr>
+    {{ end }}
+  </table>
+  {{ end }}
+
+  <!-- Write hidden inputs for requested scopes that have already been granted -->
+  {{ range $i,$scope := .Values.Scopes -}}
+    {{ if .Granted -}}
+      <input type="hidden" name="{{ $.Names.Scopes }}" value="{{ .Name }}">
+    {{- end }}
+  {{ end }}
+
+  <!-- Display requested scopes that have not been granted -->
+  <table>
+    <caption>
+      {{- if .GrantedScopes -}}
+        Additional requested permissions
+      {{- else -}}
+        Requested permissions
+      {{- end -}}
+    </caption>
+    <colgroup><col><col width="100%"></colgroup>
+  {{ range $i,$scope := .Values.Scopes }}
+    {{ if not .Granted }}
+    <tr>
+      <td>
+        <input type="checkbox" checked name="{{ $.Names.Scopes }}" value="{{ .Name }}" id="scope-{{$i}}">
+      </td>
+      <td>
+        <label for="scope-{{ $i }}">
+{{ template "scope" . }}
+        </label>
+      </td>
+    </tr>
+    {{ end }}
+  {{ end }}
+  </table>
+
+  <!-- Tell the user where they're going -->
+  {{ if .Values.RedirectURI -}}
+  <div class="redirect-info">
+    <div class="muted">You will be redirected to {{ .Values.RedirectURI }}</div>
+  </div>
+  {{- end }}
+
+  <div>
+    <input type="submit" name="{{ .Names.Approve }}" value="Allow selected permissions">
+    <input type="submit" name="{{ .Names.Deny    }}" value="Deny">
+  </div>
+</form>
+{{ end }}
+</body>
+</html>
+`

--- a/pkg/oauth/registry/test/clientauthorization.go
+++ b/pkg/oauth/registry/test/clientauthorization.go
@@ -9,11 +9,17 @@ import (
 )
 
 type ClientAuthorizationRegistry struct {
-	Err                            error
-	ClientAuthorizations           *api.OAuthClientAuthorizationList
-	ClientAuthorization            *api.OAuthClientAuthorization
-	CreatedAuthorization           *api.OAuthClientAuthorization
-	UpdatedAuthorization           *api.OAuthClientAuthorization
+	GetErr               error
+	ClientAuthorizations *api.OAuthClientAuthorizationList
+	ClientAuthorization  *api.OAuthClientAuthorization
+
+	CreateErr            error
+	CreatedAuthorization *api.OAuthClientAuthorization
+
+	UpdateErr            error
+	UpdatedAuthorization *api.OAuthClientAuthorization
+
+	DeleteErr                      error
 	DeletedClientAuthorizationName string
 }
 
@@ -22,24 +28,24 @@ func (r *ClientAuthorizationRegistry) ClientAuthorizationName(userName, clientNa
 }
 
 func (r *ClientAuthorizationRegistry) ListClientAuthorizations(ctx kapi.Context, options *kapi.ListOptions) (*api.OAuthClientAuthorizationList, error) {
-	return r.ClientAuthorizations, r.Err
+	return r.ClientAuthorizations, r.GetErr
 }
 
 func (r *ClientAuthorizationRegistry) GetClientAuthorization(ctx kapi.Context, name string) (*api.OAuthClientAuthorization, error) {
-	return r.ClientAuthorization, r.Err
+	return r.ClientAuthorization, r.GetErr
 }
 
 func (r *ClientAuthorizationRegistry) CreateClientAuthorization(ctx kapi.Context, grant *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
 	r.CreatedAuthorization = grant
-	return r.ClientAuthorization, r.Err
+	return r.ClientAuthorization, r.CreateErr
 }
 
 func (r *ClientAuthorizationRegistry) UpdateClientAuthorization(ctx kapi.Context, grant *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
 	r.UpdatedAuthorization = grant
-	return r.ClientAuthorization, r.Err
+	return r.ClientAuthorization, r.UpdateErr
 }
 
 func (r *ClientAuthorizationRegistry) DeleteClientAuthorization(ctx kapi.Context, name string) error {
 	r.DeletedClientAuthorizationName = name
-	return r.Err
+	return r.DeleteErr
 }


### PR DESCRIPTION
* displays descriptions of the requested scopes
* displays warnings about escalating scopes
* displays service account oauth clients nicely (`Service account <foo> in project <bar>...`)
* allows withholding some of the requested scopes
* ensures the username present when the grant page was shown matches the authenticated user when submitting the form

To exercise various permutations of the page:

1. Create a prompting OAuth client and an OAuth service account:

    ```
    oc create -f - <<< '{"kind":"OAuthClient","apiVersion":"v1","metadata":{"name":"myclient"},"grantMethod":"prompt","redirectURIs":["http://localhost"]}'
    oc annotate sa/builder -n default 'serviceaccounts.openshift.io/oauth-redirecturi.one=http://localhost'
    ```
2. Start the OAuth flow requesting a bunch of scopes ([example oauth client link](https://localhost:8443/oauth/authorize?client_id=myclient&response_type=token&scope=user:info user:check-access user:full role:admin:* role:admin:*:! role:admin:my-namespace role:admin:my-namespace:!), [example service account link](https://localhost:8443/oauth/authorize?client_id=system:serviceaccount:default:builder&response_type=token&scope=user:info user:check-access role:admin:default role:admin:default:!))

3. Go through the flow several times, exercising various permutations:
  * Click "Deny", you are redirected to localhost with an access_denied error
  * Uncheck all permissions and "approve selected", you are redirected to localhost with an access_denied error
  * Check only one or two permissions and "approve selected", you are redirected to localhost with an access token and the approved scopes in a scope parameter
  * After approving a couple permissions, the page shows existing access and allows selecting/unselecting remaining requested permissions
  * Once all permissions have been approved, token request flows no longer show the prompting page 

At each step, the OAuthClientAuthorization object for the user should include all the scopes approved thus far, and the created OAuthAccessToken objects should include the scopes that were both requested AND approved.


Before:
![screen shot 2016-08-10 at 1 39 02 am](https://cloud.githubusercontent.com/assets/980082/17543011/78c8eca4-5e9b-11e6-95f2-db128a740844.png)

After
No existing permissions:
![screen shot 2016-08-12 at 11 49 46 am](https://cloud.githubusercontent.com/assets/980082/17628389/19df4bc2-6083-11e6-92d0-3974a7e9ef54.png)

With existing permissions:
![screen shot 2016-08-12 at 11 50 40 am](https://cloud.githubusercontent.com/assets/980082/17628398/222ca57c-6083-11e6-9a5c-836ea68e55cf.png)

When the client is a service account:
![screen shot 2016-08-12 at 2 09 39 pm](https://cloud.githubusercontent.com/assets/980082/17632478/781735d4-6096-11e6-8505-e5afb1987f69.png)


Mobile view:
![screen shot 2016-08-15 at 10 28 49](https://cloud.githubusercontent.com/assets/980082/17667519/3c57db0e-62d3-11e6-98a0-18ba8e8493f1.png)
![screen shot 2016-08-15 at 10 29 03](https://cloud.githubusercontent.com/assets/980082/17667520/3c5cd8f2-62d3-11e6-9418-c2830e28336f.png)

![screen shot 2016-08-15 at 10 29 43](https://cloud.githubusercontent.com/assets/980082/17667521/3c6971a2-62d3-11e6-9934-a4c4ebde2721.png)
