### PR TITLE
Retry on registry client connect on tag unset

### DIFF
--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -39,9 +39,11 @@ var (
 
 	// imageNotFoundErrorPatterns will match following error examples:
 	//   the image "..." in repository "..." was not found and may have been deleted
+	//   tag "..." has not been set on repository "..."
 	// use only with non-internal registry
 	imageNotFoundErrorPatterns = []string{
 		"was not found and may have been deleted",
+		"has not been set on repository",
 	}
 )
 


### PR DESCRIPTION
Catches following error:

    tag "latest" has not been set on repository "library/rhel"

Related to #6232