### PR TITLE
fix format in build-images.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,8 @@ build-cross: clean
 
 # Install travis dependencies
 #
+# Example:
+#   make install-travis
 install-travis:
 	hack/install-tools.sh
 .PHONY: install-travis

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -19,7 +19,7 @@ if [[ "${OS_RELEASE:-}" == "n" ]]; then
   OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
 
   echo "Building images from source ${OS_RELEASE_COMMIT}:"
-	echo
+  echo
   OS_GOFLAGS="${OS_GOFLAGS:-} ${OS_IMAGE_COMPILE_GOFLAGS}" os::build::build_static_binaries "${OS_IMAGE_COMPILE_TARGETS[@]-}" "${OS_SCRATCH_IMAGE_COMPILE_TARGETS[@]-}"
 	os::build::place_bins "${OS_IMAGE_COMPILE_BINARIES[@]}"
   echo

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -115,7 +115,7 @@ function os::util::environment::update_path_var() {
 }
 readonly -f os::util::environment::update_path_var
 
-# os::util::environment::setup_misc_tmpdir_vars sets up temporary directory path variables
+# os::util::environment::setup_tmpdir_vars sets up temporary directory path variables
 #
 # Globals:
 #  - TMPDIR

--- a/hack/swagger-doc/README.md
+++ b/hack/swagger-doc/README.md
@@ -1,5 +1,5 @@
 Generating API documents
 ========================
 
-To generate docs, you must have Gradle installed at version 2.2+. Run `hack/gen-swagger-docs.sh` to create a new copy of
+To generate docs, you must have Gradle installed at version 2.2+. Run `hack/update-swagger-docs.sh` to create a new copy of
 the docs in `_output/local/docs/swagger` for the OpenShift v1 and Kubernetes v1 APIs.


### PR DESCRIPTION
It has more spaces before 'echo' than other line.  According to the format of shell,  I remove these space on line 22 in the script.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>