### PR TITLE
fix broken paths and redirects for s2i images/repos

### DIFF
--- a/pkg/cmd/experimental/buildchain/test/multiple-namespaces-bcs.yaml
+++ b/pkg/cmd/experimental/buildchain/test/multiple-namespaces-bcs.yaml
@@ -106,7 +106,6 @@ items:
           kind: DockerImage
           name: centos/ruby-22-centos7
         incremental: true
-        scripts: https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin
       type: Source
     triggers:
     - imageChange: {}
@@ -138,7 +137,6 @@ items:
           kind: DockerImage
           name: centos/ruby-22-centos7
         incremental: true
-        scripts: https://raw.githubusercontent.com/centos/ruby-22-centos7/master/.sti/bin
       type: Source
     triggers:
     - imageChange: {}

--- a/pkg/cmd/experimental/buildchain/test/single-namespace-bcs.yaml
+++ b/pkg/cmd/experimental/buildchain/test/single-namespace-bcs.yaml
@@ -102,7 +102,6 @@ items:
           kind: DockerImage
           name: centos/ruby-22-centos7
         incremental: true
-        scripts: https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin
       type: Source
     triggers:
     - imageChange: {}
@@ -134,7 +133,6 @@ items:
           kind: DockerImage
           name: centos/ruby-22-centos7
         incremental: true
-        scripts: https://raw.githubusercontent.com/centos/ruby-22-centos7/master/.sti/bin
       type: Source
     triggers:
     - imageChange: {}

--- a/test/extended/images/mongodb_replica.go
+++ b/test/extended/images/mongodb_replica.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[images][mongodb] openshift mongodb replication", func() {
 	defer g.GinkgoRecover()
 
 	const (
-		templatePath         = "https://raw.githubusercontent.com/openshift/mongodb/master/2.4/examples/replica/mongodb-clustered.json"
+		templatePath         = "https://raw.githubusercontent.com/sclorg/mongodb-container/master/2.4/examples/replica/mongodb-clustered.json"
 		deploymentConfigName = "mongodb"
 		expectedValue        = `{ "status" : "passed" }`
 		insertCmd            = "db.bar.save(" + expectedValue + ")"

--- a/test/extended/images/mysql_replica.go
+++ b/test/extended/images/mysql_replica.go
@@ -26,13 +26,13 @@ var (
 	testCases = []testCase{
 		{
 			"5.5",
-			"https://raw.githubusercontent.com/openshift/mysql/master/5.5/examples/replica/mysql_replica.json",
+			"https://raw.githubusercontent.com/sclorg/mysql-container/master/5.5/examples/replica/mysql_replica.json",
 			// NOTE: Set to true in case of flakes.
 			false,
 		},
 		{
 			"5.6",
-			"https://raw.githubusercontent.com/openshift/mysql/master/5.6/examples/replica/mysql_replica.json",
+			"https://raw.githubusercontent.com/sclorg/mysql-container/master/5.6/examples/replica/mysql_replica.json",
 			false,
 		},
 	}

--- a/test/extended/images/postgresql_replica.go
+++ b/test/extended/images/postgresql_replica.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	postgreSQLReplicationTemplate = "https://raw.githubusercontent.com/openshift/postgresql/master/examples/replica/postgresql_replica.json"
+	postgreSQLReplicationTemplate = "https://raw.githubusercontent.com/sclorg/postgresql-container/master/examples/replica/postgresql_replica.json"
 	postgreSQLEphemeralTemplate   = exutil.FixturePath("..", "..", "examples", "db-templates", "postgresql-ephemeral-template.json")
 	postgreSQLHelperName          = "postgresql-helper"
 	postgreSQLImages              = []string{

--- a/test/integration/testdata/test-buildcli-beta2.json
+++ b/test/integration/testdata/test-buildcli-beta2.json
@@ -49,7 +49,6 @@
               "kind": "ImageStreamTag",
               "name": "ruby-22-centos-buildcli:valid"
             },
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-22-centos/master/.sti/bin",
             "incremental": true
           }
         },
@@ -92,7 +91,6 @@
               "kind": "ImageStreamTag",
               "name": "ruby-22-centos-buildcli:invalid"
             },
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-22-centos/master/.sti/bin",
             "incremental": true
           }
         },

--- a/test/integration/testdata/test-buildcli.json
+++ b/test/integration/testdata/test-buildcli.json
@@ -49,7 +49,6 @@
               "kind": "DockerImage",
               "name": "centos/ruby-22-centos7"
             },
-            "scripts": "https://raw.githubusercontent.com/centos/ruby-22-centos7/master/.sti/bin",
             "incremental": true
           }
         },
@@ -92,7 +91,6 @@
               "kind": "DockerImage",
               "name": "centos/ruby-22-centos7"
             },
-            "scripts": "https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin",
             "incremental": true
           }
         },


### PR DESCRIPTION
@bparees PTAL.
btw, for example `https://raw.githubusercontent.com/centos/ruby-22-centos7/master/.sti/bin` is returning a 404, which means i'm not sure if it's actually used in the tests at all?