### PR TITLE
Fix condition on schedulable in oc adm manage-node

### DIFF
--- a/pkg/cmd/admin/node/schedulable.go
+++ b/pkg/cmd/admin/node/schedulable.go
@@ -20,7 +20,7 @@ func (s *SchedulableOptions) Run() error {
 	errList := []error{}
 	var printer kubectl.ResourcePrinter
 	for _, node := range nodes {
-		if node.Spec.Unschedulable == !s.Schedulable {
+		if node.Spec.Unschedulable == s.Schedulable {
 			node.Spec.Unschedulable = !s.Schedulable
 			node, err = s.Options.Kclient.Nodes().Update(node)
 			if err != nil {

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -73,6 +73,8 @@ status:
 
 os::cmd::expect_success_and_text 'oadm manage-node --selector= --schedulable=true' 'Ready'
 os::cmd::expect_success_and_not_text 'oadm manage-node --selector= --schedulable=true' 'Sched'
+os::cmd::expect_success_and_text 'oadm manage-node --selector= --schedulable=false' 'SchedulingDisabled'
+os::cmd::expect_success_and_not_text 'oadm manage-node --selector= --schedulable=true' 'SchedulingDisabled'
 echo "manage-node: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/11070

With this fix applied, you get the right behavior:

```console
[@dev] .../openshift/origin # oc adm manage-node dev --schedulable=true --config=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
NAME      STATUS    AGE
dev       Ready     35m
[@dev] .../openshift/origin # oc adm manage-node dev --schedulable=false --config=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
NAME      STATUS                     AGE
dev       Ready,SchedulingDisabled   35m
[@dev] .../openshift/origin # oc adm manage-node dev --schedulable=true --config=/var/lib/openshift/openshift.local.config/master/admin.kubeconfig
NAME      STATUS    AGE
dev       Ready     35m
```