### PR TITLE
WIP [DO_NOT_MERGE]: Read registry configuration from Docker daemon in new-app

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -175,6 +175,7 @@ type ImageImportSearcher struct {
 	Client        client.ImageStreamInterface
 	AllowInsecure bool
 	Fallback      Searcher
+	Registries    []string
 }
 
 // Search invokes the new ImageStreamImport API to have the server look up Docker images for the user,
@@ -196,7 +197,15 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 	result, err := s.Client.Import(isi)
 	if err != nil {
 		if err == client.ErrImageStreamImportUnsupported && s.Fallback != nil {
-			return s.Fallback.Search(precise, terms...)
+			extendedTerms := []string{}
+			for _, registryName := range s.Registries {
+				for _, imageName := range terms {
+					extendedTerms = append(extendedTerms, registryName+"/"+imageName)
+				}
+			}
+			extendedTerms = append(extendedTerms, terms...)
+			glog.V(5).Infof("falling back to the generic search (%q)", precise, strings.Join(extendedTerms, ","))
+			return s.Fallback.Search(precise, extendedTerms...)
 		}
 		return nil, []error{fmt.Errorf("can't lookup images: %v", err)}
 	}


### PR DESCRIPTION
This patch will use the engine-api client to get list of Docker registries (`ADD_REGISTRY`) configured for a Docker daemon and use that list to extended the search for the Docker image during the `new-app`.

In other words, if you have Dockerfile in your application source which has `FROM rhel7` and you have Docker that runs with `--add-registry registry.access.redhat.com` option, the `oc new-app` will include that registry when searching for image match.

@smarterclayton I think we should do something similar in image importer (we default to `docker.io` and not respecting the Docker configuration).

@csrwng you might have opinions about this.

Also fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1369769
