### PR TITLE
allow add/delete/add before pop in event queue

### DIFF
--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -83,7 +83,9 @@ var watchEventEffectMatrix = map[watch.EventType]map[watch.EventType]watchEventE
 		watch.Modified: watchEventEffectCompress,
 		watch.Deleted:  watchEventEffectCompress,
 	},
-	watch.Deleted: {},
+	watch.Deleted: {
+		watch.Added: watchEventEffectAdd,
+	},
 }
 
 // The watch event compression matrix defines how two events should be compressed.

--- a/pkg/client/cache/eventqueue_test.go
+++ b/pkg/client/cache/eventqueue_test.go
@@ -205,3 +205,23 @@ func TestEventQueue_ListConsumed(t *testing.T) {
 		t.Fatalf("expected ListConsumed to be true after queued items read")
 	}
 }
+
+func TestEventQueue_addDeleteAdd(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+
+	q.Replace([]interface{}{}, "1")
+
+	q.Add(cacheable{"foo", 3})
+	q.Delete(cacheable{key: "foo"})
+	q.Add(cacheable{"foo", 6})
+
+	event, thing, _ := q.Pop()
+	value := thing.(cacheable).value
+	if value != 6 {
+		t.Fatalf("expected %v, got %v", 6, value)
+	}
+
+	if event != watch.Added {
+		t.Fatalf("expected %s, got %s", watch.Added, event)
+	}
+}


### PR DESCRIPTION
add/delete/add was considered an illegal transition, but if you delete something you need to be allowed to re-add it before popping the delete.

This relies on adds of existing keys not going haywire since modified/delete/add could result in a compressed add being presented to clients.

Looks to have been in the initial impl here; https://github.com/openshift/origin/pull/394/files#diff-cd1b85f20aa1ae0fa305343876cab0ffR73

@smarterclayton @marun who should review?  Does anyone know if repeated Adds are handled correctly?  We should be level driven, not edge triggered, so I'd expect reasonable behavior, but I don't actually know.