### PR TITLE
Adding flag to skip available ports checking to oc cluster up

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -530,7 +530,8 @@ func (c *ClientStartConfig) CheckAvailablePorts(out io.Writer) error {
 			return nil
 		}
 	}
-	return errors.NewError("a port needed by OpenShift is not available").WithCause(err)
+	fmt.Fprintf(out, "WARNING: A port needed by OpenShift is not available: %s\n", err)
+	return nil
 }
 
 // DetermineServerIP gets an appropriate IP address to communicate with the OpenShift server


### PR DESCRIPTION

In some cases, on want to run OpenShift on some non standard ports, mainly for the router.
To avoid adding a flag for each different port or managing env for each configuration parameter, it is possible to skip the ports available step using this flag.
