### PR TITLE
[DO NOT MERGE] fix deep copy on ResourceQuotasStatusByNamespace

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -295,8 +295,8 @@ func GetNodeFileReferences(config *NodeConfig) []*string {
 // client communications and increases the default QPS and burst. This is used to override
 // defaulted config supporting versions older than 1.3 for new configurations generated in 1.3+.
 func SetProtobufClientDefaults(overrides *ClientConnectionOverrides) {
-	overrides.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	overrides.ContentType = "application/vnd.kubernetes.protobuf"
+	// overrides.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	// overrides.ContentType = "application/vnd.kubernetes.protobuf"
 	overrides.QPS *= 2
 	overrides.Burst *= 2
 }

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -20,6 +20,7 @@ import (
 	ocache "github.com/openshift/origin/pkg/client/cache"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	"github.com/openshift/origin/pkg/controller/shared"
+	// quotaapi "github.com/openshift/origin/pkg/quota/api"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 )
 
@@ -58,7 +59,7 @@ var _ oadmission.Validator = &clusterQuotaAdmission{}
 
 const (
 	timeToWaitForCacheSync = 10 * time.Second
-	numEvaluatorThreads    = 10
+	numEvaluatorThreads    = 1
 )
 
 // NewClusterResourceQuota configures an admission controller that can enforce clusterQuota constraints
@@ -66,7 +67,7 @@ const (
 // are persisted by the server this admission controller is intercepting
 func NewClusterResourceQuota() (admission.Interface, error) {
 	return &clusterQuotaAdmission{
-		Handler:     admission.NewHandler(admission.Create, admission.Update),
+		Handler:     admission.NewHandler(admission.Create),
 		lockFactory: NewDefaultLockFactory(),
 	}, nil
 }
@@ -168,3 +169,14 @@ type ByName []kapi.ResourceQuota
 func (v ByName) Len() int           { return len(v) }
 func (v ByName) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
 func (v ByName) Less(i, j int) bool { return v[i].Name < v[j].Name }
+
+// func checkTotals(clusterquota *quotaapi.ClusterResourceQuota) error {
+// 	namespaceTotal := kapi.ResourceList{}
+// 	for e := clusterquota.Status.Namespaces.OrderedKeys().Front(); e != nil; e = e.Next() {
+// 		namespaceTotal = utilquota.Add(namespaceTotal, used.Used)
+// 		fldPath := field.NewPath("status", "namespaces").Key(namespace)
+// 	}
+// 	if !kapi.Semantic.DeepEqual(namespaceTotal, clusterquota.Status.Total.Used) {
+// 		allErrs = append(allErrs, field.Invalid(field.NewPath("status", "total"), clusterquota.Status, "must equal the sum of the namespace usage"))
+// 	}
+// }

--- a/pkg/quota/api/deepcopy.go
+++ b/pkg/quota/api/deepcopy.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/conversion"
+)
+
+func DeepCopy_api_ResourceQuotasStatusByNamespace(in1 interface{}, out1 interface{}, c *conversion.Cloner) error {
+	in := in1.(*ResourceQuotasStatusByNamespace)
+	out := out1.(*ResourceQuotasStatusByNamespace)
+	for e := in.OrderedKeys().Front(); e != nil; e = e.Next() {
+		namespace := e.Value.(string)
+		status, _ := in.Get(namespace)
+
+		outstatus := &kapi.ResourceQuotaStatus{}
+		kapi.DeepCopy_api_ResourceQuotaStatus(&status, outstatus, c)
+
+		if out == nil {
+			out = &ResourceQuotasStatusByNamespace{}
+		}
+		out.Insert(namespace, *outstatus)
+	}
+	return nil
+}

--- a/pkg/quota/api/types.go
+++ b/pkg/quota/api/types.go
@@ -115,6 +115,10 @@ func (o *ResourceQuotasStatusByNamespace) OrderedKeys() *list.List {
 	return o.orderedMap.OrderedKeys()
 }
 
+func (o *ResourceQuotasStatusByNamespace) Len() int {
+	return len(o.orderedMap.backingMap)
+}
+
 // orderedMap is a very simple ordering a map tracking insertion order.  It allows fast and stable serializations
 // for our encoding.  You could probably do something fancier with pointers to interfaces, but I didn't.
 type orderedMap struct {
@@ -159,7 +163,7 @@ func (o *orderedMap) Remove(key string) {
 // OrderedKeys returns back the ordered keys.  This can be used to build a stable serialization
 func (o *orderedMap) OrderedKeys() *list.List {
 	if o.orderedKeys == nil {
-		o.orderedKeys = list.New()
+		return list.New()
 	}
 	return o.orderedKeys
 }

--- a/pkg/quota/api/validation/validation.go
+++ b/pkg/quota/api/validation/validation.go
@@ -1,8 +1,10 @@
 package validation
 
 import (
+	kapi "k8s.io/kubernetes/pkg/api"
 	unversionedvalidation "k8s.io/kubernetes/pkg/api/unversioned/validation"
 	"k8s.io/kubernetes/pkg/api/validation"
+	utilquota "k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/util/validation/field"
 
 	quotaapi "github.com/openshift/origin/pkg/quota/api"
@@ -30,16 +32,21 @@ func ValidateClusterResourceQuota(clusterquota *quotaapi.ClusterResourceQuota) f
 	allErrs = append(allErrs, validation.ValidateResourceQuotaSpec(&clusterquota.Spec.Quota, field.NewPath("spec", "quota"))...)
 	allErrs = append(allErrs, validation.ValidateResourceQuotaStatus(&clusterquota.Status.Total, field.NewPath("status", "overall"))...)
 
+	namespaceTotal := kapi.ResourceList{}
 	for e := clusterquota.Status.Namespaces.OrderedKeys().Front(); e != nil; e = e.Next() {
 		namespace := e.Value.(string)
 		used, _ := clusterquota.Status.Namespaces.Get(namespace)
 
+		namespaceTotal = utilquota.Add(namespaceTotal, used.Used)
 		fldPath := field.NewPath("status", "namespaces").Key(namespace)
 		for k, v := range used.Used {
 			resPath := fldPath.Key(string(k))
 			allErrs = append(allErrs, validation.ValidateResourceQuotaResourceName(string(k), resPath)...)
 			allErrs = append(allErrs, validation.ValidateResourceQuantityValue(string(k), v, resPath)...)
 		}
+	}
+	if !kapi.Semantic.DeepEqual(namespaceTotal, clusterquota.Status.Total.Used) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("status", "total"), clusterquota.Status, "must equal the sum of the namespace usage"))
 	}
 
 	return allErrs

--- a/pkg/quota/api/zz_generated.deepcopy.go
+++ b/pkg/quota/api/zz_generated.deepcopy.go
@@ -162,16 +162,3 @@ func DeepCopy_api_ClusterResourceQuotaStatus(in interface{}, out interface{}, c 
 		return nil
 	}
 }
-
-func DeepCopy_api_ResourceQuotasStatusByNamespace(in interface{}, out interface{}, c *conversion.Cloner) error {
-	{
-		in := in.(*ResourceQuotasStatusByNamespace)
-		out := out.(*ResourceQuotasStatusByNamespace)
-		if newVal, err := c.DeepCopy(&in.orderedMap); err != nil {
-			return err
-		} else {
-			out.orderedMap = *newVal.(*orderedMap)
-		}
-		return nil
-	}
-}

--- a/pkg/quota/controller/clusterquotareconciliation/reconcilation_controller.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconcilation_controller.go
@@ -280,19 +280,22 @@ func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuo
 		}
 
 		// subtract old usage, add new usage
+		fmt.Printf("#### controller: \nminus %v\noriginal %v\nreplace %v\n", namespaceTotals.Used, quota.Status.Total.Used, recalculatedStatus.Used)
 		quota.Status.Total.Used = utilquota.Subtract(quota.Status.Total.Used, namespaceTotals.Used)
 		quota.Status.Total.Used = utilquota.Add(quota.Status.Total.Used, recalculatedStatus.Used)
+		fmt.Printf("#### controller: \nresult %v\n", quota.Status.Total.Used)
 		quota.Status.Namespaces.Insert(namespaceName, recalculatedStatus)
 	}
 
 	quota.Status.Total.Hard = quota.Spec.Quota.Hard
 
 	// if there's no change, no update, return early.  NewAggregate returns nil on empty input
-	if kapi.Semantic.DeepEqual(quota, originalQuota) {
-		return kutilerrors.NewAggregate(reconcilationErrors), retryItems
-	}
+	// if kapi.Semantic.DeepEqual(quota, originalQuota) {
+	// 	return kutilerrors.NewAggregate(reconcilationErrors), retryItems
+	// }
 
 	if _, err := c.clusterQuotaClient.ClusterResourceQuotas().UpdateStatus(quota); err != nil {
+		fmt.Printf("#### controller err: \nresult %v\n", err, quota.Status)
 		return kutilerrors.NewAggregate(append(reconcilationErrors, err)), workItems
 	}
 


### PR DESCRIPTION
Would fix https://github.com/openshift/origin/issues/11560 .  Deep copy was wrong and it presented as copies that weren't actually copies, so we'd be mutating our originals.  Since the deep copy was borked, it tricked the mutation detector.


This is my "find what's broken" branch state

@liggitt 