### PR TITLE
The function 'NewPrintNameOrErrorAfter' is defined, but it's not used

### DIFF
--- a/pkg/config/cmd/cmd.go
+++ b/pkg/config/cmd/cmd.go
@@ -85,10 +85,6 @@ func (b *Bulk) Run(list *kapi.List, namespace string) []error {
 	return errs
 }
 
-func NewPrintNameOrErrorAfter(mapper meta.RESTMapper, short bool, operation string, out, errs io.Writer) AfterFunc {
-	return NewPrintNameOrErrorAfterIndent(mapper, short, operation, out, errs, "")
-}
-
 func NewPrintNameOrErrorAfterIndent(mapper meta.RESTMapper, short bool, operation string, out, errs io.Writer, indent string) AfterFunc {
 	return func(info *resource.Info, err error) bool {
 		if err == nil {


### PR DESCRIPTION
The function 'NewPrintNameOrErrorAfter' is defined in the `pkg/config/cmd/cmd.go`, but it's not used. So I think we should delete this function.