### PR TITLE
Take care of manifest config blob

### DIFF
--- a/pkg/cmd/admin/top/images.go
+++ b/pkg/cmd/admin/top/images.go
@@ -175,13 +175,17 @@ func (o TopImagesOptions) imagesTop() []Info {
 
 func getStorage(image *imageapi.Image) int64 {
 	storage := int64(0)
-	layerSet := sets.NewString()
+	blobSet := sets.NewString()
 	for _, layer := range image.DockerImageLayers {
-		if layerSet.Has(layer.Name) {
+		if blobSet.Has(layer.Name) {
 			continue
 		}
-		layerSet.Insert(layer.Name)
+		blobSet.Insert(layer.Name)
 		storage += layer.LayerSize
+	}
+	if len(image.DockerImageConfig) > 0 && !blobSet.Has(image.DockerImageMetadata.ID) {
+		blobSet.Insert(image.DockerImageMetadata.ID)
+		storage += int64(len(image.DockerImageConfig))
 	}
 	return storage
 }

--- a/pkg/cmd/admin/top/imagestreams_test.go
+++ b/pkg/cmd/admin/top/imagestreams_test.go
@@ -178,6 +178,56 @@ func TestImageStreamsTop(t *testing.T) {
 				},
 			},
 		},
+		"multiple images with manifest config": {
+			images: &imageapi.ImageList{
+				Items: []imageapi.Image{
+					{
+						ObjectMeta:        kapi.ObjectMeta{Name: "image1"},
+						DockerImageLayers: []imageapi.ImageLayer{{Name: "layer1", LayerSize: int64(1024)}},
+						DockerImageConfig: "raw image config",
+						DockerImageMetadata: imageapi.DockerImage{
+							ID: "manifestConfigID",
+						},
+					},
+					{
+						ObjectMeta: kapi.ObjectMeta{Name: "image2"},
+						DockerImageLayers: []imageapi.ImageLayer{
+							{Name: "layer1", LayerSize: int64(1024)},
+							{Name: "layer2", LayerSize: int64(128)},
+						},
+						DockerImageConfig: "raw image config",
+						DockerImageMetadata: imageapi.DockerImage{
+							ID: "manifestConfigID",
+						},
+					},
+				},
+			},
+			streams: &imageapi.ImageStreamList{
+				Items: []imageapi.ImageStream{
+					{
+						ObjectMeta: kapi.ObjectMeta{Name: "stream1", Namespace: "ns1"},
+						Status: imageapi.ImageStreamStatus{
+							Tags: map[string]imageapi.TagEventList{
+								"tag1": {
+									Items: []imageapi.TagEvent{{Image: "image1"}},
+								},
+								"tag2": {
+									Items: []imageapi.TagEvent{{Image: "image2"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []Info{
+				imageStreamInfo{
+					ImageStream: "ns1/stream1",
+					Storage:     int64(1152 + len("raw image config")),
+					Images:      2,
+					Layers:      3,
+				},
+			},
+		},
 		"multiple unreferenced images": {
 			images: &imageapi.ImageList{
 				Items: []imageapi.Image{

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -203,5 +203,12 @@ func imageHasBlob(
 		}
 	}
 
+	// only manifest V2 schema2 has docker image config filled where dockerImage.Metadata.id is its digest
+	if len(image.DockerImageConfig) > 0 && image.DockerImageMetadata.ID == blobDigest {
+		// remember manifest config reference of schema 2 as well
+		r.rememberLayersOfImage(image, cacheName)
+		return true
+	}
+
 	return false
 }

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -544,7 +544,7 @@ func (r *repository) getImageStreamImage(dgst digest.Digest) (*imageapi.ImageStr
 
 // rememberLayersOfImage caches the layer digests of given image
 func (r *repository) rememberLayersOfImage(image *imageapi.Image, cacheName string) {
-	if len(image.DockerImageLayers) == 0 && len(image.DockerImageManifestMediaType) > 0 {
+	if len(image.DockerImageLayers) == 0 && len(image.DockerImageManifestMediaType) > 0 && len(image.DockerImageConfig) == 0 {
 		// image has no layers
 		return
 	}
@@ -552,6 +552,10 @@ func (r *repository) rememberLayersOfImage(image *imageapi.Image, cacheName stri
 	if len(image.DockerImageLayers) > 0 {
 		for _, layer := range image.DockerImageLayers {
 			r.cachedLayers.RememberDigest(digest.Digest(layer.Name), r.blobrepositorycachettl, cacheName)
+		}
+		// remember reference to manifest config as well for schema 2
+		if image.DockerImageManifestMediaType == schema2.MediaTypeManifest && len(image.DockerImageMetadata.ID) > 0 {
+			r.cachedLayers.RememberDigest(digest.Digest(image.DockerImageMetadata.ID), r.blobrepositorycachettl, cacheName)
 		}
 		return
 	}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -452,7 +452,7 @@ func (r *repository) signedManifestFillImageMetadata(manifest *schema1.SignedMan
 
 	refs := manifest.References()
 
-	layerSet := sets.NewString()
+	blobSet := sets.NewString()
 	image.DockerImageMetadata.Size = int64(0)
 
 	blobs := r.Blobs(r.ctx)
@@ -473,10 +473,14 @@ func (r *repository) signedManifestFillImageMetadata(manifest *schema1.SignedMan
 		}
 		layer.LayerSize = desc.Size
 		// count empty layer just once (empty layer may actually have non-zero size)
-		if !layerSet.Has(layer.Name) {
+		if !blobSet.Has(layer.Name) {
 			image.DockerImageMetadata.Size += desc.Size
-			layerSet.Insert(layer.Name)
+			blobSet.Insert(layer.Name)
 		}
+	}
+	if len(image.DockerImageConfig) > 0 && !blobSet.Has(image.DockerImageMetadata.ID) {
+		blobSet.Insert(image.DockerImageMetadata.ID)
+		image.DockerImageMetadata.Size += int64(len(image.DockerImageConfig))
 	}
 
 	return nil

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -552,8 +552,8 @@ func ImageWithMetadata(image *Image) error {
 		image.DockerImageMetadata.Architecture = config.Architecture
 		image.DockerImageMetadata.Size = int64(len(image.DockerImageConfig))
 
+		layerSet := sets.NewString(image.DockerImageMetadata.ID)
 		if len(image.DockerImageLayers) > 0 {
-			layerSet := sets.NewString()
 			for _, layer := range image.DockerImageLayers {
 				if layerSet.Has(layer.Name) {
 					continue
@@ -561,8 +561,6 @@ func ImageWithMetadata(image *Image) error {
 				layerSet.Insert(layer.Name)
 				image.DockerImageMetadata.Size += layer.LayerSize
 			}
-		} else {
-			image.DockerImageMetadata.Size += config.Size
 		}
 	default:
 		return fmt.Errorf("unrecognized Docker image manifest schema %d for %q (%s)", manifest.SchemaVersion, image.Name, image.DockerImageReference)

--- a/pkg/image/importer/client_test.go
+++ b/pkg/image/importer/client_test.go
@@ -41,7 +41,7 @@ type mockRepository struct {
 
 	blobs *mockBlobStore
 
-	manifest *schema1.SignedManifest
+	manifest distribution.Manifest
 	tags     map[string]string
 }
 
@@ -79,6 +79,8 @@ func (r *mockRepository) Tags(ctx context.Context) distribution.TagService {
 type mockBlobStore struct {
 	distribution.BlobStore
 
+	blobs map[digest.Digest][]byte
+
 	statErr, serveErr, openErr error
 }
 
@@ -92,6 +94,14 @@ func (r *mockBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, re
 
 func (r *mockBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
 	return nil, r.openErr
+}
+
+func (r *mockBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	b, exists := r.blobs[dgst]
+	if !exists {
+		return nil, distribution.ErrBlobUnknown
+	}
+	return b, nil
 }
 
 type mockTagService struct {

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -7,7 +7,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -32,10 +35,23 @@ func expectStatusError(status unversioned.Status, message string) bool {
 }
 
 func TestImport(t *testing.T) {
-	m := &schema1.SignedManifest{}
-	if err := json.Unmarshal([]byte(etcdManifest), m); err != nil {
+	etcdManifestSchema1 := &schema1.SignedManifest{}
+	if err := json.Unmarshal([]byte(etcdManifest), etcdManifestSchema1); err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("etcd manifest schema 1 digest: %q", digest.FromBytes([]byte(etcdManifest)))
+	busyboxManifestSchema2 := &schema2.DeserializedManifest{}
+	if err := busyboxManifestSchema2.UnmarshalJSON([]byte(busyboxManifest)); err != nil {
+		t.Fatal(err)
+	}
+	busyboxConfigDigest := digest.FromBytes([]byte(busyboxManifestConfig))
+	busyboxManifestSchema2.Config = distribution.Descriptor{
+		Digest:    busyboxConfigDigest,
+		Size:      int64(len(busyboxManifestConfig)),
+		MediaType: schema2.MediaTypeConfig,
+	}
+	t.Logf("busybox manifest schema 2 digest: %q", digest.FromBytes([]byte(busyboxManifest)))
+
 	insecureRetriever := &mockRetriever{
 		repo: &mockRepository{
 			getTagErr:   fmt.Errorf("no such tag"),
@@ -125,7 +141,7 @@ func TestImport(t *testing.T) {
 			},
 		},
 		{
-			retriever: &mockRetriever{repo: &mockRepository{manifest: m}},
+			retriever: &mockRetriever{repo: &mockRepository{manifest: etcdManifestSchema1}},
 			isi: api.ImageStreamImport{
 				Spec: api.ImageStreamImportSpec{
 					Images: []api.ImageImportSpec{
@@ -160,7 +176,49 @@ func TestImport(t *testing.T) {
 		{
 			retriever: &mockRetriever{
 				repo: &mockRepository{
-					manifest: m,
+					blobs: &mockBlobStore{
+						blobs: map[digest.Digest][]byte{
+							busyboxConfigDigest: []byte(busyboxManifestConfig),
+						},
+					},
+					manifest: busyboxManifestSchema2,
+				},
+			},
+			isi: api.ImageStreamImport{
+				Spec: api.ImageStreamImportSpec{
+					Images: []api.ImageImportSpec{
+						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test:busybox"}},
+					},
+				},
+			},
+			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+				if len(isi.Status.Images) != 1 {
+					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
+				}
+				image := isi.Status.Images[0]
+				if image.Status.Status != unversioned.StatusSuccess {
+					t.Errorf("unexpected status: %#v", image.Status)
+				}
+				// the image name is always the sha256, and size is calculated
+				if image.Image.Name != busyboxDigest {
+					t.Errorf("unexpected image: %q != %q", image.Image.Name, busyboxDigest)
+				}
+				if image.Image.DockerImageMetadata.Size != busyboxImageSize {
+					t.Errorf("unexpected image size: %d != %d", image.Image.DockerImageMetadata.Size, busyboxImageSize)
+				}
+				// the most specific reference is returned
+				if image.Image.DockerImageReference != "test@"+busyboxDigest {
+					t.Errorf("unexpected ref: %#v", image.Image.DockerImageReference)
+				}
+				if image.Tag != "busybox" {
+					t.Errorf("unexpected tag of status: %s != busybox", image.Tag)
+				}
+			},
+		},
+		{
+			retriever: &mockRetriever{
+				repo: &mockRepository{
+					manifest: etcdManifestSchema1,
 					tags: map[string]string{
 						"v1":    "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238",
 						"other": "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238",
@@ -259,3 +317,26 @@ const etcdManifest = `
       }
    ]
 }`
+
+const busyboxDigest = "sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6"
+
+const busyboxManifest = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/octet-stream",
+      "size": 1459,
+      "digest": "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 667590,
+         "digest": "sha256:8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f"
+      }
+   ]
+}`
+
+const busyboxManifestConfig = `{"architecture":"amd64","config":{"Hostname":"55cd1f8f6e5b","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["sh"],"Image":"sha256:e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":{}},"container":"764ef4448baa9a1ce19e4ae95f8cdd4eda7a1186c512773e56dc634dff208a59","container_config":{"Hostname":"55cd1f8f6e5b","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["/bin/sh","-c","#(nop) CMD [\"sh\"]"],"Image":"sha256:e732471cb81a564575aad46b9510161c5945deaf18e9be3db344333d72f0b4b2","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":{}},"created":"2016-06-23T23:23:37.198943461Z","docker_version":"1.10.3","history":[{"created":"2016-06-23T23:23:36.73131105Z","created_by":"/bin/sh -c #(nop) ADD file:9ca60502d646bdd815bb51e612c458e2d447b597b95cf435f9673f0966d41c1a in /"},{"created":"2016-06-23T23:23:37.198943461Z","created_by":"/bin/sh -c #(nop) CMD [\"sh\"]","empty_layer":true}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:8ac8bfaff55af948c796026ee867448c5b5b5d9dd3549f4006d9759b25d4a893"]}}`
+
+const busyboxImageSize int64 = int64(1459 + 667590)

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -545,5 +545,12 @@ os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}
 os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' ${DOCKER_REGISTRY}/v2/schema2tagged/busybox/manifests/latest" "Docker-Content-Digest:\s*${busybox_name}"
 echo "[INFO] Manifest V2 schema 2 successfully converted to schema 1"
 
+echo "[INFO] Verify image size calculation"
+busybox_expected_size=$(oc get -o jsonpath='{.dockerImageManifest}' image ${busybox_name} --context="${CLUSTER_ADMIN_CONTEXT}" | jq -r '[.. | .size?] | add')
+busybox_calculated_size=$(oc get -o go-template='{{.dockerImageMetadata.Size}}' image ${busybox_name} --context="${CLUSTER_ADMIN_CONTEXT}")
+os::cmd::expect_success_and_text "echo ${busybox_expected_size:-}:${busybox_calculated_size:-}" '^[1-9][0-9]*:[1-9][0-9]*$'
+os::cmd::expect_success_and_text "echo '${busybox_expected_size}'" "${busybox_calculated_size}"
+echo "[INFO] Image size matches"
+
 os::test::junit::declare_suite_end
 unset VERBOSE

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -117,8 +117,7 @@ os::cmd::expect_success 'oc status -n default'
 
 # check to make sure a project admin can push an image to an image stream that doesn't exist
 os::cmd::expect_success 'oc project cache'
-e2e_user_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
-os::cmd::expect_success_and_text "echo ${e2e_user_token}" '.+'
+e2e_user_token=$(oc whoami -t)
 
 echo "[INFO] Docker login as e2e-user to ${DOCKER_REGISTRY}"
 os::cmd::expect_success "docker login -u e2e-user -p ${e2e_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}"
@@ -195,11 +194,40 @@ os::cmd::expect_success "oc tag cache/hello-world@${imagedigest} cross:namespace
 os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id"
 echo "[INFO] Cross namespace pull successful"
 
+os::cmd::expect_success 'oc login -u schema2-user -p pass'
+os::cmd::expect_success "oc new-project schema2"
+os::cmd::expect_success "oc project schema2"
+schema2_user_token=$(oc whoami -t)
+
+echo "[INFO] Fetch manifest V2 schema 2 image with old client using pullthrough"
+os::cmd::expect_success "oc import-image --confirm --from=hello-world:latest hello-world:pullthrough"
+os::cmd::expect_success_and_text "oc get -o jsonpath='{.image.dockerImageManifestMediaType}' istag hello-world:pullthrough" 'application/vnd\.docker\.distribution\.manifest\.v2\+json'
+hello_world_name=$(oc get -o 'jsonpath={.image.metadata.name}' istag hello-world:pullthrough)
+os::cmd::expect_success_and_text "echo ${hello_world_name:-}" '.+'
+# dockerImageManifest is retrievable only with "images" resource
+hello_world_config_name=$(oc get -o 'jsonpath={.dockerImageManifest}' image "$hello_world_name" --context="$CLUSTER_ADMIN_CONTEXT" | jq -r '.config.digest')
+hello_world_config_image=$(oc get -o 'jsonpath={.image.dockerImageConfig}' istag hello-world:pullthrough | jq -r '.container_config.Image')
+os::cmd::expect_success_and_text "echo ${hello_world_config_name:-},${hello_world_config_image:-}" '.+,.+'
+# verify we can fetch the config
+os::cmd::expect_success_and_text "curl -u 'schema2-user:${schema2_user_token}' -v -s -o ${ARTIFACT_DIR}/hello-world-config.json ${DOCKER_REGISTRY}/v2/schema2/hello-world/blobs/${hello_world_config_name} 2>&1" "Docker-Content-Digest:\s*${hello_world_config_name}"
+os::cmd::expect_success_and_text "jq -r '.container_config.Image' ${ARTIFACT_DIR}/hello-world-config.json" "${hello_world_config_image}"
+# no accept header provided, the registry will convert schema 2 to schema 1 on-the-fly
+hello_world_schema1_digest=$(curl -u schema2-user:${schema2_user_token} -s -v -o ${ARTIFACT_DIR}/hello-world-manifest.json ${DOCKER_REGISTRY}/v2/schema2/hello-world/manifests/pullthrough |& sed -n 's/.*Docker-Content-Digest:\s*\(\S\+\).*/\1/p')
+# ensure the manifest was converted to schema 1
+os::cmd::expect_success_and_text "jq -r '.schemaVersion' ${ARTIFACT_DIR}/hello-world-manifest.json" '^1$'
+os::cmd::expect_success_and_not_text "echo '${hello_world_schema1_digest:-}'" "${hello_world_name:-}"
+os::cmd::expect_success_and_text "echo '${hello_world_schema1_digest:-}'" ".+"
+os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}' '${DOCKER_REGISTRY}/v2/schema2/hello-world/manifests/${hello_world_schema1_digest}'" "404 Not Found"
+echo "[INFO] Manifest V2 schema 2 image fetched successfully with old client"
+
+echo "[INFO] Back to 'default' project with 'admin' user..."
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
+os::cmd::expect_success_and_text 'oc whoami' 'system:admin'
+
 # check to make sure an image-pusher can push an image
-os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher pusher'
+os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher -n cache pusher'
 os::cmd::expect_success 'oc login -u pusher -p pass'
-pusher_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
-os::cmd::expect_success_and_text "echo ${pusher_token}" '.+'
+pusher_token=$(oc whoami -t)
 
 echo "[INFO] Docker login as pusher to ${DOCKER_REGISTRY}"
 os::cmd::expect_success "docker login -u e2e-user -p ${pusher_token} -e pusher@openshift.com ${DOCKER_REGISTRY}"
@@ -221,9 +249,9 @@ os::cmd::try_until_text 'oc policy who-can get imagestreams/layers -n custom' 's
 os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull"
 os::cmd::expect_success "docker pull ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id"
 # unauthorized pushes return authorization errors, regardless of backing data
-os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/missing/image:tag"              "authentication required"
-os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull"    "authentication required"
-os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id" "authentication required"
+os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/missing/image:tag"              "authentication required|not authorized"
+os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull"    "authentication required|not authorized"
+os::cmd::expect_failure_and_text "docker push ${DOCKER_REGISTRY}/custom/cross:namespace-pull-id" "authentication required|not authorized"
 # test anonymous pushes
 os::cmd::expect_success 'oc policy add-role-to-user system:image-pusher system:anonymous -n custom'
 os::cmd::try_until_text 'oc policy who-can update imagestreams/layers -n custom' 'system:anonymous'
@@ -480,6 +508,42 @@ os::cmd::expect_success "oc exec -p ${registry_pod} du /registry > '${LOG_DIR}/p
 
 # make sure there were changes to the registry's storage
 os::cmd::expect_code "diff ${LOG_DIR}/prune-images.before.txt ${LOG_DIR}/prune-images.after.txt" 1
+echo "[INFO] Validated image pruning"
+
+echo "[INFO] Configure registry to accept manifest V2 schema 2"
+os::cmd::expect_success "oc project ${CLUSTER_ADMIN_CONTEXT}"
+os::cmd::expect_success 'oc env -n default dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2=true'
+wait_for_registry
+echo "[INFO] Registry configured to accept manifest V2 schema 2"
+
+echo "[INFO] Accept manifest V2 schema 2"
+os::cmd::expect_success "oc login -u schema2-user -p pass"
+os::cmd::expect_success "oc project schema2"
+# tagging remote docker.io/busybox image
+os::cmd::expect_success "docker tag --source=docker busybox '${DOCKER_REGISTRY}/schema2/busybox'"
+os::cmd::expect_success "docker login -u e2e-user -p ${schema2_user_token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}"
+os::cmd::expect_success "docker push '${DOCKER_REGISTRY}/schema2/busybox'"
+# image accepted as schema 2
+os::cmd::expect_success_and_text "oc get -o jsonpath='{.image.dockerImageManifestMediaType}' istag busybox:latest" 'application/vnd\.docker\.distribution\.manifest\.v2\+json'
+echo "[INFO] Manifest V2 schema 2 successfully accepted"
+
+echo "[INFO] Convert manifest V2 schema 2 to schema 1 for older client"
+os::cmd::expect_success 'oc login -u schema2-user -p pass'
+os::cmd::expect_success "oc new-project schema2tagged"
+os::cmd::expect_success "oc tag --source=istag schema2/busybox:latest busybox:latest"
+busybox_name=$(oc get -o 'jsonpath={.image.metadata.name}' istag busybox:latest)
+os::cmd::expect_success_and_text "echo ${busybox_name:-}" '.+'
+# no accept header provided, registry converts on-the-fly to schema 1
+busybox_schema1_digest=$(curl -u "schema2-user:${schema2_user_token}" -s -v -o ${ARTIFACT_DIR}/busybox-manifest.json ${DOCKER_REGISTRY}/v2/schema2tagged/busybox/manifests/latest |& sed -n 's/.*Docker-Content-Digest:\s*\(\S\+\).*/\1/p')
+# ensure the manifest was converted to schema 1
+os::cmd::expect_success_and_text "jq -r '.schemaVersion' ${ARTIFACT_DIR}/busybox-manifest.json" '^1$'
+os::cmd::expect_success_and_not_text "echo '${busybox_schema1_digest:-}'" "${busybox_name:-}"
+os::cmd::expect_success_and_text "echo '${busybox_schema1_digest:-}'" ".+"
+# schema 1 is generated on-the-fly, it's not stored in the registry, thus Not Found
+os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}' '${DOCKER_REGISTRY}/v2/schema2tagged/busybox/manifests/${busybox_schema1_digest}'" "404 Not Found"
+# ensure we can fetch it back as schema 2
+os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' ${DOCKER_REGISTRY}/v2/schema2tagged/busybox/manifests/latest" "Docker-Content-Digest:\s*${busybox_name}"
+echo "[INFO] Manifest V2 schema 2 successfully converted to schema 1"
 
 os::test::junit::declare_suite_end
 unset VERBOSE


### PR DESCRIPTION
Resolves #10730

Manifest V2 schema 2 introduces a special blob called config which used to be emeedded in earlier schema. See [upstream's spec](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-field-descriptions) for details. The config is stored as a regular blob on registry's storage. Thus the config needs to be treated similar to a regular layer:

1. the pullthrough middleware needs to be able to fetch it from remote repository
2. we need to increase a size of image for the size of its config
3. the config's digest needs to be cached as a regular layer inside a registry for subsequent lookups
4. image pruning needs to prune it the same way as regular layer

The PR addresses the first 3 items. I'd like to cover the pruning case in a follow-up.