### PR TITLE
Note the commit for the release packaged by hack/build-cross.sh

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -35,6 +35,11 @@ OS_GOFLAGS="${OS_GOFLAGS:-} ${OS_IMAGE_COMPILE_GOFLAGS}" os::build::build_static
 OS_RELEASE_ARCHIVE="openshift-origin"
 OS_BUILD_PLATFORMS=("${platforms[@]}")
 os::build::place_bins "${OS_CROSS_COMPILE_BINARIES[@]}"
+if [[ "${OS_GIT_TREE_STATE:-dirty}" == "clean"  ]]; then
+	# only when we are building from a clean state can we claim to
+	# have created a valid set of binaries that can resemble a release
+	echo "${OS_GIT_COMMIT}" > "${OS_LOCAL_RELEASEPATH}/.commit"
+fi
 
 # Make the image binaries release.
 OS_RELEASE_ARCHIVE="openshift-origin-image"


### PR DESCRIPTION
In order to be accepted as a valid set of releases by scripts like
hack/build-images.sh, etc., hack/build-cross.sh should note the
Git commit used to build binaries and place it in the release dir.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton 