### PR TITLE
Make OAuth provider discoverable from within a Pod

### DIFF
--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -10,6 +10,23 @@
    "version": "latest"
   },
   "paths": {
+   "/.well-known/oauth-authorization-server/": {
+    "get": {
+     "description": "get the server's OAuth 2.0 Authorization Server Metadata",
+     "produces": [
+      "application/json"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "operationId": "getOAuthAuthorizationServerMetadata",
+     "responses": {
+      "default": {
+       "description": "Default Response."
+      }
+     }
+    }
+   },
    "/api/": {
     "get": {
      "description": "get available API versions",
@@ -44079,9 +44096,6 @@
    "/version/openshift/": {
     "get": {
      "description": "get the code version",
-     "consumes": [
-      "application/json"
-     ],
      "produces": [
       "application/json"
      ],

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -50,6 +50,7 @@ var DiscoveryRule = PolicyRule{
 		"/apis", "/apis/*",
 		"/oapi", "/oapi/*",
 		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
+		"/.well-known", "/.well-known/*",
 	),
 }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -635,7 +635,7 @@ type OAuthConfig struct {
 	// MasterURL is used for making server-to-server calls to exchange authorization codes for access tokens
 	MasterURL string
 
-	// MasterPublicURL is used for building valid client redirect URLs for external access
+	// MasterPublicURL is used for building valid client redirect URLs for internal and external access
 	MasterPublicURL string
 
 	// AssetPublicURL is used for building valid client redirect URLs for external access

--- a/pkg/oauth/api/validation/validation.go
+++ b/pkg/oauth/api/validation/validation.go
@@ -18,6 +18,15 @@ import (
 
 const MinTokenLength = 32
 
+// PKCE [RFC7636] code challenge methods supported
+// https://tools.ietf.org/html/rfc7636#section-4.3
+const (
+	codeChallengeMethodPlain  = "plain"
+	codeChallengeMethodSHA256 = "S256"
+)
+
+var CodeChallengeMethodsSupported = []string{codeChallengeMethodPlain, codeChallengeMethodSHA256}
+
 func ValidateTokenName(name string, prefix bool) []string {
 	if reasons := oapi.MinimalNameRequirements(name, prefix); len(reasons) != 0 {
 		return reasons
@@ -101,10 +110,10 @@ func ValidateAuthorizeToken(authorizeToken *api.OAuthAuthorizeToken) field.Error
 		switch authorizeToken.CodeChallengeMethod {
 		case "":
 			allErrs = append(allErrs, field.Required(field.NewPath("codeChallengeMethod"), "required if codeChallenge is specified"))
-		case "plain", "S256":
+		case codeChallengeMethodPlain, codeChallengeMethodSHA256:
 			// no-op, good
 		default:
-			allErrs = append(allErrs, field.NotSupported(field.NewPath("codeChallengeMethod"), authorizeToken.CodeChallengeMethod, []string{"plain", "S256"}))
+			allErrs = append(allErrs, field.NotSupported(field.NewPath("codeChallengeMethod"), authorizeToken.CodeChallengeMethod, CodeChallengeMethodsSupported))
 		}
 	}
 

--- a/pkg/oauth/discovery/discovery.go
+++ b/pkg/oauth/discovery/discovery.go
@@ -1,0 +1,58 @@
+package discovery
+
+import (
+	"github.com/RangelReale/osin"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/oauth/api/validation"
+	"github.com/openshift/origin/pkg/oauth/server/osinserver"
+)
+
+// OauthAuthorizationServerMetadata holds OAuth 2.0 Authorization Server Metadata used for discovery
+// https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+type OauthAuthorizationServerMetadata struct {
+	// The authorization server's issuer identifier, which is a URL that uses the https scheme and has no query or fragment components.
+	// This is the location where .well-known RFC 5785 [RFC5785] resources containing information about the authorization server are published.
+	Issuer string `json:"issuer"`
+
+	// URL of the authorization server's authorization endpoint [RFC6749].
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+
+	// URL of the authorization server's token endpoint [RFC6749].
+	TokenEndpoint string `json:"token_endpoint"`
+
+	// JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this authorization server supports.
+	// Servers MAY choose not to advertise some supported scope values even when this parameter is used.
+	ScopesSupported []string `json:"scopes_supported"`
+
+	// JSON array containing a list of the OAuth 2.0 response_type values that this authorization server supports.
+	// The array values used are the same as those used with the response_types parameter defined by "OAuth 2.0 Dynamic Client Registration Protocol" [RFC7591].
+	ResponseTypesSupported osin.AllowedAuthorizeType `json:"response_types_supported"`
+
+	// JSON array containing a list of the OAuth 2.0 grant type values that this authorization server supports.
+	// The array values used are the same as those used with the grant_types parameter defined by "OAuth 2.0 Dynamic Client Registration Protocol" [RFC7591].
+	GrantTypesSupported osin.AllowedAccessType `json:"grant_types_supported"`
+
+	// JSON array containing a list of PKCE [RFC7636] code challenge methods supported by this authorization server.
+	// Code challenge method values are used in the "code_challenge_method" parameter defined in Section 4.3 of [RFC7636].
+	// The valid code challenge method values are those registered in the IANA "PKCE Code Challenge Methods" registry [IANA.OAuth.Parameters].
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+}
+
+func Get(masterPublicURL, authorizeURL, tokenURL string) OauthAuthorizationServerMetadata {
+	config := osinserver.NewDefaultServerConfig()
+	return OauthAuthorizationServerMetadata{
+		Issuer:                masterPublicURL,
+		AuthorizationEndpoint: authorizeURL,
+		TokenEndpoint:         tokenURL,
+		ScopesSupported: []string{ // Note: this list is incomplete, which is allowed per the draft spec
+			scope.UserFull,
+			scope.UserInfo,
+			scope.UserAccessCheck,
+			scope.UserListScopedProjects,
+			scope.UserListAllProjects,
+		},
+		ResponseTypesSupported:        config.AllowedAuthorizeTypes,
+		GrantTypesSupported:           osin.AllowedAccessType{osin.AUTHORIZATION_CODE, osin.AccessRequestType("implicit")}, // TODO use config.AllowedAccessTypes once our implementation handles other grant types
+		CodeChallengeMethodsSupported: validation.CodeChallengeMethodsSupported,
+	}
+}

--- a/pkg/oauth/discovery/discovery_test.go
+++ b/pkg/oauth/discovery/discovery_test.go
@@ -1,0 +1,40 @@
+package discovery
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/RangelReale/osin"
+)
+
+func TestGet(t *testing.T) {
+	actual := Get("https://localhost:8443", "https://localhost:8443/oauth/authorize", "https://localhost:8443/oauth/token")
+	expected := OauthAuthorizationServerMetadata{
+		Issuer:                "https://localhost:8443",
+		AuthorizationEndpoint: "https://localhost:8443/oauth/authorize",
+		TokenEndpoint:         "https://localhost:8443/oauth/token",
+		ScopesSupported: []string{
+			"user:full",
+			"user:info",
+			"user:check-access",
+			"user:list-scoped-projects",
+			"user:list-projects",
+		},
+		ResponseTypesSupported: osin.AllowedAuthorizeType{
+			"code",
+			"token",
+		},
+		GrantTypesSupported: osin.AllowedAccessType{
+			"authorization_code",
+			"implicit",
+		},
+		CodeChallengeMethodsSupported: []string{
+			"plain",
+			"S256",
+		},
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1497,6 +1497,8 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     nonResourceURLs:
+    - /.well-known
+    - /.well-known/*
     - /api
     - /api/*
     - /apis
@@ -2114,6 +2116,8 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     nonResourceURLs:
+    - /.well-known
+    - /.well-known/*
     - /api
     - /api/*
     - /apis


### PR DESCRIPTION
Implementation of https://tools.ietf.org/html/draft-ietf-oauth-discovery-04

From within a pod:

```
root@test:/# curl -k https://openshift.default.svc/.well-known/oauth-authorization-server
{
  "issuer": "https://10.13.129.56:8443",
  "authorization_endpoint": "https://10.13.129.56:8443/oauth/authorize",
  "token_endpoint": "https://10.13.129.56:8443/oauth/token",
  "scopes_supported": [
    "user:full",
    "user:info",
    "user:check-access",
    "user:list-scoped-projects",
    "user:list-projects"
  ],
  "response_types_supported": [
    "code",
    "token"
  ],
  "grant_types_supported": [
    "authorization_code",
    "implicit"
  ],
  "code_challenge_methods_supported": [
    "plain",
    "S256"
  ]
}
```

cc @gabemontero @bparees 

Trello ref:
https://trello.com/c/7uYQSTdR