### PR TITLE
fix json serialization in admissionConfig

### DIFF
--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -149,7 +149,7 @@ func (DNSConfig) SwaggerDoc() map[string]string {
 
 var map_DefaultAdmissionConfig = map[string]string{
 	"":        "DefaultAdmissionConfig can be used to enable or disable various admission plugins. When this type is present as the `configuration` object under `pluginConfig` and *if* the admission plugin supports it, this will cause an \"off by default\" admission plugin to be enabled",
-	"Disable": "Disable turns off an admission plugin that is enabled by default.",
+	"disable": "Disable turns off an admission plugin that is enabled by default.",
 }
 
 func (DefaultAdmissionConfig) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -1258,5 +1258,5 @@ type DefaultAdmissionConfig struct {
 	unversioned.TypeMeta `json:",inline"`
 
 	// Disable turns off an admission plugin that is enabled by default.
-	Disable bool
+	Disable bool `json:"disable"`
 }


### PR DESCRIPTION
Missing `json` tag in master-config.yaml file.  Also updated the unit tests that were intended to catch these conditions.

@csrwng ptal.