### PR TITLE
doc and template updates for jenkins openshift oauth plugin

### DIFF
--- a/examples/jenkins/jenkins-ephemeral-template.json
+++ b/examples/jenkins/jenkins-ephemeral-template.json
@@ -10,7 +10,7 @@
       "tags": "instant-app,jenkins"
     }
   },
-  "message": "A Jenkins service has been created in your project.  The username/password are admin/${JENKINS_PASSWORD}.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
+  "message": "A Jenkins service has been created in your project.  Log into Jenkins with your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
   "objects": [
     {
       "kind": "Route",
@@ -96,8 +96,12 @@
                 },
                 "env": [
                   {
-                    "name": "JENKINS_PASSWORD",
-                    "value": "${JENKINS_PASSWORD}"
+                    "name": "OPENSHIFT_ENABLE_OAUTH",
+                    "value": "true"
+                  },
+                  {
+                    "name": "OPENSHIFT_ENABLE_REDIRECT_PROMPT",
+                    "value": "true"
                   },
                   {
                     "name": "KUBERNETES_MASTER",
@@ -150,7 +154,10 @@
       "kind": "ServiceAccount",
         "apiVersion": "v1",
         "metadata": {
-            "name": "${JENKINS_SERVICE_NAME}"
+            "name": "${JENKINS_SERVICE_NAME}",
+            "annotations": {
+		"serviceaccounts.openshift.io/oauth-redirectreference.jenkins": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"${JENKINS_SERVICE_NAME}\"}}"
+            }
         }
     },
     {
@@ -234,14 +241,6 @@
       "displayName": "Jenkins JNLP Service Name",
       "description": "The name of the service used for master/slave communication.",
       "value": "jenkins-jnlp"
-    },
-    {
-      "name": "JENKINS_PASSWORD",
-      "displayName": "Jenkins Password",
-      "description": "Password for the Jenkins 'admin' user.",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{16}",
-      "required": true
     },
     {
       "name": "MEMORY_LIMIT",

--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -10,7 +10,7 @@
       "tags": "instant-app,jenkins"
     }
   },
-  "message": "A Jenkins service has been created in your project.  The username/password are admin/${JENKINS_PASSWORD}.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
+  "message": "A Jenkins service has been created in your project.  Log into Jenkins with your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
   "objects": [
     {
       "kind": "Route",
@@ -113,8 +113,12 @@
                 },
                 "env": [
                   {
-                    "name": "JENKINS_PASSWORD",
-                    "value": "${JENKINS_PASSWORD}"
+                    "name": "OPENSHIFT_ENABLE_OAUTH",
+                    "value": "true"
+                  },
+                  {
+                    "name": "OPENSHIFT_ENABLE_REDIRECT_PROMPT",
+                    "value": "true"
                   },
                   {
                     "name": "KUBERNETES_MASTER",
@@ -167,7 +171,10 @@
       "kind": "ServiceAccount",
         "apiVersion": "v1",
         "metadata": {
-            "name": "${JENKINS_SERVICE_NAME}"
+            "name": "${JENKINS_SERVICE_NAME}",
+            "annotations": {
+                  "serviceaccounts.openshift.io/oauth-redirectref.jenkins": "{\"kind\": \"Route\", \"name\": \"${JENKINS_SERVICE_NAME}\", \"group\": \"\"}"
+            }
         }
     },
     {
@@ -251,14 +258,6 @@
       "displayName": "Jenkins JNLP Service Name",
       "description": "The name of the service used for master/slave communication.",
       "value": "jenkins-jnlp"
-    },
-    {
-      "name": "JENKINS_PASSWORD",
-      "displayName": "Jenkins Password",
-      "description": "Password for the Jenkins 'admin' user.",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{16}",
-      "required": true
     },
     {
       "name": "MEMORY_LIMIT",

--- a/examples/jenkins/master-slave/README.md
+++ b/examples/jenkins/master-slave/README.md
@@ -65,10 +65,9 @@ Before you begin, ensure you have created the [default imagestreams](https://doc
    ready to be used.
 
 8. Now click on *Add to project* again and select the `jenkins-master` template.
-   Here you can pick your Jenkins administrator password, alternative Docker
-   image (by default the OpenShift Jenkins Image will be used) or the custom S2I
-   repository with your configuration. For this sample, you don't need to change
-   these values.
+   Here you can pick an alternative Docker image (by default the OpenShift Jenkins
+   Image will be used) or the custom S2I repository with your configuration. For this
+   sample, you don't need to change these values.
 
 9. Click *Create* and navigate to the *Overview* page. You should see the
    Jenkins route and the link to a `jenkins-master #1 build`. Once the build

--- a/examples/jenkins/pipeline/README.md
+++ b/examples/jenkins/pipeline/README.md
@@ -21,7 +21,7 @@ jenkins template represented by jenkinstemplate.json by running these commands a
 
         $ oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/jenkins/jenkins-persistent-template.json -n openshift
 
-2. Login as a normal user (any username is fine)
+2. Login as a normal user (any user name is fine)
 
         $ oc login
 
@@ -39,9 +39,7 @@ jenkins template represented by jenkinstemplate.json by running these commands a
 
         $ oc new-app jenkins-ephemeral
 
-    Make a note of the Jenkins password reported by new-app.
-
-    Note: eventually this will be done automatically when you create a pipeline buildconfig.
+    Note: eventually the instantiation of the Jenkins server and service account will be done automatically when you create a pipeline buildconfig.
 
 5. Run this command to instantiate the template which will create a pipeline buildconfig and some other resources in your project:
 
@@ -66,9 +64,12 @@ jenkins template represented by jenkinstemplate.json by running these commands a
 
     and access the host for the Jenkins route.
 
-    If you do not have a router, you can access jenkins directly via the service ip.  Determine the jenkins service ip ("oc get svc") and go to it in your browser on port 80.  Do not confuse it with the jenkins-jnlp service.
+    If you do not have a router, or your host system does not support xip.io name resolution you can access jenkins directly via the service ip.  Determine the jenkins service ip ("oc get svc") and go to it in your browser on port 80.  Do not confuse it with the jenkins-jnlp service.
+    If you take this approach, run the following command before attempting to log into Jenkins:
 
-    Login with the user name is `admin` and the password as recorded earlier.
+        $ oc annotate sa/jenkins serviceaccounts.openshift.io/oauth-redirecturi.1=http://<jenkins_service_ip:jenkins_service_port>/securityRealm/finishLogin --overwrite
+ 
+    Login with the user name used to create the "pipelineproject" and any non-empty password.
 
 6. Launch a new build
 

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -3217,7 +3217,7 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "tags": "instant-app,jenkins"
     }
   },
-  "message": "A Jenkins service has been created in your project.  The username/password are admin/${JENKINS_PASSWORD}.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
+  "message": "A Jenkins service has been created in your project.  Log into Jenkins with your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
   "objects": [
     {
       "kind": "Route",
@@ -3303,8 +3303,12 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
                 },
                 "env": [
                   {
-                    "name": "JENKINS_PASSWORD",
-                    "value": "${JENKINS_PASSWORD}"
+                    "name": "OPENSHIFT_ENABLE_OAUTH",
+                    "value": "true"
+                  },
+                  {
+                    "name": "OPENSHIFT_ENABLE_REDIRECT_PROMPT",
+                    "value": "true"
                   },
                   {
                     "name": "KUBERNETES_MASTER",
@@ -3357,7 +3361,10 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "kind": "ServiceAccount",
         "apiVersion": "v1",
         "metadata": {
-            "name": "${JENKINS_SERVICE_NAME}"
+            "name": "${JENKINS_SERVICE_NAME}",
+            "annotations": {
+		"serviceaccounts.openshift.io/oauth-redirectreference.jenkins": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"${JENKINS_SERVICE_NAME}\"}}"
+            }
         }
     },
     {
@@ -3443,14 +3450,6 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "value": "jenkins-jnlp"
     },
     {
-      "name": "JENKINS_PASSWORD",
-      "displayName": "Jenkins Password",
-      "description": "Password for the Jenkins 'admin' user.",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{16}",
-      "required": true
-    },
-    {
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
@@ -3502,7 +3501,7 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "tags": "instant-app,jenkins"
     }
   },
-  "message": "A Jenkins service has been created in your project.  The username/password are admin/${JENKINS_PASSWORD}.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
+  "message": "A Jenkins service has been created in your project.  Log into Jenkins with your OpenShift account.  The tutorial at https://github.com/openshift/origin/blob/master/examples/jenkins/README.md contains more information about using this template.",
   "objects": [
     {
       "kind": "Route",
@@ -3605,8 +3604,12 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
                 },
                 "env": [
                   {
-                    "name": "JENKINS_PASSWORD",
-                    "value": "${JENKINS_PASSWORD}"
+                    "name": "OPENSHIFT_ENABLE_OAUTH",
+                    "value": "true"
+                  },
+                  {
+                    "name": "OPENSHIFT_ENABLE_REDIRECT_PROMPT",
+                    "value": "true"
                   },
                   {
                     "name": "KUBERNETES_MASTER",
@@ -3659,7 +3662,10 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "kind": "ServiceAccount",
         "apiVersion": "v1",
         "metadata": {
-            "name": "${JENKINS_SERVICE_NAME}"
+            "name": "${JENKINS_SERVICE_NAME}",
+            "annotations": {
+                  "serviceaccounts.openshift.io/oauth-redirectref.jenkins": "{\"kind\": \"Route\", \"name\": \"${JENKINS_SERVICE_NAME}\", \"group\": \"\"}"
+            }
         }
     },
     {
@@ -3743,14 +3749,6 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "displayName": "Jenkins JNLP Service Name",
       "description": "The name of the service used for master/slave communication.",
       "value": "jenkins-jnlp"
-    },
-    {
-      "name": "JENKINS_PASSWORD",
-      "displayName": "Jenkins Password",
-      "description": "Password for the Jenkins 'admin' user.",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{16}",
-      "required": true
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
A couple of notes:
- still waiting on the exact format of the redirect annotations to settle in https://github.com/openshift/origin/pull/10878 ... the PR reflects the original approach (which most likely will be modified)
- on the main jenkins example readme, I toyed with converting to a `oc cluster up` form, but in the end, took the less invasive path, with the assumption that we still wanted some non-cluster up examples sprinkled in ... it probably wouldn't take much to sway me from this
- I'm thinking the redirect env var goes away when we get the new page from @jwforres 's team, assuming that page will clearly convey that both a) the login page is for jenkins, and b) the login is managed by openshift oauth ... perhaps we should get rid of it altogether, but I've left it in for now to discuss

@bparees ptal