### PR TITLE
UPSTREAM: 34763: log warning on invalid --output-version

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/result.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/result.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -228,6 +229,18 @@ func AsVersionedObject(infos []*Info, forceList bool, version unversioned.GroupV
 		}
 		object = converted
 	}
+
+	// validSpecifiedVersion resolves to true if the version passed to this function matches the
+	// version assigned to the converted object
+	actualVersion := object.GetObjectKind().GroupVersionKind()
+	if actualVersion.Version != version.Version {
+		defaultVersionInfo := ""
+		if len(actualVersion.Version) > 0 {
+			defaultVersionInfo = fmt.Sprintf("Defaulting to %q", actualVersion.Version)
+		}
+		glog.V(1).Infof(" info: the output version specified is invalid. %s\n", defaultVersionInfo)
+	}
+
 	return object, nil
 }
 


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/34763

Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1276564

Object versions default to the current version (v1) when a specified
`--output-version` is invalid. This patch logs a warning when this is
the case. Cases affected are all commands with the `--output-version`
option, and anywhere runtime objects are converted to versioned objects.

**Example**

```
$ oc get pod <mypod> -o json --output-version=invalid --loglevel=2
1006 14:48:34.090971   25620 result.go:239]  info: the output version
specified (invalid) is invalid, defaulting to v1
{
        "kind": "Pod",
            "apiVersion": "v1",
                "metadata": {
                            "name": "mypod",
                                    "namespace": "openshift",
...
```

@openshift/cli-review 
