### PR TITLE
Explicit pull the docker base image for docker build

### DIFF
--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -48,6 +48,26 @@ type DockerClient interface {
 	TagImage(name string, opts docker.TagImageOptions) error
 }
 
+func pullImage(client DockerClient, name string, authConfig docker.AuthConfiguration) error {
+	logProgress := func(s string) {
+		glog.V(0).Infof("%s", s)
+	}
+	opts := docker.PullImageOptions{
+		Repository:    name,
+		OutputStream:  imageprogress.NewPullWriter(logProgress),
+		RawJSONStream: true,
+	}
+	if glog.Is(5) {
+		opts.OutputStream = os.Stderr
+		opts.RawJSONStream = false
+	}
+	err := client.PullImage(opts, authConfig)
+	if err == nil {
+		return nil
+	}
+	return err
+}
+
 // pushImage pushes a docker image to the registry specified in its tag.
 // The method will retry to push the image when following scenarios occur:
 // - Docker registry is down temporarily or permanently


### PR DESCRIPTION
To address this [trello card](https://trello.com/c/Pzhdtv0I/1025-explicit-pull-of-base-image-for-docker-builds), and this is the build log now:

```
[root@ip-172-18-15-120 docker-builder]# oc start-build ruby-hello-world
build "ruby-hello-world-7" started
[root@ip-172-18-15-120 docker-builder]# oc logs -f build/ruby-hello-world-7
Cloning "https://github.com/openshift/ruby-hello-world" ...
	Commit:	e79d8870be808a7abb4ab304e94c8bee69d909c6 (Merge pull request #53 from danmcp/master)
	Author:	Ben Parees <bparees@users.noreply.github.com>
	Date:	Tue Apr 5 10:06:50 2016 -0400
Pulling image registry.access.redhat.com/rhscl/ruby-22-rhel7@sha256:733b79c6addd6b25dc0c2527196a4d921ca255961eae294be62806a0d2c94202 ...
Pulled 0/3 layers, 2% complete
Pulled 1/3 layers, 41% complete
Pulled 2/3 layers, 95% complete
Pulled 3/3 layers, 100% complete
Extracting
Step 1 : FROM registry.access.redhat.com/rhscl/ruby-22-rhel7@sha256:733b79c6addd6b25dc0c2527196a4d921ca255961eae294be62806a0d2c94202
 ---> c5b8ac088a6c
Step 2 : USER default
 ---> Running in b5cf641a162c
 ---> 48e5fa8b42a1
Removing intermediate container b5cf641a162c
```