### PR TITLE
add *images to `oc get`

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -161,6 +161,7 @@ __custom_func() {
    * events (aka 'ev')
    * endpoints (aka 'ep')
    * horizontalpodautoscalers (aka 'hpa')
+   * images
    * imagestreamimages (aka 'isimage')
    * imagestreams (aka 'is')
    * imagestreamtags (aka 'istag')


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/10536

Adds `* images` to the list of resources in the `oc get` output

cc @fabianofranz 
