### PR TITLE
Bug 1312230 - fix image import command to reflect the actual status

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -116,7 +116,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdNewBuild(fullName, f, in, out),
 				cmd.NewCmdStartBuild(fullName, f, in, out),
 				cmd.NewCmdCancelBuild(cmd.CancelBuildRecommendedCommandName, fullName, f, in, out),
-				cmd.NewCmdImportImage(fullName, f, out),
+				cmd.NewCmdImportImage(fullName, f, out, errout),
 				cmd.NewCmdTag(fullName, f, out),
 			},
 		},


### PR DESCRIPTION
Currently we *always* return `The import completed successfully` no matter what actually happened. This PR small check to modify slightly this information to better reflect the actual status.

Fixes [bug 1312230](https://bugzilla.redhat.com/show_bug.cgi?id=1312230).

@openshift/cli-review ptal