### PR TITLE
Fixed attempt marking code for try_until stderr

### DIFF
--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -392,7 +392,8 @@ readonly -f os::cmd::internal::print_try_until_results
 # os::cmd::internal::mark_attempt marks the end of an attempt in the stdout and stderr log files
 # this is used to make the try_until_* output more concise
 function os::cmd::internal::mark_attempt() {
-	echo -e '\x1e' >> "${os_cmd_internal_tmpout}" | tee "${os_cmd_internal_tmperr}"
+	echo -e '\x1e' >> "${os_cmd_internal_tmpout}"
+	echo -e '\x1e' >> "${os_cmd_internal_tmperr}"
 }
 readonly -f os::cmd::internal::mark_attempt
 

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -369,6 +369,13 @@ function os::cmd::internal::get_results() {
 }
 readonly -f os::cmd::internal::get_results
 
+# os::cmd::internal::get_last_results prints the stderr and stdout from the last attempt
+function os::cmd::internal::get_last_results() {
+	cat "${os_cmd_internal_tmpout}" | awk 'BEGIN { RS = "\x1e" } END { print $0 }'
+	cat "${os_cmd_internal_tmperr}" | awk 'BEGIN { RS = "\x1e" } END { print $0 }'
+}
+readonly -f os::cmd::internal::get_last_results
+
 # os::cmd::internal::mark_attempt marks the end of an attempt in the stdout and stderr log files
 # this is used to make the try_until_* output more concise
 function os::cmd::internal::mark_attempt() {
@@ -556,8 +563,8 @@ function os::cmd::internal::run_until_text() {
 	while [ $(date +%s000) -lt $deadline ]; do
 		local cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
 		local test_result
-		test_result=$( os::cmd::internal::run_collecting_output 'grep -Eq "${text}" <(os::cmd::internal::get_results)'; echo $? )
 		test_succeeded=$( os::cmd::internal::success_func "${test_result}"; echo $? )
+		test_result=$( os::cmd::internal::run_collecting_output 'grep -Eq "${text}" <(os::cmd::internal::get_last_results)'; echo $? )
 
 		if (( test_succeeded )); then
 			break

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -118,7 +118,7 @@ readonly -f os::cmd::try_until_success
 # os::cmd::try_until_failure runs the cmd until either the command fails or times out
 # the default time-out for os::cmd::try_until_failure is 60 seconds.
 function os::cmd::try_until_failure() {
-	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_success expects at least one argument, got $#"; return 1; fi
+	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_failure expects at least one argument, got $#"; return 1; fi
 	local cmd=$1
 	local duration=${2:-$minute}
 	local interval=${3:-0.2}
@@ -130,7 +130,7 @@ readonly -f os::cmd::try_until_failure
 # os::cmd::try_until_text runs the cmd until either the command outputs the desired text or times out
 # the default time-out for os::cmd::try_until_text is 60 seconds.
 function os::cmd::try_until_text() {
-	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_success expects at least two arguments, got $#"; return 1; fi
+	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_text expects at least two arguments, got $#"; return 1; fi
 	local cmd=$1
 	local text=$2
 	local duration=${3:-minute}

--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -31,7 +31,7 @@ os::cmd::try_until_text 'oc get appliedclusterresourcequota -n foo --as deads -o
 os::cmd::try_until_text 'oc get appliedclusterresourcequota -n asmail --as deads@deads.io -o name' "for-deads-email-by-annotation"
 os::cmd::try_until_text 'oc describe appliedclusterresourcequota/for-deads-by-annotation -n bar --as deads' "secrets.*1[0-9]"
 os::cmd::expect_success 'oc delete project foo'
-os::cmd::try_until_text 'oc get clusterresourcequota/for-deads-by-annotation -o jsonpath="{.status.namespaces[*].namespace}"' '^bar$'
+os::cmd::try_until_not_text 'oc get clusterresourcequota/for-deads-by-annotation -o jsonpath="{.status.namespaces[*].namespace}"' 'foo'
 os::cmd::expect_success 'oc delete project bar'
 os::cmd::expect_success 'oc delete project asmail'
 


### PR DESCRIPTION
Previously, the use of `tee` to propagate the attempt
marker to both the stdout and stderr tmpfiles was not
correctly appending the marker to the stderr file, which
lead to tests incorrectly showing no output upon
completion.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com

/cc @liggitt @DirectXMan12 

[test] me
