### PR TITLE
new SDN isolation rule organization

### DIFF
--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -38,18 +38,18 @@ add_ovs_flows() {
     fi
 
     # from container
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, arp_sha=${macaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:3"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=20, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, arp_sha=${macaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:30"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=20, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:30"
 
     # arp request/response to container (not isolated)
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=100, arp, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=40, priority=100, arp, nw_dst=${ipaddr}, actions=output:${ovs_port}"
 
     # IP to container
     if [ $tenant_id = "0" ]; then
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
     else
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
     fi
 
     # Pod ingress == OVS bridge egress

--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -45,12 +45,7 @@ add_ovs_flows() {
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=40, priority=100, arp, nw_dst=${ipaddr}, actions=output:${ovs_port}"
 
     # IP to container
-    if [ $tenant_id = "0" ]; then
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
-    else
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
-    fi
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=70, priority=100, ip, nw_dst=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG1[], load:${ovs_port}->NXM_NX_REG2[], goto_table:80"
 
     # Pod ingress == OVS bridge egress
     # linux-htb used here since that's the Kubernetes default traffic shaper too

--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -19,7 +19,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 	}
 
 	for _, policy := range policies.Items {
-		vnid, err := plugin.vnids.GetVNID(policy.Namespace)
+		vnid, err := plugin.policy.GetVNID(policy.Namespace)
 		if err != nil {
 			glog.Warningf("Could not find netid for namespace %q: %v", policy.Namespace, err)
 			continue
@@ -39,7 +39,7 @@ func (plugin *OsdnNode) watchEgressNetworkPolicies() {
 	RunEventQueue(plugin.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 
-		vnid, err := plugin.vnids.GetVNID(policy.Namespace)
+		vnid, err := plugin.policy.GetVNID(policy.Namespace)
 		if err != nil {
 			return fmt.Errorf("Could not find netid for namespace %q: %v", policy.Namespace, err)
 		}

--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -28,10 +28,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 	}
 
 	for vnid := range plugin.egressPolicies {
-		err := plugin.updateEgressNetworkPolicyRules(vnid)
-		if err != nil {
-			return err
-		}
+		plugin.updateEgressNetworkPolicyRules(vnid)
 	}
 
 	go utilwait.Forever(plugin.watchEgressNetworkPolicies, 0)
@@ -59,15 +56,12 @@ func (plugin *OsdnNode) watchEgressNetworkPolicies() {
 		}
 		plugin.egressPolicies[vnid] = policies
 
-		err = plugin.updateEgressNetworkPolicyRules(vnid)
-		if err != nil {
-			return err
-		}
+		plugin.updateEgressNetworkPolicyRules(vnid)
 		return nil
 	})
 }
 
-func (plugin *OsdnNode) UpdateEgressNetworkPolicyVNID(namespace string, oldVnid, newVnid uint32) error {
+func (plugin *OsdnNode) UpdateEgressNetworkPolicyVNID(namespace string, oldVnid, newVnid uint32) {
 	var policy *osapi.EgressNetworkPolicy
 
 	policies := plugin.egressPolicies[oldVnid]
@@ -75,21 +69,13 @@ func (plugin *OsdnNode) UpdateEgressNetworkPolicyVNID(namespace string, oldVnid,
 		if oldPolicy.Namespace == namespace {
 			policy = &oldPolicy
 			plugin.egressPolicies[oldVnid] = append(policies[:i], policies[i+1:]...)
-			err := plugin.updateEgressNetworkPolicyRules(oldVnid)
-			if err != nil {
-				return err
-			}
+			plugin.updateEgressNetworkPolicyRules(oldVnid)
 			break
 		}
 	}
 
 	if policy != nil {
 		plugin.egressPolicies[newVnid] = append(plugin.egressPolicies[newVnid], *policy)
-		err := plugin.updateEgressNetworkPolicyRules(newVnid)
-		if err != nil {
-			return err
-		}
+		plugin.updateEgressNetworkPolicyRules(newVnid)
 	}
-
-	return nil
 }

--- a/pkg/sdn/plugin/multitenant.go
+++ b/pkg/sdn/plugin/multitenant.go
@@ -1,0 +1,91 @@
+package plugin
+
+import (
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	osapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+type multiTenantPlugin struct {
+	node  *OsdnNode
+	vnids *nodeVNIDMap
+}
+
+func NewMultiTenantPlugin() osdnPolicy {
+	return &multiTenantPlugin{}
+}
+
+func (mp *multiTenantPlugin) Name() string {
+	return osapi.MultiTenantPluginName
+}
+
+func (mp *multiTenantPlugin) Start(node *OsdnNode) error {
+	mp.node = node
+	mp.vnids = newNodeVNIDMap(mp, node.osClient)
+	if err := mp.vnids.Start(); err != nil {
+		return err
+	}
+	if err := mp.node.SetupEgressNetworkPolicy(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID uint32) {
+	// FIXME: this is racy; traffic coming from the pods gets switched to the new
+	// VNID before the service and firewall rules are updated to match. We need
+	// to do the updates as a single transaction (ovs-ofctl --bundle).
+
+	pods, err := mp.node.GetLocalPods(namespace)
+	if err != nil {
+		glog.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err)
+	}
+	services, err := mp.node.kClient.Core().Services(namespace).List(kapi.ListOptions{})
+	if err != nil {
+		glog.Errorf("Could not get list of services in namespace %q: %v", namespace, err)
+		services = &kapi.ServiceList{}
+	}
+
+	// Update OF rules for the existing/old pods in the namespace
+	for _, pod := range pods {
+		err = mp.node.UpdatePod(pod)
+		if err != nil {
+			glog.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err)
+		}
+	}
+
+	// Update OF rules for the old services in the namespace
+	for _, svc := range services.Items {
+		if !kapi.IsServiceIPSet(&svc) {
+			continue
+		}
+
+		mp.node.DeleteServiceRules(&svc)
+		mp.node.AddServiceRules(&svc, netID)
+	}
+
+	// Update namespace references in egress firewall rules
+	mp.node.UpdateEgressNetworkPolicyVNID(namespace, oldNetID, netID)
+}
+
+func (mp *multiTenantPlugin) AddNetNamespace(netns *osapi.NetNamespace) {
+	mp.updatePodNetwork(netns.Name, 0, netns.NetID)
+}
+
+func (mp *multiTenantPlugin) UpdateNetNamespace(netns *osapi.NetNamespace, oldNetID uint32) {
+	mp.updatePodNetwork(netns.Name, oldNetID, netns.NetID)
+}
+
+func (mp *multiTenantPlugin) DeleteNetNamespace(netns *osapi.NetNamespace) {
+	mp.updatePodNetwork(netns.Name, netns.NetID, 0)
+}
+
+func (mp *multiTenantPlugin) GetVNID(namespace string) (uint32, error) {
+	return mp.vnids.WaitAndGetVNID(namespace)
+}
+
+func (mp *multiTenantPlugin) GetNamespaces(vnid uint32) []string {
+	return mp.vnids.GetNamespaces(vnid)
+}

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -33,9 +33,8 @@ type podManager struct {
 	runningPods map[string]*kubehostport.RunningPod
 
 	// Live pod setup/teardown stuff not used in testing code
-	multitenant     bool
 	kClient         *kclientset.Clientset
-	vnids           *nodeVNIDMap
+	policy          osdnPolicy
 	ipamConfig      []byte
 	mtu             uint32
 	hostportHandler kubehostport.HostportHandler
@@ -43,11 +42,10 @@ type podManager struct {
 }
 
 // Creates a new live podManager; used by node code
-func newPodManager(host knetwork.Host, multitenant bool, localSubnetCIDR string, netInfo *NetworkInfo, kClient *kclientset.Clientset, vnids *nodeVNIDMap, mtu uint32) (*podManager, error) {
+func newPodManager(host knetwork.Host, localSubnetCIDR string, netInfo *NetworkInfo, kClient *kclientset.Clientset, policy osdnPolicy, mtu uint32) (*podManager, error) {
 	pm := newDefaultPodManager(host)
-	pm.multitenant = multitenant
 	pm.kClient = kClient
-	pm.vnids = vnids
+	pm.policy = policy
 	pm.mtu = mtu
 	pm.hostportHandler = kubehostport.NewHostportHandler()
 	pm.podHandler = pm

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -447,6 +447,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *kubeho
 		return nil, nil, err
 	}
 
+	m.policy.RefVNID(podConfig.vnid)
 	success = true
 	return ipamResult, newPod, nil
 }
@@ -520,6 +521,9 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 		} else if err != nil {
 			return err
 		}
+	}
+	if vnid, err := m.policy.GetVNID(req.PodNamespace); err == nil {
+		m.policy.UnrefVNID(vnid)
 	}
 
 	if err := m.ipamDel(req.ContainerId); err != nil {

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -91,11 +91,9 @@ func (m *podManager) getPodConfig(req *cniserver.PodRequest) (*PodConfig, *kapi.
 	var err error
 
 	config := &PodConfig{}
-	if m.multitenant {
-		config.vnid, err = m.vnids.GetVNID(req.PodNamespace)
-		if err != nil {
-			return nil, nil, err
-		}
+	config.vnid, err = m.policy.GetVNID(req.PodNamespace)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	pod, err := m.kClient.Pods(req.PodNamespace).Get(req.PodName)

--- a/pkg/sdn/plugin/singletenant.go
+++ b/pkg/sdn/plugin/singletenant.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	osapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+type singleTenantPlugin struct{}
+
+func NewSingleTenantPlugin() osdnPolicy {
+	return &singleTenantPlugin{}
+}
+
+func (sp *singleTenantPlugin) Name() string {
+	return osapi.SingleTenantPluginName
+}
+
+func (sp *singleTenantPlugin) Start(node *OsdnNode) error {
+	return nil
+}
+
+func (sp *singleTenantPlugin) AddNetNamespace(netns *osapi.NetNamespace) {
+}
+
+func (sp *singleTenantPlugin) UpdateNetNamespace(netns *osapi.NetNamespace, oldNetID uint32) {
+}
+
+func (sp *singleTenantPlugin) DeleteNetNamespace(netns *osapi.NetNamespace) {
+}
+
+func (sp *singleTenantPlugin) GetVNID(namespace string) (uint32, error) {
+	return 0, nil
+}
+
+func (sp *singleTenantPlugin) GetNamespaces(vnid uint32) []string {
+	return nil
+}

--- a/pkg/sdn/plugin/singletenant.go
+++ b/pkg/sdn/plugin/singletenant.go
@@ -15,7 +15,9 @@ func (sp *singleTenantPlugin) Name() string {
 }
 
 func (sp *singleTenantPlugin) Start(node *OsdnNode) error {
-	return nil
+	otx := node.ovs.NewTransaction()
+	otx.AddFlow("table=80, priority=200, actions=output:NXM_NX_REG2[]")
+	return otx.EndTransaction()
 }
 
 func (sp *singleTenantPlugin) AddNetNamespace(netns *osapi.NetNamespace) {
@@ -33,4 +35,10 @@ func (sp *singleTenantPlugin) GetVNID(namespace string) (uint32, error) {
 
 func (sp *singleTenantPlugin) GetNamespaces(vnid uint32) []string {
 	return nil
+}
+
+func (sp *singleTenantPlugin) RefVNID(vnid uint32) {
+}
+
+func (sp *singleTenantPlugin) UnrefVNID(vnid uint32) {
 }

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -269,9 +269,7 @@ func (node *OsdnNode) watchSubnets() {
 					break
 				} else {
 					// Delete old subnet rules
-					if err := node.DeleteHostSubnetRules(oldSubnet); err != nil {
-						return err
-					}
+					node.DeleteHostSubnetRules(oldSubnet)
 				}
 			}
 			if err := node.networkInfo.validateNodeIP(hs.HostIP); err != nil {
@@ -279,15 +277,11 @@ func (node *OsdnNode) watchSubnets() {
 				break
 			}
 
-			if err := node.AddHostSubnetRules(hs); err != nil {
-				return err
-			}
+			node.AddHostSubnetRules(hs)
 			subnets[string(hs.UID)] = hs
 		case cache.Deleted:
 			delete(subnets, string(hs.UID))
-			if err := node.DeleteHostSubnetRules(hs); err != nil {
-				return err
-			}
+			node.DeleteHostSubnetRules(hs)
 		}
 		return nil
 	})

--- a/pkg/sdn/plugin/vnids_node_test.go
+++ b/pkg/sdn/plugin/vnids_node_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNodeVNIDMap(t *testing.T) {
-	vmap := newNodeVNIDMap()
+	vmap := newNodeVNIDMap(nil, nil)
 
 	// empty vmap
 


### PR DESCRIPTION
Last bits of reorg before starting to add the NetworkPolicy implementation... The commit messages have more details about what each commit does (especially the last one, which you will definitely want to read).

I think Ben and I had agreed a while back that it made sense to renumber all the OVS tables by multiplying by 10 so that we could change/add things later without needing to renumber the tables every time... Although now already we have both gaps in the numbering and extra numbers squeezed in, which seems ugly to me, and maybe it would be better to just renumber tables when we need to...

@openshift/networking PTAL
