### PR TITLE
restore oc login warning test-cmd

### DIFF
--- a/test/cmd/login.sh
+++ b/test/cmd/login.sh
@@ -74,8 +74,15 @@ os::cmd::expect_success 'oc logout'
 os::cmd::expect_failure_and_text 'oc get pods' '"system:anonymous" cannot list pods'
 
 # make sure we report an error if the config file we pass is not writable
-# Does not work inside of a container, determine why and reenable
-# os::cmd::expect_failure_and_text "oc login '${KUBERNETES_MASTER}' -u test -p test '--config=${templocation}/file' --insecure-skip-tls-verify" 'KUBECONFIG is set to a file that cannot be created or modified'
+# skip test altogether if running as the root user, as we are unable to verify file permission errors
+if [[ "$(id -u)" -ne 0 ]]; then
+    templocation="$( mktemp )"
+    chmod uga-w "${templocation}"
+    os::cmd::expect_failure_and_text "oc login '${KUBERNETES_MASTER}' -u test -p test '--config=${templocation}' --insecure-skip-tls-verify" 'KUBECONFIG is set to a file that cannot be created or modified'
+    echo "chattr: ok"
+else
+    echo "info: You are running as the root user. Skipping config file permission check."
+fi
 echo "login warnings: ok"
 
 # log in and set project to use from now on


### PR DESCRIPTION
Related comment: https://github.com/openshift/origin/pull/11516#discussion_r84694747

Updates [oc login warning test](https://github.com/openshift/origin/blob/master/hack/test-cmd.sh#L305) to work inside a container env.

Tested by rshing into a pod:

```
$ oc create -f test/extended/testdata/idling-echo-server.yam
$ oc rsh po/idling-echo-2-96d7a
  sh-4.2$ templocation="/tmp/testconfig"
  sh-4.2$ touch $templocation
  sh-4.2$ chmod uga-w "${templocation}"
  sh-4.2$ oc login https://10.13.137.149:8443 -u test -p test --config=${templocation} --insecure-skip-tls-verify 2>&1 | grep ""KUBECONFIG is set to a file that cannot be created or modified" && "success"
  > success
```

@openshift/cli-review 
