### PR TITLE
note the change to oc tag -d

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -91,3 +91,8 @@ references:
 1.  The existing docker registry images will not be able to support auto-provisioning of image streams based on docker pushes against new API servers.
   Upgrade your docker registry image to make auto-provisioning work again.
 1. New service accounts specific to the PersistentVolume operations of binding, recycling, and provisioning were added.  Run `oadm policy reconcile-sccs --confirm` to update your SecurityContextConstraints.
+
+## Origin 1.3.x / OSE 3.3.x
+
+1.  `oc tag -d` now matches `oc delete imagestreamtag` behavior instead of removing the spec tag and leaving the status tag.
+    The old behavior can be achieved using `oc edit` or if you just want to disabling scheduled imports, `oc tag --scheduled=false`


### PR DESCRIPTION
Added a comment explaining the new behavior in `UPGRADE.MD`.  Docs updated in https://github.com/openshift/openshift-docs/pull/2717.

@smarterclayton I think this matches what we discussed. 