### PR TITLE
Return directly if no pods found when evacuating

### DIFF
--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -89,6 +89,10 @@ func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
 	if err != nil {
 		return err
 	}
+	if len(pods.Items) == 0 {
+		fmt.Fprint(e.Options.ErrWriter, "\nNo pods found on node: ", node.ObjectMeta.Name, "\n\n")
+		return nil
+	}
 	rcs, err := e.Options.Kclient.ReplicationControllers(kapi.NamespaceAll).List(kapi.ListOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
When evacuating selected pods with command `oadm manage-node <mynode> --evacuate --pod-selector="<service=myapp>"`, if there are no fit pods found, the command won't give any prompt. Users don't know what happened. Does the command execute successfully? Has any pod been evacuated? We'd better return an error if no pods found and the error info will be printed at terminal.

/cc @fabianofranz Thanks!