### PR TITLE
add suggestion to use `describe` to obtain container names

### DIFF
--- a/pkg/cmd/templates/templater.go
+++ b/pkg/cmd/templates/templater.go
@@ -129,6 +129,8 @@ func (templater *templater) UsageFunc(exposedFlags ...string) func(*cobra.Comman
 			"rootCmd":             templater.rootCmdName,
 			"isRootCmd":           templater.isRootCmd,
 			"optionsCmdFor":       templater.optionsCmdFor,
+			"describeCmdFor":      templater.describeCmdFor,
+			"hasContainerOption":  templater.hasContainerOption,
 			"usageLine":           templater.usageLine,
 			"exposed": func(c *cobra.Command) *flag.FlagSet {
 				exposed := flag.NewFlagSet("exposed", flag.ContinueOnError)
@@ -187,6 +189,21 @@ func (t *templater) rootCmd(c *cobra.Command) *cobra.Command {
 		panic("nil root cmd")
 	}
 	return t.RootCmd
+}
+
+func (t *templater) hasContainerOption(c *cobra.Command) bool {
+	if flag := c.Flags().Lookup("container"); flag != nil {
+		return true
+	}
+	return false
+}
+
+func (t *templater) describeCmdFor(c *cobra.Command) string {
+	if !c.Runnable() {
+		return ""
+	}
+
+	return t.RootCmd.CommandPath() + " describe"
 }
 
 func (t *templater) optionsCmdFor(c *cobra.Command) string {

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -31,6 +31,8 @@ const (
 		`{{$visibleFlags := visibleFlags (flagsNotIntersected .LocalFlags .PersistentFlags)}}` +
 		`{{$explicitlyExposedFlags := exposed .}}` +
 		`{{$optionsCmdFor := optionsCmdFor .}}` +
+		`{{$describeCmdFor := describeCmdFor .}}` +
+		`{{$hasContainerOption := hasContainerOption .}}` +
 		`{{$usageLine := usageLine .}}`
 
 	mainHelpTemplate = `{{.Long | trim}}
@@ -49,7 +51,8 @@ Examples:
 {{end}}{{end}}{{ if or $visibleFlags.HasFlags $explicitlyExposedFlags.HasFlags}}
 Options:
 {{ if $visibleFlags.HasFlags}}{{flagsUsages $visibleFlags}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{flagsUsages $explicitlyExposedFlags}}{{end}}{{end}}{{ if .HasSubCommands }}
-Use "{{$rootCmd}} <command> --help" for more information about a given command.{{end}}{{ if $optionsCmdFor}}
+Use "{{$rootCmd}} <command> --help" for more information about a given command.{{end}}{{ if $optionsCmdFor}}{{ if $hasContainerOption}}
+Use "{{$describeCmdFor}} POD" to obtain container name values for that pod.{{end}}
 Use "{{$optionsCmdFor}}" for a list of global command-line options (applies to all commands).{{end}}`
 
 	optionsHelpTemplate = ``


### PR DESCRIPTION
Fixes #10283

Commands with the `--container=` option provide no suggestions to a user
on how to obtain a container's name from a pod.

This patch adds a suggestion on the usage output to use the `describe`
command on a pod to obtain the container value that is passed to the
`--container=` flag.

##### After
`$ oc exec -h`
```
Execute a command in a container

Usage:
  oc exec [options] POD [-c CONTAINER] -- COMMAND [args...]

Examples:
  # Get output from running 'date' in ruby-container from pod 'mypod'
  oc exec mypod -c ruby-container date

  # Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 'mypod' and sends stdout/stderr from 'bash' back to the client
  oc exec mypod -c ruby-container -i -t -- bash -il

Options:
  -c, --container='': Container name. If omitted, the first container in the pod will be chosen
  -p, --pod='': Pod name (deprecated)
  -i, --stdin=false: Pass stdin to the container
  -t, --tty=false: Stdin is a TTY


Use "oc describe POD" to obtain container name values for a pod.
Use "oc options" for a list of global command-line options (applies to all commands).
```

##### Commands affected
- `oc rsh -h`
- `oc rsync -h`
- `oc exec -h`
- `oc debug -h`
- `oc attach -h`
- `oc logs -h`
- `openshift kube logs -h`
- `openshift kube rolling-update -h`
- `openshift kube attach -h`
- `openshift kube exec -h`

cc @fabianofranz 