### PR TITLE
Return nil directly if err is nil 

### DIFF
--- a/pkg/cmd/cli/cmd/dockerbuild/dockerbuild.go
+++ b/pkg/cmd/cli/cmd/dockerbuild/dockerbuild.go
@@ -168,7 +168,7 @@ func (o *DockerbuildOptions) Run() error {
 
 func stripLeadingError(err error) error {
 	if err == nil {
-		return err
+		return nil
 	}
 	if strings.HasPrefix(err.Error(), "Error: ") {
 		return fmt.Errorf(strings.TrimPrefix(err.Error(), "Error: "))


### PR DESCRIPTION
When I read cli code, I found the function` stripLeadingError` return err when err is nil. I think return nil directly is more appropriate.