### PR TITLE
Refactor cli command cancelbuild and add unit tests.

### DIFF
--- a/pkg/client/testclient/fake_builds.go
+++ b/pkg/client/testclient/fake_builds.go
@@ -61,7 +61,7 @@ func (c *FakeBuilds) Watch(opts kapi.ListOptions) (watch.Interface, error) {
 }
 
 func (c *FakeBuilds) Clone(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
+	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
 	action.Subresource = "clone"
 	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
 	if obj == nil {

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -115,7 +115,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdRollback(fullName, f, out),
 				cmd.NewCmdNewBuild(fullName, f, in, out),
 				cmd.NewCmdStartBuild(fullName, f, in, out),
-				cmd.NewCmdCancelBuild(fullName, f, in, out),
+				cmd.NewCmdCancelBuild(cmd.CancelBuildRecommendedCommandName, fullName, f, in, out),
 				cmd.NewCmdImportImage(fullName, f, out),
 				cmd.NewCmdTag(fullName, f, out),
 			},

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -9,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/errors"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -22,6 +23,9 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
+// CancelBuildRecommendedCommandName is the recommended command name.
+const CancelBuildRecommendedCommandName = "cancel-build"
+
 const (
 	cancelBuildLong = `
 Cancel running, pending, or new builds
@@ -30,21 +34,22 @@ This command requests a graceful shutdown of the build. There may be a delay bet
 the build and the time the build is terminated.`
 
 	cancelBuildExample = `  # Cancel the build with the given name
-  %[1]s cancel-build ruby-build-2
+  %[1]s %[2]s ruby-build-2
 
   # Cancel the named build and print the build logs
-  %[1]s cancel-build ruby-build-2 --dump-logs
+  %[1]s %[2]s ruby-build-2 --dump-logs
 
   # Cancel the named build and create a new one with the same parameters
-  %[1]s cancel-build ruby-build-2 --restart
+  %[1]s %[2]s ruby-build-2 --restart
 
   # Cancel multiple builds
-  %[1]s cancel-build ruby-build-1 ruby-build-2 ruby-build-3
+  %[1]s %[2]s ruby-build-1 ruby-build-2 ruby-build-3
 
   # Cancel all builds created from 'ruby-build' build configuration that are in 'new' state
-  %[1]s cancel-build bc/ruby-build --state=new`
+  %[1]s %[2]s bc/ruby-build --state=new`
 )
 
+// CancelBuildOptions contains all the options for running the CancelBuild cli command.
 type CancelBuildOptions struct {
 	In          io.Reader
 	Out, ErrOut io.Writer
@@ -64,18 +69,21 @@ type CancelBuildOptions struct {
 }
 
 // NewCmdCancelBuild implements the OpenShift cli cancel-build command
-func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
+func NewCmdCancelBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
 	o := &CancelBuildOptions{}
 
 	cmd := &cobra.Command{
-		Use:        "cancel-build (BUILD | BUILDCONFIG)",
+		Use:        fmt.Sprintf("%s (BUILD | BUILDCONFIG)", name),
 		Short:      "Cancel running, pending, or new builds",
 		Long:       cancelBuildLong,
-		Example:    fmt.Sprintf(cancelBuildExample, fullName),
+		Example:    fmt.Sprintf(cancelBuildExample, baseName, name),
 		SuggestFor: []string{"builds", "stop-build"},
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(f, in, out, cmd, args))
-			kcmdutil.CheckErr(o.Run())
+			err := o.Complete(f, cmd, args, in, out)
+			kcmdutil.CheckErr(err)
+
+			err = o.RunCancelBuild()
+			kcmdutil.CheckErr(err)
 		},
 	}
 
@@ -85,7 +93,8 @@ func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, in io.Reader, out 
 	return cmd
 }
 
-func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra.Command, args []string) error {
+// Complete completes all the required options.
+func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, in io.Reader, out io.Writer) error {
 	o.In = in
 	o.Out = out
 	o.ErrOut = cmd.OutOrStderr()
@@ -130,6 +139,7 @@ func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out io
 		if err != nil {
 			return err
 		}
+
 		switch resource {
 		case buildapi.Resource("buildconfigs"):
 			list, err := buildutil.BuildConfigBuilds(o.BuildLister, o.Namespace, name, nil)
@@ -149,7 +159,8 @@ func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out io
 	return nil
 }
 
-func (o *CancelBuildOptions) Run() error {
+// RunCancelBuild implements all the necessary functionality for CancelBuild.
+func (o *CancelBuildOptions) RunCancelBuild() error {
 	var builds []*buildapi.Build
 
 	for _, name := range o.BuildNames {
@@ -158,6 +169,7 @@ func (o *CancelBuildOptions) Run() error {
 			o.ReportError(fmt.Errorf("build %s/%s not found", o.Namespace, name))
 			continue
 		}
+
 		stateMatch := false
 		for _, state := range o.States {
 			if strings.ToLower(string(build.Status.Phase)) == state {
@@ -198,7 +210,7 @@ func (o *CancelBuildOptions) Run() error {
 				switch {
 				case err == nil:
 					return true, nil
-				case errors.IsConflict(err):
+				case kapierrors.IsConflict(err):
 					build, err = o.BuildClient.Get(build.Name)
 					return false, err
 				}
@@ -208,6 +220,7 @@ func (o *CancelBuildOptions) Run() error {
 				o.ReportError(fmt.Errorf("build %s/%s failed to update: %v", build.Namespace, build.Name, err))
 				return
 			}
+
 			// Make sure the build phase is really cancelled.
 			err = wait.Poll(500*time.Millisecond, 30*time.Second, func() (bool, error) {
 				updatedBuild, err := o.BuildClient.Get(build.Name)
@@ -220,6 +233,7 @@ func (o *CancelBuildOptions) Run() error {
 				o.ReportError(fmt.Errorf("build %s/%s failed to cancel: %v", build.Namespace, build.Name, err))
 				return
 			}
+
 			resource, name, _ := cmdutil.ResolveResource(buildapi.Resource("builds"), build.Name, o.Mapper)
 			kcmdutil.PrintSuccess(o.Mapper, false, o.Out, resource.Resource, name, "cancelled")
 		}(b)
@@ -240,7 +254,7 @@ func (o *CancelBuildOptions) Run() error {
 	}
 
 	if o.HasError {
-		return fmt.Errorf("failure during the build cancellation")
+		return errors.New("failure during the build cancellation")
 	}
 
 	return nil

--- a/pkg/cmd/cli/cmd/cancelbuild_test.go
+++ b/pkg/cmd/cli/cmd/cancelbuild_test.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apimachinery/registered"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client/testclient"
+)
+
+// TestCancelBuildDefaultFlags ensures that flags default values are set.
+func TestCancelBuildDefaultFlags(t *testing.T) {
+	o := CancelBuildOptions{}
+
+	tests := map[string]struct {
+		flagName   string
+		defaultVal string
+	}{
+		"state": {
+			flagName:   "state",
+			defaultVal: "[" + strings.Join(o.States, ",") + "]",
+		},
+		"dump-logs": {
+			flagName:   "dump-logs",
+			defaultVal: strconv.FormatBool(o.DumpLogs),
+		},
+		"restart": {
+			flagName:   "restart",
+			defaultVal: strconv.FormatBool(o.Restart),
+		},
+	}
+
+	cmd := NewCmdCancelBuild("oc", CancelBuildRecommendedCommandName, nil, nil, nil)
+
+	for _, v := range tests {
+		f := cmd.Flag(v.flagName)
+		if f == nil {
+			t.Fatalf("expected flag %s to be registered but found none", v.flagName)
+		}
+
+		if f.DefValue != v.defaultVal {
+			t.Errorf("expected default value of %s for %s but found %s", v.defaultVal, v.flagName, f.DefValue)
+		}
+	}
+}
+
+// TestCancelBuildRun ensures that RunCancelBuild command calls the right actions.
+func TestCancelBuildRun(t *testing.T) {
+	tests := map[string]struct {
+		opts            *CancelBuildOptions
+		phase           buildapi.BuildPhase
+		expectedActions []testAction
+		expectedErr     error
+	}{
+		"cancelled": {
+			opts: &CancelBuildOptions{
+				Out:       ioutil.Discard,
+				Namespace: "test",
+				States:    []string{"new", "pending", "running"},
+			},
+			phase: buildapi.BuildPhaseCancelled,
+			expectedActions: []testAction{
+				{verb: "get", resource: "builds"},
+			},
+			expectedErr: nil,
+		},
+		"complete": {
+			opts: &CancelBuildOptions{
+				Out:       ioutil.Discard,
+				Namespace: "test",
+			},
+			phase: buildapi.BuildPhaseComplete,
+			expectedActions: []testAction{
+				{verb: "get", resource: "builds"},
+			},
+			expectedErr: nil,
+		},
+		"new": {
+			opts: &CancelBuildOptions{
+				Out:       ioutil.Discard,
+				Namespace: "test",
+			},
+			phase: buildapi.BuildPhaseNew,
+			expectedActions: []testAction{
+				{verb: "get", resource: "builds"},
+				{verb: "update", resource: "builds"},
+				{verb: "get", resource: "builds"},
+			},
+			expectedErr: nil,
+		},
+		"pending": {
+			opts: &CancelBuildOptions{
+				Out:       ioutil.Discard,
+				Namespace: "test",
+			},
+			phase: buildapi.BuildPhaseNew,
+			expectedActions: []testAction{
+				{verb: "get", resource: "builds"},
+				{verb: "update", resource: "builds"},
+				{verb: "get", resource: "builds"},
+			},
+			expectedErr: nil,
+		},
+		"running and restart": {
+			opts: &CancelBuildOptions{
+				Out:       ioutil.Discard,
+				Namespace: "test",
+				Restart:   true,
+			},
+			phase: buildapi.BuildPhaseNew,
+			expectedActions: []testAction{
+				{verb: "get", resource: "builds"},
+				{verb: "update", resource: "builds"},
+				{verb: "get", resource: "builds"},
+				{verb: "create", resource: "builds"},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		client := testclient.NewSimpleFake(genBuild(test.phase))
+		buildClient := NewFakeTestBuilds(client, test.opts.Namespace)
+
+		test.opts.Client = client
+		test.opts.BuildClient = buildClient
+		test.opts.ReportError = func(err error) {
+			test.opts.HasError = true
+		}
+		test.opts.Mapper = registered.RESTMapper()
+		test.opts.BuildNames = []string{"ruby-ex"}
+		test.opts.States = []string{"new", "pending", "running"}
+
+		if err := test.opts.RunCancelBuild(); err != test.expectedErr {
+			t.Fatalf("error mismatch: expected %v, got %v", test.expectedErr, err)
+		}
+
+		got := test.opts.Client.(*testclient.Fake).Actions()
+		if len(test.expectedActions) != len(got) {
+			t.Fatalf("action length mismatch: expected %d, got %d", len(test.expectedActions), len(got))
+		}
+
+		for i, action := range test.expectedActions {
+			if !got[i].Matches(action.verb, action.resource) {
+				t.Errorf("action mismatch: expected %s %s, got %s %s", action.verb, action.resource, got[i].GetVerb(), got[i].GetResource())
+			}
+		}
+	}
+
+}
+
+type FakeTestBuilds struct {
+	*testclient.FakeBuilds
+	Obj *buildapi.Build
+}
+
+func NewFakeTestBuilds(c *testclient.Fake, ns string) *FakeTestBuilds {
+	f := FakeTestBuilds{}
+	f.FakeBuilds = &testclient.FakeBuilds{}
+	f.Fake = c
+	f.Namespace = ns
+
+	return &f
+}
+
+func (c *FakeTestBuilds) Get(name string) (*buildapi.Build, error) {
+	obj, err := c.FakeBuilds.Get(name)
+	if c.Obj == nil {
+		c.Obj = obj
+	}
+
+	return c.Obj, err
+}
+
+func (c *FakeTestBuilds) Update(inObj *buildapi.Build) (*buildapi.Build, error) {
+	_, err := c.FakeBuilds.Update(inObj)
+	if inObj.Status.Cancelled == true {
+		inObj.Status.Phase = buildapi.BuildPhaseCancelled
+	}
+
+	c.Obj = inObj
+	return c.Obj, err
+}
+
+func genBuild(phase buildapi.BuildPhase) *buildapi.Build {
+	build := buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "ruby-ex",
+			Namespace: "test",
+		},
+		Status: buildapi.BuildStatus{
+			Phase: phase,
+		},
+	}
+	return &build
+}


### PR DESCRIPTION
Refactor based on openshift cmd guidelines and added unit tests for cancelbuild cli command.

Also fixed a minor bug in fake_builds.go

Related to #6316.