### PR TITLE
JenkinsPipelineStrategy nil no need check again

### DIFF
--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -148,12 +148,6 @@ func (bc *BuildController) nextBuildPhase(build *buildapi.Build) error {
 		return nil
 	}
 
-	// these builds are processed/updated/etc by the jenkins sync plugin
-	if build.Spec.Strategy.JenkinsPipelineStrategy != nil {
-		glog.V(4).Infof("Ignoring build with jenkins pipeline strategy")
-		return nil
-	}
-
 	// Set the output Docker image reference.
 	ref, err := bc.resolveOutputDockerImageReference(build)
 	if err != nil {


### PR DESCRIPTION
`build.Spec.Strategy.JenkinsPipelineStrategy != nil ` has been checked in function HandleBuild :
```
func (bc *BuildController) HandleBuild(build *buildapi.Build) error {
 	// these builds are processed/updated/etc by the jenkins sync plugin
 	if build.Spec.Strategy.JenkinsPipelineStrategy != nil {
 		glog.V(4).Infof("Ignoring build with jenkins pipeline strategy")
 		return nil
 	}
```