### PR TITLE
Add support for GitLab Push Event

### DIFF
--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrNoGitHubEvent = errors.New("missing X-GitHub-Event or X-Gogs-Event")
+	ErrNoGitHubEvent = errors.New("missing X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event")
 )
 
 // WebHook used for processing github webhook requests.
@@ -57,8 +57,8 @@ func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 		return revision, envvars, proceed, err
 	}
 	method := getEvent(req.Header)
-	if method != "ping" && method != "push" {
-		return revision, envvars, proceed, fmt.Errorf("Unknown X-GitHub-Event or X-Gogs-Event %s", method)
+	if method != "ping" && method != "push" && method != "Push Hook" {
+		return revision, envvars, proceed, fmt.Errorf("Unknown X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event %s", method)
 	}
 	if method == "ping" {
 		return revision, envvars, proceed, err
@@ -109,6 +109,9 @@ func getEvent(header http.Header) string {
 	event := header.Get("X-GitHub-Event")
 	if len(event) == 0 {
 		event = header.Get("X-Gogs-Event")
+	}
+	if len(event) == 0 {
+		event = header.Get("X-Gitlab-Event")
 	}
 	return event
 }

--- a/pkg/build/webhook/github/github_test.go
+++ b/pkg/build/webhook/github/github_test.go
@@ -147,8 +147,8 @@ func TestMissingEvent(t *testing.T) {
 	plugin := New()
 	revision, _, proceed, err := plugin.Extract(buildConfig, "secret100", "", req)
 
-	if err == nil || !strings.Contains(err.Error(), "missing X-GitHub-Event or X-Gogs-Event") {
-		t.Errorf("Expected missing X-GitHub-Event or X-Gogs-Event, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "missing X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event") {
+		t.Errorf("Expected missing X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event, got %v", err)
 	}
 	if proceed {
 		t.Error("Expected 'proceed' return value to be 'false'")
@@ -165,8 +165,8 @@ func TestWrongGitHubEvent(t *testing.T) {
 	plugin := New()
 	revision, _, proceed, err := plugin.Extract(buildConfig, "secret100", "", req)
 
-	if err == nil || !strings.Contains(err.Error(), "Unknown X-GitHub-Event or X-Gogs-Event") {
-		t.Errorf("Expected missing Unknown X-GitHub-Event or X-Gogs-Event, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "Unknown X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event") {
+		t.Errorf("Expected missing Unknown X-GitHub-Event, X-Gogs-Event or X-Gitlab-Event, got %v", err)
 	}
 	if proceed {
 		t.Error("Expected 'proceed' return value to be 'false'")


### PR DESCRIPTION
Enable WebHook for build intergrated with GitLab Push Event, fix #11002