### PR TITLE
Update func name from setup_misc_tmpdir_vars to setup_tmpdir_vars

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -115,7 +115,7 @@ function os::util::environment::update_path_var() {
 }
 readonly -f os::util::environment::update_path_var
 
-# os::util::environment::setup_misc_tmpdir_vars sets up temporary directory path variables
+# os::util::environment::setup_tmpdir_vars sets up temporary directory path variables
 #
 # Globals:
 #  - TMPDIR


### PR DESCRIPTION
The func name in comment  doesn't match with setup_images_vars().  Update func name from setup_misc_tmpdir_vars to setup_tmpdir_vars in environment.sh.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>