### PR TITLE
Fix limitRange flake for deleting namespaces

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/limit_range.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/limit_range.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
@@ -29,6 +30,7 @@ import (
 
 var _ = framework.KubeDescribe("LimitRange", func() {
 	f := framework.NewDefaultFramework("limitrange")
+	f.NamespaceDeletionTimeout = 10 * time.Minute
 
 	It("should create a LimitRange with defaults and ensure pod has those defaults applied.", func() {
 		By("Creating a LimitRange")


### PR DESCRIPTION
Increase the timeout we wait for namespace to be deleted before
giving up.

Fixes #11094 