### PR TITLE
Add previous-scale annotation for idled resources

### DIFF
--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -531,8 +531,9 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 	dcGetter := deployclient.New(oclient.RESTClient)
 	rcGetter := clientset.FromUnversionedClient(kclient)
 
-	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, dcGetter, rcGetter, func(annotations map[string]string) {
+	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, dcGetter, rcGetter, func(currentReplicas int32, annotations map[string]string) {
 		annotations[unidlingapi.IdledAtAnnotation] = nowTime.UTC().Format(time.RFC3339)
+		annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", currentReplicas)
 	})
 
 	replicas := make(map[unidlingapi.CrossGroupObjectReference]int32, len(byScalable))

--- a/pkg/unidling/api/types.go
+++ b/pkg/unidling/api/types.go
@@ -9,6 +9,10 @@ const (
 	// objects associated with the idled endpoints
 	UnidleTargetAnnotation = "idling.alpha.openshift.io/unidle-targets"
 
+	// PreviousScaleAnnotation contains the previous scale of a scalable object
+	// (currently only applied by the idler)
+	PreviousScaleAnnotation = "idling.alpha.openshift.io/previous-scale"
+
 	// NeedPodsReason is the reason for the event emitted to indicate that endpoints should be unidled
 	NeedPodsReason = "NeedPods"
 )

--- a/pkg/unidling/controller/controller.go
+++ b/pkg/unidling/controller/controller.go
@@ -267,11 +267,12 @@ func (c *UnidlingController) handleRequest(info types.NamespacedName, lastFired 
 		targetScalablesSet[v] = struct{}{}
 	}
 
-	deleteIdledAtAnnotation := func(annotations map[string]string) {
+	deleteIdlingAnnotations := func(_ int32, annotations map[string]string) {
 		delete(annotations, unidlingapi.IdledAtAnnotation)
+		delete(annotations, unidlingapi.PreviousScaleAnnotation)
 	}
 
-	scaleAnnotater := unidlingutil.NewScaleAnnotater(c.scaleNamespacer, c.dcNamespacer, c.rcNamespacer, deleteIdledAtAnnotation)
+	scaleAnnotater := unidlingutil.NewScaleAnnotater(c.scaleNamespacer, c.dcNamespacer, c.rcNamespacer, deleteIdlingAnnotations)
 
 	for _, scalableRef := range targetScalables {
 		var scale *kextapi.Scale

--- a/pkg/unidling/util/scale.go
+++ b/pkg/unidling/util/scale.go
@@ -18,7 +18,7 @@ import (
 // TODO: remove the below functions once we get a way to mark/unmark an object as idled
 // via the scale endpoint
 
-type AnnotationFunc func(annotations map[string]string)
+type AnnotationFunc func(currentReplicas int32, annotations map[string]string)
 
 func NewScaleAnnotater(scales kextclient.ScalesGetter, dcs deployclient.DeploymentConfigsGetter, rcs kclient.ReplicationControllersGetter, changeAnnots AnnotationFunc) *ScaleAnnotater {
 	return &ScaleAnnotater{
@@ -90,14 +90,14 @@ func (c *ScaleAnnotater) UpdateObjectScale(namespace string, ref unidlingapi.Cro
 		if typedObj.Annotations == nil {
 			typedObj.Annotations = make(map[string]string)
 		}
-		c.changeAnnotations(typedObj.Annotations)
+		c.changeAnnotations(typedObj.Spec.Replicas, typedObj.Annotations)
 		typedObj.Spec.Replicas = scale.Spec.Replicas
 		_, err = c.dcs.DeploymentConfigs(namespace).Update(typedObj)
 	case *kapi.ReplicationController:
 		if typedObj.Annotations == nil {
 			typedObj.Annotations = make(map[string]string)
 		}
-		c.changeAnnotations(typedObj.Annotations)
+		c.changeAnnotations(typedObj.Spec.Replicas, typedObj.Annotations)
 		typedObj.Spec.Replicas = scale.Spec.Replicas
 		_, err = c.rcs.ReplicationControllers(namespace).Update(typedObj)
 	default:

--- a/test/cmd/idle.sh
+++ b/test/cmd/idle.sh
@@ -12,8 +12,10 @@ trap os::test::junit::reconcile_output EXIT
 project="$(oc project -q)"
 idled_at_annotation='idling.alpha.openshift.io/idled-at'
 unidle_target_annotation='idling.alpha.openshift.io/unidle-targets'
+prev_scale_annotation='idling.alpha.openshift.io/previous-scale'
 idled_at_template="{{index .metadata.annotations \"${idled_at_annotation}\"}}"
 unidle_target_template="{{index .metadata.annotations \"${unidle_target_annotation}\"}}"
+prev_scale_template="{{index .metadata.annotations \"${prev_scale_annotation}\"}}"
 
 setup_idling_resources() {
     os::cmd::expect_success 'oc delete all --all'
@@ -73,4 +75,10 @@ setup_idling_resources
 os::cmd::expect_success_and_text 'oc idle --all' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/idling-echo \(unidle to 2 replicas\)"
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${idled_at_template}'" '.'
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${unidle_target_template}' | jq 'length == 1 and (.[0] | .replicas == 2 and .name == \"idling-echo\" and .kind == \"DeploymentConfig\")'" 'true'
+os::test::junit::declare_suite_end
+
+os::test::junit::declare_suite_start "cmd/idle/check-previous-scale"
+setup_idling_resources  # scales up to 2 replicas
+os::cmd::expect_success_and_text 'oc idle idling-echo' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/idling-echo \(unidle to 2 replicas\)"
+os::cmd::expect_success_and_text "oc get dc idling-echo -o go-template='${prev_scale_template}'" '2'  # we see the result of the initial scale as the previous scale
 os::test::junit::declare_suite_end


### PR DESCRIPTION
This records the previous scale of an idled resource on idling.
This is useful in situations where finding and loading the associated
endpoints object would non-ideal (e.g. the web console).