### PR TITLE
cleanup oc version output

### DIFF
--- a/pkg/cmd/cli/cmd/version.go
+++ b/pkg/cmd/cli/cmd/version.go
@@ -76,7 +76,7 @@ func (o *VersionOptions) Complete(f *clientcmd.Factory, out io.Writer) error {
 
 // RunVersion attempts to display client and server versions for Kubernetes and OpenShift
 func (o VersionOptions) RunVersion() error {
-	fmt.Fprintf(o.Out, "%s %v\n", o.BaseName, version.Get())
+	fmt.Fprintf(o.Out, "%s %s\n", o.BaseName, version.Get().LastSemanticVersion())
 	fmt.Fprintf(o.Out, "kubernetes %v\n", kubeversion.Get())
 	if o.PrintEtcdVersion {
 		fmt.Fprintf(o.Out, "etcd %v\n", etcdversion.Version)
@@ -142,7 +142,8 @@ func (o VersionOptions) RunVersion() error {
 			done <- err
 			return
 		}
-		oVersion = fmt.Sprintf("%v", ocServerInfo)
+		ocServerVersionInfo := version.Info{GitVersion: ocServerInfo.GitVersion}
+		oVersion = fmt.Sprintf("%s", ocServerVersionInfo.LastSemanticVersion())
 
 		kubeVersionBody, err := kClient.Get().AbsPath("/version").Do().Raw()
 		if kapierrors.IsNotFound(err) || kapierrors.IsUnauthorized(err) || kapierrors.IsForbidden(err) {


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1368913

`openshift version` returns unformatted "GitVersion".

This patch prints a cleaner output of the server version in `oc version`
and `openshift version` commands.

##### Before
`$ openshift version`
```
openshift v1.3.0-alpha.0+1605423-dirty
kubernetes v1.3.0+507d3a7
etcd 2.3.0+git
```

##### After
`$ openshift version`
```
openshift v1.3.0-alpha.0
kubernetes v1.3.0+507d3a7
etcd 2.3.0+git`
```

`$ oc version`
```
oc v1.3.0-alpha.0
kubernetes v1.3.0+507d3a7
features: Basic-Auth

Server https://10.13.137.149:8443
openshift v1.3.0-alpha.0
kubernetes v1.3.0+507d3a7
```

cc @fabianofranz 