### PR TITLE
Migrate System Logging Into Correct Location, Update Bash-isms

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -117,7 +117,7 @@ fi
 
 echo "Logging to ${LOG_DIR}..."
 
-os::log::start_system_logger
+os::log::system::start
 
 # Prevent user environment from colliding with the test setup
 unset KUBECONFIG

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -62,7 +62,7 @@ function cleanup()
 
 trap "cleanup" EXIT INT TERM
 
-os::log::start_system_logger
+os::log::system::start
 
 out=$(
 	set +e

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -46,7 +46,7 @@ os::util::environment::setup_all_server_vars "test-end-to-end/"
 os::util::environment::use_sudo
 reset_tmp_dir
 
-os::log::start_system_logger
+os::log::system::start
 
 configure_os_server
 start_os_server

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -35,7 +35,7 @@ else
 fi
 testexec="$(pwd)/$(os::build::find-binary "${name}.test")"
 
-os::log::start_system_logger
+os::log::system::start
 
 function exectest() {
 	echo "Running $1..."

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -27,7 +27,7 @@ os::util::environment::setup_all_server_vars "test-extended/cmd/"
 os::util::environment::use_sudo
 reset_tmp_dir
 
-os::log::start_system_logger
+os::log::system::start
 
 configure_os_server
 start_os_server

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -14,7 +14,7 @@ os::util::environment::setup_time_vars
 os::util::environment::setup_all_server_vars "${test_name}"
 os::util::environment::use_sudo
 
-os::log::start_system_logger
+os::log::system::start
 
 ensure_iptables_or_die
 reset_tmp_dir

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -26,7 +26,7 @@ os::util::environment::setup_all_server_vars "test-extended/ldap_groups/"
 os::util::environment::use_sudo
 reset_tmp_dir
 
-os::log::start_system_logger
+os::log::system::start
 
 configure_os_server
 start_os_server

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -294,7 +294,7 @@ else
   os::util::environment::setup_tmpdir_vars "test-extended/networking"
   reset_tmp_dir
 
-  os::log::start_system_logger
+  os::log::system::start
 
   os::log::info "Building docker-in-docker images"
   ${CLUSTER_CMD} build-images

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -75,9 +75,9 @@ function os::test::extended::setup () {
 			os::log::warn "/mnt/openshift-xfs-vol-dir does not exist, local storage quota tests may fail."
 		fi
 
-		os::log::start_system_logger
+		os::log::system::start
 
-		
+
 		if [[ -n "${SHOW_ALL:-}" ]]; then
 			SKIP_NODE=1
 		fi


### PR DESCRIPTION
@Miciah only need review on the last commit, as the first commit was a straight move, the second was a `sed` ... validation that nothing was missed:
```sh
$ cat /tmp/funcs 
#!/bin/bash

for func in $( curl --silent https://raw.githubusercontent.com/openshift/origin/master/hack/lib/log.sh | grep -Po '(?<=function )os::log::.*(?=\(\) \{)' ); do
    if where="$( git grep -n "${func}" )"; then
        echo "Leftover for ${func}:"
        echo "${where}"
    else
        echo "No leftovers for ${func}"
    fi
done
$ /tmp/funcs 
No leftovers for os::log::install_system_logger_cleanup
No leftovers for os::log::clean_up_logger
No leftovers for os::log::internal::prune_datafile
No leftovers for os::log::internal::plot
No leftovers for os::log::start_system_logger
No leftovers for os::log::internal::run_system_logger
```