### PR TITLE
clarify idle error and usage output

### DIFF
--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -48,15 +48,16 @@ associated resources by scaling them back up to their previous scale.`
   $ %[1]s idle --resource-names-file to-idle.txt`
 )
 
-// NewCmdStatus implements the OpenShift cli status command
+// NewCmdIdle implements the OpenShift cli idle command
 func NewCmdIdle(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	o := &IdleOptions{
-		out:    out,
-		errOut: errOut,
+		out:         out,
+		errOut:      errOut,
+		cmdFullName: fullName,
 	}
 
 	cmd := &cobra.Command{
-		Use:     "idle (SERVICES... | -l label | --all | --resource-names-file FILENAME)",
+		Use:     "idle (SERVICE_ENDPOINTS... | -l label | --all | --resource-names-file FILENAME)",
 		Short:   "Idle scalable resources",
 		Long:    idleLong,
 		Example: fmt.Sprintf(idleExample, fullName),
@@ -92,6 +93,8 @@ type IdleOptions struct {
 	selector      string
 	allNamespaces bool
 	resources     string
+
+	cmdFullName string
 
 	nowTime    time.Time
 	svcBuilder *resource.Builder
@@ -259,7 +262,7 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 
 		endpoints, isEndpoints := info.Object.(*api.Endpoints)
 		if !isEndpoints {
-			return fmt.Errorf("you must specify endpoints, not %vs", info.Mapping.Resource)
+			return fmt.Errorf("you must specify endpoints, not %v (view available endpoints with \"%s get endpoints\").", info.Mapping.Resource, o.cmdFullName)
 		}
 
 		endpointsName := types.NamespacedName{


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1367267

This patch stops appending an "s" char to the end of an error message when an
incorrect resource type is provided. Adds a suggestion to use the
`get endpoints` command to this error output. Updates the Usage output
of `oc idle -h` to include SERVICE_ENDPOINTS instead of SERVICE --
having "SERVICE" before was misleading as it implied passing a service
resource to the command, instead of an endpoint name (e.g. I assumed I
would have to pass `oc idle svc/myappendpoint` instead of `oc idle
myappendpoint`.

```
$ oc idle dc/myappendpoint
error: no valid scalable resources found to idle: you must specify
endpoints, not deploymentconfigss
```

```
$ oc idle dc/myappendpoint
error: no valid scalable resources found to idle: you must specify
endpoints, not deploymentconfigs. View available endpoints
with "oc get endpoints"
```

cc @fabianofranz 