### PR TITLE
P1 fix haproxy config bug

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -48,7 +48,7 @@ defaults
 {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "")) }}
   timeout client {{env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "30s"}}
 {{ else }}
-  timeout connect 30s
+  timeout client 30s
 {{ end }}
 {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_SERVER_TIMEOUT" "")) }}
   timeout server {{env "ROUTER_DEFAULT_SERVER_TIMEOUT" "30s"}}


### PR DESCRIPTION
As a result of adding env/annotations for timeouts in the haproxy config, there was a bug in the generated config.  Here's a  snippet of the config:
```  
...  
defaults  
  # maxconn 4096  
  # Add x-forwarded-for header.  
  timeout connect 5s  
  timeout connect 30s   #   error should be timeout client
  timeout server 30s  
  timeout http-request 10s  
...  
```

This is also what causes the warnings/errors in the log:
```  
[WARNING] 229/071010 (60) : config : missing timeouts for frontend 'fe_no_sni'.  
   | While not properly invalid, you will certainly encounter various problems  
   | with such a configuration. To fix this, please ensure that all following  
   | timeouts are set to a non-zero value: 'client', 'connect', 'server'.   
```  

Fix haproxy bug - typo in config - the `timeout connect` is repeated (should be `timeout client`).

@rajatchopra / @knobunc  PTAL and merge.  Thx