### PR TITLE
local tmpfile may be not closed when 'DownloadFromContainer' returns err

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -267,6 +267,7 @@ func copyImageSource(dockerClient DockerClient, containerID, sourceDir, destDir 
 		Path:         sourceDir,
 	})
 	if err != nil {
+		tempFile.Close()
 		return err
 	}
 	if err := tempFile.Close(); err != nil {


### PR DESCRIPTION
In function copyImageSource, if dockerClient.DownloadFromContainer returns err, tempFile will not be closed.