### PR TITLE
[WIP] Support more slashes in image names

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -8,7 +8,7 @@ import (
 )
 
 var NameMayNotBe = []string{".", ".."}
-var NameMayNotContain = []string{"/", "%"}
+var NameMayNotContain = []string{"%"}
 
 func MinimalNameRequirements(name string, prefix bool) []string {
 	for _, illegalName := range NameMayNotBe {

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -185,6 +185,13 @@ func TestParseDockerImageReference(t *testing.T) {
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 		{
+			From:      "bar/foo/baz/biz/zoo@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz/biz/zoo",
+			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+		},
+		{
 			From:      "bar:5000/foo/baz",
 			Registry:  "bar:5000",
 			Namespace: "foo",
@@ -209,10 +216,24 @@ func TestParseDockerImageReference(t *testing.T) {
 			Tag:       "tag",
 		},
 		{
+			From:      "bar:5000/foo/baf/bof/baz:tag",
+			Registry:  "bar:5000",
+			Namespace: "foo",
+			Name:      "baf/bof/baz",
+			Tag:       "tag",
+		},
+		{
 			From:      "bar:5000/foo/baz@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 			Registry:  "bar:5000",
 			Namespace: "foo",
 			Name:      "baz",
+			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+		},
+		{
+			From:      "bar:5000/foo/baf/baz@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Registry:  "bar:5000",
+			Namespace: "foo",
+			Name:      "baf/baz",
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 		{
@@ -221,9 +242,27 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:     "foo",
 		},
 		{
+			From:      "myregistry.io/foo/bar/baz",
+			Registry:  "myregistry.io",
+			Namespace: "foo",
+			Name:      "bar/baz",
+		},
+		{
 			From:     "localhost/bar",
 			Registry: "localhost",
 			Name:     "bar",
+		},
+		{
+			From:      "localhost/bar/baz",
+			Registry:  "localhost",
+			Namespace: "bar",
+			Name:      "baz",
+		},
+		{
+			From:      "localhost/bar/baz/foo",
+			Registry:  "localhost",
+			Namespace: "bar",
+			Name:      "baz/foo",
 		},
 		{
 			From:      "docker.io/library/myapp",
@@ -238,10 +277,8 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:      "myapp",
 		},
 		{
-			From:      "docker.io/user/myapp",
-			Registry:  "docker.io",
-			Namespace: "user",
-			Name:      "myapp",
+			From: "docker.io/user/myapp/foo/bar",
+			Err:  true,
 		},
 		{
 			From:      "index.docker.io/bar",
@@ -291,8 +328,10 @@ func TestParseDockerImageReference(t *testing.T) {
 			Err:  true,
 		},
 		{
-			From: "bar/foo/baz/biz",
-			Err:  true,
+			From:      "bar/foo/baz/biz",
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz/biz",
 		},
 		{
 			From: "ftp://baz/baz/biz",

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -34,12 +34,16 @@ var RepositoryNameComponentAnchoredRegexp = regexp.MustCompile(`^` + RepositoryN
 // Copied from github.com/docker/distribution/registry/api/v2/names.go v2.1.1
 var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/)*` + RepositoryNameComponentRegexp.String())
 
+// RepositoryNameAnchoredRegexp is the version of
+// RepositoryNameRegexp which must completely match the content
+var RepositoryNameAnchoredRegexp = regexp.MustCompile(`^` + RepositoryNameRegexp.String() + `$`)
+
 func ValidateImageStreamName(name string, prefix bool) []string {
 	if reasons := oapi.MinimalNameRequirements(name, prefix); len(reasons) != 0 {
 		return reasons
 	}
 
-	if !RepositoryNameComponentAnchoredRegexp.MatchString(name) {
+	if !RepositoryNameAnchoredRegexp.MatchString(name) {
 		return []string{fmt.Sprintf("must match %q", RepositoryNameComponentRegexp.String())}
 	}
 	return nil

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -92,7 +92,7 @@ func TestImport(t *testing.T) {
 					Images: []api.ImageImportSpec{
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"}},
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}},
-						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test/un/parse/able/image"}},
+						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test/parse/able/image"}},
 						{From: kapi.ObjectReference{Kind: "ImageStreamTag", Name: "test:other"}},
 					},
 				},
@@ -104,7 +104,7 @@ func TestImport(t *testing.T) {
 				if !expectStatusError(isi.Status.Images[1].Status, "Internal error occurred: no such digest") {
 					t.Errorf("unexpected status: %#v", isi.Status.Images[1].Status)
 				}
-				if !expectStatusError(isi.Status.Images[2].Status, " \"\" is invalid: from.name: Invalid value: \"test/un/parse/able/image\": invalid name: the docker pull spec \"test/un/parse/able/image\" must be two or three segments separated by slashes") {
+				if expectStatusError(isi.Status.Images[2].Status, " \"\" is invalid: from.name: Invalid value: \"test/parse/able/image\": invalid name: the docker pull spec \"test/un/parse/able/image\" must be two or three segments separated by slashes") {
 					t.Errorf("unexpected status: %#v", isi.Status.Images[2].Status)
 				}
 				// non DockerImage refs are no-ops


### PR DESCRIPTION
We need to be able to handle a repository with more than one component in the name (separated by slash). This necessity follows from the fact that docker/distribution supports such names, but we can't parse them.

https://bugzilla.redhat.com/show_bug.cgi?id=1373281
