### PR TITLE
Surface warnings events from replication controller to deployment

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -491,7 +491,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("get", "list", "watch", "update").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
 				authorizationapi.NewRule("get", "list", "watch", "create").Groups(kapiGroup).Resources("pods").RuleOrDie(),
 				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
-				authorizationapi.NewRule("create").Groups(kapiGroup).Resources("events").RuleOrDie(),
+				authorizationapi.NewRule("create", "list").Groups(kapiGroup).Resources("events").RuleOrDie(),
 
 				authorizationapi.NewRule("update").Groups(imageGroup).Resources("imagestreamtags").RuleOrDie(),
 			},

--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -40,6 +40,7 @@ func TestRecreate_initialDeployment(t *testing.T) {
 		retryPeriod:       1 * time.Millisecond,
 		getUpdateAcceptor: getUpdateAcceptor,
 		scaler:            scaler,
+		eventClient:       ktestclient.NewSimpleFake(),
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
@@ -74,6 +75,7 @@ func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
 		retryTimeout:      1 * time.Second,
 		retryPeriod:       1 * time.Millisecond,
 		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       ktestclient.NewSimpleFake(),
 		rcClient:          &fakeControllerClient{deployment: deployment},
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
@@ -106,6 +108,7 @@ func TestRecreate_deploymentPreHookFail(t *testing.T) {
 		retryTimeout:      1 * time.Second,
 		retryPeriod:       1 * time.Millisecond,
 		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       ktestclient.NewSimpleFake(),
 		rcClient:          &fakeControllerClient{deployment: deployment},
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
@@ -139,6 +142,7 @@ func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
 		retryPeriod:       1 * time.Millisecond,
 		rcClient:          &fakeControllerClient{deployment: deployment},
 		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       ktestclient.NewSimpleFake(),
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
 				hookExecuted = true
@@ -170,6 +174,7 @@ func TestRecreate_deploymentMidHookFail(t *testing.T) {
 		retryTimeout:      1 * time.Second,
 		retryPeriod:       1 * time.Millisecond,
 		rcClient:          &fakeControllerClient{deployment: deployment},
+		eventClient:       ktestclient.NewSimpleFake(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
@@ -201,6 +206,7 @@ func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
 		retryTimeout:      1 * time.Second,
 		retryPeriod:       1 * time.Millisecond,
 		rcClient:          &fakeControllerClient{deployment: deployment},
+		eventClient:       ktestclient.NewSimpleFake(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
@@ -234,6 +240,7 @@ func TestRecreate_deploymentPostHookFail(t *testing.T) {
 		retryTimeout:      1 * time.Second,
 		retryPeriod:       1 * time.Millisecond,
 		rcClient:          &fakeControllerClient{deployment: deployment},
+		eventClient:       ktestclient.NewSimpleFake(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
 			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
@@ -260,6 +267,7 @@ func TestRecreate_acceptorSuccess(t *testing.T) {
 	strategy := &RecreateDeploymentStrategy{
 		out:          &bytes.Buffer{},
 		errOut:       &bytes.Buffer{},
+		eventClient:  ktestclient.NewSimpleFake(),
 		decoder:      kapi.Codecs.UniversalDecoder(),
 		retryTimeout: 1 * time.Second,
 		retryPeriod:  1 * time.Millisecond,
@@ -309,6 +317,7 @@ func TestRecreate_acceptorFail(t *testing.T) {
 		retryTimeout: 1 * time.Second,
 		retryPeriod:  1 * time.Millisecond,
 		scaler:       scaler,
+		eventClient:  ktestclient.NewSimpleFake(),
 	}
 
 	acceptor := &testAcceptor{

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -24,8 +24,8 @@ func TestRolling_deployInitial(t *testing.T) {
 	initialStrategyInvoked := false
 
 	strategy := &RollingDeploymentStrategy{
-		decoder: kapi.Codecs.UniversalDecoder(),
-		client:  ktestclient.NewSimpleFake(),
+		decoder:  kapi.Codecs.UniversalDecoder(),
+		rcClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				initialStrategyInvoked = true
@@ -81,8 +81,8 @@ func TestRolling_deployRolling(t *testing.T) {
 
 	var rollingConfig *kubectl.RollingUpdaterConfig
 	strategy := &RollingDeploymentStrategy{
-		decoder: kapi.Codecs.UniversalDecoder(),
-		client:  fake,
+		decoder:  kapi.Codecs.UniversalDecoder(),
+		rcClient: fake,
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				t.Fatalf("unexpected call to initial strategy")
@@ -162,8 +162,8 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 	})
 
 	strategy := &RollingDeploymentStrategy{
-		decoder: kapi.Codecs.UniversalDecoder(),
-		client:  fake,
+		decoder:  kapi.Codecs.UniversalDecoder(),
+		rcClient: fake,
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				t.Fatalf("unexpected call to initial strategy")
@@ -223,8 +223,8 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 	var hookError error
 
 	strategy := &RollingDeploymentStrategy{
-		decoder: kapi.Codecs.UniversalDecoder(),
-		client:  ktestclient.NewSimpleFake(),
+		decoder:  kapi.Codecs.UniversalDecoder(),
+		rcClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				return nil

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -24,8 +24,9 @@ func TestRolling_deployInitial(t *testing.T) {
 	initialStrategyInvoked := false
 
 	strategy := &RollingDeploymentStrategy{
-		decoder:  kapi.Codecs.UniversalDecoder(),
-		rcClient: ktestclient.NewSimpleFake(),
+		decoder:     kapi.Codecs.UniversalDecoder(),
+		rcClient:    ktestclient.NewSimpleFake(),
+		eventClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				initialStrategyInvoked = true
@@ -81,8 +82,9 @@ func TestRolling_deployRolling(t *testing.T) {
 
 	var rollingConfig *kubectl.RollingUpdaterConfig
 	strategy := &RollingDeploymentStrategy{
-		decoder:  kapi.Codecs.UniversalDecoder(),
-		rcClient: fake,
+		decoder:     kapi.Codecs.UniversalDecoder(),
+		rcClient:    fake,
+		eventClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				t.Fatalf("unexpected call to initial strategy")
@@ -162,8 +164,9 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 	})
 
 	strategy := &RollingDeploymentStrategy{
-		decoder:  kapi.Codecs.UniversalDecoder(),
-		rcClient: fake,
+		decoder:     kapi.Codecs.UniversalDecoder(),
+		rcClient:    fake,
+		eventClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				t.Fatalf("unexpected call to initial strategy")
@@ -223,8 +226,9 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 	var hookError error
 
 	strategy := &RollingDeploymentStrategy{
-		decoder:  kapi.Codecs.UniversalDecoder(),
-		rcClient: ktestclient.NewSimpleFake(),
+		decoder:     kapi.Codecs.UniversalDecoder(),
+		rcClient:    ktestclient.NewSimpleFake(),
+		eventClient: ktestclient.NewSimpleFake(),
 		initialStrategy: &testStrategy{
 			deployFn: func(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor strat.UpdateAcceptor) error {
 				return nil

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -12,7 +12,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
-	"k8s.io/kubernetes/pkg/client/record"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kdeployutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/pkg/fields"
@@ -47,11 +46,11 @@ type HookExecutor struct {
 	// decoder is used for encoding/decoding.
 	decoder runtime.Decoder
 	// recorder is used to emit events from hooks
-	events record.EventSink
+	events kclient.EventNamespacer
 }
 
 // NewHookExecutor makes a HookExecutor from a client.
-func NewHookExecutor(client kclient.PodsNamespacer, tags client.ImageStreamTagsNamespacer, events record.EventSink, out io.Writer, decoder runtime.Decoder) *HookExecutor {
+func NewHookExecutor(client kclient.PodsNamespacer, tags client.ImageStreamTagsNamespacer, events kclient.EventNamespacer, out io.Writer, decoder runtime.Decoder) *HookExecutor {
 	return &HookExecutor{
 		tags:   tags,
 		events: events,

--- a/pkg/deploy/strategy/util/util.go
+++ b/pkg/deploy/strategy/util/util.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func RecordConfigEvent(events record.EventSink, deployment *kapi.ReplicationController, decoder runtime.Decoder, eventType, reason, msg string) {
+	t := unversioned.Time{Time: time.Now()}
+	var ref *kapi.ObjectReference
+	if config, err := deployutil.DecodeDeploymentConfig(deployment, decoder); err != nil {
+		glog.Errorf("Unable to decode deployment %s/%s to replication contoller: %v", deployment.Namespace, deployment.Name, err)
+		if ref, err = kapi.GetReference(deployment); err != nil {
+			glog.Errorf("Unable to get reference for %#v: %v", deployment, err)
+			return
+		}
+	} else {
+		if ref, err = kapi.GetReference(config); err != nil {
+			glog.Errorf("Unable to get reference for %#v: %v", config, err)
+			return
+		}
+	}
+	event := &kapi.Event{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace: ref.Namespace,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        msg,
+		Source: kapi.EventSource{
+			Component: deployutil.DeployerPodNameFor(deployment),
+		},
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventType,
+	}
+	if _, err := events.Create(event); err != nil {
+		glog.Errorf("Could not send event '%#v': %v", event, err)
+	}
+}

--- a/pkg/deploy/strategy/util/util.go
+++ b/pkg/deploy/strategy/util/util.go
@@ -2,32 +2,33 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/client/record"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
-func RecordConfigEvent(events record.EventSink, deployment *kapi.ReplicationController, decoder runtime.Decoder, eventType, reason, msg string) {
+// RecordConfigEvent records an event for the deployment config referenced by the
+// deployment.
+func RecordConfigEvent(client kclient.EventNamespacer, deployment *kapi.ReplicationController, decoder runtime.Decoder, eventType, reason, msg string) {
 	t := unversioned.Time{Time: time.Now()}
-	var ref *kapi.ObjectReference
-	if config, err := deployutil.DecodeDeploymentConfig(deployment, decoder); err != nil {
-		glog.Errorf("Unable to decode deployment %s/%s to replication contoller: %v", deployment.Namespace, deployment.Name, err)
-		if ref, err = kapi.GetReference(deployment); err != nil {
-			glog.Errorf("Unable to get reference for %#v: %v", deployment, err)
-			return
-		}
+	var obj runtime.Object = deployment
+	if config, err := deployutil.DecodeDeploymentConfig(deployment, decoder); err == nil {
+		obj = config
 	} else {
-		if ref, err = kapi.GetReference(config); err != nil {
-			glog.Errorf("Unable to get reference for %#v: %v", config, err)
-			return
-		}
+		glog.Errorf("Unable to decode deployment config from %s/%s: %v", deployment.Namespace, deployment.Name, err)
+	}
+	ref, err := kapi.GetReference(obj)
+	if err != nil {
+		glog.Errorf("Unable to get reference for %#v: %v", obj, err)
+		return
 	}
 	event := &kapi.Event{
 		ObjectMeta: kapi.ObjectMeta{
@@ -45,7 +46,27 @@ func RecordConfigEvent(events record.EventSink, deployment *kapi.ReplicationCont
 		Count:          1,
 		Type:           eventType,
 	}
-	if _, err := events.Create(event); err != nil {
-		glog.Errorf("Could not send event '%#v': %v", event, err)
+	if _, err := client.Events(ref.Namespace).Create(event); err != nil {
+		glog.Errorf("Could not create event '%#v': %v", event, err)
+	}
+}
+
+// RecordConfigWarnings records all warning events from the replication controller to the
+// associated deployment config.
+func RecordConfigWarnings(client kclient.EventNamespacer, rc *kapi.ReplicationController, decoder runtime.Decoder, out io.Writer) {
+	if rc == nil {
+		return
+	}
+	events, err := client.Events(rc.Namespace).Search(rc)
+	if err != nil {
+		fmt.Fprintf(out, "--> Error listing events for replication controller %s: %v\n", rc.Name, err)
+		return
+	}
+	// TODO: Do we need to sort the events?
+	for _, e := range events.Items {
+		if e.Type == kapi.EventTypeWarning {
+			fmt.Fprintf(out, "-->  %s: %s %s\n", e.Reason, rc.Name, e.Message)
+			RecordConfigEvent(client, rc, decoder, e.Type, e.Reason, e.Message)
+		}
 	}
 }

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -310,7 +310,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	}
 
 	// can tag to a stream that exists
-	exec := stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient.Events(""), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec := stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient, os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{
@@ -348,7 +348,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	}
 
 	// can execute a second time the same tag and it should work
-	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient.Events(""), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient, os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{
@@ -380,7 +380,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	}
 
 	// can lifecycle tag a new image stream
-	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient.Events(""), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClient, os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1672,6 +1672,7 @@ items:
     - events
     verbs:
     - create
+    - list
   - apiGroups:
     - ""
     attributeRestrictions: null


### PR DESCRIPTION
The first commit will reveal the warnings events from replication controllers (both from and to) in the deployer logs:

```
[@dev] .../openshift/origin # oc deploy dc/ruby-ex --latest --follow 
--> Scaling ruby-ex-1 to 1
-->  FailedCreate: ruby-ex-1 Error creating: pods "ruby-ex-1-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.volumes[0]: Invalid value: "gitRepo": gitRepo volumes are not allowed to be used]
error: couldn't scale ruby-ex-1 to 1: timed out waiting for "ruby-ex-1" to be synced
```

The second commit will make sure that any warnings events from the strategy will be surfaced back to deployment config:

```console
Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  52m		52m		1	{deploymentconfig-controller }			Normal		DeploymentCreated	Created new deployment "ruby-ex-1" for version 1
  50m		50m		1	{deploymentconfig-controller }			Normal		DeploymentScaled	Scaled deployment "ruby-ex-1" from 1 to 0
  5m		5m		1	{deploymentconfig-controller }			Normal		DeploymentCreated	Created new deployment "ruby-ex-2" for version 2
  3m		3m		1	{ruby-ex-2-deploy }				Warning		FailedCreate		Error creating: pods "ruby-ex-2-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.volumes[0]: Invalid value: "gitRepo": gitRepo volumes are not allowed to be used]
  3m		3m		1	{deploymentconfig-controller }			Normal		DeploymentScaled	Scaled deployment "ruby-ex-2" from 1 to 0
```
Fixes #10792 
Fixes #10834