### PR TITLE
Fix for BZ1364870 - connections hang around in the CLOSE_WAIT state

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -45,6 +45,7 @@ defaults
   timeout server 30s
   # Long timeout for WebSocket connections.
   timeout tunnel 1h
+  option forceclose
 
 {{ if (gt .StatsPort 0) }}
 listen stats :{{.StatsPort}}


### PR DESCRIPTION
Many HAProxy processes remain active and CPU intensive waiting in the
CLOSE_WAIT state for a client that will not respond until the timeout
tunnel expires. This should allow haproxy to activly close connections

[BZ1364870](https://bugzilla.redhat.com/show_bug.cgi?id=1364870)