### PR TITLE
Fix the typo of FatalErr

### DIFF
--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -64,7 +64,7 @@ func NewCLI(project, adminConfigPath string) *CLI {
 	client.username = "admin"
 	client.execPath = "oc"
 	if len(adminConfigPath) == 0 {
-		FatalErr(fmt.Errorf("You must set the KUBECONFIG variable to admin kubeconfig."))
+		FatalErr(fmt.Errorf("you must set the KUBECONFIG variable to admin kubeconfig"))
 	}
 	client.adminConfigPath = adminConfigPath
 


### PR DESCRIPTION
What this PR does / why we need it:
Fix the typo of FatalErr

Special notes for your reviewer:
Reference here: https://github.com/golang/go/wiki/CodeReviewComments#error-strings

Signed-off-by: yupeng yu.peng36@zte.com.cn
