### PR TITLE
add `oc describe` help suggestion to cmds with `--container` option

### DIFF
--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -230,7 +230,7 @@ const (
 
 // NewCmdExec is a wrapper for the Kubernetes cli exec command
 func NewCmdExec(fullName string, f *clientcmd.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdExec(f.Factory, cmdIn, cmdOut, cmdErr)
+	cmd := kcmd.NewCmdExec(fullName, f.Factory, cmdIn, cmdOut, cmdErr)
 	cmd.Use = "exec [options] POD [-c CONTAINER] -- COMMAND [args...]"
 	cmd.Long = execLong
 	cmd.Example = fmt.Sprintf(execExample, fullName)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -226,7 +226,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdUncordon(f, out))
 
 	cmds.AddCommand(NewCmdAttach(f, in, out, err))
-	cmds.AddCommand(NewCmdExec(f, in, out, err))
+  cmds.AddCommand(NewCmdExec("kubectl", f, in, out, err))
 	cmds.AddCommand(NewCmdPortForward(f, out, err))
 	cmds.AddCommand(NewCmdProxy(f, out))
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -226,7 +226,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdUncordon(f, out))
 
 	cmds.AddCommand(NewCmdAttach(f, in, out, err))
-  cmds.AddCommand(NewCmdExec("kubectl", f, in, out, err))
+	cmds.AddCommand(NewCmdExec("kubectl", f, in, out, err))
 	cmds.AddCommand(NewCmdPortForward(f, out, err))
 	cmds.AddCommand(NewCmdProxy(f, out))
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/exec.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/exec.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 
 	dockerterm "github.com/docker/docker/pkg/term"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
@@ -47,7 +46,7 @@ kubectl exec 123456-7890 -c ruby-container date
 kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il`
 )
 
-func NewCmdExec(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
+func NewCmdExec(cmdFullName string, f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
 			In:  cmdIn,
@@ -55,8 +54,11 @@ func NewCmdExec(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *
 			Err: cmdErr,
 		},
 
+		FullCmdName: cmdFullName,
+		
 		Executor: &DefaultRemoteExecutor{},
 	}
+
 	cmd := &cobra.Command{
 		Use:     "exec POD [-c CONTAINER] -- COMMAND [args...]",
 		Short:   "Execute a command in a container.",
@@ -121,6 +123,8 @@ type StreamOptions struct {
 type ExecOptions struct {
 	StreamOptions
 
+	FullCmdName string
+
 	Command []string
 
 	Executor RemoteExecutor
@@ -130,6 +134,10 @@ type ExecOptions struct {
 
 // Complete verifies command line arguments and loads data from the command environment
 func (p *ExecOptions) Complete(f *cmdutil.Factory, cmd *cobra.Command, argsIn []string, argsLenAtDash int) error {
+	if len(p.FullCmdName) == 0 {
+		p.FullCmdName = "kubectl"
+	}
+
 	// Let kubectl exec follow rules for `--`, see #13004 issue
 	if len(p.PodName) == 0 && (len(argsIn) == 0 || argsLenAtDash == 0) {
 		return cmdutil.UsageError(cmd, "POD is required for exec")
@@ -247,7 +255,9 @@ func (p *ExecOptions) Run() error {
 
 	containerName := p.ContainerName
 	if len(containerName) == 0 {
-		glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)
+		if len(pod.Spec.Containers) > 1 {
+			fmt.Fprintf(p.Err, "defaulting container name to %s, use '%s describe po/%s' cmd to see all containers in this pod", pod.Spec.Containers[0].Name, p.FullCmdName, p.PodName)
+		}
 		containerName = pod.Spec.Containers[0].Name
 	}
 


### PR DESCRIPTION
Fixes #10283
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/30717
This is an alternate fix to reverted PR: https://github.com/openshift/origin/pull/10360

Commands with the `--container=` option provide no suggestions to a user
on how to obtain a container's name from a pod.

This patch adds a suggestion to use `oc describe <pod_name>` as part of the output of `oc exec <pod> <cmd>`

`$ oc exec database-1-h9dl1 -- /bin/sh -c "echo test"`
```
defaulting container name to ruby-helloworld-database, use 'oc describe database-1-h9dl1' to see all containers in this pod
test
```

cc @fabianofranz @smarterclayton 