### PR TITLE
force all plugins to either default off or default on

### DIFF
--- a/pkg/cmd/server/api/latest/helpers.go
+++ b/pkg/cmd/server/api/latest/helpers.go
@@ -150,7 +150,10 @@ func IsAdmissionPluginActivated(reader io.Reader, defaultValue bool) (bool, erro
 	}
 	activationConfig, ok := obj.(*configapi.DefaultAdmissionConfig)
 	if !ok {
-		return false, fmt.Errorf("unexpected config object: %#v", obj)
+		// if we failed the cast, then we've got a config object specified for this admission plugin
+		// that means that this must be enabled and all additional validation is up to the
+		// admission plugin itself
+		return true, nil
 	}
 
 	return !activationConfig.Disable, nil

--- a/pkg/cmd/server/origin/admissionconfig_test.go
+++ b/pkg/cmd/server/origin/admissionconfig_test.go
@@ -24,7 +24,7 @@ import (
 func TestAdmissionPluginChains(t *testing.T) {
 	individualSet := sets.NewString(openshiftAdmissionControlPlugins...)
 	individualSet.Insert(KubeAdmissionPlugins...)
-	combinedSet := sets.NewString(combinedAdmissionControlPlugins...)
+	combinedSet := sets.NewString(CombinedAdmissionControlPlugins...)
 
 	if !individualSet.Equal(combinedSet) {
 		t.Fatalf("individualSets are missing: %v combinedSet is missing: %v", combinedSet.Difference(individualSet), individualSet.Difference(combinedSet))
@@ -32,26 +32,26 @@ func TestAdmissionPluginChains(t *testing.T) {
 
 	lastCurrIndex := -1
 	for _, plugin := range openshiftAdmissionControlPlugins {
-		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
-			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(CombinedAdmissionControlPlugins); lastCurrIndex++ {
+			if CombinedAdmissionControlPlugins[lastCurrIndex] == plugin {
 				break
 			}
 		}
 
-		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+		if lastCurrIndex >= len(CombinedAdmissionControlPlugins) {
 			t.Errorf("openshift admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
 		}
 	}
 
 	lastCurrIndex = -1
 	for _, plugin := range KubeAdmissionPlugins {
-		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(combinedAdmissionControlPlugins); lastCurrIndex++ {
-			if combinedAdmissionControlPlugins[lastCurrIndex] == plugin {
+		for lastCurrIndex = lastCurrIndex + 1; lastCurrIndex < len(CombinedAdmissionControlPlugins); lastCurrIndex++ {
+			if CombinedAdmissionControlPlugins[lastCurrIndex] == plugin {
 				break
 			}
 		}
 
-		if lastCurrIndex >= len(combinedAdmissionControlPlugins) {
+		if lastCurrIndex >= len(CombinedAdmissionControlPlugins) {
 			t.Errorf("kube admission plugins are out of order compared to the combined list.  Failed at %v", plugin)
 		}
 	}
@@ -87,7 +87,7 @@ var kubeAdmissionPlugins = sets.NewString(
 
 // TestAdmissionPluginNames makes sure that openshift admission plugins are prefixed with `openshift.io/`.
 func TestAdmissionPluginNames(t *testing.T) {
-	for _, plugin := range combinedAdmissionControlPlugins {
+	for _, plugin := range CombinedAdmissionControlPlugins {
 		if !strings.HasPrefix(plugin, "openshift.io/") && !kubeAdmissionPlugins.Has(plugin) && !legacyOpenshiftAdmissionPlugins.Has(plugin) {
 			t.Errorf("openshift admission plugins must be prefixed with openshift.io/ %v", plugin)
 		}
@@ -103,8 +103,8 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 		{
 			name: "stock everything",
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
-				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
-					t.Errorf("%s: expected %v, got %v", "stock everything", combinedAdmissionControlPlugins, pluginNames)
+				if !reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "stock everything", CombinedAdmissionControlPlugins, pluginNames)
 				}
 				return nil, nil
 			},
@@ -203,8 +203,8 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 				},
 			},
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
-				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
-					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", combinedAdmissionControlPlugins, pluginNames)
+				if !reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", CombinedAdmissionControlPlugins, pluginNames)
 				}
 				return nil, nil
 			},
@@ -233,8 +233,8 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 				},
 			},
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
-				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
-					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 02", combinedAdmissionControlPlugins, pluginNames)
+				if !reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 02", CombinedAdmissionControlPlugins, pluginNames)
 				}
 				return nil, nil
 			},
@@ -256,8 +256,8 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 				},
 			},
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet *internalclientset.Clientset, pluginInitializer oadmission.PluginInitializer) (admission.Interface, error) {
-				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
-					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 03", combinedAdmissionControlPlugins, pluginNames)
+				if !reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins) {
+					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 03", CombinedAdmissionControlPlugins, pluginNames)
 				}
 				return nil, nil
 			},

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -343,10 +343,10 @@ var (
 		"openshift.io/ClusterResourceQuota",
 	}
 
-	// combinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
+	// CombinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
 	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
 	// the order specified in the openshift and kube chains must match the order here.
-	combinedAdmissionControlPlugins = []string{
+	CombinedAdmissionControlPlugins = []string{
 		"ProjectRequestLimit",
 		"OriginNamespaceLifecycle",
 		"PodNodeConstraints",
@@ -452,7 +452,7 @@ func buildAdmissionChains(options configapi.MasterConfig, kubeClientSet *interna
 		pluginConfig[pluginName] = config
 	}
 
-	admissionChain, err := newAdmissionChainFunc(combinedAdmissionControlPlugins, "", pluginConfig, options, kubeClientSet, pluginInitializer)
+	admissionChain, err := newAdmissionChainFunc(CombinedAdmissionControlPlugins, "", pluginConfig, options, kubeClientSet, pluginInitializer)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cmd/server/origin/master_config_test.go
+++ b/pkg/cmd/server/origin/master_config_test.go
@@ -20,12 +20,12 @@ func TestQuotaAdmissionPluginsAreLast(t *testing.T) {
 		t.Errorf("KubeAdmissionPlugins must have ClusterResourceQuota as the last plugin")
 	}
 
-	combinedLen := len(combinedAdmissionControlPlugins)
-	if combinedAdmissionControlPlugins[combinedLen-2] != quotaadmission.PluginName {
-		t.Errorf("combinedAdmissionControlPlugins must have %s as the next to last plugin", quotaadmission.PluginName)
+	combinedLen := len(CombinedAdmissionControlPlugins)
+	if CombinedAdmissionControlPlugins[combinedLen-2] != quotaadmission.PluginName {
+		t.Errorf("CombinedAdmissionControlPlugins must have %s as the next to last plugin", quotaadmission.PluginName)
 	}
 
-	if combinedAdmissionControlPlugins[combinedLen-1] != "openshift.io/ClusterResourceQuota" {
-		t.Errorf("combinedAdmissionControlPlugins must have ClusterResourceQuota as the last plugin")
+	if CombinedAdmissionControlPlugins[combinedLen-1] != "openshift.io/ClusterResourceQuota" {
+		t.Errorf("CombinedAdmissionControlPlugins must have ClusterResourceQuota as the last plugin")
 	}
 }

--- a/pkg/cmd/server/start/admission.go
+++ b/pkg/cmd/server/start/admission.go
@@ -3,6 +3,8 @@ package start
 import (
 	"io"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/util/sets"
 
@@ -32,17 +34,51 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
+	imageadmission "github.com/openshift/origin/pkg/image/admission"
+	imagepolicy "github.com/openshift/origin/pkg/image/admission/imagepolicy/api"
+	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
+	quotaadmission "github.com/openshift/origin/pkg/quota/admission/resourcequota"
+	serviceadmit "github.com/openshift/origin/pkg/service/admission"
+	"k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+
 	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 )
 
 var (
-	defaultOnPlugins  = sets.String{}
-	defaultOffPlugins = sets.String{}
+	defaultOnPlugins = sets.NewString(
+		"OriginNamespaceLifecycle",
+		"openshift.io/JenkinsBootstrapper",
+		"BuildByStrategy",
+		imageadmission.PluginName,
+		lifecycle.PluginName,
+		"OriginPodNodeEnvironment",
+		serviceadmit.ExternalIPPluginName,
+		serviceadmit.RestrictedEndpointsPluginName,
+		"LimitRanger",
+		"ServiceAccount",
+		"SecurityContextConstraint",
+		"LimitPodHardAntiAffinityTopology",
+		"SCCExecRestrictions",
+		"PersistentVolumeLabel",
+		quotaadmission.PluginName,
+		"openshift.io/ClusterResourceQuota",
+	)
+
+	// defaultOffPlugins includes plugins which require explicit configuration to run
+	// if you wire them incorrectly, they may prevent the server from starting
+	defaultOffPlugins = sets.NewString(
+		"ProjectRequestLimit",
+		"RunOnceDuration",
+		"PodNodeConstraints",
+		overrideapi.PluginName,
+		imagepolicy.PluginName,
+		"BuildDefaults",
+		"BuildOverrides",
+		"AlwaysPullImages",
+	)
 )
 
 func init() {
-	defaultOffPlugins.Insert("AlwaysPullImages")
-	defaultOnPlugins.Insert("openshift.io/ClusterResourceQuota")
 	admission.PluginEnabledFn = IsAdmissionPluginActivated
 }
 
@@ -51,10 +87,12 @@ func IsAdmissionPluginActivated(name string, config io.Reader) bool {
 	// assume that the config was a different type and let the actual admission plugin check it
 	if defaultOnPlugins.Has(name) {
 		if enabled, err := configlatest.IsAdmissionPluginActivated(config, true); err == nil && !enabled {
+			glog.V(2).Infof("Admission plugin %v is disabled.  It will not be started.", name)
 			return false
 		}
 	} else if defaultOffPlugins.Has(name) {
 		if enabled, err := configlatest.IsAdmissionPluginActivated(config, false); err == nil && !enabled {
+			glog.V(2).Infof("Admission plugin %v is not enabled.  It will not be started.", name)
 			return false
 		}
 	}

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -57,3 +57,22 @@ func TestKubeAdmissionControllerUsage(t *testing.T) {
 		}
 	}
 }
+
+func TestAdmissionOnOffCoverage(t *testing.T) {
+	configuredAdmissionPlugins := sets.NewString(origin.CombinedAdmissionControlPlugins...)
+	allCoveredAdmissionPlugins := sets.String{}
+	allCoveredAdmissionPlugins.Insert(defaultOnPlugins.List()...)
+	allCoveredAdmissionPlugins.Insert(defaultOffPlugins.List()...)
+
+	if !configuredAdmissionPlugins.Equal(allCoveredAdmissionPlugins) {
+		t.Errorf("every admission plugin must be default on or default off. differences: %v and %v",
+			configuredAdmissionPlugins.Difference(allCoveredAdmissionPlugins),
+			allCoveredAdmissionPlugins.Difference(configuredAdmissionPlugins))
+	}
+
+	for plugin := range defaultOnPlugins {
+		if defaultOffPlugins.Has(plugin) {
+			t.Errorf("%v is both enabled and disabled", plugin)
+		}
+	}
+}


### PR DESCRIPTION
All admission plugins in our chain should be either default off or default on.  This allows fine grained control of the chain without trying to manage the order.

@csrwng ptal