### PR TITLE
Add compression to haproxy v2

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -68,6 +68,15 @@ defaults
   timeout tunnel 1h
 {{ end }}
 
+{{ if ne (env "ROUTER_ENABLE_COMPRESSION" "") ""}}
+  # enable compression.
+  # http://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4-compression
+  compression algo gzip
+  {{ with  $mimeType := (env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css") }}  
+  compression type {{$mimeType}}  
+  {{end}}
+{{end}}
+
 {{ if (gt .StatsPort 0) }}
 listen stats :{{.StatsPort}}
 {{ else }}


### PR DESCRIPTION
The original discussion was in pr  #11272 .
This pr exists because github interface have no **git stash** possibility.