### PR TITLE
sdn: don't error deleting QoS if kubelet tears down networking a second time

### DIFF
--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -113,8 +113,8 @@ del_ovs_flows() {
     ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
     ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
 
-    qos=$(ovs-vsctl get port ${veth_host} qos)
-    if [ "$qos" != "[]" ]; then
+    qos=$(ovs-vsctl get port ${veth_host} qos || true)
+    if [ -n "${qos}" -a "${qos}" != "[]" ]; then
         ovs-vsctl clear port ${veth_host} qos
         ovs-vsctl --if-exists destroy qos ${qos}
     fi


### PR DESCRIPTION
If pod teardown fails for some reason, but the network teardown was successful,
kubelet may tear down the pod networking a second time.  In this case, we
don't want to fail looking up the QoS information (since the veth is already
gone) and return an error to kubelet.
