### PR TITLE
Removing ImageChangeControllerFatalError 

### DIFF
--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -312,10 +312,7 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			retryFunc("ImageStream update", func(err error) bool {
-				_, isFatal := err.(buildcontroller.ImageChangeControllerFatalError)
-				return isFatal
-			}),
+			retryFunc("ImageStream update", nil),
 			flowcontrol.NewTokenBucketRateLimiter(1, 10),
 		),
 		Handle: func(obj interface{}) error {

--- a/pkg/build/controller/image_change_controller.go
+++ b/pkg/build/controller/image_change_controller.go
@@ -17,16 +17,6 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-// ImageChangeControllerFatalError represents a fatal error while handling an image change
-type ImageChangeControllerFatalError struct {
-	Reason string
-	Err    error
-}
-
-func (e ImageChangeControllerFatalError) Error() string {
-	return fmt.Sprintf("fatal error handling ImageStream change: %s, root error was: %s", e.Reason, e.Err.Error())
-}
-
 // ImageChangeController watches for changes to ImageRepositories and triggers
 // builds when a new version of a tag referenced by a BuildConfig
 // is available.


### PR DESCRIPTION
Removal of ImageChangeControllerFatalError and it's associated references as it is no longer used.

Opened in reference to #3309