### PR TITLE
Fixing kubernetes_plugin extended test failure

### DIFF
--- a/test/extended/image_ecosystem/kubernetes_plugin.go
+++ b/test/extended/image_ecosystem/kubernetes_plugin.go
@@ -105,7 +105,7 @@ var _ = g.Describe("[image_ecosystem][jenkins] schedule jobs on pod slaves", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("grant service account in jenkins container access to API")
-			err = oc.Run("policy").Args("add-role-to-user", "edit", "system:serviceaccount:"+oc.Namespace()+":jenkins", "-n", oc.Namespace()).Execute()
+			err = oc.Run("policy").Args("add-role-to-user", "edit", "system:serviceaccount:"+oc.Namespace()+":default", "-n", oc.Namespace()).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("instantiate the master template")


### PR DESCRIPTION
@bparees @gabemontero 
Should fix extended test failure in kubernetes_plugin.go . Test was assuming Jenkins would use "jenkins" service account while the template it was instantiating used "default".

This led to errors like:
SEVERE: Failed to configure OpenShift Jenkins Sync Plugin: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/oapi/v1/namespaces/extended-test-jenkins-kube-a67wm-tv3ra/buildconfigs. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked..

