### PR TITLE
Update a script's name for swagger-doc

### DIFF
--- a/hack/swagger-doc/README.md
+++ b/hack/swagger-doc/README.md
@@ -1,5 +1,5 @@
 Generating API documents
 ========================
 
-To generate docs, you must have Gradle installed at version 2.2+. Run `hack/gen-swagger-docs.sh` to create a new copy of
+To generate docs, it currently uses 'k8s.io/kubernetes/pkg/runtime'. Run `hack/update-generated-swagger-descriptions.sh` to create a new copy of
 the docs in `_output/local/docs/swagger` for the OpenShift v1 and Kubernetes v1 APIs.


### PR DESCRIPTION
Update the script from '`hack/gen-swagger-docs.sh' to 'hack/update-generated-swagger-descriptions.sh'  for generating swagger docs.  It currently uses "k8s.io/kubernetes/pkg/runtime" to generate doc instead of Gradle.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>