### PR TITLE
Add a `make` target to build Docker images from a present release tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,3 +249,11 @@ build-rpms:
 build-rpms-redistributable:
 	tito build --test --rpm --no-cleanup --rpmbuild-options='--define "make_redistributable 1"'
 .PHONY: build-rpms-redistributable
+
+# Build OpenShift Origin Docker images
+#
+# Example:
+#   make build-images
+build-images:
+	hack/build-images.sh
+.PHONY: build-images


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>



/cc @smarterclayton alternatively we can have a `make rpm-release` target that replaces the `build-release` step with `tito`. WDYT?