### PR TITLE
deploy: don't requeue configs on stream updates yet

### DIFF
--- a/pkg/deploy/controller/generictrigger/factory.go
+++ b/pkg/deploy/controller/generictrigger/factory.go
@@ -46,10 +46,11 @@ func NewDeploymentTriggerController(dcInformer, streamInformer framework.SharedI
 	})
 	c.dcStoreSynced = dcInformer.HasSynced
 
-	streamInformer.AddEventHandler(framework.ResourceEventHandlerFuncs{
-		AddFunc:    c.addImageStream,
-		UpdateFunc: c.updateImageStream,
-	})
+	// TODO: Re-enable in https://github.com/openshift/origin/pull/9349
+	// streamInformer.AddEventHandler(framework.ResourceEventHandlerFuncs{
+	// AddFunc:    c.addImageStream,
+	// UpdateFunc: c.updateImageStream,
+	// })
 
 	return c
 }


### PR DESCRIPTION
@mfojtik we still have the image change controller up and running so we don't need to do this just yet

I would like to have it for 1.3.

[test]