### PR TITLE
Use actual semantic versioning for Git tags

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -15,7 +15,7 @@ if [[ "${OS_RELEASE:-}" == "n" ]]; then
   imagedir="${OS_OUTPUT_BINPATH}/linux/amd64"
   # identical to build-cross.sh
   os::build::os_version_vars
-  OS_RELEASE_COMMIT="${OS_GIT_SHORT_VERSION}"
+  OS_RELEASE_COMMIT="${OS_GIT_VERSION}"
   OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
 
   echo "Building images from source ${OS_RELEASE_COMMIT}:"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -54,33 +53,12 @@ func (info Info) String() string {
 	return version
 }
 
-var (
-	reCommitSegment   = regexp.MustCompile(`\+[0-9a-f]{6,14}$`)
-	reCommitIncrement = regexp.MustCompile(`^[0-9a-f]+$`)
-)
-
 // LastSemanticVersion attempts to return a semantic version from the GitVersion - which
 // is either <semver>+<commit> or <semver> on release boundaries.
 func (info Info) LastSemanticVersion() string {
 	version := info.GitVersion
-	parts := strings.Split(version, "-")
-	// strip the modifier
-	if len(parts) > 1 && parts[len(parts)-1] == "dirty" {
-		parts = parts[:len(parts)-1]
-	}
-	// strip the Git commit
-	if len(parts) > 0 && reCommitSegment.MatchString(parts[len(parts)-1]) {
-		parts[len(parts)-1] = reCommitSegment.ReplaceAllString(parts[len(parts)-1], "")
-		if len(parts[len(parts)-1]) == 0 {
-			parts = parts[:len(parts)-1]
-		}
-		// strip a version increment, but only if we found the commit
-		if len(parts) > 1 && reCommitIncrement.MatchString(parts[len(parts)-1]) {
-			parts = parts[:len(parts)-1]
-		}
-	}
-
-	return strings.Join(parts, "-")
+	parts := strings.Split(version, "+")
+	return parts[0]
 }
 
 func init() {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -8,14 +8,16 @@ func TestLastSemanticVersion(t *testing.T) {
 	testCases := []struct {
 		in, out string
 	}{
-		{"v1.3-11+abcdef-dirty", "v1.3"},
-		{"v1.3-11+abcdef", "v1.3"},
+		{"v1.3", "v1.3"},
+		{"v1.3+dirty", "v1.3"},
+		{"v1.3-11+abcdef-dirty", "v1.3-11"},
+		{"v1.3-11+abcdef", "v1.3-11"},
 		{"v1.3-11", "v1.3-11"},
 		{"v1.3.0+abcdef", "v1.3.0"},
 		{"v1.3+abcdef", "v1.3"},
 		{"v1.3.0-alpha.1", "v1.3.0-alpha.1"},
-		{"v1.3.0-alpha.1-dirty", "v1.3.0-alpha.1"},
-		{"v1.3.0-alpha.1+abc-dirty", "v1.3.0-alpha.1+abc"},
+		{"v1.3.0-alpha.1-dirty", "v1.3.0-alpha.1-dirty"},
+		{"v1.3.0-alpha.1+abc-dirty", "v1.3.0-alpha.1"},
 		{"v1.3.0-alpha.1+abcdef-dirty", "v1.3.0-alpha.1"},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
Use --long to restore the count to binaries.  New format is:

    vX.Y.Z[-TAG]+COMMIT[-COUNT][-dirty]

Count is omitted when 0.

[test]

@stevekuznetsov 