### PR TITLE
Stop using node selector as ipfailover label

### DIFF
--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -165,8 +165,13 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 		return nil, err
 	}
 
+	labels := map[string]string{
+		"ipfailover": name,
+	}
 	podTemplate := &kapi.PodTemplateSpec{
-		ObjectMeta: kapi.ObjectMeta{Labels: selector},
+		ObjectMeta: kapi.ObjectMeta{
+			Labels: labels,
+		},
 		Spec: kapi.PodSpec{
 			SecurityContext: &kapi.PodSecurityContext{
 				HostNetwork: true,
@@ -177,11 +182,10 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 			ServiceAccountName: options.ServiceAccount,
 		},
 	}
-
 	return &dapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
-			Labels: selector,
+			Labels: labels,
 		},
 		Spec: dapi.DeploymentConfigSpec{
 			Strategy: dapi.DeploymentStrategy{
@@ -193,7 +197,6 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 			//       kubernetes would remove the need for this
 			//       manual intervention.
 			Replicas: options.Replicas,
-			Selector: selector,
 			Template: podTemplate,
 			Triggers: []dapi.DeploymentTriggerPolicy{
 				{Type: dapi.DeploymentTriggerOnConfigChange},


### PR DESCRIPTION
The ipfailover dc and its template were having the label(s) provided
for the node selector set as their label(s).  If, as in the
documentation, the router service was selecting on that label, the
service would end up targeting the keepalived pods.  This change
ensures the dc and template define a new label rather than the one
provided as the node selector.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1365176
cc: @openshift/networking 