### PR TITLE
use slice not map to save scmauth

### DIFF
--- a/pkg/build/builder/cmd/scmauth/scmauths.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths.go
@@ -22,21 +22,18 @@ func GitAuths(sourceURL *url.URL) SCMAuths {
 }
 
 func (a SCMAuths) present(files []os.FileInfo) SCMAuths {
-	scmAuthsPresent := map[string]SCMAuth{}
+	scmAuthsPresent := SCMAuths{}
 	for _, file := range files {
 		glog.V(4).Infof("Finding auth for %q", file.Name())
 		for _, scmAuth := range a {
 			if scmAuth.Handles(file.Name()) {
 				glog.V(4).Infof("Found SCMAuth %q to handle %q", scmAuth.Name(), file.Name())
-				scmAuthsPresent[scmAuth.Name()] = scmAuth
+				scmAuthsPresent = append(scmAuthsPresent, scmAuth)
+				break
 			}
 		}
 	}
-	auths := SCMAuths{}
-	for _, auth := range scmAuthsPresent {
-		auths = append(auths, auth)
-	}
-	return auths
+	return scmAuthsPresent
 }
 
 func (a SCMAuths) doSetup(secretsDir string) (*defaultSCMContext, error) {


### PR DESCRIPTION
function `present` should use slice directly to save scmauths info, and adding a `break` will be better when name was matched.