### PR TITLE
Fix processing of servingKey in `oadm registry`

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -328,7 +328,7 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 		if err != nil {
 			return fmt.Errorf("registry does not exist; could not load TLS private key file %q: %v", opts.Config.ServingKeyPath, err)
 		}
-		servingCert = data
+		servingKey = data
 	}
 
 	env := app.Environment{}


### PR DESCRIPTION
The variable `servingCert` shoud be changed to `servingKey`.


Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>