### PR TITLE
oc start-build: display an error when git is not available and --from-repo is requested

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	goruntime "runtime"
 	"sort"
 	"strings"
 	"time"
@@ -37,6 +35,7 @@ import (
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	newapp "github.com/openshift/origin/pkg/generate/app"
 	newcmd "github.com/openshift/origin/pkg/generate/app/cmd"
+	"github.com/openshift/origin/pkg/generate/git"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/util"
 )
@@ -851,12 +850,7 @@ func (r *configSecretRetriever) CACert() (string, error) {
 }
 
 func checkGitInstalled(w io.Writer) {
-	gitBinary := "git"
-	if goruntime.GOOS == "windows" {
-		gitBinary = "git.exe"
-	}
-	_, err := exec.LookPath(gitBinary)
-	if err != nil {
+	if !git.IsGitInstalled() {
 		fmt.Fprintf(w, "warning: Cannot find git. Ensure that it is installed and in your path. Git is required to work with git repositories.\n")
 	}
 }

--- a/pkg/generate/git/repository.go
+++ b/pkg/generate/git/repository.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -378,8 +379,7 @@ func timedCommand(timeout time.Duration, name, dir string, env []string, args ..
 
 	// check whether git was available in the first place
 	if err != nil {
-		_, err := exec.LookPath(name)
-		if err != nil {
+		if !isBinaryInstalled(name) {
 			return "", "", ErrGitNotAvailable
 		}
 	}
@@ -464,4 +464,20 @@ func IsExitCode(err error, exitCode int) bool {
 		return false
 	}
 	return false
+}
+
+func gitBinary() string {
+	if runtime.GOOS == "windows" {
+		return "git.exe"
+	}
+	return "git"
+}
+
+func IsGitInstalled() bool {
+	return isBinaryInstalled(gitBinary())
+}
+
+func isBinaryInstalled(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
 }


### PR DESCRIPTION
Moves git check to single place.
Returns an error when start-build --from-repo is used and git is not available

Fixes BZ 1365440