### PR TITLE
Updated bash preamble in test/cmd/run.sh

### DIFF
--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${OS_ROOT}/hack/lib/init.sh"
-os::log::stacktrace::install
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/run"


### PR DESCRIPTION
The larger commit that updated the rest of our code to
use the new initialization method merged just after the
commit that introduced this file, so this file is out
of sync with the rest of our codebase.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@deads2k PTAL -- this is fixing a file that got created as https://github.com/openshift/origin/pull/10300 was in the merge queue