### PR TITLE
Clarify how we handle compression as a router env

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -68,9 +68,7 @@ defaults
   timeout tunnel 1h
 {{ end }}
 
-{{ if ne (env "ROUTER_ENABLE_COMPRESSION" "") ""}}
-  # enable compression.
-  # http://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4-compression
+{{ if (matchPattern "true|TRUE" (env "ROUTER_ENABLE_COMPRESSION" "false")) }}
   compression algo gzip
   {{ with  $mimeType := (env "ROUTER_COMPRESSION_MIME" "text/html text/plain text/css") }}  
   compression type {{$mimeType}}  


### PR DESCRIPTION
This just cleans up how we handle compression support in the haproxy
config to make it more like the existing code.  There is no functional
change.

The original code just went in as https://github.com/openshift/origin/pull/11469
