### PR TITLE
UPSTREAM: 30839: queueActionLocked requires write lock

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/client/cache/delta_fifo.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/cache/delta_fifo.go
@@ -483,8 +483,8 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 
 // Resync will send a sync event for each item
 func (f *DeltaFIFO) Resync() error {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.lock.Lock()
+	defer f.lock.Unlock()
 	for _, k := range f.knownObjects.ListKeys() {
 		obj, exists, err := f.knownObjects.GetByKey(k)
 		if err != nil {


### PR DESCRIPTION
This caused concurrent map exceptions upstream.

[test]