### PR TITLE
Adding custom Server Ip configuration option for 'oc cluster up'

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -127,6 +127,7 @@ func NewCmdUp(name, fullName string, f *osclientcmd.Factory, out io.Writer) *cob
 	cmd.Flags().StringVar(&config.DockerMachine, "docker-machine", "", "Specify the Docker machine to use")
 	cmd.Flags().StringVar(&config.ImageVersion, "version", "", "Specify the tag for OpenShift images")
 	cmd.Flags().StringVar(&config.Image, "image", "openshift/origin", "Specify the images to use for OpenShift")
+	cmd.Flags().StringVar(&config.ServerIP, "server-ip", "", "Specify the ip address to use for OpenShift server. Otherwise it will be discovered.")
 	cmd.Flags().BoolVar(&config.SkipRegistryCheck, "skip-registry-check", false, "Skip Docker daemon registry check")
 	cmd.Flags().StringVar(&config.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
 	cmd.Flags().StringVar(&config.RoutingSuffix, "routing-suffix", "", "Default suffix for server routes")
@@ -741,6 +742,20 @@ func getDockerMachineClient(machine string, out io.Writer) (*docker.Client, *doc
 }
 
 func (c *ClientStartConfig) determineIP(out io.Writer) (string, error) {
+	if len(c.ServerIP) > 0 {
+		if ip := net.ParseIP(c.ServerIP); ip != nil && !ip.IsUnspecified() {
+			otherIPs, err := cmdutil.AllLocalIP4()
+			if err == nil {
+				for _, ip4 := range otherIPs {
+					if ip4.String() == ip.String() {
+						return ip.String(), nil
+					}
+				}
+			}
+		}
+		return "", errors.NewError("Could not use provided server IP address").WithSolution("Ensure that you provided an existing IP address of this host.")
+	}
+
 	if ip := net.ParseIP(c.PublicHostname); ip != nil && !ip.IsUnspecified() {
 		fmt.Fprintf(out, "Using public hostname IP %s as the host IP\n", ip)
 		return ip.String(), nil


### PR DESCRIPTION
I've added an option to 'oc cluster up' for letting user decide the ip address to use in case of multiple ones available.

(In the previous pull request there were some go fmt errors that I've corrected)

In my case I just wanted a way to make independent the ip address of my containerized openshift server, from the network I'm connected to with my laptop.

For example:
oc cluster up --server-ip="192.168.123.1"

I just created a new bridge interface and enabled it to communicate with docker interface through firewalld rules.

nmcli con add type bridge ifname osbr0 ip4 192.168.123.1/32

firewall-cmd --zone=internal --add-interface=docker0
firewall-cmd --zone=internal --add-interface=docker0 --permanent
firewall-cmd --zone=internal --add-interface=osbr0
firewall-cmd --zone=internal --add-interface=osbr0 --permanent
firewall-cmd --zone=internal --add-port 53/udp
firewall-cmd --zone=internal --add-port 53/udp --permanent
firewall-cmd --zone=internal --add-source 172.17.0.0/16 
firewall-cmd --zone=internal --add-source 172.17.0.0/16 --permanent

On the code side I preferred to add all the logic inside the existing function "determineIP", first of all it tries to parse the provided IP and then it tries to match the given IP with one of the existing host's IPs.

If c.ServerIP is unset it will find the IP as previously done  by the original function.
