### PR TITLE
suggest specifying flags before resource name

### DIFF
--- a/docs/man/man1/oc-rsh.1
+++ b/docs/man/man1/oc-rsh.1
@@ -20,11 +20,12 @@ This command will attempt to start a shell session in a pod for the specified re
 It works with pods, deployment configs, jobs, daemon sets, and replication controllers.
 Any of the aforementioned resources (apart from pods) will be resolved to a ready pod.
 It will default to the first container if none is specified, and will attempt to use
-'/bin/sh' as the default shell. You may pass an optional command after the resource name,
-which will be executed instead of a login shell. A TTY will be automatically allocated
-if standard input is interactive \- use \-t and \-T to override. A TERM variable is sent
-to the environment where the shell (or command) will be executed. By default its value
-is the same as the TERM variable from the local environment; if not set, 'xterm' is used.
+'/bin/sh' as the default shell. You may pass any flags supported by this command before
+the resource name, and an optional command after the resource name, which will be executed
+instead of a login shell. A TTY will be automatically allocated if standard input is
+interactive \- use \-t and \-T to override. A TERM variable is sent to the environment where
+the shell (or command) will be executed. By default its value is the same as the TERM
+variable from the local environment; if not set, 'xterm' is used.
 
 .PP
 Note, some containers may not include a shell \- use 'oc exec' if you need to run commands

--- a/docs/man/man1/openshift-cli-rsh.1
+++ b/docs/man/man1/openshift-cli-rsh.1
@@ -20,11 +20,12 @@ This command will attempt to start a shell session in a pod for the specified re
 It works with pods, deployment configs, jobs, daemon sets, and replication controllers.
 Any of the aforementioned resources (apart from pods) will be resolved to a ready pod.
 It will default to the first container if none is specified, and will attempt to use
-'/bin/sh' as the default shell. You may pass an optional command after the resource name,
-which will be executed instead of a login shell. A TTY will be automatically allocated
-if standard input is interactive \- use \-t and \-T to override. A TERM variable is sent
-to the environment where the shell (or command) will be executed. By default its value
-is the same as the TERM variable from the local environment; if not set, 'xterm' is used.
+'/bin/sh' as the default shell. You may pass any flags supported by this command before
+the resource name, and an optional command after the resource name, which will be executed
+instead of a login shell. A TTY will be automatically allocated if standard input is
+interactive \- use \-t and \-T to override. A TERM variable is sent to the environment where
+the shell (or command) will be executed. By default its value is the same as the TERM
+variable from the local environment; if not set, 'xterm' is used.
 
 .PP
 Note, some containers may not include a shell \- use 'openshift cli exec' if you need to run commands

--- a/pkg/cmd/cli/cmd/rsh.go
+++ b/pkg/cmd/cli/cmd/rsh.go
@@ -25,11 +25,12 @@ This command will attempt to start a shell session in a pod for the specified re
 It works with pods, deployment configs, jobs, daemon sets, and replication controllers.
 Any of the aforementioned resources (apart from pods) will be resolved to a ready pod.
 It will default to the first container if none is specified, and will attempt to use
-'/bin/sh' as the default shell. You may pass an optional command after the resource name,
-which will be executed instead of a login shell. A TTY will be automatically allocated
-if standard input is interactive - use -t and -T to override. A TERM variable is sent
-to the environment where the shell (or command) will be executed. By default its value
-is the same as the TERM variable from the local environment; if not set, 'xterm' is used.
+'/bin/sh' as the default shell. You may pass any flags supported by this command before
+the resource name, and an optional command after the resource name, which will be executed
+instead of a login shell. A TTY will be automatically allocated if standard input is 
+interactive - use -t and -T to override. A TERM variable is sent to the environment where 
+the shell (or command) will be executed. By default its value is the same as the TERM 
+variable from the local environment; if not set, 'xterm' is used.
 
 Note, some containers may not include a shell - use '%[1]s exec' if you need to run commands
 directly.`


### PR DESCRIPTION
Addresses comment https://github.com/openshift/origin/issues/10770#issuecomment-244139506 in https://github.com/openshift/origin/issues/10770

`oc rsh <resource>` treats everything to the right of `<resource>` a
command to execute inside a pod container. This patch updates the usage
output to clarify that flags for this command may be passed before the
resource name.

cc @openshift/cli-review 