### PR TITLE
removing unused default variables

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -50,9 +50,6 @@ const (
 
 	defaultRedirectClient  = "openshift-web-console"
 	developmentRedirectURI = "https://localhost:9000"
-
-	defaultImages         = "openshift/origin-${component}:${version}"
-	defaultOpenShiftImage = "openshift/origin:${version}"
 )
 
 var (


### PR DESCRIPTION
These variables are no longer used and prove confusing when trying to update the code to supply a different default image to use.