### PR TITLE
function addDefaultEnvVar may have risk of nil pointer

### DIFF
--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -131,6 +131,10 @@ func getBuildEnv(build *buildapi.Build) *[]kapi.EnvVar {
 }
 
 func addDefaultEnvVar(v kapi.EnvVar, envVars *[]kapi.EnvVar) {
+	if envVars == nil {
+		return
+	}
+
 	found := false
 	for i := range *envVars {
 		if (*envVars)[i].Name == v.Name {


### PR DESCRIPTION
The return value of funtion `getBuildEnv` may be a nil , so it looks like that the parameter `envVars`  of function `addDefaultEnvVar` should be checked to avoid causing a nil panic when run *envVar.
I am not sure if it will be happen in the actual situation, but I think we should do the right thing and check it since we know we can. 