### PR TITLE
Add "if" to avoid throwing panic without asset configuration

### DIFF
--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -391,7 +391,7 @@ func (m *Master) Start() error {
 	switch {
 	case m.api:
 		glog.Infof("Starting master on %s (%s)", m.config.ServingInfo.BindAddress, version.Get().String())
-		glog.Infof("Public master address is %s", m.config.AssetConfig.MasterPublicURL)
+		glog.Infof("Public master address is %s", m.config.MasterPublicURL)
 		if len(m.config.DisabledFeatures) > 0 {
 			glog.V(4).Infof("Disabled features: %s", strings.Join(m.config.DisabledFeatures, ", "))
 		}


### PR DESCRIPTION
When I deploy origin-web-console on localhost:9000 for developing front and the asset config is none, the line 394 throw a panic. 
