### PR TITLE
UPSTREAM: 32222: print resource kind prefix on single resource type

### DIFF
--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
+os::test::junit::declare_suite_start "cmd/get"
+os::cmd::expect_success_and_text 'oc create -f examples/storage-examples/local-storage-examples/local-nginx-pod.json' "pod \"local-nginx\" created"
+# mixed resource output should print resource kind
+# prefix even when only one type of resource is present
+os::cmd::expect_success_and_text 'oc get all' "po/local-nginx"
+# specific resources should not have their kind prefixed
+os::cmd::expect_success_and_text 'oc get pod' "local-nginx"
+echo "oc get: ok"
+os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -159,6 +159,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	mapper, typer := f.Object(cmdutil.GetIncludeThirdPartyAPIs(cmd))
 	filterFuncs := f.DefaultResourceFilterFunc()
 	filterOpts := f.DefaultResourceFilterOptions(cmd, allNamespaces)
+	printAll := false
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -172,6 +173,14 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	if len(args) == 0 && len(options.Filenames) == 0 {
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
+	}
+
+	// determine if args contains "all"
+	for _, a := range args {
+		if a == "all" {
+			printAll = true
+			break
+		}
 	}
 
 	// always show resources when getting by name or filename
@@ -398,7 +407,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	w := kubectl.GetNewTabWriter(out)
 	filteredResourceCount := 0
 
-	if cmdutil.MustPrintWithKinds(objs, infos, sorter) {
+	if cmdutil.MustPrintWithKinds(objs, infos, sorter, printAll) {
 		showKind = true
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -642,8 +642,12 @@ func MaybeConvertObject(obj runtime.Object, gv unversioned.GroupVersion, convert
 // with multiple resource kinds, in which case it will
 // return true, indicating resource kind will be
 // included as part of printer output
-func MustPrintWithKinds(objs []runtime.Object, infos []*resource.Info, sorter *kubectl.RuntimeSort) bool {
+func MustPrintWithKinds(objs []runtime.Object, infos []*resource.Info, sorter *kubectl.RuntimeSort, printAll bool) bool {
 	var lastMap *meta.RESTMapping
+
+	if len(infos) == 1 && printAll {
+		return true
+	}
 
 	for ix := range objs {
 		var mapping *meta.RESTMapping


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/32222
Fixes: https://github.com/openshift/origin/issues/10839

This patch forces the HumanReadablePrinter to display resource kind
prefixes when there is only one type of resource to show and a specific
resource type has not been specified as an argument to `oc get`

##### Before
`$ oc get all`
```
NAME         CLUSTER-IP   EXTERNAL-IP   PORT(S)                 AGE
kubernetes   172.30.0.1   <none>        443/TCP,53/UDP,53/TCP   2m
```

##### After
`$ oc get all`
```
NAME         CLUSTER-IP   EXTERNAL-IP   PORT(S)                 AGE
svc/kubernetes   172.30.0.1   <none>        443/TCP,53/UDP,53/TCP   2m
```

@openshift/cli-review @jwforres 