### PR TITLE
Added logging to cloning functions

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -199,7 +199,7 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 		return false, nil
 	}
 
-	glog.V(0).Infof("Downloading %q ...", gitSource.URI)
+	glog.V(0).Infof("Cloning %q ...", gitSource.URI)
 
 	// Check source URI, trying to connect to the server only if not using a proxy.
 	if err := checkSourceURI(gitClient, gitSource.URI, timeout); err != nil {
@@ -208,9 +208,6 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 
 	// check if we specify a commit, ref, or branch to check out
 	usingRef := len(gitSource.Ref) != 0 || (revision != nil && revision.Git != nil && len(revision.Git.Commit) != 0)
-
-	// Recursive clone if we're not going to checkout a ref and submodule update later
-	glog.V(3).Infof("Cloning source from %s", gitSource.URI)
 
 	// Only use the quiet flag if Verbosity is not 5 or greater
 	quiet := !glog.Is(5)
@@ -233,6 +230,14 @@ func extractGitSource(gitClient GitClient, gitSource *api.GitBuildSource, revisi
 		// Recursively update --init
 		if err := gitClient.SubmoduleUpdate(dir, true, true); err != nil {
 			return true, err
+		}
+	}
+
+	if glog.Is(0) {
+		if information, gitErr := gitClient.GetInfo(dir); gitErr == nil {
+			glog.Infof("\tCommit:\t%s (%s)\n", information.CommitID, information.Message)
+			glog.Infof("\tAuthor:\t%s <%s>\n", information.AuthorName, information.AuthorEmail)
+			glog.Infof("\tDate:\t%s\n", information.Date)
 		}
 	}
 

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -147,6 +147,13 @@ os::cmd::expect_success "oc delete all --all"
 os::cmd::expect_success "docker rmi -f ${docker_registry}/image-ns/busybox:latest"
 os::test::junit::declare_suite_end
 
+# Test to see that we're reporting the correct commit being used by the build
+os::test::junit::declare_suite_start "extended/cmd/new-build"
+os::cmd::expect_success "oc new-build https://github.com/openshift/ruby-hello-world.git#bd94cbb228465d30d9d3430e80b503757a2a1d97"
+os::cmd::try_until_text "oc logs builds/ruby-hello-world-1" "Commit:[[:space:]]*bd94cbb228465d30d9d3430e80b503757a2a1d97"
+os::cmd::expect_success "oc delete all --all"
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_start "extended/cmd/service-signer"
 # check to make sure that service serving cert signing works correctly
 # nginx currently needs to run as root


### PR DESCRIPTION
The CloneWithOptions, etc., now print out information about the
repository that was just cloned, with varying levels of verbosity.

New output loglevel=1
```
 > oc new-app https://github.com/openshift/ruby-hello-world --dry-run --loglevel=1
I0815 14:54:35.877695    7416 repository.go:225] Cloned repository "https://github.com/openshift/ruby-hello-world"
I0815 14:54:35.879821    7416 repository.go:235] Commit: e79d887 (HEAD)
--> Found Docker image 75eafc2 (5 days old) from Docker Hub for "centos/ruby-22-centos7"

    Ruby 2.2 
    -------- 
    Platform for building and running Ruby 2.2 applications

    Tags: builder, ruby, ruby22

    * An image stream will be created as "ruby-22-centos7:latest" that will track the source image
    * A Docker build using source code from https://github.com/openshift/ruby-hello-world will be created
      * The resulting image will be pushed to image stream "ruby-hello-world:latest"
      * Every time "ruby-22-centos7:latest" changes a new build will be triggered
    * This image will be deployed in deployment config "ruby-hello-world"
    * Port 8080 will be load balanced by service "ruby-hello-world"
      * Other containers can access this service through the hostname "ruby-hello-world"

--> Creating resources with label app=ruby-hello-world ...
    imagestream "ruby-22-centos7" created
    imagestream "ruby-hello-world" created
    buildconfig "ruby-hello-world" created
    deploymentconfig "ruby-hello-world" created
    service "ruby-hello-world" created
--> Success (DRY RUN)
 > 
```

New output loglevel=3
```
 > oc new-app https://github.com/openshift/ruby-hello-world --dry-run --loglevel=3
I0815 14:54:55.391109    7492 repository.go:225] Cloned repository "https://github.com/openshift/ruby-hello-world"
I0815 14:54:55.393436    7492 repository.go:230] Commit:  e79d887 (HEAD)
I0815 14:54:55.393462    7492 repository.go:230] Author:  Ben Parees <bparees@users.noreply.github.com>
I0815 14:54:55.393472    7492 repository.go:230] Summary: Merge pull request #53 from danmcp/master
I0815 14:54:55.700995    7492 dockerimagelookup.go:239] Adding Docker image "centos/ruby-22-centos7" (tag "latest"), 75eafc2, from Docker Hub, 359.071mb, author SoftwareCollections.org <sclorg@redhat.com> as component match for "centos/ruby-22-centos7" with score 0
--> Found Docker image 75eafc2 (5 days old) from Docker Hub for "centos/ruby-22-centos7"

    Ruby 2.2 
    -------- 
    Platform for building and running Ruby 2.2 applications

    Tags: builder, ruby, ruby22

    * An image stream will be created as "ruby-22-centos7:latest" that will track the source image
    * A Docker build using source code from https://github.com/openshift/ruby-hello-world will be created
      * The resulting image will be pushed to image stream "ruby-hello-world:latest"
      * Every time "ruby-22-centos7:latest" changes a new build will be triggered
    * This image will be deployed in deployment config "ruby-hello-world"
    * Port 8080 will be load balanced by service "ruby-hello-world"
      * Other containers can access this service through the hostname "ruby-hello-world"

--> Creating resources with label app=ruby-hello-world ...
    imagestream "ruby-22-centos7" created
    imagestream "ruby-hello-world" created
    buildconfig "ruby-hello-world" created
    deploymentconfig "ruby-hello-world" created
    service "ruby-hello-world" created
--> Success (DRY RUN)

```

It was discussed that we should be printing a bit of information at loglevel=0, but that seems to print even when loglevel is not referenced.  I think putting this information in every call to the changed functions would be a bit excessive, so I chose 1 for now.

@bparees @jwforres ptal?

Fixes #10296 