### PR TITLE
Fix failing deployment hook fixture

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -584,7 +584,7 @@ var _ = g.Describe("deploymentconfigs", func() {
 
 			g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
 			o.Expect(out).To(o.ContainSubstring("--> pre: Running hook pod ..."))
-			o.Expect(out).To(o.ContainSubstring("no such file or directory"))
+			o.Expect(out).To(o.ContainSubstring("pre hook logs"))
 			o.Expect(out).To(o.ContainSubstring("--> pre: Retrying hook pod (retry #1)"))
 		})
 	})

--- a/test/extended/testdata/deployments/failing-pre-hook.yaml
+++ b/test/extended/testdata/deployments/failing-pre-hook.yaml
@@ -14,7 +14,9 @@ spec:
         execNewPod:
           containerName: myapp
           command:
-          - /bin/echo `date`; /bin/true
+          - /bin/bash
+          - -c
+          - '/bin/echo pre hook logs ; exit 1'
   template:
     metadata:
       labels:


### PR DESCRIPTION
Use a more stable and predictable command to exercise failing pre-hooks
with retries. The former command assumed specific Docker 1.10 behavior
whereby missing commands produced error messages in the container output
stream, an assumption which no longer holds true in Docker 1.12.

The fixture and test assertions should now be portable across Docker
versions.

Fixes https://github.com/openshift/origin/issues/11630