### PR TITLE
Add godoc to justify use of developmentRedirectURI

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -272,7 +272,7 @@ func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 	// Create an OpenShift configuration and start a container that uses it.
 	c.addTask("Starting OpenShift container", c.StartOpenShift)
 
-	// Add default redirect URI to config
+	// Add default redirect URIs to an OAuthClient to enable local web-console development.
 	c.addConditionalTask("Adding default OAuthClient redirect URIs", c.EnsureDefaultRedirectURIs, c.ShouldInitializeData)
 
 	// Install a registry


### PR DESCRIPTION
Spawned from:
https://github.com/openshift/origin/pull/10895#issuecomment-249967277

This patch adds a brief explanation for the use of "localhost:9000" as a
default develppment redirect URI in the `oc cluster up` setup.

@openshift/cli-review 