### PR TITLE
oc new-app --search: don't require docker hub access

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -213,6 +213,8 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 		if image.Status.Status != unversioned.StatusSuccess {
 			glog.V(4).Infof("image import failed: %#v", image)
 			switch image.Status.Reason {
+			case unversioned.StatusReasonInternalError:
+				glog.Warningf("Docker registry lookup failed: %s", image.Status.Message)
 			case unversioned.StatusReasonInvalid, unversioned.StatusReasonUnauthorized, unversioned.StatusReasonNotFound:
 			default:
 				errs = append(errs, fmt.Errorf("can't look up Docker image %q: %s", term, image.Status.Message))


### PR DESCRIPTION
When using oc new-app --search in environment where OpenShift server could not reach Docker Hub, oc new-app --search had failed for any query.  This commit changes the behavior to print a warning and continue with what was found in other sources.

Fixes bug 1378647.