### PR TITLE
Work around broken run --attach for now

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -327,15 +327,23 @@ os::cmd::expect_success 'oc whoami'
 echo "[INFO] Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
 oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
+#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+os::cmd::expect_success_and_text "oc logs cli-with-token" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "oc logs cli-with-token" 'In project test'
 os::cmd::expect_success 'oc delete pod cli-with-token'
 oc run cli-with-token-2 --attach --image="openshift/origin:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
+#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+os::cmd::expect_success_and_text "oc logs cli-with-token-2" 'system:serviceaccount:test:default'
 os::cmd::expect_success 'oc delete pod cli-with-token-2'
 oc run kubectl-with-token --attach --image="openshift/origin:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
+# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
+#os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+#os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
+os::cmd::expect_success_and_text "oc logs kubectl-with-token" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "oc logs kubectl-with-token" 'kubectl-with-token'
 
 echo "[INFO] Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors


### PR DESCRIPTION
Work around an issue with `oc run --attach` not always showing all the output from the container.

xref #11240 

@smarterclayton @liggitt @mfojtik @kargakis @soltysh @pweil- @bparees @stevekuznetsov 