### PR TITLE
bugfix/remove compinit call zsh completions

### DIFF
--- a/contrib/completions/zsh/oadm
+++ b/contrib/completions/zsh/oadm
@@ -135,7 +135,6 @@ __kubectl_quote() {
     fi
 }
 
-autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -135,7 +135,6 @@ __kubectl_quote() {
     fi
 }
 
-autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed

--- a/contrib/completions/zsh/openshift
+++ b/contrib/completions/zsh/openshift
@@ -135,7 +135,6 @@ __kubectl_quote() {
     fi
 }
 
-autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/completion.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/completion.go
@@ -233,7 +233,6 @@ __kubectl_quote() {
     fi
 }
 
-autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 # use word boundary patterns for BSD or GNU sed


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/32142

Fixes: kubernetes/kubernetes#32029
Fixes: kubernetes/kubernetes#27538

The zsh completion output makes a call to "compinit" which causes the
zsh completion system to re-initialize every time `<root_cmd> completion zsh`
is sourced, overwriting any settings already applied to other commands.
This in-turn caused other commands' completions to break (such as git,
gcloud, vim) causing an error "function definition file not found" to
be returned any time a tab-completion was attempted.

This patch removes the call to `compinit` in the zsh completion output,
causing no behavioral changes to the existing `completion` command, but
fixing any issues that were caused after sourcing its output. Additionally,
since the completion system is no longer re-started on every `source`,
completions for different openshift commands can now "stack", meaning
`$ source <(oc completion zsh)` does not reset completions from a previous
sourced output, `$ source <(openshift completion zsh)`.

##### Example of bug
`$ source <(oc completion zsh)`
`$ oc <TAB>`
- *completions work*

`$ git <TAB>`
- *_git:58: _git_commands: function definition file not found*

*bug only present in zsh completion script*

cc @openshift/cli-review 