### PR TITLE
 Add a default ingress ip range

### DIFF
--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -74,6 +74,17 @@ func addDefaultingFuncs(scheme *runtime.Scheme) {
 				}
 			}
 
+			// TODO Detect cloud provider when not using built-in kubernetes
+			kubeConfig := obj.KubernetesMasterConfig
+			noCloudProvider := kubeConfig != nil && (len(kubeConfig.ControllerArguments["cloud-provider"]) == 0 || kubeConfig.ControllerArguments["cloud-provider"][0] == "")
+
+			if noCloudProvider && len(obj.NetworkConfig.IngressIPNetworkCIDR) == 0 {
+				cidr := "172.46.0.0/16"
+				if !(internal.CIDRsOverlap(cidr, obj.NetworkConfig.ClusterNetworkCIDR) || internal.CIDRsOverlap(cidr, obj.NetworkConfig.ServiceNetworkCIDR)) {
+					obj.NetworkConfig.IngressIPNetworkCIDR = cidr
+				}
+			}
+
 			// Historically, the clientCA was incorrectly used as the master's server cert CA bundle
 			// If missing from the config, migrate the ClientCA into that field
 			if obj.OAuthConfig != nil && obj.OAuthConfig.MasterCA == nil {

--- a/pkg/cmd/server/api/validation/master_test.go
+++ b/pkg/cmd/server/api/validation/master_test.go
@@ -435,33 +435,37 @@ func TestValidateIngressIPNetworkCIDR(t *testing.T) {
 			testName: "No CIDR",
 		},
 		{
-			testName:   "No cloud provider and invalid cidr",
+			testName:   "Invalid CIDR",
 			cidr:       "foo",
 			errorCount: 1,
 		},
 		{
-			testName:   "No cloud provider and unspecified cidr",
-			cidr:       "0.0.0.0/32",
-			errorCount: 1,
-		},
-		{
-			testName:    "No cloud provider and conflicting cidrs",
+			testName:    "No cloud provider and conflicting CIDRs",
 			cidr:        "172.16.0.0/16",
 			serviceCIDR: "172.16.0.0/16",
 			clusterCIDR: "172.16.0.0/16",
 			errorCount:  2,
 		},
 		{
-			testName:      "CIDR specified but cloud provider enabled",
-			cidr:          "172.16.0.0/16",
-			cloudProvider: "foo",
-			errorCount:    1,
+			testName: "No cloud provider and unspecified CIDR",
+			cidr:     "0.0.0.0/32",
 		},
 		{
-			testName:    "No cloud provider and valid, non-conflicting cidr",
+			testName:    "No cloud provider and non-conflicting CIDR",
 			cidr:        "172.16.0.0/16",
 			serviceCIDR: "172.17.0.0/16",
 			clusterCIDR: "172.18.0.0/16",
+		},
+		{
+			testName:      "Cloud provider and unspecified CIDR",
+			cidr:          "0.0.0.0/32",
+			cloudProvider: "foo",
+		},
+		{
+			testName:      "Cloud provider and CIDR",
+			cidr:          "172.16.0.0/16",
+			cloudProvider: "foo",
+			errorCount:    1,
 		},
 	}
 	for _, test := range testCases {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"net"
 	"path"
 	"reflect"
 	"strings"
@@ -488,7 +489,10 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, plu
 				// should have been caught with validation
 				return nil, err
 			}
-			allowIngressIP := len(options.NetworkConfig.IngressIPNetworkCIDR) > 0
+			allowIngressIP := false
+			if _, ipNet, err := net.ParseCIDR(options.NetworkConfig.IngressIPNetworkCIDR); err == nil && !ipNet.IP.IsUnspecified() {
+				allowIngressIP = true
+			}
 			plugins = append(plugins, serviceadmit.NewExternalIPRanger(reject, admit, allowIngressIP))
 
 		case serviceadmit.RestrictedEndpointsPluginName:

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -531,6 +531,9 @@ func (c *MasterConfig) RunIngressIPController(client *kclient.Client) {
 		// should have been caught with validation
 		glog.Fatalf("Unable to start ingress ip controller: %v", err)
 	}
+	if ipNet.IP.IsUnspecified() {
+		return
+	}
 	ingressIPController := ingressip.NewIngressIPController(client, ipNet, defaultIngressIPSyncPeriod)
 	go ingressIPController.Run(utilwait.NeverStop)
 }


### PR DESCRIPTION
If no ingress ip range is specified, default to a private range.
Ingress ip allocation can be disabled by specifying "0.0.0.0/32" for the range.

Addresses #10387 

cc: @smarterclayton