### PR TITLE
Remove manpage generation from Tito build

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -183,9 +183,6 @@ Obsoletes:        openshift-sdn-ovs < %{package_refector_version}
 # Create extended.test
 %{os_git_vars} hack/build-go.sh test/extended/extended.test
 
-# Create/Update man pages
-%{os_git_vars} hack/update-generated-docs.sh
-
 %install
 
 PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"


### PR DESCRIPTION
If a Tito build is done from a commit checked into origin/master,
the man pages will by definition be up-to-date, as verifying that
is a prerequisite for pull request acceptance.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>