### PR TITLE
Made hello-openshift read the message from an environment variable

### DIFF
--- a/examples/hello-openshift/README.md
+++ b/examples/hello-openshift/README.md
@@ -11,6 +11,12 @@ This example will serve an HTTP response of "Hello OpenShift!".
     $ curl 10.1.0.2:8080
      Hello OpenShift!
 
+The response message can be set by using the RESPONSE environment variable:
+    $ oc set env pod/hello-openshift RESPONSE="Hello World!"
+
+    $ curl 10.1.0.2:8080
+     Hello World!
+
 To test from external network, you need to create router. Please refer to [Running the router](https://github.com/openshift/origin/blob/master/docs/routing.md)
 
 If you need to rebuild the image:

--- a/examples/hello-openshift/hello_openshift.go
+++ b/examples/hello-openshift/hello_openshift.go
@@ -7,7 +7,12 @@ import (
 )
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "Hello OpenShift!")
+	response := os.Getenv("RESPONSE")
+	if len(response) == 0 {
+		response = "Hello OpenShift!"
+	}
+
+	fmt.Fprintln(w, response)
 	fmt.Println("Servicing request.")
 }
 


### PR DESCRIPTION
This is a minor enhancement to the hello-openshift image to optionally
read the response string from the RESPONSE environment variable.