### PR TITLE
make search for bindata binary consistent

### DIFF
--- a/hack/update-generated-bootstrap-bindata.sh
+++ b/hack/update-generated-bootstrap-bindata.sh
@@ -7,7 +7,7 @@ os::build::setup_env
 EXAMPLES=examples
 OUTPUT_PARENT=${OUTPUT_ROOT:-$OS_ROOT}
 
-if [[ -z "$( which go-bindata )" ]]; then
+if [[ -z "$( os::util::find-go-binary go-bindata )" ]]; then
   pushd vendor/github.com/jteeuwen/go-bindata > /dev/null
     go install ./...
   popd > /dev/null


### PR DESCRIPTION
Instead of using `which` to find the go-bindata binary, we should be using the `os::util::find-go-binary` function.