### PR TITLE
make login, project, and discovery work against kube with RBAC enabled

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -220,6 +220,9 @@ function wait-for-cluster() {
   local oc
   oc="$(os::build::find-binary oc)"
 
+  # wait for healthz to report ok before trying to get nodes
+  os::util::wait-for-condition "ok" "${oc} get --config=${kubeconfig} --raw=/healthz" "120"
+
   local msg="${expected_node_count} nodes to report readiness"
   local condition="nodes-are-ready ${kubeconfig} ${oc} ${expected_node_count}"
   local timeout=120

--- a/pkg/cmd/cli/cmd/login/helpers.go
+++ b/pkg/cmd/cli/cmd/login/helpers.go
@@ -130,7 +130,7 @@ func whoAmI(clientConfig *restclient.Config) (*api.User, error) {
 	me, err := client.Users().Get("~")
 
 	// if we're talking to kube (or likely talking to kube),
-	if kerrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		switch {
 		case len(clientConfig.BearerToken) > 0:
 			// the user has already been willing to provide the token on the CLI, so they probably

--- a/pkg/cmd/cli/cmd/login/loginoptions.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions.go
@@ -286,7 +286,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 
 	projectsList, err := oClient.Projects().List(kapi.ListOptions{})
 	// if we're running on kube (or likely kube), just set it to "default"
-	if kerrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		fmt.Fprintf(o.Out, "Using \"default\".  You can switch projects with '%s project <projectname>':\n\n", o.CommandName)
 		o.Project = "default"
 		return nil

--- a/pkg/cmd/cli/config/smart_merge.go
+++ b/pkg/cmd/cli/config/smart_merge.go
@@ -63,7 +63,7 @@ func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
 		return "", err
 	}
 	userInfo, err := client.Users().Get("~")
-	if kerrors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
 		// if we're talking to kube (or likely talking to kube), take a best guess consistent with login
 		switch {
 		case len(clientCfg.BearerToken) > 0:

--- a/pkg/cmd/util/clientcmd/negotiate.go
+++ b/pkg/cmd/util/clientcmd/negotiate.go
@@ -36,7 +36,7 @@ func negotiateVersion(client *kclient.Client, config *restclient.Config, request
 	// Get server versions
 	serverGVs, err := serverAPIVersions(client, "/oapi")
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || errors.IsForbidden(err) {
 			glog.V(4).Infof("Server path /oapi was not found, returning the requested group version %v", preferredGV)
 			return preferredGV, nil
 		}


### PR DESCRIPTION
When RBAC is enabled (see https://github.com/kubernetes/kubernetes/pull/34619), we have to tolerate 403s in addition to 404s.

@pweil- you'll probably need this if you want the tooling to work nicely (and it makes a difference)
