### PR TITLE
Updates `oc run` examples

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -2309,6 +2309,13 @@ Run a particular image on the cluster
 
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
   oc run -i --tty nginx --image=nginx --restart=Never
+
+  # Start the nginx container using the default command, but use custom
+  # arguments (arg1 .. argN) for that command.
+  oc run nginx --image=nginx -- <arg1> <arg2> ... <argN>
+
+  # Start the nginx container using a different command and custom arguments
+  oc run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
 ----
 ====
 

--- a/docs/man/man1/oc-run.1
+++ b/docs/man/man1/oc-run.1
@@ -250,6 +250,13 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
   oc run \-i \-\-tty nginx \-\-image=nginx \-\-restart=Never
 
+  # Start the nginx container using the default command, but use custom
+  # arguments (arg1 .. argN) for that command.
+  oc run nginx \-\-image=nginx \-\- <arg1> <arg2> ... <argN>
+
+  # Start the nginx container using a different command and custom arguments
+  oc run nginx \-\-image=nginx \-\-command \-\- <cmd> <arg1> ... <argN>
+
 .fi
 .RE
 

--- a/docs/man/man1/openshift-cli-run.1
+++ b/docs/man/man1/openshift-cli-run.1
@@ -250,6 +250,13 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
   openshift cli run \-i \-\-tty nginx \-\-image=nginx \-\-restart=Never
 
+  # Start the nginx container using the default command, but use custom
+  # arguments (arg1 .. argN) for that command.
+  openshift cli run nginx \-\-image=nginx \-\- <arg1> <arg2> ... <argN>
+
+  # Start the nginx container using a different command and custom arguments
+  openshift cli run nginx \-\-image=nginx \-\-command \-\- <cmd> <arg1> ... <argN>
+
 .fi
 .RE
 

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -385,16 +385,14 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
   %[1]s run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
-  %[1]s run -i --tty nginx --image=nginx --restart=Never`
+  %[1]s run -i --tty nginx --image=nginx --restart=Never
 
-	// TODO: uncomment these when arguments are delivered upstream
+  # Start the nginx container using the default command, but use custom
+  # arguments (arg1 .. argN) for that command.
+  %[1]s run nginx --image=nginx -- <arg1> <arg2> ... <argN>
 
-	// Start the nginx container using the default command, but use custom
-	// arguments (arg1 .. argN) for that command.
-	//%[1]s run nginx --image=nginx -- <arg1> <arg2> ... <argN>
-
-	// Start the nginx container using a different command and custom arguments
-	//%[1]s run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>`
+  # Start the nginx container using a different command and custom arguments
+  %[1]s run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>`
 )
 
 // NewCmdRun is a wrapper for the Kubernetes cli run command


### PR DESCRIPTION
* Removes a todo item from the list
* Test coverage provided by kubernetes/kubernetes#13917
* closes openshift/origin#8620