### PR TITLE
UPSTREAM: 35206 update default run func for cmds containing sub-commands

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/admin/cert"
 	diagnostics "github.com/openshift/origin/pkg/cmd/admin/diagnostics"
@@ -43,7 +44,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 		Use:   name,
 		Short: "Tools for managing a cluster",
 		Long:  fmt.Sprintf(adminLong),
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   kcmdutil.DefaultSubCommandRun(out),
 	}
 
 	f := clientcmd.New(cmds.PersistentFlags())
@@ -62,7 +63,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 			Commands: []*cobra.Command{
 				project.NewCmdNewProject(project.NewProjectRecommendedName, fullName+" "+project.NewProjectRecommendedName, f, out),
 				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out, errout),
-				groups.NewCmdGroups(groups.GroupsRecommendedName, fullName+" "+groups.GroupsRecommendedName, f, out),
+				groups.NewCmdGroups(groups.GroupsRecommendedName, fullName+" "+groups.GroupsRecommendedName, f, out, errout),
 				cert.NewCmdCert(cert.CertRecommendedName, fullName+" "+cert.CertRecommendedName, out, errout),
 				admin.NewCommandOverwriteBootstrapPolicy(admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out),
 			},
@@ -76,22 +77,22 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubectl.NewCmdUncordon(f.Factory, out))),
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubectl.NewCmdDrain(f.Factory, out))),
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubectl.NewCmdTaint(f.Factory, out))),
-				network.NewCmdPodNetwork(network.PodNetworkCommandName, fullName+" "+network.PodNetworkCommandName, f, out),
+				network.NewCmdPodNetwork(network.PodNetworkCommandName, fullName+" "+network.PodNetworkCommandName, f, out, errout),
 			},
 		},
 		{
 			Message: "Maintenance:",
 			Commands: []*cobra.Command{
 				diagnostics.NewCmdDiagnostics(diagnostics.DiagnosticsRecommendedName, fullName+" "+diagnostics.DiagnosticsRecommendedName, out),
-				prune.NewCommandPrune(prune.PruneRecommendedName, fullName+" "+prune.PruneRecommendedName, f, out),
+				prune.NewCommandPrune(prune.PruneRecommendedName, fullName+" "+prune.PruneRecommendedName, f, out, errout),
 				buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, out),
 				migrate.NewCommandMigrate(
-					migrate.MigrateRecommendedName, fullName+" "+migrate.MigrateRecommendedName, f, out,
+					migrate.MigrateRecommendedName, fullName+" "+migrate.MigrateRecommendedName, f, out, errout,
 					// Migration commands
 					migrateimages.NewCmdMigrateImageReferences("image-references", fullName+" "+migrate.MigrateRecommendedName+" image-references", f, in, out, errout),
 					migratestorage.NewCmdMigrateAPIStorage("storage", fullName+" "+migrate.MigrateRecommendedName+" storage", f, in, out, errout),
 				),
-				top.NewCommandTop(top.TopRecommendedName, fullName+" "+top.TopRecommendedName, f, out),
+				top.NewCommandTop(top.TopRecommendedName, fullName+" "+top.TopRecommendedName, f, out, errout),
 			},
 		},
 		{
@@ -129,7 +130,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 
 	cmds.AddCommand(
 		// part of every root command
-		cmd.NewCmdConfig(fullName, "config"),
+		cmd.NewCmdConfig(fullName, "config", out, errout),
 		cmd.NewCmdCompletion(fullName, f, out),
 
 		// hidden

--- a/pkg/cmd/admin/cert/cert.go
+++ b/pkg/cmd/admin/cert/cert.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
-	"github.com/openshift/origin/pkg/cmd/util"
 )
 
 const CertRecommendedName = "ca"
@@ -18,7 +18,7 @@ func NewCmdCert(name, fullName string, out io.Writer, errout io.Writer) *cobra.C
 		Use:   name,
 		Short: "Manage certificates and keys",
 		Long:  `Manage certificates and keys`,
-		Run:   util.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errout),
 	}
 
 	cmds.AddCommand(admin.NewCommandCreateMasterCerts(admin.CreateMasterCertsCommandName, fullName+" "+admin.CreateMasterCertsCommandName, out))

--- a/pkg/cmd/admin/groups/groups.go
+++ b/pkg/cmd/admin/groups/groups.go
@@ -4,10 +4,10 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/cli"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -18,13 +18,13 @@ var groupLong = templates.LongDesc(`
 
 	Groups are sets of users that can be used when describing policy.`)
 
-func NewCmdGroups(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdGroups(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Manage groups",
 		Long:  groupLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCmdNewGroup(NewGroupRecommendedName, fullName+" "+NewGroupRecommendedName, f, out))

--- a/pkg/cmd/admin/migrate/migrate.go
+++ b/pkg/cmd/admin/migrate/migrate.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -17,13 +17,13 @@ var migrateLong = templates.LongDesc(`
 
 	These commands assist administrators in performing preventative maintenance on a cluster.`)
 
-func NewCommandMigrate(name, fullName string, f *clientcmd.Factory, out io.Writer, cmds ...*cobra.Command) *cobra.Command {
+func NewCommandMigrate(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer, cmds ...*cobra.Command) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Migrate data in the cluster",
 		Long:  migrateLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 	cmd.AddCommand(cmds...)
 	return cmd

--- a/pkg/cmd/admin/network/pod_network.go
+++ b/pkg/cmd/admin/network/pod_network.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -19,13 +19,13 @@ var (
 		This command provides common pod network operations for administrators.`)
 )
 
-func NewCmdPodNetwork(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdPodNetwork(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Manage pod network",
 		Long:  podNetworkLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCmdJoinProjectsNetwork(JoinProjectsNetworkCommandName, fullName+" "+JoinProjectsNetworkCommandName, f, out))

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -6,6 +6,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/uuid"
 
@@ -14,7 +15,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 

--- a/pkg/cmd/admin/prune/prune.go
+++ b/pkg/cmd/admin/prune/prune.go
@@ -4,10 +4,10 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	groups "github.com/openshift/origin/pkg/cmd/admin/groups/sync/cli"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -22,13 +22,13 @@ var pruneLong = templates.LongDesc(`
 	The commands here allow administrators to manage the older versions of resources on
 	the system by removing them.`)
 
-func NewCommandPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCommandPrune(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Remove older versions of resources from the server",
 		Long:  pruneLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCmdPruneBuilds(f, fullName, PruneBuildsRecommendedName, out))

--- a/pkg/cmd/admin/top/top.go
+++ b/pkg/cmd/admin/top/top.go
@@ -6,10 +6,9 @@ import (
 	"github.com/spf13/cobra"
 
 	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -21,13 +20,13 @@ var topLong = templates.LongDesc(`
 	This command analyzes resources managed by the platform and presents current
 	usage statistics.`)
 
-func NewCommandTop(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCommandTop(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Show usage statistics of resources on the server",
 		Long:  topLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCmdTopImages(f, fullName, TopImagesRecommendedName, out))

--- a/pkg/cmd/admin/validate/validate.go
+++ b/pkg/cmd/admin/validate/validate.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
 const (
@@ -21,14 +21,14 @@ var validateLong = templates.LongDesc(`
 
 	The commands here allow administrators to validate the integrity of configuration files.`)
 
-func NewCommandValidate(name, fullName string, out io.Writer) *cobra.Command {
+func NewCommandValidate(name, fullName string, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:        name,
 		Short:      "Validate configuration file integrity",
 		Long:       validateLong,
 		Deprecated: validateDeprecationMessage,
-		Run:        cmdutil.DefaultSubCommandRun(out),
+		Run:        cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCommandValidateMasterConfig(ValidateMasterConfigRecommendedName,

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/admin"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
@@ -28,7 +29,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/secrets"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/term"
 )
@@ -77,7 +77,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 		Run: func(c *cobra.Command, args []string) {
 			explainOut := term.NewResponsiveWriter(out)
 			c.SetOutput(explainOut)
-			cmdutil.RequireNoArguments(c, args)
+			kcmdutil.RequireNoArguments(c, args)
 			fmt.Fprintf(explainOut, "%s\n\n%s\n", cliLong, fmt.Sprintf(cliExplain, fullName))
 		},
 		BashCompletionFunction: bashCompletionFunc,
@@ -86,7 +86,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	f := clientcmd.New(cmds.PersistentFlags())
 
 	loginCmd := login.NewCmdLogin(fullName, f, in, out)
-	secretcmds := secrets.NewCmdSecrets(secrets.SecretsRecommendedName, fullName+" "+secrets.SecretsRecommendedName, f, in, out, fullName+" edit")
+	secretcmds := secrets.NewCmdSecrets(secrets.SecretsRecommendedName, fullName+" "+secrets.SecretsRecommendedName, f, in, out, errout, fullName+" edit")
 
 	groups := templates.CommandGroups{
 		{
@@ -107,7 +107,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 		{
 			Message: "Build and Deploy Commands:",
 			Commands: []*cobra.Command{
-				rollout.NewCmdRollout(fullName, f, out),
+				rollout.NewCmdRollout(fullName, f, out, errout),
 				cmd.NewCmdDeploy(fullName, f, out),
 				cmd.NewCmdRollback(fullName, f, out),
 				cmd.NewCmdNewBuild(cmd.NewBuildRecommendedCommandName, fullName, f, in, out, errout),
@@ -131,7 +131,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdScale(fullName, f, out),
 				cmd.NewCmdAutoscale(fullName, f, out),
 				secretcmds,
-				sa.NewCmdServiceAccounts(sa.ServiceAccountsRecommendedName, fullName+" "+sa.ServiceAccountsRecommendedName, f, out),
+				sa.NewCmdServiceAccounts(sa.ServiceAccountsRecommendedName, fullName+" "+sa.ServiceAccountsRecommendedName, f, out, errout),
 			},
 		},
 		{
@@ -152,7 +152,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 			Message: "Advanced Commands:",
 			Commands: []*cobra.Command{
 				admin.NewCommandAdmin("adm", fullName+" "+"adm", in, out, errout),
-				cmd.NewCmdCreate(fullName, f, out),
+				cmd.NewCmdCreate(fullName, f, out, errout),
 				cmd.NewCmdReplace(fullName, f, out),
 				cmd.NewCmdApply(fullName, f, out),
 				cmd.NewCmdPatch(fullName, f, out),
@@ -160,7 +160,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdExport(fullName, f, in, out),
 				cmd.NewCmdExtract(fullName, f, in, out, errout),
 				observe.NewCmdObserve(fullName, f, out, errout),
-				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out),
+				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out, errout),
 				cmd.NewCmdConvert(fullName, f, out),
 				importer.NewCmdImport(fullName, f, in, out, errout),
 			},
@@ -169,7 +169,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 			Message: "Settings Commands:",
 			Commands: []*cobra.Command{
 				login.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out),
-				cmd.NewCmdConfig(fullName, "config"),
+				cmd.NewCmdConfig(fullName, "config", out, errout),
 				cmd.NewCmdWhoAmI(cmd.WhoAmIRecommendedCommandName, fullName+" "+cmd.WhoAmIRecommendedCommandName, f, out),
 				cmd.NewCmdCompletion(fullName, f, out),
 			},

--- a/pkg/cmd/cli/cmd/cluster/cluster.go
+++ b/pkg/cmd/cli/cmd/cluster/cluster.go
@@ -5,10 +5,10 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/bootstrap/docker"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -39,7 +39,7 @@ func NewCmdCluster(name, fullName string, f *clientcmd.Factory, out, errout io.W
 		Use:   fmt.Sprintf("%s ACTION", name),
 		Short: "Start and stop OpenShift cluster",
 		Long:  clusterLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errout),
 	}
 
 	cmds.AddCommand(docker.NewCmdUp(docker.CmdUpRecommendedName, fullName+" "+docker.CmdUpRecommendedName, f, out, errout))

--- a/pkg/cmd/cli/cmd/create/route.go
+++ b/pkg/cmd/cli/cmd/create/route.go
@@ -26,12 +26,12 @@ var (
 )
 
 // NewCmdCreateRoute is a macro command to create a secured route.
-func NewCmdCreateRoute(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateRoute(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "route",
 		Short: "Expose containers externally via secured routes",
 		Long:  fmt.Sprintf(routeLong, fullName),
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   kcmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmd.AddCommand(NewCmdCreateEdgeRoute(fullName, f, out))

--- a/pkg/cmd/cli/cmd/importer/import.go
+++ b/pkg/cmd/cli/cmd/importer/import.go
@@ -5,9 +5,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -24,7 +24,7 @@ func NewCmdImport(fullName string, f *clientcmd.Factory, in io.Reader, out, erro
 		Use:   "import COMMAND",
 		Short: "Commands that import applications",
 		Long:  importLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errout),
 	}
 
 	name := fmt.Sprintf("%s import", fullName)

--- a/pkg/cmd/cli/cmd/rollout/rollout.go
+++ b/pkg/cmd/cli/cmd/rollout/rollout.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/rollout"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -32,14 +33,12 @@ var (
 )
 
 // NewCmdRollout facilitates kubectl rollout subcommands
-func NewCmdRollout(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRollout(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rollout SUBCOMMAND",
 		Short: "rollout manages a deployment",
 		Long:  rolloutLong,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	// subcommands

--- a/pkg/cmd/cli/cmd/set/set.go
+++ b/pkg/cmd/cli/cmd/set/set.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/set"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -25,7 +25,7 @@ func NewCmdSet(fullName string, f *clientcmd.Factory, in io.Reader, out, errout 
 		Use:   "set COMMAND",
 		Short: "Commands that help set specific features on objects",
 		Long:  setLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errout),
 	}
 
 	name := fmt.Sprintf("%s set", fullName)

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -10,8 +10,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	ocutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 type concept struct {
@@ -231,7 +232,7 @@ func NewCmdTypes(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Co
 		Short:   "An introduction to concepts and types",
 		Long:    fmt.Sprintf(typesLong, buf.String()),
 		Example: fmt.Sprintf(typesExample, fullName),
-		Run:     ocutil.DefaultSubCommandRun(out),
+		Run:     kcmdutil.DefaultSubCommandRun(out),
 	}
 	return cmd
 }

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -174,8 +173,8 @@ var (
 )
 
 // NewCmdCreate is a wrapper for the Kubernetes cli create command
-func NewCmdCreate(parentName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdCreate(f.Factory, out)
+func NewCmdCreate(parentName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+	cmd := kcmd.NewCmdCreate(f.Factory, out, errOut)
 	cmd.Long = createLong
 	cmd.Example = fmt.Sprintf(createExample, parentName)
 
@@ -184,7 +183,7 @@ func NewCmdCreate(parentName string, f *clientcmd.Factory, out io.Writer) *cobra
 	templates.NormalizeAll(cmd)
 
 	// create subcommands
-	cmd.AddCommand(create.NewCmdCreateRoute(parentName, f, out))
+	cmd.AddCommand(create.NewCmdCreateRoute(parentName, f, out, errOut))
 	cmd.AddCommand(create.NewCmdCreatePolicyBinding(create.PolicyBindingRecommendedName, parentName+" create "+create.PolicyBindingRecommendedName, f, out))
 	cmd.AddCommand(create.NewCmdCreateDeploymentConfig(create.DeploymentConfigRecommendedName, parentName+" create "+create.DeploymentConfigRecommendedName, f, out))
 	cmd.AddCommand(create.NewCmdCreateClusterQuota(create.ClusterQuotaRecommendedName, parentName+" create "+create.ClusterQuotaRecommendedName, f, out))
@@ -688,7 +687,7 @@ var (
 )
 
 // NewCmdConfig is a wrapper for the Kubernetes cli config command
-func NewCmdConfig(parentName, name string) *cobra.Command {
+func NewCmdConfig(parentName, name string, out, errOut io.Writer) *cobra.Command {
 	pathOptions := &kclientcmd.PathOptions{
 		GlobalFile:       cmdconfig.RecommendedHomeFile,
 		EnvVar:           cmdconfig.OpenShiftConfigPathEnvVar,
@@ -700,7 +699,7 @@ func NewCmdConfig(parentName, name string) *cobra.Command {
 	}
 	pathOptions.LoadingRules.DoNotResolvePaths = true
 
-	cmd := config.NewCmdConfig(pathOptions, os.Stdout)
+	cmd := config.NewCmdConfig(pathOptions, out, errOut)
 	cmd.Short = "Change configuration files for the client"
 	cmd.Long = configLong
 	cmd.Example = fmt.Sprintf(configExample, parentName, name)

--- a/pkg/cmd/cli/policy/policy.go
+++ b/pkg/cmd/cli/policy/policy.go
@@ -4,21 +4,21 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	adminpolicy "github.com/openshift/origin/pkg/cmd/admin/policy"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 const PolicyRecommendedName = "policy"
 
-func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Manage authorization policy",
 		Long:  `Manage authorization policy`,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(adminpolicy.NewCmdWhoCan(adminpolicy.WhoCanRecommendedName, fullName+" "+adminpolicy.WhoCanRecommendedName, f, out))

--- a/pkg/cmd/cli/sa/subcommand.go
+++ b/pkg/cmd/cli/sa/subcommand.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -20,13 +20,13 @@ const (
 	serviceAccountsShort = `Manage service accounts in your project`
 )
 
-func NewCmdServiceAccounts(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdServiceAccounts(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:     name,
 		Short:   serviceAccountsShort,
 		Long:    serviceAccountsLong,
 		Aliases: []string{"sa"},
-		Run:     cmdutil.DefaultSubCommandRun(out),
+		Run:     cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewCommandGetServiceAccountToken(GetServiceAccountTokenRecommendedName, fullName+" "+GetServiceAccountTokenRecommendedName, f, out))

--- a/pkg/cmd/cli/secrets/subcommand.go
+++ b/pkg/cmd/cli/secrets/subcommand.go
@@ -4,10 +4,10 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/build/builder/cmd/scmauth"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -35,14 +35,14 @@ var (
     Docker registries.`)
 )
 
-func NewCmdSecrets(name, fullName string, f *clientcmd.Factory, reader io.Reader, out io.Writer, ocEditFullName string) *cobra.Command {
+func NewCmdSecrets(name, fullName string, f *clientcmd.Factory, reader io.Reader, out, errOut io.Writer, ocEditFullName string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:     name,
 		Short:   "Manage secrets",
 		Long:    secretsLong,
 		Aliases: []string{"secret"},
-		Run:     cmdutil.DefaultSubCommandRun(out),
+		Run:     cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	newSecretFullName := fullName + " " + NewSecretRecommendedCommandName

--- a/pkg/cmd/experimental/config/config.go
+++ b/pkg/cmd/experimental/config/config.go
@@ -4,9 +4,9 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -19,7 +19,7 @@ func NewCmdConfig(name, fullName string, f *clientcmd.Factory, out, errout io.Wr
 		Use:   name,
 		Short: "Manage config",
 		Long:  configLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   cmdutil.DefaultSubCommandRun(errout),
 	}
 
 	cmd.AddCommand(NewCmdPatch(PatchRecommendedName, fullName+" "+PatchRecommendedName, f, out))

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
 	"github.com/openshift/origin/pkg/cmd/admin"
 	diagnostics "github.com/openshift/origin/pkg/cmd/admin/diagnostics"
 	sync "github.com/openshift/origin/pkg/cmd/admin/groups/sync/cli"
@@ -84,7 +86,7 @@ func CommandFor(basename string) *cobra.Command {
 	case "kube-scheduler":
 		cmd = kubernetes.NewSchedulerCommand(basename, basename, out)
 	case "kubernetes":
-		cmd = kubernetes.NewCommand(basename, basename, out)
+		cmd = kubernetes.NewCommand(basename, basename, out, errout)
 	case "origin", "atomic-enterprise":
 		cmd = NewCommandOpenShift(basename)
 	default:
@@ -107,7 +109,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 		Use:   name,
 		Short: "Build, deploy, and manage your cloud applications",
 		Long:  fmt.Sprintf(openshiftLong, name, cmdutil.GetPlatformName(name), cmdutil.GetDistributionName(name)),
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Run:   kcmdutil.DefaultSubCommandRun(out),
 	}
 
 	f := clientcmd.New(pflag.NewFlagSet("", pflag.ContinueOnError))
@@ -164,7 +166,7 @@ func newExperimentalCommand(name, fullName string) *cobra.Command {
 
 	f := clientcmd.New(experimental.PersistentFlags())
 
-	experimental.AddCommand(validate.NewCommandValidate(validate.ValidateRecommendedName, fullName+" "+validate.ValidateRecommendedName, out))
+	experimental.AddCommand(validate.NewCommandValidate(validate.ValidateRecommendedName, fullName+" "+validate.ValidateRecommendedName, out, errout))
 	experimental.AddCommand(exipfailover.NewCmdIPFailoverConfig(f, fullName, "ipfailover", out, errout))
 	experimental.AddCommand(buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, out))
 	experimental.AddCommand(configcmd.NewCmdConfig(configcmd.ConfigRecommendedName, fullName+" "+configcmd.ConfigRecommendedName, f, out, errout))

--- a/pkg/cmd/server/start/kubernetes/kubernetes.go
+++ b/pkg/cmd/server/start/kubernetes/kubernetes.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"runtime"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -21,15 +22,12 @@ The primary Kubernetes server components can be started individually using their
 arguments. No configuration settings will be used when launching these components.
 `
 
-func NewCommand(name, fullName string, out io.Writer) *cobra.Command {
+func NewCommand(name, fullName string, out, errOut io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Kubernetes server components",
 		Long:  fmt.Sprintf(kubernetesLong),
-		Run: func(c *cobra.Command, args []string) {
-			c.SetOutput(os.Stdout)
-			c.Help()
-		},
+		Run:   kcmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	cmds.AddCommand(NewAPIServerCommand("apiserver", fullName+" apiserver", out))

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -118,7 +118,7 @@ func NewCommandStartAllInOne(basename string, out, errout io.Writer) (*cobra.Com
 	cmds.AddCommand(startNodeNetwork)
 	cmds.AddCommand(startEtcdServer)
 
-	startKube := kubernetes.NewCommand("kubernetes", basename, out)
+	startKube := kubernetes.NewCommand("kubernetes", basename, out, errout)
 	cmds.AddCommand(startKube)
 
 	// autocompletion hints

--- a/pkg/cmd/util/cmd.go
+++ b/pkg/cmd/util/cmd.go
@@ -33,21 +33,6 @@ func ReplaceCommandName(from, to string, c *cobra.Command) *cobra.Command {
 	return c
 }
 
-// RequireNoArguments exits with a usage error if extra arguments are provided.
-func RequireNoArguments(c *cobra.Command, args []string) {
-	if len(args) > 0 {
-		kcmdutil.CheckErr(kcmdutil.UsageError(c, fmt.Sprintf(`unknown command "%s"`, strings.Join(args, " "))))
-	}
-}
-
-func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
-	return func(c *cobra.Command, args []string) {
-		c.SetOutput(out)
-		RequireNoArguments(c, args)
-		c.Help()
-	}
-}
-
 // GetDisplayFilename returns the absolute path of the filename as long as there was no error, otherwise it returns the filename as-is
 func GetDisplayFilename(filename string) string {
 	if absName, err := filepath.Abs(filename); err == nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -258,7 +258,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 		{
 			Message: "Basic Commands (Beginner):",
 			Commands: []*cobra.Command{
-				NewCmdCreate(f, out),
+				NewCmdCreate(f, out, err),
 				NewCmdExposeService(f, out),
 				NewCmdRun(f, in, out, err),
 				set.NewCmdSet(f, out, err),
@@ -276,7 +276,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 		{
 			Message: "Deploy Commands:",
 			Commands: []*cobra.Command{
-				rollout.NewCmdRollout(f, out),
+				rollout.NewCmdRollout(f, out, err),
 				NewCmdRollingUpdate(f, out),
 				NewCmdScale(f, out),
 				NewCmdAutoscale(f, out),
@@ -286,7 +286,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 			Message: "Cluster Management Commands:",
 			Commands: []*cobra.Command{
 				NewCmdClusterInfo(f, out),
-				NewCmdTop(f, out),
+				NewCmdTop(f, out, err),
 				NewCmdCordon(f, out),
 				NewCmdUncordon(f, out),
 				NewCmdDrain(f, out),
@@ -341,7 +341,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 		)
 	}
 
-	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out))
+	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out, err))
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))
 	cmds.AddCommand(NewCmdOptions(out))

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/config.go
@@ -24,10 +24,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 // NewCmdConfig creates a command object for the "config" action, and adds all child commands to it.
-func NewCmdConfig(pathOptions *clientcmd.PathOptions, out io.Writer) *cobra.Command {
+func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
@@ -42,9 +43,7 @@ The loading order follows these rules:
 2. If $` + pathOptions.EnvVar + ` environment variable is set, then it is used a list of paths (normal path delimitting rules for your system).  These paths are merged.  When a value is modified, it is modified in the file that defines the stanza.  When a value is created, it is created in the first file that exists.  If no files in the chain exist, then it creates the last file in the list.
 3. Otherwise, ` + path.Join("${HOME}", pathOptions.GlobalFileSubpath) + ` is used and no merging takes place.
 `,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run: cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	// file paths are common to all sub commands

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/config_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/config_test.go
@@ -770,7 +770,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf)
+	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf, buf)
 	cmd.SetArgs(argsToUse)
 	cmd.Execute()
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
@@ -50,7 +50,7 @@ var (
 		cat pod.json | kubectl create -f -`)
 )
 
-func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreate(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	options := &CreateOptions{}
 
 	cmd := &cobra.Command{
@@ -60,7 +60,8 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(options.Filenames) == 0 {
-				cmd.Help()
+				defaultRunFunc := cmdutil.DefaultSubCommandRun(errOut)
+				defaultRunFunc(cmd, args)
 				return
 			}
 			cmdutil.CheckErr(ValidateArgs(cmd, args))
@@ -83,10 +84,10 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	// create subcommands
 	cmd.AddCommand(NewCmdCreateNamespace(f, out))
 	cmd.AddCommand(NewCmdCreateQuota(f, out))
-	cmd.AddCommand(NewCmdCreateSecret(f, out))
+	cmd.AddCommand(NewCmdCreateSecret(f, out, errOut))
 	cmd.AddCommand(NewCmdCreateConfigMap(f, out))
 	cmd.AddCommand(NewCmdCreateServiceAccount(f, out))
-	cmd.AddCommand(NewCmdCreateService(f, out))
+	cmd.AddCommand(NewCmdCreateService(f, out, errOut))
 	cmd.AddCommand(NewCmdCreateDeployment(f, out))
 	return cmd
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_secret.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_secret.go
@@ -28,14 +28,12 @@ import (
 )
 
 // NewCmdCreateSecret groups subcommands to create various types of secrets
-func NewCmdCreateSecret(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
+func NewCmdCreateSecret(f *cmdutil.Factory, cmdOut, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Create a secret using specified subcommand",
 		Long:  "Create a secret using specified subcommand.",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 	cmd.AddCommand(NewCmdCreateSecretDockerRegistry(f, cmdOut))
 	cmd.AddCommand(NewCmdCreateSecretTLS(f, cmdOut))

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_service.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_service.go
@@ -29,14 +29,12 @@ import (
 )
 
 // NewCmdCreateService is a macro command to create a new namespace
-func NewCmdCreateService(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
+func NewCmdCreateService(f *cmdutil.Factory, cmdOut, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "service",
 		Short: "Create a service using specified subcommand.",
 		Long:  "Create a service using specified subcommand.",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 	cmd.AddCommand(NewCmdCreateServiceClusterIP(f, cmdOut))
 	cmd.AddCommand(NewCmdCreateServiceNodePort(f, cmdOut))

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create_test.go
@@ -30,7 +30,7 @@ func TestExtraArgsFail(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 
 	f, _, _, _ := NewAPIFactory()
-	c := NewCmdCreate(f, buf)
+	c := NewCmdCreate(f, buf, buf)
 	if ValidateArgs(c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -59,7 +59,7 @@ func TestCreateObject(t *testing.T) {
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdCreate(f, buf)
+	cmd := NewCmdCreate(f, buf, buf)
 	cmd.Flags().Set("filename", "../../../examples/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
@@ -94,7 +94,7 @@ func TestCreateMultipleObject(t *testing.T) {
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdCreate(f, buf)
+	cmd := NewCmdCreate(f, buf, buf)
 	cmd.Flags().Set("filename", "../../../examples/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Flags().Set("filename", "../../../examples/guestbook/frontend-service.yaml")
 	cmd.Flags().Set("output", "name")
@@ -129,7 +129,7 @@ func TestCreateDirectory(t *testing.T) {
 	tf.Namespace = "test"
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdCreate(f, buf)
+	cmd := NewCmdCreate(f, buf, buf)
 	cmd.Flags().Set("filename", "../../../examples/guestbook/legacy")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout.go
@@ -36,16 +36,14 @@ var (
 		`)
 )
 
-func NewCmdRollout(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdRollout(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "rollout SUBCOMMAND",
 		Short:   "Manage a deployment rollout",
 		Long:    rollout_long,
 		Example: rollout_example,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run:     cmdutil.DefaultSubCommandRun(errOut),
 	}
 	// subcommands
 	cmd.AddCommand(NewCmdRolloutHistory(f, out))

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set.go
@@ -38,9 +38,7 @@ func NewCmdSet(f *cmdutil.Factory, out, err io.Writer) *cobra.Command {
 		Short:   "Set specific features on objects",
 		Long:    set_long,
 		Example: set_example,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
+		Run:     cmdutil.DefaultSubCommandRun(err),
 	}
 
 	// add subcommands

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top.go
@@ -35,26 +35,16 @@ var (
 		The top command allows you to see the resource consumption for nodes or pods.`)
 )
 
-func NewCmdTop(f *cmdutil.Factory, out io.Writer) *cobra.Command {
-	options := &TopOptions{}
-
+func NewCmdTop(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
 		Short: "Display Resource (CPU/Memory/Storage) usage",
 		Long:  topLong,
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.RunTop(f, cmd, args, out); err != nil {
-				cmdutil.CheckErr(err)
-			}
-		},
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
 	// create subcommands
 	cmd.AddCommand(NewCmdTopNode(f, out))
 	cmd.AddCommand(NewCmdTopPod(f, out))
 	return cmd
-}
-
-func (o TopOptions) RunTop(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
-	return cmd.Help()
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_test.go
@@ -23,12 +23,13 @@ import (
 	"io/ioutil"
 	"time"
 
+	"testing"
+
 	metrics_api "k8s.io/heapster/metrics/apis/metrics/v1alpha1"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
-	"testing"
 )
 
 const (
@@ -43,7 +44,7 @@ func TestTopSubcommandsExist(t *testing.T) {
 	f, _, _, _ := NewAPIFactory()
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdTop(f, buf)
+	cmd := NewCmdTop(f, buf, buf)
 	if !cmd.HasSubCommands() {
 		t.Error("top command should have subcommands")
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -744,3 +744,20 @@ func IsSiblingCommandExists(cmd *cobra.Command, targetCmdName string) bool {
 
 	return false
 }
+
+// DefaultSubCommandRun prints a command's help string to the specified output if no
+// arguments (sub-commands) are provided, or a usage error otherwise.
+func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
+	return func(c *cobra.Command, args []string) {
+		c.SetOutput(out)
+		RequireNoArguments(c, args)
+		c.Help()
+	}
+}
+
+// RequireNoArguments exits with a usage error if extra arguments are provided.
+func RequireNoArguments(c *cobra.Command, args []string) {
+	if len(args) > 0 {
+		CheckErr(UsageError(c, fmt.Sprintf(`unknown command "%s"`, strings.Join(args, " "))))
+	}
+}


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/35206

Fixes https://github.com/openshift/origin/issues/11043#event-822655239

This patch updates parent commands of sub-commands to exit with a usage
error and exit code 1 on an invalid (non-sub-command) argument.

**Example**

```
$ oc rollout
... [help output] ...

$ echo $?
0

$ oc rollout invalidsubcommand
error: unknown command "lol"
See 'oc rollout -h' for help and examples.

$ echo $?
1
```

cc @openshift/cli-review @kargakis @tnozicka 
