### PR TITLE
Enable minimization of net e2e runtime

### DIFF
--- a/test/extended/networking-minimal.sh
+++ b/test/extended/networking-minimal.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+# Wrapper to configure networking.sh to run a minimal set of tests.
+NETWORKING_E2E_MINIMAL=1 "${OS_ROOT}/test/extended/networking.sh"


### PR DESCRIPTION
- Stop running services tests that don't require multinode (and are therefore running as part of the core extended tests)
- Skip testing ovs and subnet plugin if NETWORKING_E2E_MINIMAL=1
- add ``test/extended/networking-minimal.sh`` wrapper to allow ci to run the minimal tests without requiring changes to vagrant-openshfit

cc: @openshift/networking @stevekuznetsov 