### PR TITLE
Remove `reset_tmp_dir` function from Bash library

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -121,6 +121,7 @@ readonly -f os::util::environment::update_path_var
 #  - TMPDIR
 #  - LOG_DIR
 #  - ARTIFACT_DIR
+#  - USE_SUDO
 # Arguments:
 #  - 1: the path under the root temporary directory for OpenShift where these subdirectories should be made
 # Returns:
@@ -148,7 +149,17 @@ function os::util::environment::setup_tmpdir_vars() {
     HOME="${FAKE_HOME_DIR}"
     export HOME
 
-    mkdir -p  "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"
+    # ensure that the directories are clean
+    for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
+        if [[ "${target}" == "${BASETMPDIR}"* ]]; then
+            ${USE_SUDO:+sudo} umount "${target}"
+        fi
+    done
+
+    for directory in "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"; do
+        rm -rf "${directory}"
+        mkdir -p "${directory}"
+    done
 }
 readonly -f os::util::environment::setup_tmpdir_vars
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -108,7 +108,6 @@ export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 
 os::util::environment::setup_all_server_vars "test-cmd/"
-reset_tmp_dir
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -9,9 +9,8 @@ echo "[INFO] Starting containerized end-to-end test"
 
 unset KUBECONFIG
 
-os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
 os::util::environment::use_sudo
-reset_tmp_dir
+os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
 
 function cleanup()
 {

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -42,9 +42,8 @@ trap "cleanup" EXIT
 
 
 # Start All-in-one server and wait for health
-os::util::environment::setup_all_server_vars "test-end-to-end/"
 os::util::environment::use_sudo
-reset_tmp_dir
+os::util::environment::setup_all_server_vars "test-end-to-end/"
 
 os::log::system::start
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -7,7 +7,6 @@ os::build::setup_env
 export API_SCHEME="http"
 export API_BIND_HOST="127.0.0.1"
 os::util::environment::setup_all_server_vars "test-integration/"
-reset_tmp_dir
 
 function cleanup() {
 	out=$?

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -28,9 +28,7 @@ export API_PORT=38443
 export ETCD_PORT=34001
 export ETCD_PEER_PORT=37001
 os::util::environment::setup_all_server_vars "generate-swagger-spec/"
-reset_tmp_dir
 os::start::configure_server
-
 
 SWAGGER_SPEC_REL_DIR="${1:-}"
 SWAGGER_SPEC_OUT_DIR="${OS_ROOT}/${SWAGGER_SPEC_REL_DIR}/api/swagger-spec"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -219,27 +219,6 @@ function validate_response() {
 }
 readonly -f validate_response
 
-# reset_tmp_dir will try to delete the testing directory.
-# If it fails will unmount all the mounts associated with
-# the test.
-#
-# $1 expression for which the mounts should be checked
-function reset_tmp_dir() {
-	local sudo="${USE_SUDO:+sudo}"
-
-	set +e
-	${sudo} rm -rf ${BASETMPDIR} &>/dev/null
-	if [[ $? != 0 ]]; then
-		echo "[INFO] Unmounting previously used volumes ..."
-		findmnt -lo TARGET | grep ${BASETMPDIR} | xargs -r ${sudo} umount
-		${sudo} rm -rf ${BASETMPDIR}
-	fi
-
-	mkdir -p ${BASETMPDIR} ${LOG_DIR} ${ARTIFACT_DIR} ${FAKE_HOME_DIR} ${VOLUME_DIR}
-	set -e
-}
-readonly -f reset_tmp_dir
-
 # kill_all_processes function will kill all
 # all processes created by the test script.
 function kill_all_processes() {

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -4,7 +4,6 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::setup_all_server_vars "test-extended-alternate-certs/"
-reset_tmp_dir
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
 

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -6,7 +6,6 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::setup_all_server_vars "test-extended-alternate-launches/"
-reset_tmp_dir
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
 

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -23,9 +23,8 @@ trap "cleanup" EXIT
 
 echo "[INFO] Starting server"
 
-os::util::environment::setup_all_server_vars "test-extended/cmd/"
 os::util::environment::use_sudo
-reset_tmp_dir
+os::util::environment::setup_all_server_vars "test-extended/cmd/"
 
 os::log::system::start
 

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -10,14 +10,13 @@ test_name="test-extended/${project_name}"
 
 os::build::setup_env
 
+os::util::environment::use_sudo
 os::util::environment::setup_time_vars
 os::util::environment::setup_all_server_vars "${test_name}"
-os::util::environment::use_sudo
 
 os::log::system::start
 
 ensure_iptables_or_die
-reset_tmp_dir
 
 # TODO(skuznets): Fix vagrant openshift so env vars can be passed to this script
 JUNIT_REPORT=true

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -22,9 +22,8 @@ trap "cleanup" EXIT
 echo "[INFO] Starting server"
 
 ensure_iptables_or_die
-os::util::environment::setup_all_server_vars "test-extended/ldap_groups/"
 os::util::environment::use_sudo
-reset_tmp_dir
+os::util::environment::setup_all_server_vars "test-extended/ldap_groups/"
 
 os::log::system::start
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -292,7 +292,6 @@ else
   )
 
   os::util::environment::setup_tmpdir_vars "test-extended/networking"
-  reset_tmp_dir
 
   os::log::system::start
 

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -57,10 +57,9 @@ function os::test::extended::setup () {
 		trap "cleanup" EXIT
 		os::log::info "Starting server"
 
-		os::util::environment::setup_all_server_vars "test-extended/core"
 		os::util::environment::use_sudo
+		os::util::environment::setup_all_server_vars "test-extended/core"
 		os::util::environment::setup_images_vars
-		reset_tmp_dir
 
 		local sudo=${USE_SUDO:+sudo}
 

--- a/test/extended/testdata/gssapi/scripts/test-wrapper.sh
+++ b/test/extended/testdata/gssapi/scripts/test-wrapper.sh
@@ -11,7 +11,6 @@ export TEST_NAME="test-extended/gssapiproxy-tests/$(uname -n)-${CLIENT}-${SERVER
 os::util::environment::setup_time_vars
 os::util::environment::setup_tmpdir_vars "${TEST_NAME}"
 export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
-reset_tmp_dir
 
 # use a subshell and `if` statement to prevent `exit` calls from killing this script
 if ! ( './gssapi-tests.sh' ) 2>&1; then


### PR DESCRIPTION
In no cases did we want to set up the temporary directory
variables but continue to use dirty directories from the
last run, so it makes more sense to do the temporary dir
cleanup at the same time that we're setting up the vars.
This makes the old `reset_tmp_dir` function obsolete.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>