### PR TITLE
compensate for raft/cache delay in namespace admission

### DIFF
--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -1,8 +1,13 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/project/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -14,14 +19,81 @@ func TestNamespaceLifecycleAdmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clusterAdminClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, ns := range []string{"default", "openshift", "openshift-infra"} {
-		if err := clusterAdminClient.Namespaces().Delete(ns); err == nil {
+		if err := clusterAdminKubeClient.Namespaces().Delete(ns); err == nil {
 			t.Fatalf("expected error deleting %q namespace, got none", ns)
 		}
+	}
+
+	// Create a namespace directly (not via a project)
+	ns := &kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: "test"}}
+	ns, err = clusterAdminKubeClient.Namespaces().Create(ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ns.Spec.Finalizers) == 0 {
+		t.Fatal("expected at least one finalizer")
+	}
+	found := false
+	for _, f := range ns.Spec.Finalizers {
+		if f == api.FinalizerOrigin {
+			found = true
+			break
+		}
+	}
+	if found {
+		t.Fatalf("didn't expect origin finalizer to be present, got %#v", ns.Spec.Finalizers)
+	}
+
+	// Create an origin object
+	route := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{Name: "route"},
+		Spec:       routeapi.RouteSpec{To: routeapi.RouteTargetReference{Kind: "Service", Name: "test"}},
+	}
+	route, err = clusterAdminClient.Routes(ns.Name).Create(route)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure the origin finalizer is added
+	ns, err = clusterAdminKubeClient.Namespaces().Get(ns.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for _, f := range ns.Spec.Finalizers {
+		if f == api.FinalizerOrigin {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected origin finalizer, got %#v", ns.Spec.Finalizers)
+	}
+
+	// Delete the namespace
+	// We don't have to worry about racing the namespace deletion controller because we've only started the master
+	err = clusterAdminKubeClient.Namespaces().Delete(ns.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to create an origin object in a terminating namespace and ensure it is forbidden
+	route = &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{Name: "route2"},
+		Spec:       routeapi.RouteSpec{To: routeapi.RouteTargetReference{Kind: "Service", Name: "test"}},
+	}
+	_, err = clusterAdminClient.Routes(ns.Name).Create(route)
+	if err == nil || !strings.Contains(err.Error(), "it is being terminated") {
+		t.Fatalf("Expected forbidden error because of a terminating namespace, got %v", err)
 	}
 }

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/golang/glog"
 	lru "github.com/hashicorp/golang-lru"
 
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -39,6 +40,12 @@ const (
 	PluginName = "NamespaceLifecycle"
 	// how long a namespace stays in the force live lookup cache before expiration.
 	forceLiveLookupTTL = 30 * time.Second
+	// how long to wait for a missing namespace before re-checking the cache (and then doing a live lookup)
+	// this accomplishes two things:
+	// 1. It allows a watch-fed cache time to observe a namespace creation event
+	// 2. It allows time for a namespace creation to distribute to members of a storage cluster,
+	//    so the live lookup has a better chance of succeeding even if it isn't performed against the leader.
+	missingNamespaceWait = 50 * time.Millisecond
 )
 
 func init() {
@@ -119,6 +126,19 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 		return errors.NewInternalError(err)
 	}
 
+	if !exists && a.GetOperation() == admission.Create {
+		// give the cache time to observe the namespace before rejecting a create.
+		// this helps when creating a namespace and immediately creating objects within it.
+		time.Sleep(missingNamespaceWait)
+		namespaceObj, exists, err = l.namespaceInformer.GetStore().Get(key)
+		if err != nil {
+			return errors.NewInternalError(err)
+		}
+		if exists {
+			glog.V(4).Infof("found %s in cache after waiting", a.GetNamespace())
+		}
+	}
+
 	// forceLiveLookup if true will skip looking at local cache state and instead always make a live call to server.
 	forceLiveLookup := false
 	lruItemObj, ok := l.forceLiveLookupCache.Get(a.GetNamespace())
@@ -129,7 +149,7 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 
 	// refuse to operate on non-existent namespaces
 	if !exists || forceLiveLookup {
-		// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
+		// as a last resort, make a call directly to storage
 		namespaceObj, err = l.client.Core().Namespaces().Get(a.GetNamespace())
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -137,6 +157,7 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 			}
 			return errors.NewInternalError(err)
 		}
+		glog.V(4).Infof("found %s via storage lookup", a.GetNamespace())
 	}
 
 	// ensure that we're not trying to create objects in terminating namespaces


### PR DESCRIPTION
When attempting to create an object in a just-created namespace, the admission plugin can reject the creation attempt for two reasons:

1. The cache of existing namespaces has not observed the creation watch event yet. There was already compensation to perform a live lookup if the namespace was not found in the cache.

2. The live lookup can be performed against a non-leader in a HA etcd setup, and can return NotFound if the non-leader etcd has not observed the creation.

This PR adds a delay, then rechecks the cache before proceeding with the live lookup. This gives both the cache and the backing storage more time to observe the create, before failing the request.

Fixes https://github.com/openshift/origin/issues/10909