### PR TITLE
Ensure system:master has full permissions on non-resource-urls

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -502,6 +502,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				authorizationapi.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
+				{
+					Verbs:           sets.NewString(authorizationapi.VerbAll),
+					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
+				},
 			},
 		},
 		{

--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -103,6 +103,9 @@ func TestCovers(t *testing.T) {
 	var registryAdmin *authorizationapi.ClusterRole
 	var registryEditor *authorizationapi.ClusterRole
 	var registryViewer *authorizationapi.ClusterRole
+	var systemMaster *authorizationapi.ClusterRole
+	var systemDiscovery *authorizationapi.ClusterRole
+	var clusterAdmin *authorizationapi.ClusterRole
 
 	for i := range allRoles {
 		role := allRoles[i]
@@ -119,6 +122,12 @@ func TestCovers(t *testing.T) {
 			registryEditor = &role
 		case bootstrappolicy.RegistryViewerRoleName:
 			registryViewer = &role
+		case bootstrappolicy.MasterRoleName:
+			systemMaster = &role
+		case bootstrappolicy.DiscoveryRoleName:
+			systemDiscovery = &role
+		case bootstrappolicy.ClusterAdminRoleName:
+			clusterAdmin = &role
 		}
 	}
 
@@ -138,6 +147,15 @@ func TestCovers(t *testing.T) {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(registryAdmin.Rules, registryViewer.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+
+	// Make sure we can auto-reconcile discovery
+	if covers, miss := rulevalidation.Covers(systemMaster.Rules, systemDiscovery.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+	// Make sure the master has full permissions
+	if covers, miss := rulevalidation.Covers(systemMaster.Rules, clusterAdmin.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1691,6 +1691,13 @@ items:
     - '*'
     verbs:
     - '*'
+  - apiGroups: null
+    attributeRestrictions: null
+    nonResourceURLs:
+    - '*'
+    resources: []
+    verbs:
+    - '*'
 - apiVersion: v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
Related to https://github.com/openshift/origin/pull/10785 and https://bugzilla.redhat.com/show_bug.cgi?id=1372579

Note that a role reconcile as a cluster-admin is needed when upgrading from before 1.3/3.3