### PR TITLE
Pass the container name to deployment config log options

### DIFF
--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -132,6 +132,7 @@ func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, out io.Writer, cmd
 		o.Options = bopts
 	case deployapi.Resource("deploymentconfig"):
 		dopts := &deployapi.DeploymentLogOptions{
+			Container:    podLogOptions.Container,
 			Follow:       podLogOptions.Follow,
 			Previous:     podLogOptions.Previous,
 			SinceSeconds: podLogOptions.SinceSeconds,

--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -24,6 +24,7 @@ func DeploymentToPodLogOptions(opts *DeploymentLogOptions) *kapi.PodLogOptions {
 		Timestamps:   opts.Timestamps,
 		TailLines:    opts.TailLines,
 		LimitBytes:   opts.LimitBytes,
+		Container:    opts.Container,
 	}
 }
 

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -36,6 +36,7 @@ var _ = g.Describe("deploymentconfigs", func() {
 		historyLimitedDeploymentFixture = exutil.FixturePath("testdata", "deployment-history-limit.yaml")
 		minReadySecondsFixture          = exutil.FixturePath("testdata", "deployment-min-ready-seconds.yaml")
 		multipleICTFixture              = exutil.FixturePath("testdata", "deployment-example.yaml")
+		multiContainerFixture           = exutil.FixturePath("testdata", "test-deployment-config-multicontainer.yaml")
 	)
 
 	g.Describe("when run iteratively", func() {
@@ -456,6 +457,24 @@ var _ = g.Describe("deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
+	})
+
+	g.Describe("with logging with multiple containers [Conformance]", func() {
+		g.AfterEach(func() {
+			failureTrap(oc, "test-deployment-config-multicontainer", g.CurrentGinkgoTestDescription().Failed)
+		})
+
+		g.It("should be able to get the logs from each container", func() {
+			_, name, err := createFixture(oc, multiContainerFixture)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
+
+			_, err = oc.Run("logs").Args("dc/"+name, "-c", "container1").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			_, err = oc.Run("logs").Args("dc/"+name, "-c", "container2").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
 	})
 
 	g.Describe("with failing hook", func() {

--- a/test/extended/testdata/test-deployment-config-multicontainer.yaml
+++ b/test/extended/testdata/test-deployment-config-multicontainer.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: test-deployment-config-multicontainer
+spec:
+  replicas: 1
+  selector:
+    name: test-deployment
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: test-deployment
+    spec:
+      containers:
+      - image: busybox:latest
+        imagePullPolicy: IfNotPresent
+        name: container1
+        command: ["tail", "-f", "/dev/null"]
+      - image: busybox:latest
+        imagePullPolicy: IfNotPresent
+        name: container2
+        command: ["tail", "-f", "/dev/null"]
+  triggers:
+  - type: ConfigChange
+status: {}


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/10186 (partially)

We are not passing the container name when we converting the deployment logs options to pod log options so in case you have pod with multiple container and you do `oc logs dc/foo -c bar` you will always get the error that you have to pick the container. This PR fixes that.