### PR TITLE
allow passing in AWS_SECURITY_GROUPS and aws.security_groups in vagra…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -336,6 +336,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         aws.ami               = voc['ami']
         aws.region            = voc['ami_region']
         aws.subnet_id         = ENV['AWS_SUBNET_ID'] || vagrant_openshift_config['aws']['subnet_id'] || "subnet-cf57c596"
+        if ENV['AWS_SECURITY_GROUPS']
+          aws.security_groups   = ENV['AWS_SECURITY_GROUPS'].split(',')
+        else
+          aws.security_groups   = vagrant_openshift_config['aws']['security_groups']
+        end
         aws.instance_type     = ENV['AWS_INSTANCE_TYPE'] || vagrant_openshift_config['instance_type'] || "t2.large"
         aws.instance_ready_timeout = 240
         aws.tags              = { "Name" => ENV['AWS_HOSTNAME'] || vagrant_openshift_config['instance_name'] }


### PR DESCRIPTION
…nt-aws config

Allow passing in the security groups to use in the vagrant-aws config, either via the AWS_SECURITY_GROUPS env. var. (comma delimited) or via aws.security_groups in the json configuration.
