### PR TITLE
Emit event when cancelling a deployment

### DIFF
--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -185,6 +185,7 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 				if err := c.cleanupDeployerPods(deployment); err != nil {
 					return err
 				}
+				c.emitDeploymentEvent(deployment, kapi.EventTypeNormal, "DeploymentCancelled", fmt.Sprintf("Deployment %q cancelled", deployutil.LabelForDeployment(deployment)))
 			}
 		}
 


### PR DESCRIPTION
A simple addition that allow to see the cancelled deployments in events (oc describe/console):

```
DeploymentCreated	Created new deployment "ruby-ex-8" for version 8
DeploymentCancelled	ruby-ex-8: deployment "test/ruby-ex-8" cancelled
DeploymentCreated	Created new deployment "ruby-ex-9" for version 9
```