### PR TITLE
UPSTREAM: 28234: Make sure --record=false is acknowledged when passed to commands

### DIFF
--- a/docs/man/man1/oc-annotate.1
+++ b/docs/man/man1/oc-annotate.1
@@ -61,7 +61,7 @@ Run 'oc types' for a list of valid resources.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-apply.1
+++ b/docs/man/man1/oc-apply.1
@@ -34,7 +34,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-autoscale.1
+++ b/docs/man/man1/oc-autoscale.1
@@ -70,7 +70,7 @@ increase or decrease number of pods deployed within the system as needed.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-create.1
+++ b/docs/man/man1/oc-create.1
@@ -34,7 +34,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-edit.1
+++ b/docs/man/man1/oc-edit.1
@@ -56,7 +56,7 @@ saved copy to include the latest resource version.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-expose.1
+++ b/docs/man/man1/oc-expose.1
@@ -94,7 +94,7 @@ labels from the object it exposes.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-label.1
+++ b/docs/man/man1/oc-label.1
@@ -60,7 +60,7 @@ resource\-version will be used.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-patch.1
+++ b/docs/man/man1/oc-patch.1
@@ -38,7 +38,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-replace.1
+++ b/docs/man/man1/oc-replace.1
@@ -46,7 +46,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/oc-run.1
+++ b/docs/man/man1/oc-run.1
@@ -94,7 +94,7 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-r\fP, \fB\-\-replicas\fP=1

--- a/docs/man/man1/oc-scale.1
+++ b/docs/man/man1/oc-scale.1
@@ -45,7 +45,7 @@ desired replicas in the configuration template.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-annotate.1
+++ b/docs/man/man1/openshift-cli-annotate.1
@@ -61,7 +61,7 @@ Run 'openshift cli types' for a list of valid resources.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-apply.1
+++ b/docs/man/man1/openshift-cli-apply.1
@@ -34,7 +34,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-autoscale.1
+++ b/docs/man/man1/openshift-cli-autoscale.1
@@ -70,7 +70,7 @@ increase or decrease number of pods deployed within the system as needed.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-create.1
+++ b/docs/man/man1/openshift-cli-create.1
@@ -34,7 +34,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-edit.1
+++ b/docs/man/man1/openshift-cli-edit.1
@@ -56,7 +56,7 @@ saved copy to include the latest resource version.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-expose.1
+++ b/docs/man/man1/openshift-cli-expose.1
@@ -94,7 +94,7 @@ labels from the object it exposes.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-label.1
+++ b/docs/man/man1/openshift-cli-label.1
@@ -60,7 +60,7 @@ resource\-version will be used.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-patch.1
+++ b/docs/man/man1/openshift-cli-patch.1
@@ -38,7 +38,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-replace.1
+++ b/docs/man/man1/openshift-cli-replace.1
@@ -46,7 +46,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-cli-run.1
+++ b/docs/man/man1/openshift-cli-run.1
@@ -94,7 +94,7 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-r\fP, \fB\-\-replicas\fP=1

--- a/docs/man/man1/openshift-cli-scale.1
+++ b/docs/man/man1/openshift-cli-scale.1
@@ -45,7 +45,7 @@ desired replicas in the configuration template.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-annotate.1
+++ b/docs/man/man1/openshift-kube-annotate.1
@@ -62,7 +62,7 @@ Possible resources include (case insensitive):
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-apply.1
+++ b/docs/man/man1/openshift-kube-apply.1
@@ -36,7 +36,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-autoscale.1
+++ b/docs/man/man1/openshift-kube-autoscale.1
@@ -69,7 +69,7 @@ An autoscaler can automatically increase or decrease number of pods deployed wit
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-create.1
+++ b/docs/man/man1/openshift-kube-create.1
@@ -34,7 +34,7 @@ JSON and YAML formats are accepted.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-edit.1
+++ b/docs/man/man1/openshift-kube-edit.1
@@ -56,7 +56,7 @@ saved copy to include the latest resource version.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-expose.1
+++ b/docs/man/man1/openshift-kube-expose.1
@@ -94,7 +94,7 @@ Possible resources include (case insensitive):
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-label.1
+++ b/docs/man/man1/openshift-kube-label.1
@@ -58,7 +58,7 @@ If \-\-resource\-version is specified, then updates will use this resource versi
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-patch.1
+++ b/docs/man/man1/openshift-kube-patch.1
@@ -42,7 +42,7 @@ Please refer to the models in
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-replace.1
+++ b/docs/man/man1/openshift-kube-replace.1
@@ -52,7 +52,7 @@ Please refer to the models in
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-run.1
+++ b/docs/man/man1/openshift-kube-run.1
@@ -90,7 +90,7 @@ Creates a deployment or job to manage the created container(s).
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-r\fP, \fB\-\-replicas\fP=1

--- a/docs/man/man1/openshift-kube-scale.1
+++ b/docs/man/man1/openshift-kube-scale.1
@@ -41,7 +41,7 @@ scale is sent to the server.
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/docs/man/man1/openshift-kube-set-image.1
+++ b/docs/man/man1/openshift-kube-set-image.1
@@ -49,7 +49,7 @@ Possible resources include (case insensitive):
 
 .PP
 \fB\-\-record\fP=false
-    Record current kubectl command in the resource annotation.
+    Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.
 
 .PP
 \fB\-R\fP, \fB\-\-recursive\fP=false

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run_test.go
@@ -301,7 +301,7 @@ func TestGenerateService(t *testing.T) {
 		cmd := &cobra.Command{}
 		cmd.Flags().String("output", "", "")
 		cmd.Flags().Bool(cmdutil.ApplyAnnotationsFlag, false, "")
-		cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation.")
+		cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
 		cmdutil.AddInclude3rdPartyFlags(cmd)
 		addRunFlags(cmd)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -430,7 +430,7 @@ func UpdateObject(info *resource.Info, codec runtime.Codec, updateFn func(runtim
 
 // AddCmdRecordFlag adds --record flag to command
 func AddRecordFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation.")
+	cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
 }
 
 func GetRecordFlag(cmd *cobra.Command) bool {
@@ -484,7 +484,7 @@ func ContainsChangeCause(info *resource.Info) bool {
 
 // ShouldRecord checks if we should record current change cause
 func ShouldRecord(cmd *cobra.Command, info *resource.Info) bool {
-	return GetRecordFlag(cmd) || ContainsChangeCause(info)
+	return GetRecordFlag(cmd) || (ContainsChangeCause(info) && !cmd.Flags().Changed("record"))
 }
 
 // GetThirdPartyGroupVersions returns the thirdparty "group/versions"s and


### PR DESCRIPTION
Cherry-pick of upstream commit:

Ensures that when --record=false is explicity set that no ChangeCauseAnnotations are set on the object. Previously, if --record=true was used then all following actions triggered a ChangeCauseAnnotation even if --record=false was set, due to the prior ChangeCauseAnnotation existing.

Reference to bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1351127