### PR TITLE
Disable go 1.6 in travis - it can't compile in under 10 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
 
 install:


### PR DESCRIPTION
[merge]