### PR TITLE
Fix NetNamespaces, which got accidentally broken in rebase

### DIFF
--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -1,7 +1,6 @@
 package etcd
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -19,19 +18,11 @@ type REST struct {
 	registry.Store
 }
 
-const etcdPrefix = "/r"
-
 // NewREST returns a RESTStorage object that will work against netnamespaces
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:     func() runtime.Object { return &api.NetNamespace{} },
 		NewListFunc: func() runtime.Object { return &api.NetNamespaceList{} },
-		KeyRootFunc: func(ctx kapi.Context) string {
-			return etcdPrefix
-		},
-		KeyFunc: func(ctx kapi.Context, name string) (string, error) {
-			return registry.NoNamespaceKeyFunc(ctx, etcdPrefix, name)
-		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*api.NetNamespace).NetName, nil
 		},


### PR DESCRIPTION
The pkg/sdn/registry/netnamespace/ changes in 58e8f93 "Refactor NewConfigGetter again to get closer to correct behavior" were wrong (some sort of bad automated edit / accidental half-undo / ?). This fixes it to be the same as all the other edits in that commit.

extended network tests are currently offline, but without this change, the multitenant plugin is completely broken (because it can't watch for NetNamespace creation, etc), and with it, it works again.

@smarterclayton 