### PR TITLE
test-cmd fails when the user is root

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -300,8 +300,10 @@ os::cmd::expect_success_and_text 'oc config view' "current-context.+/${API_HOST}
 os::cmd::expect_success 'oc logout'
 os::cmd::expect_failure_and_text 'oc get pods' '"system:anonymous" cannot list pods'
 
-# make sure we handle invalid config file destination
-os::cmd::expect_failure_and_text "oc login '${KUBERNETES_MASTER}' -u test -p test --config=/src --insecure-skip-tls-verify" 'KUBECONFIG is set to a file that cannot be created or modified'
+# make sure we report an error if the config file we pass is not writable
+templocation=$( mktemp )
+chmod uga-w "${templocation}"
+os::cmd::expect_failure_and_text "oc login '${KUBERNETES_MASTER}' -u test -p test '--config=${templocation}' --insecure-skip-tls-verify" 'KUBECONFIG is set to a file that cannot be created or modified'
 echo "login warnings: ok"
 
 # log in and set project to use from now on


### PR DESCRIPTION
The test was verifying /src was not writable, but that's not true for
all users.  Explicitly create a read only file instead.

[merge] blocks container testing