### PR TITLE
Expose test build option for RPM `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,24 +237,33 @@ install-travis:
 
 # Build RPMs only for the Linux AMD64 target
 #
+# Args:
+#   BUILD_TESTS: whether or not to build a test RPM, off by default
+#
 # Example:
 #   make build-rpms
 build-rpms:
-	OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
+	BUILD_TESTS=$(BUILD_TESTS) OS_ONLY_BUILD_PLATFORMS='linux/amd64' hack/build-rpm-release.sh
 .PHONY: build-rpms
 
 # Build RPMs for all architectures
 #
+# Args:
+#   BUILD_TESTS: whether or not to build a test RPM, off by default
+#
 # Example:
 #   make build-rpms-redistributable
 build-rpms-redistributable:
-	hack/build-rpm-release.sh
+	BUILD_TESTS=$(BUILD_TESTS) hack/build-rpm-release.sh
 .PHONY: build-rpms-redistributable
 
 # Build a release of OpenShift using tito for linux/amd64 and the images that depend on it.
 #
+# Args:
+#   BUILD_TESTS: whether or not to build a test RPM, off by default
+#
 # Example:
-#   make release
+#   make release-rpms BUILD_TESTS=1
 release-rpms: clean build-rpms
 	hack/build-images.sh
 	hack/extract-release.sh

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -3,7 +3,8 @@
 # This script generates release zips and RPMs into _output/releases.
 # tito and other build dependencies are required on the host. We will
 # be running `hack/build-cross.sh` under the covers, so we transitively
-# consume all of the relevant envars.
+# consume all of the relevant envars. We also consume:
+#  - BUILD_TESTS: whether or not to build a test RPM, off by default
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::build::setup_env
 os::util::environment::setup_tmpdir_vars "build-rpm-release"
@@ -20,7 +21,7 @@ os::log::info 'Building Origin release RPMs with tito...'
 tito_tmp_dir="${BASETMPDIR}/tito"
 mkdir -p "${tito_tmp_dir}"
 tito build --output="${tito_tmp_dir}" --rpm --test --no-cleanup \
-           --rpmbuild-options="--define 'make_redistributable ${make_redistributable}'"
+           --rpmbuild-options="--define 'make_redistributable ${make_redistributable}' --define 'build_tests ${BUILD_TESTS:-0}'"
 
 os::log::info 'Unpacking tito artifacts for reuse...'
 output_directories=( $( find "${tito_tmp_dir}" -type d -name 'rpmbuild-origin*' ) )


### PR DESCRIPTION
Building an RPM with test binaries is off by default, but
users should be able to turn the option back on if they want.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton 