### PR TITLE
UPSTREAM: 34997: Fix kube vsphere.kerneltime

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -215,7 +215,7 @@ func readInstance(cfg *VSphereConfig) (string, string, error) {
 		var rp mo.ResourcePool
 		err = s.Properties(ctx, *vm.ResourcePool, []string{"parent"}, &rp)
 		if err == nil {
-			var ccr mo.ClusterComputeResource
+			var ccr mo.ComputeResource
 			err = s.Properties(ctx, *rp.Parent, []string{"name"}, &ccr)
 			if err == nil {
 				cluster = ccr.Name


### PR DESCRIPTION
This fixes kube-up to correctly install and configure on vSphere and
avoid panics when only a single ESX(hypervisor) is used instead of a
cluster.