### PR TITLE
UPSTREAM: 33677: add linebreak between resource groups

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -443,6 +443,14 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 				allErrs = append(allErrs, err)
 				continue
 			}
+
+			// add linebreak between resource groups (if there is more than one)
+			// skip linebreak above first resource group
+			noHeaders := cmdutil.GetFlagBool(cmd, "no-headers")
+			if lastMapping != nil && !noHeaders {
+				fmt.Fprintf(errOut, "%s\n", "")
+			}
+
 			lastMapping = mapping
 		}
 


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/33677

Related Trello Card: https://trello.com/c/04lpfTQR/451-8-cli-improved-flows-and-ux-in-the-cli-evg-ux-p3
Related discussion: https://docs.google.com/a/redhat.com/document/d/1azhwziQq584FtfX3DgTebLnfA3dL1eHCX5w2-WypM8A/edit?usp=sharing

Printing multiple groups via `oc get all` can produce output that is
hard to read in cases where there are a lot of resource types to display
/ some resource types contain varying column amounts.

This patch adds a linebreak above each group of resources only when
there is more than one group to display, and always omitting the
linebreak above the first group. This makes for slightly improved
output.

**Before**
```
$ oc get all
NAME                   TYPE      FROM      LATEST
bc/ruby-sample-build   Source    Git       1
NAME                         TYPE      FROM      STATUS
STARTED   DURATION
builds/ruby-sample-build-1   Source    Git       Failed
(ExceededRetryTimeout)
NAME                    DOCKER REPO              TAGS      UPDATED
is/origin-ruby-sample
is/ruby-22-centos7      centos/ruby-22-centos7   latest    27 hours ago
NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
dc/database      1          1         1         config
dc/frontend      0          2         0
config,image(origin-ruby-sample:latest)
dc/idling-echo   1          2         2         config
NAME               DESIRED   CURRENT   READY     AGE
rc/database-1      1         1         1         1d
rc/idling-echo-1   2         2         2         1d
NAME                           HOST/PORT
PATH      SERVICES      PORT      TERMINATION
routes/idling-echo
idling-echo-default.router.default.svc.cluster.local
idling-echo   <all>
routes/idling-echo-reencrypt
idling-echo-reencrypt-default.router.default.svc.cluster.local
idling-echo   <all>     reencrypt
routes/route-edge              www.example.com
frontend      <all>     edge
NAME              CLUSTER-IP       EXTERNAL-IP   PORT(S)
AGE
svc/database      172.30.11.104    <none>        5434/TCP
1d
svc/frontend      172.30.196.217   <none>        5432/TCP
1d
svc/idling-echo   172.30.115.67    <none>        8675/TCP,3090/UDP
1d
svc/kubernetes    172.30.0.1       <none>        443/TCP,53/UDP,53/TCP
1d
svc/mynodeport    172.30.81.254    <nodes>       8080/TCP
1d
svc/mynodeport1   172.30.198.193   <nodes>       8080/TCP
1d
svc/mynodeport2   172.30.149.48    <nodes>       8080/TCP
1d
svc/mynodeport3   172.30.195.235   <nodes>       8080/TCP
1d
NAME                     READY     STATUS    RESTARTS   AGE
po/database-1-u9m9l      1/1       Running   1          1d
po/idling-echo-1-9fmz6   2/2       Running   3          1d
po/idling-echo-1-gzb0v   2/2       Running   3          1d
```

**After**
```
$ oc get all
NAME                   TYPE      FROM      LATEST
bc/ruby-sample-build   Source    Git       1
0000
NAME                         TYPE      FROM      STATUS
STARTED   DURATION
builds/ruby-sample-build-1   Source    Git       Failed
(ExceededRetryTimeout)

NAME                    DOCKER REPO              TAGS      UPDATED
is/origin-ruby-sample
is/ruby-22-centos7      centos/ruby-22-centos7   latest    27 hours ago

NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
dc/database      1          1         1         config
dc/frontend      0          2         0
config,image(origin-ruby-sample:latest)
dc/idling-echo   1          2         2         config

NAME               DESIRED   CURRENT   READY     AGE
rc/database-1      1         1         1         1d
rc/idling-echo-1   2         2         2         1d

NAME                           HOST/PORT
PATH      SERVICES      PORT      TERMINATION
routes/idling-echo
idling-echo-default.router.default.svc.cluster.local
idling-echo   <all>
routes/idling-echo-reencrypt
idling-echo-reencrypt-default.router.default.svc.cluster.local
idling-echo   <all>     reencrypt
routes/route-edge              www.example.com
frontend      <all>     edge

NAME              CLUSTER-IP       EXTERNAL-IP   PORT(S)
AGE
svc/database      172.30.11.104    <none>        5434/TCP
1d
svc/frontend      172.30.196.217   <none>        5432/TCP
1d
svc/idling-echo   172.30.115.67    <none>        8675/TCP,3090/UDP
1d
svc/kubernetes    172.30.0.1       <none>        443/TCP,53/UDP,53/TCP
1d
svc/mynodeport    172.30.81.254    <nodes>       8080/TCP
1d
svc/mynodeport1   172.30.198.193   <nodes>       8080/TCP
1d
svc/mynodeport2   172.30.149.48    <nodes>       8080/TCP
1d
svc/mynodeport3   172.30.195.235   <nodes>       8080/TCP
1d

NAME                     READY     STATUS    RESTARTS   AGE
po/database-1-u9m9l      1/1       Running   1          1d
po/idling-echo-1-9fmz6   2/2       Running   3          1d
po/idling-echo-1-gzb0v   2/2       Running   3          1d
```

cc @openshift/cli-review 