### PR TITLE
HAProxy Router: Don't health-check idled services

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -291,17 +291,21 @@ backend be_edge_http_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{$healthIntv}} cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ else }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ end }}
+            {{ if not $endpoint.NoHealthCheck }}
+              server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
             {{ else }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ else }}
+              {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{$healthIntv}} cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ else }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ end }}
+              {{ else }}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ else }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ end }}
               {{ end }}
             {{ end }}
           {{ end }}
@@ -334,17 +338,21 @@ backend be_tcp_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{$healthIntv}} weight {{$weight}}
-              {{ else }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms weight {{$weight}}
-              {{ end }}
+            {{ if not $endpoint.NoHealthCheck }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
             {{ else }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} weight {{$weight}}
-              {{ else }}
+              {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{$healthIntv}} weight {{$weight}}
+                {{ else }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms weight {{$weight}}
+                {{ end }}
+              {{ else }}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} weight {{$weight}}
+                {{ else }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms weight {{$weight}}
+                {{ end }}
               {{ end }}
             {{ end }}
           {{ end }}{{/* end range endpointsForAlias */}}
@@ -382,19 +390,23 @@ backend be_secure_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter {{$healthIntv}} verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ else }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ end }}
+            {{ if not $endpoint.NoHealthCheck }}
+  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
             {{ else }}
-              {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
+              {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $healthIntv) }}
+    server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter {{$healthIntv}} verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ else }}
+    server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ end }}
               {{ else }}
-  server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
-              {{ end }}
-            {{ end }}{{/* end get health interval annotation */}}
+                {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_BACKEND_CHECK_INTERVAL" "")) }}
+    server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter {{env "ROUTER_BACKEND_CHECK_INTERVAL" "5000ms"}} verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ else }}
+    server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{$workingDir}}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
+                {{ end }}
+              {{ end }}{{/* end get health interval annotation */}}
+            {{ end }}{{/* end else no health check */}}
           {{ end }}{{/* end range endpointsForAlias */}}
         {{ end }}{{/* end get serviceUnit from its name */}}
       {{ end }}{{/* end if weight != 0 */}}

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -69,12 +69,13 @@ type Certificate struct {
 
 // Endpoint is an internal representation of a k8s endpoint.
 type Endpoint struct {
-	ID         string
-	IP         string
-	Port       string
-	TargetName string
-	PortName   string
-	IdHash     string
+	ID            string
+	IP            string
+	Port          string
+	TargetName    string
+	PortName      string
+	IdHash        string
+	NoHealthCheck bool
 }
 
 // certificateManager provides the ability to write certificates for a ServiceAliasConfig

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -199,7 +199,7 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 	}))
 }
 
-var _ = g.Describe("idling and uidling", func() {
+var _ = g.Describe("idling and unidling", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                  = exutil.NewCLI("cli-idling", exutil.KubeConfigPath()).Verbose()
@@ -281,7 +281,7 @@ var _ = g.Describe("idling and uidling", func() {
 
 		g.It("should work with TCP (when fully idled)", func() {
 			g.By("Idling the service")
-			_, err := oc.Run("idle").Args("-f", idlingFile).Output()
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Waiting for the pods to have terminated")
@@ -310,7 +310,7 @@ var _ = g.Describe("idling and uidling", func() {
 
 		g.It("should work with TCP (while idling)", func() {
 			g.By("Idling the service")
-			_, err := oc.Run("idle").Args("-f", idlingFile).Output()
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Connecting to the service IP and repeatedly connecting, making sure we seamlessly idle and come back up")
@@ -334,7 +334,7 @@ var _ = g.Describe("idling and uidling", func() {
 
 		g.It("should handle many TCP connections by dropping those under a certain bound", func() {
 			g.By("Idling the service")
-			_, err := oc.Run("idle").Args("-f", idlingFile).Output()
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Waiting for the pods to have terminated")
@@ -384,7 +384,7 @@ var _ = g.Describe("idling and uidling", func() {
 
 		g.It("should work with UDP", func() {
 			g.By("Idling the service")
-			_, err := oc.Run("idle").Args("-f", idlingFile).Output()
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Waiting for the pods to have terminated")
@@ -413,7 +413,7 @@ var _ = g.Describe("idling and uidling", func() {
 
 		g.It("should handle many UDP senders (by continuing to drop all packets on the floor)", func() {
 			g.By("Idling the service")
-			_, err := oc.Run("idle").Args("-f", idlingFile).Output()
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
 
 			g.By("Waiting for the pods to have terminated")

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -162,11 +162,12 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 	_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 	o.Expect(err).ToNot(o.HaveOccurred())
 
-	g.By("Ensuring the scale is zero")
+	g.By("Ensuring the scale is zero (and stays zero)")
 	objName := resources[resourceName][0]
-	replicas, err := oc.Run("get").Args(resourceName+"/"+objName, "--output=jsonpath=\"{.spec.replicas}\"").Output()
-	o.Expect(err).ToNot(o.HaveOccurred())
-	o.Expect(replicas).To(o.ContainSubstring("0"))
+	// make sure we don't get woken up by an incorrect router health check or anything like that
+	o.Consistently(func() (string, error) {
+		return oc.Run("get").Args(resourceName+"/"+objName, "--output=jsonpath=\"{.spec.replicas}\"").Output()
+	}, 5*time.Second, 500*time.Millisecond).Should(o.ContainSubstring("0"))
 
 	g.By("Fetching the service and checking the annotations are present")
 	serviceName := resources["service"][0]

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -65,3 +65,35 @@ items:
     to:
       kind: Service
       name: idling-echo
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: idling-echo-reencrypt
+  spec:
+    tls:
+      termination: reencrypt
+      # the actual certificate here is not relevant, since we're not
+      # actually serving TLS
+      destinationCACertificate: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx
+        CzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl
+        ZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3
+        dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu
+        Y29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP
+        d3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq
+        hkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx
+        EDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv
+        gu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm
+        47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M
+        mNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC
+        MAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd
+        TMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m
+        V7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc
+        yfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j
+        jhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q
+        +Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=
+        -----END CERTIFICATE-----
+    to:
+      kind: Service
+      name: idling-echo


### PR DESCRIPTION
Previously, all "endpoints" were health-checked by HAProxy.  For
backends which connected via non-secured connections, this entailed
partial establishment of a TCP connection by HAProxy, which did not
trigger the unidler proxy.  However, for secured backends, the health
check involved attempting to start a TLS connection, which used a full
TCP connection, which caused a wakeup to occur.

This commit adds an extra field to the template data's endpoint
structure which indicates that a particular endpoint is to be considered
an "idled" endpoint, meaning that no health check is necessary.  The
default template then uses this to disable health checking on the given
backend endpoints, which actually point to service IPs backed by the
unidling proxy.

Fixes bug 1366180