### PR TITLE
dind: Ensure unique node config and fix perms

### DIFF
--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -32,9 +32,9 @@ function ensure-master-config() {
     --master="https://${ip_addr}:8443" \
     --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}"
 
-  # ensure the configuration is readable outside of the container
-  find "${config_path}" -exec chmod ga+rw {} \;
-  find "${config_path}" -type d -exec chmod ga+x {} \;
+  # ensure the configuration can be used outside of the container
+  chmod -R ga+rX "${master_path}"
+  chmod ga+w "${master_path}/admin.kubeconfig"
 }
 
 ensure-master-config

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -24,18 +24,19 @@ function ensure-node-config() {
     host="${host}-node"
   fi
   local node_config_path="${config_path}/node-${host}"
-  local config_file="${node_config_path}/node-config.yaml"
+  local node_config_file="${node_config_path}/node-config.yaml"
 
   # If the node config has not been generated
-  if [[ ! -f "${config_file}" ]]; then
+  if [[ ! -f "${node_config_file}" ]]; then
     local master_config_path="${config_path}/master"
+    local master_config_file="${master_config_path}/admin.kubeconfig"
 
     # Wait for the master to generate its config
-    local condition="test -f ${master_config_path}/admin.kubeconfig"
+    local condition="test -f ${master_config_file}"
     os::util::wait-for-condition "admin config" "${condition}" "${OS_WAIT_FOREVER}"
 
     local master_host
-    master_host="$(grep server "${master_config_path}/admin.kubeconfig" | grep -v localhost | awk '{print $2}')"
+    master_host="$(grep server "${master_config_file}" | grep -v localhost | awk '{print $2}')"
 
     local ip_addr
     ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
@@ -59,9 +60,12 @@ function ensure-node-config() {
     ) 200>"${config_path}"/.openshift-generate-node-config.lock
   fi
 
+  # ensure the configuration is readable outside of the container
+  chmod -R ga+rX "${node_config_path}"
+
   # Deploy the node config
   mkdir -p "${deployed_config_path}"
-  cp -r "${config_path}"/* "${deployed_config_path}"
+  cp -r "${node_config_path}"/* "${deployed_config_path}/"
 }
 
 ensure-node-config

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -40,17 +40,23 @@ function ensure-node-config() {
     local ip_addr
     ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
 
-    /usr/local/bin/openshift admin create-node-config \
-      --node-dir="${config_path}" \
-      --node="${host}" \
-      --master="${master_host}" \
-      --hostnames="${host},${ip_addr}" \
-      --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
-      --node-client-certificate-authority="${master_config_path}/ca.crt" \
-      --certificate-authority="${master_config_path}/ca.crt" \
-      --signer-cert="${master_config_path}/ca.crt" \
-      --signer-key="${master_config_path}/ca.key" \
-      --signer-serial="${master_config_path}/ca.serial.txt"
+    # Hold a lock on the shared volume to ensure cert generation is
+    # performed serially.  Cert generation is not compatible with
+    # concurrent execution since the file passed to --signer-serial
+    # needs to be incremented by each invocation.
+    (flock 200;
+     /usr/local/bin/openshift admin create-node-config \
+       --node-dir="${node_config_path}" \
+       --node="${host}" \
+       --master="${master_host}" \
+       --hostnames="${host},${ip_addr}" \
+       --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
+       --node-client-certificate-authority="${master_config_path}/ca.crt" \
+       --certificate-authority="${master_config_path}/ca.crt" \
+       --signer-cert="${master_config_path}/ca.crt" \
+       --signer-key="${master_config_path}/ca.key" \
+       --signer-serial="${master_config_path}/ca.serial.txt"
+    ) 200>"${config_path}"/.openshift-generate-node-config.lock
   fi
 
   # Deploy the node config


### PR DESCRIPTION
A dind deployment flake on #11315 revealed that config permissions are not being set correctly to allow cluster artifacts to be saved.  This change ensures the cluster configuration is readable so it can be saved.

cc: @openshift/networking @stevekuznetsov 

Should also fix #11274