### PR TITLE
Switch deployment utils to loop by index

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -634,7 +634,7 @@ var _ = g.Describe("deploymentconfigs", func() {
 
 			// the deployments we continue to keep should be the latest ones
 			for _, deployment := range oldDeployments {
-				o.Expect(deployutil.DeploymentVersionFor(&deployment)).To(o.BeNumerically(">", iterations-revisionHistoryLimit))
+				o.Expect(deployutil.DeploymentVersionFor(&deployment)).To(o.BeNumerically(">=", iterations-revisionHistoryLimit))
 			}
 		})
 	})


### PR DESCRIPTION
@kargakis For #10662. The max number of "rc" with the same name in store  is  "revisionHistoryLimit" value which include the lastest compete "rc". 
Assign "revisionHistoryLimit" 3 in configuration, execute “oc set env dc/history-limit A=1” serveral times.   The result of command "oc get rc" is below.
[root@master0 testdata]# oc get rc
NAME              DESIRED   CURRENT   AGE
history-limit-2   0         0         22m
history-limit-3   0         0         14m
history-limit-4   1         1         31s
The result by the new code is below.  And I have attempted to modify the line 637 in file "test/extended/deployments/deployments.go"
[root@master0 testdata]# oc get rc
NAME              DESIRED   CURRENT   AGE
history-limit-2   0         0         15m
history-limit-3   0         0         7m
history-limit-4   0         0         4m
history-limit-5   1         1         1m