### PR TITLE
fix error messages for clusterrolebinding

### DIFF
--- a/pkg/authorization/registry/clusterrole/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy/proxy.go
@@ -34,7 +34,8 @@ func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry,
 
 			RuleResolver:   ruleResolver,
 			CreateStrategy: roleregistry.ClusterStrategy,
-			UpdateStrategy: roleregistry.ClusterStrategy},
+			UpdateStrategy: roleregistry.ClusterStrategy,
+			Resource:       authorizationapi.Resource("clusterrole")},
 	}
 }
 

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -35,6 +35,7 @@ func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Re
 			RuleResolver:   ruleResolver,
 			CreateStrategy: rolebindingregistry.ClusterStrategy,
 			UpdateStrategy: rolebindingregistry.ClusterStrategy,
+			Resource:       authorizationapi.Resource("clusterrolebinding"),
 		},
 	}
 }

--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -29,11 +29,12 @@ type VirtualStorage struct {
 	RuleResolver   rulevalidation.AuthorizationRuleResolver
 	CreateStrategy rest.RESTCreateStrategy
 	UpdateStrategy rest.RESTUpdateStrategy
+	Resource       unversioned.GroupResource
 }
 
 // NewVirtualStorage creates a new REST for policies.
-func NewVirtualStorage(policyStorage policyregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver) roleregistry.Storage {
-	return &VirtualStorage{policyStorage, ruleResolver, roleregistry.LocalStrategy, roleregistry.LocalStrategy}
+func NewVirtualStorage(policyStorage policyregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver, resource unversioned.GroupResource) roleregistry.Storage {
+	return &VirtualStorage{policyStorage, ruleResolver, roleregistry.LocalStrategy, roleregistry.LocalStrategy, resource}
 }
 
 func (m *VirtualStorage) New() runtime.Object {
@@ -67,7 +68,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runt
 func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 	policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
 	if kapierrors.IsNotFound(err) {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+		return nil, kapierrors.NewNotFound(m.Resource, name)
 	}
 	if err != nil {
 		return nil, err
@@ -75,7 +76,7 @@ func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, err
 
 	role, exists := policy.Roles[name]
 	if !exists {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+		return nil, kapierrors.NewNotFound(m.Resource, name)
 	}
 
 	return role, nil
@@ -86,14 +87,14 @@ func (m *VirtualStorage) Delete(ctx kapi.Context, name string, options *kapi.Del
 	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
 		policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
 		if kapierrors.IsNotFound(err) {
-			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 		if err != nil {
 			return err
 		}
 
 		if _, exists := policy.Roles[name]; !exists {
-			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 
 		delete(policy.Roles, name)
@@ -129,7 +130,7 @@ func (m *VirtualStorage) createRole(ctx kapi.Context, obj runtime.Object, allowE
 
 	role := obj.(*authorizationapi.Role)
 	if !allowEscalation {
-		if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
+		if err := rulevalidation.ConfirmNoEscalation(ctx, m.Resource, role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
 			return nil, err
 		}
 	}
@@ -140,7 +141,7 @@ func (m *VirtualStorage) createRole(ctx kapi.Context, obj runtime.Object, allowE
 			return err
 		}
 		if _, exists := policy.Roles[role.Name]; exists {
-			return kapierrors.NewAlreadyExists(authorizationapi.Resource("role"), role.Name)
+			return kapierrors.NewAlreadyExists(m.Resource, role.Name)
 		}
 
 		role.ResourceVersion = policy.ResourceVersion
@@ -170,7 +171,7 @@ func (m *VirtualStorage) updateRole(ctx kapi.Context, name string, objInfo rest.
 	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
 		policy, err := m.PolicyStorage.GetPolicy(ctx, authorizationapi.PolicyName)
 		if kapierrors.IsNotFound(err) {
-			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 		if err != nil {
 			return err
@@ -178,7 +179,7 @@ func (m *VirtualStorage) updateRole(ctx kapi.Context, name string, objInfo rest.
 
 		oldRole, exists := policy.Roles[name]
 		if !exists {
-			return kapierrors.NewNotFound(authorizationapi.Resource("role"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 
 		obj, err := objInfo.UpdatedObject(ctx, oldRole)
@@ -200,7 +201,7 @@ func (m *VirtualStorage) updateRole(ctx kapi.Context, name string, objInfo rest.
 		}
 
 		if !allowEscalation {
-			if err := rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("role"), role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
+			if err := rulevalidation.ConfirmNoEscalation(ctx, m.Resource, role.Name, m.RuleResolver, authorizationinterfaces.NewLocalRoleAdapter(role)); err != nil {
 				return err
 			}
 		}

--- a/pkg/authorization/registry/role/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage_test.go
@@ -49,14 +49,14 @@ func testNewLocalPolicies() []authorizationapi.Policy {
 func makeLocalTestStorage() roleregistry.Storage {
 	policyRegistry := test.NewPolicyRegistry(testNewLocalPolicies(), nil)
 
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}))
+	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("role"))
 }
 
 func makeClusterTestStorage() roleregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	policyRegistry := clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry)
 
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(nil, &test.PolicyBindingRegistry{}, clusterPolicyRegistry, &test.ClusterPolicyBindingRegistry{}))
+	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(nil, &test.PolicyBindingRegistry{}, clusterPolicyRegistry, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("clusterrole"))
 }
 
 func TestCreateValidationError(t *testing.T) {

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -27,16 +27,18 @@ type VirtualStorage struct {
 	RuleResolver   rulevalidation.AuthorizationRuleResolver
 	CreateStrategy rest.RESTCreateStrategy
 	UpdateStrategy rest.RESTUpdateStrategy
+	Resource       unversioned.GroupResource
 }
 
 // NewVirtualStorage creates a new REST for policies.
-func NewVirtualStorage(bindingRegistry policybindingregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver) rolebindingregistry.Storage {
+func NewVirtualStorage(bindingRegistry policybindingregistry.Registry, ruleResolver rulevalidation.AuthorizationRuleResolver, resource unversioned.GroupResource) rolebindingregistry.Storage {
 	return &VirtualStorage{
 		BindingRegistry: bindingRegistry,
 
 		RuleResolver:   ruleResolver,
 		CreateStrategy: rolebindingregistry.LocalStrategy,
 		UpdateStrategy: rolebindingregistry.LocalStrategy,
+		Resource:       resource,
 	}
 }
 
@@ -71,7 +73,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runt
 func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 	policyBinding, err := m.getPolicyBindingOwningRoleBinding(ctx, name)
 	if kapierrors.IsNotFound(err) {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), name)
+		return nil, kapierrors.NewNotFound(m.Resource, name)
 	}
 	if err != nil {
 		return nil, err
@@ -79,7 +81,7 @@ func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, err
 
 	binding, exists := policyBinding.RoleBindings[name]
 	if !exists {
-		return nil, kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), name)
+		return nil, kapierrors.NewNotFound(m.Resource, name)
 	}
 	return binding, nil
 }
@@ -88,14 +90,14 @@ func (m *VirtualStorage) Delete(ctx kapi.Context, name string, options *kapi.Del
 	if err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
 		owningPolicyBinding, err := m.getPolicyBindingOwningRoleBinding(ctx, name)
 		if kapierrors.IsNotFound(err) {
-			return kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 		if err != nil {
 			return err
 		}
 
 		if _, exists := owningPolicyBinding.RoleBindings[name]; !exists {
-			return kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), name)
+			return kapierrors.NewNotFound(m.Resource, name)
 		}
 
 		delete(owningPolicyBinding.RoleBindings, name)
@@ -146,7 +148,7 @@ func (m *VirtualStorage) createRoleBinding(ctx kapi.Context, obj runtime.Object,
 
 		_, exists := policyBinding.RoleBindings[roleBinding.Name]
 		if exists {
-			return kapierrors.NewAlreadyExists(authorizationapi.Resource("rolebinding"), roleBinding.Name)
+			return kapierrors.NewAlreadyExists(m.Resource, roleBinding.Name)
 		}
 
 		roleBinding.ResourceVersion = policyBinding.ResourceVersion
@@ -200,7 +202,7 @@ func (m *VirtualStorage) updateRoleBinding(ctx kapi.Context, name string, objInf
 		}
 		oldRoleBinding, exists = policyBinding.RoleBindings[roleBinding.Name]
 		if !exists {
-			return kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), roleBinding.Name)
+			return kapierrors.NewNotFound(m.Resource, roleBinding.Name)
 		}
 
 		if len(roleBinding.ResourceVersion) == 0 && m.UpdateStrategy.AllowUnconditionalUpdate() {
@@ -241,7 +243,7 @@ func (m *VirtualStorage) updateRoleBinding(ctx kapi.Context, name string, objInf
 	}); err != nil {
 		if roleBindingConflicted {
 			// construct the typed conflict error
-			return nil, false, kapierrors.NewConflict(authorizationapi.Resource("rolebinding"), name, err)
+			return nil, false, kapierrors.NewConflict(m.Resource, name, err)
 		}
 		return nil, false, err
 	}
@@ -254,7 +256,7 @@ func (m *VirtualStorage) confirmNoEscalation(ctx kapi.Context, roleBinding *auth
 		return err
 	}
 
-	return rulevalidation.ConfirmNoEscalation(ctx, authorizationapi.Resource("rolebinding"), roleBinding.Name, m.RuleResolver, modifyingRole)
+	return rulevalidation.ConfirmNoEscalation(ctx, m.Resource, roleBinding.Name, m.RuleResolver, modifyingRole)
 }
 
 // ensurePolicyBindingToMaster returns a PolicyBinding object that has a PolicyRef pointing to the Policy in the passed namespace.
@@ -320,5 +322,5 @@ func (m *VirtualStorage) getPolicyBindingOwningRoleBinding(ctx kapi.Context, bin
 		}
 	}
 
-	return nil, kapierrors.NewNotFound(authorizationapi.Resource("rolebinding"), bindingName)
+	return nil, kapierrors.NewNotFound(m.Resource, bindingName)
 }

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
@@ -69,7 +69,7 @@ func makeTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	policyRegistry := test.NewPolicyRegistry([]authorizationapi.Policy{}, nil)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry), authorizationapi.Resource("rolebinding"))
 }
 
 func makeClusterTestStorage() rolebindingregistry.Storage {
@@ -77,7 +77,7 @@ func makeClusterTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	bindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterBindingRegistry)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry), authorizationapi.Resource("clusterrolebinding"))
 }
 
 func TestCreateValidationError(t *testing.T) {
@@ -354,7 +354,7 @@ func TestDeleteError(t *testing.T) {
 	bindingRegistry := &test.PolicyBindingRegistry{}
 	bindingRegistry.Err = errors.New("Sample Error")
 
-	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}))
+	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), authorizationapi.Resource("rolebinding"))
 	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})
 	_, err := storage.Delete(ctx, "foo", nil)
 	if err != bindingRegistry.Err {

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -162,8 +162,8 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 		clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
 	)
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver)
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver)
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver, authorizationapi.Resource("role"))
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver, authorizationapi.Resource("rolebinding"))
 	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -98,6 +98,7 @@ import (
 	appliedclusterresourcequotaregistry "github.com/openshift/origin/pkg/quota/registry/appliedclusterresourcequota"
 	clusterresourcequotaregistry "github.com/openshift/origin/pkg/quota/registry/clusterresourcequota"
 
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	clusterpolicystorage "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy/etcd"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
@@ -542,8 +543,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, c.Informers.ClusterPolicies().Lister().ClusterPolicies())
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver)
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver)
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver, authorizationapi.Resource("role"))
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver, authorizationapi.Resource("rolebinding"))
 	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry)
 


### PR DESCRIPTION
when accessing clusterrolebindings, on an error the system currently
displays the type erroneously as rolebinding by adding the type to the
struct makes it easy to return the correct type

fixes bug 1323997