### PR TITLE
add localhost:9000 as a redirect URL

### DIFF
--- a/pkg/client/oauthclient.go
+++ b/pkg/client/oauthclient.go
@@ -17,6 +17,7 @@ type OAuthClientInterface interface {
 	Get(name string) (*oauthapi.OAuthClient, error)
 	Delete(name string) error
 	Watch(opts kapi.ListOptions) (watch.Interface, error)
+	Update(client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error)
 }
 
 type oauthClients struct {
@@ -54,4 +55,10 @@ func (c *oauthClients) Delete(name string) (err error) {
 
 func (c *oauthClients) Watch(opts kapi.ListOptions) (watch.Interface, error) {
 	return c.r.Get().Prefix("watch").Resource("oAuthClients").VersionedParams(&opts, kapi.ParameterCodec).Watch()
+}
+
+func (c *oauthClients) Update(client *oauthapi.OAuthClient) (result *oauthapi.OAuthClient, err error) {
+	result = &oauthapi.OAuthClient{}
+	err = c.r.Put().Resource("oAuthClients").Name(client.Name).Body(client).Do().Into(result)
+	return
 }

--- a/pkg/client/testclient/fake_oauthclient.go
+++ b/pkg/client/testclient/fake_oauthclient.go
@@ -47,3 +47,12 @@ func (c *FakeOAuthClient) Delete(name string) error {
 func (c *FakeOAuthClient) Watch(opts kapi.ListOptions) (watch.Interface, error) {
 	return c.Fake.InvokesWatch(ktestclient.NewRootWatchAction("oauthclients", opts))
 }
+
+func (c *FakeOAuthClient) Update(client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootUpdateAction("oauthclients", client), &oauthapi.OAuthClient{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*oauthapi.OAuthClient), err
+}


### PR DESCRIPTION
Depends on: https://github.com/openshift/origin/pull/10819
Fixes: https://github.com/openshift/origin/issues/10885

This patch adds `https://localhost:9000` as a default redirect URI to
the webconsole oauthclient. This is done as a new `oc cluster up`
startup task.

```
$ oc cluster up

...
-- Finding server IP ...
   Using <IP> as the server IP
-- Starting OpenShift container ...
   Creating initial OpenShift configuration
   Starting OpenShift using container 'origin'
   Waiting for API server to start listening
   OpenShift server started
-- Adding default OAuthClient redirect URIs ... OK
-- Installing registry ... OK
-- Installing router ... OK
-- Importing image streams ... OK
-- Importing templates ... OK
-- Login to server ... OK
-- Creating initial project "myproject" ... OK
...
```

```
$ oc login -u system:admin
$ oc get oauthclients

NAME                              WWW-CHALLENGE   REDIRECT URIS
openshift-web-console             FALSE           https://localhost:9000
```

cc @fabianofranz @jwforres @csrwng 