### PR TITLE
reduce default deserialization cache size

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -101,6 +101,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	server.APIGroupPrefix = KubeAPIGroupPrefix
 	server.SecurePort = port
 	server.MasterCount = options.KubernetesMasterConfig.MasterCount
+	server.StorageConfig.DeserializationCacheSize = 1000
 
 	// resolve extended arguments
 	// TODO: this should be done in config validation (along with the above) so we can provide

--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -10,7 +10,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	genericserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	genericrest "k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -108,7 +107,7 @@ func (g *configRESTOptionsGetter) GetRESTOptions(resource unversioned.GroupResou
 		// TODO: choose destination group/version based on input group/resource
 		// TODO: Tune the cache size
 		groupVersion := unversioned.GroupVersion{Group: "", Version: g.masterOptions.EtcdStorageConfig.OpenShiftStorageVersion}
-		g.etcdHelper = etcdstorage.NewEtcdStorage(etcdClient, kapi.Codecs.LegacyCodec(groupVersion), g.masterOptions.EtcdStorageConfig.OpenShiftStoragePrefix, false, genericserveroptions.DefaultDeserializationCacheSize)
+		g.etcdHelper = etcdstorage.NewEtcdStorage(etcdClient, kapi.Codecs.LegacyCodec(groupVersion), g.masterOptions.EtcdStorageConfig.OpenShiftStoragePrefix, false, 1000)
 	}
 
 	configuredCacheSize, specified := g.cacheSizes[resource]


### PR DESCRIPTION
There is a recurring issue with the openshift master growing to occupy a larger than expected amount of memory over time.

https://bugzilla.redhat.com/show_bug.cgi?id=1323733
https://bugzilla.redhat.com/show_bug.cgi?id=1371277

A parameter, `deserialization-cache-size`, was added to the upstream kubernetes API server and is now present in origin after the latest rebase.  However, the default value for the parameter remains unchanged from the previously fixed value of 50k cache entries per.

This PR sets the cache size to 1000, which is a more appropriate value for most clusters assuming any one cluster doesn't have more that 1000 active resources in a single RESTStorage.

@ncdc @smarterclayton @liggitt @deads2k 
