### PR TITLE
UPSTREAM: 32000: Update node status instead of node in kubelet

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1219,7 +1219,7 @@ func (kl *Kubelet) tryRegisterWithApiServer(node *api.Node) bool {
 		// annotation.
 		requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(node, existingNode)
 		if requiresUpdate {
-			if _, err := kl.kubeClient.Core().Nodes().Update(existingNode); err != nil {
+			if _, err := kl.kubeClient.Core().Nodes().UpdateStatus(existingNode); err != nil {
 				glog.Errorf("Unable to reconcile node %q with API server: error updating node: %v", kl.nodeName, err)
 				return false
 			}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1242,7 +1242,7 @@ func (kl *Kubelet) tryRegisterWithApiServer(node *api.Node) bool {
 				// controller-managed attach detach annotation for this node.
 				requiresUpdate := kl.reconcileCMADAnnotationWithExistingNode(node, existingNode)
 				if requiresUpdate {
-					if _, err := kl.kubeClient.Core().Nodes().Update(existingNode); err != nil {
+					if _, err := kl.kubeClient.Core().Nodes().UpdateStatus(existingNode); err != nil {
 						glog.Errorf("Unable to reconcile node %q with API server: error updating node: %v", kl.nodeName, err)
 						return false
 					}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
@@ -4096,13 +4096,17 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 			// Return an existing (matching) node on get.
 			return true, tc.existingNode, tc.getError
 		})
-		kubeClient.AddReactor("update", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, nil, tc.updateError
+		kubeClient.AddReactor("update", "*", func(action core.Action) (bool, runtime.Object, error) {
+			if action.GetResource().Resource == "nodes" && action.GetSubresource() == "status" {
+				return true, nil, tc.updateError
+			}
+			return true, nil, fmt.Errorf("no reaction implemented for %s", action)
 		})
 		kubeClient.AddReactor("delete", "nodes", func(action core.Action) (bool, runtime.Object, error) {
 			return true, nil, tc.deleteError
 		})
 		kubeClient.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
+			t.Logf("no reaction implemented for %s", action)
 			return true, nil, fmt.Errorf("no reaction implemented for %s", action)
 		})
 


### PR DESCRIPTION
Needed to avoid changing the permissions of the node role.