### PR TITLE
Add a line break when no events in describe

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/describe.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/describe.go
@@ -2054,7 +2054,7 @@ func getPodsTotalRequestsAndLimits(podList *api.PodList) (reqs map[api.ResourceN
 
 func DescribeEvents(el *api.EventList, w io.Writer) {
 	if len(el.Items) == 0 {
-		fmt.Fprint(w, "No events.")
+		fmt.Fprint(w, "No events.\n")
 		return
 	}
 	sort.Sort(SortableEvents(el.Items))


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/31463
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1369321

Adds a line break in the events describer in case of no events. Without this fix, after https://github.com/kubernetes/kubernetes/commit/6caf4d5a3fed5e818e389c6c72a00de207c40517 a describe without events would result in no line break before exiting to terminal.

```
$ oc describe pod mypod
Name:			mypod
Namespace:		mynamespace
(...)
QoS Tier:	BestEffort
No events.user@localhost ~$
```