### PR TITLE
[DO NOT MERGE] registry: Suppress unnecessary unauthorized errors

### DIFF
--- a/pkg/dockerregistry/server/errormanifestservice.go
+++ b/pkg/dockerregistry/server/errormanifestservice.go
@@ -16,28 +16,28 @@ type errorManifestService struct {
 var _ distribution.ManifestService = &errorManifestService{}
 
 func (em *errorManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
-	if err := em.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, em.repo.namespace, em.repo.name); err != nil {
 		return false, err
 	}
 	return em.manifests.Exists(ctx, dgst)
 }
 
 func (em *errorManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
-	if err := em.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, em.repo.namespace, em.repo.name); err != nil {
 		return nil, err
 	}
 	return em.manifests.Get(ctx, dgst, options...)
 }
 
 func (em *errorManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
-	if err := em.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, em.repo.namespace, em.repo.name); err != nil {
 		return "", err
 	}
 	return em.manifests.Put(ctx, manifest, options...)
 }
 
 func (em *errorManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
-	if err := em.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, em.repo.namespace, em.repo.name); err != nil {
 		return err
 	}
 	return em.manifests.Delete(ctx, dgst)

--- a/pkg/dockerregistry/server/errortagservice.go
+++ b/pkg/dockerregistry/server/errortagservice.go
@@ -15,35 +15,35 @@ type errorTagService struct {
 var _ distribution.TagService = &errorTagService{}
 
 func (t *errorTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
-	if err := t.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, t.repo.namespace, t.repo.name); err != nil {
 		return distribution.Descriptor{}, err
 	}
 	return t.tags.Get(ctx, tag)
 }
 
 func (t *errorTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
-	if err := t.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, t.repo.namespace, t.repo.name); err != nil {
 		return err
 	}
 	return t.tags.Tag(ctx, tag, desc)
 }
 
 func (t *errorTagService) Untag(ctx context.Context, tag string) error {
-	if err := t.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, t.repo.namespace, t.repo.name); err != nil {
 		return err
 	}
 	return t.tags.Untag(ctx, tag)
 }
 
 func (t *errorTagService) All(ctx context.Context) ([]string, error) {
-	if err := t.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, t.repo.namespace, t.repo.name); err != nil {
 		return nil, err
 	}
 	return t.tags.All(ctx)
 }
 
 func (t *errorTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
-	if err := t.repo.checkPendingErrors(ctx); err != nil {
+	if err := checkPendingErrors(ctx, t.repo.namespace, t.repo.name); err != nil {
 		return nil, err
 	}
 	return t.tags.Lookup(ctx, digest)

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -390,26 +390,3 @@ func (r *repository) manifestFromImageWithCachedLayers(image *imageapi.Image, ca
 	r.rememberLayersOfManifest(dgst, manifest, cacheName)
 	return
 }
-
-func (r *repository) checkPendingErrors(ctx context.Context) error {
-	return checkPendingErrors(context.GetLogger(r.ctx), ctx, r.namespace, r.name)
-}
-
-func checkPendingErrors(logger context.Logger, ctx context.Context, namespace, name string) error {
-	if !AuthPerformed(ctx) {
-		return fmt.Errorf("openshift.auth.completed missing from context")
-	}
-
-	deferredErrors, haveDeferredErrors := DeferredErrorsFrom(ctx)
-	if !haveDeferredErrors {
-		return nil
-	}
-
-	repoErr, haveRepoErr := deferredErrors.Get(namespace, name)
-	if !haveRepoErr {
-		return nil
-	}
-
-	logger.Debugf("Origin auth: found deferred error for %s/%s: %v", namespace, name, repoErr)
-	return repoErr
-}

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -258,8 +258,8 @@ func TestRepositoryBlobStat(t *testing.T) {
 			name:           "deferred error",
 			stat:           "nm/is@" + testImages["nm/is:latest"][0].DockerImageLayers[0].Name,
 			imageStreams:   []imageapi.ImageStream{{ObjectMeta: kapi.ObjectMeta{Namespace: "nm", Name: "is"}}},
-			deferredErrors: deferredErrors{"nm/is": ErrOpenShiftAccessDenied},
-			expectedError:  ErrOpenShiftAccessDenied,
+			deferredErrors: deferredErrors{"nm/is": ErrAccessDenied},
+			expectedError:  ErrAccessDenied,
 		},
 	} {
 		ref, err := reference.Parse(tc.stat)


### PR DESCRIPTION
During a cross-repo mount request, it's quite common to forbid access to a source repository picked by Docker daemon regardless of user having access there. This produces error messages that appear severe but in fact they're not. This patch delays their logging until the very last repository access check and lowers their severity.

Closes #9649
