### PR TITLE
Allow users to choose database images version in the DB templates

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -60,7 +60,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:3.2",
+                "name": "mongodb:${MONGODB_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -209,6 +209,13 @@
       "description": "Password for the database admin user.",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "MONGODB_VERSION",
+      "displayName": "Version of MongoDB Image",
+      "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+      "value": "3.2",
       "required": true
     }
   ],

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -77,7 +77,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:3.2",
+                "name": "mongodb:${MONGODB_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -233,6 +233,13 @@
       "displayName": "Volume Capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_VERSION",
+      "displayName": "Version of MongoDB Image",
+      "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+      "value": "3.2",
       "required": true
     }
   ],

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -59,7 +59,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mysql:${MYSQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -197,6 +197,13 @@
       "displayName": "MySQL Database Name",
       "description": "Name of the MySQL database accessed.",
       "value": "sampledb",
+      "required": true
+    },
+    {
+      "name": "MYSQL_VERSION",
+      "displayName": "Version of MySQL Image",
+      "description": "Version of MySQL image to be used (5.5, 5.6 or latest).",
+      "value": "5.6",
       "required": true
     }
   ],

--- a/examples/db-templates/mysql-persistent-template.json
+++ b/examples/db-templates/mysql-persistent-template.json
@@ -65,7 +65,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mysql:${MYSQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               }
             }
@@ -199,6 +199,13 @@
       "displayName": "Volume Capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "MYSQL_VERSION",
+      "displayName": "Version of MySQL Image",
+      "description": "Version of MySQL image to be used (5.5, 5.6 or latest).",
+      "value": "5.6",
       "required": true
     }
   ],

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -60,7 +60,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:9.5",
+                "name": "postgresql:${POSTGRESQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -197,6 +197,13 @@
       "displayName": "PostgreSQL Database Name",
       "description": "Name of the PostgreSQL database accessed.",
       "value": "sampledb",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.2, 9.4, 9.5 or latest).",
+      "value": "9.5",
       "required": true
     }
   ],

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -77,7 +77,7 @@
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:9.5",
+                "name": "postgresql:${POSTGRESQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -221,6 +221,13 @@
       "displayName": "Volume Capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.2, 9.4, 9.5 or latest).",
+      "value": "9.5",
       "required": true
     }
   ],

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -1800,7 +1800,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:3.2",
+                "name": "mongodb:${MONGODB_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -1950,6 +1950,13 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
       "required": true
+    },
+    {
+      "name": "MONGODB_VERSION",
+      "displayName": "Version of MongoDB Image",
+      "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+      "value": "3.2",
+      "required": true
     }
   ],
   "labels": {
@@ -2053,7 +2060,7 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mongodb:3.2",
+                "name": "mongodb:${MONGODB_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -2210,6 +2217,13 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
       "required": true
+    },
+    {
+      "name": "MONGODB_VERSION",
+      "displayName": "Version of MongoDB Image",
+      "description": "Version of MongoDB image to be used (2.4, 2.6, 3.2 or latest).",
+      "value": "3.2",
+      "required": true
     }
   ],
   "labels": {
@@ -2295,7 +2309,7 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mysql:${MYSQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -2434,6 +2448,13 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
       "description": "Name of the MySQL database accessed.",
       "value": "sampledb",
       "required": true
+    },
+    {
+      "name": "MYSQL_VERSION",
+      "displayName": "Version of MySQL Image",
+      "description": "Version of MySQL image to be used (5.5, 5.6 or latest).",
+      "value": "5.6",
+      "required": true
     }
   ],
   "labels": {
@@ -2524,7 +2545,7 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mysql:5.6",
+                "name": "mysql:${MYSQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               }
             }
@@ -2659,6 +2680,13 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
       "required": true
+    },
+    {
+      "name": "MYSQL_VERSION",
+      "displayName": "Version of MySQL Image",
+      "description": "Version of MySQL image to be used (5.5, 5.6 or latest).",
+      "value": "5.6",
+      "required": true
     }
   ],
   "labels": {
@@ -2744,7 +2772,7 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:9.5",
+                "name": "postgresql:${POSTGRESQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -2882,6 +2910,13 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
       "description": "Name of the PostgreSQL database accessed.",
       "value": "sampledb",
       "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.2, 9.4, 9.5 or latest).",
+      "value": "9.5",
+      "required": true
     }
   ],
   "labels": {
@@ -2984,7 +3019,7 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "postgresql:9.5",
+                "name": "postgresql:${POSTGRESQL_VERSION}",
                 "namespace": "${NAMESPACE}"
               },
               "lastTriggeredImage": ""
@@ -3128,6 +3163,13 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
       "displayName": "Volume Capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
       "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "POSTGRESQL_VERSION",
+      "displayName": "Version of PostgreSQL Image",
+      "description": "Version of PostgreSQL image to be used (9.2, 9.4, 9.5 or latest).",
+      "value": "9.5",
       "required": true
     }
   ],


### PR DESCRIPTION
Currently, MongoDB, MySQL and PostgreSQL templates are stuck with
a fixed version of the database images. Users cannot change the
version directly without exporting the templates and doing manual
editing and importing the templates back again.

A new environment variable <DB-NAME>_VERSION is added to each template
to allow to users to change it directly on UI or via CLI directly
before the submission. No more manual editing for DB templates.

Signed-off-by: Vu Dinh <vdinh@redhat.com>