### PR TITLE
sdn: miscellaneous fixes after the CNI merge

### DIFF
--- a/images/dind/dind-setup.sh
+++ b/images/dind/dind-setup.sh
@@ -42,4 +42,5 @@ function enable-overlay-storage() {
 }
 
 mount --make-shared /
+mount --make-shared /run
 enable-overlay-storage

--- a/pkg/sdn/plugin/cniserver/cniserver.go
+++ b/pkg/sdn/plugin/cniserver/cniserver.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
+
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
 )
 
 // *** The CNIServer is PRIVATE API between OpenShift SDN components and may be
@@ -141,7 +144,11 @@ func (s *CNIServer) Start(requestFunc cniRequestFunc) error {
 	}
 
 	s.SetKeepAlivesEnabled(false)
-	go s.Serve(l)
+	go utilwait.Forever(func() {
+		if err := s.Serve(l); err != nil {
+			utilruntime.HandleError(fmt.Errorf("CNI server Serve() failed: %v", err))
+		}
+	}, 0)
 	return nil
 }
 

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -90,7 +90,7 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR, clusterNetworkCIDR 
 	}
 	found = false
 	for _, addr := range addrs {
-		if strings.Contains(addr, localSubnetGatewayCIDR+" ") {
+		if strings.Contains(addr, localSubnetGatewayCIDR) {
 			found = true
 			break
 		}

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -207,6 +207,9 @@ func (node *OsdnNode) Start() error {
 	if err != nil {
 		return err
 	}
+	if err := node.podManager.Start(cniserver.CNIServerSocketPath); err != nil {
+		return err
+	}
 
 	if networkChanged {
 		var pods []kapi.Pod
@@ -221,10 +224,6 @@ func (node *OsdnNode) Start() error {
 				log.Warningf("Could not update pod %q (%s): %s", p.Name, containerID, err)
 			}
 		}
-	}
-
-	if err := node.podManager.Start(cniserver.CNIServerSocketPath); err != nil {
-		return err
 	}
 
 	node.markPodNetworkReady()

--- a/pkg/sdn/plugin/plugin.go
+++ b/pkg/sdn/plugin/plugin.go
@@ -8,6 +8,8 @@ import (
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	kcni "k8s.io/kubernetes/pkg/kubelet/network/cni"
 	utilsets "k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/golang/glog"
 )
 
 // This kubelet network plugin shim only exists to grab the knetwork.Host
@@ -22,7 +24,13 @@ func (node *OsdnNode) Init(host knetwork.Host, hairpinMode componentconfig.Hairp
 	node.host = host
 	node.kubeletCniPlugin = plugins[0]
 
-	return node.kubeletCniPlugin.Init(host, hairpinMode, nonMasqueradeCIDR, mtu)
+	err := node.kubeletCniPlugin.Init(host, hairpinMode, nonMasqueradeCIDR, mtu)
+
+	// Let initial pod updates happen if they need to
+	glog.V(5).Infof("openshift-sdn CNI plugin initialized")
+	close(node.kubeletInitReady)
+
+	return err
 }
 
 func (node *OsdnNode) Name() string {


### PR DESCRIPTION
The podManager must be started (so it can process requests) before we try to call Update on pods at startup if networking has changed.

Fixes: cf69a41bfed068adcd54b00bcf856120c0273c48
Fixes bug 1388856
Fixes bug 1389717
