### PR TITLE
Implement Factory interface and mock for test.

### DIFF
--- a/pkg/bootstrap/docker/status.go
+++ b/pkg/bootstrap/docker/status.go
@@ -104,7 +104,7 @@ func isHealthy(f *clientcmd.Factory) (bool, error) {
 	}
 
 	var statusCode int
-	osClient.Client.Timeout = 10 * time.Second
+	osClient.SetTimeout(10 * time.Second)
 	osClient.Get().AbsPath("/healthz").Do().StatusCode(&statusCode)
 	return statusCode == 200, nil
 }

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -795,7 +795,7 @@ func (c *ClientStartConfig) Factory() (*clientcmd.Factory, error) {
 }
 
 // Clients returns clients for OpenShift and Kube
-func (c *ClientStartConfig) Clients() (*client.Client, *kclient.Client, error) {
+func (c *ClientStartConfig) Clients() (client.Interface, *kclient.Client, error) {
 	f, err := c.Factory()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
@@ -795,7 +794,7 @@ func (c *ClientStartConfig) Factory() (*clientcmd.Factory, error) {
 }
 
 // Clients returns clients for OpenShift and Kube
-func (c *ClientStartConfig) Clients() (client.Interface, *kclient.Client, error) {
+func (c *ClientStartConfig) Clients() (client.Interface, client.KClientInterface, error) {
 	f, err := c.Factory()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/build/cmd/reaper.go
+++ b/pkg/build/cmd/reaper.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewBuildConfigReaper returns a new reaper for buildConfigs
-func NewBuildConfigReaper(oc *client.Client) kubectl.Reaper {
+func NewBuildConfigReaper(oc client.Interface) kubectl.Reaper {
 	return &BuildConfigReaper{oc: oc, pollInterval: kubectl.Interval, timeout: kubectl.Timeout}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,6 +25,7 @@ type KClientInterface interface {
 	kclient.Interface
 	kclient.DaemonSetsNamespacer
 	kclient.ScaleNamespacer
+	kclient.ReplicaSetsNamespacer
 	resource.RESTClient
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
@@ -65,6 +66,10 @@ type Interface interface {
 	ClusterRoleBindingsInterface
 	ClusterResourceQuotasInterface
 	AppliedClusterResourceQuotasNamespacer
+
+	// Openshift specific methods.
+	Discovery() discovery.DiscoveryInterface
+	GetRESTClient() *restclient.RESTClient
 }
 
 // Builds provides a REST client for Builds
@@ -315,6 +320,10 @@ func New(c *restclient.Config) (*Client, error) {
 func (c *Client) Discovery() discovery.DiscoveryInterface {
 	d := NewDiscoveryClient(c.RESTClient)
 	return d
+}
+
+func (c *Client) GetRESTClient() *restclient.RESTClient {
+	return c.RESTClient
 }
 
 // SetOpenShiftDefaults sets the default settings on the passed

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
@@ -80,6 +81,8 @@ type Interface interface {
 	AppliedClusterResourceQuotasNamespacer
 	// Openshift specific methods.
 	Discovery() discovery.DiscoveryInterface
+	SetTimeout(d time.Duration)
+
 	// Implements kubectl RESTClient
 	resource.RESTClient
 }
@@ -349,6 +352,10 @@ func (c *Client) Get() *restclient.Request {
 }
 func (c *Client) Delete() *restclient.Request {
 	return c.RESTClient.Delete()
+}
+
+func (c *Client) SetTimeout(d time.Duration) {
+	c.RESTClient.Client.Timeout = d
 }
 
 // SetOpenShiftDefaults sets the default settings on the passed

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
-	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 // DiscoveryClient implements the functions that discovery server-supported API groups,
@@ -64,6 +63,6 @@ func (d *DiscoveryClient) ServerResources() (map[string]*unversioned.APIResource
 }
 
 // New creates a new DiscoveryClient for the given RESTClient.
-func NewDiscoveryClient(c resource.RESTClient) *DiscoveryClient {
-	return &DiscoveryClient{discovery.NewDiscoveryClient(c.(*restclient.RESTClient))}
+func NewDiscoveryClient(c *restclient.RESTClient) *DiscoveryClient {
+	return &DiscoveryClient{discovery.NewDiscoveryClient(c)}
 }

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 // DiscoveryClient implements the functions that discovery server-supported API groups,
@@ -63,6 +64,6 @@ func (d *DiscoveryClient) ServerResources() (map[string]*unversioned.APIResource
 }
 
 // New creates a new DiscoveryClient for the given RESTClient.
-func NewDiscoveryClient(c *restclient.RESTClient) *DiscoveryClient {
-	return &DiscoveryClient{discovery.NewDiscoveryClient(c)}
+func NewDiscoveryClient(c resource.RESTClient) *DiscoveryClient {
+	return &DiscoveryClient{discovery.NewDiscoveryClient(c.(*restclient.RESTClient))}
 }

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -3,6 +3,7 @@ package testclient
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -353,6 +354,8 @@ func (c *Fake) AppliedClusterResourceQuotas(namespace string) client.AppliedClus
 func (c *Fake) Discovery() discovery.DiscoveryInterface {
 	return nil
 }
+
+func (c *Fake) SetTimeout(time.Duration) {}
 
 func (c *Fake) Post() *restclient.Request {
 	return nil

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -354,6 +354,18 @@ func (c *Fake) Discovery() discovery.DiscoveryInterface {
 	return nil
 }
 
-func (c *Fake) GetRESTClient() *restclient.RESTClient {
+func (c *Fake) Post() *restclient.Request {
+	return nil
+}
+func (c *Fake) Put() *restclient.Request {
+	return nil
+}
+func (c *Fake) Patch(pt kapi.PatchType) *restclient.Request {
+	return nil
+}
+func (c *Fake) Get() *restclient.Request {
+	return nil
+}
+func (c *Fake) Delete() *restclient.Request {
 	return nil
 }

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -6,6 +6,8 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
@@ -346,4 +348,12 @@ func (c *Fake) ClusterResourceQuotas() client.ClusterResourceQuotaInterface {
 
 func (c *Fake) AppliedClusterResourceQuotas(namespace string) client.AppliedClusterResourceQuotaInterface {
 	return &FakeAppliedClusterResourceQuotas{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Discovery() discovery.DiscoveryInterface {
+	return nil
+}
+
+func (c *Fake) GetRESTClient() *restclient.RESTClient {
+	return nil
 }

--- a/pkg/client/testclient/fake_buildconfigs.go
+++ b/pkg/client/testclient/fake_buildconfigs.go
@@ -77,23 +77,17 @@ func (c *FakeBuildConfigs) WebHookURL(name string, trigger *buildapi.BuildTrigge
 }
 
 func (c *FakeBuildConfigs) Instantiate(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
+	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
 	action.Subresource = "instantiate"
-	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
-	if obj == nil {
-		return nil, err
-	}
+	_, _ = c.Fake.Invokes(action, &buildapi.Build{})
 
-	return obj.(*buildapi.Build), err
+	return &buildapi.Build{}, err
 }
 
 func (c *FakeBuildConfigs) InstantiateBinary(request *buildapi.BinaryBuildRequestOptions, r io.Reader) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
+	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
 	action.Subresource = "instantiatebinary"
-	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
-	if obj == nil {
-		return nil, err
-	}
+	_, _ = c.Fake.Invokes(action, &buildapi.Build{})
 
-	return obj.(*buildapi.Build), err
+	return &buildapi.Build{}, err
 }

--- a/pkg/cmd/admin/diagnostics/client.go
+++ b/pkg/cmd/admin/diagnostics/client.go
@@ -46,7 +46,7 @@ func (o DiagnosticsOptions) buildClientDiagnostics(rawConfig *clientcmdapi.Confi
 			}
 		case clientdiags.DiagnosticPodName:
 			diagnostics = append(diagnostics, &clientdiags.DiagnosticPod{
-				KubeClient:          *kubeClient,
+				KubeClient:          kubeClient,
 				Namespace:           rawConfig.Contexts[rawConfig.CurrentContext].Namespace,
 				Level:               o.LogOptions.Level,
 				Factory:             o.Factory,

--- a/pkg/cmd/admin/diagnostics/cluster.go
+++ b/pkg/cmd/admin/diagnostics/cluster.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	clientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -44,7 +43,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 
 	var (
 		clusterClient  client.Interface
-		kclusterClient *kclient.Client
+		kclusterClient client.KClientInterface
 	)
 
 	clusterClient, kclusterClient, found, serverUrl, err := o.findClusterClients(rawConfig)
@@ -84,7 +83,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 }
 
 // attempts to find which context in the config might be a cluster-admin for the server in the current context.
-func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (client.Interface, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (client.Interface, client.KClientInterface, bool, string, error) {
 	if o.ClientClusterContext != "" { // user has specified cluster context to use
 		if context, exists := rawConfig.Contexts[o.ClientClusterContext]; exists {
 			configErr := fmt.Errorf("Specified '%s' as cluster-admin context, but it was not found in your client configuration.", o.ClientClusterContext)
@@ -120,7 +119,7 @@ func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (
 }
 
 // makes the client from the specified context and determines whether it is a cluster-admin.
-func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (client.Interface, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (client.Interface, client.KClientInterface, bool, string, error) {
 	overrides := &clientcmd.ConfigOverrides{Context: *context}
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, overrides)
 	serverUrl := rawConfig.Clusters[context.Cluster].Server

--- a/pkg/cmd/admin/diagnostics/cluster.go
+++ b/pkg/cmd/admin/diagnostics/cluster.go
@@ -43,7 +43,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 	}
 
 	var (
-		clusterClient  *client.Client
+		clusterClient  client.Interface
 		kclusterClient *kclient.Client
 	)
 
@@ -84,7 +84,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 }
 
 // attempts to find which context in the config might be a cluster-admin for the server in the current context.
-func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*client.Client, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (client.Interface, *kclient.Client, bool, string, error) {
 	if o.ClientClusterContext != "" { // user has specified cluster context to use
 		if context, exists := rawConfig.Contexts[o.ClientClusterContext]; exists {
 			configErr := fmt.Errorf("Specified '%s' as cluster-admin context, but it was not found in your client configuration.", o.ClientClusterContext)
@@ -120,7 +120,7 @@ func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (
 }
 
 // makes the client from the specified context and determines whether it is a cluster-admin.
-func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*client.Client, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (client.Interface, *kclient.Client, bool, string, error) {
 	overrides := &clientcmd.ConfigOverrides{Context: *context}
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, overrides)
 	serverUrl := rawConfig.Clusters[context.Cluster].Server

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -29,7 +29,7 @@ import (
 type ProjectOptions struct {
 	DefaultNamespace string
 	Oclient          osclient.Interface
-	Kclient          *kclient.Client
+	Kclient          kclient.Interface
 	Out              io.Writer
 
 	Mapper            meta.RESTMapper

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -28,7 +28,7 @@ import (
 
 type ProjectOptions struct {
 	DefaultNamespace string
-	Oclient          *osclient.Client
+	Oclient          osclient.Interface
 	Kclient          *kclient.Client
 	Out              io.Writer
 

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -12,7 +12,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -21,12 +20,13 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 
+	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type NodeOptions struct {
 	DefaultNamespace string
-	KubeClient       *client.Client
+	KubeClient       client.KClientInterface
 	Writer           io.Writer
 	ErrWriter        io.Writer
 

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -23,7 +23,7 @@ const WhoCanRecommendedName = "who-can"
 type whoCanOptions struct {
 	allNamespaces    bool
 	bindingNamespace string
-	client           *client.Client
+	client           client.Interface
 
 	verb         string
 	resource     unversioned.GroupVersionResource

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -424,7 +424,7 @@ func (p *describingManifestDeleter) DeleteManifest(registryClient *http.Client, 
 }
 
 // getClients returns a Kube client, OpenShift client, and registry client.
-func getClients(f *clientcmd.Factory, caBundle string) (client.Interface, *kclient.Client, *http.Client, error) {
+func getClients(f *clientcmd.Factory, caBundle string) (client.Interface, client.KClientInterface, *http.Client, error) {
 	clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, nil, err
@@ -433,7 +433,7 @@ func getClients(f *clientcmd.Factory, caBundle string) (client.Interface, *kclie
 	var (
 		token          string
 		osClient       client.Interface
-		kClient        *kclient.Client
+		kClient        client.KClientInterface
 		registryClient *http.Client
 	)
 

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -424,7 +424,7 @@ func (p *describingManifestDeleter) DeleteManifest(registryClient *http.Client, 
 }
 
 // getClients returns a Kube client, OpenShift client, and registry client.
-func getClients(f *clientcmd.Factory, caBundle string) (*client.Client, *kclient.Client, *http.Client, error) {
+func getClients(f *clientcmd.Factory, caBundle string) (client.Interface, *kclient.Client, *http.Client, error) {
 	clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, nil, err
@@ -432,7 +432,7 @@ func getClients(f *clientcmd.Factory, caBundle string) (*client.Client, *kclient
 
 	var (
 		token          string
-		osClient       *client.Client
+		osClient       client.Interface
 		kClient        *kclient.Client
 		registryClient *http.Client
 	)

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -24,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/intstr"
 
 	authapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -298,7 +298,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out, errout io.
 
 // generateSecretsConfig generates any Secret and Volume objects, such
 // as SSH private keys, that are necessary for the router container.
-func generateSecretsConfig(cfg *RouterConfig, kClient *kclient.Client,
+func generateSecretsConfig(cfg *RouterConfig, kClient client.KClientInterface,
 	namespace string, defaultCert []byte, certName string) ([]*kapi.Secret, []kapi.Volume, []kapi.VolumeMount,
 	error) {
 	var secrets []*kapi.Secret
@@ -856,7 +856,7 @@ func generateStatsPassword() string {
 	return strings.Join(password, "")
 }
 
-func validateServiceAccount(client *kclient.Client, ns string, serviceAccount string, hostNetwork, hostPorts bool) error {
+func validateServiceAccount(client client.KClientInterface, ns string, serviceAccount string, hostNetwork, hostPorts bool) error {
 	if !hostNetwork && !hostPorts {
 		return nil
 	}

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -111,7 +111,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdDeploy(fullName, f, out),
 				cmd.NewCmdRollback(fullName, f, out),
 				cmd.NewCmdNewBuild(cmd.NewBuildRecommendedCommandName, fullName, f, in, out, errout),
-				cmd.NewCmdStartBuild(fullName, f, in, out, errout),
+				cmd.NewCmdStartBuild(cmd.StartBuildRecommendedCommandName, fullName, f, in, out, errout),
 				cmd.NewCmdCancelBuild(cmd.CancelBuildRecommendedCommandName, fullName, f, in, out, errout),
 				cmd.NewCmdImportImage(fullName, f, out, errout),
 				cmd.NewCmdTag(fullName, f, out),

--- a/pkg/cmd/cli/cmd/cancelbuild_test.go
+++ b/pkg/cmd/cli/cmd/cancelbuild_test.go
@@ -124,7 +124,7 @@ func TestCancelBuildRun(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		client := testclient.NewSimpleFake(genBuild(test.phase))
+		client := testclient.NewSimpleFake(genBuild("ruby-ex", "test", test.phase))
 		buildClient := NewFakeTestBuilds(client, test.opts.Namespace)
 
 		test.opts.Client = client
@@ -187,11 +187,11 @@ func (c *FakeTestBuilds) Update(inObj *buildapi.Build) (*buildapi.Build, error) 
 	return c.Obj, err
 }
 
-func genBuild(phase buildapi.BuildPhase) *buildapi.Build {
+func genBuild(name, ns string, phase buildapi.BuildPhase) *buildapi.Build {
 	build := buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "ruby-ex",
-			Namespace: "test",
+			Name:      name,
+			Namespace: ns,
 		},
 		Status: buildapi.BuildStatus{
 			Phase: phase,

--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -278,7 +278,7 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 	if err != nil {
 		return err
 	}
-	o.Attach.Client = kc
+	o.Attach.Client = kc.(*kclient.Client)
 	return nil
 }
 func (o DebugOptions) Validate() error {

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -13,6 +13,8 @@ import (
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	utilerrors "github.com/openshift/origin/pkg/util/errors"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kubeclient "k8s.io/kubernetes/pkg/client/unversioned"
+
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -532,8 +534,8 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 	}
 
 	delegScaleGetter := osclient.NewDelegatingScaleNamespacer(oclient, kclient)
-	dcGetter := deployclient.New(oclient.GetRESTClient())
-	rcGetter := clientset.FromUnversionedClient(kclient)
+	dcGetter := deployclient.New(oclient)
+	rcGetter := clientset.FromUnversionedClient(kclient.(*kubeclient.Client))
 
 	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, dcGetter, rcGetter, func(currentReplicas int32, annotations map[string]string) {
 		annotations[unidlingapi.IdledAtAnnotation] = nowTime.UTC().Format(time.RFC3339)

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -532,7 +532,7 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 	}
 
 	delegScaleGetter := osclient.NewDelegatingScaleNamespacer(oclient, kclient)
-	dcGetter := deployclient.New(oclient.RESTClient)
+	dcGetter := deployclient.New(oclient.GetRESTClient())
 	rcGetter := clientset.FromUnversionedClient(kclient)
 
 	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, dcGetter, rcGetter, func(currentReplicas int32, annotations map[string]string) {

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -27,7 +27,7 @@ import (
 type ProjectOptions struct {
 	Config       clientcmdapi.Config
 	ClientConfig *restclient.Config
-	ClientFn     func() (*client.Client, kclient.Interface, error)
+	ClientFn     func() (client.Interface, kclient.Interface, error)
 	Out          io.Writer
 	PathOptions  *kclientcmd.PathOptions
 
@@ -107,7 +107,7 @@ func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Wr
 		return err
 	}
 
-	o.ClientFn = func() (*client.Client, kclient.Interface, error) {
+	o.ClientFn = func() (client.Interface, kclient.Interface, error) {
 		return f.Clients()
 	}
 
@@ -279,7 +279,7 @@ func (o ProjectOptions) RunProject() error {
 	return nil
 }
 
-func confirmProjectAccess(currentProject string, oClient *client.Client, kClient kclient.Interface) error {
+func confirmProjectAccess(currentProject string, oClient client.Interface, kClient kclient.Interface) error {
 	_, projectErr := oClient.Projects().Get(currentProject)
 	if !kapierrors.IsNotFound(projectErr) {
 		return projectErr
@@ -294,7 +294,7 @@ func confirmProjectAccess(currentProject string, oClient *client.Client, kClient
 	return projectErr
 }
 
-func getProjects(oClient *client.Client, kClient kclient.Interface) ([]api.Project, error) {
+func getProjects(oClient client.Interface, kClient kclient.Interface) ([]api.Project, error) {
 	projects, err := oClient.Projects().List(kapi.ListOptions{})
 	if err == nil {
 		return projects.Items, nil

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -23,7 +23,7 @@ import (
 type ProjectsOptions struct {
 	Config       clientcmdapi.Config
 	ClientConfig *restclient.Config
-	Client       *client.Client
+	Client       client.Interface
 	KubeClient   kclient.Interface
 	Out          io.Writer
 	PathOptions  *kclientcmd.PathOptions

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -113,7 +113,7 @@ type StartBuildOptions struct {
 }
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
-func NewCmdStartBuild(name, baseName string, f clientcmd.InterfaceFactory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdStartBuild(name, baseName string, f clientcmd.FactoryInterface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	o := &StartBuildOptions{}
 
 	cmd := &cobra.Command{
@@ -149,7 +149,7 @@ func NewCmdStartBuild(name, baseName string, f clientcmd.InterfaceFactory, in io
 	return cmd
 }
 
-func (o *StartBuildOptions) Complete(baseName string, f clientcmd.InterfaceFactory, cmd *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *StartBuildOptions) Complete(baseName string, f clientcmd.FactoryInterface, cmd *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	o.In = in
 	o.Out = out
 	o.ErrOut = errout
@@ -167,7 +167,7 @@ func (o *StartBuildOptions) Complete(baseName string, f clientcmd.InterfaceFacto
 		if len(args) > 0 || len(o.FromBuild) > 0 || len(o.FromFile) > 0 || len(o.FromDir) > 0 || len(o.FromRepo) > 0 {
 			return kcmdutil.UsageError(cmd, "The '--from-webhook' flag is incompatible with arguments and all '--from-*' flags")
 		}
-		if !strings.HasSuffix(webhook, "/generic") {
+		if !strings.HasSuffix(o.FromWebhook, "/generic") {
 			fmt.Fprintf(errout, "warning: the '--from-webhook' flag should be called with a generic webhook URL.\n")
 		}
 		return nil

--- a/pkg/cmd/cli/cmd/startbuild_test.go
+++ b/pkg/cmd/cli/cmd/startbuild_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 
@@ -225,7 +224,7 @@ func TestStartBuildComplete(t *testing.T) {
 		OnObject: func(bool) (kmeta.RESTMapper, kruntime.ObjectTyper) {
 			return registered.RESTMapper(), kapi.Scheme
 		},
-		OnClients: func() (client.Interface, *kclient.Client, error) {
+		OnClients: func() (client.Interface, client.KClientInterface, error) {
 			return osclient, nil, nil
 		},
 		OnOSClientConfig: func() kclientcmd.ClientConfig {

--- a/pkg/cmd/cli/cmd/startbuild_test.go
+++ b/pkg/cmd/cli/cmd/startbuild_test.go
@@ -12,40 +12,21 @@ import (
 	"strings"
 	"testing"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	kmeta "k8s.io/kubernetes/pkg/api/meta"
+	kruntime "k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/client"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/client/restclient"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
-
-type FakeClientConfig struct {
-	Raw      clientcmdapi.Config
-	Client   *restclient.Config
-	NS       string
-	Explicit bool
-	Err      error
-}
-
-func (c *FakeClientConfig) ConfigAccess() kclientcmd.ConfigAccess {
-	return nil
-}
-
-// RawConfig returns the merged result of all overrides
-func (c *FakeClientConfig) RawConfig() (clientcmdapi.Config, error) {
-	return c.Raw, c.Err
-}
-
-// ClientConfig returns a complete client config
-func (c *FakeClientConfig) ClientConfig() (*restclient.Config, error) {
-	return c.Client, c.Err
-}
-
-// Namespace returns the namespace resulting from the merged result of all overrides
-func (c *FakeClientConfig) Namespace() (string, bool, error) {
-	return c.NS, c.Explicit, c.Err
-}
 
 func TestStartBuildWebHook(t *testing.T) {
 	invoked := make(chan struct{}, 1)
@@ -144,4 +125,253 @@ func TestStartBuildHookPostReceive(t *testing.T) {
 	if event.Git.Refs[0].Commit != "2384" {
 		t.Fatalf("unexpected ref: %#v", event.Git.Refs[0])
 	}
+}
+
+// TestStartBuildComplete ensures that Complete works like expected.
+func TestStartBuildComplete(t *testing.T) {
+	tests := []struct {
+		name            string
+		opts            *StartBuildOptions
+		args            []string
+		expectedActions []testAction
+		expectedErr     string
+	}{
+		{
+			name:        "no args",
+			opts:        &StartBuildOptions{},
+			expectedErr: "Must pass a name of a build config or specify build name with '--from-build' flag.",
+		},
+		{
+			name: "fromwebhook with args",
+			opts: &StartBuildOptions{
+				FromWebhook: "http://test.com/webhook",
+			},
+			args:        []string{"test"},
+			expectedErr: "The '--from-webhook' flag is incompatible with arguments and all '--from-*' flags",
+		},
+		{
+			name: "frombuild with binary",
+			opts: &StartBuildOptions{
+				FromBuild: "hello-world",
+				FromFile:  "test.xml",
+			},
+			expectedErr: "Cannot use '--from-build' flag with binary builds",
+		},
+		{
+			name: "fromwebhook",
+			opts: &StartBuildOptions{
+				FromWebhook: "test/webhook",
+			},
+		},
+		{
+			name: "frombuild buildconfigs",
+			opts: &StartBuildOptions{
+				FromBuild: "hello-world-1",
+			},
+		},
+		{
+			name: "resource buildconfigs",
+			opts: &StartBuildOptions{},
+			args: []string{"hello-world"},
+		},
+		{
+			name:        "resource builds",
+			opts:        &StartBuildOptions{},
+			args:        []string{"builds/hello-world"},
+			expectedErr: "use --from-build to rerun your builds",
+		},
+		{
+			name:        "unknown resource",
+			opts:        &StartBuildOptions{},
+			args:        []string{"buildlogs/hello-world"},
+			expectedErr: "invalid resource provided: { buildlogs}",
+		},
+		{
+			name: "ListWebhooks no buildconfig",
+			opts: &StartBuildOptions{
+				ListWebhooks: "all",
+				FromBuild:    "hello-world-1",
+			},
+			expectedErr: `the provided Build "hello-world-1" was not created from a BuildConfig and cannot have webhooks`,
+		},
+		{
+			name: "ListWebhooks buildconfig no name",
+			opts: &StartBuildOptions{
+				ListWebhooks: "all",
+				FromBuild:    "hello-world-2",
+			},
+			expectedErr: `a resource name is required either as an argument or by using --from-build`,
+		},
+		{
+			name: "ListWebhooks Success",
+			opts: &StartBuildOptions{
+				ListWebhooks: "all",
+				FromBuild:    "hello-world-3",
+			},
+		},
+	}
+
+	builds := []*buildapi.Build{
+		genBuild("hello-world-1", "test", buildapi.BuildPhaseNew),
+		genBuild("hello-world-2", "test", buildapi.BuildPhaseNew),
+		genBuild("hello-world-3", "test", buildapi.BuildPhaseNew),
+	}
+	builds[1].Status.Config = &kapi.ObjectReference{Namespace: "test"}
+	builds[2].Status.Config = &kapi.ObjectReference{Name: "test", Namespace: "test"}
+
+	osclient := testclient.NewSimpleFake(builds[0], builds[1], builds[2])
+
+	f := &clientcmd.MockFactory{
+		OnObject: func(bool) (kmeta.RESTMapper, kruntime.ObjectTyper) {
+			return registered.RESTMapper(), kapi.Scheme
+		},
+		OnClients: func() (client.Interface, *kclient.Client, error) {
+			return osclient, nil, nil
+		},
+		OnOSClientConfig: func() kclientcmd.ClientConfig {
+			return &FakeClientConfig{Client: &restclient.Config{}}
+		},
+		OnDefaultNamespace: func() (string, bool, error) {
+			return "test", false, nil
+		},
+	}
+
+	for _, test := range tests {
+
+		cmd := NewCmdStartBuild("start-build", "oc", f, os.Stdin, os.Stdout)
+
+		if err := test.opts.Complete("oc", f, cmd, test.args, os.Stdin, os.Stdout); err != nil {
+			if len(test.expectedErr) == 0 {
+				t.Fatalf("[%s] error not expected: %v", test.name, err)
+			}
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Fatalf("[%s] error not expected: %v", test.name, err)
+			}
+		} else if len(test.expectedErr) != 0 {
+			t.Fatalf("[%s] expected error: %v, got nil", test.name, test.expectedErr)
+		}
+	}
+}
+
+// TestStartBuildRun ensures that Run works like expected.
+func TestStartBuildRun(t *testing.T) {
+	type testAction struct {
+		verb, resource, subresource string
+	}
+
+	tests := []struct {
+		name            string
+		opts            *StartBuildOptions
+		expectedActions []testAction
+		expectedErr     string
+	}{
+		{
+			name: "create builds clone",
+			opts: &StartBuildOptions{
+				FromBuild: "hello-world-1",
+			},
+			expectedActions: []testAction{
+				{verb: "create", resource: "builds", subresource: "clone"},
+			},
+		},
+		{
+			name: "create buildconfigs instantiate",
+			opts: &StartBuildOptions{
+				Name: "hello-world",
+			},
+			expectedActions: []testAction{
+				{verb: "create", resource: "buildconfigs", subresource: "instantiate"},
+			},
+		},
+		{
+			name: "binary with dir, file",
+			opts: &StartBuildOptions{
+				AsBinary: true,
+				FromDir:  "src/",
+				FromFile: "test.xml",
+				Name:     "hello-world",
+			},
+			expectedErr: "only one of --from-file, --from-repo, or --from-dir may be specified",
+		},
+		{
+			name: "binary",
+			opts: &StartBuildOptions{
+				AsBinary: true,
+				Name:     "hello-world",
+			},
+			expectedActions: []testAction{
+				{verb: "create", resource: "buildconfigs", subresource: "instantiatebinary"},
+			},
+		},
+		{
+			name: "fromrepo with commit tag",
+			opts: &StartBuildOptions{
+				FromRepo: "../hello-world",
+				Commit:   "v2",
+				Name:     "hello-world",
+			},
+			expectedActions: []testAction{
+				{verb: "create", resource: "buildconfigs", subresource: "instantiate"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		osclient := testclient.NewSimpleFake(genBuild("hello-world-1", "test", buildapi.BuildPhaseNew))
+
+		test.opts.Client = osclient
+		test.opts.Out = ioutil.Discard
+		test.opts.ErrOut = ioutil.Discard
+		test.opts.Mapper = registered.RESTMapper()
+
+		if err := test.opts.Run(); err != nil {
+			if len(test.expectedErr) == 0 {
+				t.Fatalf("[%s] RUN: error not expected: %v", test.name, err)
+			}
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Fatalf("[%s] RUN: error not expected: %v", test.name, err)
+			}
+		} else if len(test.expectedErr) != 0 {
+			t.Fatalf("[%s] RUN: expected error: %v, got nil", test.name, test.expectedErr)
+		}
+
+		got := osclient.Actions()
+		if len(test.expectedActions) != len(got) {
+			t.Fatalf("action length mismatch: expected %d, got %d", len(test.expectedActions), len(got))
+		}
+
+		for i, action := range test.expectedActions {
+			if !got[i].Matches(action.verb, action.resource) {
+				t.Errorf("action mismatch: expected %s %s, got %s %s", action.verb, action.resource, got[i].GetVerb(), got[i].GetResource())
+			}
+		}
+	}
+}
+
+// FakeClientConfig mocks a kubernetes ClientConfig.
+type FakeClientConfig struct {
+	Raw      clientcmdapi.Config
+	Client   *restclient.Config
+	NS       string
+	Explicit bool
+	Err      error
+}
+
+func (c *FakeClientConfig) ConfigAccess() kclientcmd.ConfigAccess {
+	return nil
+}
+
+// RawConfig returns the merged result of all overrides
+func (c *FakeClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.Raw, c.Err
+}
+
+// ClientConfig returns a complete client config
+func (c *FakeClientConfig) ClientConfig() (*restclient.Config, error) {
+	return c.Client, c.Err
+}
+
+// Namespace returns the namespace resulting from the merged result of all overrides
+func (c *FakeClientConfig) Namespace() (string, bool, error) {
+	return c.NS, c.Explicit, c.Err
 }

--- a/pkg/cmd/cli/cmd/startbuild_test.go
+++ b/pkg/cmd/cli/cmd/startbuild_test.go
@@ -237,9 +237,9 @@ func TestStartBuildComplete(t *testing.T) {
 
 	for _, test := range tests {
 
-		cmd := NewCmdStartBuild("start-build", "oc", f, os.Stdin, os.Stdout)
+		cmd := NewCmdStartBuild("start-build", "oc", f, os.Stdin, os.Stdout, os.Stdout)
 
-		if err := test.opts.Complete("oc", f, cmd, test.args, os.Stdin, os.Stdout); err != nil {
+		if err := test.opts.Complete("oc", f, cmd, test.args, os.Stdin, os.Stdout, os.Stdout); err != nil {
 			if len(test.expectedErr) == 0 {
 				t.Fatalf("[%s] error not expected: %v", test.name, err)
 			}

--- a/pkg/cmd/cli/cmd/version.go
+++ b/pkg/cmd/cli/cmd/version.go
@@ -10,7 +10,6 @@ import (
 	etcdversion "github.com/coreos/etcd/version"
 
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kubeversion "k8s.io/kubernetes/pkg/version"
@@ -33,7 +32,7 @@ type VersionOptions struct {
 	Out      io.Writer
 
 	ClientConfig kclientcmd.ClientConfig
-	Clients      func() (client.Interface, *kclient.Client, error)
+	Clients      func() (client.Interface, client.KClientInterface, error)
 
 	Timeout time.Duration
 
@@ -158,7 +157,7 @@ func (o VersionOptions) RunVersion() error {
 			return
 		}
 
-		ocVersionBody, err := oClient.GetRESTClient().Get().AbsPath("/version/openshift").Do().Raw()
+		ocVersionBody, err := oClient.Get().AbsPath("/version/openshift").Do().Raw()
 		switch {
 		case err == nil:
 			var ocServerInfo version.Info

--- a/pkg/cmd/cli/cmd/version.go
+++ b/pkg/cmd/cli/cmd/version.go
@@ -33,7 +33,7 @@ type VersionOptions struct {
 	Out      io.Writer
 
 	ClientConfig kclientcmd.ClientConfig
-	Clients      func() (*client.Client, *kclient.Client, error)
+	Clients      func() (client.Interface, *kclient.Client, error)
 
 	Timeout time.Duration
 
@@ -158,7 +158,7 @@ func (o VersionOptions) RunVersion() error {
 			return
 		}
 
-		ocVersionBody, err := oClient.Get().AbsPath("/version/openshift").Do().Raw()
+		ocVersionBody, err := oClient.GetRESTClient().Get().AbsPath("/version/openshift").Do().Raw()
 		switch {
 		case err == nil:
 			var ocServerInfo version.Info

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -202,7 +202,7 @@ func Run(f *clientcmd.Factory, options *ipfailover.IPFailoverConfigCmdOptions, c
 	return nil
 }
 
-func validateServiceAccount(client *kclient.Client, ns string, serviceAccount string) error {
+func validateServiceAccount(client kclient.Interface, ns string, serviceAccount string) error {
 
 	sccList, err := client.SecurityContextConstraints().List(kapi.ListOptions{})
 	if err != nil {

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -327,7 +327,7 @@ func GetKubeClient(kubeConfigFile string, overrides *ClientConnectionOverrides) 
 // TODO: clients should be copied and instantiated from a common client config, tweaked, then
 // given to individual controllers and other infrastructure components. Overrides are optional
 // and may alter the default configuration.
-func GetOpenShiftClient(kubeConfigFile string, overrides *ClientConnectionOverrides) (*client.Client, *restclient.Config, error) {
+func GetOpenShiftClient(kubeConfigFile string, overrides *ClientConnectionOverrides) (client.Interface, *restclient.Config, error) {
 	loadingRules := &clientcmd.ClientConfigLoadingRules{}
 	loadingRules.ExplicitPath = kubeConfigFile
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -326,7 +326,7 @@ func (c *MasterConfig) RunDisruptionBudgetController(client *client.Client) {
 }
 
 // RunHPAController starts the Kubernetes hpa controller sync loop
-func (c *MasterConfig) RunHPAController(oc *osclient.Client, kc *client.Client, heapsterNamespace string) {
+func (c *MasterConfig) RunHPAController(oc osclient.Interface, kc *client.Client, heapsterNamespace string) {
 	clientsetClient := clientadapter.FromUnversionedClient(kc)
 	delegatingScaleNamespacer := osclient.NewDelegatingScaleNamespacer(oc, kc)
 	podautoscaler := podautoscalercontroller.NewHorizontalController(

--- a/pkg/cmd/server/kubernetes/node_auth.go
+++ b/pkg/cmd/server/kubernetes/node_auth.go
@@ -145,7 +145,7 @@ func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 	return authzadapter.KubernetesAuthorizerAttributes(namespace, u, attrs)
 }
 
-func newAuthorizer(c *oclient.Client, cacheTTL time.Duration, cacheSize int) (kauthorizer.Authorizer, error) {
+func newAuthorizer(c oclient.Interface, cacheTTL time.Duration, cacheSize int) (kauthorizer.Authorizer, error) {
 	var (
 		authz oauthorizer.Authorizer
 		err   error

--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -415,7 +415,7 @@ func buildKubeProxyConfig(options configapi.NodeConfig) (*proxyoptions.ProxyServ
 	return proxyconfig, nil
 }
 
-func validateNetworkPluginName(originClient *osclient.Client, pluginName string) error {
+func validateNetworkPluginName(originClient osclient.Interface, pluginName string) error {
 	if sdnapi.IsOpenShiftNetworkPlugin(pluginName) {
 		// Detect any plugin mismatches between node and master
 		clusterNetwork, err := originClient.ClusterNetwork().Get(sdnapi.ClusterNetworkDefault)

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -157,7 +157,7 @@ type MasterConfig struct {
 	// built from PrivilegedLoopbackClientConfig. It should only be accessed via the *Client() helper methods.
 	// To apply different access control to a system component, create a separate client/config specifically
 	// for that component.
-	PrivilegedLoopbackOpenShiftClient *osclient.Client
+	PrivilegedLoopbackOpenShiftClient osclient.Interface
 
 	// Informers is a shared factory for getting SharedInformers. It is important to get your informers, indexers, and listers
 	// from here so that we only end up with a single cache of objects
@@ -828,21 +828,21 @@ func (c *MasterConfig) OAuthServerClients() (*osclient.Client, *kclient.Client) 
 //  list, watch all policyBindings in all namespaces
 //  list, watch all policies in all namespaces
 //  create resourceAccessReviews in all namespaces
-func (c *MasterConfig) PolicyClient() *osclient.Client {
+func (c *MasterConfig) PolicyClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // ServiceAccountRoleBindingClient returns the client object used to bind roles to service accounts
 // It must have the following capabilities:
 //  get, list, update, create policyBindings and clusterPolicyBindings in all namespaces
-func (c *MasterConfig) ServiceAccountRoleBindingClient() *osclient.Client {
+func (c *MasterConfig) ServiceAccountRoleBindingClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // SdnClient returns the sdn client object
 // It must have the capability to get/list/watch/create/delete
 // HostSubnets. And have the capability to get ClusterNetwork.
-func (c *MasterConfig) SdnClient() *osclient.Client {
+func (c *MasterConfig) SdnClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
@@ -864,12 +864,12 @@ func (c *MasterConfig) BuildLogClient() *kclient.Client {
 }
 
 // BuildConfigWebHookClient returns the webhook client object
-func (c *MasterConfig) BuildConfigWebHookClient() *osclient.Client {
+func (c *MasterConfig) BuildConfigWebHookClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // BuildControllerClients returns the build controller client objects
-func (c *MasterConfig) BuildControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) BuildControllerClients() (osclient.Interface, *kclient.Client) {
 	_, osClient, kClient, err := c.GetServiceAccountClients(bootstrappolicy.InfraBuildControllerServiceAccountName)
 	if err != nil {
 		glog.Fatal(err)
@@ -878,37 +878,37 @@ func (c *MasterConfig) BuildControllerClients() (*osclient.Client, *kclient.Clie
 }
 
 // BuildPodControllerClients returns the build pod controller client objects
-func (c *MasterConfig) BuildPodControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) BuildPodControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // BuildImageChangeTriggerControllerClients returns the build image change trigger controller client objects
-func (c *MasterConfig) BuildImageChangeTriggerControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) BuildImageChangeTriggerControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // BuildConfigChangeControllerClients returns the build config change controller client objects
-func (c *MasterConfig) BuildConfigChangeControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) BuildConfigChangeControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // ImageChangeControllerClient returns the openshift client object
-func (c *MasterConfig) ImageChangeControllerClient() *osclient.Client {
+func (c *MasterConfig) ImageChangeControllerClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // ImageImportControllerClient returns the deployment client object
-func (c *MasterConfig) ImageImportControllerClient() *osclient.Client {
+func (c *MasterConfig) ImageImportControllerClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // DeploymentConfigInstantiateClients returns the clients used by the instantiate endpoint.
-func (c *MasterConfig) DeploymentConfigInstantiateClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) DeploymentConfigInstantiateClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // DeploymentControllerClients returns the deployment controller client objects
-func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) DeploymentControllerClients() (osclient.Interface, *kclient.Client) {
 	_, osClient, kClient, err := c.GetServiceAccountClients(bootstrappolicy.InfraDeploymentConfigControllerServiceAccountName)
 	if err != nil {
 		glog.Fatal(err)
@@ -917,17 +917,17 @@ func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient
 }
 
 // DeploymentConfigClients returns deploymentConfig and deployment client objects
-func (c *MasterConfig) DeploymentConfigClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) DeploymentConfigClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // DeploymentConfigControllerClients returns the deploymentConfig controller client objects
-func (c *MasterConfig) DeploymentConfigControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) DeploymentConfigControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // DeploymentTriggerControllerClient returns the deploymentConfig trigger controller client object
-func (c *MasterConfig) DeploymentTriggerControllerClient() *osclient.Client {
+func (c *MasterConfig) DeploymentTriggerControllerClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
@@ -942,12 +942,12 @@ func (c *MasterConfig) SecurityAllocationControllerClient() *kclient.Client {
 }
 
 // SDNControllerClients returns the SDN controller client objects
-func (c *MasterConfig) SDNControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) SDNControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // RouteAllocatorClients returns the route allocator client objects
-func (c *MasterConfig) RouteAllocatorClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) RouteAllocatorClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
@@ -957,13 +957,13 @@ func (c *MasterConfig) ImageStreamSecretClient() *kclient.Client {
 }
 
 // ImageStreamImportSecretClient returns the client capable of retrieving image secrets for a namespace
-func (c *MasterConfig) ImageStreamImportSecretClient() *osclient.Client {
+func (c *MasterConfig) ImageStreamImportSecretClient() osclient.Interface {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
 // ResourceQuotaManagerClients returns the client capable of retrieving resources needed for resource quota
 // evaluation
-func (c *MasterConfig) ResourceQuotaManagerClients() (*osclient.Client, *internalclientset.Clientset) {
+func (c *MasterConfig) ResourceQuotaManagerClients() (osclient.Interface, *internalclientset.Clientset) {
 	return c.PrivilegedLoopbackOpenShiftClient, clientadapter.FromUnversionedClient(c.PrivilegedLoopbackKubernetesClient)
 }
 
@@ -975,12 +975,12 @@ func (c *MasterConfig) WebConsoleEnabled() bool {
 // OriginNamespaceControllerClients returns a client for openshift and kubernetes.
 // The openshift client object must have authority to delete openshift content in any namespace
 // The kubernetes client object must have authority to execute a finalize request on a namespace
-func (c *MasterConfig) OriginNamespaceControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) OriginNamespaceControllerClients() (osclient.Interface, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
 // UnidlingControllerClients returns the unidling controller clients
-func (c *MasterConfig) UnidlingControllerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) UnidlingControllerClients() (osclient.Interface, *kclient.Client) {
 	_, osClient, kClient, err := c.GetServiceAccountClients(bootstrappolicy.InfraUnidlingControllerServiceAccountName)
 	if err != nil {
 		glog.Fatal(err)
@@ -990,7 +990,7 @@ func (c *MasterConfig) UnidlingControllerClients() (*osclient.Client, *kclient.C
 
 // GetServiceAccountClients returns an OpenShift and Kubernetes client with the credentials of the
 // named service account in the infra namespace
-func (c *MasterConfig) GetServiceAccountClients(name string) (*restclient.Config, *osclient.Client, *kclient.Client, error) {
+func (c *MasterConfig) GetServiceAccountClients(name string) (*restclient.Config, osclient.Interface, *kclient.Client, error) {
 	if len(name) == 0 {
 		return nil, nil, nil, errors.New("No service account name specified")
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -819,7 +819,7 @@ func (c *MasterConfig) KubeClient() *kclient.Client {
 
 // OAuthServerClients returns the openshift and kubernetes OAuth server client objects
 // The returned clients are privileged
-func (c *MasterConfig) OAuthServerClients() (*osclient.Client, *kclient.Client) {
+func (c *MasterConfig) OAuthServerClients() (osclient.Interface, osclient.KClientInterface) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -557,7 +557,7 @@ func (c *MasterConfig) RunUnidlingController() {
 	resyncPeriod := 2 * time.Hour
 	scaleNamespacer := osclient.NewDelegatingScaleNamespacer(oc, kc)
 	coreClient := clientadapter.FromUnversionedClient(kc).Core()
-	dcCoreClient := deployclient.New(oc.RESTClient)
+	dcCoreClient := deployclient.New(oc.GetRESTClient())
 	cont := unidlingcontroller.NewUnidlingController(scaleNamespacer, coreClient, coreClient, dcCoreClient, coreClient, resyncPeriod)
 
 	cont.Run(utilwait.NeverStop)

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -557,7 +557,7 @@ func (c *MasterConfig) RunUnidlingController() {
 	resyncPeriod := 2 * time.Hour
 	scaleNamespacer := osclient.NewDelegatingScaleNamespacer(oc, kc)
 	coreClient := clientadapter.FromUnversionedClient(kc).Core()
-	dcCoreClient := deployclient.New(oc.GetRESTClient())
+	dcCoreClient := deployclient.New(oc)
 	cont := unidlingcontroller.NewUnidlingController(scaleNamespacer, coreClient, coreClient, dcCoreClient, coreClient, resyncPeriod)
 
 	cont.Run(utilwait.NeverStop)

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -222,7 +222,7 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		}
 
 		cacheDir := computeDiscoverCacheDir(filepath.Join(homedir.HomeDir(), ".kube"), cfg.Host)
-		cachedDiscoverClient := NewCachedDiscoveryClient(client.NewDiscoveryClient(oclient), cacheDir, time.Duration(10*time.Minute))
+		cachedDiscoverClient := NewCachedDiscoveryClient(client.NewDiscoveryClient(oclient.(*client.Client).RESTClient), cacheDir, time.Duration(10*time.Minute))
 
 		// if we can't find the server version or its too old to have Kind information in the discovery doc, skip the discovery RESTMapper
 		// and use our hardcoded levels
@@ -768,7 +768,7 @@ func getProtocols(spec api.PodSpec) map[string]string {
 	return result
 }
 
-func ResourceMapper(f *Factory) *resource.Mapper {
+func ResourceMapper(f FactoryInterface) *resource.Mapper {
 	mapper, typer := f.Object(false)
 	return &resource.Mapper{
 		RESTMapper:   mapper,

--- a/pkg/cmd/util/clientcmd/factory_interface.go
+++ b/pkg/cmd/util/clientcmd/factory_interface.go
@@ -19,17 +19,9 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
-// InterfaceFactory represents an interface for a Factory.
-type InterfaceFactory interface {
-	UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error)
-	ExtractFileContents(obj runtime.Object) (map[string][]byte, bool, error)
-	ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error)
-	PodForResource(resource string, timeout time.Duration) (string, error)
-	Clients() (client.Interface, *kclient.Client, error)
-	OriginSwaggerSchema(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
-	OSClientConfig() kclientcmd.ClientConfig
-
-	// Methods below are wrappers for kubernetes Factory methods.
+// KubernetesFactory represents the kubernetes Factory interface.
+// TODO: When implemented in kubernetes this can be removed.
+type KubernetesFactory interface {
 	Object(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper)
 	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error)
 	Decoder(toInternal bool) runtime.Decoder
@@ -64,9 +56,22 @@ type InterfaceFactory interface {
 	PrintObjectSpecificMessage(obj runtime.Object, out io.Writer)
 }
 
-// Missing methods to turn Factory a InterfaceFactory interface.
+// FactoryInterface represents an interface for a Factory.
+type FactoryInterface interface {
+	KubernetesFactory
 
-// OSClientConfig returns an Openshift CLientConfig.
+	UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error)
+	ExtractFileContents(obj runtime.Object) (map[string][]byte, bool, error)
+	ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error)
+	PodForResource(resource string, timeout time.Duration) (string, error)
+	Clients() (client.Interface, client.KClientInterface, error)
+	OriginSwaggerSchema(client resource.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	OSClientConfig() kclientcmd.ClientConfig
+}
+
+// Missing methods needed to make Factory implement FactoryInterface.
+
+// OSClientConfig returns an Openshift ClientConfig.
 func (f *Factory) OSClientConfig() kclientcmd.ClientConfig {
 	return f.OpenShiftClientConfig
 }

--- a/pkg/cmd/util/clientcmd/factory_interface.go
+++ b/pkg/cmd/util/clientcmd/factory_interface.go
@@ -1,0 +1,200 @@
+package clientcmd
+
+import (
+	"io"
+	"time"
+
+	"github.com/emicklei/go-restful/swagger"
+	"github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// InterfaceFactory represents an interface for a Factory.
+type InterfaceFactory interface {
+	UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error)
+	ExtractFileContents(obj runtime.Object) (map[string][]byte, bool, error)
+	ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error)
+	PodForResource(resource string, timeout time.Duration) (string, error)
+	Clients() (client.Interface, *kclient.Client, error)
+	OriginSwaggerSchema(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	OSClientConfig() kclientcmd.ClientConfig
+
+	// Methods below are wrappers for kubernetes Factory methods.
+	Object(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper)
+	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error)
+	Decoder(toInternal bool) runtime.Decoder
+	JSONEncoder() runtime.Encoder
+	Client() (*kclient.Client, error)
+	ClientConfig() (*restclient.Config, error)
+	ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	Describer(mapping *meta.RESTMapping) (kubectl.Describer, error)
+	Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error)
+	Scaler(mapping *meta.RESTMapping) (kubectl.Scaler, error)
+	Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error)
+	HistoryViewer(mapping *meta.RESTMapping) (kubectl.HistoryViewer, error)
+	Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker, error)
+	StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusViewer, error)
+	MapBasedSelectorForObject(object runtime.Object) (string, error)
+	PortsForObject(object runtime.Object) ([]string, error)
+	ProtocolsForObject(object runtime.Object) (map[string]string, error)
+	LabelsForObject(object runtime.Object) (map[string]string, error)
+	LogsForObject(object, options runtime.Object) (*restclient.Request, error)
+	PauseObject(object runtime.Object) (bool, error)
+	ResumeObject(object runtime.Object) (bool, error)
+	Validator(validate bool, cacheDir string) (validation.Schema, error)
+	SwaggerSchema(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error)
+	DefaultNamespace() (string, bool, error)
+	Generators(cmdName string) map[string]kubectl.Generator
+	CanBeExposed(kind unversioned.GroupKind) error
+	CanBeAutoscaled(kind unversioned.GroupKind) error
+	AttachablePodForObject(object runtime.Object) (*api.Pod, error)
+	UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error)
+	EditorEnvs() []string
+	PrintObjectSpecificMessage(obj runtime.Object, out io.Writer)
+}
+
+// Missing methods to turn Factory a InterfaceFactory interface.
+
+// OSClientConfig returns an Openshift CLientConfig.
+func (f *Factory) OSClientConfig() kclientcmd.ClientConfig {
+	return f.OpenShiftClientConfig
+}
+
+// Methods below are wrappers for kubernetes Factory functions.
+func (f *Factory) Object(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper) {
+	return f.Factory.Object(thirdPartyDiscovery)
+}
+
+func (f *Factory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+	return f.Factory.UnstructuredObject()
+}
+
+func (f *Factory) Decoder(toInternal bool) runtime.Decoder {
+	return f.Factory.Decoder(toInternal)
+}
+
+func (f *Factory) JSONEncoder() runtime.Encoder {
+	return f.Factory.JSONEncoder()
+}
+
+func (f *Factory) Client() (*kclient.Client, error) {
+	return f.Factory.Client()
+}
+
+func (f *Factory) ClientConfig() (*restclient.Config, error) {
+	return f.Factory.ClientConfig()
+}
+
+func (f *Factory) ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return f.Factory.ClientForMapping(mapping)
+}
+
+func (f *Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return f.Factory.UnstructuredClientForMapping(mapping)
+}
+
+func (f *Factory) Describer(mapping *meta.RESTMapping) (kubectl.Describer, error) {
+	return f.Factory.Describer(mapping)
+}
+
+func (f *Factory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
+	return f.Factory.Printer(mapping, options)
+}
+
+func (f *Factory) Scaler(mapping *meta.RESTMapping) (kubectl.Scaler, error) {
+	return f.Factory.Scaler(mapping)
+}
+
+func (f *Factory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error) {
+	return f.Factory.Reaper(mapping)
+}
+
+func (f *Factory) HistoryViewer(mapping *meta.RESTMapping) (kubectl.HistoryViewer, error) {
+	return f.Factory.HistoryViewer(mapping)
+}
+
+func (f *Factory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker, error) {
+	return f.Factory.Rollbacker(mapping)
+}
+
+func (f *Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusViewer, error) {
+	return f.Factory.StatusViewer(mapping)
+}
+
+func (f *Factory) MapBasedSelectorForObject(object runtime.Object) (string, error) {
+	return f.Factory.MapBasedSelectorForObject(object)
+}
+
+func (f *Factory) PortsForObject(object runtime.Object) ([]string, error) {
+	return f.Factory.PortsForObject(object)
+}
+
+func (f *Factory) ProtocolsForObject(object runtime.Object) (map[string]string, error) {
+	return f.Factory.ProtocolsForObject(object)
+}
+
+func (f *Factory) LabelsForObject(object runtime.Object) (map[string]string, error) {
+	return f.Factory.LabelsForObject(object)
+}
+
+func (f *Factory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
+	return f.Factory.LogsForObject(object, options)
+}
+
+func (f *Factory) PauseObject(object runtime.Object) (bool, error) {
+	return f.Factory.PauseObject(object)
+}
+
+func (f *Factory) ResumeObject(object runtime.Object) (bool, error) {
+	return f.Factory.ResumeObject(object)
+}
+
+func (f *Factory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
+	return f.Factory.Validator(validate, cacheDir)
+}
+
+func (f *Factory) SwaggerSchema(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
+	return f.Factory.SwaggerSchema(gvk)
+}
+
+func (f *Factory) DefaultNamespace() (string, bool, error) {
+	return f.Factory.DefaultNamespace()
+}
+
+func (f *Factory) Generators(cmdName string) map[string]kubectl.Generator {
+	return f.Factory.Generators(cmdName)
+}
+
+func (f *Factory) CanBeExposed(kind unversioned.GroupKind) error {
+	return f.Factory.CanBeExposed(kind)
+}
+
+func (f *Factory) CanBeAutoscaled(kind unversioned.GroupKind) error {
+	return f.Factory.CanBeAutoscaled(kind)
+}
+
+func (f *Factory) AttachablePodForObject(object runtime.Object) (*api.Pod, error) {
+	return f.Factory.AttachablePodForObject(object)
+}
+func (f *Factory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
+	return f.Factory.UpdatePodSpecForObject(obj, fn)
+}
+
+func (f *Factory) EditorEnvs() []string {
+	return f.Factory.EditorEnvs()
+}
+
+func (f *Factory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
+	f.Factory.PrintObjectSpecificMessage(obj, out)
+}

--- a/pkg/cmd/util/clientcmd/factory_mock.go
+++ b/pkg/cmd/util/clientcmd/factory_mock.go
@@ -1,0 +1,226 @@
+package clientcmd
+
+import (
+	"io"
+	"time"
+
+	"github.com/emicklei/go-restful/swagger"
+	"github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// MockFactory implements FactoryInterface to test.
+type MockFactory struct {
+	OnUpdateObjectEnvironment         func(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error)
+	OnExtractFileContents             func(obj runtime.Object) (map[string][]byte, bool, error)
+	OnApproximatePodTemplateForObject func(object runtime.Object) (*api.PodTemplateSpec, error)
+	OnPodForResource                  func(resource string, timeout time.Duration) (string, error)
+	OnClients                         func() (client.Interface, *kclient.Client, error)
+	OnOriginSwaggerSchema             func(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	OnOSClientConfig                  func() kclientcmd.ClientConfig
+
+	// Kubernetes Factory functions.
+	OnObject                       func(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper)
+	OnUnstructuredObject           func() (meta.RESTMapper, runtime.ObjectTyper, error)
+	OnDecoder                      func(toInternal bool) runtime.Decoder
+	OnJSONEncoder                  func() runtime.Encoder
+	OnClient                       func() (*kclient.Client, error)
+	OnClientConfig                 func() (*restclient.Config, error)
+	OnClientForMapping             func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	OnUnstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	OnDescriber                    func(mapping *meta.RESTMapping) (kubectl.Describer, error)
+	OnPrinter                      func(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error)
+	OnScaler                       func(mapping *meta.RESTMapping) (kubectl.Scaler, error)
+	OnReaper                       func(mapping *meta.RESTMapping) (kubectl.Reaper, error)
+	OnHistoryViewer                func(mapping *meta.RESTMapping) (kubectl.HistoryViewer, error)
+	OnRollbacker                   func(mapping *meta.RESTMapping) (kubectl.Rollbacker, error)
+	OnStatusViewer                 func(mapping *meta.RESTMapping) (kubectl.StatusViewer, error)
+	OnMapBasedSelectorForObject    func(object runtime.Object) (string, error)
+	OnPortsForObject               func(object runtime.Object) ([]string, error)
+	OnProtocolsForObject           func(object runtime.Object) (map[string]string, error)
+	OnLabelsForObject              func(object runtime.Object) (map[string]string, error)
+	OnLogsForObject                func(object, options runtime.Object) (*restclient.Request, error)
+	OnPauseObject                  func(object runtime.Object) (bool, error)
+	OnResumeObject                 func(object runtime.Object) (bool, error)
+	OnValidator                    func(validate bool, cacheDir string) (validation.Schema, error)
+	OnSwaggerSchema                func(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error)
+	OnDefaultNamespace             func() (string, bool, error)
+	OnGenerators                   func(cmdName string) map[string]kubectl.Generator
+	OnCanBeExposed                 func(kind unversioned.GroupKind) error
+	OnCanBeAutoscaled              func(kind unversioned.GroupKind) error
+	OnAttachablePodForObject       func(object runtime.Object) (*api.Pod, error)
+	OnUpdatePodSpecForObject       func(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error)
+	OnEditorEnvs                   func() []string
+	OnPrintObjectSpecificMessage   func(obj runtime.Object, out io.Writer)
+}
+
+func (m *MockFactory) UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error) {
+	return m.OnUpdateObjectEnvironment(obj, fn)
+}
+
+func (m *MockFactory) ExtractFileContents(obj runtime.Object) (map[string][]byte, bool, error) {
+	return m.OnExtractFileContents(obj)
+}
+
+func (m *MockFactory) ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
+	return m.OnApproximatePodTemplateForObject(object)
+}
+
+func (m *MockFactory) PodForResource(resource string, timeout time.Duration) (string, error) {
+	return m.OnPodForResource(resource, timeout)
+}
+
+// Clients returns an OpenShift and Kubernetes client.
+func (m *MockFactory) Clients() (client.Interface, *kclient.Client, error) {
+	return m.OnClients()
+}
+
+// OriginSwaggerSchema returns a swagger API doc for an Origin schema under the /oapi prefix.
+func (m *MockFactory) OriginSwaggerSchema(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+	return m.OnOriginSwaggerSchema(client, version)
+}
+
+// OSClientConfig returns an Openshift CLientConfig.
+func (m *MockFactory) OSClientConfig() kclientcmd.ClientConfig {
+	return m.OnOSClientConfig()
+}
+
+// Methods below are wrappers for kubernetes Factory functions.
+
+func (m *MockFactory) Object(thirdPartyDiscovery bool) (meta.RESTMapper, runtime.ObjectTyper) {
+	return m.OnObject(thirdPartyDiscovery)
+}
+
+func (m *MockFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+	return m.OnUnstructuredObject()
+}
+
+func (m *MockFactory) Decoder(toInternal bool) runtime.Decoder {
+	return m.OnDecoder(toInternal)
+}
+
+func (m *MockFactory) JSONEncoder() runtime.Encoder {
+	return m.OnJSONEncoder()
+}
+
+func (m *MockFactory) Client() (*kclient.Client, error) {
+	return m.OnClient()
+}
+
+func (m *MockFactory) ClientConfig() (*restclient.Config, error) {
+	return m.OnClientConfig()
+}
+
+func (m *MockFactory) ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return m.OnClientForMapping(mapping)
+}
+
+func (m *MockFactory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+	return m.OnUnstructuredClientForMapping(mapping)
+}
+
+func (m *MockFactory) Describer(mapping *meta.RESTMapping) (kubectl.Describer, error) {
+	return m.OnDescriber(mapping)
+}
+
+func (m *MockFactory) Printer(mapping *meta.RESTMapping, options kubectl.PrintOptions) (kubectl.ResourcePrinter, error) {
+	return m.OnPrinter(mapping, options)
+}
+
+func (m *MockFactory) Scaler(mapping *meta.RESTMapping) (kubectl.Scaler, error) {
+	return m.OnScaler(mapping)
+}
+
+func (m *MockFactory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error) {
+	return m.OnReaper(mapping)
+}
+
+func (m *MockFactory) HistoryViewer(mapping *meta.RESTMapping) (kubectl.HistoryViewer, error) {
+	return m.OnHistoryViewer(mapping)
+}
+
+func (m *MockFactory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker, error) {
+	return m.OnRollbacker(mapping)
+}
+
+func (m *MockFactory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusViewer, error) {
+	return m.OnStatusViewer(mapping)
+}
+
+func (m *MockFactory) MapBasedSelectorForObject(object runtime.Object) (string, error) {
+	return m.OnMapBasedSelectorForObject(object)
+}
+
+func (m *MockFactory) PortsForObject(object runtime.Object) ([]string, error) {
+	return m.OnPortsForObject(object)
+}
+
+func (m *MockFactory) ProtocolsForObject(object runtime.Object) (map[string]string, error) {
+	return m.OnProtocolsForObject(object)
+}
+
+func (m *MockFactory) LabelsForObject(object runtime.Object) (map[string]string, error) {
+	return m.OnLabelsForObject(object)
+}
+
+func (m *MockFactory) LogsForObject(object, options runtime.Object) (*restclient.Request, error) {
+	return m.OnLogsForObject(object, options)
+}
+
+func (m *MockFactory) PauseObject(object runtime.Object) (bool, error) {
+	return m.OnPauseObject(object)
+}
+
+func (m *MockFactory) ResumeObject(object runtime.Object) (bool, error) {
+	return m.OnResumeObject(object)
+}
+
+func (m *MockFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
+	return m.OnValidator(validate, cacheDir)
+}
+
+func (m *MockFactory) SwaggerSchema(gvk unversioned.GroupVersionKind) (*swagger.ApiDeclaration, error) {
+	return m.OnSwaggerSchema(gvk)
+}
+
+func (m *MockFactory) DefaultNamespace() (string, bool, error) {
+	return m.OnDefaultNamespace()
+}
+
+func (m *MockFactory) Generators(cmdName string) map[string]kubectl.Generator {
+	return m.OnGenerators(cmdName)
+}
+
+func (m *MockFactory) CanBeExposed(kind unversioned.GroupKind) error {
+	return m.OnCanBeExposed(kind)
+}
+
+func (m *MockFactory) CanBeAutoscaled(kind unversioned.GroupKind) error {
+	return m.OnCanBeAutoscaled(kind)
+}
+
+func (m *MockFactory) AttachablePodForObject(object runtime.Object) (*api.Pod, error) {
+	return m.OnAttachablePodForObject(object)
+}
+
+func (m *MockFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
+	return m.OnUpdatePodSpecForObject(obj, fn)
+}
+
+func (m *MockFactory) EditorEnvs() []string {
+	return m.OnEditorEnvs()
+}
+
+func (m *MockFactory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
+	m.OnPrintObjectSpecificMessage(obj, out)
+}

--- a/pkg/cmd/util/clientcmd/factory_mock.go
+++ b/pkg/cmd/util/clientcmd/factory_mock.go
@@ -25,8 +25,8 @@ type MockFactory struct {
 	OnExtractFileContents             func(obj runtime.Object) (map[string][]byte, bool, error)
 	OnApproximatePodTemplateForObject func(object runtime.Object) (*api.PodTemplateSpec, error)
 	OnPodForResource                  func(resource string, timeout time.Duration) (string, error)
-	OnClients                         func() (client.Interface, *kclient.Client, error)
-	OnOriginSwaggerSchema             func(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
+	OnClients                         func() (client.Interface, client.KClientInterface, error)
+	OnOriginSwaggerSchema             func(client resource.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error)
 	OnOSClientConfig                  func() kclientcmd.ClientConfig
 
 	// Kubernetes Factory functions.
@@ -81,12 +81,12 @@ func (m *MockFactory) PodForResource(resource string, timeout time.Duration) (st
 }
 
 // Clients returns an OpenShift and Kubernetes client.
-func (m *MockFactory) Clients() (client.Interface, *kclient.Client, error) {
+func (m *MockFactory) Clients() (client.Interface, client.KClientInterface, error) {
 	return m.OnClients()
 }
 
 // OriginSwaggerSchema returns a swagger API doc for an Origin schema under the /oapi prefix.
-func (m *MockFactory) OriginSwaggerSchema(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+func (m *MockFactory) OriginSwaggerSchema(client resource.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
 	return m.OnOriginSwaggerSchema(client, version)
 }
 

--- a/pkg/cmd/util/clientcmd/factory_test.go
+++ b/pkg/cmd/util/clientcmd/factory_test.go
@@ -56,7 +56,7 @@ func TestClientConfigForVersion(t *testing.T) {
 	client.SetOpenShiftDefaults(defaultConfig)
 
 	clients := &clientCache{
-		clients:       make(map[string]*client.Client),
+		clients:       make(map[string]client.Interface),
 		configs:       make(map[string]*restclient.Config),
 		defaultConfig: defaultConfig,
 	}

--- a/pkg/cmd/util/route.go
+++ b/pkg/cmd/util/route.go
@@ -5,16 +5,16 @@ import (
 	"strconv"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/intstr"
 
+	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/route/api"
 )
 
 // UnsecuredRoute will return a route with enough info so that it can direct traffic to
 // the service provided by --service. Callers of this helper are responsible for providing
 // tls configuration, path, and the hostname of the route.
-func UnsecuredRoute(kc *kclient.Client, namespace, routeName, serviceName, portString string) (*api.Route, error) {
+func UnsecuredRoute(kc client.KClientInterface, namespace, routeName, serviceName, portString string) (*api.Route, error) {
 	if len(routeName) == 0 {
 		routeName = serviceName
 	}

--- a/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
+++ b/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
@@ -4,16 +4,17 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	registered "k8s.io/kubernetes/pkg/apimachinery/registered"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	GetRESTClient() resource.RESTClient
 	DeploymentConfigsGetter
 }
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	resource.RESTClient
 }
 
 func (c *CoreClient) DeploymentConfigs(namespace string) DeploymentConfigInterface {
@@ -44,7 +45,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c resource.RESTClient) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -77,7 +78,7 @@ func setConfigDefaults(config *restclient.Config) error {
 
 // GetRESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) GetRESTClient() resource.RESTClient {
 	if c == nil {
 		return nil
 	}

--- a/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_core_client.go
+++ b/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/fake/fake_core_client.go
@@ -2,8 +2,8 @@ package fake
 
 import (
 	unversioned "github.com/openshift/origin/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned"
-	restclient "k8s.io/kubernetes/pkg/client/restclient"
 	core "k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 type FakeCore struct {
@@ -16,6 +16,6 @@ func (c *FakeCore) DeploymentConfigs(namespace string) unversioned.DeploymentCon
 
 // GetRESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCore) GetRESTClient() *restclient.RESTClient {
+func (c *FakeCore) GetRESTClient() resource.RESTClient {
 	return nil
 }

--- a/pkg/diagnostics/client/run_diagnostics_pod.go
+++ b/pkg/diagnostics/client/run_diagnostics_pod.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
+	"github.com/openshift/origin/pkg/client"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/diagnostics/types"
@@ -21,7 +21,7 @@ const (
 
 // DiagnosticPod is a diagnostic that runs a diagnostic pod and relays the results.
 type DiagnosticPod struct {
-	KubeClient          kclient.Client
+	KubeClient          client.KClientInterface
 	Namespace           string
 	Level               int
 	Factory             *osclientcmd.Factory

--- a/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
@@ -7,7 +7,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 
 	authapi "github.com/openshift/origin/pkg/authorization/api"
@@ -27,7 +26,7 @@ type AggregatedLogging struct {
 	masterConfig     *configapi.MasterConfig
 	MasterConfigFile string
 	OsClient         client.Interface
-	KubeClient       *kclient.Client
+	KubeClient       client.KClientInterface
 	result           types.DiagnosticResult
 }
 
@@ -45,7 +44,7 @@ const (
 var loggingSelector = labels.Set{loggingInfraKey: "support"}
 
 //NewAggregatedLogging returns the AggregatedLogging Diagnostic
-func NewAggregatedLogging(masterConfigFile string, kclient *kclient.Client, osclient client.Interface) *AggregatedLogging {
+func NewAggregatedLogging(masterConfigFile string, kclient client.KClientInterface, osclient client.Interface) *AggregatedLogging {
 	return &AggregatedLogging{nil, masterConfigFile, osclient, kclient, types.NewDiagnosticResult(AggregatedLoggingName)}
 }
 

--- a/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
@@ -26,7 +26,7 @@ import (
 type AggregatedLogging struct {
 	masterConfig     *configapi.MasterConfig
 	MasterConfigFile string
-	OsClient         *client.Client
+	OsClient         client.Interface
 	KubeClient       *kclient.Client
 	result           types.DiagnosticResult
 }
@@ -45,7 +45,7 @@ const (
 var loggingSelector = labels.Set{loggingInfraKey: "support"}
 
 //NewAggregatedLogging returns the AggregatedLogging Diagnostic
-func NewAggregatedLogging(masterConfigFile string, kclient *kclient.Client, osclient *client.Client) *AggregatedLogging {
+func NewAggregatedLogging(masterConfigFile string, kclient *kclient.Client, osclient client.Interface) *AggregatedLogging {
 	return &AggregatedLogging{nil, masterConfigFile, osclient, kclient, types.NewDiagnosticResult(AggregatedLoggingName)}
 }
 
@@ -158,7 +158,7 @@ and updating the annotation:
 
 `
 
-func retrieveLoggingProject(r types.DiagnosticResult, masterCfg *configapi.MasterConfig, osClient *client.Client) string {
+func retrieveLoggingProject(r types.DiagnosticResult, masterCfg *configapi.MasterConfig, osClient client.Interface) string {
 	r.Debug("AGL0010", fmt.Sprintf("masterConfig.AssetConfig.LoggingPublicURL: '%s'", masterCfg.AssetConfig.LoggingPublicURL))
 	projectName := ""
 	if len(masterCfg.AssetConfig.LoggingPublicURL) == 0 {

--- a/pkg/diagnostics/cluster/aggregated_logging/kibana.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/kibana.go
@@ -22,7 +22,7 @@ const (
 )
 
 //checkKibana verifies the various integration points between Kibana and logging
-func checkKibana(r types.DiagnosticResult, osClient *client.Client, kClient *kclient.Client, project string) {
+func checkKibana(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string) {
 	oauthclient, err := osClient.OAuthClients().Get(kibanaProxyOauthClientName)
 	if err != nil {
 		r.Error("AGL0115", err, fmt.Sprintf("Error retrieving the OauthClient '%s': %s. Unable to check Kibana", kibanaProxyOauthClientName, err))
@@ -33,7 +33,7 @@ func checkKibana(r types.DiagnosticResult, osClient *client.Client, kClient *kcl
 }
 
 //checkKibanaSecret confirms the secret used by kibana matches that configured in the oauth client
-func checkKibanaSecret(r types.DiagnosticResult, osClient *client.Client, kClient *kclient.Client, project string, oauthclient *oauthapi.OAuthClient) {
+func checkKibanaSecret(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string, oauthclient *oauthapi.OAuthClient) {
 	r.Debug("AGL0100", "Checking oauthclient secrets...")
 	secret, err := kClient.Secrets(project).Get(kibanaProxySecretName)
 	if err != nil {
@@ -54,7 +54,7 @@ func checkKibanaSecret(r types.DiagnosticResult, osClient *client.Client, kClien
 }
 
 //checkKibanaRoutesInOauthClient verifies the client contains the correct redirect uris
-func checkKibanaRoutesInOauthClient(r types.DiagnosticResult, osClient *client.Client, project string, oauthclient *oauthapi.OAuthClient) {
+func checkKibanaRoutesInOauthClient(r types.DiagnosticResult, osClient client.Interface, project string, oauthclient *oauthapi.OAuthClient) {
 	r.Debug("AGL0141", "Checking oauthclient redirectURIs for the logging routes...")
 	routeList, err := osClient.Routes(project).List(kapi.ListOptions{LabelSelector: loggingSelector.AsSelector()})
 	if err != nil {

--- a/pkg/diagnostics/cluster/aggregated_logging/kibana.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/kibana.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/client"
@@ -22,7 +21,7 @@ const (
 )
 
 //checkKibana verifies the various integration points between Kibana and logging
-func checkKibana(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string) {
+func checkKibana(r types.DiagnosticResult, osClient client.Interface, kClient client.KClientInterface, project string) {
 	oauthclient, err := osClient.OAuthClients().Get(kibanaProxyOauthClientName)
 	if err != nil {
 		r.Error("AGL0115", err, fmt.Sprintf("Error retrieving the OauthClient '%s': %s. Unable to check Kibana", kibanaProxyOauthClientName, err))
@@ -33,7 +32,7 @@ func checkKibana(r types.DiagnosticResult, osClient client.Interface, kClient *k
 }
 
 //checkKibanaSecret confirms the secret used by kibana matches that configured in the oauth client
-func checkKibanaSecret(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string, oauthclient *oauthapi.OAuthClient) {
+func checkKibanaSecret(r types.DiagnosticResult, osClient client.Interface, kClient client.KClientInterface, project string, oauthclient *oauthapi.OAuthClient) {
 	r.Debug("AGL0100", "Checking oauthclient secrets...")
 	secret, err := kClient.Secrets(project).Get(kibanaProxySecretName)
 	if err != nil {

--- a/pkg/diagnostics/cluster/master_node.go
+++ b/pkg/diagnostics/cluster/master_node.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -27,7 +26,7 @@ to proxy to pods over the Open vSwitch SDN.
 // This is currently required to have the master on the Open vSwitch SDN and able to communicate
 // with other nodes.
 type MasterNode struct {
-	KubeClient       *kclient.Client
+	KubeClient       osclient.KClientInterface
 	OsClient         osclient.Interface
 	ServerUrl        string
 	MasterConfigFile string // may often be empty if not being run on the host

--- a/pkg/diagnostics/cluster/master_node.go
+++ b/pkg/diagnostics/cluster/master_node.go
@@ -28,7 +28,7 @@ to proxy to pods over the Open vSwitch SDN.
 // with other nodes.
 type MasterNode struct {
 	KubeClient       *kclient.Client
-	OsClient         *osclient.Client
+	OsClient         osclient.Interface
 	ServerUrl        string
 	MasterConfigFile string // may often be empty if not being run on the host
 }

--- a/pkg/diagnostics/cluster/metrics.go
+++ b/pkg/diagnostics/cluster/metrics.go
@@ -8,14 +8,14 @@ import (
 	"fmt"
 
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
+	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 )
 
 // MetricsApiProxy is a Diagnostic for diagnosing the API proxy and HPA/metrics.
 type MetricsApiProxy struct {
-	KubeClient *kclient.Client
+	KubeClient client.KClientInterface
 }
 
 const (

--- a/pkg/diagnostics/cluster/node_definitions.go
+++ b/pkg/diagnostics/cluster/node_definitions.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -47,7 +46,7 @@ other options for 'oadm manage-node').
 
 // NodeDefinitions is a Diagnostic for analyzing the nodes in a cluster.
 type NodeDefinitions struct {
-	KubeClient *kclient.Client
+	KubeClient osclient.KClientInterface
 	OsClient   osclient.Interface
 }
 

--- a/pkg/diagnostics/cluster/node_definitions.go
+++ b/pkg/diagnostics/cluster/node_definitions.go
@@ -48,7 +48,7 @@ other options for 'oadm manage-node').
 // NodeDefinitions is a Diagnostic for analyzing the nodes in a cluster.
 type NodeDefinitions struct {
 	KubeClient *kclient.Client
-	OsClient   *osclient.Client
+	OsClient   osclient.Interface
 }
 
 const NodeDefinitionsName = "NodeDefinitions"

--- a/pkg/diagnostics/cluster/registry.go
+++ b/pkg/diagnostics/cluster/registry.go
@@ -21,7 +21,7 @@ import (
 // ClusterRegistry is a Diagnostic to check that there is a working Docker registry.
 type ClusterRegistry struct {
 	KubeClient          *kclient.Client
-	OsClient            *osclient.Client
+	OsClient            osclient.Interface
 	PreventModification bool
 }
 

--- a/pkg/diagnostics/cluster/registry.go
+++ b/pkg/diagnostics/cluster/registry.go
@@ -9,7 +9,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrs "k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -20,7 +19,7 @@ import (
 
 // ClusterRegistry is a Diagnostic to check that there is a working Docker registry.
 type ClusterRegistry struct {
-	KubeClient          *kclient.Client
+	KubeClient          osclient.KClientInterface
 	OsClient            osclient.Interface
 	PreventModification bool
 }
@@ -252,7 +251,7 @@ func (d *ClusterRegistry) getRegistryPods(service *kapi.Service, r types.Diagnos
 
 func (d *ClusterRegistry) checkRegistryLogs(pod *kapi.Pod, r types.DiagnosticResult) {
 	// pull out logs from the pod
-	readCloser, err := d.KubeClient.RESTClient.Get().
+	readCloser, err := d.KubeClient.Get().
 		Namespace("default").Name(pod.ObjectMeta.Name).
 		Resource("pods").SubResource("log").
 		Param("follow", "false").

--- a/pkg/diagnostics/cluster/router.go
+++ b/pkg/diagnostics/cluster/router.go
@@ -11,7 +11,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrs "k8s.io/kubernetes/pkg/api/errors"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -22,7 +21,7 @@ import (
 
 // ClusterRouter is a Diagnostic to check that there is a working router.
 type ClusterRouter struct {
-	KubeClient *kclient.Client
+	KubeClient osclient.KClientInterface
 	OsClient   osclient.Interface
 }
 
@@ -170,7 +169,7 @@ func (s *lineScanner) Text() string { return s.Scanner.Text() }
 func (s *lineScanner) Close() error { return s.ReadCloser.Close() }
 
 func (d *ClusterRouter) getPodLogScanner(pod *kapi.Pod) (*lineScanner, error) {
-	readCloser, err := d.KubeClient.RESTClient.Get().
+	readCloser, err := d.KubeClient.Get().
 		Namespace(pod.ObjectMeta.Namespace).
 		Name(pod.ObjectMeta.Name).
 		Resource("pods").SubResource("log").

--- a/pkg/diagnostics/cluster/router.go
+++ b/pkg/diagnostics/cluster/router.go
@@ -23,7 +23,7 @@ import (
 // ClusterRouter is a Diagnostic to check that there is a working router.
 type ClusterRouter struct {
 	KubeClient *kclient.Client
-	OsClient   *osclient.Client
+	OsClient   osclient.Interface
 }
 
 const (

--- a/pkg/diagnostics/cluster/service_externalip.go
+++ b/pkg/diagnostics/cluster/service_externalip.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
+	"github.com/openshift/origin/pkg/client"
 	hostdiag "github.com/openshift/origin/pkg/diagnostics/host"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 	"github.com/openshift/origin/pkg/service/admission"
@@ -19,7 +19,7 @@ import (
 // Background: https://github.com/openshift/origin/issues/7808
 type ServiceExternalIPs struct {
 	MasterConfigFile string
-	KclusterClient   *kclient.Client
+	KclusterClient   client.KClientInterface
 }
 
 const ServiceExternalIPsName = "ServiceExternalIPs"

--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -12,7 +12,6 @@ import (
 	flag "github.com/spf13/pflag"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	osclient "github.com/openshift/origin/pkg/client"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -26,8 +25,8 @@ const (
 
 // NetworkDiagnostic is a diagnostic that runs a network diagnostic pod and relays the results.
 type NetworkDiagnostic struct {
-	KubeClient          *kclient.Client
-	OSClient            *osclient.Client
+	KubeClient          osclient.KClientInterface
+	OSClient            osclient.Interface
 	ClientFlags         *flag.FlagSet
 	Level               int
 	Factory             *osclientcmd.Factory

--- a/pkg/diagnostics/networkpod/collect.go
+++ b/pkg/diagnostics/networkpod/collect.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	osclient "github.com/openshift/origin/pkg/client"
 
 	"github.com/openshift/origin/pkg/diagnostics/networkpod/util"
 	"github.com/openshift/origin/pkg/diagnostics/types"
@@ -17,7 +17,7 @@ const (
 
 // CollectNetworkInfo is a Diagnostic to collect network information in the cluster.
 type CollectNetworkInfo struct {
-	KubeClient *kclient.Client
+	KubeClient osclient.KClientInterface
 }
 
 // Name is part of the Diagnostic interface and just returns name.

--- a/pkg/diagnostics/networkpod/node.go
+++ b/pkg/diagnostics/networkpod/node.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	osclient "github.com/openshift/origin/pkg/client"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 
@@ -20,7 +20,7 @@ const (
 
 // CheckNodeNetwork is a Diagnostic to check that pods in the cluster can access its own node
 type CheckNodeNetwork struct {
-	KubeClient *kclient.Client
+	KubeClient osclient.KClientInterface
 }
 
 // Name is part of the Diagnostic interface and just returns name.

--- a/pkg/diagnostics/networkpod/pod.go
+++ b/pkg/diagnostics/networkpod/pod.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 
@@ -22,8 +21,8 @@ const (
 
 // CheckPodNetwork is a Diagnostic to check communication between pods in the cluster.
 type CheckPodNetwork struct {
-	KubeClient *kclient.Client
-	OSClient   *osclient.Client
+	KubeClient osclient.KClientInterface
+	OSClient   osclient.Interface
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult

--- a/pkg/diagnostics/networkpod/service.go
+++ b/pkg/diagnostics/networkpod/service.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 
@@ -22,8 +21,8 @@ const (
 
 // CheckServiceNetwork is a Diagnostic to check communication between services in the cluster.
 type CheckServiceNetwork struct {
-	KubeClient *kclient.Client
-	OSClient   *osclient.Client
+	KubeClient osclient.KClientInterface
+	OSClient   osclient.Interface
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult
@@ -141,7 +140,7 @@ func (d CheckServiceNetwork) checkConnection(pods []kapi.Pod, services []kapi.Se
 	}
 }
 
-func getAllServices(kubeClient *kclient.Client) ([]kapi.Service, error) {
+func getAllServices(kubeClient osclient.KClientInterface) ([]kapi.Service, error) {
 	filtered_srvs := []kapi.Service{}
 	serviceList, err := kubeClient.Services(kapi.NamespaceAll).List(kapi.ListOptions{})
 	if err != nil {

--- a/pkg/diagnostics/networkpod/util/log.go
+++ b/pkg/diagnostics/networkpod/util/log.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	osclient "github.com/openshift/origin/pkg/client"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 
@@ -20,7 +21,7 @@ type LogInterface struct {
 	Logdir string
 }
 
-func (l *LogInterface) LogNode(kubeClient *kclient.Client) {
+func (l *LogInterface) LogNode(kubeClient osclient.KClientInterface) {
 	l.LogSystem()
 	l.LogServices()
 

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -32,7 +32,7 @@ type REST struct {
 	templateNamespace string
 	templateName      string
 
-	openshiftClient *client.Client
+	openshiftClient client.Interface
 	kubeClient      *kclient.Client
 
 	// policyBindings is an auth cache that is shared with the authorizer for the API server.
@@ -40,7 +40,7 @@ type REST struct {
 	policyBindings client.PolicyBindingsListerNamespacer
 }
 
-func NewREST(message, templateNamespace, templateName string, openshiftClient *client.Client, kubeClient *kclient.Client, policyBindingCache client.PolicyBindingsListerNamespacer) *REST {
+func NewREST(message, templateNamespace, templateName string, openshiftClient client.Interface, kubeClient *kclient.Client, policyBindingCache client.PolicyBindingsListerNamespacer) *REST {
 	return &REST{
 		message:           message,
 		templateNamespace: templateNamespace,
@@ -152,7 +152,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 			ObjectTyper: kapi.Scheme,
 			ClientMapper: resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
 				if latest.OriginKind(mapping.GroupVersionKind) {
-					return r.openshiftClient, nil
+					return r.openshiftClient.GetRESTClient(), nil
 				}
 				return r.kubeClient, nil
 			}),

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -152,7 +152,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 			ObjectTyper: kapi.Scheme,
 			ClientMapper: resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
 				if latest.OriginKind(mapping.GroupVersionKind) {
-					return r.openshiftClient.GetRESTClient(), nil
+					return r.openshiftClient, nil
 				}
 				return r.kubeClient, nil
 			}),

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -75,7 +75,7 @@ func (ni *NetworkInfo) validateNodeIP(nodeIP string) error {
 	return nil
 }
 
-func getNetworkInfo(osClient *osclient.Client) (*NetworkInfo, error) {
+func getNetworkInfo(osClient osclient.Interface) (*NetworkInfo, error) {
 	cn, err := osClient.ClusterNetwork().Get(osapi.ClusterNetworkDefault)
 	if err != nil {
 		return nil, err

--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -39,7 +39,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 }
 
 func (plugin *OsdnNode) watchEgressNetworkPolicies() {
-	RunEventQueue(plugin.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(plugin.osClient.GetRESTClient(), EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 
 		vnid, err := plugin.vnids.GetVNID(policy.Namespace)

--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -39,7 +39,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 }
 
 func (plugin *OsdnNode) watchEgressNetworkPolicies() {
-	RunEventQueue(plugin.osClient.GetRESTClient(), EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(plugin.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 
 		vnid, err := plugin.vnids.GetVNID(policy.Namespace)

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -19,13 +19,13 @@ import (
 
 type OsdnMaster struct {
 	kClient         *kclient.Client
-	osClient        *osclient.Client
+	osClient        osclient.Interface
 	networkInfo     *NetworkInfo
 	subnetAllocator *netutils.SubnetAllocator
 	vnids           *masterVNIDMap
 }
 
-func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclient.Client, kClient *kclient.Client) error {
+func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient osclient.Interface, kClient *kclient.Client) error {
 	if !osapi.IsOpenShiftNetworkPlugin(networkConfig.NetworkPluginName) {
 		return nil
 	}

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -32,7 +32,7 @@ import (
 type OsdnNode struct {
 	multitenant        bool
 	kClient            *kclient.Client
-	osClient           *osclient.Client
+	osClient           osclient.Interface
 	ovs                *ovs.Interface
 	networkInfo        *NetworkInfo
 	podManager         *podManager
@@ -53,7 +53,7 @@ type OsdnNode struct {
 }
 
 // Called by higher layers to create the plugin SDN node instance
-func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string, iptablesSyncPeriod time.Duration, mtu uint32) (*OsdnNode, error) {
+func NewNodePlugin(pluginName string, osClient osclient.Interface, kClient *kclient.Client, hostname string, selfIP string, iptablesSyncPeriod time.Duration, mtu uint32) (*OsdnNode, error) {
 	if !osapi.IsOpenShiftNetworkPlugin(pluginName) {
 		return nil, nil
 	}

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -69,7 +69,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsConfigHandler) error 
 }
 
 func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
-	RunEventQueue(proxy.osClient.GetRESTClient(), EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(proxy.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 		if delta.Type == cache.Deleted {
 			policy.Spec.Egress = nil

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -24,7 +24,7 @@ type proxyFirewallItem struct {
 
 type OsdnProxy struct {
 	kClient              *kclient.Client
-	osClient             *osclient.Client
+	osClient             osclient.Interface
 	networkInfo          *NetworkInfo
 	baseEndpointsHandler pconfig.EndpointsConfigHandler
 
@@ -34,7 +34,7 @@ type OsdnProxy struct {
 }
 
 // Called by higher layers to create the proxy plugin instance; only used by nodes
-func NewProxyPlugin(pluginName string, osClient *osclient.Client, kClient *kclient.Client) (*OsdnProxy, error) {
+func NewProxyPlugin(pluginName string, osClient osclient.Interface, kClient *kclient.Client) (*OsdnProxy, error) {
 	if !osapi.IsOpenShiftMultitenantNetworkPlugin(pluginName) {
 		return nil, nil
 	}
@@ -69,7 +69,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsConfigHandler) error 
 }
 
 func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
-	RunEventQueue(proxy.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(proxy.osClient.GetRESTClient(), EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 		if delta.Type == cache.Deleted {
 			policy.Spec.Egress = nil

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -254,7 +254,7 @@ func (master *OsdnMaster) watchSubnets() {
 // Only run on the nodes
 func (node *OsdnNode) watchSubnets() {
 	subnets := make(map[string]*osapi.HostSubnet)
-	RunEventQueue(node.osClient.GetRESTClient(), HostSubnets, func(delta cache.Delta) error {
+	RunEventQueue(node.osClient, HostSubnets, func(delta cache.Delta) error {
 		hs := delta.Object.(*osapi.HostSubnet)
 		if hs.HostIP == node.localIP {
 			return nil

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -254,7 +254,7 @@ func (master *OsdnMaster) watchSubnets() {
 // Only run on the nodes
 func (node *OsdnNode) watchSubnets() {
 	subnets := make(map[string]*osapi.HostSubnet)
-	RunEventQueue(node.osClient, HostSubnets, func(delta cache.Delta) error {
+	RunEventQueue(node.osClient.GetRESTClient(), HostSubnets, func(delta cache.Delta) error {
 		hs := delta.Object.(*osapi.HostSubnet)
 		if hs.HostIP == node.localIP {
 			return nil

--- a/pkg/sdn/plugin/vnids_master.go
+++ b/pkg/sdn/plugin/vnids_master.go
@@ -71,7 +71,7 @@ func (vmap *masterVNIDMap) isAdminNamespace(nsName string) bool {
 	return false
 }
 
-func (vmap *masterVNIDMap) populateVNIDs(osClient *osclient.Client) error {
+func (vmap *masterVNIDMap) populateVNIDs(osClient osclient.Interface) error {
 	netnsList, err := osClient.NetNamespaces().List(kapi.ListOptions{})
 	if err != nil {
 		return err
@@ -196,7 +196,7 @@ func (vmap *masterVNIDMap) updateNetID(nsName string, action osapi.PodNetworkAct
 }
 
 // assignVNID, revokeVNID and updateVNID methods updates in-memory structs and persists etcd objects
-func (vmap *masterVNIDMap) assignVNID(osClient *osclient.Client, nsName string) error {
+func (vmap *masterVNIDMap) assignVNID(osClient osclient.Interface, nsName string) error {
 	vmap.lock.Lock()
 	defer vmap.lock.Unlock()
 
@@ -222,7 +222,7 @@ func (vmap *masterVNIDMap) assignVNID(osClient *osclient.Client, nsName string) 
 	return nil
 }
 
-func (vmap *masterVNIDMap) revokeVNID(osClient *osclient.Client, nsName string) error {
+func (vmap *masterVNIDMap) revokeVNID(osClient osclient.Interface, nsName string) error {
 	vmap.lock.Lock()
 	defer vmap.lock.Unlock()
 
@@ -237,7 +237,7 @@ func (vmap *masterVNIDMap) revokeVNID(osClient *osclient.Client, nsName string) 
 	return nil
 }
 
-func (vmap *masterVNIDMap) updateVNID(osClient *osclient.Client, netns *osapi.NetNamespace) error {
+func (vmap *masterVNIDMap) updateVNID(osClient osclient.Interface, netns *osapi.NetNamespace) error {
 	action, args, err := osapi.GetChangePodNetworkAnnotation(netns)
 	if err == osapi.ErrorPodNetworkAnnotationNotFound {
 		// Nothing to update
@@ -294,7 +294,7 @@ func (master *OsdnMaster) watchNamespaces() {
 }
 
 func (master *OsdnMaster) watchNetNamespaces() {
-	RunEventQueue(master.osClient, NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(master.osClient.GetRESTClient(), NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 		name := netns.ObjectMeta.Name
 

--- a/pkg/sdn/plugin/vnids_master.go
+++ b/pkg/sdn/plugin/vnids_master.go
@@ -294,7 +294,7 @@ func (master *OsdnMaster) watchNamespaces() {
 }
 
 func (master *OsdnMaster) watchNetNamespaces() {
-	RunEventQueue(master.osClient.GetRESTClient(), NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(master.osClient, NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 		name := netns.ObjectMeta.Name
 

--- a/pkg/sdn/plugin/vnids_node.go
+++ b/pkg/sdn/plugin/vnids_node.go
@@ -122,7 +122,7 @@ func (vmap *nodeVNIDMap) unsetVNID(name string) (id uint32, err error) {
 	return id, nil
 }
 
-func (vmap *nodeVNIDMap) populateVNIDs(osClient *osclient.Client) error {
+func (vmap *nodeVNIDMap) populateVNIDs(osClient osclient.Interface) error {
 	nets, err := osClient.NetNamespaces().List(kapi.ListOptions{})
 	if err != nil {
 		return err
@@ -195,7 +195,7 @@ func (node *OsdnNode) updatePodNetwork(namespace string, oldNetID, netID uint32)
 }
 
 func (node *OsdnNode) watchNetNamespaces() {
-	RunEventQueue(node.osClient, NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(node.osClient.GetRESTClient(), NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 
 		log.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, netns.ObjectMeta.Name)

--- a/pkg/sdn/plugin/vnids_node.go
+++ b/pkg/sdn/plugin/vnids_node.go
@@ -195,7 +195,7 @@ func (node *OsdnNode) updatePodNetwork(namespace string, oldNetID, netID uint32)
 }
 
 func (node *OsdnNode) watchNetNamespaces() {
-	RunEventQueue(node.osClient.GetRESTClient(), NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(node.osClient, NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 
 		log.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, netns.ObjectMeta.Name)

--- a/pkg/serviceaccounts/client.go
+++ b/pkg/serviceaccounts/client.go
@@ -55,7 +55,7 @@ func (s *ClientLookupTokenRetriever) GetToken(namespace, name string) (string, e
 
 // Clients returns an OpenShift and Kubernetes client with the credentials of the named service account
 // TODO: change return types to client.Interface/kclient.Interface to allow auto-reloading credentials
-func Clients(config restclient.Config, tokenRetriever TokenRetriever, namespace, name string) (*restclient.Config, *client.Client, *kclient.Client, error) {
+func Clients(config restclient.Config, tokenRetriever TokenRetriever, namespace, name string) (*restclient.Config, client.Interface, *kclient.Client, error) {
 	// Clear existing auth info
 	config.Username = ""
 	config.Password = ""

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -222,7 +222,7 @@ func addE2EServiceAccountsToSCC(c *kclient.Client, namespaces []kapi.Namespace, 
 	}
 }
 
-func addRoleToE2EServiceAccounts(c *client.Client, namespaces []kapi.Namespace, roleName string) {
+func addRoleToE2EServiceAccounts(c client.Interface, namespaces []kapi.Namespace, roleName string) {
 	err := kclient.RetryOnConflict(kclient.DefaultRetry, func() error {
 		for _, ns := range namespaces {
 			if strings.HasPrefix(ns.Name, "e2e-") && ns.Status.Phase != kapi.NamespaceTerminating {


### PR DESCRIPTION
This PR implements an Interface for Factory and a Mock to make easy to test cli cmds,

To see how this can help, look at startbuild_test.go TestStartBuildComplete test.

Also refactored openshift to use client.Interface instead of *client.Client, also for tests purpose.

If accepted, I will refactor all cmds to use the factory interface (like startbuild.go) and create the tests.

I understand this is a big change, but it's hard to test cli commands without this. 
