### PR TITLE
UPSTREAM: 32722: warn on empty oc get output

### DIFF
--- a/test/cmd/sdn.sh
+++ b/test/cmd/sdn.sh
@@ -49,7 +49,7 @@ os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/sdn/hostsubnets"
 # test-cmd environment has no nodes, hence no hostsubnets
-os::cmd::expect_success_and_not_text 'oc get hostsubnets' '.'
+os::cmd::expect_success_and_text 'oc get hostsubnets' 'No resources found.'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/sdn/egressnetworkpolicies"

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[builds][Conformance] remove all builds when build configura
 			err = wait.Poll(3*time.Second, 3*time.Minute, func() (bool, error) {
 				out, err := oc.Run("get").Args("-o", "name", "builds").Output()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				if len(out) == 0 {
+				if out == "No resources found." {
 					return true, nil
 				}
 				return false, nil

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -80,7 +80,7 @@ var (
 
 // NewCmdGet creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+func NewCmdGet(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	options := &GetOptions{}
 
 	// retrieve a list of handled resources from printer as valid args
@@ -125,7 +125,7 @@ func NewCmdGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comma
 
 // RunGet implements the generic Get command
 // TODO: convert all direct flag accessors to a struct and pass that instead of cmd
-func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
+func RunGet(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args []string, options *GetOptions) error {
 	if len(options.Raw) > 0 {
 		client, err := f.Client()
 		if err != nil {
@@ -325,6 +325,9 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 			}
 			errs = append(errs, err)
 		}
+		if len(infos) == 0 {
+			outputEmptyListWarning(errOut)
+		}
 
 		res := ""
 		if len(infos) > 0 {
@@ -376,6 +379,9 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 	infos, err := r.Infos()
 	if err != nil {
 		allErrs = append(allErrs, err)
+	}
+	if len(infos) == 0 {
+		outputEmptyListWarning(errOut)
 	}
 
 	objs := make([]runtime.Object, len(infos))
@@ -497,4 +503,10 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		cmdutil.PrintFilterCount(filteredResourceCount, lastMapping.Resource, errOut, filterOpts)
 	}
 	return utilerrors.NewAggregate(allErrs)
+}
+
+// outputEmptyListWarning outputs a warning indicating that no items are available to display
+func outputEmptyListWarning(out io.Writer) error {
+	_, err := fmt.Fprintf(out, "%s\n", "No resources found.")
+	return err
 }


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/32722

Fixes: https://github.com/openshift/origin/issues/10285
Related Trello Card:
https://trello.com/c/04lpfTQR/451-8-cli-improved-flows-and-ux-in-the-cli-evg-ux-p3

The current default behavior of `oc get` is to return an empty
output when there are no resources to display. This patch improves
usability by returning a warning through stderr in the case of an empty
list.
##### Before

`$ oc get roles`
_empty output_
##### After

`oc get roles`

```
There are no resources to display.
```

cc @openshift/cli-review 
