### PR TITLE
Added a mention of 'oc get' to 'oc get --help'

### DIFF
--- a/docs/man/man1/oc-get.1
+++ b/docs/man/man1/oc-get.1
@@ -16,9 +16,10 @@ oc get \- Display one or many resources
 Display one or many resources
 
 .PP
-Possible resources include builds, buildConfigs, services, pods, etc.
-Some resources may omit advanced details that you can see with '\-o wide'.
-If you want an even more detailed view, use 'oc describe'.
+Possible resources include builds, buildConfigs, services, pods, etc. To see a
+list of common resources, use 'oc get'. Some resources may omit
+advanced details that you can see with '\-o wide'.  If you want an even more
+detailed view, use 'oc describe'.
 
 
 .SH OPTIONS

--- a/docs/man/man1/openshift-cli-get.1
+++ b/docs/man/man1/openshift-cli-get.1
@@ -16,9 +16,10 @@ openshift cli get \- Display one or many resources
 Display one or many resources
 
 .PP
-Possible resources include builds, buildConfigs, services, pods, etc.
-Some resources may omit advanced details that you can see with '\-o wide'.
-If you want an even more detailed view, use 'openshift cli describe'.
+Possible resources include builds, buildConfigs, services, pods, etc. To see a
+list of common resources, use 'openshift cli get'. Some resources may omit
+advanced details that you can see with '\-o wide'.  If you want an even more
+detailed view, use 'openshift cli describe'.
 
 
 .SH OPTIONS

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -37,9 +37,10 @@ func adjustCmdExamples(cmd *cobra.Command, parentName string, name string) {
 const (
 	getLong = `Display one or many resources
 
-Possible resources include builds, buildConfigs, services, pods, etc.
-Some resources may omit advanced details that you can see with '-o wide'.
-If you want an even more detailed view, use '%[1]s describe'.`
+Possible resources include builds, buildConfigs, services, pods, etc. To see a
+list of common resources, use '%[1]s get'. Some resources may omit
+advanced details that you can see with '-o wide'.  If you want an even more
+detailed view, use '%[1]s describe'.`
 
 	getExample = `  # List all pods in ps output format.
   %[1]s get pods


### PR DESCRIPTION
Fixes #9326 

@juanvallejo @fabianofranz @deads2k @liggitt ptal?

New output:
```bash
 $ oc get --help
Display one or many resources

Possible resources include builds, buildConfigs, services, pods, etc. To see a
list of common resources, use 'oc get'. Some resources may omit
advanced details that you can see with '-o wide'.  If you want an even more
detailed view, use 'oc describe'.
```