### PR TITLE
Enable secure cookie for secure-only edge routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -288,7 +288,11 @@ backend be_edge_http_{{$cfgIdx}}
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  {{ if and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "None") }}
+  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
+  {{ else }}
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
+  {{ end }}
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
     {{ range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
       {{ if ne $weight 0 }}


### PR DESCRIPTION
#10544 disabled secure cookies for routes allowing insecure connections to avoid breaking session persistence.  This change re-enables secure cookies for edge routes that disallow insecure termination.

cc: @smarterclayton @openshift/networking  