### PR TITLE
start-build from-webhook: use canonical hostport to compare with config

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -26,6 +26,7 @@ import (
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	"k8s.io/kubernetes/pkg/fields"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/third_party/forked/golang/netutil"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -598,7 +599,7 @@ func (o *StartBuildOptions) RunStartBuildWebHook() error {
 		config, err := o.ClientConfig.ClientConfig()
 		if err == nil {
 			if url, _, err := restclient.DefaultServerURL(config.Host, "", unversioned.GroupVersion{}, true); err == nil {
-				if url.Host == hook.Host && url.Scheme == hook.Scheme {
+				if netutil.CanonicalAddr(url) == netutil.CanonicalAddr(hook) && url.Scheme == hook.Scheme {
 					if rt, err := restclient.TransportFor(config); err == nil {
 						httpClient = &http.Client{Transport: rt}
 					}


### PR DESCRIPTION
When deciding whether to use the transport from the client config, use a canonical host/port string to compare the webhook URL with the config address.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1373788