### PR TITLE
Add logging to assist in determining openid claims

### DIFF
--- a/pkg/auth/oauth/external/openid/openid.go
+++ b/pkg/auth/oauth/external/openid/openid.go
@@ -193,9 +193,11 @@ func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentit
 		}
 	}
 
+	glog.V(5).Infof("openid claims: %#v", claims)
+
 	id, _ := getClaimValue(claims, p.IDClaims)
 	if id == "" {
-		return nil, false, fmt.Errorf("Could not retrieve id claim for %#v", p.IDClaims)
+		return nil, false, fmt.Errorf("Could not retrieve id claim for %#v from %#v", p.IDClaims, claims)
 	}
 	identity := authapi.NewDefaultUserIdentityInfo(p.providerName, id)
 


### PR DESCRIPTION
OpenID providers don't always document their returned claims well. This would allow increasing debug levels to determine what claims are being returned