### PR TITLE
Check if hostBits equals zero and add some test cases

### DIFF
--- a/pkg/util/netutils/subnet_allocator.go
+++ b/pkg/util/netutils/subnet_allocator.go
@@ -25,7 +25,9 @@ func NewSubnetAllocator(network string, hostBits uint32, inUse []string) (*Subne
 	}
 
 	netMaskSize, _ := netIP.Mask.Size()
-	if hostBits > (32 - uint32(netMaskSize)) {
+	if hostBits == 0 {
+		return nil, fmt.Errorf("Host capacity cannot be zero.")
+	} else if hostBits > (32 - uint32(netMaskSize)) {
 		return nil, fmt.Errorf("Subnet capacity cannot be larger than number of networks available.")
 	}
 	subnetBits := 32 - uint32(netMaskSize) - hostBits

--- a/pkg/util/netutils/subnet_allocator_test.go
+++ b/pkg/util/netutils/subnet_allocator_test.go
@@ -144,6 +144,44 @@ func TestAllocateSubnetOverlapping(t *testing.T) {
 	}
 }
 
+// 10.1.HHHHHHHH.HHHHHHHH
+func TestAllocateSubnetNoSubnetBits(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 16, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/16" {
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
+	}
+
+	sn, err = sna.GetNetwork()
+	if err == nil {
+		t.Fatalf("Unexpectedly succeeded in getting network (sn=%s)", sn.String())
+	}
+}
+
+func TestAllocateSubnetInvalidHostBitsOrCIDR(t *testing.T) {
+	_, err := NewSubnetAllocator("10.1.0.0/16", 18, nil)
+	if err == nil {
+		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
+	}
+
+	_, err = NewSubnetAllocator("10.1.0.0/16", 0, nil)
+	if err == nil {
+		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
+	}
+
+	_, err = NewSubnetAllocator("10.1.0.0/33", 16, nil)
+	if err == nil {
+		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
+	}
+}
+
 func TestAllocateSubnetInUse(t *testing.T) {
 	inUse := []string{"10.1.0.0/24", "10.1.2.0/24", "10.2.2.2/24", "Invalid"}
 	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, inUse)


### PR DESCRIPTION
When creating a new subnet allocator, the parameter `hostBits` should not be zero.

This PR:
1. adds a condition to check if `hostBits` equals zero.
2. adds a test case to test that when there is no subnet bits, e.g. `10.1.HHHHHHHH.HHHHHHHH`
3. adds a test case to test invalid cases: invalid hostBits or invalid CIDR.