### PR TITLE
UPSTREAM: 33024: Make status errors with  multiple causes cleaner

### DIFF
--- a/pkg/cmd/cli/cmd/set/helper.go
+++ b/pkg/cmd/cli/cmd/set/helper.go
@@ -7,6 +7,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -40,6 +41,10 @@ func handlePodUpdateError(out io.Writer, err error, resource string) {
 				}
 			}
 			if all && match {
+				return
+			}
+		} else {
+			if ok := kcmdutil.PrintErrorWithCauses(err, out); ok {
 				return
 			}
 		}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/helper.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/helper.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
@@ -57,6 +58,10 @@ func handlePodUpdateError(out io.Writer, err error, resource string) {
 				}
 			}
 			if all && match {
+				return
+			}
+		} else {
+			if ok := kcmdutil.PrintErrorWithCauses(err, out); ok {
 				return
 			}
 		}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -248,6 +248,26 @@ func MultilineError(prefix string, err error) string {
 	return fmt.Sprintf("%s%s\n", prefix, err)
 }
 
+// PrintErrorWithCauses prints an error's kind, name, and each of the error's causes in a new line.
+// The returned string will end with a newline.
+// Returns true if the error type can be handled, or false otherwise.
+func PrintErrorWithCauses(err error, errOut io.Writer) bool {
+	switch t := err.(type) {
+	case *kerrors.StatusError:
+		errorDetails := t.Status().Details
+		if errorDetails != nil {
+			fmt.Fprintf(errOut, "error: %s %q is invalid\n\n", errorDetails.Kind, errorDetails.Name)
+			for _, cause := range errorDetails.Causes {
+				fmt.Fprintf(errOut, "* %s: %s\n", cause.Field, cause.Message)
+			}
+			return true
+		}
+	}
+
+	fmt.Fprintf(errOut, "error: %v\n", err)
+	return false
+}
+
 // MultipleErrors returns a newline delimited string containing
 // the prefix and referenced errors in standard form.
 func MultipleErrors(prefix string, errs []error) string {


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/33024
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1355703

Invalid status errors for resources are printed without any formatting.
This makes an error message hard to read when the error contains
multiple causes.

This patch loops through all of the error's causes, and prints each one
in its own line.

##### Before
```
$ oc set probe dc/hello --liveness --get-url="www.sample.com:80"

error: DeploymentConfig "hello" is invalid: [spec.template.spec.containers[0].livenessProbe.httpGet.port: 
Invalid value: "": must be an IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*
[a-z0-9])*, it must contain at least one letter [a-z], and hyphens cannot be adjacent to other hyphens): e.g.
"http", spec.template.spec.containers[0].livenessProbe.httpGet.scheme: Invalid value: 
"WWW.SAMPLE.COM": must be one of [HTTP HTTPS]]
```

##### After

```
$ oc set probe dc/hello --liveness --get-url="www.sample.com:80"
error: DeploymentConfig "hello" is invalid

* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must be an IANA_SVC_NAME (at most 15 characters, matching regex [a-z0-9]([a-z0-9-]*[a-z0-9])*, it must contain at least one letter [a-z], and hyphens cannot be adjacent to other hyphens): e.g. "http"
* spec.template.spec.containers[0].livenessProbe.httpGet.scheme: Invalid value: "WWW.SAMPLE.COM": must be one of [HTTP HTTPS]
```

@openshift/cli-review 