### PR TITLE
Improve the image stream describer

### DIFF
--- a/test/cmd/images_tests.sh
+++ b/test/cmd/images_tests.sh
@@ -211,10 +211,10 @@ os::cmd::expect_success "oc project $project"
 # test scheduled and insecure tagging
 os::cmd::expect_success 'oc tag --source=docker mysql:5.7 newrepo:latest --scheduled'
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 1).importPolicy.scheduled}}'" 'true'
-os::cmd::expect_success_and_text "oc describe is/newrepo" '\* tag is scheduled'
+os::cmd::expect_success_and_text "oc describe is/newrepo" 'updates automatically from registry mysql:5.7'
 os::cmd::expect_success 'oc tag --source=docker mysql:5.7 newrepo:latest --insecure'
-os::cmd::expect_success_and_text "oc describe is/newrepo" '\! tag is insecure'
-os::cmd::expect_success_and_not_text "oc describe is/newrepo" '\* tag is scheduled'
+os::cmd::expect_success_and_text "oc describe is/newrepo" 'will use insecure HTTPS or HTTP connections'
+os::cmd::expect_success_and_not_text "oc describe is/newrepo" 'updates automatically from'
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 1).importPolicy.insecure}}'" 'true'
 
 # test creating streams that don't exist

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe.go
@@ -133,6 +133,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		allErrs = append(allErrs, err)
 	}
 
+	first := true
 	for _, info := range infos {
 		mapping := info.ResourceMapping()
 		describer, err := f.Describer(mapping)
@@ -145,7 +146,12 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 			allErrs = append(allErrs, err)
 			continue
 		}
-		fmt.Fprintf(out, "%s\n\n", s)
+		if first {
+			first = false
+		} else {
+			fmt.Fprintf(out, "\n\n")
+		}
+		fmt.Fprint(out, s)
 	}
 
 	return utilerrors.NewAggregate(allErrs)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe_test.go
@@ -44,7 +44,7 @@ func TestDescribeUnknownSchemaObject(t *testing.T) {
 		t.Errorf("unexpected describer: %#v", d)
 	}
 
-	if buf.String() != fmt.Sprintf("%s\n\n", d.Output) {
+	if buf.String() != fmt.Sprintf("%s", d.Output) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -77,7 +77,7 @@ func TestDescribeObject(t *testing.T) {
 		t.Errorf("unexpected describer: %#v", d)
 	}
 
-	if buf.String() != fmt.Sprintf("%s\n\n", d.Output) {
+	if buf.String() != fmt.Sprintf("%s", d.Output) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -96,7 +96,7 @@ func TestDescribeListObjects(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdDescribe(f, buf)
 	cmd.Run(cmd, []string{"pods"})
-	if buf.String() != fmt.Sprintf("%s\n\n%s\n\n", d.Output, d.Output) {
+	if buf.String() != fmt.Sprintf("%s\n\n%s", d.Output, d.Output) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }


### PR DESCRIPTION
Multiple entries

```
$ oc describe is wildfly

		Unique Images:	3
		Tags:		5

		latest
		  pushed image

		  * registry:5000/foo/bar@sha256:4bd26aef1ce78b4f05ede83496276f11e3343441574ca1ce89dffd146c708c16
		      17 months ago
		    registry:5000/foo/bar@sha256:062b80555a5dd7f5d58e78b266785a399277ff8c3e402ce5fa5d8571788e6bad
		      17 months ago

		spec1
		  tagged from foo/bar:latest

		  * registry:5000/foo/bar@sha256:4bd26aef1ce78b4f05ede83496276f11e3343441574ca1ce89dffd146c708c16
		      17 months ago

		spec2
		  tagged from mysql/latest@sha256:e52c6534db85036dabac5e71ff14e720db94def2d90f986f3548425ea27b3719

		  * mysql:latest
		      17 months ago	sha256:e52c6534db85036dabac5e71ff14e720db94def2d90f986f3548425ea27b3719

		spec3
		  updates automatically from registry mysql

		  ~ importing latest image ...
		  ! error: Import failed (NotFound): Image not found due to error
		      292 years ago
		  * mysql:latest
		      17 months ago	sha256:e52c6534db85036dabac5e71ff14e720db94def2d90f986f3548425ea27b3719

		spec4
		  reference to registry mysql:2
```
