### PR TITLE
group podLists from different nodes into single list

### DIFF
--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -38,6 +38,13 @@ func (l *ListPodsOptions) Run() error {
 		}
 	}
 
+	// determine if printer kind is json or yaml and modify output
+	// to combine all pod lists into a single list
+	if l.Options.CmdPrinterOutput {
+		errs := l.handleRESTOutput(nodes, printer)
+		return kerrors.NewAggregate(errs)
+	}
+
 	errList := []error{}
 	for _, node := range nodes {
 		err := l.runListPods(node, printer)
@@ -61,8 +68,37 @@ func (l *ListPodsOptions) runListPods(node *kapi.Node, printer kubectl.ResourceP
 	if err != nil {
 		return err
 	}
+
 	fmt.Fprint(l.Options.ErrWriter, "\nListing matched pods on node: ", node.ObjectMeta.Name, "\n\n")
 	printer.PrintObj(pods, l.Options.Writer)
 
 	return err
+}
+
+// handleRESTOutput receives a list of nodes, and a REST output type, and combines *kapi.PodList
+// objects for every node, into a single list. This allows output containing multiple nodes to be
+// printed to a single writer, and be easily parsed as a single data format.
+func (l *ListPodsOptions) handleRESTOutput(nodes []*kapi.Node, printer kubectl.ResourcePrinter) []error {
+	unifiedPodList := &kapi.PodList{}
+
+	errList := []error{}
+	for _, node := range nodes {
+		labelSelector, err := labels.Parse(l.Options.PodSelector)
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+		fieldSelector := fields.Set{GetPodHostFieldLabel(node.TypeMeta.APIVersion): node.ObjectMeta.Name}.AsSelector()
+
+		pods, err := l.Options.KubeClient.Pods(kapi.NamespaceAll).List(kapi.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+
+		unifiedPodList.Items = append(unifiedPodList.Items, pods.Items...)
+	}
+
+	printer.PrintObj(unifiedPodList, l.Options.Writer)
+	return errList
 }


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1381621

When listing pods as JSON or YAML for one or more nodes with `oadm manage-node`, the
node name is printed to stderr, while the PodList object is printed to stdout.

This patch updates the output of `oadm manage-node --list-pods` to join the list of
pods of every node into a single PodList, allowing the output to consist of a single
api.PodList object.

**Before**
```
$ oadm manage-node --selector="type=infra" --list-pods -o json

Listing matched pods on node: ip-172-31-53-15.ec2.internal

{
    "metadata": {
        "selfLink": "/api/v1/pods",
        "resourceVersion": "350009"
    },
    "items": [
        {
....
}

Listing matched pods on node: ip-172-31-53-16.ec2.internal

{
    "metadata": {
        "selfLink": "/api/v1/pods",
        "resourceVersion": "350009"
    },
    "items": [
        {
...
}
```

**After**

`"items" will contain the pods of every node`
```
$ oadm manage-node --selector="type=infra" --list-pods -o json
{
    "metadata": {
        "selfLink": "/api/v1/pods",
        "resourceVersion": "350009"
    },
    "items": [
        {
...
}
```

@openshift/cli-review 