### PR TITLE
tests: wait_for_registry: use oc rollout status

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -247,15 +247,6 @@ function install_registry() {
 }
 readonly -f install_registry
 
-function wait_for_registry() {
-	local generation="$(oc get dc/docker-registry -o 'jsonpath={.metadata.generation}')"
-	local onereplicajs='{.status.observedGeneration},{.status.replicas},{.status.updatedReplicas},{.status.availableReplicas}'
-	wait_for_command "oc get dc/docker-registry -o 'jsonpath=${onereplicajs}' --config='${ADMIN_KUBECONFIG}' | grep '^${generation},1,1,1$'"  "$((5*TIME_MIN))"
-	local readyjs='{.items[*].status.conditions[?(@.type=="Ready")].status}'
-	wait_for_command "oc get pod -l deploymentconfig=docker-registry -o 'jsonpath=${readyjs}' --config='${ADMIN_KUBECONFIG}' | grep -qi true" "${TIME_MIN}"
-}
-readonly -f wait_for_registry
-
 # Wait for builds to start
 # $1 namespace
 function os::build:wait_for_start() {

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -82,7 +82,7 @@ os::cmd::expect_success "openshift admin policy add-scc-to-user privileged -z ip
 os::cmd::expect_success "openshift admin ipfailover --images='${USE_IMAGES}' --virtual-ips='1.2.3.4' --service-account=ipfailover"
 
 echo "[INFO] Waiting for Docker registry pod to start"
-wait_for_registry
+os::cmd::expect_success 'oc rollout status dc/docker-registry'
 
 echo "[INFO] Waiting for IP failover to deploy"
 os::cmd::expect_success 'oc rollout status dc/ipfailover'
@@ -536,7 +536,7 @@ echo "[INFO] Validated image pruning"
 echo "[INFO] Configure registry to accept manifest V2 schema 2"
 os::cmd::expect_success "oc project '${CLUSTER_ADMIN_CONTEXT}'"
 os::cmd::expect_success 'oc env -n default dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2=true'
-wait_for_registry
+os::cmd::expect_success 'oc rollout status dc/docker-registry'
 echo "[INFO] Registry configured to accept manifest V2 schema 2"
 
 echo "[INFO] Accept manifest V2 schema 2"

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -38,7 +38,7 @@ oc login -u system:admin -n default
 oadm policy add-role-to-group view system:authenticated -n default
 
 install_registry
-wait_for_registry
+oc rollout status dc/docker-registry
 docker_registry="$( oc get service/docker-registry -n default -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}' )"
 
 os::test::junit::declare_suite_start "extended/cmd"

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -89,7 +89,7 @@ os::start::server
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 
 install_registry
-wait_for_registry
+os::cmd::expect_success 'oc rollout status dc/docker-registry'
 
 os::cmd::expect_success 'oc login -u system:admin'
 os::cmd::expect_success "oc new-project ${project_name}"

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -33,7 +33,7 @@ os::start::server
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 
 install_registry
-wait_for_registry
+oc rollout status dc/docker-registry
 
 oc login ${MASTER_ADDR} -u ldap -p password --certificate-authority=${MASTER_CONFIG_DIR}/ca.crt
 oc new-project openldap

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -120,7 +120,7 @@ function os::test::extended::setup () {
 
 		install_registry
 		if [[ -z "${SKIP_NODE:-}" ]]; then
-			wait_for_registry
+			oc rollout status dc/docker-registry
 		fi
 		DROP_SYN_DURING_RESTART=1 CREATE_ROUTER_CERT=1 install_router
 


### PR DESCRIPTION
Prevents the function from hanging when observedGeneration is higher than the number we're waiting for.

Fixes #11406
Related to #11410
