### PR TITLE
delete a unused function in the 'pkg/cmd/admin/policy/policy.go'

### DIFF
--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -96,14 +95,6 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out, errout io.Wr
 	templates.ActsAsRootCommand(cmds, []string{"options"}, groups...)
 
 	return cmds
-}
-
-func getFlagString(cmd *cobra.Command, flag string) string {
-	f := cmd.Flags().Lookup(flag)
-	if f == nil {
-		glog.Fatalf("Flag accessed but not defined for command %s: %s", cmd.Name(), flag)
-	}
-	return f.Value.String()
 }
 
 func getUniqueName(basename string, existingNames *sets.String) string {


### PR DESCRIPTION
Delete the function `getFlagString` in the `pkg/cmd/admin/policy/policy.go`, because It has been replaced by the function `GetFlagString` in the `pkg/kubectl/cmd/util/helpers.go`.