### PR TITLE
Fix logical errors of the function 'RunCmdRouter' in the `oadm router` and the funtion 'RunCmdRegistry' in the `oadm registry`

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -257,19 +257,19 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 
 	output := opts.Config.Action.ShouldPrint()
 	generate := output
-	if !generate {
-		service, err := opts.serviceClient.Services(opts.namespace).Get(name)
-		if err != nil {
-			if !errors.IsNotFound(err) && !generate {
+	service, err := opts.serviceClient.Services(opts.namespace).Get(name)
+	if err != nil {
+		if !generate {
+			if !errors.IsNotFound(err) {
 				return fmt.Errorf("can't check for existing docker-registry %q: %v", name, err)
 			}
-			if !output && opts.Config.Action.DryRun {
+			if opts.Config.Action.DryRun {
 				return fmt.Errorf("Docker registry %q service does not exist", name)
 			}
 			generate = true
-		} else {
-			clusterIP = service.Spec.ClusterIP
 		}
+	} else {
+		clusterIP = service.Spec.ClusterIP
 	}
 
 	if !generate {

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -539,9 +539,9 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 
 	output := cfg.Action.ShouldPrint()
 	generate := output
-	if !generate {
-		service, err := kClient.Services(namespace).Get(name)
-		if err != nil {
+	service, err := kClient.Services(namespace).Get(name)
+	if err != nil {
+		if !generate {
 			if !errors.IsNotFound(err) {
 				return fmt.Errorf("can't check for existing router %q: %v", name, err)
 			}
@@ -549,10 +549,11 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 				return fmt.Errorf("Router %q service does not exist", name)
 			}
 			generate = true
-		} else {
-			clusterIP = service.Spec.ClusterIP
 		}
+	} else {
+		clusterIP = service.Spec.ClusterIP
 	}
+
 	if !generate {
 		fmt.Fprintf(out, "Router %q service exists\n", name)
 		return nil


### PR DESCRIPTION
Fix a logical error of the function `RunCmdRouter` in the `oadm router`. 
In the original code, `service.Spec.ClusterIP` will never be used. Because the function will return in the next `if`  when `generate` is "false".


This error exists in the `oadm registry`.