### PR TITLE
Compare additionally generation when comparing ImageStreamTag status with spec

### DIFF
--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -645,6 +645,20 @@ func DifferentTagEvent(stream *ImageStream, tag string, next TagEvent) bool {
 	return !(sameRef && sameImage)
 }
 
+// DifferentTagEvent compares the generation on tag's spec vs its status.
+// Returns if spec generation is newer than status one.
+func DifferentTagGeneration(stream *ImageStream, tag string) bool {
+	specTag, ok := stream.Spec.Tags[tag]
+	if !ok || specTag.Generation == nil {
+		return true
+	}
+	statusTag, ok := stream.Status.Tags[tag]
+	if !ok || len(statusTag.Items) == 0 {
+		return true
+	}
+	return *specTag.Generation > statusTag.Items[0].Generation
+}
+
 // AddTagEventToImageStream attempts to update the given image stream with a tag event. It will
 // collapse duplicate entries - returning true if a change was made or false if no change
 // occurred. Any successful tag resets the status field.

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -368,7 +368,7 @@ func (r *REST) importSuccessful(
 	}
 
 	// ensure the spec and status tag match the imported image
-	changed := api.DifferentTagEvent(stream, tag, tagEvent)
+	changed := api.DifferentTagEvent(stream, tag, tagEvent) || api.DifferentTagGeneration(stream, tag)
 	specTag, ok := stream.Spec.Tags[tag]
 	if changed || !ok {
 		specTag = ensureSpecTag(stream, tag, from, importPolicy, true)

--- a/pkg/image/registry/imagestreamimport/rest_test.go
+++ b/pkg/image/registry/imagestreamimport/rest_test.go
@@ -1,0 +1,200 @@
+package imagestreamimport
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+type fakeImageCreater struct{}
+
+func (_ fakeImageCreater) New() runtime.Object {
+	return nil
+}
+
+func (_ fakeImageCreater) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	return obj, nil
+}
+
+func TestImportSuccessful(t *testing.T) {
+	one := int64(1)
+	two := int64(2)
+	now := unversioned.Now()
+	tests := map[string]struct {
+		image    *api.Image
+		stream   *api.ImageStream
+		expected api.TagEvent
+	}{
+		"reference differs": {
+			image: &api.Image{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "image",
+				},
+				DockerImageReference: "registry.com/namespace/image:mytag",
+			},
+			stream: &api.ImageStream{
+				Spec: api.ImageStreamSpec{
+					Tags: map[string]api.TagReference{
+						"mytag": {
+							Name: "mytag",
+							From: &kapi.ObjectReference{
+								Kind: "DockerImage",
+								Name: "registry.com/namespace/image:mytag",
+							},
+							Generation: &one,
+						},
+					},
+				},
+				Status: api.ImageStreamStatus{
+					Tags: map[string]api.TagEventList{
+						"mytag": {
+							Items: []api.TagEvent{{
+								DockerImageReference: "registry.com/namespace/image:othertag",
+								Image:                "image",
+								Generation:           one,
+							}},
+						},
+					},
+				},
+			},
+			expected: api.TagEvent{
+				DockerImageReference: "registry.com/namespace/image:mytag",
+				Image:                "image",
+				Generation:           two,
+			},
+		},
+		"image differs": {
+			image: &api.Image{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "image",
+				},
+				DockerImageReference: "registry.com/namespace/image:mytag",
+			},
+			stream: &api.ImageStream{
+				Spec: api.ImageStreamSpec{
+					Tags: map[string]api.TagReference{
+						"mytag": {
+							Name: "mytag",
+							From: &kapi.ObjectReference{
+								Kind: "DockerImage",
+								Name: "registry.com/namespace/image:mytag",
+							},
+							Generation: &one,
+						},
+					},
+				},
+				Status: api.ImageStreamStatus{
+					Tags: map[string]api.TagEventList{
+						"mytag": {
+							Items: []api.TagEvent{{
+								DockerImageReference: "registry.com/namespace/image:othertag",
+								Image:                "non-image",
+								Generation:           one,
+							}},
+						},
+					},
+				},
+			},
+			expected: api.TagEvent{
+				Created:              now,
+				DockerImageReference: "registry.com/namespace/image:mytag",
+				Image:                "image",
+				Generation:           two,
+			},
+		},
+		"empty status": {
+			image: &api.Image{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "image",
+				},
+				DockerImageReference: "registry.com/namespace/image:mytag",
+			},
+			stream: &api.ImageStream{
+				Spec: api.ImageStreamSpec{
+					Tags: map[string]api.TagReference{
+						"mytag": {
+							Name: "mytag",
+							From: &kapi.ObjectReference{
+								Kind: "DockerImage",
+								Name: "registry.com/namespace/image:mytag",
+							},
+							Generation: &one,
+						},
+					},
+				},
+				Status: api.ImageStreamStatus{},
+			},
+			expected: api.TagEvent{
+				Created:              now,
+				DockerImageReference: "registry.com/namespace/image:mytag",
+				Image:                "image",
+				Generation:           two,
+			},
+		},
+		// https://github.com/openshift/origin/issues/10402:
+		"only generation differ": {
+			image: &api.Image{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "image",
+				},
+				DockerImageReference: "registry.com/namespace/image:mytag",
+			},
+			stream: &api.ImageStream{
+				Spec: api.ImageStreamSpec{
+					Tags: map[string]api.TagReference{
+						"mytag": {
+							Name: "mytag",
+							From: &kapi.ObjectReference{
+								Kind: "DockerImage",
+								Name: "registry.com/namespace/image:mytag",
+							},
+							Generation: &two,
+						},
+					},
+				},
+				Status: api.ImageStreamStatus{
+					Tags: map[string]api.TagEventList{
+						"mytag": {
+							Items: []api.TagEvent{{
+								DockerImageReference: "registry.com/namespace/image:mytag",
+								Image:                "image",
+								Generation:           one,
+							}},
+						},
+					},
+				},
+			},
+			expected: api.TagEvent{
+				DockerImageReference: "registry.com/namespace/image:mytag",
+				Image:                "image",
+				Generation:           two,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		ref, err := api.ParseDockerImageReference(test.image.DockerImageReference)
+		if err != nil {
+			t.Errorf("%s: error parsing image ref: %v", name, err)
+			continue
+		}
+
+		importPolicy := api.TagImportPolicy{}
+		importedImages := make(map[string]error)
+		updatedImages := make(map[string]*api.Image)
+		storage := REST{images: fakeImageCreater{}}
+		_, ok := storage.importSuccessful(kapi.NewDefaultContext(), test.image, test.stream,
+			ref.Tag, ref.Exact(), two, now, importPolicy, importedImages, updatedImages)
+		if !ok {
+			t.Errorf("%s: expected success, didn't get one", name)
+		}
+		actual := test.stream.Status.Tags[ref.Tag].Items[0]
+		if !kapi.Semantic.DeepEqual(actual, test.expected) {
+			t.Errorf("%s: expected %#v, got %#v", name, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #10402.

The root cause in the linked issue was that there is no actual change in image ID or it's reference and thus this change was not caught when comparing. I've added comparing generation in that code, as well.

@smarterclayton ptal
@mfojtik fyi