### PR TITLE
Remove -a flag from hack/test-integration.sh

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -237,7 +237,7 @@ readonly -f os::build::setup_env
 #   OS_BUILD_PLATFORMS - Incoming variable of targets to build for.  If unset
 #     then just the host architecture is built.
 function os::build::build_static_binaries() {
-  CGO_ENABLED=0 os::build::build_binaries -a -installsuffix=cgo $@
+  CGO_ENABLED=0 os::build::build_binaries -installsuffix=cgo "$@"
 }
 readonly -f os::build::build_static_binaries
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -31,7 +31,7 @@ verbose="${VERBOSE:-}"
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
   echo "WARNING: Skipping build due to OPENSHIFT_SKIP_BUILD"
 else
-	CGO_ENABLED=0 "${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test" -a -installsuffix=cgo
+	CGO_ENABLED=0 "${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test" -installsuffix=cgo
 fi
 testexec="$(pwd)/$(os::build::find-binary "${name}.test")"
 


### PR DESCRIPTION
@smarterclayton I believe you added this build flag, but it makes it a real pain to work on the integration tests (it takes under 30 seconds to a do an incremental build vs 8 minutes to do a full build).  If we need it for some reason, I could add a new config flag to `hack/test-integration.sh` such as `OPENSHIFT_INCREMENTAL_BUILD`.

````
-a
    force rebuilding of packages that are already up-to-date.
```

Signed-off-by: Monis Khan <mkhan@redhat.com>