### PR TITLE
Remove --credentials flags, stop generating router/registry client certs

### DIFF
--- a/docs/man/man1/oadm-ca-create-master-certs.1
+++ b/docs/man/man1/oadm-ca-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/oadm-create-master-certs.1
+++ b/docs/man/man1/oadm-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/oadm-ipfailover.1
+++ b/docs/man/man1/oadm-ipfailover.1
@@ -36,10 +36,6 @@ If an IP failover configuration does not exist with the given name, the \-\-crea
     If true, create the configuration if it does not exist.
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-dry\-run\fP=false
     If true, show the result of the operation without performing it.
 

--- a/docs/man/man1/oadm-registry.1
+++ b/docs/man/man1/oadm-registry.1
@@ -34,10 +34,6 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.
-
-.PP
 \fB\-\-daemonset\fP=false
     If true, use a daemonset instead of a deployment config.
 

--- a/docs/man/man1/oadm-router.1
+++ b/docs/man/man1/oadm-router.1
@@ -28,10 +28,6 @@ If a router does not exist with the given name, this command will create a deplo
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-default\-cert\fP=""
     Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.
 

--- a/docs/man/man1/oc-adm-ca-create-master-certs.1
+++ b/docs/man/man1/oc-adm-ca-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/oc-adm-create-master-certs.1
+++ b/docs/man/man1/oc-adm-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/oc-adm-ipfailover.1
+++ b/docs/man/man1/oc-adm-ipfailover.1
@@ -36,10 +36,6 @@ If an IP failover configuration does not exist with the given name, the \-\-crea
     If true, create the configuration if it does not exist.
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-dry\-run\fP=false
     If true, show the result of the operation without performing it.
 

--- a/docs/man/man1/oc-adm-registry.1
+++ b/docs/man/man1/oc-adm-registry.1
@@ -34,10 +34,6 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.
-
-.PP
 \fB\-\-daemonset\fP=false
     If true, use a daemonset instead of a deployment config.
 

--- a/docs/man/man1/oc-adm-router.1
+++ b/docs/man/man1/oc-adm-router.1
@@ -28,10 +28,6 @@ If a router does not exist with the given name, this command will create a deplo
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-default\-cert\fP=""
     Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.
 

--- a/docs/man/man1/openshift-admin-ca-create-master-certs.1
+++ b/docs/man/man1/openshift-admin-ca-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/openshift-admin-create-master-certs.1
+++ b/docs/man/man1/openshift-admin-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/openshift-admin-ipfailover.1
+++ b/docs/man/man1/openshift-admin-ipfailover.1
@@ -36,10 +36,6 @@ If an IP failover configuration does not exist with the given name, the \-\-crea
     If true, create the configuration if it does not exist.
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-dry\-run\fP=false
     If true, show the result of the operation without performing it.
 

--- a/docs/man/man1/openshift-admin-registry.1
+++ b/docs/man/man1/openshift-admin-registry.1
@@ -34,10 +34,6 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.
-
-.PP
 \fB\-\-daemonset\fP=false
     If true, use a daemonset instead of a deployment config.
 

--- a/docs/man/man1/openshift-admin-router.1
+++ b/docs/man/man1/openshift-admin-router.1
@@ -28,10 +28,6 @@ If a router does not exist with the given name, this command will create a deplo
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-default\-cert\fP=""
     Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.
 

--- a/docs/man/man1/openshift-cli-adm-ca-create-master-certs.1
+++ b/docs/man/man1/openshift-cli-adm-ca-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/openshift-cli-adm-create-master-certs.1
+++ b/docs/man/man1/openshift-cli-adm-create-master-certs.1
@@ -25,7 +25,6 @@ All files are expected or created in standard locations under the cert\-dir.
 openshift.local.config/master/
       ca.{crt,key,serial.txt}
       master.server.{crt,key}
-      openshift\-router.{crt,key,kubeconfig}
       admin.{crt,key,kubeconfig}
       ...
 

--- a/docs/man/man1/openshift-cli-adm-ipfailover.1
+++ b/docs/man/man1/openshift-cli-adm-ipfailover.1
@@ -36,10 +36,6 @@ If an IP failover configuration does not exist with the given name, the \-\-crea
     If true, create the configuration if it does not exist.
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-dry\-run\fP=false
     If true, show the result of the operation without performing it.
 

--- a/docs/man/man1/openshift-cli-adm-registry.1
+++ b/docs/man/man1/openshift-cli-adm-registry.1
@@ -34,10 +34,6 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.
-
-.PP
 \fB\-\-daemonset\fP=false
     If true, use a daemonset instead of a deployment config.
 

--- a/docs/man/man1/openshift-cli-adm-router.1
+++ b/docs/man/man1/openshift-cli-adm-router.1
@@ -28,10 +28,6 @@ If a router does not exist with the given name, this command will create a deplo
     deprecated; this is now the default behavior
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-default\-cert\fP=""
     Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.
 

--- a/docs/man/man1/openshift-ex-ipfailover.1
+++ b/docs/man/man1/openshift-ex-ipfailover.1
@@ -36,10 +36,6 @@ If an IP failover configuration does not exist with the given name, the \-\-crea
     If true, create the configuration if it does not exist.
 
 .PP
-\fB\-\-credentials\fP=""
-    Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.
-
-.PP
 \fB\-\-dry\-run\fP=false
     If true, show the result of the operation without performing it.
 

--- a/docs/proposals/ha-configuration.md
+++ b/docs/proposals/ha-configuration.md
@@ -57,7 +57,6 @@ ability to setup a high availability configuration on a selection of nodes.
             <options> = One or more of:
                 --type=keepalived  #  For now, always keepalived.
                 --create
-                --credentials=<credentials>
                 --no-headers=<headers>
                 -o|--output=<format>
                 --output-version=<version>
@@ -69,9 +68,6 @@ ability to setup a high availability configuration on a selection of nodes.
                 -i|--interface=<interface>
                 -w|--watch-port=<port>
                 -u|--unicast  # optional for now - add support later.
-            <credentials> = <string> - Path to .kubeconfig file containing
-                                       the credentials to use to contact
-                                       the master.
             <headers> = true|false - When using default output, whether or
                                      not to print headers.
             <format> = Output format.
@@ -169,14 +165,12 @@ example shown below.
         $ #  Note: This step can also be performed after starting the
         $ #        target or monitored service (in this example the
         $ #        HAProxy router below).
-        $ openshift admin ha-config --credentials="${KUBECONFIG}"   \
-                                    --virtual-ips=10.1.1.100-104    \
+        $ openshift admin ha-config --virtual-ips=10.1.1.100-104    \
                                     --selector="hac=router-west"    \
                                     --watch-port=80 --create
 
         $ #  Finally, start up the router using the same selector.
-        openshift admin router --credentials="${KUBECONFIG}"        \
-                               --selector="hac=router-west" --create
+        openshift admin router --selector="hac=router-west" --create
 
 
 ## Exclusions

--- a/pkg/bootstrap/docker/openshift/admin.go
+++ b/pkg/bootstrap/docker/openshift/admin.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	kapi "k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -21,6 +20,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/registry"
 	"github.com/openshift/origin/pkg/cmd/admin/router"
 	"github.com/openshift/origin/pkg/cmd/server/admin"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
@@ -151,7 +151,6 @@ func (h *Helper) InstallRouter(kubeClient kclientset.Interface, f *clientcmd.Fac
 		Ports:              "80:80,443:443",
 		Replicas:           1,
 		Labels:             "router=<name>",
-		Credentials:        filepath.Join(masterDir, "admin.kubeconfig"),
 		DefaultCertificate: filepath.Join(masterDir, "router.pem"),
 		StatsPort:          1936,
 		StatsUsername:      "admin",

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -92,7 +92,6 @@ func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out, 
 	cmd.Flags().StringVar(&options.ImageTemplate.Format, "images", options.ImageTemplate.Format, "The image to base this IP failover configurator on - ${component} will be replaced based on --type.")
 	cmd.Flags().BoolVar(&options.ImageTemplate.Latest, "latest-images", options.ImageTemplate.Latest, "If true, attempt to use the latest images instead of the current release")
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter nodes on.")
-	cmd.Flags().StringVar(&options.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.")
 	cmd.Flags().StringVar(&options.ServiceAccount, "service-account", options.ServiceAccount, "Name of the service account to use to run the ipfailover pod.")
 
 	cmd.Flags().BoolVar(&options.Create, "create", options.Create, "If true, create the configuration if it does not exist.")
@@ -107,10 +106,6 @@ func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out, 
 	cmd.Flags().IntVarP(&options.WatchPort, "watch-port", "w", ipfailover.DefaultWatchPort, "Port to monitor or watch for resource availability.")
 	cmd.Flags().IntVar(&options.VRRPIDOffset, "vrrp-id-offset", options.VRRPIDOffset, "Offset to use for setting ids of VRRP instances (default offset is 0). This allows multiple ipfailover instances to run within the same cluster.")
 	cmd.Flags().Int32VarP(&options.Replicas, "replicas", "r", options.Replicas, "The replication factor of this IP failover configuration; commonly 2 when high availability is desired. Please ensure this matches the number of nodes that satisfy the selector (or default selector) specified.")
-
-	// autocompletion hints
-	cmd.MarkFlagFilename("credentials", "kubeconfig")
-	cmd.Flags().MarkDeprecated("credentials", "use --service-account to specify the service account the ipfailover pod will use to make API calls")
 
 	options.Action.BindForOutput(cmd.Flags())
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -37,7 +37,6 @@ var masterCertLong = templates.LongDesc(`
 	    openshift.local.config/master/
 		    ca.{crt,key,serial.txt}
 		    master.server.{crt,key}
-			openshift-router.{crt,key,kubeconfig}
 			admin.{crt,key,kubeconfig}
 			...
 

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -104,32 +104,6 @@ func DefaultAPIClientCerts(certDir string) []ClientCertInfo {
 	return []ClientCertInfo{
 		DefaultOpenshiftLoopbackClientCertInfo(certDir),
 		DefaultClusterAdminClientCertInfo(certDir),
-		DefaultRouterClientCertInfo(certDir),
-		DefaultRegistryClientCertInfo(certDir),
-	}
-}
-
-func DefaultRouterClientCertInfo(certDir string) ClientCertInfo {
-	return ClientCertInfo{
-		CertLocation: configapi.CertInfo{
-			CertFile: DefaultCertFilename(certDir, bootstrappolicy.RouterUnqualifiedUsername),
-			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.RouterUnqualifiedUsername),
-		},
-		UnqualifiedUser: bootstrappolicy.RouterUnqualifiedUsername,
-		User:            bootstrappolicy.RouterUsername,
-		Groups:          sets.NewString(bootstrappolicy.RouterGroup),
-	}
-}
-
-func DefaultRegistryClientCertInfo(certDir string) ClientCertInfo {
-	return ClientCertInfo{
-		CertLocation: configapi.CertInfo{
-			CertFile: DefaultCertFilename(certDir, bootstrappolicy.RegistryUnqualifiedUsername),
-			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.RegistryUnqualifiedUsername),
-		},
-		UnqualifiedUser: bootstrappolicy.RegistryUnqualifiedUsername,
-		User:            bootstrappolicy.RegistryUsername,
-		Groups:          sets.NewString(bootstrappolicy.RegistryGroup),
 	}
 }
 

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -12,13 +12,9 @@ const (
 	BuilderServiceAccountName  = "builder"
 	DeployerServiceAccountName = "deployer"
 
-	MasterUnqualifiedUsername   = "openshift-master"
-	RouterUnqualifiedUsername   = "openshift-router"
-	RegistryUnqualifiedUsername = "openshift-registry"
+	MasterUnqualifiedUsername = "openshift-master"
 
 	MasterUsername      = "system:" + MasterUnqualifiedUsername
-	RouterUsername      = "system:" + RouterUnqualifiedUsername
-	RegistryUsername    = "system:" + RegistryUnqualifiedUsername
 	SystemAdminUsername = "system:admin"
 
 	// Not granted any API permissions, just an identity for a client certificate for the API proxy to use
@@ -45,8 +41,6 @@ const (
 	NodesGroup              = "system:nodes"
 	NodeAdminsGroup         = "system:node-admins"
 	NodeReadersGroup        = "system:node-readers"
-	RouterGroup             = "system:routers"
-	RegistryGroup           = "system:registries"
 )
 
 // Roles

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -1005,24 +1005,6 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: RouterRoleBindingName,
-			},
-			RoleRef: kapi.ObjectReference{
-				Name: RouterRoleName,
-			},
-			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: RouterGroup}},
-		},
-		{
-			ObjectMeta: kapi.ObjectMeta{
-				Name: RegistryRoleBindingName,
-			},
-			RoleRef: kapi.ObjectReference{
-				Name: RegistryRoleName,
-			},
-			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: RegistryGroup}},
-		},
-		{
-			ObjectMeta: kapi.ObjectMeta{
 				Name: NodeRoleBindingName,
 			},
 			RoleRef: kapi.ObjectReference{

--- a/pkg/ipfailover/types.go
+++ b/pkg/ipfailover/types.go
@@ -39,7 +39,6 @@ type IPFailoverConfigCmdOptions struct {
 
 	Type           string
 	ImageTemplate  variable.ImageTemplate
-	Credentials    string
 	ServicePort    int
 	Selector       string
 	Create         bool

--- a/test/cmd/certs.sh
+++ b/test/cmd/certs.sh
@@ -182,7 +182,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"
@@ -205,7 +205,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"
@@ -294,7 +294,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/start-master/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"
@@ -320,7 +320,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/start-master/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"
@@ -347,7 +347,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/start-all/master/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"
@@ -383,7 +383,7 @@ for CERT_FILE in ca.crt ca-bundle.crt service-signer.crt; do
 done
 
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
-for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-{master,registry,router}.crt; do
+for CERT_FILE in admin.crt {master,etcd}.server.crt master.{etcd,kubelet,proxy}-client.crt openshift-master.crt; do
     os::cmd::expect_success_and_text \
         "openssl x509 -in '${CERT_DIR}/start-all/master/${CERT_FILE}' -enddate -noout | awk '{print \$4}'" \
         "${expected_year}"

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -24,7 +24,6 @@ os::cmd::expect_failure_and_text 'oadm router --dry-run --host-network=false -o 
 os::cmd::expect_success_and_not_text 'oadm router --dry-run --host-network=false --host-ports=false -o yaml' 'hostPort: 1936'
 os::cmd::expect_failure_and_text 'oadm router --dry-run --host-network=false --stats-port=1937 -o yaml' 'hostPort: 1937'
 os::cmd::expect_failure_and_text 'oadm router --dry-run --service-account=other -o yaml' 'service account "other" is not allowed to access the host network on nodes'
-os::cmd::expect_failure_and_not_text 'oadm router --dry-run --host-network=false -o yaml --credentials=${KUBECONFIG}' 'ServiceAccount'
 # set ports internally
 os::cmd::expect_failure_and_text 'oadm router --dry-run --host-network=false -o yaml' 'containerPort: 80'
 os::cmd::expect_failure_and_text 'oadm router --dry-run --host-network=false --ports=80:8080 -o yaml' 'port: 8080'
@@ -36,7 +35,6 @@ os::cmd::expect_success_and_not_text "oadm router --dry-run --host-network=false
 # client env vars are optional
 os::cmd::expect_success_and_not_text 'oadm router --dry-run --host-network=false --host-ports=false -o yaml' 'OPENSHIFT_MASTER'
 os::cmd::expect_success_and_not_text 'oadm router --dry-run --host-network=false --host-ports=false --secrets-as-env -o yaml' 'OPENSHIFT_MASTER'
-os::cmd::expect_success_and_text 'oadm router --dry-run --host-network=false --host-ports=false --secrets-as-env --credentials=${KUBECONFIG} -o yaml' 'OPENSHIFT_MASTER'
 # canonical hostname
 os::cmd::expect_success_and_text 'oadm router --dry-run --host-network=false --host-ports=false --router-canonical-hostname=a.b.c.d -o yaml' 'a.b.c.d'
 os::cmd::expect_success_and_text 'oadm router --dry-run --host-network=false --host-ports=false --router-canonical-hostname=1a.b.c.d -o yaml' '1a.b.c.d'
@@ -57,15 +55,14 @@ os::cmd::expect_success_and_text "oadm router --dry-run -o yaml" 'host: localhos
 os::cmd::expect_success_and_text "oadm router --dry-run --host-network=false -o yaml" 'hostPort'
 os::cmd::expect_failure_and_text "oadm router --ports=80,8443:443" 'container port 8443 and host port 443 must be equal'
 
-os::cmd::expect_success_and_text "oadm router -o yaml --credentials=${KUBECONFIG}" 'image:.*-haproxy-router:'
-os::cmd::expect_success "oadm router --credentials=${KUBECONFIG} --images='${USE_IMAGES}'"
+os::cmd::expect_success_and_text "oadm router -o yaml" 'image:.*-haproxy-router:'
+os::cmd::expect_success "oadm router --images='${USE_IMAGES}'"
 os::cmd::expect_success_and_text 'oadm router' 'service exists'
 os::cmd::expect_success_and_text 'oc get dc/router -o yaml' 'readinessProbe'
 
 # only when using hostnetwork should we force the probes to use localhost
-os::cmd::expect_success_and_not_text "oadm router -o yaml --credentials=${KUBECONFIG} --host-network=false" 'host: localhost'
-os::cmd::expect_success "oc delete dc/router"
-os::cmd::expect_success "oc delete service router"
+os::cmd::expect_success_and_not_text "oadm router -o yaml --host-network=false" 'host: localhost'
+os::cmd::expect_success "oadm router -o yaml | oc delete -f -"
 echo "router: ok"
 
 # test ipfailover

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -296,12 +296,13 @@ echo "Log in as 'e2e-user' to see the 'test' project."
 
 # install the router
 echo "[INFO] Installing the router"
-# COMPATIBILITY add --service-account parameter
-openshift admin router --create --credentials="${MASTER_CONFIG_DIR}/openshift-router.kubeconfig" --images="${USE_IMAGES}" --service-account=router
+# COMPATIBILITY remove --credentials parameter
+openshift admin router --create --images="${USE_IMAGES}"
 
 # install the registry. The --mount-host option is provided to reuse local storage.
 echo "[INFO] Installing the registry"
-openshift admin registry --create --credentials="${MASTER_CONFIG_DIR}/openshift-registry.kubeconfig" --images="${USE_IMAGES}"
+# COMPATIBILITY remove --credentials parameter
+openshift admin registry --create --images="${USE_IMAGES}"
 
 echo "[INFO] Pre-pulling and pushing ruby-22-centos7"
 docker pull centos/ruby-22-centos7:latest

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -134,32 +134,6 @@ items:
   userNames: null
 - apiVersion: v1
   groupNames:
-  - system:routers
-  kind: ClusterRoleBinding
-  metadata:
-    creationTimestamp: null
-    name: system:routers
-  roleRef:
-    name: system:router
-  subjects:
-  - kind: SystemGroup
-    name: system:routers
-  userNames: null
-- apiVersion: v1
-  groupNames:
-  - system:registries
-  kind: ClusterRoleBinding
-  metadata:
-    creationTimestamp: null
-    name: system:registrys
-  roleRef:
-    name: system:registry
-  subjects:
-  - kind: SystemGroup
-    name: system:registries
-  userNames: null
-- apiVersion: v1
-  groupNames:
   - system:nodes
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
Fixes #3951

doc in https://github.com/openshift/openshift-docs/pull/3552

ansible hasn't used this since 3.2