### PR TITLE
UPSTREAM: 0000: improve err for resource by name with --all-namespaces option

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 
+	"strings"
+
 	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -288,6 +290,12 @@ func RunGet(f *cmdutil.Factory, out io.Writer, errOut io.Writer, cmd *cobra.Comm
 		Do()
 	err = r.Err()
 	if err != nil {
+		if strings.Contains(err.Error(), "across multiple namespaces") {
+			parentCmd := cmd.Parent()
+			if parentCmd != nil {
+				return fmt.Errorf("%v (e.g. %s get pod mypod --all-namespaces)", err, parentCmd.CommandPath())
+			}
+		}
 		return err
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -624,7 +624,7 @@ func (b *Builder) visitorResult() *Result {
 				selectorNamespace = ""
 			} else {
 				if len(b.namespace) == 0 {
-					return &Result{singular: isSingular, err: fmt.Errorf("namespace may not be empty when retrieving a resource by name")}
+					return &Result{singular: isSingular, err: fmt.Errorf("resources cannot be retrieved by name across multiple namespaces")}
 				}
 			}
 
@@ -671,7 +671,7 @@ func (b *Builder) visitorResult() *Result {
 			selectorNamespace = ""
 		} else {
 			if len(b.namespace) == 0 {
-				return &Result{singular: isSingular, err: fmt.Errorf("namespace may not be empty when retrieving a resource by name")}
+				return &Result{singular: isSingular, err: fmt.Errorf("resources cannot be retrieved by name across multiple namespaces")}
 			}
 		}
 


### PR DESCRIPTION
Related Trello card:
https://trello.com/c/04lpfTQR/451-8-cli-improved-flows-and-ux-in-the-cli-evg-ux-p3

Related discussion:
https://docs.google.com/document/d/1azhwziQq584FtfX3DgTebLnfA3dL1eHCX5w2-WypM8A/edit?disco=AAAAA1uD2Os

This patch makes the error message more clear when a user specifies the
`--all-namespaces` flag when `get`ting a resource by name.

**Before**
```
$ oc get pod <mypod> --all-namespaces

error: namespace may not be empty when retrieving a resource by name
```

**After**
```
$ oc get pod <mypod> --all-namespaces

error: resources cannot be retrieved by name across multiple namespaces
(e.g. oc get pod mypod --all-namespaces)
```

@openshift/cli-review 