### PR TITLE
The main purpose of validateClusterNetwork is not validate

### DIFF
--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -32,7 +32,7 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 	}
 
 	// Validate command-line/config parameters
-	ni, err := validateClusterNetwork(networkConfig.ClusterNetworkCIDR, networkConfig.HostSubnetLength, networkConfig.ServiceNetworkCIDR, networkConfig.NetworkPluginName)
+	ni, err := getNetworkInfo(networkConfig.ClusterNetworkCIDR, networkConfig.HostSubnetLength, networkConfig.ServiceNetworkCIDR, networkConfig.NetworkPluginName)
 	if err != nil {
 		return err
 	}

--- a/pkg/sdn/plugin/registry.go
+++ b/pkg/sdn/plugin/registry.go
@@ -158,7 +158,7 @@ func (registry *Registry) CreateClusterNetwork(ni *NetworkInfo) error {
 	return nil
 }
 
-func validateClusterNetwork(network string, hostSubnetLength uint32, serviceNetwork string, pluginName string) (*NetworkInfo, error) {
+func getNetworkInfo(network string, hostSubnetLength uint32, serviceNetwork string, pluginName string) (*NetworkInfo, error) {
 	_, cn, err := net.ParseCIDR(network)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse ClusterNetwork CIDR %s: %v", network, err)
@@ -192,7 +192,7 @@ func (registry *Registry) GetNetworkInfo() (*NetworkInfo, error) {
 		return nil, err
 	}
 
-	registry.NetworkInfo, err = validateClusterNetwork(cn.Network, cn.HostSubnetLength, cn.ServiceNetwork, cn.PluginName)
+	registry.NetworkInfo, err = getNetworkInfo(cn.Network, cn.HostSubnetLength, cn.ServiceNetwork, cn.PluginName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The main purpose of function` validateClusterNetwork` is constructing `NeworkInfo`, not validate the field of clusternetwork. If we use `validateClusterNetwork`, it should only return a error info just like in function `ValidateClusterNetwork`(/sdn/api/validation/validation.go) did. Rename the function with `getNetworkInfo` may be better.