### PR TITLE
fix fake_buildconfigs methods

### DIFF
--- a/pkg/client/testclient/fake_buildconfigs.go
+++ b/pkg/client/testclient/fake_buildconfigs.go
@@ -77,7 +77,7 @@ func (c *FakeBuildConfigs) WebHookURL(name string, trigger *buildapi.BuildTrigge
 }
 
 func (c *FakeBuildConfigs) Instantiate(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
+	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
 	action.Subresource = "instantiate"
 	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
 	if obj == nil {
@@ -88,7 +88,7 @@ func (c *FakeBuildConfigs) Instantiate(request *buildapi.BuildRequest) (result *
 }
 
 func (c *FakeBuildConfigs) InstantiateBinary(request *buildapi.BinaryBuildRequestOptions, r io.Reader) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
+	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
 	action.Subresource = "instantiatebinary"
 	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
 	if obj == nil {


### PR DESCRIPTION
This PR fixes the follow error when testing buildconfig `Instantiate` and `InstantiateBinary` methods:

error:
```
panic: interface conversion: runtime.Object is *api.BuildConfig, not *api.Build [recovered]
	panic: interface conversion: runtime.Object is *api.BuildConfig, not *api.Build
```