### PR TITLE
UPSTREAM: 34434: Print valid json/yaml output in `oc set image`

### DIFF
--- a/pkg/cmd/cli/cmd/set/set.go
+++ b/pkg/cmd/cli/cmd/set/set.go
@@ -39,7 +39,7 @@ func NewCmdSet(fullName string, f *clientcmd.Factory, in io.Reader, out, errout 
 				NewCmdVolume(name, f, out, errout),
 				NewCmdProbe(name, f, out, errout),
 				NewCmdDeploymentHook(name, f, out, errout),
-				NewCmdImage(name, f, out),
+				NewCmdImage(name, f, out, errout),
 			},
 		},
 		{
@@ -86,8 +86,8 @@ Update existing container image(s) of resources.`)
 )
 
 // NewCmdImage is a wrapper for the Kubernetes CLI set image command
-func NewCmdImage(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	cmd := set.NewCmdImage(f.Factory, out)
+func NewCmdImage(fullName string, f *clientcmd.Factory, out, err io.Writer) *cobra.Command {
+	cmd := set.NewCmdImage(f.Factory, out, err)
 	cmd.Long = setImageLong
 	cmd.Example = fmt.Sprintf(setImageExample, fullName)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set.go
@@ -32,7 +32,6 @@ var (
 	set_example = dedent.Dedent(``)
 )
 
-
 func NewCmdSet(f *cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set SUBCOMMAND",
@@ -45,7 +44,7 @@ func NewCmdSet(f *cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	}
 
 	// add subcommands
-	cmd.AddCommand(NewCmdImage(f, out))
+	cmd.AddCommand(NewCmdImage(f, out, err))
 	cmd.AddCommand(NewCmdResources(f, out, err))
 
 	return cmd

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
@@ -80,9 +80,10 @@ var (
 		kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml`)
 )
 
-func NewCmdImage(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdImage(f *cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	options := &ImageOptions{
 		Out: out,
+		Err: err,
 	}
 
 	cmd := &cobra.Command{
@@ -210,7 +211,7 @@ func (o *ImageOptions) Run() error {
 		}
 
 		if o.Local {
-			fmt.Fprintln(o.Out, "running in local mode...")
+			fmt.Fprintln(o.Err, "running in local mode...")
 			return o.PrintObject(o.Cmd, o.Mapper, info.Object, o.Out)
 		}
 


### PR DESCRIPTION
Related UPSTREAM: https://github.com/kubernetes/kubernetes/pull/34434
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1390140

This patch updates `oc set image` to print the info `running in local
mode...` through stderr in order to allow only json or yaml output when
using the `--local` flag. 

This patch also prevents a potential panic [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/set/set_image.go#L217), by assigning a non-nil value to `o.Err` in `set_image.go`.

@openshift/cli-review 