### PR TITLE
tolerate multiple =s in a parameter value

### DIFF
--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -302,16 +302,17 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 func injectUserVars(values []string, t *templateapi.Template) []error {
 	var errors []error
 	for _, keypair := range values {
-		p := strings.Split(keypair, "=")
+		p := strings.SplitN(keypair, "=", 2)
 		if len(p) != 2 {
 			errors = append(errors, fmt.Errorf("invalid parameter assignment in %q: %q\n", t.Name, keypair))
-		}
-		if v := template.GetParameterByName(t, p[0]); v != nil {
-			v.Value = p[1]
-			v.Generate = ""
-			template.AddParameter(t, *v)
 		} else {
-			errors = append(errors, fmt.Errorf("unknown parameter name %q\n", p[0]))
+			if v := template.GetParameterByName(t, p[0]); v != nil {
+				v.Value = p[1]
+				v.Generate = ""
+				template.AddParameter(t, *v)
+			} else {
+				errors = append(errors, fmt.Errorf("unknown parameter name %q\n", p[0]))
+			}
 		}
 	}
 	return errors

--- a/test/cmd/process.sh
+++ b/test/cmd/process.sh
@@ -42,14 +42,16 @@ os::cmd::expect_failure_and_text "oc process -f '${OS_ROOT}/test/testdata/basic-
 
 # not providing required parameter should fail
 os::cmd::expect_failure_and_text "oc process -f '${required_params}'" 'parameter required_param is required and must be specified'
-# not providiing an optional param is OK
+# not providing an optional param is OK
 os::cmd::expect_success "oc process -f '${required_params}' --value=required_param=someval | oc create -f -"
+# parameters with multiple equal signs are OK
+os::cmd::expect_success "oc process -f '${required_params}' required_param=someval=moreval | oc create -f -"
 # we should have overwritten the template param
 os::cmd::expect_success_and_text 'oc get user someval -o jsonpath={.Name}' 'someval'
 # providing a value not in the template should fail
 os::cmd::expect_failure_and_text "oc process -f '${required_params}' --value=required_param=someval --value=other_param=otherval" 'unknown parameter name "other_param"'
 # failure on values fails the entire call
-os::cmd::expect_failure_and_text "oc process -f '${required_params}' --value=required_param=someval --value=optional_param=some=series=of=values=" 'invalid parameter assignment in'
+os::cmd::expect_failure_and_text "oc process -f '${required_params}' --value=required_param=someval --value=optional_param" 'invalid parameter assignment in'
 # failure on labels fails the entire call
 os::cmd::expect_failure_and_text "oc process -f '${required_params}' --value=required_param=someval --labels======" 'error parsing labels'
 


### PR DESCRIPTION
@stevekuznetsov @smarterclayton this was introduced in https://github.com/openshift/origin/commit/6eaf7a2690b72c352b417c62209911e462b96b9c (thanks @fabianofranz for digging it up).

it seems like a fairly bad regression (https://bugzilla.redhat.com/show_bug.cgi?id=1375275)

so if we're still doing merges to 3.3, i'd say this is a candidate.
