### PR TITLE
An independent branch dealing with errors

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -141,22 +141,23 @@ func DeploymentDeepCopy(rc *api.ReplicationController) (*api.ReplicationControll
 func DecodeDeploymentConfig(controller *api.ReplicationController, decoder runtime.Decoder) (*deployapi.DeploymentConfig, error) {
 	encodedConfig := []byte(EncodedDeploymentConfigFor(controller))
 	decoded, err := runtime.Decode(decoder, encodedConfig)
-	if err == nil {
-		if config, ok := decoded.(*deployapi.DeploymentConfig); ok {
-			return config, nil
-		}
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DeploymentConfig from controller: %v", err)
+	}
+	config, ok := decoded.(*deployapi.DeploymentConfig)
+	if !ok {
 		return nil, fmt.Errorf("decoded object from controller is not a DeploymentConfig")
 	}
-	return nil, fmt.Errorf("failed to decode DeploymentConfig from controller: %v", err)
+	return config, nil
 }
 
 // EncodeDeploymentConfig encodes config as a string using codec.
 func EncodeDeploymentConfig(config *deployapi.DeploymentConfig, codec runtime.Codec) (string, error) {
-	if bytes, err := runtime.Encode(codec, config); err == nil {
-		return string(bytes[:]), nil
-	} else {
+	bytes, err := runtime.Encode(codec, config)
+	if err != nil {
 		return "", err
 	}
+	return string(bytes[:]), nil
 }
 
 // MakeDeployment creates a deployment represented as a ReplicationController and based on the given


### PR DESCRIPTION
I think the code style like below maybe be a little more favorable
pkg/deploy/util/util.go
func DeploymentDeepCopy(rc *api.ReplicationController) (*api.ReplicationController, error) {
	objCopy, err := api.Scheme.DeepCopy(rc)
	if err != nil {
		return nil, err
	}
	copied, ok := objCopy.(*api.ReplicationController)
	if !ok {
		return nil, fmt.Errorf("expected ReplicationController, got %#v", objCopy)
	}
	return copied, nil
}
