### PR TITLE
test: extend timeout in ICT tests to the IC controller resync interval

### DIFF
--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -296,7 +296,9 @@ func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
 	var newConfig *deployapi.DeploymentConfig
 	t.Log("Waiting for the initial deploymentconfig update in response to the imagestream update")
 
-	timeout := time.After(30 * time.Second)
+	// TODO: Once https://github.com/openshift/origin/pull/9349 is merged, we can stop waiting for the image
+	// change controller ie. we can reduce this
+	timeout := time.After(2 * time.Minute)
 
 	// This is the initial deployment with automatic=false in its ICT - it should be updated to pullSpec
 out:
@@ -444,7 +446,9 @@ func TestTriggers_MultipleICTs(t *testing.T) {
 		t.Fatalf("Couldn't create deploymentconfig: %v", err)
 	}
 
-	timeout := time.After(30 * time.Second)
+	// TODO: Once https://github.com/openshift/origin/pull/9349 is merged, we can stop waiting for the image
+	// change controller ie. we can reduce this
+	timeout := time.After(2 * time.Minute)
 
 	t.Log("Should not trigger a new deployment in response to the first imagestream update")
 	createTagEvent(imageStream.Name, imageapi.DefaultImageTag, updatedImage, updatedPullSpec)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/9856
Fixes https://github.com/openshift/origin/issues/9683

@mfojtik PTAL