### PR TITLE
Fix EgressNetworkPolicy match-all-IPs special case

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -373,7 +373,7 @@ func (plugin *OsdnNode) updateEgressNetworkPolicyRules(vnid uint32) error {
 			}
 
 			var dst string
-			if rule.To.CIDRSelector == "0.0.0.0/32" {
+			if rule.To.CIDRSelector == "0.0.0.0/0" {
 				dst = ""
 			} else {
 				dst = fmt.Sprintf(", nw_dst=%s", rule.To.CIDRSelector)


### PR DESCRIPTION
OVS doesn't let you say `nw_dst=0.0.0.0/0`; you have to just not specify `nw_dst` instead. We had a workaround for this, except it was backwards...

@openshift/networking PTAL