### PR TITLE
Don't give builds/custom access to system:authenticated by default

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -959,11 +959,6 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
 		},
 		{
-			ObjectMeta: kapi.ObjectMeta{Name: BuildStrategyCustomRoleBindingName},
-			RoleRef:    kapi.ObjectReference{Name: BuildStrategyCustomRoleName},
-			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
-		},
-		{
 			ObjectMeta: kapi.ObjectMeta{Name: BuildStrategySourceRoleBindingName},
 			RoleRef:    kapi.ObjectReference{Name: BuildStrategySourceRoleName},
 			Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -59,22 +59,24 @@ os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/custom' 
 os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/source' 'namespaced-user'
 os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/jenkinspipeline' 'namespaced-user'
 os::cmd::expect_success_and_text     'oadm policy who-can create builds/docker' 'system:authenticated'
-os::cmd::expect_success_and_text     'oadm policy who-can create builds/custom' 'system:authenticated'
 os::cmd::expect_success_and_text     'oadm policy who-can create builds/source' 'system:authenticated'
 os::cmd::expect_success_and_text     'oadm policy who-can create builds/jenkinspipeline' 'system:authenticated'
 # if this method for removing access to docker/custom/source/jenkinspipeline builds changes, docs need to be updated as well
-os::cmd::expect_success 'oadm policy remove-cluster-role-from-group system:build-strategy-custom system:authenticated'
 os::cmd::expect_success 'oadm policy remove-cluster-role-from-group system:build-strategy-docker system:authenticated'
 os::cmd::expect_success 'oadm policy remove-cluster-role-from-group system:build-strategy-source system:authenticated'
 os::cmd::expect_success 'oadm policy remove-cluster-role-from-group system:build-strategy-jenkinspipeline system:authenticated'
 # ensure build strategy permissions no longer exist
 os::cmd::try_until_failure           'oadm policy who-can create builds/source | grep system:authenticated'
 os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/docker' 'system:authenticated'
-os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/custom' 'system:authenticated'
 os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/source' 'system:authenticated'
 os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/jenkinspipeline' 'system:authenticated'
-os::cmd::expect_success 'oadm policy reconcile-cluster-role-bindings --confirm'
 
+# ensure system:authenticated users can not create custom builds by default, but can if explicitly granted access
+os::cmd::expect_success_and_not_text 'oadm policy who-can create builds/custom' 'system:authenticated'
+os::cmd::expect_success 'oadm policy add-cluster-role-to-group system:build-strategy-custom system:authenticated'
+os::cmd::expect_success_and_text 'oadm policy who-can create builds/custom' 'system:authenticated'
+
+os::cmd::expect_success 'oadm policy reconcile-cluster-role-bindings --confirm'
 
 os::cmd::expect_success_and_text 'oc policy can-i --list' 'get update.*imagestreams/layers'
 os::cmd::expect_success_and_text 'oc policy can-i create pods --all-namespaces' 'yes'

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -248,19 +248,6 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
-    name: system:build-strategy-custom-binding
-  roleRef:
-    name: system:build-strategy-custom
-  subjects:
-  - kind: SystemGroup
-    name: system:authenticated
-  userNames: null
-- apiVersion: v1
-  groupNames:
-  - system:authenticated
-  kind: ClusterRoleBinding
-  metadata:
-    creationTimestamp: null
     name: system:build-strategy-source-binding
   roleRef:
     name: system:build-strategy-source


### PR DESCRIPTION
Updated bootstrap policy to not grant builds/custom privs for system:authenticated users by default
Permissions can still be granted by an administrator if needed

Fixes bug 1380462 - https://bugzilla.redhat.com/show_bug.cgi?id=1380462
