### PR TITLE
Refactor dind

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -228,27 +228,29 @@ Follow these steps to ensure that virtual box interfaces are unmanaged:
 === Develop and test using a docker-in-docker cluster
 
 It's possible to run an OpenShift multinode cluster on a single host
-via docker-in-docker (dind).  Cluster creation is cheaper since each
-node is a container instead of a VM.  This was implemented primarily
-to support multinode network testing, but may prove useful for other
-use cases.
+thanks to docker-in-docker (dind).  Cluster creation is cheaper since
+each node is a container instead of a VM.  This was initially
+implemented to support multinode network testing, but has proven
+useful for development as well.
 
-To run a dind cluster in a VM, follow steps 1-3 of the Vagrant
-instructions and then execute the following:
+Prerequisites:
 
-        $ export OPENSHIFT_DIND_DEV_CLUSTER=true
-        $ vagrant up
+1. Host running docker and with SELinux disabled.
+2. An environment with the tools necessary to build origin.
+3. A clone of the origin repo.
 
-Bringing up the VM for the first time will take a while due to the
-overhead of package installation, building docker images, and building
-openshift.  Assuming the 'vagrant up' command completes without error,
-a dind OpenShift cluster should now be running on the VM.  To access
-the cluster, login to the VM:
+From the root of the origin repo, run the following command to launch
+a new cluster:
 
-        $ vagrant ssh
+        # -b to build origin, -i to build images
+        $ hack/dind-cluster.sh start -b -i
 
-Once on the VM, the 'oc' and 'openshift' commands can be used to
-interact with the cluster:
+Once the cluster is up, source the cluster's rc file to configure the
+environment to use it:
+
+        $ . dind-openshift.rc
+
+Now the 'oc' command can be used to interact with the cluster:
 
         $ oc get nodes
 
@@ -272,22 +274,12 @@ at the top of the dind-cluster.sh script.
 
 Attempting to start a cluster when one is already running will result
 in an error message from docker indicating that the named containers
-already exist.  To redeploy a cluster after making changes, use the
-'start' and 'stop' or 'restart' commands.  OpenShift is always built
-as part of the dind cluster deployment initiated by 'start' or
-'restart'.
+already exist.  To redeploy a cluster use the 'start' command with the
+'-r' flag to remove an existing cluster.
 
-By default the cluster will consist of a master and 2 nodes.  The
-OPENSHIFT_NUM_MINIONS environment variable can be used to override the
-default of 2 nodes.
-
-Containers are torn down on stop and restart, but the root of the
-origin repo is mounted to /data in each container to allow for a
-persistent installation target.
-
-While it is possible to run a dind cluster on any host (not just a
-vagrant VM), it is recommended to consider the warnings at the top of
-the dind-cluster.sh script.
+While it is possible to run a dind cluster directly on a linux host,
+it is recommended to consider the warnings at the top of the
+dind-cluster.sh script.
 
 ==== Testing networking with docker-in-docker
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -235,9 +235,17 @@ useful for development as well.
 
 Prerequisites:
 
-1. Host running docker and with SELinux disabled.
-2. An environment with the tools necessary to build origin.
-3. A clone of the origin repo.
+1. A host running docker and with SELinux disabled.
+
+2. It is acceptable to load some kernel modules (overlay, openvswitch
+and br_netfilter) on the docker host.
+
+3. It is acceptable to have net.bridge.bridge-nf-call-iptables set to
+0 on the docker host.
+
+4. An environment with the tools necessary to build origin.
+
+5. A clone of the origin repo.
 
 From the root of the origin repo, run the following command to launch
 a new cluster:
@@ -276,10 +284,6 @@ Attempting to start a cluster when one is already running will result
 in an error message from docker indicating that the named containers
 already exist.  To redeploy a cluster use the 'start' command with the
 '-r' flag to remove an existing cluster.
-
-While it is possible to run a dind cluster directly on a linux host,
-it is recommended to consider the warnings at the top of the
-dind-cluster.sh script.
 
 ==== Testing networking with docker-in-docker
 

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-# WARNING: The script modifies the host on which it is run.  It loads
-# the openvwitch and br_netfilter modules and sets
-# net.bridge.bridge-nf-call-iptables=0.  Consider creating dind
-# clusters in a VM if this modification is undesirable:
-#
-#   OPENSHIFT_DIND_DEV_CLUSTER=1 vagrant up'
+# WARNING: The script modifies the host that docker is running on.  It
+# attempts to load the overlay, openvswitch and br_netfilter modules
+# and sets net.bridge.bridge-nf-call-iptables=0.  If this modification
+# is undesirable consider running docker in a VM.
 #
 # Overview
 # ========
@@ -19,7 +17,7 @@
 # Dependencies
 # ------------
 #
-# This script has been tested on Fedora 21, but should work on any
+# This script has been tested on Fedora 24, but should work on any
 # release.  Docker is assumed to be installed.  At this time,
 # boot2docker is not supported.
 #
@@ -34,20 +32,12 @@
 # -----------------------
 #
 # By default, a dind openshift cluster stores its configuration
-# (openshift.local.*) in /tmp/openshift-dind-cluster/openshift.  Since
-# configuration is stored in a different location than a
-# vagrant-deployed cluster (which stores configuration in the root of
-# the origin tree), vagrant and dind clusters can run simultaneously
-# without conflict.  It's also possible to run multiple dind clusters
-# simultaneously by overriding the instance prefix.  The following
-# command would ensure configuration was stored at
-# /tmp/openshift-dind/cluster/my-cluster:
+# (openshift.local.*) in /tmp/openshift-dind-cluster/openshift.  It's
+# possible to run multiple dind clusters simultaneously by overriding
+# the instance prefix.  The following command would ensure
+# configuration was stored at /tmp/openshift-dind/cluster/my-cluster:
 #
-#    OPENSHIFT_INSTANCE_PREFIX=my-cluster hack/dind-cluster.sh [command]
-#
-# It is also possible to specify an entirely different configuration path:
-#
-#    OPENSHIFT_CONFIG_ROOT=[path] hack/dind-cluster.sh [command]
+#    OPENSHIFT_CLUSTER_ID=my-cluster hack/dind-cluster.sh [command]
 #
 # Suggested Workflow
 # ------------------
@@ -55,10 +45,6 @@
 # When making changes to the deployment of a dind cluster or making
 # breaking golang changes, the 'restart' command will ensure that an
 # existing cluster is cleaned up before deploying a new cluster.
-#
-# When only making non-breaking changes to golang code, the 'redeploy'
-# command avoids restarting the cluster.  'redeploy' rebuilds the
-# openshift binaries and deploys them to the existing cluster.
 #
 # Running Tests
 # -------------
@@ -71,175 +57,61 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DIND_MANAGEMENT_SCRIPT=true
-
-source $(dirname "${BASH_SOURCE}")/../contrib/vagrant/provision-config.sh
-
-# Enable xtrace for container script invocations if it is enabled
-# for this script.
-BASH_CMD=
-if set +o | grep -q '\-o xtrace'; then
-  BASH_CMD="bash -x"
-fi
-
-DOCKER_CMD=${DOCKER_CMD:-"sudo docker"}
-
-# Override the default CONFIG_ROOT path with one that is
-# cluster-specific.
-TMPDIR="${TMPDIR:-"/tmp"}"
-CONFIG_ROOT=${OPENSHIFT_CONFIG_ROOT:-${TMPDIR}/openshift-dind-cluster/${INSTANCE_PREFIX}}
-
-DEPLOY_SSH=${OPENSHIFT_DEPLOY_SSH:-true}
-
-DEPLOYED_CONFIG_ROOT="/config"
-
-DEPLOYED_ROOT="/data/src/github.com/openshift/origin"
-
-SCRIPT_ROOT="${DEPLOYED_ROOT}/contrib/vagrant"
-
-function check-selinux() {
-  if [[ "$(getenforce)" = "Enforcing" ]]; then
-    >&2 echo "Error: This script is not compatible with SELinux enforcing mode."
-    exit 1
-  fi
-}
-
-DIND_IMAGE="openshift/dind"
-BUILD_IMAGES="${OPENSHIFT_DIND_BUILD_IMAGES:-1}"
-
-function build-image() {
-  local build_root=$1
-  local image_name=$2
-
-  pushd "${build_root}" > /dev/null
-    ${DOCKER_CMD} build -t "${image_name}" .
-  popd > /dev/null
-}
-
-function build-images() {
-  # Building images is done by default but can be disabled to allow
-  # separation of image build from cluster creation.
-  if [[ "${BUILD_IMAGES}" = "1" ]]; then
-    echo "Building container images"
-    build-image "${OS_ROOT}/images/dind" "${DIND_IMAGE}"
-  fi
-}
-
-function get-docker-ip() {
-  local cid=$1
-
-  ${DOCKER_CMD} inspect --format '{{ .NetworkSettings.IPAddress }}' "${cid}"
-}
-
-function docker-exec-script() {
-    local cid=$1
-    local cmd=$2
-
-    ${DOCKER_CMD} exec -t "${cid}" ${BASH_CMD} ${cmd}
-}
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+source "${OS_ROOT}/images/dind/node/openshift-dind-lib.sh"
 
 function start() {
+  local origin_root=$1
+  local config_root=$2
+  local deployed_config_root=$3
+  local cluster_id=$4
+  local network_plugin=$5
+  local wait_for_cluster=$6
+  local node_count=$7
+
   # docker-in-docker's use of volumes is not compatible with SELinux
   check-selinux
 
-  echo "Configured network plugin: ${NETWORK_PLUGIN}"
+  echo "Starting dind cluster '${cluster_id}' with plugin '${network_plugin}'"
 
-  # TODO(marun) - perform these operations in a container for boot2docker compat
-  echo "Ensuring compatible host configuration"
-  sudo modprobe openvswitch
-  sudo modprobe br_netfilter 2> /dev/null || true
-  sudo sysctl -w net.bridge.bridge-nf-call-iptables=0 > /dev/null
-  # overlayfs, if available, will be faster than vfs
-  sudo modprobe overlay 2> /dev/null || true
-  mkdir -p "${CONFIG_ROOT}"
+  # Ensuring compatible host configuration
+  #
+  # Running in a container ensures that the docker host will be affected even
+  # if docker is running remotely.  The openshift/dind-node image was chosen
+  # due to its having sysctl installed.
+  ${DOCKER_CMD} run --privileged --net=host --rm -v /lib/modules:/lib/modules \
+                openshift/dind-node bash -e -c \
+                '/usr/sbin/sysctl -w net.bridge.bridge-nf-call-iptables=0 > /dev/null;
+                /usr/sbin/modprobe openvswitch;
+                /usr/sbin/modprobe overlay 2> /dev/null || true;
+                /usr/sbin/modprobe br_netfilter 2> /dev/null || true;'
 
-  if [[ "${SKIP_BUILD}" = "true" ]]; then
-    echo "WARNING: Skipping image build due to OPENSHIFT_SKIP_BUILD=true"
-  else
-    build-images
-  fi
+  # Initialize the cluster config path
+  mkdir -p "${config_root}"
+  echo "OPENSHIFT_NETWORK_PLUGIN=${network_plugin}" > "${config_root}/network-plugin"
+  copy-runtime "${origin_root}" "${config_root}/"
 
-  ## Create containers
-  echo "Launching containers"
-  local root_volume="-v ${OS_ROOT}:${DEPLOYED_ROOT}"
-  local config_volume="-v ${CONFIG_ROOT}:${DEPLOYED_CONFIG_ROOT}"
-  local volumes="${root_volume} ${config_volume}"
-  # systemd requires RTMIN+3 to shutdown properly
-  local stop="--stop-signal=$(kill -l RTMIN+3)"
-  local base_run_cmd="${DOCKER_CMD} run -dt ${stop} ${volumes}"
+  local volumes="-v ${config_root}:${deployed_config_root}"
+  local run_cmd="${DOCKER_CMD} run -dt ${volumes}  --privileged"
 
-  local master_cid="$(${base_run_cmd} --privileged --name="${MASTER_NAME}" \
-      --hostname="${MASTER_NAME}" "${DIND_IMAGE}")"
-  local master_ip="$(get-docker-ip "${master_cid}")"
-
-  local node_cids=()
-  local node_ips=()
+  # Create containers
+  ${run_cmd} --name="${MASTER_NAME}" --hostname="${MASTER_NAME}" "${MASTER_IMAGE}" > /dev/null
   for name in "${NODE_NAMES[@]}"; do
-    local cid="$(${base_run_cmd} --privileged --name="${name}" \
-        --hostname="${name}" "${DIND_IMAGE}")"
-    node_cids+=( "${cid}" )
-    node_ips+=( "$(get-docker-ip "${cid}")" )
-  done
-  node_ips="$(os::provision::join , ${node_ips[@]})"
-
-  ## Provision containers
-  local args="${master_ip} ${NODE_COUNT} ${node_ips} ${INSTANCE_PREFIX} \
--n ${NETWORK_PLUGIN}"
-  if [[ "${SKIP_BUILD}" = "true" ]]; then
-      args="${args} -s"
-  fi
-
-  echo "Provisioning ${MASTER_NAME}"
-  local cmd="${SCRIPT_ROOT}/provision-master.sh ${args} -c \
-${DEPLOYED_CONFIG_ROOT}"
-  docker-exec-script "${master_cid}" "${cmd}"
-
-  if [[ "${DEPLOY_SSH}" = "true" ]]; then
-    ${DOCKER_CMD} exec -t "${master_cid}" ssh-keygen -N '' -q -f /root/.ssh/id_rsa
-    cmd="cat /root/.ssh/id_rsa.pub"
-    local public_key="$(${DOCKER_CMD} exec -t "${master_cid}" ${cmd})"
-    cmd="cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys"
-    ${DOCKER_CMD} exec -t "${master_cid}" ${cmd}
-    ${DOCKER_CMD} exec -t "${master_cid}" systemctl start sshd
-  fi
-
-  # Ensure that all users (e.g. outside the container) have read-write
-  # access to the openshift configuration.  Security shouldn't be a
-  # concern for dind since it should only be used for dev and test.
-  local openshift_config_path="${CONFIG_ROOT}/openshift.local.config"
-  find "${openshift_config_path}" -exec sudo chmod ga+rw {} \;
-  find "${openshift_config_path}" -type d -exec sudo chmod ga+x {} \;
-
-  for (( i=0; i < ${#node_cids[@]}; i++ )); do
-    local node_index=$((i + 1))
-    local cid="${node_cids[$i]}"
-    local name="${NODE_NAMES[$i]}"
-    echo "Provisioning ${name}"
-    cmd="${SCRIPT_ROOT}/provision-node.sh ${args} -i ${node_index} -c \
-${DEPLOYED_CONFIG_ROOT}"
-    docker-exec-script "${cid}" "${cmd}"
-
-    if [[ "${DEPLOY_SSH}" = "true" ]]; then
-      ${DOCKER_CMD} exec -t "${cid}" mkdir -p /root/.ssh
-      cmd="echo ${public_key} > /root/.ssh/authorized_keys"
-      ${DOCKER_CMD} exec -t "${cid}" bash -c "${cmd}"
-      ${DOCKER_CMD} exec -t "${cid}" systemctl start sshd
-    fi
+    ${run_cmd} --name="${name}" --hostname="${name}" "${NODE_IMAGE}" > /dev/null
   done
 
-  local rc_file="dind-${INSTANCE_PREFIX}.rc"
-  local admin_config="$(os::provision::get-admin-config ${CONFIG_ROOT})"
-  local bin_path="$(os::build::get-bin-output-path "${OS_ROOT}")"
+  local rc_file="dind-${cluster_id}.rc"
+  local admin_config
+  admin_config="$(get-admin-config "${CONFIG_ROOT}")"
+  local bin_path
+  bin_path="$(os::build::get-bin-output-path "${OS_ROOT}")"
   cat >"${rc_file}" <<EOF
 export KUBECONFIG=${admin_config}
 export PATH=\$PATH:${bin_path}
 EOF
 
-  # Disable the sdn node as late as possible to allow time for the
-  # node to register itself.
-  if [[ "${SDN_NODE}" = "true" ]]; then
-    os::provision::disable-node "${OS_ROOT}" "${CONFIG_ROOT}" \
-        "${SDN_NODE_NAME}"
+  if [[ -n "${wait_for_cluster}" ]]; then
+    wait-for-cluster "${config_root}" "${node_count}"
   fi
 
   if [[ "${KUBECONFIG:-}" != "${admin_config}"  ||
@@ -255,82 +127,116 @@ cluster's rc file to configure the bash environment:
 }
 
 function stop() {
-  echo "Cleaning up docker-in-docker containers"
+  local config_root=$1
+  local cluster_id=$2
 
-  local master_cid="$(${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}")"
+  echo "Stopping dind cluster '${cluster_id}'"
+
+  local master_cid
+  master_cid="$(${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}")"
   if [[ "${master_cid}" ]]; then
-    ${DOCKER_CMD} rm -f "${master_cid}"
+    ${DOCKER_CMD} rm -f "${master_cid}" > /dev/null
   fi
 
-  local node_cids="$(${DOCKER_CMD} ps -qa --filter "name=${NODE_PREFIX}")"
+  local node_cids
+  node_cids="$(${DOCKER_CMD} ps -qa --filter "name=${NODE_PREFIX}")"
   if [[ "${node_cids}" ]]; then
     node_cids=(${node_cids//\n/ })
     for cid in "${node_cids[@]}"; do
-      ${DOCKER_CMD} rm -f "${cid}"
+      ${DOCKER_CMD} rm -f "${cid}" > /dev/null
     done
   fi
 
-  echo "Cleanup up configuration to avoid conflict with a future cluster"
+  # Cleaning up configuration to avoid conflict with a future cluster
   # The container will have created configuration as root
-  sudo rm -rf ${CONFIG_ROOT}/openshift.local.*
+  sudo rm -rf "${config_root}"/openshift.local.etcd
+  sudo rm -rf "${config_root}"/openshift.local.config
 
   # Cleanup orphaned volumes
   #
   # See: https://github.com/jpetazzo/dind#important-warning-about-disk-usage
   #
-  echo "Cleaning up volumes used by docker-in-docker daemons"
-  local volume_ids=$(${DOCKER_CMD} volume ls -qf dangling=true)
-  if [[ "${volume_ids}" ]]; then
-    ${DOCKER_CMD} volume rm ${volume_ids}
-  fi
-}
-
-# Build and deploy openshift binaries to an existing cluster
-function redeploy() {
-  local node_service="openshift-node"
-
-  ${DOCKER_CMD} exec -t "${MASTER_NAME}" bash -c "\
-. ${SCRIPT_ROOT}/provision-util.sh ; \
-os::provision::build-origin ${DEPLOYED_ROOT} ${SKIP_BUILD}"
-
-  echo "Stopping ${MASTER_NAME} service(s)"
-  ${DOCKER_CMD} exec -t "${MASTER_NAME}" systemctl stop "${MASTER_NAME}"
-  if [[ "${SDN_NODE}" = "true" ]]; then
-    ${DOCKER_CMD} exec -t "${MASTER_NAME}" systemctl stop "${node_service}"
-  fi
-  echo "Updating ${MASTER_NAME} binaries"
-  ${DOCKER_CMD} exec -t "${MASTER_NAME}" bash -c \
-". ${SCRIPT_ROOT}/provision-util.sh ; \
-os::provision::install-cmds ${DEPLOYED_ROOT}"
-  echo "Starting ${MASTER_NAME} service(s)"
-  ${DOCKER_CMD} exec -t "${MASTER_NAME}" systemctl start "${MASTER_NAME}"
-  if [[ "${SDN_NODE}" = "true" ]]; then
-    ${DOCKER_CMD} exec -t "${MASTER_NAME}" systemctl start "${node_service}"
-  fi
-
-  for node_name in "${NODE_NAMES[@]}"; do
-    echo "Stopping ${node_name} service"
-    ${DOCKER_CMD} exec -t "${node_name}" systemctl stop "${node_service}"
-    echo "Updating ${node_name} binaries"
-    ${DOCKER_CMD} exec -t "${node_name}" bash -c "\
-. ${SCRIPT_ROOT}/provision-util.sh ; \
-os::provision::install-cmds ${DEPLOYED_ROOT}"
-    echo "Starting ${node_name} service"
-    ${DOCKER_CMD} exec -t "${node_name}" systemctl start "${node_service}"
+  for volume in $( ${DOCKER_CMD} volume ls -qf dangling=true ); do
+    ${DOCKER_CMD} volume rm "${volume}" > /dev/null
   done
 }
 
+function check-selinux() {
+  if [[ "$(getenforce)" = "Enforcing" ]]; then
+    >&2 echo "Error: This script is not compatible with SELinux enforcing mode."
+    exit 1
+  fi
+}
+
+function get-network-plugin() {
+  local plugin=$1
+
+  local subnet_plugin="redhat/openshift-ovs-subnet"
+  local multitenant_plugin="redhat/openshift-ovs-multitenant"
+  local default_plugin="${subnet_plugin}"
+
+  if [[ "${plugin}" != "${subnet_plugin}" &&
+          "${plugin}" != "${multitenant_plugin}" &&
+          "${plugin}" != "cni" ]]; then
+    if [[ -n "${plugin}" ]]; then
+      >&2 echo "Invalid network plugin: ${plugin}"
+    fi
+    plugin="${default_plugin}"
+  fi
+  echo "${plugin}"
+}
+
+function get-docker-ip() {
+  local cid=$1
+
+  ${DOCKER_CMD} inspect --format '{{ .NetworkSettings.IPAddress }}' "${cid}"
+}
+
+function get-admin-config() {
+  local config_root=$1
+
+  echo "${config_root}/openshift.local.config/master/admin.kubeconfig"
+}
+
+function copy-runtime() {
+  local origin_root=$1
+  local target=$2
+
+  cp "$(os::build::find-binary openshift)" "${target}"
+  local osdn_plugin_path="${origin_root}/pkg/sdn/plugin/bin"
+  cp "${osdn_plugin_path}/openshift-sdn-ovs" "${target}"
+  cp "${osdn_plugin_path}/openshift-sdn-docker-setup.sh" "${target}"
+}
+
+function wait-for-cluster() {
+  local config_root=$1
+  local expected_node_count=$2
+
+  # Increment the node count to ensure that the sdn node also reports readiness
+  (( expected_node_count++ ))
+
+  local kubeconfig
+  kubeconfig="$(get-admin-config "${config_root}")"
+  local oc
+  oc="$(os::build::find-binary oc)"
+
+  local msg="${expected_node_count} nodes to report readiness"
+  local condition="nodes-are-ready ${kubeconfig} ${oc} ${expected_node_count}"
+  os::util::wait-for-condition "${msg}" "${condition}"
+}
+
 function nodes-are-ready() {
-  local oc="$(os::build::find-binary oc)"
-  local kc="$(os::provision::get-admin-config ${CONFIG_ROOT})"
+  local kubeconfig=$1
+  local oc=$2
+  local expected_node_count=$3
+
+  # TODO - do not count any node whose name matches the master node e.g. 'node-master'
   read -d '' template <<'EOF'
 {{range $item := .items}}
-  {{if not .spec.unschedulable}}
-    {{range .status.conditions}}
-      {{if eq .type "Ready"}}
-        {{if eq .status "True"}}
-          {{printf "%s\\n" $item.metadata.name}}
-        {{end}}
+  {{range .status.conditions}}
+    {{if eq .type "Ready"}}
+      {{if eq .status "True"}}
+        {{printf "%s\\n" $item.metadata.name}}
       {{end}}
     {{end}}
   {{end}}
@@ -338,42 +244,130 @@ function nodes-are-ready() {
 EOF
   # Remove formatting before use
   template="$(echo "${template}" | tr -d '\n' | sed -e 's/} \+/}/g')"
-  local count="$("${oc}" --config="${kc}" get nodes \
-                         --template "${template}" | wc -l)"
-  test "${count}" -ge "${NODE_COUNT}"
+  local count
+  count="$("${oc}" --config="${kubeconfig}" get nodes \
+                   --template "${template}" 2> /dev/null | \
+                   wc -l)"
+  test "${count}" -ge "${expected_node_count}"
 }
 
-function wait-for-cluster() {
-  local msg="nodes to register with the master"
-  local condition="nodes-are-ready"
-  os::provision::wait-for-condition "${msg}" "${condition}"
+function build-images() {
+  local origin_root=$1
+
+  echo "Building container images"
+  build-image "${origin_root}/images/dind/" "${BASE_IMAGE}"
+  build-image "${origin_root}/images/dind/node" "${NODE_IMAGE}"
+  build-image "${origin_root}/images/dind/master" "${MASTER_IMAGE}"
 }
+
+function build-image() {
+  local build_root=$1
+  local image_name=$2
+
+  pushd "${build_root}" > /dev/null
+    ${DOCKER_CMD} build -t "${image_name}" .
+  popd > /dev/null
+}
+
+DOCKER_CMD=${DOCKER_CMD:-"sudo docker"}
+
+CLUSTER_ID="${OPENSHIFT_CLUSTER_ID:-openshift}"
+
+TMPDIR="${TMPDIR:-"/tmp"}"
+CONFIG_ROOT="${OPENSHIFT_CONFIG_ROOT:-${TMPDIR}/openshift-dind-cluster/${CLUSTER_ID}}"
+DEPLOYED_CONFIG_ROOT="/data"
+
+MASTER_NAME="${CLUSTER_ID}-master"
+NODE_PREFIX="${CLUSTER_ID}-node-"
+NODE_COUNT=2
+NODE_NAMES=()
+for (( i=1; i<=NODE_COUNT; i++ )); do
+  NODE_NAMES+=( "${NODE_PREFIX}${i}" )
+done
+
+BASE_IMAGE="openshift/dind"
+NODE_IMAGE="openshift/dind-node"
+MASTER_IMAGE="openshift/dind-master"
 
 case "${1:-""}" in
   start)
-    start
+    BUILD=
+    BUILD_IMAGES=
+    WAIT_FOR_CLUSTER=1
+    NETWORK_PLUGIN=
+    REMOVE_EXISTING_CLUSTER=
+    OPTIND=2
+    while getopts ":bin:rs" opt; do
+      case $opt in
+        b)
+          BUILD=1
+          ;;
+        i)
+          BUILD_IMAGES=1
+          ;;
+        n)
+          NETWORK_PLUGIN="${OPTARG}"
+          ;;
+        r)
+          REMOVE_EXISTING_CLUSTER=1
+          ;;
+        s)
+          WAIT_FOR_CLUSTER=
+          ;;
+        \?)
+          echo "Invalid option: -${OPTARG}" >&2
+          exit 1
+          ;;
+        :)
+          echo "Option -${OPTARG} requires an argument." >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    if [[ -n "${REMOVE_EXISTING_CLUSTER}" ]]; then
+      stop "${CONFIG_ROOT}" "${CLUSTER_ID}"
+    fi
+
+    # Build origin if requested or required
+    if [[ -n "${BUILD}" || -z "$(os::build::find-binary oc)" ]]; then
+      "${OS_ROOT}/hack/build-go.sh"
+    fi
+
+    # Build images if requested or required
+    if [[ -n "${BUILD_IMAGES}" ||
+            -z "$(${DOCKER_CMD} images -q ${MASTER_IMAGE})" ]]; then
+      build-images "${OS_ROOT}"
+    fi
+
+    NETWORK_PLUGIN="$(get-network-plugin "${NETWORK_PLUGIN}")"
+    start "${OS_ROOT}" "${CONFIG_ROOT}" "${DEPLOYED_CONFIG_ROOT}" \
+          "${CLUSTER_ID}" "${NETWORK_PLUGIN}" "${WAIT_FOR_CLUSTER}" \
+          "${NODE_COUNT}" "${NODE_PREFIX}"
     ;;
   stop)
-    stop
-    ;;
-  restart)
-    stop
-    start
-    ;;
-  redeploy)
-    redeploy
+    stop "${CONFIG_ROOT}" "${CLUSTER_ID}"
     ;;
   wait-for-cluster)
-    wait-for-cluster
+    wait-for-cluster "${CONFIG_ROOT}" "${NODE_COUNT}"
     ;;
   build-images)
-    BUILD_IMAGES=1
-    build-images
-    ;;
-  config-host)
-    os::provision::set-os-env "${OS_ROOT}" "${CONFIG_ROOT}"
+    build-images "${OS_ROOT}"
     ;;
   *)
-    echo "Usage: $0 {start|stop|restart|redeploy|wait-for-cluster|build-images|config-host}"
+    >&2 echo "Usage: $0 {start|stop|wait-for-cluster|build-images}
+
+start accepts the following arguments:
+
+ -n [net plugin]   the name of the network plugin to deploy
+
+ -b                build origin before starting the cluster
+
+ -i                build container images before starting the cluster
+
+ -r                remove an existing cluster
+
+ -s                skip waiting for nodes to become ready
+"
     exit 2
 esac

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -52,6 +52,7 @@ RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
 RUN dnf -y update && dnf -y install\
  docker\
  iptables\
+ openssh-clients\
  openssh-server\
  && dnf clean all
 

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -1,13 +1,35 @@
 #
-# This image is used for running a host of an openshift dev cluster. This image is
-# a development support image and should not be used in production environments.
+# Image configured with systemd and docker-in-docker.  Useful for
+# simulating multinode deployments.
 #
 # The standard name for this image is openshift/dind
 #
+# Notes:
+#
+#  - disable SELinux on the docker host (not compatible with dind)
+#
+#  - to use the overlay graphdriver, ensure the overlay module is
+#    installed on the docker host
+#
+#      $ modprobe overlay
+#
+#  - run with --privileged
+#
+#      $ docker run -d --privileged openshift/dind
+#
+
 FROM fedora:24
 
+# Fix 'WARNING: terminal is not fully functional' when TERM=dumb
+ENV TERM=xterm
+
 ## Configure systemd to run in a container
+
 ENV container=docker
+
+VOLUME ["/run", "/tmp"]
+
+STOPSIGNAL SIGRTMIN+3
 
 RUN systemctl mask\
  auditd.service\
@@ -24,34 +46,33 @@ RUN systemctl mask\
  systemd-udev-trigger.service\
  systemd-udevd.service\
  systemd-vconsole-setup.service
+RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
+ sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 
-RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; \
-  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+RUN dnf -y update && dnf -y install\
+ docker\
+ iptables\
+ openssh-server\
+ && dnf clean all
 
-VOLUME ["/run", "/tmp"]
+## Configure docker
 
-## Install packages
-RUN dnf -y update && dnf -y install git golang hg tar make findutils \
-  gcc hostname bind-utils iproute iputils which procps-ng openssh-server \
-  # Node-specific packages
-  docker openvswitch bridge-utils ethtool iptables-services \
-  && dnf clean all
-
-# sshd should be enabled as needed
-RUN systemctl disable sshd.service
+RUN systemctl enable docker.service
 
 # Default storage to vfs.  overlay will be enabled at runtime if available.
 RUN echo "DOCKER_STORAGE_OPTIONS=--storage-driver vfs" >\
  /etc/sysconfig/docker-storage
 
-RUN systemctl enable docker
+COPY dind-setup.sh /usr/local/bin
+COPY dind-setup.service /etc/systemd/system/
+RUN systemctl enable dind-setup.service
 
-VOLUME /var/lib/docker
+VOLUME ["/var/lib/docker"]
 
-## Hardlink init to another name to avoid having oci-systemd-hooks
-## detect containers using this image as requiring read-only cgroup
-## mounts.  dind containers should be run with --privileged to ensure
-## cgroups mounted with read-write permissions.
+# Hardlink init to another name to avoid having oci-systemd-hooks
+# detect containers using this image as requiring read-only cgroup
+# mounts.  containers running docker need to be run with --privileged
+# to ensure cgroups are mounted with read-write permissions.
 RUN ln /usr/sbin/init /usr/sbin/dind_init
 
 CMD ["/usr/sbin/dind_init"]

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -49,11 +49,19 @@ RUN systemctl mask\
 RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 
+# Remove non-english translations for glibc to reduce image size by 100mb.
+# docker-v1.10-migrator is unnecessary for a new docker installation
+# selinux-policy-minimum is unnecessary since selinux won't be enabled
 RUN dnf -y update && dnf -y install\
  docker\
+ glibc-langpack-en\
  iptables\
  openssh-clients\
  openssh-server\
+ && dnf -y remove\
+ docker-v1.10-migrator\
+ glibc-all-langpacks\
+ selinux-policy-minimum\
  && dnf clean all
 
 ## Configure docker

--- a/images/dind/Dockerfile.centos7
+++ b/images/dind/Dockerfile.centos7
@@ -1,13 +1,35 @@
 #
-# This image is used for running a host of an openshift dev cluster. This image is
-# a development support image and should not be used in production environments.
+# Image configured with systemd and docker-in-docker.  Useful for
+# simulating multinode deployments.
 #
 # The standard name for this image is openshift/dind
 #
-FROM centos:centos7
+# Notes:
+#
+#  - disable SELinux on the docker host (not compatible with dind)
+#
+#  - to use the overlay graphdriver, ensure the overlay module is
+#    installed on the docker host
+#
+#      $ modprobe overlay
+#
+#  - run with --privileged
+#
+#      $ docker run -d --privileged openshift/dind
+#
+
+FROM centos:systemd
+
+# Fix 'WARNING: terminal is not fully functional' when TERM=dumb
+ENV TERM=xterm
 
 ## Configure systemd to run in a container
+
 ENV container=docker
+
+VOLUME ["/run", "/tmp"]
+
+STOPSIGNAL SIGRTMIN+3
 
 RUN systemctl mask\
  auditd.service\
@@ -24,44 +46,33 @@ RUN systemctl mask\
  systemd-udev-trigger.service\
  systemd-udevd.service\
  systemd-vconsole-setup.service
+RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
+ sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 
-RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; \
-  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+RUN yum -y update && yum -y install\
+ docker\
+ iptables\
+ openssh-server\
+ && yum clean all
 
-VOLUME ["/run", "/tmp"]
+## Configure docker
 
-## Install origin repo
-RUN INSTALL_PKGS="centos-release-openshift-origin" && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    yum clean all
+RUN systemctl enable docker.service
 
-## Install packages
-RUN INSTALL_PKGS="git golang mercurial tar make findutils \
-      gcc hostname bind-utils iproute iputils which procps-ng openssh-server \
-      docker openvswitch bridge-utils ethtool iptables-services" && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V --nofiles $INSTALL_PKGS && \
-    yum clean all
+# Default storage to vfs.  overlay will be enabled at runtime if available.
+RUN echo "DOCKER_STORAGE_OPTIONS=--storage-driver vfs" >\
+ /etc/sysconfig/docker-storage
 
-# sshd should be enabled as needed
-RUN systemctl disable sshd.service
+COPY dind-setup.sh /usr/local/bin
+COPY dind-setup.service /etc/systemd/system/
+RUN systemctl enable dind-setup.service
 
-## Configure dind
-ENV DIND_COMMIT 81aa1b507f51901eafcfaad70a656da376cf937d
-RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" \
-  -o /usr/local/bin/dind && chmod +x /usr/local/bin/dind
-RUN mkdir -p /etc/systemd/system/docker.service.d
-COPY dind.conf /etc/systemd/system/docker.service.d/
+VOLUME ["/var/lib/docker"]
 
-RUN systemctl enable docker
-
-VOLUME /var/lib/docker
-
-## Hardlink init to another name to avoid having oci-systemd-hooks
-## detect containers using this image as requiring read-only cgroup
-## mounts.  dind containers should be run with --privileged to ensure
-## cgroups mounted with read-write permissions.
+# Hardlink init to another name to avoid having oci-systemd-hooks
+# detect containers using this image as requiring read-only cgroup
+# mounts.  containers running docker need to be run with --privileged
+# to ensure cgroups are mounted with read-write permissions.
 RUN ln /usr/sbin/init /usr/sbin/dind_init
 
 CMD ["/usr/sbin/dind_init"]

--- a/images/dind/dind-setup.service
+++ b/images/dind/dind-setup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=docker-in-docker setup
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash /usr/local/bin/dind-setup.sh
+
+[Install]
+RequiredBy=docker.service

--- a/images/dind/dind-setup.sh
+++ b/images/dind/dind-setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Enable overlayfs for dind if it can be tested to work.
+function enable-overlay-storage() {
+  local storage_dir=${1:-/var/lib/docker}
+
+  local msg=""
+
+  if grep -q overlay /proc/filesystems; then
+    # Smoke test the overlay filesystem:
+
+    # 1. create smoke dir in the storage dir being mounted
+    local d="${storage_dir}/smoke"
+    mkdir -p "${d}/upper" "${d}/lower" "${d}/work" "${d}/mount"
+
+    # 2. try to mount an overlay fs on top of the smoke dir
+    local overlay_works=1
+    mount -t overlay overlay\
+          -o"lowerdir=${d}/lower,upperdir=${d}/upper,workdir=${d}/work"\
+          "${d}/mount" &&\
+    # 3. try to write a file in the overlay mount
+          echo foo > "${d}/mount/probe" || overlay_works=
+
+    umount -f "${d}/mount" || true
+    rm -rf "${d}" || true
+
+    if [[ -n "${overlay_works}" ]]; then
+      msg="Enabling overlay storage for docker-in-docker"
+      sed -i -e 's+vfs+overlay+' /etc/sysconfig/docker-storage
+    fi
+  fi
+
+  if [[ -z "${msg}" ]]; then
+    msg="WARNING: Unable to enable overlay storage for docker-in-docker"
+  fi
+
+  echo "${msg}"
+}
+
+mount --make-shared /
+enable-overlay-storage

--- a/images/dind/master/Dockerfile
+++ b/images/dind/master/Dockerfile
@@ -1,0 +1,29 @@
+#
+# This image is for the master of an openshift dind dev cluster.
+#
+# The standard name for this image is openshift/dind-master
+#
+
+FROM openshift/dind-node
+
+# Disable iptables on the master since it will prevent access to the
+# openshift api from outside the master.
+RUN systemctl disable iptables.service
+
+COPY openshift-generate-master-config.sh /usr/local/bin/
+
+COPY openshift-disable-master-node.sh /usr/local/bin/
+COPY openshift-disable-master-node.service /etc/systemd/system/
+RUN systemctl enable openshift-disable-master-node.service
+
+COPY openshift-get-hosts.sh /usr/local/bin/
+COPY openshift-add-to-hosts.sh /usr/local/bin/
+COPY openshift-remove-from-hosts.sh /usr/local/bin/
+COPY openshift-sync-etc-hosts.service /etc/systemd/system/
+RUN systemctl enable openshift-sync-etc-hosts.service
+
+COPY openshift-master.service /etc/systemd/system/
+RUN systemctl enable openshift-master.service
+
+RUN mkdir -p /etc/systemd/system/openshift-node.service.d
+COPY master-node.conf /etc/systemd/system/openshift-node.service.d/

--- a/images/dind/master/master-node.conf
+++ b/images/dind/master/master-node.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=network.target openshift-master.service
+After=docker.target network.target openshift-master.service

--- a/images/dind/master/openshift-add-to-hosts.sh
+++ b/images/dind/master/openshift-add-to-hosts.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ENTRY="$2\t$1"
+if ! grep -qP "${ENTRY}" /etc/hosts; then
+  # The ip + hostname combination are not present
+  if grep -qP "\t$1$" /etc/hosts; then
+    # The hostname is present with a different ip
+    /usr/local/bin/openshift-remove-from-hosts.sh "$1"
+  fi
+  echo -e "${ENTRY}" >> /etc/hosts
+fi

--- a/images/dind/master/openshift-disable-master-node.service
+++ b/images/dind/master/openshift-disable-master-node.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Disable scheduling for master node
+Requires=openshift-node.service
+After=openshift-node.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/openshift-disable-master-node.sh
+
+[Install]
+WantedBy=openshift-node.service

--- a/images/dind/master/openshift-disable-master-node.sh
+++ b/images/dind/master/openshift-disable-master-node.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+
+function is-node-registered() {
+  local config=$1
+  local node_name=$2
+
+  /usr/local/bin/oc --config="${config}" get nodes "${node_name}" &> /dev/null
+}
+
+function disable-node() {
+  local config=$1
+  local node_name=$2
+
+  local msg="${node_name} to register with the master"
+  local condition="is-node-registered ${config} ${node_name}"
+  os::util::wait-for-condition "${msg}" "${condition}" "${OS_WAIT_FOREVER}"
+
+  echo "Disabling scheduling for node ${node_name}"
+  /usr/local/bin/osadm --config="${config}" manage-node "${node_name}" --schedulable=false > /dev/null
+}
+
+disable-node /data/openshift.local.config/master/admin.kubeconfig "$(hostname)-node"

--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Should set OPENSHIFT_NETWORK_PLUGIN
+source /data/network-plugin
+
+function ensure-master-config() {
+  local config_path="/data/openshift.local.config"
+  local master_path="${config_path}/master"
+  local config_file="${master_path}/master-config.yaml"
+
+  if [[ -f "${config_file}" ]]; then
+    # Config has already been generated
+    return
+  fi
+
+  local ip_addr
+  ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+  local name
+  name="$(hostname)"
+
+  /usr/local/bin/openshift admin ca create-master-certs \
+    --overwrite=false \
+    --cert-dir="${master_path}" \
+    --master="https://${ip_addr}:8443" \
+    --hostnames="${ip_addr},${name}"
+
+  /usr/local/bin/openshift start master --write-config="${master_path}" \
+    --master="https://${ip_addr}:8443" \
+    --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}"
+
+  # ensure the configuration is readable outside of the container
+  find "${config_path}" -exec chmod ga+rw {} \;
+  find "${config_path}" -type d -exec chmod ga+x {} \;
+}
+
+ensure-master-config

--- a/images/dind/master/openshift-get-hosts.sh
+++ b/images/dind/master/openshift-get-hosts.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+grep '\-node' /etc/hosts | awk '{print $2}'

--- a/images/dind/master/openshift-master.service
+++ b/images/dind/master/openshift-master.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenShift Master
+Requires=network.target
+After=docker.target network.target
+
+[Service]
+ExecStartPre=/usr/local/bin/openshift-generate-master-config.sh
+ExecStart=/usr/local/bin/openshift start master --loglevel=5 \
+  --config=/data/openshift.local.config/master/master-config.yaml
+WorkingDirectory=/data
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/images/dind/master/openshift-remove-from-hosts.sh
+++ b/images/dind/master/openshift-remove-from-hosts.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+grep -vP "\t$1$" /etc/hosts > /tmp/newhosts
+# mv -f won't work due to the way docker mounts /etc/hosts
+cat /tmp/newhosts > /etc/hosts
+rm /tmp/newhosts

--- a/images/dind/master/openshift-sync-etc-hosts.service
+++ b/images/dind/master/openshift-sync-etc-hosts.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Synchronize /etc/hosts with cluster node state
+Requires=openshift-master.service
+After=openshift-master.service
+
+[Service]
+ExecStart=/usr/local/bin/oc observe nodes -a '{ .status.addresses[0].address }' \
+  --config=/data/openshift.local.config/master/admin.kubeconfig \
+  --names /usr/local/bin/openshift-get-hosts.sh \
+  --delete /usr/local/bin/openshift-remove-from-hosts.sh \
+  -- /usr/local/bin/openshift-add-to-hosts.sh
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=openshift-master.service

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf -y update && dnf -y install\
  hostname\
  iproute\
  iputils\
+ less\
  procps-ng\
  tar\
  which\

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -44,6 +44,10 @@ RUN systemctl enable openshift-node.service
 # Ensure the working directory for the unit file exists
 RUN mkdir -p /var/lib/origin
 
+COPY openshift-enable-ssh-access.sh /usr/local/bin/
+COPY openshift-enable-ssh-access.service /etc/systemd/system/
+RUN systemctl enable openshift-enable-ssh-access.service
+
 # Symlink from the data path intended to be mounted as a volume to
 # make reloading easy.  Revisit if/when dind becomes useful for more
 # than dev/test.

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -1,0 +1,63 @@
+#
+# This is the base image for nodes of an openshift dind dev cluster.
+#
+# The standard name for this image is openshift/dind-node
+#
+
+FROM openshift/dind
+
+## Install packages
+RUN dnf -y update && dnf -y install\
+ bind-utils\
+ findutils\
+ hostname\
+ iproute\
+ iputils\
+ procps-ng\
+ tar\
+ which\
+ # Node-specific packages
+ bridge-utils\
+ ethtool\
+ iptables-services\
+ openvswitch\
+ && dnf clean all
+
+# A default deny firewall (either iptables or firewalld) is
+# installed by default on non-cloud fedora and rhel, so all
+# network plugins need to be able to work with one enabled.
+RUN systemctl enable iptables.service
+
+# Ensure that master-to-kubelet communication will work with iptables
+COPY iptables /etc/sysconfig/
+
+COPY openshift-generate-node-config.sh /usr/local/bin/
+COPY openshift-dind-lib.sh /usr/local/bin/
+
+RUN mkdir -p /etc/systemd/system/docker.service.d
+COPY docker-sdn-ovs.conf /etc/systemd/system/docker.service.d/
+
+RUN systemctl enable openvswitch
+
+COPY openshift-node.service /etc/systemd/system/
+RUN systemctl enable openshift-node.service
+# Ensure the working directory for the unit file exists
+RUN mkdir -p /var/lib/origin
+
+# Symlink from the data path intended to be mounted as a volume to
+# make reloading easy.  Revisit if/when dind becomes useful for more
+# than dev/test.
+RUN ln -sf /data/openshift-sdn-ovs /usr/local/bin/ && \
+    ln -sf /data/openshift-sdn-docker-setup.sh /usr/local/bin/ && \
+    ln -sf /data/openshift /usr/local/bin/ && \
+    ln -sf /data/openshift /usr/local/bin/oc && \
+    ln -sf /data/openshift /usr/local/bin/oadm && \
+    ln -sf /data/openshift /usr/local/bin/osc && \
+    ln -sf /data/openshift /usr/local/bin/osadm && \
+    ln -sf /data/openshift /usr/local/bin/kubectl && \
+    ln -sf /data/openshift /usr/local/bin/openshift-deploy && \
+    ln -sf /data/openshift /usr/local/bin/openshift-docker-build && \
+    ln -sf /data/openshift /usr/local/bin/openshift-sti-build && \
+    ln -sf /data/openshift /usr/local/bin/openshift-f5-router
+
+ENV KUBECONFIG /data/openshift.local.config/master/admin.kubeconfig

--- a/images/dind/node/docker-sdn-ovs.conf
+++ b/images/dind/node/docker-sdn-ovs.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=-/run/openshift-sdn/docker-network

--- a/images/dind/node/iptables
+++ b/images/dind/node/iptables
@@ -1,0 +1,16 @@
+# sample configuration for iptables service
+# you can edit this manually or use system-config-firewall
+# please do not ask us to add additional ports/services to this default configuration
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+# Ensure the master can talk to the kubelet
+-A INPUT -p tcp -m state --state NEW -m tcp --dport 10250 -j ACCEPT
+-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+COMMIT

--- a/images/dind/node/openshift-dind-lib.sh
+++ b/images/dind/node/openshift-dind-lib.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# This library holds utility functions used by dind deployment and images.  Since
+# it is intended to be distributed standalone in dind images, it cannot depend
+# on any functions outside of this file.
+
+# os::util::wait-for-condition blocks until the provided condition becomes true
+#
+# Globals:
+#  None
+# Arguments:
+#  - 1: message indicating what conditions is being waited for (e.g. 'config to be written')
+#  - 2: a string representing an eval'able condition.  When eval'd it should not output
+#       anything to stdout or stderr.
+#  - 3: optional timeout in seconds.  If not provided, defaults to 60s.  If OS_WAIT_FOREVER
+#       is provided, wait forever.
+# Returns:
+#  1 if the condition is not met before the timeout
+readonly OS_WAIT_FOREVER=-1
+function os::util::wait-for-condition() {
+  local msg=$1
+  # condition should be a string that can be eval'd.  When eval'd, it
+  # should not output anything to stderr or stdout.
+  local condition=$2
+  local timeout=${3:-60}
+
+  local start_msg="Waiting for ${msg}"
+  local error_msg="[ERROR] Timeout waiting for ${msg}"
+
+  local counter=0
+  while ! ${condition}; do
+    if [[ "${counter}" = "0" ]]; then
+      echo "${start_msg}"
+    fi
+
+    if [[ "${counter}" -lt "${timeout}" ||
+            "${timeout}" = "${OS_WAIT_FOREVER}" ]]; then
+      counter=$((counter + 1))
+      if [[ "${timeout}" != "${OS_WAIT_FOREVER}" ]]; then
+        echo -n '.'
+      fi
+      sleep 1
+    else
+      echo -e "\n${error_msg}"
+      return 1
+    fi
+  done
+
+  if [[ "${counter}" != "0" && "${timeout}" != "${OS_WAIT_FOREVER}" ]]; then
+    echo -e '\nDone'
+  fi
+}
+readonly -f os::util::wait-for-condition

--- a/images/dind/node/openshift-dind-lib.sh
+++ b/images/dind/node/openshift-dind-lib.sh
@@ -51,3 +51,16 @@ function os::util::wait-for-condition() {
   fi
 }
 readonly -f os::util::wait-for-condition
+
+# os::util::is-master indicates whether the host is configured to be an OpenShift master
+#
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  1 if host is a master, 0 otherwise
+function os::util::is-master() {
+   test -f "/etc/systemd/system/openshift-master.service"
+}
+readonly -f os::util::is-master

--- a/images/dind/node/openshift-enable-ssh-access.service
+++ b/images/dind/node/openshift-enable-ssh-access.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Enable ssh access to cluster
+Requires=sshd.service
+After=sshd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/openshift-enable-ssh-access.sh
+
+[Install]
+WantedBy=sshd.service

--- a/images/dind/node/openshift-enable-ssh-access.sh
+++ b/images/dind/node/openshift-enable-ssh-access.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+
+PUBLIC_KEY="/data/id_rsa.pub"
+
+if os::util::is-master; then
+  # Generate the keypair
+  ssh-keygen -N '' -q -f /root/.ssh/id_rsa
+  cp /root/.ssh/id_rsa.pub "${PUBLIC_KEY}"
+else
+  # Wait for the master to generate the keypair
+  CONDITION="test -f ${PUBLIC_KEY}"
+  os::util::wait-for-condition "public key to be generated" "${CONDITION}" "${OS_WAIT_FOREVER}"
+fi
+
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+cp "${PUBLIC_KEY}" /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+# Should set OPENSHIFT_NETWORK_PLUGIN
+source /data/network-plugin
+
+function ensure-node-config() {
+  local deployed_config_path="/var/lib/origin/openshift.local.config/node"
+  local deployed_config_file="${deployed_config_path}/node-config.yaml"
+
+  if [[ -f "${deployed_config_file}" ]]; then
+    # Config has already been deployed
+    return
+  fi
+
+  local config_path="/data/openshift.local.config"
+  local host
+  host="$(hostname)"
+  if [[ -f "/etc/systemd/system/openshift-master.service" ]]; then
+    host="${host}-node"
+  fi
+  local node_config_path="${config_path}/node-${host}"
+  local config_file="${node_config_path}/node-config.yaml"
+
+  # If the node config has not been generated
+  if [[ ! -f "${config_file}" ]]; then
+    local master_config_path="${config_path}/master"
+
+    # Wait for the master to generate its config
+    local condition="test -f ${master_config_path}/admin.kubeconfig"
+    os::util::wait-for-condition "admin config" "${condition}" "${OS_WAIT_FOREVER}"
+
+    local master_host
+    master_host="$(grep server "${master_config_path}/admin.kubeconfig" | grep -v localhost | awk '{print $2}')"
+
+    local ip_addr
+    ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+
+    /usr/local/bin/openshift admin create-node-config \
+      --node-dir="${config_path}" \
+      --node="${host}" \
+      --master="${master_host}" \
+      --hostnames="${host},${ip_addr}" \
+      --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
+      --node-client-certificate-authority="${master_config_path}/ca.crt" \
+      --certificate-authority="${master_config_path}/ca.crt" \
+      --signer-cert="${master_config_path}/ca.crt" \
+      --signer-key="${master_config_path}/ca.key" \
+      --signer-serial="${master_config_path}/ca.serial.txt"
+  fi
+
+  # Deploy the node config
+  mkdir -p "${deployed_config_path}"
+  cp -r "${config_path}"/* "${deployed_config_path}"
+}
+
+ensure-node-config

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -20,7 +20,7 @@ function ensure-node-config() {
   local config_path="/data/openshift.local.config"
   local host
   host="$(hostname)"
-  if [[ -f "/etc/systemd/system/openshift-master.service" ]]; then
+  if os::util::is-master; then
     host="${host}-node"
   fi
   local node_config_path="${config_path}/node-${host}"

--- a/images/dind/node/openshift-node.service
+++ b/images/dind/node/openshift-node.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenShift Node
+Requires=network.target
+After=docker.target network.target
+
+[Service]
+ExecStartPre=/usr/local/bin/openshift-generate-node-config.sh
+ExecStart=/usr/local/bin/openshift start node --loglevel=5 \
+  --config=/var/lib/origin/openshift.local.config/node/node-config.yaml
+WorkingDirectory=/var/lib/origin
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This looks like a big change, but it's mostly shifting code around to remove dependency on contrib/vagrant and move towards being able to deploy on kube/openshift.

- refactor hack/dind-cluster.sh
   - remove dependency on contrib/vagrant/* so it can be deleted as part of the move to openshift-ansible for dev cluster deployment (cc: @stevekuznetsov)
   - use flags as much as possible when starting a cluster (cc: @danwinship)
   - build images and binaries only if necessary or requested to do so, and build on the host rather than in the container (cc: @smarterclayton)
   - perform host modification in a privileged docker container to ensure the docker host is modified even if docker is running remotely
   - minimize unnecessary output
- create new openshift/dind base image that runs only systemd+dind so it can be reused for testing things like openshift-ansible (cc: @sdodson, @stevekuznetsov)
- create new openshift/dind-node and openshift/dind-master images
   - use systemd units instead of post-build configuration for:
     - generating cluster configuration (likely to be replaced by something kubeadm-like)
     - disabling the master node
 
cc: @openshift/networking 