### PR TITLE
Deprecate --list option from `volumes` cmd

### DIFF
--- a/pkg/cmd/cli/cmd/set/volume.go
+++ b/pkg/cmd/cli/cmd/set/volume.go
@@ -188,6 +188,9 @@ func NewCmdVolume(fullName string, f *clientcmd.Factory, out, errOut io.Writer) 
 
 	cmd.MarkFlagFilename("filename", "yaml", "yml", "json")
 
+	// deprecate --list option
+	cmd.Flags().MarkDeprecated("list", "Volumes and volume mounts can be listed by providing a resource with no additional options.")
+
 	return cmd
 }
 


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1366560

The `--list` flag in `oc volumes` and `oc set volumes` is redundant. The
command does not take more than one operation at a time (add|remove|list)
and its default operation when none is provided is to list volumes and
volume mounts for the given resource.

The following commands give the exact same output:

- `$ oc set volumes dc database`
- `$ oc set volumes dc database --list=true`
- `$ oc set volumes dc database --list=false`

```
deploymentconfigs/database
  empty directory as ruby-helloworld-data
    mounted at /var/lib/mysql/data
```

This patch removes the `--list` flag from the command's help output.

cc @fabianofranz 