### PR TITLE
Fix oc project|projects when in cluster config

### DIFF
--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -122,8 +122,11 @@ func (o ProjectOptions) RunProject() error {
 	clientCfg := o.ClientConfig
 	out := o.Out
 
+	var currentProject string
 	currentContext := config.Contexts[config.CurrentContext]
-	currentProject := currentContext.Namespace
+	if currentContext != nil {
+		currentProject = currentContext.Namespace
+	}
 
 	// No argument provided, we will just print info
 	if len(o.ProjectName) == 0 {

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -111,8 +111,11 @@ func (o ProjectsOptions) RunProjects() error {
 	clientCfg := o.ClientConfig
 	out := o.Out
 
+	var currentProject string
 	currentContext := config.Contexts[config.CurrentContext]
-	currentProject := currentContext.Namespace
+	if currentContext != nil {
+		currentProject = currentContext.Namespace
+	}
 
 	var currentProjectExists bool
 	var currentProjectErr error
@@ -125,7 +128,10 @@ func (o ProjectsOptions) RunProjects() error {
 		}
 	}
 
-	defaultContextName := cliconfig.GetContextNickname(currentContext.Namespace, currentContext.Cluster, currentContext.AuthInfo)
+	var defaultContextName string
+	if currentContext != nil {
+		defaultContextName = cliconfig.GetContextNickname(currentContext.Namespace, currentContext.Cluster, currentContext.AuthInfo)
+	}
 
 	var msg string
 	projects, err := getProjects(client)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1367655

When `oc` is used inside a pod, we get [a slightly different config based on the serviceaccount Kube gives to pods](https://github.com/fabianofranz/origin/blob/37608e05a59c176cd6be78e2bcdcb446ebcf796f/vendor/k8s.io/kubernetes/pkg/client/restclient/config.go#L244-L247). In these cases, although we still get a working config, some information like a `CurrentContext` may be missing. `oc project` and `oc projects` need to protect against that.