### PR TITLE
rectify the t.Fatalf output format in handlers_test.go

### DIFF
--- a/pkg/assets/handlers_test.go
+++ b/pkg/assets/handlers_test.go
@@ -152,7 +152,7 @@ func TestWithGzipRealAndMultipleVaryHeaders(t *testing.T) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if string(body) != raw {
-		t.Fatalf(`did not find expected "%s" but got "%s" instead`, raw, string(body))
+		t.Fatalf("did not find expected '%s' but got '%s' instead", raw, string(body))
 	}
 	vary := resp.Header["Vary"]
 	if !reflect.DeepEqual(vary, []string{"Accept-Encoding", "Foo"}) {


### PR DESCRIPTION
rectify the t.Fatalf output format in handlers_test.go