### PR TITLE
Fix regression from #9481 about defaulting prune images arguments

### DIFF
--- a/pkg/build/prune/prune.go
+++ b/pkg/build/prune/prune.go
@@ -47,6 +47,9 @@ type PrunerOptions struct {
 
 // NewPruner returns a Pruner over specified data using specified options.
 func NewPruner(options PrunerOptions) Pruner {
+	glog.V(1).Infof("Creating build pruner with keepYoungerThan=%v, orphans=%v, keepComplete=%v, keepFailed=%v",
+		options.KeepYoungerThan, options.Orphans, options.KeepComplete, options.KeepFailed)
+
 	filter := &andFilter{
 		filterPredicates: []FilterPredicate{NewFilterBeforePredicate(options.KeepYoungerThan)},
 	}

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -120,14 +120,15 @@ func (o *PruneImagesOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 		return kcmdutil.UsageError(cmd, "no arguments are allowed to this command")
 	}
 
-	if !cmd.Flags().Lookup("keep-younger-than").Changed {
-		o.KeepYoungerThan = nil
-	}
-	if !cmd.Flags().Lookup("keep-tag-revisions").Changed {
-		o.KeepTagRevisions = nil
-	}
 	if !cmd.Flags().Lookup("prune-over-size-limit").Changed {
 		o.PruneOverSizeLimit = nil
+	} else {
+		if !cmd.Flags().Lookup("keep-younger-than").Changed {
+			o.KeepYoungerThan = nil
+		}
+		if !cmd.Flags().Lookup("keep-tag-revisions").Changed {
+			o.KeepTagRevisions = nil
+		}
 	}
 	o.Namespace = kapi.NamespaceAll
 	if cmd.Flags().Lookup("namespace").Changed {

--- a/pkg/deploy/prune/prune.go
+++ b/pkg/deploy/prune/prune.go
@@ -50,6 +50,9 @@ type PrunerOptions struct {
 // NewPruner returns a Pruner over specified data using specified options.
 // deploymentConfigs, deployments, opts.KeepYoungerThan, opts.Orphans, opts.KeepComplete, opts.KeepFailed, deploymentPruneFunc
 func NewPruner(options PrunerOptions) Pruner {
+	glog.V(1).Infof("Creating deployment pruner with keepYoungerThan=%v, orphans=%v, keepComplete=%v, keepFailed=%v",
+		options.KeepYoungerThan, options.Orphans, options.KeepComplete, options.KeepFailed)
+
 	filter := &andFilter{
 		filterPredicates: []FilterPredicate{
 			FilterDeploymentsPredicate,

--- a/pkg/image/prune/prune.go
+++ b/pkg/image/prune/prune.go
@@ -244,10 +244,16 @@ func (*dryRunRegistryPinger) ping(registry string) error {
 // Also automatically remove any image layer that is no longer referenced by any
 // images.
 func NewPruner(options PrunerOptions) Pruner {
-	g := graph.New()
-
-	glog.V(1).Infof("Creating image pruner with keepYoungerThan=%v, keepTagRevisions=%v, pruneOverSizeLimit=%v",
-		options.KeepYoungerThan, options.KeepTagRevisions, options.PruneOverSizeLimit)
+	keepTagRevisions := "<nil>"
+	if options.KeepTagRevisions != nil {
+		keepTagRevisions = fmt.Sprintf("%d", *options.KeepTagRevisions)
+	}
+	pruneOverSizeLimit := "<nil>"
+	if options.PruneOverSizeLimit != nil {
+		pruneOverSizeLimit = fmt.Sprintf("%v", *options.PruneOverSizeLimit)
+	}
+	glog.V(1).Infof("Creating image pruner with keepYoungerThan=%v, keepTagRevisions=%s, pruneOverSizeLimit=%s",
+		options.KeepYoungerThan, keepTagRevisions, pruneOverSizeLimit)
 
 	algorithm := pruneAlgorithm{}
 	if options.KeepYoungerThan != nil {
@@ -261,6 +267,7 @@ func NewPruner(options PrunerOptions) Pruner {
 	}
 	algorithm.namespace = options.Namespace
 
+	g := graph.New()
 	addImagesToGraph(g, options.Images, algorithm)
 	addImageStreamsToGraph(g, options.Streams, options.LimitRanges, algorithm)
 	addPodsToGraph(g, options.Pods, algorithm)


### PR DESCRIPTION
Currently `oadm prune images` has no default arguments, but `keepTagRevisions` should be 3 and `keepYoungerThan` should be 60 mins. Upon adding `pruneOverSizeLimit` that was broken (compare to #9481, [here](https://github.com/openshift/origin/pull/9481/commits/25d167cdc48ac88246dbd99e02e66affac17efa7#diff-f412d79f61f6eacd3ce5f0a0370778a5R118) specifically), this commit fixes that problem. 
Additionally, I've added logs about what the parameters are set to other prune commands.

@miminar I've mentioned you that on IRC