### PR TITLE
Correctly parse git versions with longer short hashes

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -693,7 +693,7 @@ function os::build::os_version_vars() {
       #
       # TODO: We continue calling this "git version" because so many
       # downstream consumers are expecting it there.
-      OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7\}\)$/\+\2/")
+      OS_GIT_VERSION=$(echo "${OS_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7,40\}\)$/\+\2/")
       if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
         # git describe --dirty only considers changes to existing files, but
         # that is problematic since new untracked .go files affect the build,
@@ -724,7 +724,7 @@ function os::build::kube_version_vars() {
   #
   # TODO: We continue calling this "git version" because so many
   # downstream consumers are expecting it there.
-  KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7\}\)$/\+\2/")
+  KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{7,40\}\)$/\+\2/")
 
   # Try to match the "git describe" output to a regex to try to extract
   # the "major" and "minor" versions and whether this is the exact tagged


### PR DESCRIPTION
I have a branch whose HEAD commit has a short hash that is 8 characters long instead of 7:

    > git log --abbrev-commit --oneline bad-git-version | head -3
    e3fa196a (danwinship/bad-git-version, bad-git-version) Make the OVS flow tests more generic
    4862e44 Renumber OVS tables
    2006b2c Update ovs.AddPort()/DeletePort() semantics

This trips up the git version parsing in the build scripts, which then causes the binaries to have an incorrect version:

    > oc version
    oc v1.4.0-alpha.0-356-ge3fa196a

(should be `oc v1.4.0-alpha.0+e3fa196a`) which in turn causes origin to try to fetch an incorrectly-versioned origin-pod image (one with the tag `v1.4.0-alpha.0-356-ge3fa196a` rather than `v1.4.0-alpha.0`), which doesn't exist.

Fix is easy, just allow the commit hash to be 7-or-more hex digits rather than 7.

(The conflict is with a blob with the hash e3fa196b14ff6f9ec85aee2963e400c8653c20bc. Assuming that's an object in the main origin tree, you should be able to check out the "bad-git-version" branch of danwinship/origin and see the problem.)