### PR TITLE
To break the for loop when found = true

### DIFF
--- a/pkg/authorization/rulevalidation/policy_comparator_test.go
+++ b/pkg/authorization/rulevalidation/policy_comparator_test.go
@@ -344,6 +344,7 @@ func rulesMatch(expectedRules, actualRules []authorizationapi.PolicyRule) bool {
 		for _, actualRule := range actualRules {
 			if reflect.DeepEqual(expectedRule, actualRule) {
 				found = true
+				break
 			}
 		}
 


### PR DESCRIPTION
To break the for loop when found = true

		for _, actualRule := range actualRules {
			if reflect.DeepEqual(expectedRule, actualRule) {
				found = true
			}
		}

		if !found {
			return false
		}