### PR TITLE
Allow users to pass in `make_redistributable` to the Origin spec file

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -29,11 +29,13 @@
 %global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_MAJOR='' OS_GIT_MINOR='' OS_GIT_TREE_STATE=''
 }
 
+%{!?make_redistributable:
 %if 0%{?fedora} || 0%{?epel}
 %global make_redistributable 0
 %else
 %global make_redistributable 1
 %endif
+}
 
 %if "%{dist}" == ".el7aos"
 %global package_name atomic-openshift


### PR DESCRIPTION
In order to allow for users building the Origin RPMs on a RHEL system
to only build the native Linux binaries needed to use the RPMs for a
full install, we need to allow the user to pass in the `make_redis-
tributable` flag and only set it automatically if it is not passed in.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>