### PR TITLE
Removed the `tryuntil` utility from our Bash libraries

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -40,27 +40,6 @@ function ensure_iptables_or_die() {
 }
 readonly -f ensure_iptables_or_die
 
-# tryuntil loops, retrying an action until it succeeds or times out after 90 seconds.
-function tryuntil() {
-	timeout=$(($(date +%s) + 90))
-	echo "++ Retrying until success or timeout: ${@}"
-	while [ 1 ]; do
-		if eval "${@}" >/dev/null 2>&1; then
-			return 0
-		fi
-		if [[ $(date +%s) -gt $timeout ]]; then
-			# run it one more time so we can display the output
-			# for debugging, since above we /dev/null the output
-			if eval "${@}"; then
-				return 0
-			fi
-			echo "++ timed out"
-			return 1
-		fi
-	done
-}
-readonly -f tryuntil
-
 # wait_for_command executes a command and waits for it to
 # complete or times out after max_wait.
 #


### PR DESCRIPTION
The old `tryuntil` utility was the least feature-full utility
for trying an action for some amount of time, and work was done
previously to remove it from use. Today we have no calls to it
in the rest of our Bash scripts, so it is finally time to get
rid of it completely. Future work to merge `wait_for_command`
and the internals of `os::cmd::try_until_success` is necessary
to leave us with only one implementation of this functionality.
Other consumers outside of the Origin repository that still use
`tryuntil` should migrate to one of the above listed functions.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>