### PR TITLE
API to autocreate subnets for external hosts

### DIFF
--- a/pkg/sdn/plugin/plugin.go
+++ b/pkg/sdn/plugin/plugin.go
@@ -25,6 +25,7 @@ const (
 	IngressBandwidthAnnotation string = "kubernetes.io/ingress-bandwidth"
 	EgressBandwidthAnnotation  string = "kubernetes.io/egress-bandwidth"
 	AssignMacVlanAnnotation    string = "pod.network.openshift.io/assign-macvlan"
+	AssignHostSubnetAnnotation string = "pod.network.openshift.io/assign-subnet"
 )
 
 func IsOpenShiftNetworkPlugin(pluginName string) bool {

--- a/pkg/util/netutils/subnet_allocator.go
+++ b/pkg/util/netutils/subnet_allocator.go
@@ -3,6 +3,7 @@ package netutils
 import (
 	"fmt"
 	"net"
+	"sync"
 )
 
 type SubnetAllocator struct {
@@ -14,6 +15,7 @@ type SubnetAllocator struct {
 	rightMask  uint32
 	next       uint32
 	allocMap   map[string]bool
+	mutex      sync.Mutex
 }
 
 func NewSubnetAllocator(network string, hostBits uint32, inUse []string) (*SubnetAllocator, error) {
@@ -85,6 +87,9 @@ func (sna *SubnetAllocator) GetNetwork() (*net.IPNet, error) {
 		numSubnets    uint32
 		numSubnetBits uint32
 	)
+	sna.mutex.Lock()
+	defer sna.mutex.Unlock()
+
 	baseipu := IPToUint32(sna.network.IP)
 	netMaskSize, _ := sna.network.Mask.Size()
 	numSubnetBits = 32 - uint32(netMaskSize) - sna.hostBits
@@ -109,6 +114,8 @@ func (sna *SubnetAllocator) GetNetwork() (*net.IPNet, error) {
 }
 
 func (sna *SubnetAllocator) ReleaseNetwork(ipnet *net.IPNet) error {
+	sna.mutex.Lock()
+	defer sna.mutex.Unlock()
 	if !sna.network.Contains(ipnet.IP) {
 		return fmt.Errorf("Provided subnet %v doesn't belong to the network %v.", ipnet, sna.network)
 	}


### PR DESCRIPTION
One can now allocate hostsubnets for hosts that are not part of the cluster. This is useful when a host wants to be part of the SDN, but not part of the cluster (e.g. F5)
Trello: https://trello.com/c/fnW1tPCY/155-8-f5-integration-get-lease-from-cluster-cidr

Implementation details:
1. Allow creation of a hostsubnet resource without the 'subnet' field being present. But only if a specific annotation exists ('hostsubnet.sdn.openshift.io/autocreate').
2. Let the master also watch hostsubnets, but only bother with the ones that have the annotation. The rest of them are also created by master, but by watching nodes.
3. When the master learns about a hostsubnet being created with the annotation, it allocates a subnet of the clusterNetwork IPAM, deletes the annotated hostsubnet and recreates a new one with the assigned subnet.

The deletion and recreation have been done so that migration of existing infrastructure can go on smoothly. Even if one were to update master and not the nodes, and add an F5 machine in the middle, no issues should appear.