### PR TITLE
make service controller failure non-fatal

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -450,9 +450,10 @@ func (c *MasterConfig) RunServiceLoadBalancerController(client *client.Client) {
 	}
 	serviceController, err := servicecontroller.New(c.CloudProvider, clientadapter.FromUnversionedClient(client), c.ControllerManager.ClusterName)
 	if err != nil {
-		glog.Fatalf("Unable to start service controller: %v", err)
+		glog.Errorf("Unable to start service controller: %v", err)
+	} else {
+		serviceController.Run(int(c.ControllerManager.ConcurrentServiceSyncs))
 	}
-	serviceController.Run(int(c.ControllerManager.ConcurrentServiceSyncs))
 }
 
 // RunPetSetController starts the PetSet controller


### PR DESCRIPTION
Make failure of the ServiceController non-fatal even when using a cloud provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1389205

@smarterclayton @ncdc @derekwaynecarr @jhou1 