### PR TITLE
Fix a bug in text/extended/networking/ovs.go if a test fails

### DIFF
--- a/test/extended/networking/ovs.go
+++ b/test/extended/networking/ovs.go
@@ -134,6 +134,7 @@ var _ = Describe("[networking] OVS", func() {
 			}
 			node, err = f1.Client.Nodes().Create(node)
 			Expect(err).NotTo(HaveOccurred())
+			defer f1.Client.Nodes().Delete(node.Name)
 
 			osClient, err := testutil.GetClusterAdminClient(testexutil.KubeConfigPath())
 			Expect(err).NotTo(HaveOccurred())
@@ -174,7 +175,7 @@ var _ = Describe("[networking] OVS", func() {
 				Expect(reflect.DeepEqual(origFlows[nodeName], otherFlows)).To(BeTrue(), "Flows should be unchanged except for the new node")
 			}
 
-			err = f1.Client.Nodes().Delete(nodeName)
+			err = f1.Client.Nodes().Delete(node.Name)
 			Expect(err).NotTo(HaveOccurred())
 			e2e.Logf("Waiting up to %v for HostSubnet to be deleted", hostSubnetTimeout)
 			for start := time.Now(); time.Since(start) < hostSubnetTimeout; time.Sleep(time.Second) {


### PR DESCRIPTION
If the "when nodes are added and removed" test failed in certain spots, it would cause the test to exit without deleting the fake node record, which would cause slowdowns later on as the test infrastructure would occasionally wait 1m for the fake node to become ready before giving up on it and continuing.

Also, use "node.Name" consistently rather than "nodeName" (which gets used for something else nearby anyway).

----

(This isn't causing any problems in master, I found it after breaking the test locally. @openshift/networking PTAL.)