### PR TITLE
[BZ1365986] new-app: validate that EXPOSEd ports are numbers

### DIFF
--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -168,6 +168,7 @@ func (o *NewBuildOptions) Complete(baseName, commandName string, f *clientcmd.Fa
 	o.Action.Bulk.Retry = retryBuildConfig
 
 	o.Config.DryRun = o.Action.DryRun
+	o.Config.AllowNonNumericExposedPorts = true
 
 	o.BaseName = baseName
 	o.CommandPath = c.CommandPath()


### PR DESCRIPTION
Add validation to `oc new-app` to ensure that exposed ports from the `Dockerfile` in a user's repository are numbers.

Example:
```console
$ oc new-app https://github.com/php-coder/s2i-test#use_arg_directive 
error: the Dockerfile has an invalid EXPOSE instruction: could not parse "$JETTY_PORT": must be numerical
```
At the same time `oc new-build` works as before:
```console
$ oc new-build https://github.com/php-coder/s2i-test#use_arg_directive 
--> Found Docker image 34a035d (2 days old) from Docker Hub for "java:8"

	* An image stream will be created as "java:8" that will track the source image
	* A Docker build using source code from https://github.com/php-coder/s2i-test#use_arg_directive will be created
	  * The resulting image will be pushed to image stream "s2i-test:latest"
	  * Every time "java:8" changes a new build will be triggered

--> Creating resources with label build=s2i-test ...
	imagestream "java" created
	imagestream "s2i-test" created
	buildconfig "s2i-test" created
--> Success
	Build configuration "s2i-test" created and build triggered.
	Run 'new-build logs -f bc/s2i-test' to stream the build progress.
```

PTAL @bparees 

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1365986