### PR TITLE
Allowed 'true' for the DROP_SYN_DURING_RESTART variable

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -58,7 +58,7 @@ old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' |
 reload_status=0
 installed_iptables=0
 if [ -n "$old_pids" ]; then
-  if $(set | grep DROP_SYN_DURING_RESTART= > /dev/null) && [[ "$DROP_SYN_DURING_RESTART" == 1 ]]; then
+  if $(set | grep DROP_SYN_DURING_RESTART= > /dev/null) && [[ "$DROP_SYN_DURING_RESTART" == 'true' || "$DROP_SYN_DURING_RESTART" == '1' ]]; then
     # We install the syn eater so that connections that come in during the restart don't
     # go onto the wrong socket, which is then closed.
     ports=$(grep -E '^\s*bind\s+:[[:digit:]]+\w' "$config_file" | cut -f2 -d: | paste -d, -s)


### PR DESCRIPTION
To better conform to the other environment variables, 'true' is
supported to enable the SYN eater during haproxy reloads.  '1' is the
existing value that is still supported to maintain backwards
compatability.

For bug 1269488