### PR TITLE
Make extended test build optional in origin.spec

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -35,6 +35,9 @@
 %global make_redistributable 1
 %endif
 
+# by default build the test binaries for Origin
+%{!?build_tests: %global build_tests 1 }
+
 %if "%{dist}" == ".el7aos"
 %global package_name atomic-openshift
 %global product_name Atomic OpenShift
@@ -97,12 +100,14 @@ Obsoletes:      openshift-master < %{package_refector_version}
 %description master
 %{summary}
 
+%if 0%{build_tests}
 %package tests
 Summary: %{product_name} Test Suite
 Requires:       %{name} = %{version}-%{release}
 
 %description tests
 %{summary}
+%endif
 
 %package node
 Summary:        %{product_name} Node
@@ -180,8 +185,10 @@ Obsoletes:        openshift-sdn-ovs < %{package_refector_version}
 # Create Binaries
 %{os_git_vars} hack/build-cross.sh
 
+%if 0%{build_tests}
 # Create extended.test
 %{os_git_vars} hack/build-go.sh test/extended/extended.test
+%endif
 
 %install
 
@@ -195,7 +202,9 @@ do
   install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
 done
 install -d %{buildroot}%{_libexecdir}/%{name}
+%if 0%{build_tests}
 install -p -m 755 _output/local/bin/${PLATFORM}/extended.test %{buildroot}%{_libexecdir}/%{name}/
+%endif
 
 %if 0%{?make_redistributable}
 # Install client executable for windows and mac
@@ -329,10 +338,11 @@ if [ -d "%{_sharedstatedir}/openshift" ]; then
   fi
 fi
 
+%if 0%{build_tests}
 %files tests
 %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/extended.test
-
+%endif
 
 %files master
 %{_unitdir}/%{name}-master.service


### PR DESCRIPTION
In order to support development environment and continuous
integration use cases for the tito build where the entire
extended test binary is not necessary, it is required to be
able to specify that the tito build not create it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>