### PR TITLE
sdn: copy HostSubnet to node.Spec.PodCIDR for route controller

### DIFF
--- a/pkg/sdn/plugin/registry.go
+++ b/pkg/sdn/plugin/registry.go
@@ -259,6 +259,10 @@ func (registry *Registry) GetEgressNetworkPolicies() ([]osapi.EgressNetworkPolic
 	return policyList.Items, nil
 }
 
+func (registry *Registry) UpdateNode(node *kapi.Node) (*kapi.Node, error) {
+	return registry.kClient.Nodes().Update(node)
+}
+
 // Run event queue for the given resource
 func (registry *Registry) RunEventQueue(resourceName ResourceName) *oscache.EventQueue {
 	var client cache.Getter


### PR DESCRIPTION
The k8s route controller uses the Node's PodCIDR and will refuse to
create a route when nodes don't have one.  Instead of setting the
node's PodCIDR, OpenShift SDN uses one or more HostSubnets to record
pod CIDRs assigned to the node.

When using cloud providers like AWS and GCE, kubelet/openshift-node
set an initial NodeNetworkUnavailable error condition on the node,
preventing the node from being scheduled.  This error condition is
supposed to be cleared by the route controller when routes are
created, but the route controller does not do this when the PodCIDR
is empty.

To work around this, copy the OpenShift SDN HostSubnet for the node
to that node's PodCIDR.  This is a temporary hack that gets things
working for GCE until we can fix the route controller to be more
flexible.

https://bugzilla.redhat.com/show_bug.cgi?id=1357474