### PR TITLE
return error in `oc set env RESOURCE` when no env args are provided

### DIFF
--- a/pkg/cmd/cli/cmd/set/env.go
+++ b/pkg/cmd/cli/cmd/set/env.go
@@ -529,6 +529,12 @@ updates:
 		}
 		info.Refresh(obj, true)
 
+		// make sure arguments to set or replace environment variables are set
+		// before returning a successful message
+		if len(env) == 0 && len(envArgs) == 0 {
+			return fmt.Errorf("at least one environment variable must be provided")
+		}
+
 		shortOutput := kcmdutil.GetFlagString(cmd, "output") == "name"
 		kcmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, "updated")
 	}

--- a/test/cmd/env.sh
+++ b/test/cmd/env.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/set-env"
+# This test validates the value of --image for oc run
+os::cmd::expect_success 'oc new-app node'
+os::cmd::expect_failure_and_text 'oc set env dc/node' 'error: at least one environment variable must be provided'
+os::cmd::expect_success_and_text 'oc set env dc/node key=value' 'deploymentconfig "node" updated'
+os::cmd::expect_success_and_text 'oc set env dc/node --list' 'deploymentconfigs node, container node'
+os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" key-' 'deploymentconfig "node" updated'
+os::cmd::expect_failure_and_text 'oc set env dc --all --containers="node"' 'error: at least one environment variable must be provided'
+os::cmd::expect_failure_and_not_text 'oc set env --from=secret/mysecret dc/node' 'error: at least one environment variable must be provided'
+echo "oc set env: ok"
+os::test::junit::declare_suite_end


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1366559

The command `oc set RESOURCE` prompts a user that the resource has been
updated even when no other args are provided:

```
$ oc set env dc/database
deploymentconfig "database" updated
```

This patch makes sure that at least one pair of environment variable
arguments are passed before returning a successful message:

```
$ oc set env dc/database
error: at least one environment variable must be provided in the form of
KEY=VALUE
```

cc @fabianofranz 