### PR TITLE
IngressIP controller: Fix Service update in an exponential backoff manner

### DIFF
--- a/pkg/service/controller/ingressip/controller.go
+++ b/pkg/service/controller/ingressip/controller.go
@@ -34,6 +34,7 @@ const (
 
 	clientRetryCount    = 5
 	clientRetryInterval = 5 * time.Second
+	clientRetryFactor   = 1.1
 )
 
 // IngressIPController is responsible for allocating ingress ip
@@ -663,6 +664,7 @@ func persistService(client kclient.ServicesNamespacer, service *kapi.Service, ta
 	backoff := wait.Backoff{
 		Steps:    clientRetryCount,
 		Duration: clientRetryInterval,
+		Factor:   clientRetryFactor,
 	}
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		var err error


### PR DESCRIPTION

With out wait.Backoff.Factor, the adjusted sleep time will be zero.