### PR TITLE
UPSTREAM: 30717: fix oc describe suggestion in oc rsh output

### DIFF
--- a/pkg/cmd/cli/cmd/rsh.go
+++ b/pkg/cmd/cli/cmd/rsh.go
@@ -74,7 +74,8 @@ func NewCmdRsh(name string, parent string, f *clientcmd.Factory, in io.Reader, o
 				Stdin: true,
 			},
 
-			Executor: &kubecmd.DefaultRemoteExecutor{},
+			FullCmdName: parent,
+			Executor:    &kubecmd.DefaultRemoteExecutor{},
 		},
 	}
 


### PR DESCRIPTION
UPSTREAM PR: https://github.com/kubernetes/kubernetes/pull/30717

`oc rsh <podname>` outputs the line `defaulting container name to
<podname_top_level_container>, use ' describe po/<podname>' cmd to see all
containers in this pod`; however this suggestion is missing the root
command (oc, kube, openshift cli ...) before `describe po/<podname>`.
This patch adds the root command used to invoke the `rsh` command to
this suggestion.

`$ openshift cli rsh <podname>`
```
defaulting container name to idling-tcp-echo, use 'openshift cli describe
po/<podname>' to see all containers in this pod
```

cc @fabianofranz 