### PR TITLE
Only pay attention to origin types in project lifecycle admission

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -336,8 +336,8 @@ var (
 
 	// KubeAdmissionPlugins gives the in-order default admission chain for kube resources.
 	KubeAdmissionPlugins = []string{
-		"RunOnceDuration",
 		lifecycle.PluginName,
+		"RunOnceDuration",
 		"PodNodeConstraints",
 		"OriginPodNodeEnvironment",
 		overrideapi.PluginName,
@@ -364,6 +364,7 @@ var (
 	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
 	// the order specified in the openshift and kube chains must match the order here.
 	CombinedAdmissionControlPlugins = []string{
+		lifecycle.PluginName,
 		"ProjectRequestLimit",
 		"OriginNamespaceLifecycle",
 		"PodNodeConstraints",
@@ -371,7 +372,6 @@ var (
 		"BuildByStrategy",
 		imageadmission.PluginName,
 		"RunOnceDuration",
-		lifecycle.PluginName,
 		"PodNodeConstraints",
 		"OriginPodNodeEnvironment",
 		overrideapi.PluginName,

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -73,7 +73,7 @@ func TestAdmissionExists(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
-	err := handler.Admit(admission.NewAttributesRecord(build, nil, kapi.Kind("Build").WithVersion("version"), "namespace", "name", kapi.Resource("builds").WithVersion("version"), "", "CREATE", nil))
+	err := handler.Admit(admission.NewAttributesRecord(build, nil, kapi.Kind("Build").WithVersion("v1"), "namespace", "name", kapi.Resource("builds").WithVersion("v1"), "", "CREATE", nil))
 	if err == nil {
 		t.Errorf("Expected an error because namespace does not exist")
 	}
@@ -106,7 +106,7 @@ func TestSAR(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		err := handler.Admit(admission.NewAttributesRecord(nil, nil, kapi.Kind(v.kind).WithVersion("version"), "foo", "name", kapi.Resource(v.resource).WithVersion("version"), "", "CREATE", nil))
+		err := handler.Admit(admission.NewAttributesRecord(nil, nil, kapi.Kind(v.kind).WithVersion("v1"), "foo", "name", kapi.Resource(v.resource).WithVersion("v1"), "", "CREATE", nil))
 		if err != nil {
 			t.Errorf("Unexpected error for %s returned from admission handler: %v", k, err)
 		}


### PR DESCRIPTION
Fixes #11094:
* origin finalizer is now only added for creation of origin types
* namespace finalizer is moved to the front of the chain, and already does a lot of work to deny creation requests against a terminating namespace while avoiding flakes