### PR TITLE
Bug 1363630 - Print shortened parent ID in oadm top images

### DIFF
--- a/pkg/cmd/admin/top/images.go
+++ b/pkg/cmd/admin/top/images.go
@@ -32,6 +32,7 @@ usage statistics.`
 
 	topImagesExample = `  # Show usage statistics for Images
   %[1]s %[2]s`
+	maxImageIDLength = 20
 )
 
 // NewCmdTopImages implements the OpenShift cli top images command.
@@ -127,7 +128,15 @@ var _ Info = &imageInfo{}
 func (i imageInfo) PrintLine(out io.Writer) {
 	printValue(out, i.Image)
 	printArray(out, i.ImageStreamTags)
-	printArray(out, i.Parents)
+	shortParents := make([]string, len(i.Parents))
+	for i, p := range i.Parents {
+		if len(p) > maxImageIDLength {
+			shortParents[i] = p[:maxImageIDLength-3] + "..."
+		} else {
+			shortParents[i] = p
+		}
+	}
+	printArray(out, shortParents)
 	printArray(out, i.Usage)
 	printBool(out, i.Metadata)
 	printSize(out, i.Storage)

--- a/pkg/cmd/admin/top/printer.go
+++ b/pkg/cmd/admin/top/printer.go
@@ -31,7 +31,11 @@ func printHeader(out io.Writer, columns []string) {
 }
 
 func printArray(out io.Writer, values []string) {
-	printValue(out, strings.Join(values, ","))
+	if len(values) == 0 {
+		printValue(out, "<none>")
+	} else {
+		printValue(out, strings.Join(values, ", "))
+	}
 }
 
 func printValue(out io.Writer, value interface{}) {

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -489,7 +489,7 @@ os::test::junit::declare_suite_start "cmd/admin/images"
 
 # import image and check its information
 os::cmd::expect_success "oc create -f ${OS_ROOT}/test/testdata/stable-busybox.yaml"
-os::cmd::expect_success_and_text "oadm top images" "sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6\W+default/busybox \(latest\)\W+yes\W+0.65MiB"
+os::cmd::expect_success_and_text "oadm top images" "sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6\W+default/busybox \(latest\)\W+<none>\W+<none>\W+yes\W+0\.65MiB"
 os::cmd::expect_success_and_text "oadm top imagestreams" "default/busybox\W+0.65MiB\W+1\W+1"
 
 # log in as an image-pruner and test that oadm prune images works against the atomic binary


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1363630.

@miminar || @legionus ptal