### PR TITLE
Ensure iptables is updated when idling is disabled

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -455,6 +455,9 @@ func (c *NodeConfig) RunProxy() {
 
 		iptInterface.AddReloadFunc(hybridProxier.Sync)
 		serviceConfig.RegisterHandler(hybridProxier)
+	} else {
+		iptInterface.AddReloadFunc(proxier.Sync)
+		serviceConfig.RegisterHandler(proxier)
 	}
 
 	endpointsConfig := pconfig.NewEndpointsConfig()


### PR DESCRIPTION
#9473 introduced idling and unidling, but accidentally removed having the node watch services and update iptables if idling is disabled.

Fixes bug 1370435