### PR TITLE
Ensure only endpoints are specified in `oc idle`

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1576,7 +1576,7 @@ Idle scalable resources
 [options="nowrap"]
 ----
   # Idle the scalable controllers associated with the services listed in to-idle.txt
-  $ oc idle -f to-idle.txt
+  $ oc idle --resource-names-file to-idle.txt
 ----
 ====
 

--- a/docs/man/man1/oc-idle.1
+++ b/docs/man/man1/oc-idle.1
@@ -120,7 +120,7 @@ associated resources by scaling them back up to their previous scale.
 
 .nf
   # Idle the scalable controllers associated with the services listed in to\-idle.txt
-  $ oc idle \-f to\-idle.txt
+  $ oc idle \-\-resource\-names\-file to\-idle.txt
 
 .fi
 .RE

--- a/docs/man/man1/openshift-cli-idle.1
+++ b/docs/man/man1/openshift-cli-idle.1
@@ -120,7 +120,7 @@ associated resources by scaling them back up to their previous scale.
 
 .nf
   # Idle the scalable controllers associated with the services listed in to\-idle.txt
-  $ openshift cli idle \-f to\-idle.txt
+  $ openshift cli idle \-\-resource\-names\-file to\-idle.txt
 
 .fi
 .RE

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -45,7 +45,7 @@ Upon receiving network traffic, the services (and any associated routes) will "w
 associated resources by scaling them back up to their previous scale.`
 
 	idleExample = `  # Idle the scalable controllers associated with the services listed in to-idle.txt
-  $ %[1]s idle -f to-idle.txt`
+  $ %[1]s idle --resource-names-file to-idle.txt`
 )
 
 // NewCmdStatus implements the OpenShift cli status command

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -253,7 +253,15 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 
 	decoder := f.Decoder(true)
 	err = o.svcBuilder.Do().Visit(func(info *resource.Info, err error) error {
-		endpoints := info.Object.(*api.Endpoints)
+		if err != nil {
+			return err
+		}
+
+		endpoints, isEndpoints := info.Object.(*api.Endpoints)
+		if !isEndpoints {
+			return fmt.Errorf("you must specify endpoints, not %vs", info.Mapping.Resource)
+		}
+
 		endpointsName := types.NamespacedName{
 			Namespace: endpoints.Namespace,
 			Name:      endpoints.Name,

--- a/test/cmd/idle.sh
+++ b/test/cmd/idle.sh
@@ -59,6 +59,7 @@ EOF
 
 os::test::junit::declare_suite_start "cmd/idle/by-name"
 setup_idling_resources
+os::cmd::expect_failure 'oc idle dc/idling-echo' # make sure manually passing non-endpoints resources fails
 os::cmd::expect_success_and_text 'oc idle idling-echo' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/idling-echo \(unidle to 2 replicas\)"
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${idled_at_template}'" '.'
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${unidle_target_template}' | jq 'length == 1 and (.[0] | .replicas == 2 and .name == \"idling-echo\" and .kind == \"DeploymentConfig\")'" 'true'


### PR DESCRIPTION
When you call `oc idle` with only names, it treats those names as
endpoints.  However, if you manually specify a different resource
in "resource/name" format, `oc idle` would panic, as it was expecting
only endpoints.  This commit throws an error instead when this situation
is encountered.

This PR also contains a fix for a typo in the `oc idle` help text.

Fixes bug 1365838 
Fixes bug 1365803