### PR TITLE
Improve exec/attach error message

### DIFF
--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -1,6 +1,7 @@
 package admission
 
 import (
+	"fmt"
 	"io"
 
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
@@ -48,7 +49,7 @@ func (d *sccExecRestrictions) Admit(a kadmission.Attributes) (err error) {
 	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
 	createAttributes := kadmission.NewAttributesRecord(pod, pod, kapi.Kind("Pod").WithVersion(""), a.GetNamespace(), a.GetName(), a.GetResource(), "", kadmission.Create, a.GetUserInfo())
 	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
-		return kadmission.NewForbidden(a, err)
+		return kadmission.NewForbidden(a, fmt.Errorf("%s operation is not allowed because the pod's security context exceeds your permissions: %v", a.GetSubresource(), err))
 	}
 
 	return nil


### PR DESCRIPTION
Improves the message from:
`
$ oc rsh ruby-sample-build-1-build
Error from server: pods "ruby-sample-build-1-build" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
`
to
`
$ oc rsh ruby-sample-build-1-build
Error from server: pods "ruby-sample-build-1-build" is forbidden: exec operation is not allowed because the pod's security context exceeds your permissions: unable to validate against any security context constraint: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
`