### PR TITLE
Do not use "*" as DockerImageReference.Name for ImageStreamImport

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -75,7 +75,7 @@ func (r DockerClientSearcher) Search(precise bool, terms ...string) (ComponentMa
 		termMatches := ScoredComponentMatches{}
 
 		// first look for the image in the remote docker registry
-		if r.RegistrySearcher != nil {
+		if r.RegistrySearcher != nil && ref.String() != "*" {
 			glog.V(4).Infof("checking remote registry for %q", ref.String())
 			matches, err := r.RegistrySearcher.Search(precise, term)
 			errs = append(errs, err...)


### PR DESCRIPTION
Fix #11418 

@miminar @soltysh please review.