### PR TITLE
Secrets for Gluster provisioner

### DIFF
--- a/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/README.md
+++ b/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/README.md
@@ -65,16 +65,21 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
-  restuserkey: "password"
+  secretNamespace: "default"
+  secretName: "heketi-secret"
 ```
 
 * `endpoint`: `glusterfs-cluster` is the endpoint/service name which includes GlusterFS trusted pool IP addresses and this parameter is mandatory.
 * `resturl` : Gluster REST service url which provision gluster volumes on demand. The format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner.
-* `restauthenabled` : Gluster REST service authentication boolean is required if the authentication is enabled on the REST server. If this value is 'true', 'restuser' and 'restuserkey' have to be filled.
+* `restauthenabled` : Gluster REST service authentication boolean that enables authentication to the REST server. If this value is 'true', `restuser` and `restuserkey` or `secretNamespace` + `secretName` have to be filled. This option is deprecated, authentication is enabled when any of `restuser`, `restuserkey`, `secretName` or `secretNamespace` is specified.
 * `restuser` : Gluster REST service user who has access to create volumes in the Gluster Trusted Pool.
-* `restuserkey` : Gluster REST service user's password which will be used for authentication to the REST server.
+* `restuserkey` : Gluster REST service/Heketi user's password which will be used for authentication to the REST server. This parameter is deprecated in favor of `secretNamespace` + `secretName`.
+* `secretNamespace` + `secretName` : Identification of Secret instance that containes user password to use when talking to Gluster REST service. These parameters are optional, empty password will be used when both `secretNamespace` and `secretName` are omitted.
+
+When both `restuserkey` and `secretNamespace` + `secretName` is specified, the secret will be used.
+
+Example of a secret can be found in [glusterfs-provisioning-secret.yaml](glusterfs-provisioning-secret.yaml).
 
 #### OpenStack Cinder
 

--- a/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -6,6 +6,6 @@ provisioner: kubernetes.io/glusterfs
 parameters:
   endpoint: "glusterfs-cluster"
   resturl: "http://127.0.0.1:8081"
-  restauthenabled: "true"
   restuser: "admin"
-  restuserkey: "password"
+  secretNamespace: "default"
+  secretName: "heketi-secret"

--- a/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
+++ b/vendor/k8s.io/kubernetes/examples/experimental/persistent-volume-provisioning/glusterfs-provisioning-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: heketi-secret
+  namespace: default
+data:
+  # base64 encoded password. E.g.: echo -n "mypassword" | base64
+  key: bXlwYXNzd29yZA==

--- a/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
@@ -55,6 +55,8 @@ var _ volume.Deleter = &glusterfsVolumeDeleter{}
 const (
 	glusterfsPluginName = "kubernetes.io/glusterfs"
 	volprefix           = "vol_"
+	replicacount        = 3
+	durabilitytype      = "replicate"
 )
 
 func (plugin *glusterfsPlugin) Init(host volume.VolumeHost) error {
@@ -467,7 +469,7 @@ func (p *glusterfsVolumeProvisioner) CreateVolume() (r *api.GlusterfsVolumeSourc
 		glog.Errorf("glusterfs: failed to create gluster rest client")
 		return nil, 0, fmt.Errorf("failed to create gluster REST client, REST server authentication failed")
 	}
-	volumeReq := &gapi.VolumeCreateRequest{Size: sz}
+	volumeReq := &gapi.VolumeCreateRequest{Size: sz, Durability: gapi.VolumeDurabilityInfo{Type: durabilitytype, Replicate: gapi.ReplicaDurability{Replica: replicacount}}}
 	volume, err := cli.VolumeCreate(volumeReq)
 	if err != nil {
 		glog.Errorf("glusterfs: error creating volume %s ", err)

--- a/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs_test.go
@@ -236,3 +236,63 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		t.Errorf("Expected true for mounter.IsReadOnly")
 	}
 }
+
+func TestAnnotations(t *testing.T) {
+	// Pass a provisioningConfigs through paramToAnnotations and back through
+	// annotationsToParam and check it did not change in the process.
+	tests := []provisioningConfig{
+		{
+		// Everything empty
+		},
+		{
+			// Everything with a value
+			url:             "http://localhost",
+			user:            "admin",
+			secretNamespace: "default",
+			secretName:      "gluster-secret",
+			userKey:         "mykey",
+		},
+		{
+			// No secret
+			url:             "http://localhost",
+			user:            "admin",
+			secretNamespace: "",
+			secretName:      "",
+			userKey:         "",
+		},
+	}
+
+	for i, test := range tests {
+		provisioner := &glusterfsVolumeProvisioner{
+			provisioningConfig: test,
+		}
+		deleter := &glusterfsVolumeDeleter{}
+
+		pv := &api.PersistentVolume{
+			ObjectMeta: api.ObjectMeta{
+				Name: "pv",
+			},
+		}
+
+		provisioner.paramToAnnotations(pv)
+		err := deleter.annotationsToParam(pv)
+		if err != nil {
+			t.Errorf("test %d failed: %v", i, err)
+		}
+		if test.url != deleter.url {
+			t.Errorf("test %d failed: expected url %q, got %q", i, test.url, deleter.url)
+		}
+		if test.user != deleter.user {
+			t.Errorf("test %d failed: expected user %q, got %q", i, test.user, deleter.user)
+		}
+		if test.userKey != deleter.userKey {
+			t.Errorf("test %d failed: expected userKey %q, got %q", i, test.userKey, deleter.userKey)
+		}
+		if test.secretNamespace != deleter.secretNamespace {
+			t.Errorf("test %d failed: expected secretNamespace %q, got %q", i, test.secretNamespace, deleter.secretNamespace)
+		}
+		if test.secretName != deleter.secretName {
+			t.Errorf("test %d failed: expected secretName %q, got %q", i, test.secretName, deleter.secretName)
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/volume/util/util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/util/util.go
@@ -22,6 +22,8 @@ import (
 	"path"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -107,4 +109,51 @@ func PathExists(path string) (bool, error) {
 	} else {
 		return false, err
 	}
+}
+
+// GetSecret locates secret by name and namespace and returns secret map
+func GetSecret(namespace, secretName string, kubeClient clientset.Interface) (map[string]string, error) {
+	secret := make(map[string]string)
+	if kubeClient == nil {
+		return secret, fmt.Errorf("Cannot get kube client")
+	}
+
+	secrets, err := kubeClient.Core().Secrets(namespace).Get(secretName)
+	if err != nil {
+		return secret, err
+	}
+	for name, data := range secrets.Data {
+		secret[name] = string(data)
+	}
+	return secret, nil
+}
+
+// AddVolumeAnnotations adds a golang Map as annotation to a PersistentVolume
+func AddVolumeAnnotations(pv *api.PersistentVolume, annotations map[string]string) {
+	if pv.Annotations == nil {
+		pv.Annotations = map[string]string{}
+	}
+
+	for k, v := range annotations {
+		pv.Annotations[k] = v
+	}
+}
+
+// ParseVolumeAnnotations reads the defined annoations from a PersistentVolume
+func ParseVolumeAnnotations(pv *api.PersistentVolume, parseAnnotations []string) (map[string]string, error) {
+	result := map[string]string{}
+
+	if pv.Annotations == nil {
+		return result, fmt.Errorf("cannot parse volume annotations: no annotations found")
+	}
+
+	for _, annotation := range parseAnnotations {
+		if val, ok := pv.Annotations[annotation]; ok {
+			result[annotation] = val
+		} else {
+			return result, fmt.Errorf("cannot parse volume annotations: annotation %s not found", annotation)
+		}
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
There are two UPSTREAM patches that update glusterfs provisioner to use secrets instead of plaintext password in storage class.

Parts of vendor/k8s.io/kubernetes/pkg/volume/util/util.go are taken from Kubernetes PRs #31434 and #31251 that are not related to Gluster and we don't want them in Origin until next rebase.