### PR TITLE
hack/env upgrades - use rsync for sync

### DIFF
--- a/hack/env
+++ b/hack/env
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-# This script generates release zips into _output/releases. It requires the openshift/origin-release
-# image to be built prior to executing this command via hack/build-base-images.sh.
+# This starts a Docker container using the release image (openshift/origin-release:golang-1.6)
+# and syncs the local directory into that image. The default mode performs a 'git archive' of
+# the current HEAD, so you get a reproducible environment. You can also set
+# OS_BUILD_ENV_REUSE_VOLUME to a docker volume name to rsync (or docker cp) the contents of
+# the current directory into the image.
+#
+# Examples:
+#   # sync local dir into the volume and print the Docker create command
+#   $ hack/env
+#
+#   # builds the current HEAD in the container
+#   $ hack/env make
+#
+#   # builds the current HEAD and copy _output/releases back locally afterwards
+#   $ OS_BUILD_ENV_PRESERVE=_output/releases hack/env make release
+#
+#   # run all update tasks and copy the api, pkg, and docs directories back out
+#   $ OS_BUILD_ENV_PRESERVE=api:docs:pkg hack/env make update
+#
+#   # rsync the contents of the current directory into the 'local' docker volume
+#   # and iteratively build
+#   $ export OS_BUILD_ENV_REUSE_VOLUME=local
+#   $ export OS_BUILD_ENV_DOCKER_ARGS='-e OS_VERSION_FILE= '
+#   $ hack/env make # slow
+#   $ hack/env make # fast!
+#
 
 # NOTE:   only committed code is built.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.6 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.4.3 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.6.3 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=1.7.1 \
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN mkdir $TMPDIR && \
-    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc" && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Falls back to tar if the command fails. Also doc the various options and
ensure `hack/env` prints out the docker container create command as well
as performing a sync.

[merge]