### PR TITLE
add zsh compatibility note to `completion` usage output

### DIFF
--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -68,16 +68,18 @@ Output shell completion code for the given shell (bash or zsh)
   oadm completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # The above example depends on the bash-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash-completion
   source $(brew --prefix)/etc/bash_completion
   oadm completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oadm completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 ----
 ====
 

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -68,16 +68,18 @@ Output shell completion code for the given shell (bash or zsh)
   oc adm completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # The above example depends on the bash-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash-completion
   source $(brew --prefix)/etc/bash_completion
   oc adm completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oc adm completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 ----
 ====
 
@@ -878,16 +880,18 @@ Output shell completion code for the given shell (bash or zsh)
   oc completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # The above example depends on the bash-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash-completion
   source $(brew --prefix)/etc/bash_completion
   oc completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oc completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 ----
 ====
 

--- a/docs/man/man1/oadm-completion.1
+++ b/docs/man/man1/oadm-completion.1
@@ -92,16 +92,18 @@ completion of oadm commands.
   oadm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   oadm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oadm completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/oc-adm-completion.1
+++ b/docs/man/man1/oc-adm-completion.1
@@ -92,16 +92,18 @@ completion of oc adm commands.
   oc adm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   oc adm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oc adm completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/oc-completion.1
+++ b/docs/man/man1/oc-completion.1
@@ -92,16 +92,18 @@ completion of oc commands.
   oc completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   oc completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(oc completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/openshift-admin-completion.1
+++ b/docs/man/man1/openshift-admin-completion.1
@@ -92,16 +92,18 @@ completion of openshift admin commands.
   openshift admin completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   openshift admin completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(openshift admin completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/openshift-cli-adm-completion.1
+++ b/docs/man/man1/openshift-cli-adm-completion.1
@@ -92,16 +92,18 @@ completion of openshift cli adm commands.
   openshift cli adm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   openshift cli adm completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(openshift cli adm completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/openshift-cli-completion.1
+++ b/docs/man/man1/openshift-cli-completion.1
@@ -92,16 +92,18 @@ completion of openshift cli commands.
   openshift cli completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   openshift cli completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(openshift cli completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/openshift-completion.1
+++ b/docs/man/man1/openshift-completion.1
@@ -36,16 +36,18 @@ completion of openshift commands.
   openshift completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # The above example depends on the bash\-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash\-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash\-completion
   source $(brew \-\-prefix)/etc/bash\_completion
   openshift completion bash > bash\_completion.sh
   source bash\_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
+  # In zsh*, the following will load openshift cli zsh completion:
   source <(openshift completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/docs/man/man1/openshift-kube-completion.1
+++ b/docs/man/man1/openshift-kube-completion.1
@@ -253,10 +253,11 @@ $ brew install bash\-completion
 $ source $(brew \-\-prefix)/etc/bash\_completion
 $ source <(kubectl completion bash)
 
-If you use zsh, the following will load kubectl zsh completion:
+If you use zsh*, the following will load kubectl zsh completion:
 
 $ source <(kubectl completion zsh)
 
+* zsh completions are only supported in versions of zsh >= 5.2
 
 .fi
 .RE

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -191,16 +191,18 @@ completion of %s commands.`
   %s completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # The above example depends on the bash-completion
-framework. It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
+  # The above example depends on the bash-completion framework.
+  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:
 
   brew install bash-completion
   source $(brew --prefix)/etc/bash_completion
   %s completion bash > bash_completion.sh
   source bash_completion.sh
 
-  # In zsh, the following will load openshift cli zsh completion:
-  source <(%s completion zsh)`
+  # In zsh*, the following will load openshift cli zsh completion:
+  source <(%s completion zsh)
+
+  * zsh completions are only supported in versions of zsh >= 5.2`
 )
 
 func NewCmdCompletion(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/completion.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/completion.go
@@ -41,10 +41,11 @@ $ brew install bash-completion
 $ source $(brew --prefix)/etc/bash_completion
 $ source <(kubectl completion bash)
 
-If you use zsh, the following will load kubectl zsh completion:
+If you use zsh*, the following will load kubectl zsh completion:
 
 $ source <(kubectl completion zsh)
-`
+
+* zsh completions are only supported in versions of zsh >= 5.2`
 )
 
 var (


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/30460

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1349291
Related BZ comment (internal):
https://bugzilla.redhat.com/show_bug.cgi?id=1349291#c3

zsh completions are not supported on versions of zsh < 5.2

Advice user on supported versions of zsh when using the `completion`
command to avoid potential UX failure.

`$ oc completion -h`
```
This command prints shell code which must be evaluated to provide interactive
completion of oc commands.

Usage:
  oc completion SHELL [options]

Examples:
  # Generate the oc completion code for bash
  oc completion bash > bash_completion.sh
  source bash_completion.sh

  # The above example depends on the bash-completion framework.
  It must be sourced before sourcing the openshift cli completion, i.e. on the Mac:

  brew install bash-completion
  source $(brew --prefix)/etc/bash_completion
  oc completion bash > bash_completion.sh
  source bash_completion.sh

  # In zsh*, the following will load openshift cli zsh completion:
  source <(oc completion zsh)

  * zsh completions are only supported in versions of zsh >= 5.2

Use "oc options" for a list of global command-line options (applies to all commands).
```

cc @fabianofranz 