### PR TITLE
Update hack/update-generated-bootstrap-bindata.sh

### DIFF
--- a/hack/update-generated-bootstrap-bindata.sh
+++ b/hack/update-generated-bootstrap-bindata.sh
@@ -7,7 +7,7 @@ os::build::setup_env
 EXAMPLES=examples
 OUTPUT_PARENT=${OUTPUT_ROOT:-$OS_ROOT}
 
-if [[ -z "$( which go-bindata )" ]]; then
+if [[ -z "$(os::util::find-go-binary go-bindata)" ]]; then
   pushd vendor/github.com/jteeuwen/go-bindata > /dev/null
     go install ./...
   popd > /dev/null
@@ -28,7 +28,7 @@ pushd "${OS_ROOT}" > /dev/null
     ${EXAMPLES}/jenkins \
     ${EXAMPLES}/jenkins/pipeline \
     ${EXAMPLES}/quickstarts/... \
-	${EXAMPLES}/logging/... \
+    ${EXAMPLES}/logging/... \
     pkg/image/admission/imagepolicy/api/v1/...
 popd > /dev/null
 


### PR DESCRIPTION
Update the hack/update-generated-bootstrap-bindata.sh script to use the same functionality to
verify if the go-bindata binary is available as it does to run the binary

Fixes #11672