### PR TITLE
check CustomStrategy validation at begin

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -23,6 +23,9 @@ type CustomBuildStrategy struct {
 // CreateBuildPod creates the pod to be used for the Custom build
 func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
 	strategy := build.Spec.Strategy.CustomStrategy
+	if strategy == nil {
+		return nil, errors.New("CustomBuildStrategy cannot be executed without CustomStrategy parameters")
+	}
 
 	codec := bs.Codec
 	if len(strategy.BuildAPIVersion) != 0 {
@@ -52,7 +55,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		}
 	}
 
-	if strategy == nil || len(strategy.From.Name) == 0 {
+	if len(strategy.From.Name) == 0 {
 		return nil, errors.New("CustomBuildStrategy cannot be executed without image")
 	}
 


### PR DESCRIPTION
if we are't sure whether `build.Spec.Strategy.CustomStrategy`  is nil in

 `if strategy == nil || len(strategy.From.Name) == 0 {
		return nil, errors.New("CustomBuildStrategy cannot be executed without image")
}`

we should check pointer `build.Spec.Strategy.CustomStrategy`  at begin.