### PR TITLE
Fixes issue #10108 - make check failing with go-bindata not found

### DIFF
--- a/hack/update-generated-bootstrap-bindata.sh
+++ b/hack/update-generated-bootstrap-bindata.sh
@@ -2,6 +2,8 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+os::build::setup_env
+
 EXAMPLES=examples
 OUTPUT_PARENT=${OUTPUT_ROOT:-$OS_ROOT}
 


### PR DESCRIPTION
Adds os::build::setup_env to hack/update-generated-bootstrap-bindata.sh
which ensures that the GOPATH env variable is set and not empty