### PR TITLE
UPSTREAM: 25451: Allow callers to bypass CheckErr

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -159,7 +159,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 			}
 			kcmdutil.CheckErr(opts.Complete(f, cmd, out, args))
 			err := opts.RunCmdRegistry()
-			if err == cmdutil.ErrExit {
+			if err == kcmdutil.ErrExit {
 				os.Exit(1)
 			}
 			kcmdutil.CheckErr(err)
@@ -477,7 +477,7 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 	}
 
 	if errs := opts.Config.Action.WithMessage(fmt.Sprintf("Creating registry %s", opts.Config.Name), "created").Run(list, opts.namespace); len(errs) > 0 {
-		return cmdutil.ErrExit
+		return kcmdutil.ErrExit
 	}
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -89,22 +89,25 @@ func DefaultBehaviorOnFatal() {
 	fatalErrHandler = fatal
 }
 
-// fatal prints the message if set and then exits. If V(2) or greater, glog.Fatal
-// is invoked for extended information.
+// fatal prints the message (if provided) and then exits. If V(2) or greater,
+// glog.Fatal is invoked for extended information.
 func fatal(msg string, code int) {
+	if glog.V(2) {
+		glog.FatalDepth(2, msg)
+	}
 	if len(msg) > 0 {
 		// add newline if needed
 		if !strings.HasSuffix(msg, "\n") {
 			msg += "\n"
 		}
-
-		if glog.V(2) {
-			glog.FatalDepth(2, msg)
-		}
 		fmt.Fprint(os.Stderr, msg)
 	}
 	os.Exit(code)
 }
+
+// ErrExit may be passed to CheckError to instruct it to output nothing but exit with
+// status code 1.
+var ErrExit = fmt.Errorf("exit")
 
 // CheckErr prints a user friendly error to STDERR and exits with a non-zero
 // exit code. Unrecognized errors will be printed with an "error: " prefix.
@@ -130,6 +133,9 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 
 	switch {
 	case err == nil:
+		return
+	case err == ErrExit:
+		handleErr("")
 		return
 	case kerrors.IsInvalid(err):
 		details := err.(*kerrors.StatusError).Status().Details


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/34721

Fixes: https://github.com/openshift/origin/issues/10404

This patch defines CheckErr
https://github.com/kubernetes/kubernetes/pull/25451/commits/eedb67a30d3591bb609d649043a99f8fc46cd64a in upstream's cmdutil

It makes use of the newly defined `CheckErr` from upstream on a failed registry create

cc @openshift/cli-review @smarterclayton 
