### PR TITLE
add pod bash completion `oc exec`

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -282,7 +282,7 @@ __custom_func() {
             ;;
 
         # first arg is a pod name
-        oc_rsh)
+        oc_rsh | oc_exec)
             if [[ ${#nouns[@]} -eq 0 ]]; then
                 __oc_parse_get pods
             fi;

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -443,7 +443,7 @@ __custom_func() {
             ;;
 
         # first arg is a pod name
-        oc_rsh)
+        oc_rsh | oc_exec)
             if [[ ${#nouns[@]} -eq 0 ]]; then
                 __oc_parse_get pods
             fi;

--- a/pkg/cmd/cli/cli_bashcomp_func.go
+++ b/pkg/cmd/cli/cli_bashcomp_func.go
@@ -60,7 +60,7 @@ __custom_func() {
             ;;
 
         # first arg is a pod name
-        oc_rsh)
+        oc_rsh | oc_exec)
             if [[ ${#nouns[@]} -eq 0 ]]; then
                 __oc_parse_get pods
             fi;


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/10273

Adds bash and zsh tab completion to `oc exec`

cc @stevekuznetsov @openshift/cli-review 