### PR TITLE
Add example of install-travis in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,8 +224,10 @@ build-cross: clean
 	hack/build-cross.sh
 .PHONY: build-cross
 
-# Install travis dependencies
+# Install travis dependencies.
 #
+# Example:
+#   make install-travis
 install-travis:
 	hack/install-tools.sh
 .PHONY: install-travis


### PR DESCRIPTION
The example may be missed for install-travis in Makefile. Add example of install-travis which is helpful to understand how to use it.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>