### PR TITLE
Add a missing import to origin custom tito tagger.

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 
 from tito.common import (
+    debug,
     find_git_root,
     get_latest_commit,
     run_command,


### PR DESCRIPTION
Stack trace will appear if you tito tag with --no-auto-changelog (which
we should be using), due to the missing import for this.
