### PR TITLE
sdn: set veth TX queue length to unblock QoS

### DIFF
--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -95,6 +95,7 @@ add_ovs_flows() {
     # Pod ingress == OVS bridge egress
     # linux-htb used here since that's the Kubernetes default traffic shaper too
     if [ -n "${ingress_bw}" ]; then
+        ip link set dev ${veth_host} qlen 1000
         qos=$(ovs-vsctl create qos type=linux-htb other-config:max-rate=${ingress_bw})
         ovs-vsctl set port ${veth_host} qos=${qos}
     fi


### PR DESCRIPTION
docker/libnetwork appear to create the pod veth interfaces with
an explicitly 0 txqlen instead of leaving the default 1000 that
the kernel would assign.  A txqlen of 0 blocks any packets when
QoS is enabled for a port due to the way the Linux HTB shaper
works.  Explicitly set the veth txqlen to make QoS work again.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1378000