### PR TITLE
Remove redundant comment in build-base-images.sh

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # This script builds the base and release images for use by the release build and image builds.
-#
-# Set OS_IMAGE_PUSH=true to push images to a registry
-#
+
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 


### PR DESCRIPTION
OS_IMAGE_PUSH can't be found in  origin. I think it should be a redundant constant var and remove it from the comment in build-base-images.sh

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>