### PR TITLE
Update to start-build --follow, somewhat contradicting #6268

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -315,58 +314,36 @@ func (o *StartBuildOptions) Run() error {
 
 	kcmdutil.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, "build", newBuild.Name, "started")
 
-	var (
-		wg      sync.WaitGroup
-		exitErr error
-	)
-
-	// Wait for the build to complete
-	if o.WaitForComplete {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			exitErr = WaitForBuildComplete(o.Client.Builds(o.Namespace), newBuild.Name)
-		}()
-	}
-
 	// Stream the logs from the build
 	if o.Follow {
-		wg.Add(1)
-		go func() {
-			// if --wait option is set, then don't wait for logs to finish streaming
-			// but wait for the build to reach its final state
-			if o.WaitForComplete {
-				wg.Done()
-			} else {
-				defer wg.Done()
-			}
-			opts := buildapi.BuildLogOptions{
-				Follow: true,
-				NoWait: false,
-			}
-			for {
-				rd, err := o.Client.BuildLogs(o.Namespace).Get(newBuild.Name, opts).Stream()
-				if err != nil {
-					// if --wait options is set, then retry the connection to build logs
-					// when we hit the timeout.
-					if o.WaitForComplete && oerrors.IsTimeoutErr(err) {
-						continue
-					}
-					fmt.Fprintf(o.ErrOut, "error getting logs: %v\n", err)
-					return
+		opts := buildapi.BuildLogOptions{
+			Follow: true,
+			NoWait: false,
+		}
+		for {
+			rd, err := o.Client.BuildLogs(o.Namespace).Get(newBuild.Name, opts).Stream()
+			if err != nil {
+				// retry the connection to build logs when we hit the timeout.
+				if oerrors.IsTimeoutErr(err) {
+					fmt.Fprintf(o.ErrOut, "timed out getting logs, retrying\n")
+					continue
 				}
-				defer rd.Close()
-				if _, err = io.Copy(o.Out, rd); err != nil {
-					fmt.Fprintf(o.ErrOut, "error streaming logs: %v\n", err)
-				}
+				fmt.Fprintf(o.ErrOut, "error getting logs (%v), waiting for build to complete\n", err)
 				break
 			}
-		}()
+			defer rd.Close()
+			if _, err = io.Copy(o.Out, rd); err != nil {
+				fmt.Fprintf(o.ErrOut, "error streaming logs (%v), waiting for build to complete\n", err)
+			}
+			break
+		}
 	}
 
-	wg.Wait()
+	if o.Follow || o.WaitForComplete {
+		return WaitForBuildComplete(o.Client.Builds(o.Namespace), newBuild.Name)
+	}
 
-	return exitErr
+	return nil
 }
 
 // RunListBuildWebHooks prints the webhooks for the provided build config.


### PR DESCRIPTION
- make --follow always retry on timeouts
- make --follow imply --wait: guarantee returning an error, or ensure stream
  has finished and build status is in complete, failed, cancelled,
  error (aka not new, pending, running)
- remove possible undesirable race condition (I think --follow --wait
  could unwittingly truncate returned logs)