### PR TITLE
HAProxy Router: Invert health-check idled check

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -298,7 +298,7 @@ backend be_edge_http_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ if not $endpoint.NoHealthCheck }}
+            {{ if $endpoint.NoHealthCheck }}
               server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
             {{ else }}
               {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
@@ -362,7 +362,7 @@ backend be_tcp_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ if not $endpoint.NoHealthCheck }}
+            {{ if $endpoint.NoHealthCheck }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
             {{ else }}
               {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
@@ -436,7 +436,7 @@ backend be_secure_{{$cfgIdx}}
       {{ if ne $weight 0 }}
         {{ with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-            {{ if not $endpoint.NoHealthCheck }}
+            {{ if $endpoint.NoHealthCheck }}
   server {{$endpoint.IdHash}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.IdHash}} weight {{$weight}}
             {{ else }}
               {{ with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -167,7 +167,7 @@ func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]s
 	// make sure we don't get woken up by an incorrect router health check or anything like that
 	o.Consistently(func() (string, error) {
 		return oc.Run("get").Args(resourceName+"/"+objName, "--output=jsonpath=\"{.spec.replicas}\"").Output()
-	}, 5*time.Second, 500*time.Millisecond).Should(o.ContainSubstring("0"))
+	}, 20*time.Second, 500*time.Millisecond).Should(o.ContainSubstring("0"))
 
 	g.By("Fetching the service and checking the annotations are present")
 	serviceName := resources["service"][0]
@@ -250,7 +250,7 @@ var _ = g.Describe("idling and unidling", func() {
 	})
 
 	g.Describe("idling", func() {
-		g.Context("with a single service and DeploymentConfig", func() {
+		g.Context("with a single service and DeploymentConfig [Conformance]", func() {
 			g.BeforeEach(func() {
 				framework.BeforeEach()
 				fixture = echoServerFixture
@@ -279,7 +279,7 @@ var _ = g.Describe("idling and unidling", func() {
 			fixture = echoServerFixture
 		})
 
-		g.It("should work with TCP (when fully idled)", func() {
+		g.It("should work with TCP (when fully idled) [Conformance]", func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())


### PR DESCRIPTION
The check for no endpoints got inverted at some point during the PR,
causing health checks to be enabled *only* when a service was idled,
instead of the other way around.  This fixes that.

Fixes bug 1366180