### PR TITLE
dind: bump deployment timeout

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -222,7 +222,8 @@ function wait-for-cluster() {
 
   local msg="${expected_node_count} nodes to report readiness"
   local condition="nodes-are-ready ${kubeconfig} ${oc} ${expected_node_count}"
-  os::util::wait-for-condition "${msg}" "${condition}"
+  local timeout=60
+  os::util::wait-for-condition "${msg}" "${condition}" "${timeout}"
 }
 
 function nodes-are-ready() {

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -222,7 +222,7 @@ function wait-for-cluster() {
 
   local msg="${expected_node_count} nodes to report readiness"
   local condition="nodes-are-ready ${kubeconfig} ${oc} ${expected_node_count}"
-  local timeout=60
+  local timeout=120
   os::util::wait-for-condition "${msg}" "${condition}" "${timeout}"
 }
 

--- a/images/dind/master/openshift-disable-master-node.sh
+++ b/images/dind/master/openshift-disable-master-node.sh
@@ -19,7 +19,7 @@ function disable-node() {
 
   local msg="${node_name} to register with the master"
   local condition="is-node-registered ${config} ${node_name}"
-  os::util::wait-for-condition "${msg}" "${condition}" "${OS_WAIT_FOREVER}"
+  os::util::wait-for-condition "${msg}" "${condition}"
 
   echo "Disabling scheduling for node ${node_name}"
   /usr/local/bin/osadm --config="${config}" manage-node "${node_name}" --schedulable=false > /dev/null

--- a/images/dind/node/openshift-dind-lib.sh
+++ b/images/dind/node/openshift-dind-lib.sh
@@ -12,17 +12,15 @@
 #  - 1: message indicating what conditions is being waited for (e.g. 'config to be written')
 #  - 2: a string representing an eval'able condition.  When eval'd it should not output
 #       anything to stdout or stderr.
-#  - 3: optional timeout in seconds.  If not provided, defaults to 60s.  If OS_WAIT_FOREVER
-#       is provided, wait forever.
+#  - 3: optional timeout in seconds.  If not provided, waits forever.
 # Returns:
 #  1 if the condition is not met before the timeout
-readonly OS_WAIT_FOREVER=-1
 function os::util::wait-for-condition() {
   local msg=$1
   # condition should be a string that can be eval'd.  When eval'd, it
   # should not output anything to stderr or stdout.
   local condition=$2
-  local timeout=${3:-60}
+  local timeout=${3:-}
 
   local start_msg="Waiting for ${msg}"
   local error_msg="[ERROR] Timeout waiting for ${msg}"
@@ -33,10 +31,9 @@ function os::util::wait-for-condition() {
       echo "${start_msg}"
     fi
 
-    if [[ "${counter}" -lt "${timeout}" ||
-            "${timeout}" = "${OS_WAIT_FOREVER}" ]]; then
+    if [[ -z "${timeout}" || "${counter}" -lt "${timeout}" ]]; then
       counter=$((counter + 1))
-      if [[ "${timeout}" != "${OS_WAIT_FOREVER}" ]]; then
+      if [[ -n "${timeout}" ]]; then
         echo -n '.'
       fi
       sleep 1
@@ -46,7 +43,7 @@ function os::util::wait-for-condition() {
     fi
   done
 
-  if [[ "${counter}" != "0" && "${timeout}" != "${OS_WAIT_FOREVER}" ]]; then
+  if [[ "${counter}" != "0" && -n "${timeout}" ]]; then
     echo -e '\nDone'
   fi
 }

--- a/images/dind/node/openshift-enable-ssh-access.sh
+++ b/images/dind/node/openshift-enable-ssh-access.sh
@@ -15,7 +15,7 @@ if os::util::is-master; then
 else
   # Wait for the master to generate the keypair
   CONDITION="test -f ${PUBLIC_KEY}"
-  os::util::wait-for-condition "public key to be generated" "${CONDITION}" "${OS_WAIT_FOREVER}"
+  os::util::wait-for-condition "public key to be generated" "${CONDITION}"
 fi
 
 mkdir -p /root/.ssh

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -33,7 +33,7 @@ function ensure-node-config() {
 
     # Wait for the master to generate its config
     local condition="test -f ${master_config_file}"
-    os::util::wait-for-condition "admin config" "${condition}" "${OS_WAIT_FOREVER}"
+    os::util::wait-for-condition "admin config" "${condition}"
 
     local master_host
     master_host="$(grep server "${master_config_file}" | grep -v localhost | awk '{print $2}')"

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -82,7 +82,7 @@ function save-container-logs() {
     if [[ ! -d "${dest_dir}" ]]; then
       mkdir -p "${dest_dir}"
     fi
-    sudo docker exec -t "${container_name}" bash -c "journalctl -xe | \
+    sudo docker exec -t "${container_name}" bash -c "journalctl | \
 gzip > ${container_log_file}"
     sudo docker cp "${container_name}:${container_log_file}" "${dest_dir}"
     # Output container logs to stdout to ensure that jenkins has


### PR DESCRIPTION
A recent ci failure indicated that nodes did not become ready in the expected 60s.  The systemd logs didn't indicate a problem - the nodes had become ready - but likely just needed more than 60s to do so.  60s might have been enough time to wait for node readiness when all nodes were already configured, but the recent refactor means that the time required for configuration generation needs to be accounted for.  This change bumps the timeout to 120s.

cc: @openshift/networking 