### PR TITLE
UPSTREAM: 34020: Allow empty annotation values

### DIFF
--- a/test/cmd/annotations.sh
+++ b/test/cmd/annotations.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
+os::test::junit::declare_suite_start "cmd/annotate"
+# This test validates empty values in key-value pairs set by the annotate command
+os::cmd::expect_success_and_text 'oc process -f examples/zookeeper/template.json | oc apply -f -' 'pod "zookeeper-1" created'
+os::cmd::expect_success_and_text 'oc annotate pod zookeeper-1 node-selector=""' 'pod "zookeeper-1" annotated'
+os::cmd::expect_success_and_text 'oc get pod zookeeper-1 --template="{{.metadata.annotations}}"' 'node-selector:'
+
+echo "annotate: ok"
+os::test::junit::declare_suite_end
+
+os::test::junit::declare_suite_start "cmd/label"
+# This test validates empty values in key-value pairs set by the label command
+os::cmd::expect_success_and_text 'oc label pod zookeeper-1 label2=""' 'pod "zookeeper-1" labeled'
+os::cmd::expect_success_and_text 'oc get pod zookeeper-1 --template="{{.metadata.labels}}"' 'label2\: '
+
+echo "label: ok"
+os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/annotate_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/annotate_test.go
@@ -143,15 +143,16 @@ func TestParseAnnotations(t *testing.T) {
 			expectErr:   true,
 		},
 		{
-			annotations: []string{"a="},
-			expectedErr: "invalid annotation format: a=",
-			scenario:    "incorrect annotation input (missing value)",
-			expectErr:   true,
+			annotations:    []string{"a="},
+			expected:       map[string]string{"a": ""},
+			expectedRemove: []string{},
+			scenario:       "add valid annotation with empty value",
+			expectErr:      false,
 		},
 		{
 			annotations: []string{"ab", "a="},
-			expectedErr: "invalid annotation format: ab, a=",
-			scenario:    "incorrect multiple annotation input (missing value)",
+			expectedErr: "invalid annotation format: ab",
+			scenario:    "incorrect annotation input (missing =value)",
 			expectErr:   true,
 		},
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label.go
@@ -129,7 +129,7 @@ func parseLabels(spec []string) (map[string]string, []string, error) {
 	for _, labelSpec := range spec {
 		if strings.Index(labelSpec, "=") != -1 {
 			parts := strings.Split(labelSpec, "=")
-			if len(parts) != 2 || len(parts[1]) == 0 {
+			if len(parts) != 2 {
 				return nil, nil, fmt.Errorf("invalid label spec: %v", labelSpec)
 			}
 			if errs := validation.IsValidLabelValue(parts[1]); len(errs) != 0 {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label_test.go
@@ -127,8 +127,8 @@ func TestParseLabels(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			labels:    []string{"a="},
-			expectErr: true,
+			labels:   []string{"a="},
+			expected: map[string]string{"a": ""},
 		},
 		{
 			labels:    []string{"a=%^$"},

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -601,7 +601,7 @@ func ParsePairs(pairArgs []string, pairType string, supportRemove bool) (newPair
 	for _, pairArg := range pairArgs {
 		if strings.Index(pairArg, "=") != -1 {
 			parts := strings.SplitN(pairArg, "=", 2)
-			if len(parts) != 2 || len(parts[1]) == 0 {
+			if len(parts) != 2 {
 				if invalidBuf.Len() > 0 {
 					invalidBuf.WriteString(", ")
 				}


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/34020

Fixes:
https://github.com/openshift/origin/issues/11175

Annotations with empty values can be used, for example, in oadm
diagnostics logging. This patch removes the client-side check for empty
values in an annotation key-value pair.

**Before**
```
$ oc annotate pod zookeeper-1 openshift.io/node-selector="" --overwrite
error: invalid annotation format: openshift.io/node-selector=
```

**After**
```
$ oc annotate pod zookeeper-1 openshift.io/node-selector="" --overwrite
pod "zookeper-1" annotated
```

```
$ oc get po/zookeeper-1 --template='{{.metadata.annotations}}'
map[... openshift.io/node-selector: openshift.io/scc:anyuid test-label:test]
```

@openshift/cli-review 