### PR TITLE
Suggest `oc get dc` in output of `oc deploy`

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -156,7 +156,8 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 
 func (o DeployOptions) Validate() error {
 	if len(o.deploymentConfigName) == 0 {
-		return errors.New("a deployment config name is required.")
+		msg := fmt.Sprintf("a deployment config name is required.\nUse \"%s get dc\" for a list of available deployment configs.", o.baseCommandName)
+		return errors.New(msg)
 	}
 	numOptions := 0
 	if o.deployLatest {


### PR DESCRIPTION
This patch suggests `<root_cmd> get dc` as part of the output in `oc
deploy` in order to help a user find a list of available deployment
configs.

`$ oc deploy`
```
error: a deployment config name is required. Use "oc get dc" for a list
of available deployment configs.
See 'oc deploy -h' for help and examples.
```

@openshift/cli-review 