### PR TITLE
Atomic registry systemd install bugfixes 

### DIFF
--- a/examples/atomic-registry/systemd/services/unit_files/atomic-registry-master.service
+++ b/examples/atomic-registry/systemd/services/unit_files/atomic-registry-master.service
@@ -10,7 +10,7 @@ Wants=atomic-registry.service
 EnvironmentFile=/etc/sysconfig/atomic-registry-master
 Environment=GOTRACEBACK=crash
 ExecStartPre=-/usr/bin/docker rm -f atomic-registry-master
-ExecStart=/usr/bin/docker run --rm --privileged --name atomic-registry-master -p ${MASTERPORT}:${MASTERPORT} --env-file=/etc/sysconfig/atomic-registry-master -v /var/lib/atomic-registry/etcd:/var/lib/atomic-registry/etcd -v /etc/atomic-registry/:/etc/atomic-registry/ ${MASTERIMAGE}:${MASTERTAG} start master --config=/etc/atomic-registry/master/master-config.yaml $OPTIONS
+ExecStart=/usr/bin/docker run --rm --privileged --name atomic-registry-master -p ${MASTERPORT}:${MASTERPORT} --env-file=/etc/sysconfig/atomic-registry-master -v /var/lib/atomic-registry/etcd:/var/lib/atomic-registry/etcd -v /etc/atomic-registry/:/etc/atomic-registry/ -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro ${MASTERIMAGE}:${MASTERTAG} start master --config=/etc/atomic-registry/master/master-config.yaml $OPTIONS
 ExecStop=/usr/bin/docker stop atomic-registry-master
 LimitNOFILE=131072
 LimitCORE=infinity

--- a/examples/atomic-registry/systemd/services/unit_files/atomic-registry.service
+++ b/examples/atomic-registry/systemd/services/unit_files/atomic-registry.service
@@ -7,7 +7,7 @@ Requires=docker.service
 [Service]
 EnvironmentFile=/etc/sysconfig/atomic-registry
 ExecStartPre=-/usr/bin/docker rm -f atomic-registry
-ExecStart=/usr/bin/docker run --rm --env-file=/etc/sysconfig/atomic-registry --name atomic-registry -p ${REGISTRYPORT}:${REGISTRYPORT} --net=host -v /var/lib/atomic-registry/registry:/registry:Z -v /etc/atomic-registry/registry:/etc/atomic-registry/registry -v /etc/atomic-registry/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount -u 1001 ${REGISTRYIMAGE}:${REGISTRYTAG}
+ExecStart=/usr/bin/docker run --rm --env-file=/etc/sysconfig/atomic-registry --name atomic-registry -p ${REGISTRYPORT}:${REGISTRYPORT} --net=host -v /var/lib/atomic-registry/registry:/registry:Z -v /etc/atomic-registry/registry:/etc/atomic-registry/registry -v /etc/atomic-registry/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro -u 1001 ${REGISTRYIMAGE}:${REGISTRYTAG}
 ExecStop=/usr/bin/docker stop atomic-registry
 LimitNOFILE=131072
 LimitCORE=infinity

--- a/examples/atomic-registry/systemd/setup-atomic-registry.sh
+++ b/examples/atomic-registry/systemd/setup-atomic-registry.sh
@@ -7,7 +7,7 @@ CONSOLEPORT=$(awk -F '=' '/CONSOLEPORT/ {print $2}' /etc/sysconfig/atomic-regist
 
 # we're running this on the host
 # the commands will be exec'd in the master container that has the oc client
-CMD="docker exec -it"
+CMD="docker exec"
 
 # boostrap the registry components using the supported command
 # we'll delete the dc and service components later


### PR DESCRIPTION
Do not use TTY during install to support unattended installs
Bindmount /etc/pki/ca-trust from host

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>