### PR TITLE
Enable pods-per-core by default, and increase max pods

### DIFF
--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -156,7 +156,8 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	server.FileCheckFrequency = unversioned.Duration{Duration: time.Duration(fileCheckInterval) * time.Second}
 	server.PodInfraContainerImage = imageTemplate.ExpandOrDie("pod")
 	server.CPUCFSQuota = true // enable cpu cfs quota enforcement by default
-	server.MaxPods = 110
+	server.MaxPods = 250
+	server.PodsPerCore = 10
 	server.SerializeImagePulls = false          // disable serialized image pulls by default
 	server.EnableControllerAttachDetach = false // stay consistent with existing config, but admins should enable it
 	if enableDNS {


### PR DESCRIPTION
Requested by @jeremyeder in https://bugzilla.redhat.com/show_bug.cgi?id=1371309

This may impact testing scenarios as machines with 0-10 cores will now have a smaller max pod capacity than previously configured.

/cc @smarterclayton @liggitt @timothysc 