### PR TITLE
set image ref namespace when src project not specified

### DIFF
--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -389,6 +389,9 @@ func (o TagOptions) RunTag() error {
 			default:
 				istag.Tag.From.Name = localRef.NameString()
 				istag.Tag.From.Namespace = o.ref.Namespace
+				if len(o.ref.Namespace) == 0 && o.destNamespace[i] != o.namespace {
+					istag.Tag.From.Namespace = o.namespace
+				}
 			}
 
 			msg := ""

--- a/pkg/cmd/cli/cmd/tag_test.go
+++ b/pkg/cmd/cli/cmd/tag_test.go
@@ -43,6 +43,74 @@ func testData() []*imageapi.ImageStream {
 				},
 			},
 		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "rails", Namespace: "myproject", ResourceVersion: "10", CreationTimestamp: unversioned.Now()},
+			Spec: imageapi.ImageStreamSpec{
+				DockerImageRepository: "",
+				Tags: map[string]imageapi.TagReference{
+					"latest": {
+						From: &api.ObjectReference{
+							Name:      "ruby",
+							Namespace: "openshift",
+							Kind:      "ImageStreamTag",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRunTag_AddAccrossNamespaces(t *testing.T) {
+	streams := testData()
+	client := testclient.NewSimpleFake(streams[2], streams[0])
+	client.PrependReactor("create", "imagestreamtags", func(action ktc.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, kapierrors.NewMethodNotSupported(imageapi.Resource("imagestreamtags"), "create")
+	})
+	client.PrependReactor("update", "imagestreamtags", func(action ktc.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, kapierrors.NewMethodNotSupported(imageapi.Resource("imagestreamtags"), "update")
+	})
+
+	test := struct {
+		opts            *TagOptions
+		expectedActions []testAction
+		expectedErr     error
+	}{
+		opts: &TagOptions{
+			out:      os.Stdout,
+			osClient: client,
+			ref: imageapi.DockerImageReference{
+				Namespace: "openshift",
+				Name:      "ruby",
+				Tag:       "latest",
+			},
+			namespace:      "myproject2",
+			sourceKind:     "ImageStreamTag",
+			destNamespace:  []string{"yourproject"},
+			destNameAndTag: []string{"rails:tip"},
+		},
+		expectedActions: []testAction{
+			{verb: "update", resource: "imagestreamtags"},
+			{verb: "create", resource: "imagestreamtags"},
+			{verb: "get", resource: "imagestreams"},
+			{verb: "update", resource: "imagestreams"},
+		},
+		expectedErr: nil,
+	}
+
+	if err := test.opts.RunTag(); err != test.expectedErr {
+		t.Fatalf("error mismatch: expected %v, got %v", test.expectedErr, err)
+	}
+
+	got := client.Actions()
+	if len(test.expectedActions) != len(got) {
+		t.Fatalf("action length mismatch: expectedc %d, got %d", len(test.expectedActions), len(got))
+	}
+
+	for i, action := range test.expectedActions {
+		if !got[i].Matches(action.verb, action.resource) {
+			t.Errorf("action mismatch: expected %s %s, got %s %s", action.verb, action.resource, got[i].GetVerb(), got[i].GetResource())
+		}
 	}
 }
 

--- a/test/cmd/images_tests.sh
+++ b/test/cmd/images_tests.sh
@@ -198,6 +198,9 @@ os::cmd::expect_success 'oc new-project test-cmd-images-2'
 os::cmd::expect_success "oc tag $project/mysql:5.5 newrepo:latest"
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}'" 'ImageStreamImage'
 os::cmd::expect_success_and_text 'oc get istag/newrepo:latest -o jsonpath={.image.dockerImageReference}' 'mysql@sha256:'
+# tag accross projects without specifying the source's project
+os::cmd::expect_success_and_text "oc tag newrepo:latest '${project}/mysql:tag1'" "mysql:tag1 set to"
+os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 0).name}}'" "latest"
 # tagging an image with a DockerImageReference that points to the internal registry across namespaces updates the reference
 os::cmd::expect_success "oc tag $project/test:new newrepo:direct"
 # reference should point to the current repository, and that repository should match the reported dockerImageRepository for pushes


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1315625

`oc tag [source project/]<is name:tag1> [another destination project/]<is
name:tag2>` fails when "[source project/]" is not provided.

This patch ensures that the source image ref has a namespace when no
project name is provided for it.

cc @fabianofranz 