### PR TITLE
Run go 1.7 on travis, allow tip failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: go
 
 go:
   - 1.6
+  - 1.7
   - tip
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - go: tip
 
 install:
   - export PATH=$GOPATH/bin:./_output/tools/etcd/bin:$PATH


### PR DESCRIPTION
fixes #10445 by marking tip builds as allowed to fail in travis