### PR TITLE
Make it easier to extract content from hack/env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.6
-  - tip
+  - 1.7
 
 install:
   - export PATH=$GOPATH/bin:./_output/tools/etcd/bin:$PATH

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -24,9 +24,7 @@ trap "os::build::environment::cleanup ${container}" EXIT
   os::build::get_version_vars
   echo "++ Building release ${OS_GIT_VERSION}"
 )
-os::build::environment::withsource "${container}" "${OS_GIT_COMMIT:-HEAD}"
-# Get the command output
-docker cp "${container}:/go/src/github.com/openshift/origin/_output/local/releases" "${OS_OUTPUT}"
+OS_BUILD_ENV_PRESERVE=_output/local/releases os::build::environment::withsource "${container}" "${OS_GIT_COMMIT:-HEAD}"
 echo "${OS_GIT_COMMIT}" > "${OS_LOCAL_RELEASEPATH}/.commit"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1066,6 +1066,21 @@ function os::build::environment::withsource() {
 
   docker start "${container}" > /dev/null
   docker logs -f "${container}"
+
+  # extract content from the image
+  if [[ -n "${OS_BUILD_ENV_PRESERVE-}" ]]; then
+    local workingdir
+    workingdir="$(docker inspect -f '{{ index . "Config" "WorkingDir" }}' "${container}")"
+    local oldIFS="${IFS}"
+    IFS=:
+    for path in ${OS_BUILD_ENV_PRESERVE}; do
+      local parent
+      parent="$( dirname ${path} )"
+      mkdir -p "${parent}"
+      docker cp "${container}:${workingdir}/${path}" "${parent}"
+    done
+    IFS="${oldIFS}"
+  fi
 }
 readonly -f os::build::environment::withsource
 


### PR DESCRIPTION
OS_BUILD_ENV_PRESERVE=_output/local/releases hack/env make release

Allows content to be extracted back to the working dir (relative) after
a build.

[test] @stevekuznetsov for bashisms

fixes #10445 by removing tip from travis matrix