### PR TITLE
Remove `get_object_assert` utility from our Bash libraries

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -583,23 +583,3 @@ function os::util::base64decode() {
 	fi
 }
 readonly -f os::util::base64decode
-
-function os::util::get_object_assert() {
-	local object=$1
-	local request=$2
-	local expected=$3
-
-	res=$(eval oc get $object -o go-template=\"$request\")
-
-	if [[ "$res" =~ ^$expected$ ]]; then
-		echo "Successful get $object $request: $res"
-		return 0
-	else
-		echo "FAIL!"
-		echo "Get $object $request"
-		echo "  Expected: $expected"
-		echo "  Got:	$res"
-		return 1
-	fi
-}
-readonly -f os::util::get_object_assert


### PR DESCRIPTION
This utility function was a vestige of a failed attempt to
integrate with the upstream Kubernetes test-cmd paradigm.
We do not use it today in our tests and prefer instead to
use `os::cmd::expect_success_and_text` on a `oc get` with
a `jsonpath` query or similar.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>