### PR TITLE
default sourceSecret admission plugin

### DIFF
--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -95,8 +95,6 @@ func (a *buildDefaults) Admit(attributes admission.Attributes) error {
 
 func (a *buildDefaults) applyBuildDefaults(build *buildapi.Build) {
 	// Apply default env
-
-	glog.V(5).Infof("MJ TEST")
 	buildEnv := getBuildEnv(build)
 	for _, envVar := range a.defaultsConfig.Env {
 		glog.V(5).Infof("Adding default environment variable %s=%s to build %s/%s", envVar.Name, envVar.Value, build.Namespace, build.Name)
@@ -141,7 +139,7 @@ func (a *buildDefaults) applyBuildDefaults(build *buildapi.Build) {
 	if len(a.defaultsConfig.GitNoProxy) != 0 {
 		if build.Spec.Source.Git.NoProxy == nil {
 			t := a.defaultsConfig.GitNoProxy
-			glog.V(5).Infof("Setting default GIT no proxy of build %s/%s to %s", build.Namespace, build.Name, t)
+			glog.V(5).Infof("Setting default Git no proxy of build %s/%s to %s", build.Namespace, build.Name, t)
 			build.Spec.Source.Git.NoProxy = &t
 		}
 	}

--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -16,6 +16,7 @@ import (
 
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
+	//clientcache "k8s.io/kubernetes/pkg/client/cache"
 )
 
 func init() {
@@ -25,6 +26,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+		//	c.Core().Pods(pod.Namespace).Delete(pod.Name, &api.DeleteOptions{GracePeriodSeconds: &zero})
 
 		glog.V(5).Infof("Initializing BuildDefaults plugin with config: %#v", defaultsConfig)
 		return NewBuildDefaults(defaultsConfig), nil
@@ -48,6 +50,7 @@ type buildDefaults struct {
 	*admission.Handler
 	defaultsConfig *defaultsapi.BuildDefaultsConfig
 	cache          *projectcache.ProjectCache
+	//	secretsNamespacer clientcache.Store
 }
 
 // NewBuildDefaults returns an admission control for builds that sets build defaults
@@ -93,6 +96,8 @@ func (a *buildDefaults) Admit(attributes admission.Attributes) error {
 
 func (a *buildDefaults) applyBuildDefaults(build *buildapi.Build) {
 	// Apply default env
+
+	glog.V(5).Infof("MJ TEST")
 	buildEnv := getBuildEnv(build)
 	for _, envVar := range a.defaultsConfig.Env {
 		glog.V(5).Infof("Adding default environment variable %s=%s to build %s/%s", envVar.Name, envVar.Value, build.Namespace, build.Name)
@@ -147,7 +152,7 @@ func (a *buildDefaults) applyBuildDefaults(build *buildapi.Build) {
 	secret, err := a.setDefaultSourceSecret(build)
 	if err == nil {
 		if build.Spec.Source.SourceSecret == nil {
-			glog.V(5).Infof("Setting default Git SourceSecret  %s/%s to %s", build.Namespace, build.Name, secret)
+			glog.V(5).Infof("Setting default Git sourceSecret  %s/%s to %s", build.Namespace, build.Name, secret)
 			//var ss kapi.LocalObjectReference
 			t := secret
 			build.Spec.Source.SourceSecret.Name = t

--- a/pkg/build/admission/defaults/admission.go
+++ b/pkg/build/admission/defaults/admission.go
@@ -221,7 +221,7 @@ func (a *buildDefaults) setDefaultSourceSecret(build *buildapi.Build) (string, e
 }
 
 func contains(s map[string]string, e string) bool {
-	for k, _ := range s {
+	for k := range s {
 		if k == e {
 			return true
 		}

--- a/pkg/build/admission/defaults/api/types.go
+++ b/pkg/build/admission/defaults/api/types.go
@@ -20,6 +20,9 @@ type BuildDefaultsConfig struct {
 	// GitNoProxy is the list of domains for which the proxy should not be used
 	GitNoProxy string
 
+	//SourceSecret sets default build source secret if none is set. For corporate env where everything is secure
+	SourceSecret string
+
 	// Env is a set of default environment variables that will be applied to the
 	// build if the specified variables do not exist on the build
 	Env []kapi.EnvVar

--- a/pkg/build/admission/defaults/api/v1/swagger_doc.go
+++ b/pkg/build/admission/defaults/api/v1/swagger_doc.go
@@ -10,6 +10,7 @@ var map_BuildDefaultsConfig = map[string]string{
 	"gitHTTPProxy":  "GitHTTPProxy is the location of the HTTPProxy for Git source",
 	"gitHTTPSProxy": "GitHTTPSProxy is the location of the HTTPSProxy for Git source",
 	"gitNoProxy":    "GitNoProxy is the list of domains for which the proxy should not be used",
+	"sourceSecret":  "SourceSecret sets default build source secret if none is set. For corporate env where everything is secure",
 	"env":           "Env is a set of default environment variables that will be applied to the build if the specified variables do not exist on the build",
 	"sourceStrategyDefaults": "SourceStrategyDefaults are default values that apply to builds using the source strategy.",
 	"imageLabels":            "ImageLabels is a list of docker labels that are applied to the resulting image. User can override a default label by providing a label with the same name in their Build/BuildConfig.",

--- a/pkg/build/admission/defaults/api/v1/types.go
+++ b/pkg/build/admission/defaults/api/v1/types.go
@@ -20,6 +20,9 @@ type BuildDefaultsConfig struct {
 	// GitNoProxy is the list of domains for which the proxy should not be used
 	GitNoProxy string `json:"gitNoProxy,omitempty"`
 
+	//SourceSecret sets default build source secret if none is set. For corporate env where everything is secure
+	SourceSecret string `json:"sourceSecret,omitempty"`
+
 	// Env is a set of default environment variables that will be applied to the
 	// build if the specified variables do not exist on the build
 	Env []kapi.EnvVar `json:"env,omitempty"`


### PR DESCRIPTION
POC for default build secret for build.

2 outstanding questions:
first: if I add defualt secret, build fails, because secret is not mounted. How and where secret get mounted as volumes?
second: how I can initiate k8s client to list all available secrets in the project? I would like to check if secret exist before setting it.

previous pull request where we discussed this one:
https://github.com/openshift/origin/pull/11275
@jim-minter @bparees @liggitt @csrwng 