### PR TITLE
the parameter no need set again

### DIFF
--- a/pkg/build/controller/jenkins/jenkins.go
+++ b/pkg/build/controller/jenkins/jenkins.go
@@ -101,7 +101,6 @@ func substituteTemplateParameters(params map[string]string, t *templateapi.Templ
 		if v := template.GetParameterByName(t, name); v != nil {
 			v.Value = value
 			v.Generate = ""
-			template.AddParameter(t, *v)
 		} else {
 			errors = append(errors, fmt.Errorf("unknown parameter %q specified for template", name))
 		}

--- a/pkg/build/controller/jenkins/jenkins_test.go
+++ b/pkg/build/controller/jenkins/jenkins_test.go
@@ -1,0 +1,41 @@
+package jenkins
+
+import (
+	"fmt"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	"testing"
+)
+
+func TestSubstituteTemplateParameters(t *testing.T) {
+	template := &templateapi.Template{
+		Parameters: []templateapi.Parameter{
+			{Name: "parameter_foo_bar_exist", Value: "value_foo_bar_exist_old"},
+			{Name: "parameter_foo_bar_2", Value: "value_foo_bar_2"}},
+	}
+	oldParameterNum := len(template.Parameters)
+	testParamMap := map[string]string{}
+	testParamMap["parameter_foo_bar_exist"] = "value_foo_bar_exist_new"
+	testParamMap["parameter_foo_bar_no_exist"] = "value_foo_bar_no_exist"
+	testParamMap[""] = "value_foo_bar_empty"
+
+	errors := substituteTemplateParameters(testParamMap, template)
+	if len(errors) != 2 {
+		for index, err := range errors {
+			fmt.Printf("errors[%d] : %v\n", index, err)
+		}
+		t.Errorf("expect unknown parameter and empty errors")
+	}
+	if len(template.Parameters) != oldParameterNum {
+		t.Errorf("expect parameters num : %d", oldParameterNum)
+	}
+	if !(template.Parameters[0].Name == "parameter_foo_bar_exist" &&
+		template.Parameters[0].Value == "value_foo_bar_exist_new") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_exist", "value_foo_bar_exist_new", template.Parameters[0].Name, template.Parameters[0].Value)
+	}
+	if !(template.Parameters[1].Name == "parameter_foo_bar_2" &&
+		template.Parameters[1].Value == "value_foo_bar_2") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_2", "value_foo_bar_2", template.Parameters[1].Name, template.Parameters[1].Value)
+	}
+}

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -302,7 +302,6 @@ func injectUserVars(values []string, t *templateapi.Template) []error {
 			if v := template.GetParameterByName(t, p[0]); v != nil {
 				v.Value = p[1]
 				v.Generate = ""
-				template.AddParameter(t, *v)
 			} else {
 				errors = append(errors, fmt.Errorf("unknown parameter name %q\n", p[0]))
 			}

--- a/pkg/cmd/cli/cmd/process_test.go
+++ b/pkg/cmd/cli/cmd/process_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	"testing"
+)
+
+func TestInjectUserVars(t *testing.T) {
+	template := &templateapi.Template{
+		Parameters: []templateapi.Parameter{
+			{Name: "parameter_foo_bar_exist", Value: "value_foo_bar_exist_old"},
+			{Name: "parameter_foo_bar_2", Value: "value_foo_bar_2"}},
+	}
+	oldParameterNum := len(template.Parameters)
+	testParam := []string{"parameter_foo_bar_exist=value_foo_bar_exist_new",
+		"parameter_foo_bar_no_exist=value_foo_bar_no_exist",
+		"parameter_foo_bar_error=value_foo_bar_error=value_foo_bar_error"}
+
+	errors := injectUserVars(testParam, template)
+	if len(errors) != 2 {
+		for index, err := range errors {
+			fmt.Printf("errors[%d] : %v\n", index, err)
+		}
+		t.Errorf("expect invalid parameter and unknown parameter errors")
+	}
+	if len(template.Parameters) != oldParameterNum {
+		t.Errorf("expect parameters num : %d", oldParameterNum)
+	}
+	if !(template.Parameters[0].Name == "parameter_foo_bar_exist" &&
+		template.Parameters[0].Value == "value_foo_bar_exist_new") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_exist", "value_foo_bar_exist_new", template.Parameters[0].Name, template.Parameters[0].Value)
+	}
+	if !(template.Parameters[1].Name == "parameter_foo_bar_2" &&
+		template.Parameters[1].Value == "value_foo_bar_2") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_2", "value_foo_bar_2", template.Parameters[1].Name, template.Parameters[1].Value)
+	}
+}

--- a/pkg/generate/app/cmd/template.go
+++ b/pkg/generate/app/cmd/template.go
@@ -25,7 +25,6 @@ func TransformTemplate(tpl *templateapi.Template, client client.TemplateConfigsN
 		}
 		v.Value = value
 		v.Generate = ""
-		template.AddParameter(tpl, *v)
 	}
 
 	name := localOrRemoteName(tpl.ObjectMeta, namespace)

--- a/pkg/generate/app/cmd/template_test.go
+++ b/pkg/generate/app/cmd/template_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/openshift/origin/pkg/client/testclient"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"testing"
+)
+
+func TestTransformTemplate(t *testing.T) {
+	templatefoobar := &templateapi.Template{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "foo_bar_template_name",
+			Namespace: "foo_bar_namespace",
+		},
+		Parameters: []templateapi.Parameter{
+			{Name: "parameter_foo_bar_exist", Value: "value_foo_bar_exist_old"},
+			{Name: "parameter_foo_bar_2", Value: "value_foo_bar_2"}},
+	}
+	oldParameterNum := len(templatefoobar.Parameters)
+	testParamMap := map[string]string{}
+	testParamMap["parameter_foo_bar_exist"] = "value_foo_bar_exist_new"
+
+	fakeosClient := &testclient.Fake{}
+
+	template, err := TransformTemplate(templatefoobar, fakeosClient, "foo_bar_namespace", testParamMap)
+	if err != nil {
+		t.Errorf("unexpect err : %v", err)
+	}
+	if len(template.Parameters) != oldParameterNum {
+		t.Errorf("expect parameters num : %d", oldParameterNum)
+	}
+	if !(template.Parameters[0].Name == "parameter_foo_bar_exist" &&
+		template.Parameters[0].Value == "value_foo_bar_exist_new") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_exist", "value_foo_bar_exist_new", template.Parameters[0].Name, template.Parameters[0].Value)
+	}
+	if !(template.Parameters[1].Name == "parameter_foo_bar_2" &&
+		template.Parameters[1].Value == "value_foo_bar_2") {
+		t.Errorf("expect Name : %q Value : %q get Name : %q Value : %q",
+			"parameter_foo_bar_2", "value_foo_bar_2", template.Parameters[1].Name, template.Parameters[1].Value)
+	}
+}


### PR DESCRIPTION
The parameter value has been set in` v.Value = value`, and `v` is a pointer pointed to the parameter exist in template.  why set the value again by running function `AddParameter`? I think it is redundant in this context.