### PR TITLE
Drop EgressNetworkPolicy 1.2->1.3 upgrade code

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/origin/pkg/util/ovs"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapierrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/sysctl"
@@ -36,8 +35,6 @@ const (
 	VXLAN    = "vxlan0"
 
 	VXLAN_PORT = "4789"
-
-	EgressNetworkPolicyFailureLabel = "network.openshift.io/not-enforcing-egress-network-policy"
 )
 
 func getPluginVersion(multitenant bool) []string {
@@ -356,46 +353,10 @@ func (plugin *OsdnNode) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesNe
 	return true, nil
 }
 
-func (plugin *OsdnNode) updateEgressNetworkPolicyFailureLabel(failure bool) error {
-	node, err := plugin.kClient.Nodes().Get(plugin.hostName)
-	if err != nil {
-		return err
-	}
-	if failure {
-		if node.Labels == nil {
-			node.Labels = make(map[string]string)
-		}
-		node.Labels[EgressNetworkPolicyFailureLabel] = "true"
-	} else {
-		label, ok := node.Labels[EgressNetworkPolicyFailureLabel]
-		if !ok || label != "true" {
-			return nil
-		}
-		delete(node.Labels, EgressNetworkPolicyFailureLabel)
-	}
-
-	_, err = plugin.kClient.Nodes().UpdateStatus(node)
-	return err
-}
-
 func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 	policies, err := plugin.osClient.EgressNetworkPolicies(kapi.NamespaceAll).List(kapi.ListOptions{})
 	if err != nil {
-		if kapierrs.IsForbidden(err) {
-			// 1.3 node running with 1.2-bootstrapped policies
-			glog.Errorf("WARNING: EgressNetworkPolicy is not being enforced - please ensure your nodes have access to view EgressNetworkPolicy (eg, 'oadm policy reconcile-cluster-roles')")
-			err := plugin.updateEgressNetworkPolicyFailureLabel(true)
-			if err != nil {
-				return fmt.Errorf("could not update %q label on Node: %v", EgressNetworkPolicyFailureLabel, err)
-			}
-			return nil
-		}
-		return fmt.Errorf("could not get EgressNetworkPolicies: %s", err)
-	} else {
-		err = plugin.updateEgressNetworkPolicyFailureLabel(false)
-		if err != nil {
-			glog.Warningf("could not remove %q label on Node: %v", EgressNetworkPolicyFailureLabel, err)
-		}
+		return fmt.Errorf("Could not get EgressNetworkPolicies: %s", err)
 	}
 
 	for _, policy := range policies.Items {

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/origin/pkg/sdn/plugin/api"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapierrs "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	pconfig "k8s.io/kubernetes/pkg/proxy/config"
@@ -60,11 +59,7 @@ func (proxy *ovsProxyPlugin) Start(baseHandler pconfig.EndpointsConfigHandler) e
 
 	policies, err := proxy.osClient.EgressNetworkPolicies(kapi.NamespaceAll).List(kapi.ListOptions{})
 	if err != nil {
-		if kapierrs.IsForbidden(err) {
-			// controller.go will log an error about this
-			return nil
-		}
-		return fmt.Errorf("could not get EgressNetworkPolicies: %s", err)
+		return fmt.Errorf("Could not get EgressNetworkPolicies: %s", err)
 	}
 	for _, policy := range policies.Items {
 		proxy.updateNetworkPolicy(policy)


### PR DESCRIPTION
This drops the code we added to warn people about doing reconcile-cluster-roles after a 1.2->1.3 upgrade, as per discussion in #10358.

Closes #10413 

@openshift/networking PTAL