### PR TITLE
Fix the documentation to show how to set a custom message

### DIFF
--- a/examples/hello-openshift/README.md
+++ b/examples/hello-openshift/README.md
@@ -11,8 +11,32 @@ This example will serve an HTTP response of "Hello OpenShift!".
     $ curl 10.1.0.2:8080
      Hello OpenShift!
 
-The response message can be set by using the RESPONSE environment variable:
-    $ oc set env pod/hello-openshift RESPONSE="Hello World!"
+The response message can be set by using the RESPONSE environment
+variable.  You will need to edit the pod definition and add an
+environment variable to the container definition and run the new pod.
+To do this, edit hello-pod.json and add the following to the container
+section.  Just add the env clause after the image name so you end up with:
+```
+    "containers": [
+      {
+        "name": "hello-openshift",
+        "image": "openshift/hello-openshift",
+        "env": [
+          { "name": "RESPONSE",
+            "value": "Hello World!"
+          }
+        ],
+        ...
+      }
+    ],
+```
+
+After that, if you are running the pod from above, delete it:
+
+    $ oc delete pod hello-openshift
+
+Then you can re-create the pod as with the first example, get the new IP
+address, and then curl will show your new message:
 
     $ curl 10.1.0.2:8080
      Hello World!


### PR DESCRIPTION
I had added a feature to get a custom message from hello-openshift by
using an environment variable.  But when I documented it, I used oc
set env (which worked for me since I was using a dc to test, but with
a bare pod, it can not work).  So, this changes the documentation to
show how to set an env in the pod definition, and how to make use of
it.

Fixes https://github.com/openshift/origin/issues/11093