### PR TITLE
Propose to add new default cluster-role for storage-admin

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -54,6 +54,7 @@ const (
 	ClusterAdminRoleName       = "cluster-admin"
 	SudoerRoleName             = "sudoer"
 	ClusterReaderRoleName      = "cluster-reader"
+	StorageAdminRoleName       = "storage-admin"
 	AdminRoleName              = "admin"
 	EditRoleName               = "edit"
 	ViewRoleName               = "view"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -217,7 +217,16 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("create").Groups(buildGroup).Resources(authorizationapi.JenkinsPipelineBuildResource).RuleOrDie(),
 			},
 		},
-
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: StorageAdminRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule(readWrite...).Groups(kapiGroup).Resources("persistentvolumes").RuleOrDie(),
+				authorizationapi.NewRule(readWrite...).Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("persistentvolumeclaims", "events").RuleOrDie(),
+			},
+		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name: AdminRoleName,
@@ -388,6 +397,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("get").Groups(userGroup).Resources("users").Names("~").RuleOrDie(),
 				authorizationapi.NewRule("list").Groups(projectGroup).Resources("projectrequests").RuleOrDie(),
 				authorizationapi.NewRule("get", "list").Groups(authzGroup).Resources("clusterroles").RuleOrDie(),
+				authorizationapi.NewRule("list").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				authorizationapi.NewRule("list", "watch").Groups(projectGroup).Resources("projects").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(authzGroup).Resources("selfsubjectrulesreviews").RuleOrDie(),
 				{Verbs: sets.NewString("create"), APIGroups: []string{authzGroup}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},

--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -106,6 +106,7 @@ func TestCovers(t *testing.T) {
 	var systemMaster *authorizationapi.ClusterRole
 	var systemDiscovery *authorizationapi.ClusterRole
 	var clusterAdmin *authorizationapi.ClusterRole
+	var storageAdmin *authorizationapi.ClusterRole
 
 	for i := range allRoles {
 		role := allRoles[i]
@@ -128,6 +129,8 @@ func TestCovers(t *testing.T) {
 			systemDiscovery = &role
 		case bootstrappolicy.ClusterAdminRoleName:
 			clusterAdmin = &role
+		case bootstrappolicy.StorageAdminRoleName:
+			storageAdmin = &role
 		}
 	}
 
@@ -141,6 +144,9 @@ func TestCovers(t *testing.T) {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(admin.Rules, registryAdmin.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+	if covers, miss := rulevalidation.Covers(clusterAdmin.Rules, storageAdmin.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(registryAdmin.Rules, registryEditor.Rules); !covers {

--- a/test/cmd/policy-storage-admin.sh
+++ b/test/cmd/policy-storage-admin.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+project="$( oc project -q )"
+
+os::test::junit::declare_suite_start "cmd/policy-storage-admin"
+
+# Test storage-admin role and impersonation
+os::cmd::expect_success 'oadm policy add-cluster-role-to-user storage-admin storage-adm'
+os::cmd::expect_success 'oadm policy add-cluster-role-to-user storage-admin storage-adm2'
+os::cmd::expect_success 'oadm policy add-role-to-user admin storage-adm2'
+os::cmd::expect_success_and_text 'oc policy who-can impersonate storage-admin' 'cluster-admin'
+
+# Test storage-admin role as user level
+os::cmd::expect_success 'oc login -u storage-adm -p pw'
+os::cmd::expect_success_and_text 'oc whoami' "storage-adm"
+os::cmd::expect_failure 'oc whoami --as=basic-user'
+os::cmd::expect_failure 'oc whoami --as=cluster-admin'
+
+# Test storage-admin can not do normal project scoped tasks
+os::cmd::expect_success_and_text 'oc policy can-i create pods --all-namespaces' 'no'
+os::cmd::expect_success_and_text 'oc policy can-i create projects' 'no'
+os::cmd::expect_success_and_text 'oc policy can-i get pods --all-namespaces' 'no'
+os::cmd::expect_success_and_text 'oc policy can-i create pvc' 'no'
+
+# Test storage-admin can read pvc and create pv and storageclass
+os::cmd::expect_success_and_text 'oc policy can-i get pvc --all-namespaces' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i get storageclass' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create pv' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create storageclass' 'yes'
+
+# Test failure to change policy on users for storage-admin
+os::cmd::expect_failure_and_text 'oc policy add-role-to-user admin storage-adm' 'cannot get policybindings'
+os::cmd::expect_failure_and_text 'oc policy remove-user screeley' 'cannot list policybindings'
+os::cmd::expect_success 'oc logout'
+
+# Test that scoped storage-admin now an admin in project foo
+os::cmd::expect_success 'oc login -u storage-adm2 -p pw'
+os::cmd::expect_success_and_text 'oc whoami' "storage-adm2"
+os::cmd::expect_success 'oc new-project foo'
+os::cmd::expect_success_and_text 'oc policy can-i create pod --all-namespaces' 'no'
+os::cmd::expect_success_and_text 'oc policy can-i create pod' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create pvc' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i create endpoints' 'yes'
+os::cmd::expect_success 'oc delete project foo'

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -430,6 +430,50 @@ items:
   kind: ClusterRole
   metadata:
     creationTimestamp: null
+    name: storage-admin
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - persistentvolumes
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    attributeRestrictions: null
+    resources:
+    - storageclasses
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    - persistentvolumeclaims
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
     name: admin
   rules:
   - apiGroups:
@@ -1418,6 +1462,13 @@ items:
     - clusterroles
     verbs:
     - get
+    - list
+  - apiGroups:
+    - storage.k8s.io
+    attributeRestrictions: null
+    resources:
+    - storageclasses
+    verbs:
     - list
   - apiGroups:
     - ""


### PR DESCRIPTION
storage-admin is someone who is tasked with managing enterprise or project storage needs and assets but not necessarily involved in the management of the cluster or the development or maintenance of the projects/applications.  This person essentially owns/admins some level of storage in the enterprise and has been asked to make it available to the cluster and various projects.  This means they will set up StorageClasses, PV, endpoints (gluster), services (gluster, etc...), possibly secrets for the storage/db, petsets, and possibly some basic read ability as well in the cluster.

I've proposed a starting point for this role but would like some review and input as maybe some resources are missing or some are not needed.