### PR TITLE
Removed executable check from test-cmd test filter

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -85,7 +85,7 @@ trap "cleanup" EXIT
 set -e
 
 function find_tests {
-  find "${OS_ROOT}/test/cmd" -name '*.sh' -executable | grep -E "${1}" | sort -u
+  find "${OS_ROOT}/test/cmd" -name '*.sh' -not -wholename '*images_tests.sh' | grep -E "${1}" | sort -u
 }
 tests=( $(find_tests ${1:-.*}) )
 


### PR DESCRIPTION
In order to make hack/test-cmd.sh work on OSX, the GNU
extension `-executable` on `find` cannot be used. As
the extension was used to filter out `images_tests.sh`,
this check can instead be factored to literally black-
list that script.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/origin/issues/10381
[test]

@liggitt 