### PR TITLE
new-app: warn when source credentials are needed

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -118,6 +118,8 @@ type SourceRef struct {
 	DockerfileContents string
 
 	Binary bool
+
+	RequiresAuth bool
 }
 
 func urlWithoutRef(url url.URL) string {

--- a/pkg/generate/app/cmd/describe.go
+++ b/pkg/generate/app/cmd/describe.go
@@ -199,6 +199,11 @@ func describeBuildPipelineWithImage(out io.Writer, ref app.ComponentReference, p
 				fmt.Fprintf(out, "      * Use 'start-build' to trigger a new build\n")
 			}
 		}
+
+		if pipeline.Build.Source.RequiresAuth {
+			fmt.Fprintf(out, "      * WARNING: this source repository may require credentials.\n"+
+				"                 Create a secret with your git credentials and use 'set build-secret' to assign it to the build config.\n")
+		}
 	}
 	if pipeline.Deployment != nil {
 		if pipeline.Deployment.AsTest {

--- a/pkg/generate/app/test/fakegit.go
+++ b/pkg/generate/app/test/fakegit.go
@@ -92,3 +92,11 @@ func (f *FakeGit) TimedListRemote(timeout time.Duration, url string, args ...str
 func (f *FakeGit) GetInfo(location string) (*git.SourceInfo, []error) {
 	return nil, nil
 }
+
+func (f *FakeGit) Add(location string, spec string) error {
+	return nil
+}
+
+func (f *FakeGit) Commit(location string, message string) error {
+	return nil
+}

--- a/pkg/generate/git/repository.go
+++ b/pkg/generate/git/repository.go
@@ -34,6 +34,8 @@ type Repository interface {
 	SubmoduleUpdate(dir string, init, recursive bool) error
 	Archive(dir, ref, format string, w io.Writer) error
 	Init(dir string, bare bool) error
+	Add(dir string, spec string) error
+	Commit(dir string, message string) error
 	AddRemote(dir string, name, url string) error
 	AddLocalConfig(dir, name, value string) error
 	ShowFormat(dir, commit, format string) (string, error)
@@ -299,7 +301,22 @@ func (r *repository) ShowFormat(location, ref, format string) (string, error) {
 
 // Init initializes a new git repository in the provided location
 func (r *repository) Init(location string, bare bool) error {
-	_, _, err := r.git("", "init", "--bare", location)
+	args := []string{"init"}
+	if bare {
+		args = append(args, "--bare")
+	}
+	args = append(args, location)
+	_, _, err := r.git("", args...)
+	return err
+}
+
+func (r *repository) Add(location, spec string) error {
+	_, _, err := r.git(location, "add", spec)
+	return err
+}
+
+func (r *repository) Commit(location, message string) error {
+	_, _, err := r.git(location, "commit", "-m", message)
 	return err
 }
 


### PR DESCRIPTION
When showing new-app results, displays a warning if a secret may be needed to access a git repository.