### PR TITLE
show namespace for custom strategy bc

### DIFF
--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -317,6 +317,11 @@ func printBuildConfig(bc *buildapi.BuildConfig, w io.Writer, opts kctl.PrintOpti
 	from := describeSourceShort(bc.Spec.CommonSpec)
 
 	if bc.Spec.Strategy.CustomStrategy != nil {
+		if opts.WithNamespace {
+			if _, err := fmt.Fprintf(w, "%s\t", bc.Namespace); err != nil {
+				return err
+			}
+		}
 		_, err := fmt.Fprintf(w, "%s\t%v\t%s\t%d\n", name, buildapi.StrategyType(bc.Spec.Strategy), bc.Spec.Strategy.CustomStrategy.From.Name, bc.Status.LastVersion)
 		return err
 	}

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -300,20 +300,6 @@ os::cmd::expect_success_and_text "oc get route route-with-set-port --template='{
 echo "expose: ok"
 os::test::junit::declare_suite_end
 
-# Test that resource printer includes resource kind on multiple resources
-os::test::junit::declare_suite_start "cmd/basicresources/get"
-os::cmd::expect_success 'oc create imagestream test1'
-os::cmd::expect_success 'oc new-app node'
-os::cmd::expect_success_and_text 'oc get all' 'is/test1'
-os::cmd::expect_success_and_not_text 'oc get is' 'is/test1'
-echo "resource printer: ok"
-# Test that resource printer includes namespaces for buildconfigs with custom strategies
-os::cmd::expect_success 'oc create -f examples/sample-app/application-template-custombuild.json'
-os::cmd::expect_failure_and_text 'oc new-app ruby-helloworld-sample' 'deploymentconfig "frontend" created'
-os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-basicresources[\ ]+bc\/ruby\-sample\-build'
-echo "resource printer namespace handling: ok"
-os::test::junit::declare_suite_end
-
 # Test OAuth access token describer
 os::cmd::expect_success 'oc create -f test/testdata/oauthaccesstoken.yaml'
 os::cmd::expect_success_and_text "oc describe oauthaccesstoken DYGZDLucARCPIfUeKPhsgPfn0WBLR_9KdeREH0c9iod" "DYGZDLucARCPIfUeKPhsgPfn0WBLR_9KdeREH0c9iod"

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -307,6 +307,11 @@ os::cmd::expect_success 'oc new-app node'
 os::cmd::expect_success_and_text 'oc get all' 'is/test1'
 os::cmd::expect_success_and_not_text 'oc get is' 'is/test1'
 echo "resource printer: ok"
+# Test that resource printer includes namespaces for buildconfigs with custom strategies
+os::cmd::expect_success 'oc create -f examples/sample-app/application-template-custombuild.json'
+os::cmd::expect_failure_and_text 'oc new-app ruby-helloworld-sample' 'deploymentconfig "frontend" created'
+os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-basicresources[\ ]+bc\/ruby\-sample\-build'
+echo "resource printer namespace handling: ok"
 os::test::junit::declare_suite_end
 
 # Test OAuth access token describer

--- a/test/cmd/printer.sh
+++ b/test/cmd/printer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+# Test that resource printer includes resource kind on multiple resources
+os::test::junit::declare_suite_start "cmd/basicresources/printer"
+os::cmd::expect_success 'oc create imagestream test1'
+os::cmd::expect_success 'oc new-app node'
+os::cmd::expect_success_and_text 'oc get all' 'is/test1'
+os::cmd::expect_success_and_not_text 'oc get is' 'is/test1'
+
+# Test that resource printer includes namespaces for buildconfigs with custom strategies
+os::cmd::expect_success 'oc create -f examples/sample-app/application-template-custombuild.json'
+os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample' 'deploymentconfig "frontend" created'
+os::cmd::expect_success_and_text 'oc get all --all-namespaces' 'cmd-printer[\ ]+bc\/ruby\-sample\-build'
+echo "resource printer: ok"
+os::test::junit::declare_suite_end


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1365460

If there is a `bc` using a custom strategy, `oc get all --all-namespaces` does not show namespace for that `bc`.

cc @fabianofranz 