### PR TITLE
UPSTREAM: 32593: Audit test fails to take into account timezone

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/apiserver/audit/audit_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/apiserver/audit/audit_test.go
@@ -95,14 +95,14 @@ func TestAudit(t *testing.T) {
 	if len(line) != 2 {
 		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
 	}
-	match, err := regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="admin" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
 	if err != nil {
 		t.Errorf("Unexpected error matching first line: %v", err)
 	}
 	if !match {
 		t.Errorf("Unexpected first line of audit: %s", line[0])
 	}
-	match, err = regexp.MatchString(`[\d\:\-\.\+]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	match, err = regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" response="200"`, line[1])
 	if err != nil {
 		t.Errorf("Unexpected error matching second line: %v", err)
 	}


### PR DESCRIPTION
Timezones cause audit_test.go to fail

[merge]