### PR TITLE
fix up image policy admission plugin

### DIFF
--- a/pkg/image/admission/imagepolicy/accept.go
+++ b/pkg/image/admission/imagepolicy/accept.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/api/meta"
 	"github.com/openshift/origin/pkg/image/admission/imagepolicy/rules"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 var errRejectByPolicy = fmt.Errorf("this image is prohibited by policy")
@@ -47,6 +48,12 @@ func accept(accepter rules.Accepter, resolver imageResolver, m meta.ImageReferen
 			// use the most generic policy rule here because we don't even know the image name
 			if attrs == nil {
 				attrs = &rules.ImagePolicyAttributes{}
+
+				// an objectref that is DockerImage ref will have a name that corresponds to its pull spec.  We can parse that
+				// to a docker image ref
+				if ref != nil && ref.Kind == "DockerImage" {
+					attrs.Name, _ = imageapi.ParseDockerImageReference(ref.Name)
+				}
 			}
 			attrs.Resource = gr
 			attrs.ExcludedRules = excludedRules

--- a/pkg/image/admission/imagepolicy/rules/accept.go
+++ b/pkg/image/admission/imagepolicy/rules/accept.go
@@ -124,6 +124,7 @@ func (r *executionAccepter) Accepts(attrs *ImagePolicyAttributes) bool {
 		if attrs.ExcludedRules.Has(rule.Name) && !rule.IgnoreNamespaceOverride {
 			continue
 		}
+
 		matches := matchImageCondition(&rule.ImageCondition, r.integratedRegistryMatcher, attrs)
 		glog.V(5).Infof("Validate image %v against rule %q: %t", attrs.Name, rule.Name, matches)
 		if matches {


### PR DESCRIPTION
Found these while trying to write up documentation and examples for the ImagePolicy admission plugin.

I think we should move resolve to a top level element that is an enum
 1. RequiredRewrite - require resolution to succeed and rewrite the resource to use it
 1. Required - require resolution to succeed, but don't rewrite the image pull spec
 1. AttemptRewrite - attempt resolution, rewrite if successful
 1. Attempt - attempt resolution, don't rewrite
 1. DoNotAttempt

Individual rules could have a `SkipOnResolutionFailure` which would allow a best effor attempt.  It would be a validation error to choose DoNotAttempt with a policy rule that requires it.

This would remove some of the craziness I faced when trying to match a registry name and having to say that I tolerated resolution failures.

@smarterclayton 