### PR TITLE
Bump the timeout for deployment logs

### DIFF
--- a/pkg/deploy/registry/deploylog/rest.go
+++ b/pkg/deploy/registry/deploylog/rest.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// defaultTimeout is the default time to wait for the logs of a deployment.
-	defaultTimeout time.Duration = 20 * time.Second
+	defaultTimeout time.Duration = 60 * time.Second
 	// defaultInterval is the default interval for polling a not found deployment.
 	defaultInterval time.Duration = 1 * time.Second
 )


### PR DESCRIPTION
This is just a hot-fix to unblock the merge queue. The proper fix should be to add `--timeout` option to `oc deploy` so `--follow` can follow forever or have configurable timeout.

This is also not fixing https://github.com/openshift/origin/issues/11016 