### PR TITLE
When openshift-sdn-ovs is used, make the node PartOf=openvswitch.service

### DIFF
--- a/contrib/systemd/openshift-sdn-ovs.conf
+++ b/contrib/systemd/openshift-sdn-ovs.conf
@@ -1,3 +1,4 @@
 [Unit]
 Requires=openvswitch.service
 After=openvswitch.service
+PartOf=openvswitch.service


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1316202