### PR TITLE
Use non-secure cookie when tls and non-tls enabled

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -288,11 +288,7 @@ backend be_edge_http_{{$cfgIdx}}
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
-  {{ if (eq $cfg.TLSTermination "") }}
-    cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
-  {{ else }}
-  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
-  {{ end }}
+  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
     {{ range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
       {{ if ne $weight 0 }}


### PR DESCRIPTION
Previously when a router's insecureEdgeTerminationPolicy allowed both
tls and non-tls, a secure cookie was set.  When a client connected
over http the cookie would be dropped, breaking session persistence.
This change sets the cookie to be non-secure to avoid this problem.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1368525

cc: @openshift/networking 