### PR TITLE
delete a redundant arg

### DIFF
--- a/pkg/image/importer/client.go
+++ b/pkg/image/importer/client.go
@@ -219,7 +219,7 @@ func schema2ToImage(manifest *schema2.DeserializedManifest, imageConfig []byte, 
 	return image, nil
 }
 
-func schema0ToImage(dockerImage *dockerregistry.Image, id string) (*api.Image, error) {
+func schema0ToImage(dockerImage *dockerregistry.Image) (*api.Image, error) {
 	var baseImage api.DockerImage
 	if err := kapi.Scheme.Convert(&dockerImage.Image, &baseImage, nil); err != nil {
 		return nil, fmt.Errorf("could not convert image: %#v", err)

--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -606,7 +606,7 @@ func importRepositoryFromDockerV1(ctx gocontext.Context, repository *importRepos
 			continue
 		}
 		// we do not preserve manifests of legacy images
-		importDigest.Image, err = schema0ToImage(image, importDigest.Name)
+		importDigest.Image, err = schema0ToImage(image)
 		if err != nil {
 			importDigest.Err = err
 			continue
@@ -625,7 +625,7 @@ func importRepositoryFromDockerV1(ctx gocontext.Context, repository *importRepos
 			continue
 		}
 		// we do not preserve manifests of legacy images
-		importTag.Image, err = schema0ToImage(image, "")
+		importTag.Image, err = schema0ToImage(image)
 		if err != nil {
 			importTag.Err = err
 			continue


### PR DESCRIPTION
The arg `id` isn't used in the func `schema0ToImage`, I think we should delete it.
