### PR TITLE
Reduce the amount of allocations in policy use by trying a cached resolver first

### DIFF
--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -414,7 +414,7 @@ func TestGlobalPolicyOutranksLocalPolicy(t *testing.T) {
 			Resource: "roles",
 		},
 		expectedAllowed: true,
-		expectedReason:  "allowed by cluster rule",
+		expectedReason:  "allowed by rule in adze",
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = append(test.policies, newAdzePolicies()...)

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -23,7 +23,7 @@ func TestClusterAdminUseGroup(t *testing.T) {
 			Resource: "jobs",
 		},
 		expectedAllowed: true,
-		expectedReason:  "allowed by cluster rule",
+		expectedReason:  "allowed by rule in mallet",
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.clusterBindings = newDefaultClusterPolicyBindings()
@@ -40,7 +40,7 @@ func TestClusterReaderUseGroup(t *testing.T) {
 			Resource: "jobs",
 		},
 		expectedAllowed: true,
-		expectedReason:  "allowed by cluster rule",
+		expectedReason:  "allowed by rule in mallet",
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.clusterBindings = newDefaultClusterPolicyBindings()

--- a/pkg/authorization/registry/clusterrole/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy/proxy.go
@@ -18,7 +18,7 @@ type ClusterRoleStorage struct {
 	roleStorage rolestorage.VirtualStorage
 }
 
-func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterBindingRegistry clusterpolicybindingregistry.Registry) *ClusterRoleStorage {
+func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterBindingRegistry clusterpolicybindingregistry.Registry, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleStorage {
 	simulatedPolicyRegistry := clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry)
 
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
@@ -32,7 +32,9 @@ func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry,
 		roleStorage: rolestorage.VirtualStorage{
 			PolicyStorage: simulatedPolicyRegistry,
 
-			RuleResolver:   ruleResolver,
+			RuleResolver:       ruleResolver,
+			CachedRuleResolver: cachedRuleResolver,
+
 			CreateStrategy: roleregistry.ClusterStrategy,
 			UpdateStrategy: roleregistry.ClusterStrategy,
 			Resource:       authorizationapi.Resource("clusterrole")},

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -18,7 +18,7 @@ type ClusterRoleBindingStorage struct {
 	roleBindingStorage rolebindingstorage.VirtualStorage
 }
 
-func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterPolicyBindingRegistry clusterpolicybindingregistry.Registry) *ClusterRoleBindingStorage {
+func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterPolicyBindingRegistry clusterpolicybindingregistry.Registry, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleBindingStorage {
 	simulatedPolicyBindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterPolicyBindingRegistry)
 
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
@@ -32,7 +32,9 @@ func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Re
 		rolebindingstorage.VirtualStorage{
 			BindingRegistry: simulatedPolicyBindingRegistry,
 
-			RuleResolver:   ruleResolver,
+			RuleResolver:       ruleResolver,
+			CachedRuleResolver: cachedRuleResolver,
+
 			CreateStrategy: rolebindingregistry.ClusterStrategy,
 			UpdateStrategy: rolebindingregistry.ClusterStrategy,
 			Resource:       authorizationapi.Resource("clusterrolebinding"),

--- a/pkg/authorization/registry/role/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage_test.go
@@ -49,14 +49,14 @@ func testNewLocalPolicies() []authorizationapi.Policy {
 func makeLocalTestStorage() roleregistry.Storage {
 	policyRegistry := test.NewPolicyRegistry(testNewLocalPolicies(), nil)
 
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("role"))
+	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("role"))
 }
 
 func makeClusterTestStorage() roleregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	policyRegistry := clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry)
 
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(nil, &test.PolicyBindingRegistry{}, clusterPolicyRegistry, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("clusterrole"))
+	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(nil, &test.PolicyBindingRegistry{}, clusterPolicyRegistry, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("clusterrole"))
 }
 
 func TestCreateValidationError(t *testing.T) {

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
@@ -69,7 +69,7 @@ func makeTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	policyRegistry := test.NewPolicyRegistry([]authorizationapi.Policy{}, nil)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry), authorizationapi.Resource("rolebinding"))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry), nil, authorizationapi.Resource("rolebinding"))
 }
 
 func makeClusterTestStorage() rolebindingregistry.Storage {
@@ -77,7 +77,7 @@ func makeClusterTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	bindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterBindingRegistry)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry), authorizationapi.Resource("clusterrolebinding"))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry), nil, authorizationapi.Resource("clusterrolebinding"))
 }
 
 func TestCreateValidationError(t *testing.T) {
@@ -354,7 +354,7 @@ func TestDeleteError(t *testing.T) {
 	bindingRegistry := &test.PolicyBindingRegistry{}
 	bindingRegistry.Err = errors.New("Sample Error")
 
-	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("rolebinding"))
+	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("rolebinding"))
 	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})
 	_, err := storage.Delete(ctx, "foo", nil)
 	if err != bindingRegistry.Err {

--- a/pkg/authorization/registry/subjectrulesreview/storage.go
+++ b/pkg/authorization/registry/subjectrulesreview/storage.go
@@ -74,25 +74,14 @@ func GetEffectivePolicyRules(ctx kapi.Context, ruleResolver rulevalidation.Autho
 		return nil, []error{kapierrors.NewBadRequest(fmt.Sprintf("user missing from context"))}
 	}
 
-	errors := []error{}
-	rules := []authorizationapi.PolicyRule{}
-
-	namespaceRules, err := ruleResolver.GetEffectivePolicyRules(ctx)
+	var errors []error
+	var rules []authorizationapi.PolicyRule
+	namespaceRules, err := ruleResolver.RulesFor(user, namespace)
 	if err != nil {
 		errors = append(errors, err)
 	}
 	for _, rule := range namespaceRules {
 		rules = append(rules, rulevalidation.BreakdownRule(rule)...)
-	}
-	if len(namespace) != 0 {
-		masterContext := kapi.WithNamespace(ctx, kapi.NamespaceNone)
-		clusterRules, err := ruleResolver.GetEffectivePolicyRules(masterContext)
-		if err != nil {
-			errors = append(errors, err)
-		}
-		for _, rule := range clusterRules {
-			rules = append(rules, rulevalidation.BreakdownRule(rule)...)
-		}
 	}
 
 	if scopes := user.GetExtra()[authorizationapi.ScopesKey]; len(scopes) > 0 {

--- a/pkg/authorization/rulevalidation/user_covers.go
+++ b/pkg/authorization/rulevalidation/user_covers.go
@@ -11,53 +11,46 @@ import (
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	authorizationinterfaces "github.com/openshift/origin/pkg/authorization/interfaces"
 )
 
 func ConfirmNoEscalation(ctx kapi.Context, resource unversioned.GroupResource, name string, ruleResolver AuthorizationRuleResolver, role authorizationinterfaces.Role) error {
-	ruleResolutionErrors := []error{}
+	var ruleResolutionErrors []error
 
-	ownerLocalRules, err := ruleResolver.GetEffectivePolicyRules(ctx)
+	user, ok := kapi.UserFrom(ctx)
+	if !ok {
+		return kapierrors.NewForbidden(resource, name, fmt.Errorf("no user provided in context"))
+	}
+	namespace, _ := kapi.NamespaceFrom(ctx)
+
+	ownerRules, err := ruleResolver.RulesFor(user, namespace)
 	if err != nil {
 		// do not fail in this case.  Rules are purely additive, so we can continue with a coverage check based on the rules we have
-		user, _ := kapi.UserFrom(ctx)
-		glog.V(1).Infof("non-fatal error getting local rules for %v: %v", user, err)
+		glog.V(1).Infof("non-fatal error getting rules for %v: %v", user, err)
 		ruleResolutionErrors = append(ruleResolutionErrors, err)
 	}
-	masterContext := kapi.WithNamespace(ctx, "")
-	ownerGlobalRules, err := ruleResolver.GetEffectivePolicyRules(masterContext)
-	if err != nil {
-		// do not fail in this case.  Rules are purely additive, so we can continue with a coverage check based on the rules we have
-		user, _ := kapi.UserFrom(ctx)
-		glog.V(1).Infof("non-fatal error getting global rules for %v: %v", user, err)
-		ruleResolutionErrors = append(ruleResolutionErrors, err)
-	}
-
-	ownerRules := make([]authorizationapi.PolicyRule, 0, len(ownerGlobalRules)+len(ownerLocalRules))
-	ownerRules = append(ownerRules, ownerLocalRules...)
-	ownerRules = append(ownerRules, ownerGlobalRules...)
 
 	ownerRightsCover, missingRights := Covers(ownerRules, role.Rules())
-	if !ownerRightsCover {
-		if compactedMissingRights, err := CompactRules(missingRights); err == nil {
-			missingRights = compactedMissingRights
-		}
-
-		missingRightsStrings := make([]string, 0, len(missingRights))
-		for _, missingRight := range missingRights {
-			missingRightsStrings = append(missingRightsStrings, missingRight.CompactString())
-		}
-		sort.Strings(missingRightsStrings)
-		user, _ := kapi.UserFrom(ctx)
-		var internalErr error
-		if len(ruleResolutionErrors) > 0 {
-			internalErr = fmt.Errorf("user %q cannot grant extra privileges:\n%v\nrule resolution errors: %v)", user.GetName(), strings.Join(missingRightsStrings, "\n"), ruleResolutionErrors)
-		} else {
-			internalErr = fmt.Errorf("user %q cannot grant extra privileges:\n%v", user.GetName(), strings.Join(missingRightsStrings, "\n"))
-		}
-		return kapierrors.NewForbidden(resource, name, internalErr)
+	if ownerRightsCover {
+		return nil
 	}
 
-	return nil
+	// determine what resources the user is missing
+	if compactedMissingRights, err := CompactRules(missingRights); err == nil {
+		missingRights = compactedMissingRights
+	}
+
+	missingRightsStrings := make([]string, 0, len(missingRights))
+	for _, missingRight := range missingRights {
+		missingRightsStrings = append(missingRightsStrings, missingRight.CompactString())
+	}
+	sort.Strings(missingRightsStrings)
+
+	var internalErr error
+	if len(ruleResolutionErrors) > 0 {
+		internalErr = fmt.Errorf("user %q cannot grant extra privileges:\n%v\nrule resolution errors: %v)", user.GetName(), strings.Join(missingRightsStrings, "\n"), ruleResolutionErrors)
+	} else {
+		internalErr = fmt.Errorf("user %q cannot grant extra privileges:\n%v", user.GetName(), strings.Join(missingRightsStrings, "\n"))
+	}
+	return kapierrors.NewForbidden(resource, name, internalErr)
 }

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -162,10 +162,10 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 		clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
 	)
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver, authorizationapi.Resource("role"))
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver, authorizationapi.Resource("rolebinding"))
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver, nil, authorizationapi.Resource("role"))
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver, nil, authorizationapi.Resource("rolebinding"))
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, nil)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, nil)
 
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -556,10 +556,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, c.Informers.ClusterPolicies().Lister().ClusterPolicies())
 	subjectRulesReviewStorage := subjectrulesreview.NewREST(c.RuleResolver, c.Informers.ClusterPolicies().Lister().ClusterPolicies())
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver, authorizationapi.Resource("role"))
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver, authorizationapi.Resource("rolebinding"))
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver, nil, authorizationapi.Resource("role"))
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver, nil, authorizationapi.Resource("rolebinding"))
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
 
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -283,8 +283,15 @@ func TestAuthorizationResolution(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// try to add Valerie to a non-existent role
-	if err := addValerie.AddRole(); !kapierror.IsNotFound(err) {
+	// try to add Valerie to a non-existent role, looping until it is true due to
+	// the policy cache taking time to react
+	if err := wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+		err := addValerie.AddRole()
+		if kapierror.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -315,6 +322,17 @@ func TestAuthorizationResolution(t *testing.T) {
 
 	buildListerClient, _, _, err := testutil.GetClientForUser(*clusterAdminConfig, "build-lister")
 	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// the authorization cache may not be up to date, retry
+	if err := wait.Poll(10*time.Millisecond, 2*time.Minute, func() (bool, error) {
+		_, err := buildListerClient.Builds(kapi.NamespaceDefault).List(kapi.ListOptions{})
+		if kapierror.IsForbidden(err) {
+			return false, nil
+		}
+		return err == nil, err
+	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -730,7 +730,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		},
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   true,
-			Reason:    "allowed by cluster rule",
+			Reason:    "allowed by rule in any-project",
 			Namespace: "any-project",
 		},
 	}.run(t)
@@ -742,7 +742,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		},
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   true,
-			Reason:    "allowed by cluster rule",
+			Reason:    "allowed by rule in any-project",
 			Namespace: "any-project",
 		},
 	}.run(t)
@@ -754,7 +754,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		},
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   true,
-			Reason:    "allowed by cluster rule",
+			Reason:    "allowed by rule in any-project",
 			Namespace: "any-project",
 		},
 	}.run(t)
@@ -766,7 +766,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		},
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   true,
-			Reason:    "allowed by cluster rule",
+			Reason:    "allowed by rule in any-project",
 			Namespace: "any-project",
 		},
 	}.run(t)


### PR DESCRIPTION
Simplified RuleResolver to be closer to upstream. Used a cached RuleResolver
in the NoEscalation checks and when fetching the binding on update. Remove a use of deepequal on a common path.

Not passing all tests yet, but @deads2k please take a look at the general structure.

This drops policy pretty far down the list in test-cmd - resolving #11003 for good
hopefully.