### PR TITLE
UPSTREAM: 35608: Update PodAntiAffinity to ignore calls to subresources

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/antiaffinity/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/antiaffinity/admission.go
@@ -51,7 +51,8 @@ func NewInterPodAntiAffinity(client clientset.Interface) admission.Interface {
 // Admit will deny any pod that defines AntiAffinity topology key other than unversioned.LabelHostname i.e. "kubernetes.io/hostname"
 // in  requiredDuringSchedulingRequiredDuringExecution and requiredDuringSchedulingIgnoredDuringExecution.
 func (p *plugin) Admit(attributes admission.Attributes) (err error) {
-	if attributes.GetResource().GroupResource() != api.Resource("pods") {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}
 	pod, ok := attributes.GetObject().(*api.Pod)


### PR DESCRIPTION
Upon curling Pod's evict endpoint I'm getting: `Resource was marked with kind Pod but was unable to be converted` since the code in antiaffinity admission is trying to cast Pod to Eviction, which fails. This PR is a cherry-pick from upstream that fixes that problem.
