### PR TITLE
sdn: fix single-tenant pod setup and leave docker0 around

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -308,14 +308,6 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 		return false, err
 	}
 
-	// Clean up docker0 since docker won't
-	itx = ipcmd.NewTransaction(exec, "docker0")
-	itx.SetLink("down")
-	itx.IgnoreError()
-	itx.DeleteLink()
-	itx.IgnoreError()
-	_ = itx.EndTransaction()
-
 	sysctl := sysctl.New()
 
 	// Enable IP forwarding for ipv4 packets


### PR DESCRIPTION
Single-tenant needs to set vnid=0 for pod setup.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1388556

@eparis @openshift/networking 