### PR TITLE
DO NOT MERGE - quota debugging

### DIFF
--- a/pkg/quota/api/deep_copy_test.go
+++ b/pkg/quota/api/deep_copy_test.go
@@ -1,0 +1,74 @@
+package api_test
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+
+	"github.com/openshift/origin/pkg/quota/api"
+	_ "github.com/openshift/origin/pkg/quota/api/install"
+)
+
+func TestDeepCopy(t *testing.T) {
+	make := func() *api.ClusterResourceQuota {
+		q := resource.Quantity{}
+		q.Set(100)
+		crq := &api.ClusterResourceQuota{}
+		crq.Status.Namespaces.Insert("ns1", kapi.ResourceQuotaStatus{Hard: kapi.ResourceList{"a": q.DeepCopy()}, Used: kapi.ResourceList{"a": q.DeepCopy()}})
+		crq.Status.Namespaces.Insert("ns2", kapi.ResourceQuotaStatus{Hard: kapi.ResourceList{"b": q.DeepCopy()}, Used: kapi.ResourceList{"b": q.DeepCopy()}})
+		return crq
+	}
+
+	check := make()
+
+	original := make()
+	if !reflect.DeepEqual(check, original) {
+		t.Error("before mutation of copy, check and original should be identical but are not, likely failure in deepequal")
+	}
+	if !kapi.Semantic.DeepEqual(check, original) {
+		t.Error("before mutation of copy, check and original should be identical but are not, likely failure in deepequal")
+	}
+
+	copiedObj, err := kapi.Scheme.Copy(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	copied := copiedObj.(*api.ClusterResourceQuota)
+	if !reflect.DeepEqual(copied, original) {
+		t.Error("before mutation of copy, copied and original should be identical but are not, likely failure in deepequal")
+	}
+	if !kapi.Semantic.DeepEqual(copied, original) {
+		t.Error("before mutation of copy, copied and original should be identical but are not, likely failure in deepequal")
+	}
+
+	// Mutate the copy
+	for e := copied.Status.Namespaces.OrderedKeys().Front(); e != nil; e = e.Next() {
+		k := e.Value.(string)
+		ns, _ := copied.Status.Namespaces.Get(k)
+		for k2, v2 := range ns.Hard {
+			v2.Set(v2.Value() + 2)
+			ns.Hard[k2] = v2
+		}
+		for k2, v2 := range ns.Used {
+			v2.Set(v2.Value() + 1)
+			ns.Used[k2] = v2
+		}
+		copied.Status.Namespaces.Insert(k, ns)
+	}
+
+	if !reflect.DeepEqual(check, original) {
+		t.Error("after mutation of copy, check and original should be identical but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
+	}
+	if !kapi.Semantic.DeepEqual(check, original) {
+		t.Error("after mutation of copy, check and original should be identical but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
+	}
+
+	if reflect.DeepEqual(original, copied) {
+		t.Error("after mutation of copy, original and copied should be different but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
+	}
+	if kapi.Semantic.DeepEqual(original, copied) {
+		t.Error("after mutation of copy, original and copied should be different but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
+	}
+}

--- a/pkg/quota/api/types.go
+++ b/pkg/quota/api/types.go
@@ -159,7 +159,7 @@ func (o *orderedMap) Remove(key string) {
 // OrderedKeys returns back the ordered keys.  This can be used to build a stable serialization
 func (o *orderedMap) OrderedKeys() *list.List {
 	if o.orderedKeys == nil {
-		o.orderedKeys = list.New()
+		return list.New()
 	}
 	return o.orderedKeys
 }

--- a/pkg/quota/api/zz_generated.deepcopy.go
+++ b/pkg/quota/api/zz_generated.deepcopy.go
@@ -156,9 +156,7 @@ func DeepCopy_api_ClusterResourceQuotaStatus(in interface{}, out interface{}, c 
 		if err := pkg_api.DeepCopy_api_ResourceQuotaStatus(&in.Total, &out.Total, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_api_ResourceQuotasStatusByNamespace(&in.Namespaces, &out.Namespaces, c); err != nil {
-			return err
-		}
+		out.Namespaces = in.Namespaces.DeepCopy()
 		return nil
 	}
 }


### PR DESCRIPTION
with the deepcopy fix in place, I still saw a total != sum(namespaces) mismatch, though it was far far harder to reproduce.

From a clean start, I ran the following:
oc create clusterquota for-deads-by-annotation --project-annotation-selector=openshift.io/requester=deads --hard=secrets=50
oc new-project foo --as=deads
oc new-project bar --as=deads
oc new-project baz --as=deads
oc get clusterresourcequota/for-deads-by-annotation -o yaml
oc delete project foo bar baz

During the project delete, I saw the total set to 1 while namespaces were all 0.
