### PR TITLE
Should hide the labels for route by oc get route

### DIFF
--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -581,7 +581,12 @@ func printRoute(route *routeapi.Route, w io.Writer, opts kctl.PrintOptions) erro
 		port = "<all>"
 	}
 
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", name, host, route.Spec.Path, strings.Join(backendInfo, ","), port, policy)
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s", name, host, route.Spec.Path, strings.Join(backendInfo, ","), port, policy); err != nil {
+		return err
+	}
+
+	err := appendItemLabels(route.Labels, w, opts.ColumnLabels, opts.ShowLabels)
+
 	return err
 }
 

--- a/test/cmd/routes.sh
+++ b/test/cmd/routes.sh
@@ -14,6 +14,7 @@ os::test::junit::declare_suite_start "cmd/routes"
 
 os::cmd::expect_success 'oc get routes'
 os::cmd::expect_success 'oc create -f test/integration/testdata/test-route.json'
+os::cmd::expect_success_and_text 'oc get routes testroute --show-labels' 'rtlabel1'
 os::cmd::expect_success 'oc delete routes testroute'
 os::cmd::expect_success 'oc create -f test/integration/testdata/test-service.json'
 os::cmd::expect_success 'oc create route passthrough --service=svc/frontend'

--- a/test/integration/testdata/test-route.json
+++ b/test/integration/testdata/test-route.json
@@ -3,7 +3,10 @@
   "apiVersion": "v1",
   "metadata": {
     "name": "testroute",
-    "creationTimestamp": null
+    "creationTimestamp": null,
+    "labels": {
+       "rtlabel1": "greatroute"
+    }
   },
   "spec": {
     "host": "test.example.com",


### PR DESCRIPTION
oc get route --show-labels does not display the labels.

Here is the output from the fixed code:
```
oc get route --show-labels
NAME          HOST/PORT                        PATH      SERVICES
PORT      TERMINATION   LABELS
hello-route   hello-openshift-v3.mycloud.com             hello-svc
<all>                   goodroute=great,team=red

oc get route
NAME          HOST/PORT                        PATH      SERVICES
PORT      TERMINATION
hello-route   hello-openshift-v3.mycloud.com             hello-svc
<all>
```


Fixes bug 1332499