### PR TITLE
Make evacuate aware of replica set and daemon set

### DIFF
--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -57,7 +57,7 @@ func (l *ListPodsOptions) runListPods(node *kapi.Node, printer kubectl.ResourceP
 	fieldSelector := fields.Set{GetPodHostFieldLabel(node.TypeMeta.APIVersion): node.ObjectMeta.Name}.AsSelector()
 
 	// Filter all pods that satisfies pod label selector and belongs to the given node
-	pods, err := l.Options.Kclient.Pods(kapi.NamespaceAll).List(kapi.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
+	pods, err := l.Options.KubeClient.Pods(kapi.NamespaceAll).List(kapi.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -26,7 +26,7 @@ import (
 
 type NodeOptions struct {
 	DefaultNamespace string
-	Kclient          *client.Client
+	KubeClient       *client.Client
 	Writer           io.Writer
 	ErrWriter        io.Writer
 
@@ -61,7 +61,7 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	mapper, typer := f.Object(false)
 
 	n.DefaultNamespace = defaultNamespace
-	n.Kclient = kc
+	n.KubeClient = kc
 	n.Writer = out
 	n.ErrWriter = errout
 	n.Mapper = mapper

--- a/pkg/cmd/admin/node/schedulable.go
+++ b/pkg/cmd/admin/node/schedulable.go
@@ -23,7 +23,7 @@ func (s *SchedulableOptions) Run() error {
 	for _, node := range nodes {
 		if node.Spec.Unschedulable != unschedulable {
 			node.Spec.Unschedulable = unschedulable
-			node, err = s.Options.Kclient.Nodes().Update(node)
+			node, err = s.Options.KubeClient.Nodes().Update(node)
 			if err != nil {
 				errList = append(errList, err)
 				continue


### PR DESCRIPTION
@kargakis this is asking for refactoring desperately and I need to find the appropriate helper in upstream to use for matching labels with `unversioned.LabelSelector`, but PTAL.


Fixes: https://github.com/openshift/origin/issues/11193