### PR TITLE
Remove the unuse parameter in function ActiveDeployment

### DIFF
--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -94,7 +94,7 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string, settings kc
 		fmt.Fprintln(out)
 
 		latestDeploymentName := deployutil.LatestDeploymentNameForConfig(deploymentConfig)
-		if activeDeployment := deployutil.ActiveDeployment(deploymentConfig, deploymentsHistory); activeDeployment != nil {
+		if activeDeployment := deployutil.ActiveDeployment(deploymentsHistory); activeDeployment != nil {
 			activeDeploymentName = activeDeployment.Name
 		}
 

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -216,7 +216,7 @@ func (c *DeploymentConfigController) reconcileDeployments(existingDeployments []
 		// can't hurt.
 		return c.updateStatus(config, existingDeployments)
 	}
-	activeDeployment := deployutil.ActiveDeployment(config, existingDeployments)
+	activeDeployment := deployutil.ActiveDeployment(existingDeployments)
 	// Compute the replica count for the active deployment (even if the active
 	// deployment doesn't exist). The active replica count is the value that
 	// should be assigned to the config, to allow the replica propagation to

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -40,7 +40,7 @@ func LatestDeploymentInfo(config *deployapi.DeploymentConfig, deployments []api.
 // ActiveDeployment returns the latest complete deployment, or nil if there is
 // no such deployment. The active deployment is not always the same as the
 // latest deployment.
-func ActiveDeployment(config *deployapi.DeploymentConfig, input []api.ReplicationController) *api.ReplicationController {
+func ActiveDeployment(input []api.ReplicationController) *api.ReplicationController {
 	var activeDeployment *api.ReplicationController
 	var lastCompleteDeploymentVersion int64 = 0
 	for i := range input {
@@ -414,7 +414,7 @@ func DeploymentsForCleanup(configuration *deployapi.DeploymentConfig, deployment
 	sort.Sort(ByLatestVersionAsc(deployments))
 
 	relevantDeployments := []api.ReplicationController{}
-	activeDeployment := ActiveDeployment(configuration, deployments)
+	activeDeployment := ActiveDeployment(deployments)
 	if activeDeployment == nil {
 		// if cleanup policy is set but no successful deployments have happened, there will be
 		// no active deployment. We can consider all of the deployments in this case except for


### PR DESCRIPTION
Config  is an unused parameter in function ActiveDeployment, and I suggest that remove this parameter.


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>