### PR TITLE
remove redundant example from `oc projects`

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1909,19 +1909,6 @@ Switch to another project
 ====
 
 
-== oc projects
-Display existing projects
-
-====
-
-[options="nowrap"]
-----
-  # Display the projects that currently exist
-  oc
-----
-====
-
-
 == oc proxy
 Run a proxy to the Kubernetes API server
 

--- a/docs/man/man1/oc-projects.1
+++ b/docs/man/man1/oc-projects.1
@@ -92,18 +92,6 @@ command.
     The name of the kubeconfig user to use
 
 
-.SH EXAMPLE
-.PP
-.RS
-
-.nf
-  # Display the projects that currently exist
-  oc
-
-.fi
-.RE
-
-
 .SH SEE ALSO
 .PP
 \fBoc(1)\fP,

--- a/docs/man/man1/openshift-cli-projects.1
+++ b/docs/man/man1/openshift-cli-projects.1
@@ -92,18 +92,6 @@ command.
     The name of the kubeconfig user to use
 
 
-.SH EXAMPLE
-.PP
-.RS
-
-.nf
-  # Display the projects that currently exist
-  openshift cli
-
-.fi
-.RE
-
-
 .SH SEE ALSO
 .PP
 \fBopenshift\-cli(1)\fP,

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -50,9 +50,6 @@ Display information about the current active project and existing projects on th
 
 For advanced configuration, or to manage the contents of your config file, use the 'config'
 command.`
-
-	projectsExample = `  # Display the projects that currently exist
-  %[1]s`
 )
 
 // NewCmdProjects implements the OpenShift cli rollback command
@@ -60,10 +57,9 @@ func NewCmdProjects(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	options := &ProjectsOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "projects",
-		Short:   "Display existing projects",
-		Long:    projectsLong,
-		Example: fmt.Sprintf(projectsExample, fullName),
+		Use:   "projects",
+		Short: "Display existing projects",
+		Long:  projectsLong,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
 


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1351979
Removes unneeded example from `oc projects` usage text.

##### Before
`$ oc projects -h`
```
Display information about the current active project and existing projects on the server.

For advanced configuration, or to manage the contents of your config file, use the 'config'
command.

Usage:
  oc projects [options]

Examples:
  # Display the projects that currently exist
  oc

Options:
  -q, --short=false: If true, display only the project names

Use "oc options" for a list of global command-line options (applies to all commands).
```

##### After
`$ oc projects -h`
```
Display information about the current active project and existing projects on the server.

For advanced configuration, or to manage the contents of your config file, use the 'config'
command.

Usage:
  oc projects [options]
Options:
  -q, --short=false: If true, display only the project names

Use "oc options" for a list of global command-line options (applies to all commands).
```

cc @fabianofranz 