### PR TITLE
Fixup tito tagger and builder libs

### DIFF
--- a/.tito/lib/origin/builder/__init__.py
+++ b/.tito/lib/origin/builder/__init__.py
@@ -61,6 +61,7 @@ class OriginBuilder(Builder):
             os_git_commit = run_command("bash -c '{0}'".format(cmd))
             cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_VERSION}'
             os_git_version = run_command("bash -c '{0}'".format(cmd))
+            os_git_version = os_git_version.replace('-dirty', '')
             cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MAJOR}'
             os_git_major = run_command("bash -c '{0}'".format(cmd))
             cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MINOR}'
@@ -78,17 +79,6 @@ class OriginBuilder(Builder):
                         self.spec_file
                     )
             output = run_command(update_os_git_vars)
-
-            ## Fixup ldflags
-            cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; echo $(os::build::ldflags)'
-            ldflags = run_command("bash -c '{0}'".format(cmd))
-            print("LDFLAGS::{0}".format(ldflags))
-            update_ldflags = \
-                    "sed -i 's|^%global ldflags .*$|%global ldflags {0}|' {1}".format(
-                        ' '.join([ldflag.strip() for ldflag in ldflags.split()]),
-                        self.spec_file
-                    )
-            output = run_command(update_ldflags)
 
             # Add bundled deps for Fedora Guidelines as per:
             # https://fedoraproject.org/wiki/Packaging:Guidelines#Bundling_and_Duplication_of_system_libraries


### PR DESCRIPTION
Update origin.spec os_git_vars on tag
Do not do -dirty during rpm builds
Clean out build flags commands since they are no longer used in origin.spec file