### PR TITLE
Router: factor RouteValidator out of UniqueHost

### DIFF
--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -177,7 +177,9 @@ func (o *F5RouterOptions) Run() error {
 	}
 
 	statusPlugin := controller.NewStatusAdmitter(f5Plugin, oc, o.RouterName)
-	plugin := controller.NewUniqueHost(statusPlugin, o.RouteSelectionFunc(), statusPlugin)
+	uniqueHostPlugin := controller.NewUniqueHost(statusPlugin, statusPlugin)
+	plugin := controller.NewRouteValidator(uniqueHostPlugin,
+		o.HostnameTemplate, o.OverrideHostname, statusPlugin)
 
 	factory := o.RouterSelection.NewFactory(oc, kc)
 	controller := factory.Create(plugin)

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -16,9 +15,6 @@ import (
 
 	oclient "github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/variable"
-	routeapi "github.com/openshift/origin/pkg/route/api"
-	"github.com/openshift/origin/pkg/router/controller"
 	controllerfactory "github.com/openshift/origin/pkg/router/controller/factory"
 )
 
@@ -55,32 +51,6 @@ func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.ProjectLabelSelector, "project-labels", cmdutil.Env("PROJECT_LABELS", ""), "A label selector to apply to projects to watch; if '*' watches all projects the client can access")
 	flag.StringVar(&o.NamespaceLabelSelector, "namespace-labels", cmdutil.Env("NAMESPACE_LABELS", ""), "A label selector to apply to namespaces to watch")
 	flag.BoolVar(&o.IncludeUDP, "include-udp-endpoints", false, "If true, UDP endpoints will be considered as candidates for routing")
-}
-
-// RouteSelectionFunc returns a func that identifies the host for a route.
-func (o *RouterSelection) RouteSelectionFunc() controller.RouteHostFunc {
-	if len(o.HostnameTemplate) == 0 {
-		return controller.HostForRoute
-	}
-	return func(route *routeapi.Route) string {
-		if !o.OverrideHostname && len(route.Spec.Host) > 0 {
-			return route.Spec.Host
-		}
-		s, err := variable.ExpandStrict(o.HostnameTemplate, func(key string) (string, bool) {
-			switch key {
-			case "name":
-				return route.Name, true
-			case "namespace":
-				return route.Namespace, true
-			default:
-				return "", false
-			}
-		})
-		if err != nil {
-			return ""
-		}
-		return strings.Trim(s, "\"'")
-	}
 }
 
 // Complete converts string representations of field and label selectors to their parsed equivalent, or

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -207,7 +207,10 @@ func (o *TemplateRouterOptions) Run() error {
 	if o.ExtendedValidation {
 		nextPlugin = controller.NewExtendedValidator(nextPlugin, controller.RejectionRecorder(statusPlugin))
 	}
-	plugin := controller.NewUniqueHost(nextPlugin, o.RouteSelectionFunc(), controller.RejectionRecorder(statusPlugin))
+	uniqueHostPlugin := controller.NewUniqueHost(nextPlugin, controller.RejectionRecorder(statusPlugin))
+	plugin := controller.NewRouteValidator(uniqueHostPlugin,
+		o.HostnameTemplate, o.OverrideHostname,
+		controller.RejectionRecorder(statusPlugin))
 
 	factory := o.RouterSelection.NewFactory(oc, kc)
 	controller := factory.Create(plugin)

--- a/pkg/router/controller/rejection_recorder.go
+++ b/pkg/router/controller/rejection_recorder.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"github.com/golang/glog"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+// RejectionRecorder is an object capable of recording why a route was rejected.
+type RejectionRecorder interface {
+	RecordRouteRejection(route *routeapi.Route, reason, message string)
+}
+
+var LogRejections = logRecorder{}
+
+type logRecorder struct{}
+
+func (_ logRecorder) RecordRouteRejection(route *routeapi.Route, reason, message string) {
+	glog.V(4).Infof("Rejected route %s: %s: %s", route.Name, reason, message)
+}

--- a/pkg/router/controller/route_validator.go
+++ b/pkg/router/controller/route_validator.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/cmd/util/variable"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	"github.com/openshift/origin/pkg/router"
+)
+
+// RouteHostFunc returns a host for a route. It may return an empty string.
+type RouteHostFunc func(*routeapi.Route) string
+
+// HostForRoute returns the host set on the route.
+func HostForRoute(route *routeapi.Route) string {
+	return route.Spec.Host
+}
+
+// routeSelectionFunc returns a function that returns the host for a route,
+// possibly generated according to the specified template.
+func routeSelectionFunc(hostnameTemplate string,
+	overrideHostname bool) RouteHostFunc {
+	if len(hostnameTemplate) == 0 {
+		return HostForRoute
+	}
+	return func(route *routeapi.Route) string {
+		if !overrideHostname && len(route.Spec.Host) > 0 {
+			return route.Spec.Host
+		}
+		s, err := variable.ExpandStrict(hostnameTemplate,
+			func(key string) (string, bool) {
+				switch key {
+				case "name":
+					return route.Name, true
+				case "namespace":
+					return route.Namespace, true
+				default:
+					return "", false
+				}
+			})
+		if err != nil {
+			return ""
+		}
+		return strings.Trim(s, "\"'")
+	}
+}
+
+// RouteValidator implements the router.Plugin interface and validates
+// routes before passing them along to another router.Plugin.
+type RouteValidator struct {
+	plugin router.Plugin
+
+	recorder RejectionRecorder
+
+	hostForRoute RouteHostFunc
+
+	// nil means different than empty
+	allowedNamespaces sets.String
+}
+
+// NewRouteValidator creates a plugin wrapper that validates properties of
+// the route before passing it into the underlying plugin.
+func NewRouteValidator(plugin router.Plugin, hostnameTemplate string,
+	overrideHostname bool, recorder RejectionRecorder) *RouteValidator {
+	return &RouteValidator{
+		plugin:       plugin,
+		hostForRoute: routeSelectionFunc(hostnameTemplate, overrideHostname),
+
+		recorder: recorder,
+	}
+}
+
+// HandleEndpoints processes watch events on the Endpoints resource.
+func (p *RouteValidator) HandleEndpoints(eventType watch.EventType,
+	endpoints *kapi.Endpoints) error {
+	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(endpoints.Namespace) {
+		return nil
+	}
+	return p.plugin.HandleEndpoints(eventType, endpoints)
+}
+
+// HandleRoute processes watch events on the Route resource.
+func (p *RouteValidator) HandleRoute(eventType watch.EventType,
+	route *routeapi.Route) error {
+	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
+		return nil
+	}
+
+	host := p.hostForRoute(route)
+	if len(host) == 0 {
+		glog.V(4).Infof("Route %s has no host value", routeNameKey(route))
+		p.recorder.RecordRouteRejection(route, "NoHostValue", "no host value was defined for the route")
+		return nil
+	}
+	route.Spec.Host = host
+
+	switch eventType {
+	case watch.Added, watch.Modified:
+		return p.plugin.HandleRoute(eventType, route)
+
+	case watch.Deleted:
+		return p.plugin.HandleRoute(eventType, route)
+	}
+	return nil
+}
+
+// HandleNamespaces limits the scope of valid routes to only those that match
+// the provided namespace list.
+func (p *RouteValidator) HandleNamespaces(namespaces sets.String) error {
+	p.allowedNamespaces = namespaces
+	return p.plugin.HandleNamespaces(namespaces)
+}
+
+func (p *RouteValidator) SetLastSyncProcessed(processed bool) error {
+	return p.plugin.SetLastSyncProcessed(processed)
+}

--- a/pkg/router/controller/route_validator_test.go
+++ b/pkg/router/controller/route_validator_test.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+type rejection struct {
+	route   *routeapi.Route
+	reason  string
+	message string
+}
+
+type fakeRejections struct {
+	rejections []rejection
+}
+
+func (r *fakeRejections) RecordRouteRejection(route *routeapi.Route, reason, message string) {
+	r.rejections = append(r.rejections, rejection{route: route, reason: reason, message: message})
+}
+
+type testPlugin struct {
+	route *routeapi.Route
+}
+
+func (p *testPlugin) HandleRoute(_ watch.EventType, route *routeapi.Route) error {
+	p.route = route
+	return nil
+}
+func (p *testPlugin) HandleEndpoints(watch.EventType, *kapi.Endpoints) error {
+	return fmt.Errorf("not expected")
+}
+func (p *testPlugin) HandleNamespaces(namespaces sets.String) error {
+	return fmt.Errorf("not expected")
+}
+func (p *testPlugin) SetLastSyncProcessed(processed bool) error {
+	return fmt.Errorf("not expected")
+}
+
+// If a route with no host is added, and there is no template defined, then the
+// route should be ignored.
+func TestTemplateEmptyHostEmpty(t *testing.T) {
+	testPlugin := &testPlugin{}
+	rejections := &fakeRejections{}
+	routeValidator := NewRouteValidator(testPlugin, "", false, rejections)
+	err := routeValidator.HandleRoute(watch.Added, &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "route1",
+			Namespace: "default",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "",
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if testPlugin.route != nil {
+		t.Fatalf("route was added when it should have been ignored: %v",
+			testPlugin.route)
+	}
+
+	if len(rejections.rejections) != 1 ||
+		rejections.rejections[0].route.Name != "route1" ||
+		rejections.rejections[0].reason != "NoHostValue" ||
+		rejections.rejections[0].message != "no host value was defined for the route" {
+		t.Fatalf("did not record expected rejection: %#v", rejections)
+	}
+}
+
+// If a route with no host is added, and there is a template defined, then the
+// route should be added with a host generated according to the template.
+func TestTemplatePresentHostEmpty(t *testing.T) {
+	testPlugin := &testPlugin{}
+	rejections := &fakeRejections{}
+	routeValidator := NewRouteValidator(testPlugin,
+		"${name}-${namespace}.myapps.mycompany.com", false, rejections)
+	err := routeValidator.HandleRoute(watch.Added, &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "route1",
+			Namespace: "default",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "",
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rejections.rejections) > 0 {
+		t.Fatalf("did not expect a recorded rejection: %#v", rejections)
+	}
+
+	if testPlugin.route == nil {
+		t.Fatal("route was not added when it should have been")
+	}
+
+	if testPlugin.route.Spec.Host != "route1-default.myapps.mycompany.com" {
+		t.Fatalf("route was added with wrong host: %v",
+			testPlugin.route)
+	}
+}
+
+// If a route is added, and there is a template defined, and the override flag
+// is enabled, then the route should be added with a host generated according to
+// the template.
+func TestTemplatePresentHostOverride(t *testing.T) {
+	testPlugin := &testPlugin{}
+	rejections := &fakeRejections{}
+	routeValidator := NewRouteValidator(testPlugin,
+		"${name}-${namespace}.myapps.mycompany.com", true, rejections)
+	err := routeValidator.HandleRoute(watch.Added, &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "route1",
+			Namespace: "default",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "bar-default.myapps.mycompany.com",
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rejections.rejections) > 0 {
+		t.Fatalf("did not expect a recorded rejection: %#v", rejections)
+	}
+
+	if testPlugin.route == nil {
+		t.Fatal("route was not added when it should have been")
+	}
+
+	if testPlugin.route.Spec.Host != "route1-default.myapps.mycompany.com" {
+		t.Fatalf("route was added with wrong host: %v",
+			testPlugin.route)
+	}
+}

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -12,37 +12,25 @@ import (
 	"github.com/openshift/origin/pkg/router"
 )
 
-// RouteHostFunc returns a host for a route. It may return an empty string.
-type RouteHostFunc func(*routeapi.Route) string
-
-// HostForRoute returns the host set on the route.
-func HostForRoute(route *routeapi.Route) string {
-	return route.Spec.Host
-}
-
 type HostToRouteMap map[string][]*routeapi.Route
 type RouteToHostMap map[string]string
 
 // UniqueHost implements the router.Plugin interface to provide
 // a template based, backend-agnostic router.
 type UniqueHost struct {
-	plugin       router.Plugin
-	hostForRoute RouteHostFunc
+	plugin router.Plugin
 
 	recorder RejectionRecorder
 
 	hostToRoute HostToRouteMap
 	routeToHost RouteToHostMap
-	// nil means different than empty
-	allowedNamespaces sets.String
 }
 
 // NewUniqueHost creates a plugin wrapper that ensures only unique routes are
 // passed into the underlying plugin.
-func NewUniqueHost(plugin router.Plugin, fn RouteHostFunc, recorder RejectionRecorder) *UniqueHost {
+func NewUniqueHost(plugin router.Plugin, recorder RejectionRecorder) *UniqueHost {
 	return &UniqueHost{
-		plugin:       plugin,
-		hostForRoute: fn,
+		plugin: plugin,
 
 		recorder: recorder,
 
@@ -64,9 +52,6 @@ func (p *UniqueHost) HostLen() int {
 
 // HandleEndpoints processes watch events on the Endpoints resource.
 func (p *UniqueHost) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
-	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(endpoints.Namespace) {
-		return nil
-	}
 	return p.plugin.HandleEndpoints(eventType, endpoints)
 }
 
@@ -75,19 +60,14 @@ func (p *UniqueHost) HandleEndpoints(eventType watch.EventType, endpoints *kapi.
 //   determines which component needs to be recalculated (which template) and then does so
 //   on demand.
 func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Route) error {
-	if p.allowedNamespaces != nil && !p.allowedNamespaces.Has(route.Namespace) {
-		return nil
-	}
-
 	routeName := routeNameKey(route)
 
-	host := p.hostForRoute(route)
+	host := route.Spec.Host
 	if len(host) == 0 {
 		glog.V(4).Infof("Route %s has no host value", routeName)
 		p.recorder.RecordRouteRejection(route, "NoHostValue", "no host value was defined for the route")
 		return nil
 	}
-	route.Spec.Host = host
 
 	// ensure hosts can only be claimed by one namespace at a time
 	// TODO: this could be abstracted above this layer?
@@ -176,10 +156,9 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 	return nil
 }
 
-// HandleAllowedNamespaces limits the scope of valid routes to only those that match
-// the provided namespace list.
+// HandleNamespaces updates the hostToRoute and routeToHost maps with respect to
+// changes to the set of watched namespaces.
 func (p *UniqueHost) HandleNamespaces(namespaces sets.String) error {
-	p.allowedNamespaces = namespaces
 	changed := false
 	for k, v := range p.hostToRoute {
 		if namespaces.Has(v[0].Namespace) {

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -23,19 +23,6 @@ func HostForRoute(route *routeapi.Route) string {
 type HostToRouteMap map[string][]*routeapi.Route
 type RouteToHostMap map[string]string
 
-// RejectionRecorder is an object capable of recording why a route was rejected
-type RejectionRecorder interface {
-	RecordRouteRejection(route *routeapi.Route, reason, message string)
-}
-
-var LogRejections = logRecorder{}
-
-type logRecorder struct{}
-
-func (_ logRecorder) RecordRouteRejection(route *routeapi.Route, reason, message string) {
-	glog.V(4).Infof("Rejected route %s: %s: %s", route.Name, reason, message)
-}
-
 // UniqueHost implements the router.Plugin interface to provide
 // a template based, backend-agnostic router.
 type UniqueHost struct {
@@ -50,9 +37,8 @@ type UniqueHost struct {
 	allowedNamespaces sets.String
 }
 
-// NewUniqueHost creates a plugin wrapper that ensures only unique routes are passed into
-// the underlying plugin. Recorder is an interface for indicating why a route was
-// rejected.
+// NewUniqueHost creates a plugin wrapper that ensures only unique routes are
+// passed into the underlying plugin.
 func NewUniqueHost(plugin router.Plugin, fn RouteHostFunc, recorder RejectionRecorder) *UniqueHost {
 	return &UniqueHost{
 		plugin:       plugin,

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -331,7 +331,7 @@ func TestHandleEndpoints(t *testing.T) {
 	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
-	plugin := controller.NewUniqueHost(templatePlugin, controller.HostForRoute, controller.LogRejections)
+	plugin := controller.NewUniqueHost(templatePlugin, controller.LogRejections)
 
 	for _, tc := range testCases {
 		plugin.HandleEndpoints(tc.eventType, tc.endpoints)
@@ -445,7 +445,7 @@ func TestHandleTCPEndpoints(t *testing.T) {
 	templatePlugin := newDefaultTemplatePlugin(router, false, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
-	plugin := controller.NewUniqueHost(templatePlugin, controller.HostForRoute, controller.LogRejections)
+	plugin := controller.NewUniqueHost(templatePlugin, controller.LogRejections)
 
 	for _, tc := range testCases {
 		plugin.HandleEndpoints(tc.eventType, tc.endpoints)
@@ -491,7 +491,7 @@ func TestHandleRoute(t *testing.T) {
 	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
-	plugin := controller.NewUniqueHost(templatePlugin, controller.HostForRoute, rejections)
+	plugin := controller.NewUniqueHost(templatePlugin, rejections)
 
 	original := unversioned.Time{Time: time.Now()}
 
@@ -670,7 +670,7 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
 	extendedValidatorPlugin := controller.NewExtendedValidator(templatePlugin, rejections)
-	plugin := controller.NewUniqueHost(extendedValidatorPlugin, controller.HostForRoute, rejections)
+	plugin := controller.NewUniqueHost(extendedValidatorPlugin, rejections)
 
 	original := unversioned.Time{Time: time.Now()}
 
@@ -1022,7 +1022,10 @@ func TestNamespaceScopingFromEmpty(t *testing.T) {
 	templatePlugin := newDefaultTemplatePlugin(router, true, nil)
 	// TODO: move tests that rely on unique hosts to pkg/router/controller and remove them from
 	// here
-	plugin := controller.NewUniqueHost(templatePlugin, controller.HostForRoute, controller.LogRejections)
+	uniqueHostPlugin := controller.NewUniqueHost(templatePlugin,
+		controller.LogRejections)
+	plugin := controller.NewRouteValidator(uniqueHostPlugin, "", false,
+		controller.LogRejections)
 
 	// no namespaces allowed
 	plugin.HandleNamespaces(sets.String{})
@@ -1042,7 +1045,7 @@ func TestNamespaceScopingFromEmpty(t *testing.T) {
 	// ignores all events for namespace that doesn't match
 	for _, s := range []watch.EventType{watch.Added, watch.Modified, watch.Deleted} {
 		plugin.HandleRoute(s, route)
-		if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
+		if _, ok := router.FindServiceUnit("foo/TestService"); ok || uniqueHostPlugin.HostLen() != 0 {
 			t.Errorf("unexpected router state %#v", router)
 		}
 	}
@@ -1051,7 +1054,7 @@ func TestNamespaceScopingFromEmpty(t *testing.T) {
 	plugin.HandleNamespaces(sets.NewString("bar"))
 	for _, s := range []watch.EventType{watch.Added, watch.Modified, watch.Deleted} {
 		plugin.HandleRoute(s, route)
-		if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
+		if _, ok := router.FindServiceUnit("foo/TestService"); ok || uniqueHostPlugin.HostLen() != 0 {
 			t.Errorf("unexpected router state %#v", router)
 		}
 	}
@@ -1059,21 +1062,21 @@ func TestNamespaceScopingFromEmpty(t *testing.T) {
 	// allow foo
 	plugin.HandleNamespaces(sets.NewString("foo", "bar"))
 	plugin.HandleRoute(watch.Added, route)
-	if _, ok := router.FindServiceUnit("foo/TestService"); !ok || plugin.HostLen() != 1 {
+	if _, ok := router.FindServiceUnit("foo/TestService"); !ok || uniqueHostPlugin.HostLen() != 1 {
 		t.Errorf("unexpected router state %#v", router)
 	}
 
 	// forbid foo, and make sure it's cleared
 	plugin.HandleNamespaces(sets.NewString("bar"))
-	if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
+	if _, ok := router.FindServiceUnit("foo/TestService"); ok || uniqueHostPlugin.HostLen() != 0 {
 		t.Errorf("unexpected router state %#v", router)
 	}
 	plugin.HandleRoute(watch.Modified, route)
-	if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
+	if _, ok := router.FindServiceUnit("foo/TestService"); ok || uniqueHostPlugin.HostLen() != 0 {
 		t.Errorf("unexpected router state %#v", router)
 	}
 	plugin.HandleRoute(watch.Added, route)
-	if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
+	if _, ok := router.FindServiceUnit("foo/TestService"); ok || uniqueHostPlugin.HostLen() != 0 {
 		t.Errorf("unexpected router state %#v", router)
 	}
 }

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -269,9 +269,11 @@ func launchRouter(oc osclient.Interface, kc kclient.Interface, maxDelay int32, n
 
 	validationPlugin := controller.NewExtendedValidator(statusPlugin, controller.RejectionRecorder(statusPlugin))
 
-	uniquePlugin := controller.NewUniqueHost(validationPlugin, controller.HostForRoute, controller.RejectionRecorder(statusPlugin))
+	uniquePlugin := controller.NewUniqueHost(validationPlugin, controller.RejectionRecorder(statusPlugin))
 
-	var plugin router.Plugin = uniquePlugin
+	routeValidatorPlugin := controller.NewRouteValidator(uniquePlugin, "", false, controller.LogRejections)
+
+	var plugin router.Plugin = routeValidatorPlugin
 	if maxDelay > 0 {
 		plugin = NewDelayPlugin(plugin, maxDelay)
 	}


### PR DESCRIPTION
Currently, the UniqueHost router plugin wrapper performs several functions:

• Filter route and endpoint updates per `--namespace-labels`/`NAMESPACE_LABELS`.

• Ensure that the route has a non-empty host.

• Ensure that a new route does not claim a host held by an existing route.

Additionally, the core router code performs the following function:

• Override the route's host using the template specified with `--subdomain`/`ROUTER_SUBDOMAIN` if the host is blank or if `--force-subdomain`/`ROUTER_OVERRIDE_HOSTNAME` is specified.

This PR defines a new plugin wrapper, RouterValidator, to perform the first, second, and fourth of these functions, leaving UniqueHost to do exactly what its name implies and reducing the amount of ancillary login in the core router code.  This PR also adds some tests for RouteValidator.

These changes were previously included in https://github.com/openshift/origin/pull/9043 but are being introduced independently in this PR while we argue over the remaining changes in https://github.com/openshift/origin/pull/9043.
## 
#### router: Move `RejectionRecorder` to its own file

Move the `RejectionRecorder` interface and default implementation from `unique_host.go` into its own file, `rejection_recorder.go`.
#### router: Factor `RouteValidator` out of `UniqueHost`

Define a new plugin wrapper, `RouteValidator`.  Move existing validation from `UniqueHost` into `RouteValidator`:

• Reject the route if it is not from an allowed namespace.

• Override the hostname using the defined template if it is blank or if the plugin wrapper is configured to override hostnames.

Move `allowedNamespaces` and `hostForRoute` from `UniqueHost` to `RouteValidator`.

Move `RouteSelectionFunc` from `pkg/cmd/infra/router/router.go` to `pkg/router/controller/route_validator.go`, and modify it to take the hostname template and hostname-override flag as parameters instead of taking `RouterSelection` as a receiver and reading the parameters from there.

Call `RouteSelectionFunc` from `NewRouteValidator`, which now sets the `hostForRoute` callback, instead of calling `RouteSelectionFunc` in `NewUniqueHost`'s caller.

Move namespace validation, host validation, and host template expansion from `UniqueHost`'s `HandleEndpoints`, `HandleRoute`, and `HandleNamespace` callbacks to `RouteValidator`'s.

Update callers of `NewUniqueHost` to drop the `hostToRoute` argument if they do not need route validation or to use `NewRouteValidator` to create a `RouteValidator` that wraps a `UniqueHost` if they do need route validation.
#### router: Add tests for `RouteValidator`

Add tests for `RouteValidator`.
## 

openshift-bot, please [test]!
