### PR TITLE
Fix scrub pod container command

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -194,7 +194,7 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, na
 	defaultScrubPod.Namespace = namespace
 	defaultScrubPod.Spec.ServiceAccountName = recyclerServiceAccountName
 	defaultScrubPod.Spec.Containers[0].Image = recyclerImageName
-	defaultScrubPod.Spec.Containers[0].Command = []string{"/usr/bin/recycle"}
+	defaultScrubPod.Spec.Containers[0].Command = []string{"/usr/bin/openshift-recycle"}
 	defaultScrubPod.Spec.Containers[0].Args = []string{"/scrub"}
 	defaultScrubPod.Spec.Containers[0].SecurityContext = &kapi.SecurityContext{RunAsUser: &uid}
 	defaultScrubPod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent


### PR DESCRIPTION
As seen in https://bugzilla.redhat.com/show_bug.cgi?id=1360658 , `container start failed: RunContainerError: runContainer: Error response from daemon: Container command not found or does not exist.`