### PR TITLE
update invalid oc extract usage flag to "keys"

### DIFF
--- a/docs/man/man1/oc-extract.1
+++ b/docs/man/man1/oc-extract.1
@@ -21,7 +21,7 @@ Each key in the config map or secret is created as a separate file with the name
 is when you mount a secret or config map into a container.
 
 .PP
-You can limit which keys are extracted with the \-\-only=NAME flag, or set the directory to extract to
+You can limit which keys are extracted with the \-\-keys=NAME flag, or set the directory to extract to
 with \-\-to=DIRECTORY.
 
 

--- a/docs/man/man1/openshift-cli-extract.1
+++ b/docs/man/man1/openshift-cli-extract.1
@@ -21,7 +21,7 @@ Each key in the config map or secret is created as a separate file with the name
 is when you mount a secret or config map into a container.
 
 .PP
-You can limit which keys are extracted with the \-\-only=NAME flag, or set the directory to extract to
+You can limit which keys are extracted with the \-\-keys=NAME flag, or set the directory to extract to
 with \-\-to=DIRECTORY.
 
 

--- a/pkg/cmd/cli/cmd/extract.go
+++ b/pkg/cmd/cli/cmd/extract.go
@@ -28,7 +28,7 @@ The extract command makes it easy to download the contents of a config map or se
 Each key in the config map or secret is created as a separate file with the name of the key, as it
 is when you mount a secret or config map into a container.
 
-You can limit which keys are extracted with the --only=NAME flag, or set the directory to extract to
+You can limit which keys are extracted with the --keys=NAME flag, or set the directory to extract to
 with --to=DIRECTORY.`
 
 	extractExample = `  # extract the secret "test" to the current directory


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1369371

`oc extract --help` uses the flag `--only` as example, but this flag has been replaced by `--keys=[]`.
Using this flag with the command, renders the error: `Error: unknown flag: --only`.

This patch updates the help usage for this command to make use of the valid `--keys=[]` flag.

cc @fabianofranz