### PR TITLE
[wip] Ensure `tito` builds don't clean up after themselves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ install-travis:
 # Example:
 #   make build-rpms
 build-rpms:
-	OS_ONLY_BUILD_PLATFORMS='linux/amd64' tito build --test --rpm --no-cleanup --rpmbuild-options='--define "make_redistributable 0"'
+	OS_ONLY_BUILD_PLATFORMS='linux/amd64' tito build --test --rpm --no-cleanup --rpmbuild-options='--noclean --define "make_redistributable 0"'
 .PHONY: build-rpms
 
 # Build RPMs for all architectures
@@ -247,5 +247,5 @@ build-rpms:
 # Example:
 #   make build-rpms-redistributable
 build-rpms-redistributable:
-	tito build --test --rpm --no-cleanup --rpmbuild-options='--define "make_redistributable 1"'
+	tito build --test --rpm --no-cleanup --rpmbuild-options='--noclean --define "make_redistributable 1"'
 .PHONY: build-rpms-redistributable

--- a/origin.spec
+++ b/origin.spec
@@ -289,6 +289,8 @@ done
 install -d -m 755 %{buildroot}%{_sysconfdir}/systemd/system.conf.d/
 install -p -m 644 contrib/systemd/origin-accounting.conf %{buildroot}%{_sysconfdir}/systemd/system.conf.d/
 
+%clean
+
 %files
 %doc README.md
 %license LICENSE


### PR DESCRIPTION
Follow up to https://github.com/openshift/origin/pull/11182

Fixes #11184 

/cc @dgoodwin @tdawson @sdodson 