### PR TITLE
Updating error message and indentation

### DIFF
--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -2,7 +2,7 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3.0."* ]]; then
-  echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
+  echo "Generating protobuf requires protoc 3.0.x. Please download and"
   echo "install the platform appropriate Protobuf package for your OS: "
   echo
   echo "  https://github.com/google/protobuf/releases"


### PR DESCRIPTION
Updating error message to exclude usage of protoc newer than the 3.0* range.

Also updated some indentation