### PR TITLE
update oc env, return resources in list

### DIFF
--- a/pkg/cmd/cli/cmd/set/env.go
+++ b/pkg/cmd/cli/cmd/set/env.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubectl"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -489,11 +490,20 @@ func RunEnv(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra.Comman
 		if err != nil {
 			return err
 		}
-		for _, object := range objects {
-			if err := p.PrintObj(object, out); err != nil {
-				return err
-			}
+
+		resourceList := &kapi.List{
+			TypeMeta: unversioned.TypeMeta{
+				Kind:       "List",
+				APIVersion: outputVersion.Version,
+			},
+			ListMeta: unversioned.ListMeta{},
+			Items:    objects,
 		}
+
+		if err := p.PrintObj(resourceList, out); err != nil {
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/11377

Running a command such as
`oc new-app https://myrepo -o yaml | oc set env -f - MYVAR=value -o
yaml` will not return a set of resources in an `api.List`, but rather
print them out individually. This prevents all items from being piped to
another `oc` command successfully, as only the last item will be parsed.

This patch appends all resources to an api.List before printing.

cc @openshift/cli-review @csrwng