### PR TITLE
extended: fix polling the status of a config that needs to be synced

### DIFF
--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -297,7 +297,11 @@ func waitForSyncedConfig(oc *exutil.CLI, name string, timeout time.Duration) err
 	}
 	generation := dc.Generation
 	return wait.PollImmediate(200*time.Millisecond, timeout, func() (bool, error) {
-		return deployutil.HasSynced(dc, generation), nil
+		config, err := oc.REST().DeploymentConfigs(oc.Namespace()).Get(name)
+		if err != nil {
+			return false, err
+		}
+		return deployutil.HasSynced(config, generation), nil
 	})
 }
 


### PR DESCRIPTION
@mfojtik quick test fix that I have seen flaking around

[test]