### PR TITLE
emit warning on no liveness probe defined for pods

### DIFF
--- a/pkg/api/kubegraph/analysis/hpa.go
+++ b/pkg/api/kubegraph/analysis/hpa.go
@@ -11,6 +11,7 @@ import (
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	"github.com/openshift/origin/pkg/api/kubegraph"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
 	kubenodes "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph"
 	deploynodes "github.com/openshift/origin/pkg/deploy/graph/nodes"
@@ -117,6 +118,7 @@ func FindOverlappingHPAs(graph osgraph.Graph, namer osgraph.Namer) []osgraph.Mar
 	edgeFilter := osgraph.EdgesOfKind(
 		kubegraph.ScalingEdgeKind,
 		deploygraph.DeploymentEdgeKind,
+		kubeedges.ManagedByControllerEdgeKind,
 	)
 
 	hpaSubGraph := graph.Subgraph(nodeFilter, edgeFilter)

--- a/pkg/api/kubegraph/analysis/podspec_test.go
+++ b/pkg/api/kubegraph/analysis/podspec_test.go
@@ -80,3 +80,23 @@ func TestUnmountableSecrets(t *testing.T) {
 		t.Errorf("expected %v, got %v", expectedSecret2, markers)
 	}
 }
+
+func TestMissingLivenessProbes(t *testing.T) {
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/simple-deployment.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kubeedges.AddAllExposedPodEdges(g)
+
+	markers := FindMissingLivenessProbes(g, osgraph.DefaultNamer, "oc set probe")
+	if e, a := 1, len(markers); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	actualDC := osgraph.GetTopLevelContainerNode(g, markers[0].Node)
+	expectedDC := g.Find(osgraph.UniqueName("DeploymentConfig|/simple-deployment"))
+	if e, a := expectedDC.ID(), actualDC.ID(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -383,6 +383,9 @@ func getMarkerScanners(logsCommandName, securityPolicyCommandFormat, setProbeCom
 		func(g osgraph.Graph, f osgraph.Namer) []osgraph.Marker {
 			return deployanalysis.FindDeploymentConfigReadinessWarnings(g, f, setProbeCommandName)
 		},
+		func(g osgraph.Graph, f osgraph.Namer) []osgraph.Marker {
+			return kubeanalysis.FindMissingLivenessProbes(g, f, setProbeCommandName)
+		},
 		routeanalysis.FindPortMappingIssues,
 		routeanalysis.FindMissingTLSTerminationType,
 		routeanalysis.FindPathBasedPassthroughRoutes,

--- a/pkg/deploy/graph/edges.go
+++ b/pkg/deploy/graph/edges.go
@@ -6,6 +6,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
@@ -73,6 +74,7 @@ func AddDeploymentEdges(g osgraph.MutableUniqueGraph, node *deploygraph.Deployme
 			}
 			if BelongsToDeploymentConfig(node.DeploymentConfig, rcNode.ReplicationController) {
 				g.AddEdge(node, rcNode, DeploymentEdgeKind)
+				g.AddEdge(rcNode, node, kubeedges.ManagedByControllerEdgeKind)
 			}
 		}
 	}

--- a/test/cmd/set-liveness-probe.sh
+++ b/test/cmd/set-liveness-probe.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
+os::test::junit::declare_suite_start "cmd/set-probe-liveness"
+# This test setting a liveness probe, without warning about replication controllers whose deployment depends on deployment configs
+os::cmd::expect_success_and_text 'oc create -f pkg/api/graph/test/simple-deployment.yaml' 'deploymentconfig "simple-deployment" created'
+os::cmd::expect_success_and_text 'oc status -v' 'dc/simple-deployment has no liveness probe'
+os::cmd::expect_success_and_not_text 'oc status -v' 'rc/simple-deployment-1 has no liveness probe'
+os::cmd::expect_success_and_text 'oc set probe dc/simple-deployment --liveness --get-url=http://google.com:80' 'deploymentconfig "simple-deployment" updated'
+os::cmd::expect_success_and_not_text 'oc status -v' 'dc/simple-deployment has no liveness probe'
+echo "set-probe-liveness: ok"
+os::test::junit::declare_suite_end


### PR DESCRIPTION
fixes #10271

This patch iterates through pod specs, listing specs with no liveness
probes set. Any replication controllers whose deployment is fulfilled by
a DeploymentConfig are ignored.

**Example**
```
$ oc create -f pkg/api/graph/test/simple-deployment
deploymentconfig "simple-deployment" created

$ oc get all
NAME                   REVISION   DESIRED   CURRENT   TRIGGERED BY
dc/simple-deployment   1          1         0         config

NAME                     DESIRED   CURRENT   READY     AGE
rc/simple-deployment-1   0         0         0         1m

NAME                            READY     STATUS              RESTARTS
AGE
po/simple-deployment-1-deploy   0/1       ContainerCreating   0
1m

$ oc status -v
In project test on server https://10.111.123.56:8443

dc/simple-deployment deploys docker.io/openshift/deployment-example:v1
  deployment #1 pending 26 seconds ago

Warnings:
  * pod/simple-deployment-1-deploy has no liveness probe to verify pods are still running.
    try: oc set probe pod/simple-deployment-1-deploy --liveness ...
  * dc/simple-deployment has no liveness probe to verify pods are still running.
    try: oc set probe dc/simple-deployment --liveness ...

View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.
```
cc @fabianofranz @stevekuznetsov 