### PR TITLE
BuildConfig: emit event on missing ImageStream

### DIFF
--- a/pkg/build/controller/config_controller.go
+++ b/pkg/build/controller/config_controller.go
@@ -83,6 +83,7 @@ func (c *BuildConfigController) HandleBuildConfig(bc *buildapi.BuildConfig) erro
 			return &ConfigControllerFatalError{err.Error()}
 		} else {
 			instantiateErr = fmt.Errorf("error instantiating Build from BuildConfig %s/%s: %v", bc.Namespace, bc.Name, err)
+			c.Recorder.Event(bc, kapi.EventTypeWarning, "BuildConfigInstantiateFailed", instantiateErr.Error())
 			utilruntime.HandleError(instantiateErr)
 		}
 		return instantiateErr

--- a/pkg/build/controller/config_controller_test.go
+++ b/pkg/build/controller/config_controller_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/client/record"
+
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -44,6 +46,7 @@ func TestHandleBuildConfig(t *testing.T) {
 		}
 		controller := &BuildConfigController{
 			BuildConfigInstantiator: instantiator,
+			Recorder:                &record.FakeRecorder{},
 		}
 		err := controller.HandleBuildConfig(tc.bc)
 		if err != nil {

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -227,6 +227,9 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 	}
 
 	if err := g.updateImageTriggers(ctx, bc, request.From, request.TriggeredByImage); err != nil {
+		if _, ok := err.(errors.APIStatus); ok {
+			return nil, err
+		}
 		return nil, errors.NewInternalError(err)
 	}
 
@@ -573,10 +576,8 @@ func (g *BuildGenerator) resolveImageStreamReference(ctx kapi.Context, from kapi
 	case "ImageStreamImage":
 		imageStreamImage, err := g.Client.GetImageStreamImage(kapi.WithNamespace(ctx, namespace), from.Name)
 		if err != nil {
-			glog.V(2).Infof("Error ImageStreamReference %s in namespace %s: %v", from.Name, namespace, err)
-			if errors.IsNotFound(err) {
-				return "", err
-			}
+			err = resolveError(from.Kind, namespace, from.Name, err)
+			glog.V(2).Info(err)
 			return "", err
 		}
 		image := imageStreamImage.Image
@@ -585,10 +586,8 @@ func (g *BuildGenerator) resolveImageStreamReference(ctx kapi.Context, from kapi
 	case "ImageStreamTag":
 		imageStreamTag, err := g.Client.GetImageStreamTag(kapi.WithNamespace(ctx, namespace), from.Name)
 		if err != nil {
-			glog.V(2).Infof("Error resolving ImageStreamTag reference %s in namespace %s: %v", from.Name, namespace, err)
-			if errors.IsNotFound(err) {
-				return "", err
-			}
+			err = resolveError(from.Kind, namespace, from.Name, err)
+			glog.V(2).Info(err)
 			return "", err
 		}
 		image := imageStreamTag.Image
@@ -614,10 +613,8 @@ func (g *BuildGenerator) resolveImageStreamDockerRepository(ctx kapi.Context, fr
 	case "ImageStreamImage":
 		imageStreamImage, err := g.Client.GetImageStreamImage(kapi.WithNamespace(ctx, namespace), from.Name)
 		if err != nil {
-			glog.V(2).Infof("Error ImageStreamReference %s in namespace %s: %v", from.Name, namespace, err)
-			if errors.IsNotFound(err) {
-				return "", err
-			}
+			err = resolveError(from.Kind, namespace, from.Name, err)
+			glog.V(2).Info(err)
 			return "", err
 		}
 		image := imageStreamImage.Image
@@ -627,10 +624,8 @@ func (g *BuildGenerator) resolveImageStreamDockerRepository(ctx kapi.Context, fr
 		name := strings.Split(from.Name, ":")[0]
 		is, err := g.Client.GetImageStream(kapi.WithNamespace(ctx, namespace), name)
 		if err != nil {
-			glog.V(2).Infof("Error getting ImageStream %s/%s: %v", namespace, name, err)
-			if errors.IsNotFound(err) {
-				return "", err
-			}
+			err = resolveError("ImageStream", namespace, from.Name, err)
+			glog.V(2).Info(err)
 			return "", err
 		}
 		image, err := imageapi.DockerImageReferenceForStream(is)
@@ -672,6 +667,24 @@ func (g *BuildGenerator) resolveImageSecret(ctx kapi.Context, secrets []kapi.Sec
 	}
 	glog.V(4).Infof("No secrets found for pushing or pulling the %s  %s/%s", imageRef.Kind, buildNamespace, imageRef.Name)
 	return nil
+}
+
+func resolveError(kind string, namespace string, name string, err error) error {
+	msg := fmt.Sprintf("Error resolving %s %s in namespace %s: %v", kind, name, namespace, err)
+	return &errors.StatusError{unversioned.Status{
+		Status:  unversioned.StatusFailure,
+		Code:    errors.StatusUnprocessableEntity,
+		Reason:  unversioned.StatusReasonInvalid,
+		Message: msg,
+		Details: &unversioned.StatusDetails{
+			Kind: kind,
+			Name: name,
+			Causes: []unversioned.StatusCause{{
+				Field:   "from",
+				Message: msg,
+			}},
+		},
+	}}
 }
 
 // getNextBuildName returns name of the next build and increments BuildConfig's LastVersion.

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
@@ -440,6 +441,30 @@ func TestInstantiateWithLastVersion(t *testing.T) {
 	_, err = g.Instantiate(kapi.NewDefaultContext(), &buildapi.BuildRequest{LastVersion: &lastVersion})
 	if err == nil {
 		t.Errorf("Expected an error and did not get one")
+	}
+}
+
+func TestInstantiateWithMissingImageStream(t *testing.T) {
+	g := mockBuildGenerator()
+	c := g.Client.(Client)
+	c.GetImageStreamTagFunc = func(ctx kapi.Context, name string) (*imageapi.ImageStreamTag, error) {
+		return nil, errors.NewNotFound(imageapi.Resource("imagestreamtags"), "testRepo")
+	}
+	g.Client = c
+
+	_, err := g.Instantiate(kapi.NewDefaultContext(), &buildapi.BuildRequest{})
+	se, ok := err.(*errors.StatusError)
+
+	if !ok {
+		t.Errorf("Expected errors.StatusError, got %T", err)
+	}
+
+	if se.ErrStatus.Code != errors.StatusUnprocessableEntity {
+		t.Errorf("Expected status 422, got %d", se.ErrStatus.Code)
+	}
+
+	if !strings.Contains(se.ErrStatus.Message, "testns") {
+		t.Errorf("Error message does not contain namespace: %q", se.ErrStatus.Message)
 	}
 }
 

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -124,7 +124,7 @@ func TestDescribers(t *testing.T) {
 		name string
 	}{
 		{&BuildDescriber{c, fakeKube}, "bar"},
-		{&BuildConfigDescriber{c, ""}, "bar"},
+		{&BuildConfigDescriber{c, fakeKube, ""}, "bar"},
 		{&ImageDescriber{c}, "bar"},
 		{&ImageStreamDescriber{c}, "bar"},
 		{&ImageStreamTagDescriber{c}, "bar:latest"},


### PR DESCRIPTION
Fixes #8523.

This is probably not the right fix but I'd like to open a PR to ask some questions:

* Where in the chain of `if err != nil ... return err` should the event be created? It probably makes sense to do it right after `resolveImageStream` returns error in `pkg/build/generator/generator.go:generateBuildFromConfig` however I'm not really sure how to get hold of `EventRecorder` or how to initialize it if it should be a new member of `BuildGenerator` struct.
* Because BuildConfigs haven't generated events before they are not displayed in `oc describe bc foo`, should I extend `oc` to do this?
* I noticed some harmless bugs, like [this redundant if](https://github.com/openshift/origin/blob/v1.3.0-rc1/pkg/build/generator/generator.go#L577), should I include it in this commit, open separate PR or just ignore it?