### PR TITLE
WIP: Plugin ext test to image eco

### DIFF
--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -13,7 +13,6 @@ import (
 	_ "github.com/openshift/origin/test/extended/image_ecosystem"
 	_ "github.com/openshift/origin/test/extended/imageapis"
 	_ "github.com/openshift/origin/test/extended/images"
-	_ "github.com/openshift/origin/test/extended/jenkins"
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/networking"

--- a/test/extended/image_ecosystem/kubernetes_plugin.go
+++ b/test/extended/image_ecosystem/kubernetes_plugin.go
@@ -1,4 +1,4 @@
-package jenkins
+package image_ecosystem
 
 import (
 	"encoding/json"
@@ -50,7 +50,7 @@ func patchTemplate(filename string, outDir string) string {
 	return outputFile
 }
 
-var _ = g.Describe("[jenkins] schedule jobs on pod slaves", func() {
+var _ = g.Describe("[image_ecosystem][jenkins] schedule jobs on pod slaves", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/image_ecosystem/plugin.go
+++ b/test/extended/image_ecosystem/plugin.go
@@ -1,4 +1,4 @@
-package jenkins
+package image_ecosystem
 
 import (
 	g "github.com/onsi/ginkgo"
@@ -29,6 +29,7 @@ func getAdminPassword(oc *exutil.CLI) string {
 			return s[1]
 		}
 	}
+	// use the image default of password if not set
 	return "password"
 }
 
@@ -119,7 +120,7 @@ func jenkinsJobBytes(filename, namespace string) []byte {
 	return data
 }
 
-var _ = g.Describe("[jenkins][Slow] openshift pipeline plugin", func() {
+var _ = g.Describe("[image_ecosystem][jenkins][Slow] openshift pipeline plugin", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("jenkins-plugin", exutil.KubeConfigPath())
 	var hostPort string


### PR DESCRIPTION
@bparees @csrwng @jupierce @oatmealraisin FYI

this is the commit I mentioned that fixes the kubernetes_plugin.go test and *starts* the move of the jenkins extended tests to image_ecosystem.

my plan is to run a series of test runs out of this PR to get a sense of the stability of the kubernetes_plugin.go test, and if it proves stable enough, move it to image_ecosystem as well. Then, once each of your respective extended test PRs merge, I'll rebase your PRs on top of this and ultimately ask that this PR be considered for merging.

thanks