### PR TITLE
Scale helpers: always fetch scale object for DCs

### DIFF
--- a/pkg/deploy/cmd/scale.go
+++ b/pkg/deploy/cmd/scale.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -11,7 +9,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/openshift/origin/pkg/client"
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -61,17 +58,13 @@ func (scaler *DeploymentConfigScaler) Scale(namespace, name string, newSize uint
 // ScaleSimple does a simple one-shot attempt at scaling - not useful on its
 // own, but a necessary building block for Scale
 func (scaler *DeploymentConfigScaler) ScaleSimple(namespace, name string, preconditions *kubectl.ScalePrecondition, newSize uint) error {
-	dc, err := scaler.dcClient.DeploymentConfigs(namespace).Get(name)
+	scale, err := scaler.dcClient.DeploymentConfigs(namespace).GetScale(name)
 	if err != nil {
 		return err
 	}
-	if dc.Spec.Test {
-		fmt.Fprintln(os.Stderr, "Replica size for a test deployment applies only when the deployment is running.")
-	}
-	scale := deployapi.ScaleFromConfig(dc)
 	scale.Spec.Replicas = int32(newSize)
 	if _, err := scaler.dcClient.DeploymentConfigs(namespace).UpdateScale(scale); err != nil {
-		return kubectl.ScaleError{FailureType: kubectl.ScaleUpdateFailure, ResourceVersion: dc.ResourceVersion, ActualError: err}
+		return kubectl.ScaleError{FailureType: kubectl.ScaleUpdateFailure, ResourceVersion: "Unknown", ActualError: err}
 	}
 	return nil
 }


### PR DESCRIPTION
The scale helper for DeploymentConfigs previously would fetch the raw
deployment, covert that into a scale object, and then submit that scale
object as an update to the scale subresource of the DeploymentConfig.
This caused issues when using recent clients against older API servers
since new metadata (the UID) was added to scale, and the older API
servers would choke while validating the update.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1370058