### PR TITLE
Replace uses of `validate_reponse` with `os::cmd::try_until_text`

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -160,34 +160,6 @@ function set_curl_args() {
 }
 readonly -f set_curl_args
 
-# Search for a regular expression in a HTTP response.
-#
-# $1 - a valid URL (e.g.: http://127.0.0.1:8080)
-# $2 - a regular expression or text
-function validate_response() {
-	url=$1
-	expected_response=$2
-	wait=${3:-0.2}
-	times=${4:-10}
-
-	set +e
-	for i in $(seq 1 $times); do
-		response=`curl $url`
-		echo $response | grep -q "$expected_response"
-		if [ $? -eq 0 ]; then
-			echo "[INFO] Response is valid."
-			set -e
-			return 0
-		fi
-		sleep $wait
-	done
-
-	echo "[INFO] Response is invalid: $response"
-	set -e
-	return 1
-}
-readonly -f validate_response
-
 # kill_all_processes function will kill all
 # all processes created by the test script.
 function kill_all_processes() {

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -472,14 +472,14 @@ echo "[INFO] Validating routed app response..."
 # will be reachable via the ip of its pod.
 router_ip=$(oc get pod "${router_pod}" --template='{{.status.podIP}}')
 CONTAINER_ACCESSIBLE_API_HOST="${CONTAINER_ACCESSIBLE_API_HOST:-${router_ip}}"
-validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST} https://www.example.com" "Hello from OpenShift" 0.2 50
+os::cmd::try_until_text "curl -s -k --resolve 'www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST}' https://www.example.com" "Hello from OpenShift" "$((10*TIME_SEC))"
 # Validate that oc create route edge will create an edge terminated route.
 os::cmd::expect_success 'oc delete route/route-edge -n test'
 os::cmd::expect_success "oc create route edge --service=frontend --cert=${MASTER_CONFIG_DIR}/ca.crt \
                                               --key=${MASTER_CONFIG_DIR}/ca.key                     \
                                               --ca-cert=${MASTER_CONFIG_DIR}/ca.crt                 \
                                               --hostname=www.example.com -n test"
-validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST} https://www.example.com" "Hello from OpenShift" 0.2 50
+os::cmd::try_until_text "curl -s -k --resolve 'www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST}' https://www.example.com" "Hello from OpenShift" "$((10*TIME_SEC))"
 
 # Pod node selection
 echo "[INFO] Validating pod.spec.nodeSelector rejections"


### PR DESCRIPTION
The old `validate_response` function added no additional utility
over what could be achieved with `os::cmd::try_until_text` other
than specifying that `curl` was the executable to be used in the
test. We can safely replace uses of the old function.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton PTAL or nominate someone