### PR TITLE
deploy: api types refactor

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_deploy_api_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_deploy_api_v1.proto
@@ -269,7 +269,9 @@ message DeploymentStrategy {
   // Type is the name of a deployment strategy.
   optional string type = 1;
 
-  // CustomParams are the input to the Custom deployment strategy.
+  // CustomParams are the input to the Custom deployment strategy, and may also
+  // be specified for the Recreate and Rolling strategies to customize the execution
+  // process that runs the deployment.
   optional CustomDeploymentStrategyParams customParams = 2;
 
   // RecreateParams are the input to the Recreate deployment strategy.
@@ -278,7 +280,7 @@ message DeploymentStrategy {
   // RollingParams are the input to the Rolling deployment strategy.
   optional RollingDeploymentStrategyParams rollingParams = 4;
 
-  // Resources contains resource requirements to execute the deployment and any hooks
+  // Resources contains resource requirements to execute the deployment and any hooks.
   optional k8s.io.kubernetes.pkg.api.v1.ResourceRequirements resources = 5;
 
   // Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
@@ -424,8 +426,8 @@ message RollingDeploymentStrategyParams {
   optional LifecycleHook pre = 7;
 
   // Post is a lifecycle hook which is executed after the strategy has
-  // finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
-  // is NOT supported.
+  // finished all deployment logic. All LifecycleHookFailurePolicy values
+  // are supported.
   optional LifecycleHook post = 8;
 }
 

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -23218,7 +23218,7 @@
      },
      "customParams": {
       "$ref": "v1.CustomDeploymentStrategyParams",
-      "description": "CustomParams are the input to the Custom deployment strategy."
+      "description": "CustomParams are the input to the Custom deployment strategy, and may also be specified for the Recreate and Rolling strategies to customize the execution process that runs the deployment."
      },
      "recreateParams": {
       "$ref": "v1.RecreateDeploymentStrategyParams",
@@ -23230,7 +23230,7 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Resources contains resource requirements to execute the deployment and any hooks"
+      "description": "Resources contains resource requirements to execute the deployment and any hooks."
      },
      "labels": {
       "type": "object",
@@ -23399,7 +23399,7 @@
      },
      "post": {
       "$ref": "v1.LifecycleHook",
-      "description": "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. The LifecycleHookFailurePolicyAbort policy is NOT supported."
+      "description": "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. All LifecycleHookFailurePolicy values are supported."
      }
     }
    },

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -6,176 +6,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
-// DeploymentStatus describes the possible states a deployment can be in.
-type DeploymentStatus string
-
-const (
-	// DeploymentStatusNew means the deployment has been accepted but not yet acted upon.
-	DeploymentStatusNew DeploymentStatus = "New"
-	// DeploymentStatusPending means the deployment been handed over to a deployment strategy,
-	// but the strategy has not yet declared the deployment to be running.
-	DeploymentStatusPending DeploymentStatus = "Pending"
-	// DeploymentStatusRunning means the deployment strategy has reported the deployment as
-	// being in-progress.
-	DeploymentStatusRunning DeploymentStatus = "Running"
-	// DeploymentStatusComplete means the deployment finished without an error.
-	DeploymentStatusComplete DeploymentStatus = "Complete"
-	// DeploymentStatusFailed means the deployment finished with an error.
-	DeploymentStatusFailed DeploymentStatus = "Failed"
-)
-
-// DeploymentStrategy describes how to perform a deployment.
-type DeploymentStrategy struct {
-	// Type is the name of a deployment strategy.
-	Type DeploymentStrategyType
-
-	// RecreateParams are the input to the Recreate deployment strategy.
-	RecreateParams *RecreateDeploymentStrategyParams
-	// RollingParams are the input to the Rolling deployment strategy.
-	RollingParams *RollingDeploymentStrategyParams
-
-	// CustomParams are the input to the Custom deployment strategy, and may also
-	// be specified for the Recreate and Rolling strategies to customize the execution
-	// process that runs the deployment.
-	CustomParams *CustomDeploymentStrategyParams
-
-	// Resources contains resource requirements to execute the deployment
-	Resources kapi.ResourceRequirements
-	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
-	Labels map[string]string
-	// Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
-	Annotations map[string]string
-}
-
-// DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
-type DeploymentStrategyType string
-
-const (
-	// DeploymentStrategyTypeRecreate is a simple strategy suitable as a default.
-	DeploymentStrategyTypeRecreate DeploymentStrategyType = "Recreate"
-	// DeploymentStrategyTypeCustom is a user defined strategy. It is optional to set.
-	DeploymentStrategyTypeCustom DeploymentStrategyType = "Custom"
-	// DeploymentStrategyTypeRolling uses the Kubernetes RollingUpdater.
-	DeploymentStrategyTypeRolling DeploymentStrategyType = "Rolling"
-)
-
-// CustomDeploymentStrategyParams are the input to the Custom deployment strategy.
-type CustomDeploymentStrategyParams struct {
-	// Image specifies a Docker image which can carry out a deployment.
-	Image string
-	// Environment holds the environment which will be given to the container for Image.
-	Environment []kapi.EnvVar
-	// Command is optional and overrides CMD in the container Image.
-	Command []string
-}
-
-// RecreateDeploymentStrategyParams are the input to the Recreate deployment
-// strategy.
-type RecreateDeploymentStrategyParams struct {
-	// TimeoutSeconds is the time to wait for updates before giving up. If the
-	// value is nil, a default will be used.
-	TimeoutSeconds *int64
-	// Pre is a lifecycle hook which is executed before the strategy manipulates
-	// the deployment. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook
-	// Mid is a lifecycle hook which is executed while the deployment is scaled down to zero before the first new
-	// pod is created. All LifecycleHookFailurePolicy values are supported.
-	Mid *LifecycleHook
-	// Post is a lifecycle hook which is executed after the strategy has
-	// finished all deployment logic.
-	Post *LifecycleHook
-}
-
-// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
-type LifecycleHook struct {
-	// FailurePolicy specifies what action to take if the hook fails.
-	FailurePolicy LifecycleHookFailurePolicy
-
-	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
-	ExecNewPod *ExecNewPodHook
-
-	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag if the deployment succeeds.
-	TagImages []TagImageHook
-}
-
-// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
-type LifecycleHookFailurePolicy string
-
-const (
-	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
-	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
-	// LifecycleHookFailurePolicyAbort means abort the deployment (if possible).
-	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
-	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
-	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
-)
-
-// ExecNewPodHook is a hook implementation which runs a command in a new pod
-// based on the specified container which is assumed to be part of the
-// deployment template.
-type ExecNewPodHook struct {
-	// Command is the action command and its arguments.
-	Command []string
-	// Env is a set of environment variables to supply to the hook pod's container.
-	Env []kapi.EnvVar
-	// ContainerName is the name of a container in the deployment pod template
-	// whose Docker image will be used for the hook pod's container.
-	ContainerName string
-	// Volumes is a list of named volumes from the pod template which should be
-	// copied to the hook pod.
-	Volumes []string
-}
-
-// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
-type TagImageHook struct {
-	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag
-	ContainerName string
-	// To is the target ImageStreamTag to set the image of
-	To kapi.ObjectReference
-}
-
-// RollingDeploymentStrategyParams are the input to the Rolling deployment
-// strategy.
-type RollingDeploymentStrategyParams struct {
-	// UpdatePeriodSeconds is the time to wait between individual pod updates.
-	// If the value is nil, a default will be used.
-	UpdatePeriodSeconds *int64
-	// IntervalSeconds is the time to wait between polling deployment status
-	// after update. If the value is nil, a default will be used.
-	IntervalSeconds *int64
-	// TimeoutSeconds is the time to wait for updates before giving up. If the
-	// value is nil, a default will be used.
-	TimeoutSeconds *int64
-	// The maximum number of pods that can be unavailable during the update.
-	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
-	// Absolute number is calculated from percentage by rounding up.
-	// This can not be 0 if MaxSurge is 0.
-	// By default, a fixed value of 1 is used.
-	// Example: when this is set to 30%, the old RC can be scaled down by 30%
-	// immediately when the rolling update starts. Once new pods are ready, old RC
-	// can be scaled down further, followed by scaling up the new RC, ensuring
-	// that at least 70% of original number of pods are available at all times
-	// during the update.
-	MaxUnavailable intstr.IntOrString
-	// The maximum number of pods that can be scheduled above the original number of
-	// pods.
-	// Value can be an absolute number (ex: 5) or a percentage of total pods at
-	// the start of the update (ex: 10%). This can not be 0 if MaxUnavailable is 0.
-	// Absolute number is calculated from percentage by rounding up.
-	// By default, a value of 1 is used.
-	// Example: when this is set to 30%, the new RC can be scaled up by 30%
-	// immediately when the rolling update starts. Once old pods have been killed,
-	// new RC can be scaled up further, ensuring that total number of pods running
-	// at any time during the update is atmost 130% of original pods.
-	MaxSurge intstr.IntOrString
-	// Pre is a lifecycle hook which is executed before the deployment process
-	// begins. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook
-	// Post is a lifecycle hook which is executed after the strategy has
-	// finished all deployment logic.
-	Post *LifecycleHook
-}
-
+// These constants represent defaults used in the deployment process.
 const (
 	// DefaultRollingTimeoutSeconds is the default TimeoutSeconds for RollingDeploymentStrategyParams.
 	DefaultRollingTimeoutSeconds int64 = 10 * 60
@@ -183,6 +14,10 @@ const (
 	DefaultRollingIntervalSeconds int64 = 1
 	// DefaultRollingUpdatePeriodSeconds is the default PeriodSeconds for RollingDeploymentStrategyParams.
 	DefaultRollingUpdatePeriodSeconds int64 = 1
+	// MaxDeploymentDurationSeconds represents the maximum duration that a deployment is allowed to run.
+	// This is set as the default value for ActiveDeadlineSeconds for the deployer pod.
+	// Currently set to 6 hours.
+	MaxDeploymentDurationSeconds int64 = 21600
 )
 
 // These constants represent keys used for correlating objects related to deployments.
@@ -248,6 +83,13 @@ const (
 	PostHookPodSuffix = "hook-post"
 )
 
+// These constants represent values used in deployment annotations.
+const (
+	// DeploymentCancelledAnnotationValue represents the value for the DeploymentCancelledAnnotation
+	// annotation that signifies that the deployment should be cancelled
+	DeploymentCancelledAnnotationValue = "true"
+)
+
 // These constants represent the various reasons for cancelling a deployment
 // or for a deployment being placed in a failed state
 const (
@@ -257,18 +99,23 @@ const (
 	DeploymentFailedDeployerPodNoLongerExists = "deployer pod no longer exists"
 )
 
-// MaxDeploymentDurationSeconds represents the maximum duration that a deployment is allowed to run
-// This is set as the default value for ActiveDeadlineSeconds for the deployer pod
-// Currently set to 6 hours
-const MaxDeploymentDurationSeconds int64 = 21600
+// DeploymentStatus describes the possible states a deployment can be in.
+type DeploymentStatus string
 
-// DeploymentCancelledAnnotationValue represents the value for the DeploymentCancelledAnnotation
-// annotation that signifies that the deployment should be cancelled
-const DeploymentCancelledAnnotationValue = "true"
-
-// DeploymentInstantiatedAnnotationValue represents the value for the DeploymentInstantiatedAnnotation
-// annotation that signifies that the deployment should be instantiated.
-const DeploymentInstantiatedAnnotationValue = "true"
+const (
+	// DeploymentStatusNew means the deployment has been accepted but not yet acted upon.
+	DeploymentStatusNew DeploymentStatus = "New"
+	// DeploymentStatusPending means the deployment been handed over to a deployment strategy,
+	// but the strategy has not yet declared the deployment to be running.
+	DeploymentStatusPending DeploymentStatus = "Pending"
+	// DeploymentStatusRunning means the deployment strategy has reported the deployment as
+	// being in-progress.
+	DeploymentStatusRunning DeploymentStatus = "Running"
+	// DeploymentStatusComplete means the deployment finished without an error.
+	DeploymentStatusComplete DeploymentStatus = "Complete"
+	// DeploymentStatusFailed means the deployment finished with an error.
+	DeploymentStatusFailed DeploymentStatus = "Failed"
+)
 
 // +genclient=true
 
@@ -326,27 +173,162 @@ type DeploymentConfigSpec struct {
 	Template *kapi.PodTemplateSpec
 }
 
-// DeploymentConfigStatus represents the current deployment state.
-type DeploymentConfigStatus struct {
-	// LatestVersion is used to determine whether the current deployment associated with a deployment
-	// config is out of sync.
-	LatestVersion int64
-	// ObservedGeneration is the most recent generation observed by the deployment config controller.
-	ObservedGeneration int64
-	// Replicas is the total number of pods targeted by this deployment config.
-	Replicas int32
-	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
-	// that have the desired template spec.
-	UpdatedReplicas int32
-	// AvailableReplicas is the total number of available pods targeted by this deployment config.
-	AvailableReplicas int32
-	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
-	UnavailableReplicas int32
-	// Details are the reasons for the update to this deployment config.
-	// This could be based on a change made by the user or caused by an automatic trigger
-	Details *DeploymentDetails
-	// Conditions represents the latest available observations of a deployment config's current state.
-	Conditions []DeploymentCondition
+// DeploymentStrategy describes how to perform a deployment.
+type DeploymentStrategy struct {
+	// Type is the name of a deployment strategy.
+	Type DeploymentStrategyType
+
+	// CustomParams are the input to the Custom deployment strategy, and may also
+	// be specified for the Recreate and Rolling strategies to customize the execution
+	// process that runs the deployment.
+	CustomParams *CustomDeploymentStrategyParams
+	// RecreateParams are the input to the Recreate deployment strategy.
+	RecreateParams *RecreateDeploymentStrategyParams
+	// RollingParams are the input to the Rolling deployment strategy.
+	RollingParams *RollingDeploymentStrategyParams
+
+	// Resources contains resource requirements to execute the deployment and any hooks.
+	Resources kapi.ResourceRequirements
+	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Labels map[string]string
+	// Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Annotations map[string]string
+}
+
+// DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
+type DeploymentStrategyType string
+
+const (
+	// DeploymentStrategyTypeRecreate is a simple strategy suitable as a default.
+	DeploymentStrategyTypeRecreate DeploymentStrategyType = "Recreate"
+	// DeploymentStrategyTypeCustom is a user defined strategy.
+	DeploymentStrategyTypeCustom DeploymentStrategyType = "Custom"
+	// DeploymentStrategyTypeRolling uses the Kubernetes RollingUpdater.
+	DeploymentStrategyTypeRolling DeploymentStrategyType = "Rolling"
+)
+
+// CustomDeploymentStrategyParams are the input to the Custom deployment strategy.
+type CustomDeploymentStrategyParams struct {
+	// Image specifies a Docker image which can carry out a deployment.
+	Image string
+	// Environment holds the environment which will be given to the container for Image.
+	Environment []kapi.EnvVar
+	// Command is optional and overrides CMD in the container Image.
+	Command []string
+}
+
+// RecreateDeploymentStrategyParams are the input to the Recreate deployment
+// strategy.
+type RecreateDeploymentStrategyParams struct {
+	// TimeoutSeconds is the time to wait for updates before giving up. If the
+	// value is nil, a default will be used.
+	TimeoutSeconds *int64
+	// Pre is a lifecycle hook which is executed before the strategy manipulates
+	// the deployment. All LifecycleHookFailurePolicy values are supported.
+	Pre *LifecycleHook
+	// Mid is a lifecycle hook which is executed while the deployment is scaled down to zero before the first new
+	// pod is created. All LifecycleHookFailurePolicy values are supported.
+	Mid *LifecycleHook
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all deployment logic. All LifecycleHookFailurePolicy values are supported.
+	Post *LifecycleHook
+}
+
+// RollingDeploymentStrategyParams are the input to the Rolling deployment
+// strategy.
+type RollingDeploymentStrategyParams struct {
+	// UpdatePeriodSeconds is the time to wait between individual pod updates.
+	// If the value is nil, a default will be used.
+	UpdatePeriodSeconds *int64
+	// IntervalSeconds is the time to wait between polling deployment status
+	// after update. If the value is nil, a default will be used.
+	IntervalSeconds *int64
+	// TimeoutSeconds is the time to wait for updates before giving up. If the
+	// value is nil, a default will be used.
+	TimeoutSeconds *int64
+	// MaxUnavailable is the maximum number of pods that can be unavailable
+	// during the update. Value can be an absolute number (ex: 5) or a
+	// percentage of total pods at the start of update (ex: 10%). Absolute
+	// number is calculated from percentage by rounding up.
+	//
+	// This cannot be 0 if MaxSurge is 0. By default, 25% is used.
+	//
+	// Example: when this is set to 30%, the old RC can be scaled down by 30%
+	// immediately when the rolling update starts. Once new pods are ready, old
+	// RC can be scaled down further, followed by scaling up the new RC,
+	// ensuring that at least 70% of original number of pods are available at
+	// all times during the update.
+	MaxUnavailable intstr.IntOrString
+	// MaxSurge is the maximum number of pods that can be scheduled above the
+	// original number of pods. Value can be an absolute number (ex: 5) or a
+	// percentage of total pods at the start of the update (ex: 10%). Absolute
+	// number is calculated from percentage by rounding up.
+	//
+	// This cannot be 0 if MaxUnavailable is 0. By default, 25% is used.
+	//
+	// Example: when this is set to 30%, the new RC can be scaled up by 30%
+	// immediately when the rolling update starts. Once old pods have been
+	// killed, new RC can be scaled up further, ensuring that total number of
+	// pods running at any time during the update is atmost 130% of original
+	// pods.
+	MaxSurge intstr.IntOrString
+	// Pre is a lifecycle hook which is executed before the deployment process
+	// begins. All LifecycleHookFailurePolicy values are supported.
+	Pre *LifecycleHook
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all deployment logic. All LifecycleHookFailurePolicy values
+	// are supported.
+	Post *LifecycleHook
+}
+
+// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy
+
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook
+
+	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.
+	TagImages []TagImageHook
+}
+
+// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
+const (
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyAbort means abort the deployment.
+	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
+	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
+)
+
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the specified container which is assumed to be part of the
+// deployment template.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar
+	// ContainerName is the name of a container in the deployment pod template
+	// whose Docker image will be used for the hook pod's container.
+	ContainerName string
+	// Volumes is a list of named volumes from the pod template which should be
+	// copied to the hook pod. Volumes names not found in pod spec are ignored.
+	// An empty list means no volumes will be copied.
+	Volumes []string
+}
+
+// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
+type TagImageHook struct {
+	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single
+	// container this value will be defaulted to the name of that container.
+	ContainerName string
+	// To is the target ImageStreamTag to set the container's image onto.
+	To kapi.ObjectReference
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
@@ -384,6 +366,29 @@ type DeploymentTriggerImageChangeParams struct {
 	From kapi.ObjectReference
 	// LastTriggeredImage is the last image to be triggered.
 	LastTriggeredImage string
+}
+
+// DeploymentConfigStatus represents the current deployment state.
+type DeploymentConfigStatus struct {
+	// LatestVersion is used to determine whether the current deployment associated with a deployment
+	// config is out of sync.
+	LatestVersion int64
+	// ObservedGeneration is the most recent generation observed by the deployment config controller.
+	ObservedGeneration int64
+	// Replicas is the total number of pods targeted by this deployment config.
+	Replicas int32
+	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
+	// that have the desired template spec.
+	UpdatedReplicas int32
+	// AvailableReplicas is the total number of available pods targeted by this deployment config.
+	AvailableReplicas int32
+	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
+	UnavailableReplicas int32
+	// Details are the reasons for the update to this deployment config.
+	// This could be based on a change made by the user or caused by an automatic trigger
+	Details *DeploymentDetails
+	// Conditions represents the latest available observations of a deployment config's current state.
+	Conditions []DeploymentCondition
 }
 
 // DeploymentDetails captures information about the causes of a deployment.

--- a/pkg/deploy/api/v1/generated.proto
+++ b/pkg/deploy/api/v1/generated.proto
@@ -269,7 +269,9 @@ message DeploymentStrategy {
   // Type is the name of a deployment strategy.
   optional string type = 1;
 
-  // CustomParams are the input to the Custom deployment strategy.
+  // CustomParams are the input to the Custom deployment strategy, and may also
+  // be specified for the Recreate and Rolling strategies to customize the execution
+  // process that runs the deployment.
   optional CustomDeploymentStrategyParams customParams = 2;
 
   // RecreateParams are the input to the Recreate deployment strategy.
@@ -278,7 +280,7 @@ message DeploymentStrategy {
   // RollingParams are the input to the Rolling deployment strategy.
   optional RollingDeploymentStrategyParams rollingParams = 4;
 
-  // Resources contains resource requirements to execute the deployment and any hooks
+  // Resources contains resource requirements to execute the deployment and any hooks.
   optional k8s.io.kubernetes.pkg.api.v1.ResourceRequirements resources = 5;
 
   // Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
@@ -424,8 +426,8 @@ message RollingDeploymentStrategyParams {
   optional LifecycleHook pre = 7;
 
   // Post is a lifecycle hook which is executed after the strategy has
-  // finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
-  // is NOT supported.
+  // finished all deployment logic. All LifecycleHookFailurePolicy values
+  // are supported.
   optional LifecycleHook post = 8;
 }
 

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -177,10 +177,10 @@ func (DeploymentRequest) SwaggerDoc() map[string]string {
 var map_DeploymentStrategy = map[string]string{
 	"":               "DeploymentStrategy describes how to perform a deployment.",
 	"type":           "Type is the name of a deployment strategy.",
-	"customParams":   "CustomParams are the input to the Custom deployment strategy.",
+	"customParams":   "CustomParams are the input to the Custom deployment strategy, and may also be specified for the Recreate and Rolling strategies to customize the execution process that runs the deployment.",
 	"recreateParams": "RecreateParams are the input to the Recreate deployment strategy.",
 	"rollingParams":  "RollingParams are the input to the Rolling deployment strategy.",
-	"resources":      "Resources contains resource requirements to execute the deployment and any hooks",
+	"resources":      "Resources contains resource requirements to execute the deployment and any hooks.",
 	"labels":         "Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
 	"annotations":    "Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
 }
@@ -254,7 +254,7 @@ var map_RollingDeploymentStrategyParams = map[string]string{
 	"maxUnavailable":      "MaxUnavailable is the maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%). Absolute number is calculated from percentage by rounding up.\n\nThis cannot be 0 if MaxSurge is 0. By default, 25% is used.\n\nExample: when this is set to 30%, the old RC can be scaled down by 30% immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that at least 70% of original number of pods are available at all times during the update.",
 	"maxSurge":            "MaxSurge is the maximum number of pods that can be scheduled above the original number of pods. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up.\n\nThis cannot be 0 if MaxUnavailable is 0. By default, 25% is used.\n\nExample: when this is set to 30%, the new RC can be scaled up by 30% immediately when the rolling update starts. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of original pods.",
 	"pre":                 "Pre is a lifecycle hook which is executed before the deployment process begins. All LifecycleHookFailurePolicy values are supported.",
-	"post":                "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. The LifecycleHookFailurePolicyAbort policy is NOT supported.",
+	"post":                "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. All LifecycleHookFailurePolicy values are supported.",
 }
 
 func (RollingDeploymentStrategyParams) SwaggerDoc() map[string]string {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -8,37 +8,83 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
-// DeploymentPhase describes the possible states a deployment can be in.
-type DeploymentPhase string
+// +genclient=true
 
-const (
-	// DeploymentPhaseNew means the deployment has been accepted but not yet acted upon.
-	DeploymentPhaseNew DeploymentPhase = "New"
-	// DeploymentPhasePending means the deployment been handed over to a deployment strategy,
-	// but the strategy has not yet declared the deployment to be running.
-	DeploymentPhasePending DeploymentPhase = "Pending"
-	// DeploymentPhaseRunning means the deployment strategy has reported the deployment as
-	// being in-progress.
-	DeploymentPhaseRunning DeploymentPhase = "Running"
-	// DeploymentPhaseComplete means the deployment finished without an error.
-	DeploymentPhaseComplete DeploymentPhase = "Complete"
-	// DeploymentPhaseFailed means the deployment finished with an error.
-	DeploymentPhaseFailed DeploymentPhase = "Failed"
-)
+// Deployment Configs define the template for a pod and manages deploying new images or configuration changes.
+// A single deployment configuration is usually analogous to a single micro-service. Can support many different
+// deployment patterns, including full restart, customizable rolling updates, and  fully custom behaviors, as
+// well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller.
+//
+// A deployment is "triggered" when its configuration is changed or a tag in an Image Stream is changed.
+// Triggers can be disabled to allow manual control over a deployment. The "strategy" determines how the deployment
+// is carried out and may be changed at any time. The `latestVersion` field is updated when a new deployment
+// is triggered by any means.
+type DeploymentConfig struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	kapi.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Spec represents a desired deployment state and how to deploy to it.
+	Spec DeploymentConfigSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+
+	// Status represents the current deployment state.
+	Status DeploymentConfigStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+}
+
+// DeploymentConfigSpec represents the desired state of the deployment.
+type DeploymentConfigSpec struct {
+	// Strategy describes how a deployment is executed.
+	Strategy DeploymentStrategy `json:"strategy" protobuf:"bytes,1,opt,name=strategy"`
+
+	// MinReadySeconds is the minimum number of seconds for which a newly created pod should
+	// be ready without any of its container crashing, for it to be considered available.
+	// Defaults to 0 (pod will be considered available as soon as it is ready)
+	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,9,opt,name=minReadySeconds"`
+
+	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
+	// are defined, a new deployment can only occur as a result of an explicit client update to the
+	// DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.
+	Triggers DeploymentTriggerPolicies `json:"triggers" protobuf:"bytes,2,rep,name=triggers"`
+
+	// Replicas is the number of desired replicas.
+	Replicas int32 `json:"replicas" protobuf:"varint,3,opt,name=replicas"`
+
+	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
+	// This field is a pointer to allow for differentiation between an explicit zero and not specified.
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,4,opt,name=revisionHistoryLimit"`
+
+	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
+	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
+	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+	Test bool `json:"test" protobuf:"varint,5,opt,name=test"`
+
+	// Paused indicates that the deployment config is paused resulting in no new deployments on template
+	// changes or changes in the template caused by other triggers.
+	Paused bool `json:"paused,omitempty" protobuf:"varint,6,opt,name=paused"`
+
+	// Selector is a label query over pods that should match the Replicas count.
+	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,7,rep,name=selector"`
+
+	// Template is the object that describes the pod that will be created if
+	// insufficient replicas are detected.
+	Template *kapi.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,8,opt,name=template"`
+}
 
 // DeploymentStrategy describes how to perform a deployment.
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
 	Type DeploymentStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=DeploymentStrategyType"`
 
-	// CustomParams are the input to the Custom deployment strategy.
+	// CustomParams are the input to the Custom deployment strategy, and may also
+	// be specified for the Recreate and Rolling strategies to customize the execution
+	// process that runs the deployment.
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty" protobuf:"bytes,2,opt,name=customParams"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty" protobuf:"bytes,3,opt,name=recreateParams"`
 	// RollingParams are the input to the Rolling deployment strategy.
 	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty" protobuf:"bytes,4,opt,name=rollingParams"`
 
-	// Resources contains resource requirements to execute the deployment and any hooks
+	// Resources contains resource requirements to execute the deployment and any hooks.
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,5,opt,name=resources"`
 	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,6,rep,name=labels"`
@@ -85,56 +131,6 @@ type RecreateDeploymentStrategyParams struct {
 	Post *LifecycleHook `json:"post,omitempty" protobuf:"bytes,4,opt,name=post"`
 }
 
-// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
-type LifecycleHook struct {
-	// FailurePolicy specifies what action to take if the hook fails.
-	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy" protobuf:"bytes,1,opt,name=failurePolicy,casttype=LifecycleHookFailurePolicy"`
-
-	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
-	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty" protobuf:"bytes,2,opt,name=execNewPod"`
-
-	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.
-	TagImages []TagImageHook `json:"tagImages,omitempty" protobuf:"bytes,3,rep,name=tagImages"`
-}
-
-// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
-type LifecycleHookFailurePolicy string
-
-const (
-	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
-	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
-	// LifecycleHookFailurePolicyAbort means abort the deployment (if possible).
-	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
-	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
-	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
-)
-
-// ExecNewPodHook is a hook implementation which runs a command in a new pod
-// based on the specified container which is assumed to be part of the
-// deployment template.
-type ExecNewPodHook struct {
-	// Command is the action command and its arguments.
-	Command []string `json:"command" protobuf:"bytes,1,rep,name=command"`
-	// Env is a set of environment variables to supply to the hook pod's container.
-	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,2,rep,name=env"`
-	// ContainerName is the name of a container in the deployment pod template
-	// whose Docker image will be used for the hook pod's container.
-	ContainerName string `json:"containerName" protobuf:"bytes,3,opt,name=containerName"`
-	// Volumes is a list of named volumes from the pod template which should be
-	// copied to the hook pod. Volumes names not found in pod spec are ignored.
-	// An empty list means no volumes will be copied.
-	Volumes []string `json:"volumes,omitempty" protobuf:"bytes,4,rep,name=volumes"`
-}
-
-// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
-type TagImageHook struct {
-	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single
-	// container this value will be defaulted to the name of that container.
-	ContainerName string `json:"containerName" protobuf:"bytes,1,opt,name=containerName"`
-	// To is the target ImageStreamTag to set the container's image onto.
-	To kapi.ObjectReference `json:"to" protobuf:"bytes,2,opt,name=to"`
-}
-
 // RollingDeploymentStrategyParams are the input to the Rolling deployment
 // strategy.
 type RollingDeploymentStrategyParams struct {
@@ -177,81 +173,59 @@ type RollingDeploymentStrategyParams struct {
 	// begins. All LifecycleHookFailurePolicy values are supported.
 	Pre *LifecycleHook `json:"pre,omitempty" protobuf:"bytes,7,opt,name=pre"`
 	// Post is a lifecycle hook which is executed after the strategy has
-	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
-	// is NOT supported.
+	// finished all deployment logic. All LifecycleHookFailurePolicy values
+	// are supported.
 	Post *LifecycleHook `json:"post,omitempty" protobuf:"bytes,8,opt,name=post"`
 }
 
-// These constants represent keys used for correlating objects related to deployments.
+// LifecycleHook defines a specific deployment lifecycle action. Only one type of action may be specified at any time.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy" protobuf:"bytes,1,opt,name=failurePolicy,casttype=LifecycleHookFailurePolicy"`
+
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty" protobuf:"bytes,2,opt,name=execNewPod"`
+
+	// TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.
+	TagImages []TagImageHook `json:"tagImages,omitempty" protobuf:"bytes,3,rep,name=tagImages"`
+}
+
+// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
 const (
-	// DeploymentConfigAnnotation is an annotation name used to correlate a deployment with the
-	// DeploymentConfig on which the deployment is based.
-	DeploymentConfigAnnotation = "openshift.io/deployment-config.name"
-	// DeploymentAnnotation is an annotation on a deployer Pod. The annotation value is the name
-	// of the deployment (a ReplicationController) on which the deployer Pod acts.
-	DeploymentAnnotation = "openshift.io/deployment.name"
-	// DeploymentPodAnnotation is an annotation on a deployment (a ReplicationController). The
-	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
-	// to implement the deployment behavior.
-	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
-	// DeploymentPodTypeLabel is a label with which contains a type of deployment pod.
-	DeploymentPodTypeLabel = "openshift.io/deployer-pod.type"
-	// DeployerPodForDeploymentLabel is a label which groups pods related to a
-	// deployment. The value is a deployment name. The deployer pod and hook pods
-	// created by the internal strategies will have this label. Custom
-	// strategies can apply this label to any pods they create, enabling
-	// platform-provided cancellation and garbage collection support.
-	DeployerPodForDeploymentLabel = "openshift.io/deployer-pod-for.name"
-	// DeploymentPhaseAnnotation is an annotation name used to retrieve the DeploymentPhase of
-	// a deployment.
-	DeploymentPhaseAnnotation = "openshift.io/deployment.phase"
-	// DeploymentEncodedConfigAnnotation is an annotation name used to retrieve specific encoded
-	// DeploymentConfig on which a given deployment is based.
-	DeploymentEncodedConfigAnnotation = "openshift.io/encoded-deployment-config"
-	// DeploymentVersionAnnotation is an annotation on a deployment (a ReplicationController). The
-	// annotation value is the LatestVersion value of the DeploymentConfig which was the basis for
-	// the deployment.
-	DeploymentVersionAnnotation = "openshift.io/deployment-config.latest-version"
-	// DeploymentLabel is the name of a label used to correlate a deployment with the Pod created
-	// to execute the deployment logic.
-	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once
-	// annotations are available on PodTemplate, audit this constant with the goal of removing it.
-	DeploymentLabel = "deployment"
-	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
-	// DeploymentConfigs on which the deployment is based.
-	DeploymentConfigLabel = "deploymentconfig"
-	// DeploymentStatusReasonAnnotation represents the reason for deployment being in a given state
-	// Used for specifying the reason for cancellation or failure of a deployment
-	DeploymentStatusReasonAnnotation = "openshift.io/deployment.status-reason"
-	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
-	// The annotation value does not matter and its mere presence indicates cancellation
-	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
-	// DeploymentInstantiatedAnnotation indicates that the deployment has been instantiated.
-	// The annotation value does not matter and its mere presence indicates instantiation.
-	DeploymentInstantiatedAnnotation = "openshift.io/deployment.instantiated"
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyAbort means abort the deployment.
+	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
+	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
 )
 
-// +genclient=true
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the specified container which is assumed to be part of the
+// deployment template.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string `json:"command" protobuf:"bytes,1,rep,name=command"`
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar `json:"env,omitempty" protobuf:"bytes,2,rep,name=env"`
+	// ContainerName is the name of a container in the deployment pod template
+	// whose Docker image will be used for the hook pod's container.
+	ContainerName string `json:"containerName" protobuf:"bytes,3,opt,name=containerName"`
+	// Volumes is a list of named volumes from the pod template which should be
+	// copied to the hook pod. Volumes names not found in pod spec are ignored.
+	// An empty list means no volumes will be copied.
+	Volumes []string `json:"volumes,omitempty" protobuf:"bytes,4,rep,name=volumes"`
+}
 
-// Deployment Configs define the template for a pod and manages deploying new images or configuration changes.
-// A single deployment configuration is usually analogous to a single micro-service. Can support many different
-// deployment patterns, including full restart, customizable rolling updates, and  fully custom behaviors, as
-// well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller.
-//
-// A deployment is "triggered" when its configuration is changed or a tag in an Image Stream is changed.
-// Triggers can be disabled to allow manual control over a deployment. The "strategy" determines how the deployment
-// is carried out and may be changed at any time. The `latestVersion` field is updated when a new deployment
-// is triggered by any means.
-type DeploymentConfig struct {
-	unversioned.TypeMeta `json:",inline"`
-	// Standard object's metadata.
-	kapi.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	// Spec represents a desired deployment state and how to deploy to it.
-	Spec DeploymentConfigSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
-
-	// Status represents the current deployment state.
-	Status DeploymentConfigStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+// TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.
+type TagImageHook struct {
+	// ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single
+	// container this value will be defaulted to the name of that container.
+	ContainerName string `json:"containerName" protobuf:"bytes,1,opt,name=containerName"`
+	// To is the target ImageStreamTag to set the container's image onto.
+	To kapi.ObjectReference `json:"to" protobuf:"bytes,2,opt,name=to"`
 }
 
 // DeploymentTriggerPolicies is a list of policies where nil values and different from empty arrays.
@@ -261,68 +235,6 @@ type DeploymentTriggerPolicies []DeploymentTriggerPolicy
 
 func (t DeploymentTriggerPolicies) String() string {
 	return fmt.Sprintf("%v", []DeploymentTriggerPolicy(t))
-}
-
-// DeploymentConfigSpec represents the desired state of the deployment.
-type DeploymentConfigSpec struct {
-	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy" protobuf:"bytes,1,opt,name=strategy"`
-
-	// MinReadySeconds is the minimum number of seconds for which a newly created pod should
-	// be ready without any of its container crashing, for it to be considered available.
-	// Defaults to 0 (pod will be considered available as soon as it is ready)
-	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,9,opt,name=minReadySeconds"`
-
-	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
-	// are defined, a new deployment can only occur as a result of an explicit client update to the
-	// DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.
-	Triggers DeploymentTriggerPolicies `json:"triggers" protobuf:"bytes,2,rep,name=triggers"`
-
-	// Replicas is the number of desired replicas.
-	Replicas int32 `json:"replicas" protobuf:"varint,3,opt,name=replicas"`
-
-	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
-	// This field is a pointer to allow for differentiation between an explicit zero and not specified.
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,4,opt,name=revisionHistoryLimit"`
-
-	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
-	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
-	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
-	Test bool `json:"test" protobuf:"varint,5,opt,name=test"`
-
-	// Paused indicates that the deployment config is paused resulting in no new deployments on template
-	// changes or changes in the template caused by other triggers.
-	Paused bool `json:"paused,omitempty" protobuf:"varint,6,opt,name=paused"`
-
-	// Selector is a label query over pods that should match the Replicas count.
-	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,7,rep,name=selector"`
-
-	// Template is the object that describes the pod that will be created if
-	// insufficient replicas are detected.
-	Template *kapi.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,8,opt,name=template"`
-}
-
-// DeploymentConfigStatus represents the current deployment state.
-type DeploymentConfigStatus struct {
-	// LatestVersion is used to determine whether the current deployment associated with a deployment
-	// config is out of sync.
-	LatestVersion int64 `json:"latestVersion,omitempty" protobuf:"varint,1,opt,name=latestVersion"`
-	// ObservedGeneration is the most recent generation observed by the deployment config controller.
-	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,2,opt,name=observedGeneration"`
-	// Replicas is the total number of pods targeted by this deployment config.
-	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,3,opt,name=replicas"`
-	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
-	// that have the desired template spec.
-	UpdatedReplicas int32 `json:"updatedReplicas,omitempty" protobuf:"varint,4,opt,name=updatedReplicas"`
-	// AvailableReplicas is the total number of available pods targeted by this deployment config.
-	AvailableReplicas int32 `json:"availableReplicas,omitempty" protobuf:"varint,5,opt,name=availableReplicas"`
-	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
-	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,6,opt,name=unavailableReplicas"`
-	// Details are the reasons for the update to this deployment config.
-	// This could be based on a change made by the user or caused by an automatic trigger
-	Details *DeploymentDetails `json:"details,omitempty" protobuf:"bytes,7,opt,name=details"`
-	// Conditions represents the latest available observations of a deployment config's current state.
-	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,8,rep,name=conditions"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
@@ -358,6 +270,29 @@ type DeploymentTriggerImageChangeParams struct {
 	From kapi.ObjectReference `json:"from" protobuf:"bytes,3,opt,name=from"`
 	// LastTriggeredImage is the last image to be triggered.
 	LastTriggeredImage string `json:"lastTriggeredImage,omitempty" protobuf:"bytes,4,opt,name=lastTriggeredImage"`
+}
+
+// DeploymentConfigStatus represents the current deployment state.
+type DeploymentConfigStatus struct {
+	// LatestVersion is used to determine whether the current deployment associated with a deployment
+	// config is out of sync.
+	LatestVersion int64 `json:"latestVersion,omitempty" protobuf:"varint,1,opt,name=latestVersion"`
+	// ObservedGeneration is the most recent generation observed by the deployment config controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,2,opt,name=observedGeneration"`
+	// Replicas is the total number of pods targeted by this deployment config.
+	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,3,opt,name=replicas"`
+	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
+	// that have the desired template spec.
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty" protobuf:"varint,4,opt,name=updatedReplicas"`
+	// AvailableReplicas is the total number of available pods targeted by this deployment config.
+	AvailableReplicas int32 `json:"availableReplicas,omitempty" protobuf:"varint,5,opt,name=availableReplicas"`
+	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
+	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,6,opt,name=unavailableReplicas"`
+	// Details are the reasons for the update to this deployment config.
+	// This could be based on a change made by the user or caused by an automatic trigger
+	Details *DeploymentDetails `json:"details,omitempty" protobuf:"bytes,7,opt,name=details"`
+	// Conditions represents the latest available observations of a deployment config's current state.
+	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,8,rep,name=conditions"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.

--- a/pkg/deploy/api/v1/zz_generated.conversion.go
+++ b/pkg/deploy/api/v1/zz_generated.conversion.go
@@ -671,6 +671,15 @@ func Convert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *DeploymentStrat
 
 func autoConvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *api.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
 	out.Type = DeploymentStrategyType(in.Type)
+	if in.CustomParams != nil {
+		in, out := &in.CustomParams, &out.CustomParams
+		*out = new(CustomDeploymentStrategyParams)
+		if err := Convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
+	}
 	if in.RecreateParams != nil {
 		in, out := &in.RecreateParams, &out.RecreateParams
 		*out = new(RecreateDeploymentStrategyParams)
@@ -688,15 +697,6 @@ func autoConvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *api.Deploym
 		}
 	} else {
 		out.RollingParams = nil
-	}
-	if in.CustomParams != nil {
-		in, out := &in.CustomParams, &out.CustomParams
-		*out = new(CustomDeploymentStrategyParams)
-		if err := Convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(*in, *out, s); err != nil {
-			return err
-		}
-	} else {
-		out.CustomParams = nil
 	}
 	if err := api_v1.Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err

--- a/pkg/deploy/api/zz_generated.deepcopy.go
+++ b/pkg/deploy/api/zz_generated.deepcopy.go
@@ -365,6 +365,15 @@ func DeepCopy_api_DeploymentStrategy(in interface{}, out interface{}, c *convers
 		in := in.(*DeploymentStrategy)
 		out := out.(*DeploymentStrategy)
 		out.Type = in.Type
+		if in.CustomParams != nil {
+			in, out := &in.CustomParams, &out.CustomParams
+			*out = new(CustomDeploymentStrategyParams)
+			if err := DeepCopy_api_CustomDeploymentStrategyParams(*in, *out, c); err != nil {
+				return err
+			}
+		} else {
+			out.CustomParams = nil
+		}
 		if in.RecreateParams != nil {
 			in, out := &in.RecreateParams, &out.RecreateParams
 			*out = new(RecreateDeploymentStrategyParams)
@@ -382,15 +391,6 @@ func DeepCopy_api_DeploymentStrategy(in interface{}, out interface{}, c *convers
 			}
 		} else {
 			out.RollingParams = nil
-		}
-		if in.CustomParams != nil {
-			in, out := &in.CustomParams, &out.CustomParams
-			*out = new(CustomDeploymentStrategyParams)
-			if err := DeepCopy_api_CustomDeploymentStrategyParams(*in, *out, c); err != nil {
-				return err
-			}
-		} else {
-			out.CustomParams = nil
 		}
 		if err := pkg_api.DeepCopy_api_ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
 			return err


### PR DESCRIPTION
Started out as a simple godoc fix but I ended up refactoring most of our api
types. All internal api (annotation keys, types, defaults) now exists on top
of deploy/api/types.go. Rest of the types are layed out in a top-down manner.

@mfojtik PTAL

cc: @jhadvig 