### PR TITLE
fix `oc set env` key-value pair matching

### DIFF
--- a/test/cmd/env.sh
+++ b/test/cmd/env.sh
@@ -11,5 +11,6 @@ os::cmd::expect_success_and_text 'oc set env dc/node --list' 'deploymentconfigs 
 os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" key-' 'deploymentconfig "node" updated'
 os::cmd::expect_failure_and_text 'oc set env dc --all --containers="node"' 'error: at least one environment variable must be provided'
 os::cmd::expect_failure_and_not_text 'oc set env --from=secret/mysecret dc/node' 'error: at least one environment variable must be provided'
+os::cmd::expect_failure_and_text 'oc set env dc/node test#abc=1234' 'environment variables must be of the form key=value'
 echo "oc set env: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1369679

Passing key-value pairs to `oc set env` with certain invalid characters
causes an unrelated error to be rendered. This is caused because the
regex that separates key-value pairs from resource-type/resource
arguments does not account for invalid key-value pairs with invalid
characters (other than "-"). This means that when a command such as
`oc set env rc/node-1 test#abc=1234` is executed, `test#abc=1234`
will not be recognized as a key-value pair, and instead be treated
as a resource without a resource type, giving a user the wrong reason
for command failure.

This patch updates the regex matching env key-value pairs to match
any character from the beginning of the arg to the equal sign rather
than a select amount of characters, ensuring that key-value pair
arguments with any kind of invalid character are still recognized as
such.

##### Before
`$ oc set env rc/node-1 test-@abc=1234`
```
there is no need to specify a resource type as a separate argument when
passing arguments in resource/name form (e.g. 'oc get
resource/<resource_name>' instead of 'oc get resource
resource/<resource_name>'
```

##### After
`$ oc set env rc/node-1 test@-abc=1234`
```
error: environment variables must be of the form key=value and can only contain letters, numbers, and underscores
```

cc @fabianofranz 