### PR TITLE
suggest exposable resources oc expose

### DIFF
--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -89,7 +89,7 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 		Do()
 	infos, err := r.Infos()
 	if err != nil {
-		return err
+		return kcmdutil.UsageError(cmd, err.Error())
 	}
 	if len(infos) > 1 {
 		return fmt.Errorf("multiple resources provided: %v", args)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
@@ -147,7 +147,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		Do()
 	err = r.Err()
 	if err != nil {
-		return err
+		return cmdutil.UsageError(cmd, err.Error())
 	}
 
 	// Get the generator, setup and validate all required parameters


### PR DESCRIPTION
Related Trello Card:
https://trello.com/c/04lpfTQR/451-8-cli-improved-flows-and-ux-in-the-cli-evg-ux-p3

This patch updates `oc expose` output (with no resources provided)
to a `kcmdutil.UsageError` so that a suggestion to use `oc  expose -h`
is displayed.

##### Before
`$ oc expose`
```
error: you must provide one or more resources by argument or filename (.json|.yaml|.yml|stdin)
```

##### After
```
error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   'pods my-pod'
   'services'
See 'oc expose -h' for help and examples.
```

cc @openshift/cli-review 