### PR TITLE
[RPMs] tito builds are always clean

### DIFF
--- a/.tito/lib/origin/builder/__init__.py
+++ b/.tito/lib/origin/builder/__init__.py
@@ -55,7 +55,7 @@ class OriginBuilder(Builder):
             )
             # Custom Openshift v3 stuff follows, everything above is the standard
             # builder
-            
+
             ## Fixup os_git_vars
             cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_COMMIT}'
             os_git_commit = run_command("bash -c '{0}'".format(cmd))
@@ -70,7 +70,7 @@ class OriginBuilder(Builder):
             print("OS_GIT_MAJOR::{0}".format(os_git_major))
             print("OS_GIT_MINOR::{0}".format(os_git_minor))
             update_os_git_vars = \
-                    "sed -i 's|^%global os_git_vars .*$|%global os_git_vars OS_GIT_VERSION={0} OS_GIT_COMMIT={1} OS_GIT_MAJOR={2} OS_GIT_MINOR={3}|' {4}".format(
+                    "sed -i 's|^%global os_git_vars .*$|%global os_git_vars OS_GIT_TREE_STATE='clean' OS_GIT_VERSION={0} OS_GIT_COMMIT={1} OS_GIT_MAJOR={2} OS_GIT_MINOR={3}|' {4}".format(
                         os_git_version,
                         os_git_commit,
                         os_git_major,

--- a/origin.spec
+++ b/origin.spec
@@ -26,7 +26,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # os_git_vars needed to run hack scripts during rpm builds
 %{!?os_git_vars:
-%global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_MAJOR='' OS_GIT_MINOR=''
+%global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_MAJOR='' OS_GIT_MINOR='' OS_GIT_TREE_STATE=''
 }
 
 %if 0%{?fedora} || 0%{?epel}


### PR DESCRIPTION
Tito generates the archive, then generates the OS_GIT variables and modifies the spec file with those values dirtying the tree so when hack/build-cross.sh runs it detects that the tree is dirty. However tito only produces archives (minus the spec changes) from the current HEAD, so therefore we should override the tree status detection. Without this, all builds were being marked as -dirty.