### PR TITLE
Change default node permission check to <apiVerb> nodes/proxy

### DIFF
--- a/pkg/cmd/server/kubernetes/node_auth.go
+++ b/pkg/cmd/server/kubernetes/node_auth.go
@@ -96,16 +96,6 @@ func isSubpath(r *http.Request, path string) bool {
 //    /logs/*    => verb=<api verb from request>, resource=nodes/log
 func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) kauthorizer.Attributes {
 
-	// Default verb/resource is proxy nodes, which allows full access to the kubelet API
-	attrs := oauthorizer.DefaultAuthorizationAttributes{
-		APIVersion:   "v1",
-		APIGroup:     "",
-		Verb:         "proxy",
-		Resource:     "nodes",
-		ResourceName: n.nodeName,
-		URL:          r.URL.Path,
-	}
-
 	namespace := ""
 
 	apiVerb := ""
@@ -120,6 +110,16 @@ func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 		apiVerb = "patch"
 	case "DELETE":
 		apiVerb = "delete"
+	}
+
+	// Default verb/resource is <apiVerb> nodes/proxy, which allows full access to the kubelet API
+	attrs := oauthorizer.DefaultAuthorizationAttributes{
+		APIVersion:   "v1",
+		APIGroup:     "",
+		Verb:         apiVerb,
+		Resource:     "nodes/proxy",
+		ResourceName: n.nodeName,
+		URL:          r.URL.Path,
 	}
 
 	// Override verb/resource for specific paths


### PR DESCRIPTION
1.3 policy allows `*` on `nodes/proxy`. Switching nodes to check that permission.
fixes #8065