### PR TITLE
generate_vrrp_sync_groups calls expand_ip_ranges on an already expanded ranges

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -246,7 +246,7 @@ function generate_failover_config() {
 
 $(generate_global_config "$HA_CONFIG_NAME")
 $(generate_script_config "$ipaddr" "$port")
-$(generate_vrrp_sync_groups "$HA_CONFIG_NAME" "$vips")
+$(generate_vrrp_sync_groups "$HA_CONFIG_NAME" "$HA_VIPS")
 "
 
   local ipkey=$(echo "$ipaddr" | cut -f 4 -d '.')


### PR DESCRIPTION

broken version generates :
```
vrrp_sync_group group_OpenShift_IPFailover {
   group {
      OpenShift_IPFailover_VIP_1   # VIP 1.2.3.41.2.3.51.2.3.6
   }
}
```

patched version generates :
```
vrrp_sync_group group_OpenShift_IPFailover {
   group {
      OpenShift_IPFailover_VIP_1   # VIP 1.2.3.4
      OpenShift_IPFailover_VIP_2   # VIP 1.2.3.5
      OpenShift_IPFailover_VIP_3   # VIP 1.2.3.6
   }
}
```