### PR TITLE
Fix test debugging

### DIFF
--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -5,6 +5,9 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 source "${OS_ROOT}/test/extended/setup.sh"
 
+# cgo must be disabled to have the symbol table available
+export CGO_ENABLED=0
+
 os::test::extended::setup
 os::test::extended::focus "$@"
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -265,7 +265,8 @@ if [[ "${OPENSHIFT_SKIP_BUILD:-false}" = "true" ]] &&
      [[ -n $(os::build::find-binary extended.test) ]]; then
   os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=true"
 else
-  hack/build-go.sh test/extended/extended.test
+  # cgo must be disabled to have the symbol table available
+  CGO_ENABLED=0 hack/build-go.sh test/extended/extended.test
 fi
 TEST_BINARY="${OS_ROOT}/$(os::build::find-binary extended.test)"
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -220,7 +220,11 @@ function run-extended-tests() {
   fi
 
   if [[ -n "${log_path}" ]]; then
-    test_cmd="${test_cmd} | tee ${log_path}"
+    if [[ -n "${dlv_debug}" ]]; then
+      os::log::warn "Not logging to file since DLV_DEBUG is enabled"
+    else
+      test_cmd="${test_cmd} | tee ${log_path}"
+    fi
   fi
 
   pushd "${EXTENDED_TEST_PATH}/networking" > /dev/null


### PR DESCRIPTION
 - disable cgo when building extended.test so the symbol table is available when debugging
 - fix dlv invocation in networking.sh when running in 'ci mode' (test-managed cluster deployment)