### PR TITLE
UPSTREAM: openshift/source-to-image: 576: increase default docker tim…

### DIFF
--- a/vendor/github.com/openshift/source-to-image/pkg/docker/docker.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/docker/docker.go
@@ -53,7 +53,7 @@ const (
 
 	// DefaultDockerTimeout specifies a timeout for Docker API calls. When this
 	// timeout is reached, certain Docker API calls might error out.
-	DefaultDockerTimeout = 20 * time.Second
+	DefaultDockerTimeout = 60 * time.Second
 )
 
 // containerNamePrefix prefixes the name of containers launched by S2I. We


### PR DESCRIPTION
…eout

per hall chat with @bparees , @deads2k, and myself, followed by devexp scrum discussion his AM, this is a s2i upstream merge of the no-risk, bump the default docker timeout, portion of the fix for bugzilla 1370265 that is being driven by s2i pull 576.

This commit passed `make verify` and `hack/verify-upstream-commits.sh`

@bparees @csrwng @deads2k PTAL

and of course, if we change our mind and don't want to bother with even this portion of the fix for 3.3, I can nuke this pr.

thanks