### PR TITLE
Fix SDN network plugin detection

### DIFF
--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -442,6 +442,8 @@ func validateAndGetNetworkPluginName(originClient *osclient.Client, pluginName s
 		clusterNetwork, err := originClient.ClusterNetwork().Get(sdnapi.ClusterNetworkDefault)
 		if err == nil {
 			return clusterNetwork.PluginName, nil
+		} else if !kerrs.IsNotFound(err) {
+			return "", fmt.Errorf("cannot fetch %q cluster network: %v", sdnapi.ClusterNetworkDefault, err)
 		}
 	}
 


### PR DESCRIPTION
When OpenShift master and node are started at the same time.
We could end up in a state where node registration succeeds but
API call to ClusterNetwork resource fails. We ignore the error
assuming that it's not openshift specific network plugin but this
can lead to master running openshift sdn plugin and node without
sdn plugin.
So the fix is to only ignore the error if ClusterNetwork API call
fails with 'not found' error. Anything else(api not ready, etcd error,
etc.) should throw an error.