### PR TITLE
Display warning instead of error if ports 80/443 in use

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -44,7 +44,8 @@ var (
 		"/sys:/sys:ro",
 		"/var/lib/docker:/var/lib/docker",
 	}
-	BasePorts             = []int{80, 443, 4001, 7001, 8443, 10250}
+	BasePorts             = []int{4001, 7001, 8443, 10250}
+	RouterPorts           = []int{80, 443}
 	DefaultPorts          = append(BasePorts, DefaultDNSPort)
 	PortsWithAlternateDNS = append(BasePorts, AlternateDNSPort)
 	SocatPidFile          = filepath.Join(homedir.HomeDir(), cliconfig.OpenShiftConfigHomeDir, "socat-8443.pid")

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -591,6 +591,12 @@ func (c *ClientStartConfig) EnsureDefaultRedirectURIs(out io.Writer) error {
 
 // CheckAvailablePorts ensures that ports used by OpenShift are available on the Docker host
 func (c *ClientStartConfig) CheckAvailablePorts(out io.Writer) error {
+	for _, port := range openshift.RouterPorts {
+		err := c.OpenShiftHelper().TestPorts([]int{port})
+		if err != nil {
+			fmt.Fprintf(out, "WARNING: Port %d is already in use and may cause routing issues for applications.\n", port)
+		}
+	}
 	err := c.OpenShiftHelper().TestPorts(openshift.DefaultPorts)
 	if err == nil {
 		c.DNSPort = openshift.DefaultDNSPort
@@ -608,6 +614,7 @@ func (c *ClientStartConfig) CheckAvailablePorts(out io.Writer) error {
 			return nil
 		}
 	}
+
 	return errors.NewError("a port needed by OpenShift is not available").WithCause(err)
 }
 


### PR DESCRIPTION
Display warnings if ports 80 and/or 443 are already in use instead of an error,
as these ports are only needed for routing requests to the applications

Replaces pull request #10717