### PR TITLE
deploy: record cancellation time in deployments

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
 	"time"
 
 	"github.com/docker/docker/pkg/units"
@@ -15,6 +14,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -323,6 +323,11 @@ func (o DeployOptions) retry(config *deployapi.DeploymentConfig) error {
 	return nil
 }
 
+// nowFn is extracted from the cancel method for unit testing.
+var nowFn = func() time.Time {
+	return unversioned.Now().Time
+}
+
 // cancel cancels any deployment process in progress for config.
 func (o DeployOptions) cancel(config *deployapi.DeploymentConfig) error {
 	if config.Spec.Paused {
@@ -351,6 +356,8 @@ func (o DeployOptions) cancel(config *deployapi.DeploymentConfig) error {
 			}
 
 			deployment.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
+			adaptedToServerTimestamp := nowFn().In(deployment.CreationTimestamp.Location()).Format(time.RFC3339)
+			deployment.Annotations[deployapi.DeploymentCancelledAtAnnotation] = adaptedToServerTimestamp
 			deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledByUser
 			_, err := o.kubeClient.ReplicationControllers(deployment.Namespace).Update(&deployment)
 			if err == nil {

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -241,7 +241,11 @@ const (
 	DeploymentStatusReasonAnnotation = "openshift.io/deployment.status-reason"
 	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
 	// The annotation value does not matter and its mere presence indicates cancellation
+	// DEPRECATED in favor of openshift.io/deployment.cancelled-at
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
+	// DeploymentCancelledAtAnnotation indicates that the deployment has been cancelled
+	// The annotation value holds the time a deployment was cancelled in UTC format.
+	DeploymentCancelledAtAnnotation = "openshift.io/deployment.cancelled-at"
 	// DeploymentReplicasAnnotation is for internal use only and is for
 	// detecting external modifications to deployment replica counts.
 	DeploymentReplicasAnnotation = "openshift.io/deployment.replicas"

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
@@ -125,7 +127,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 					if err != nil {
 						return err
 					}
-					copied.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
+					copied.Annotations[deployapi.DeploymentCancelledAtAnnotation] = unversioned.Now().Format(time.RFC3339)
 					copied.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledNewerDeploymentExists
 					updatedDeployment, err = c.rn.ReplicationControllers(copied.Namespace).Update(copied)
 					return err

--- a/pkg/deploy/controller/deploymentconfig/controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/controller/framework"
@@ -37,6 +38,8 @@ func TestHandleScenarios(t *testing.T) {
 		cancelled bool
 	}
 
+	cancelledAt := unversioned.Now().Format(time.RFC3339)
+
 	mkdeployment := func(d deployment) kapi.ReplicationController {
 		config := deploytest.OkDeploymentConfig(d.version)
 		if d.test {
@@ -46,7 +49,7 @@ func TestHandleScenarios(t *testing.T) {
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codecs.LegacyCodec(deployv1.SchemeGroupVersion))
 		deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(d.status)
 		if d.cancelled {
-			deployment.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
+			deployment.Annotations[deployapi.DeploymentCancelledAtAnnotation] = cancelledAt
 			deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledNewerDeploymentExists
 		}
 		if d.replicasA != nil {

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -321,9 +321,12 @@ func DeploymentVersionFor(obj runtime.Object) int64 {
 	return v
 }
 
+// IsDeploymentCancelled returns true if the deployment has been marked as cancelled.
 func IsDeploymentCancelled(deployment *api.ReplicationController) bool {
 	value := annotationFor(deployment, deployapi.DeploymentCancelledAnnotation)
-	return strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
+	oldExists := strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
+	_, newExists := deployment.Annotations[deployapi.DeploymentCancelledAtAnnotation]
+	return oldExists || newExists
 }
 
 func HasSynced(dc *deployapi.DeploymentConfig) bool {


### PR DESCRIPTION
@mfojtik will help in debugging https://github.com/openshift/origin/issues/10765#issuecomment-244568884

Also useful on its own (we can update `oc status` to use these timestamps)

@openshift/api-review  may be considered as an api change since essentially I am deprecating [DeploymentCancelledAnnotationValue](https://github.com/openshift/origin/blob/e3e0f5378aed5171fac1f1f645f7b6555f740e6a/pkg/deploy/api/types.go#L270-L272)