### PR TITLE
add permissions for jenkins

### DIFF
--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "authorization.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/build/api/register.go
+++ b/pkg/build/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "build.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -231,6 +231,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+				// access to jenkins.  multiple values to ensure that covers relationships
+				authorizationapi.NewRule("admin", "edit", "view").Groups(buildapi.FutureGroupName).Resources("jenkins").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(deployGroup).Resources("deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/rollback", "deploymentconfigs/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),
@@ -283,6 +285,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(buildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+				// access to jenkins.  multiple values to ensure that covers relationships
+				authorizationapi.NewRule("edit", "view").Groups(buildapi.FutureGroupName).Resources("jenkins").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(deployGroup).Resources("deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/rollback", "deploymentconfigs/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),
@@ -330,6 +334,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup).Resources("builds/log").RuleOrDie(),
+				// access to jenkins
+				authorizationapi.NewRule("view").Groups(buildapi.FutureGroupName).Resources("jenkins").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs", "deploymentconfigs/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(deployGroup).Resources("deploymentconfigs/log", "deploymentconfigs/status").RuleOrDie(),

--- a/pkg/deploy/api/register.go
+++ b/pkg/deploy/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "deploy.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/image/api/register.go
+++ b/pkg/image/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "image.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/oauth/api/register.go
+++ b/pkg/oauth/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "oauth.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/project/api/register.go
+++ b/pkg/project/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "project.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/route/api/register.go
+++ b/pkg/route/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "route.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/sdn/api/register.go
+++ b/pkg/sdn/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "networking.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/security/api/register.go
+++ b/pkg/security/api/register.go
@@ -7,6 +7,9 @@ import (
 
 const GroupName = ""
 
+// TODO no one likes the name security because it so broad as to be meaningless.
+// const FutureGroupName = "security.openshift.io"
+
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 

--- a/pkg/template/api/register.go
+++ b/pkg/template/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "template.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/pkg/user/api/register.go
+++ b/pkg/user/api/register.go
@@ -6,6 +6,7 @@ import (
 )
 
 const GroupName = ""
+const FutureGroupName = "user.openshift.io"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -591,6 +591,15 @@ items:
     verbs:
     - create
   - apiGroups:
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - jenkins
+    verbs:
+    - admin
+    - edit
+    - view
+  - apiGroups:
     - ""
     attributeRestrictions: null
     resources:
@@ -933,6 +942,14 @@ items:
     verbs:
     - create
   - apiGroups:
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - jenkins
+    verbs:
+    - edit
+    - view
+  - apiGroups:
     - ""
     attributeRestrictions: null
     resources:
@@ -1189,6 +1206,13 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - jenkins
+    verbs:
+    - view
   - apiGroups:
     - ""
     attributeRestrictions: null


### PR DESCRIPTION
Adds permissions to the admin, edit, and view roles for jenkins access as allowed by https://github.com/openshift/jenkins-openshift-login-plugin/pull/2 .

@bparees @gabemontero are we trying to push this into 1.3?