### PR TITLE
Bind socat to 127.0.0.1 when using it on OS X

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -63,6 +63,7 @@ type Helper struct {
 // StartOptions represent the parameters sent to the start command
 type StartOptions struct {
 	ServerIP           string
+	RouterIP           string
 	DNSPort            int
 	UseSharedVolume    bool
 	SetPropagationMode bool
@@ -289,7 +290,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 		if err != nil {
 			return "", errors.NewError("could not copy OpenShift configuration").WithCause(err)
 		}
-		err = h.updateConfig(configDir, opt.HostConfigDir, opt.ServerIP, opt.MetricsHost)
+		err = h.updateConfig(configDir, opt.HostConfigDir, opt.RouterIP, opt.MetricsHost)
 		if err != nil {
 			cleanupConfig()
 			return "", errors.NewError("could not update OpenShift configuration").WithCause(err)
@@ -443,7 +444,7 @@ func (h *Helper) copyConfig(hostDir string) (string, error) {
 	return filepath.Join(tempDir, filepath.Base(hostDir)), nil
 }
 
-func (h *Helper) updateConfig(configDir, hostDir, serverIP, metricsHost string) error {
+func (h *Helper) updateConfig(configDir, hostDir, routerIP, metricsHost string) error {
 	masterConfig := filepath.Join(configDir, "master", "master-config.yaml")
 	glog.V(1).Infof("Reading master config from %s", masterConfig)
 	cfg, err := configapilatest.ReadMasterConfig(masterConfig)
@@ -455,7 +456,7 @@ func (h *Helper) updateConfig(configDir, hostDir, serverIP, metricsHost string) 
 	if len(h.routingSuffix) > 0 {
 		cfg.RoutingConfig.Subdomain = h.routingSuffix
 	} else {
-		cfg.RoutingConfig.Subdomain = fmt.Sprintf("%s.xip.io", serverIP)
+		cfg.RoutingConfig.Subdomain = fmt.Sprintf("%s.xip.io", routerIP)
 	}
 
 	if len(metricsHost) > 0 && cfg.AssetConfig != nil {

--- a/pkg/bootstrap/docker/openshift/helper_unix.go
+++ b/pkg/bootstrap/docker/openshift/helper_unix.go
@@ -63,7 +63,7 @@ func (h *Helper) startSocatTunnel() error {
 	if err != nil {
 		glog.V(1).Infof("error: cannot kill socat: %v", err)
 	}
-	cmd := exec.Command("socat", "TCP-L:8443,reuseaddr,fork,backlog=20", "SYSTEM:\"docker exec -i origin socat - TCP\\:localhost\\:8443,nodelay\"")
+	cmd := exec.Command("socat", "TCP-L:8443,reuseaddr,fork,backlog=20,bind=127.0.0.1", "SYSTEM:\"docker exec -i origin socat - TCP\\:localhost\\:8443,nodelay\"")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
On OS X using Docker for Mac, it is not possible to access the Docker VM directly via host IP (this is not the case with Windows). The workaround we use in cluster up is to start a socat bridge that will listen on the Mac's local interface and forward traffic to the origin container. 

Until now, the socat process has been bound to all interfaces on the Mac. This exposes the OpenShift master endpoint to the external world. It's not the case when using docker-machine because the vm's IP is only accessible to the Mac. This change makes it so the socat process on the Mac will only bind to 127.0.0.1. 

The router ip is still based on the default IP of the Mac and routes for applications running on OpenShift on the Mac will still be visible to the outside world.