### PR TITLE
Revert openshift sdn plugin auto detection on the node

### DIFF
--- a/docs/man/man1/oadm-create-node-config.1
+++ b/docs/man/man1/oadm-create-node-config.1
@@ -65,7 +65,7 @@ Create a configuration bundle for a node
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    Name of the network plugin to hook to for pod networking. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    Name of the network plugin to hook to for pod networking.
 
 .PP
 \fB\-\-node\fP=""

--- a/docs/man/man1/oc-adm-create-node-config.1
+++ b/docs/man/man1/oc-adm-create-node-config.1
@@ -65,7 +65,7 @@ Create a configuration bundle for a node
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    Name of the network plugin to hook to for pod networking. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    Name of the network plugin to hook to for pod networking.
 
 .PP
 \fB\-\-node\fP=""

--- a/docs/man/man1/openshift-admin-create-node-config.1
+++ b/docs/man/man1/openshift-admin-create-node-config.1
@@ -65,7 +65,7 @@ Create a configuration bundle for a node
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    Name of the network plugin to hook to for pod networking. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    Name of the network plugin to hook to for pod networking.
 
 .PP
 \fB\-\-node\fP=""

--- a/docs/man/man1/openshift-cli-adm-create-node-config.1
+++ b/docs/man/man1/openshift-cli-adm-create-node-config.1
@@ -65,7 +65,7 @@ Create a configuration bundle for a node
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    Name of the network plugin to hook to for pod networking. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    Name of the network plugin to hook to for pod networking.
 
 .PP
 \fB\-\-node\fP=""

--- a/docs/man/man1/openshift-start-network.1
+++ b/docs/man/man1/openshift-start-network.1
@@ -58,7 +58,7 @@ run in the foreground until you terminate the process.
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    The network plugin to be called for configuring networking for pods. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    The network plugin to be called for configuring networking for pods.
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/docs/man/man1/openshift-start-node.1
+++ b/docs/man/man1/openshift-start-node.1
@@ -67,7 +67,7 @@ foreground until you terminate the process.
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    The network plugin to be called for configuring networking for pods. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    The network plugin to be called for configuring networking for pods.
 
 .PP
 \fB\-\-volume\-dir\fP="openshift.local.volumes"

--- a/docs/man/man1/openshift-start.1
+++ b/docs/man/man1/openshift-start.1
@@ -94,7 +94,7 @@ You may also pass \-\-kubeconfig=<path> to connect to an external Kubernetes clu
 
 .PP
 \fB\-\-network\-plugin\fP=""
-    The network plugin to be called for configuring networking for pods. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
+    The network plugin to be called for configuring networking for pods.
 
 .PP
 \fB\-\-node\-config\fP=""

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -95,7 +95,7 @@ func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *c
 	flags.StringVar(&options.NodeClientCAFile, "node-client-certificate-authority", options.NodeClientCAFile, "The file containing signing authorities to use to verify requests to the node. If empty, all requests will be allowed.")
 	flags.StringVar(&options.APIServerURL, "master", options.APIServerURL, "The API server's URL.")
 	flags.StringSliceVar(&options.APIServerCAFiles, "certificate-authority", options.APIServerCAFiles, "Files containing signing authorities to use to verify the API server's serving certificate.")
-	flags.StringVar(&options.NetworkPluginName, "network-plugin", options.NetworkPluginName, "Name of the network plugin to hook to for pod networking. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.")
+	flags.StringVar(&options.NetworkPluginName, "network-plugin", options.NetworkPluginName, "Name of the network plugin to hook to for pod networking.")
 
 	// autocompletion hints
 	cmd.MarkFlagFilename("node-dir")

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -174,7 +174,6 @@ type LocalQuota struct {
 // NodeNetworkConfig provides network options for the node
 type NodeNetworkConfig struct {
 	// NetworkPluginName is a string specifying the networking plugin
-	// Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
 	NetworkPluginName string
 	// Maximum transmission unit for the network packets
 	MTU uint32

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -549,7 +549,7 @@ func (NodeConfig) SwaggerDoc() map[string]string {
 
 var map_NodeNetworkConfig = map[string]string{
 	"":                  "NodeNetworkConfig provides network options for the node",
-	"networkPluginName": "NetworkPluginName is a string specifying the networking plugin Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.",
+	"networkPluginName": "NetworkPluginName is a string specifying the networking plugin",
 	"mtu":               "Maximum transmission unit for the network packets",
 }
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -120,8 +120,7 @@ type NodeAuthConfig struct {
 // NodeNetworkConfig provides network options for the node
 type NodeNetworkConfig struct {
 	// NetworkPluginName is a string specifying the networking plugin
-	// Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.
-	NetworkPluginName string `json:"networkPluginName,omitempty"`
+	NetworkPluginName string `json:"networkPluginName"`
 	// Maximum transmission unit for the network packets
 	MTU uint32 `json:"mtu"`
 }

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -45,6 +45,7 @@ masterClientConnectionOverrides: null
 masterKubeConfig: ""
 networkConfig:
   mtu: 0
+  networkPluginName: ""
 nodeIP: ""
 nodeName: ""
 podManifestConfig:

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -80,7 +80,7 @@ func BindNodeArgs(args *NodeArgs, flags *pflag.FlagSet, prefix string, component
 		args.Components.Bind(flags, prefix+"%s", "The set of node components to")
 	}
 
-	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The network plugin to be called for configuring networking for pods. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.")
+	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The network plugin to be called for configuring networking for pods.")
 
 	flags.StringVar(&args.VolumeDir, prefix+"volume-dir", "openshift.local.volumes", "The volume storage directory.")
 	// TODO rename this node-name and recommend uname -n
@@ -97,7 +97,7 @@ func BindNodeArgs(args *NodeArgs, flags *pflag.FlagSet, prefix string, component
 func BindNodeNetworkArgs(args *NodeArgs, flags *pflag.FlagSet, prefix string) {
 	args.Components.Bind(flags, "%s", "The set of network components to")
 
-	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The network plugin to be called for configuring networking for pods. Optional for OpenShift network plugin, node will auto detect network plugin configured by OpenShift master.")
+	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The network plugin to be called for configuring networking for pods.")
 }
 
 // NewDefaultNodeArgs creates NodeArgs with sub-objects created and default values set.

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -286,8 +286,6 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 		return err
 	}
 
-	// In case of openshift network plugin, nodeConfig.networkPluginName is optional and is auto detected/finalized
-	// once we build kubernetes node config. So perform plugin name related check here.
 	if sdnplugin.IsOpenShiftNetworkPlugin(config.KubeletServer.NetworkPluginName) {
 		// TODO: SDN plugin depends on the Kubelet registering as a Node and doesn't retry cleanly,
 		// and Kubelet also can't start the PodSync loop until the SDN plugin has loaded.


### PR DESCRIPTION
When openshift master and node are started at the same time, we could end up in a race condition when node tries to auto detect the network plugin. Issues: https://github.com/openshift/origin/pull/10724 and https://github.com/openshift/origin/pull/10473

We need a better solution. This PR will keep the master/node plugin validation in https://github.com/openshift/origin/pull/9147 but reverts the plugin auto detection feature.