### PR TITLE
Add additional warning for oc cluster up not being able to access port 8443

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -372,7 +372,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 	fmt.Fprintf(out, "Waiting for API server to start listening\n")
 	masterHost := fmt.Sprintf("%s:8443", opt.ServerIP)
 	if err = cmdutil.WaitForSuccessfulDial(true, "tcp", masterHost, 200*time.Millisecond, 1*time.Second, serverUpTimeout); err != nil {
-		return "", ErrTimedOutWaitingForStart(h.containerName).WithDetails(h.OriginLog())
+		return "", errors.NewError("timed out waiting for OpenShift container %q \nWARNING: %s:8443 may be blocked by firewall rules", h.containerName, opt.ServerIP).WithSolution("Ensure that you can access %s from your machine", masterHost).WithDetails(h.OriginLog())
 	}
 	// Check for healthz endpoint to be ready
 	client, err := masterHTTPClient(configDir)

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -604,7 +604,7 @@ func (c *ClientStartConfig) CheckAvailablePorts(out io.Writer) error {
 		err = c.OpenShiftHelper().TestPorts(openshift.PortsWithAlternateDNS)
 		if err == nil {
 			c.DNSPort = openshift.AlternateDNSPort
-			fmt.Fprintf(out, "WARNING: Binding DNS on port %d instead of 53, which may be not be resolvable from all clients.\n", openshift.AlternateDNSPort)
+			fmt.Fprintf(out, "WARNING: Binding DNS on port %d instead of 53, which may not be resolvable from all clients.\n", openshift.AlternateDNSPort)
 			return nil
 		}
 	}


### PR DESCRIPTION
Adding warning about port 8443 potentially being blocked by firewall rules on oc cluster up

Fixes issue #10807