### PR TITLE
deploy: default maxSurge/maxUnavailable separately

### DIFF
--- a/pkg/deploy/api/v1/defaults.go
+++ b/pkg/deploy/api/v1/defaults.go
@@ -71,6 +71,7 @@ func SetDefaults_RecreateDeploymentStrategyParams(obj *RecreateDeploymentStrateg
 		obj.TimeoutSeconds = mkintp(deployapi.DefaultRollingTimeoutSeconds)
 	}
 }
+
 func SetDefaults_RollingDeploymentStrategyParams(obj *RollingDeploymentStrategyParams) {
 	if obj.IntervalSeconds == nil {
 		obj.IntervalSeconds = mkintp(deployapi.DefaultRollingIntervalSeconds)
@@ -88,6 +89,18 @@ func SetDefaults_RollingDeploymentStrategyParams(obj *RollingDeploymentStrategyP
 		maxUnavailable := intstr.FromString("25%")
 		obj.MaxUnavailable = &maxUnavailable
 
+		maxSurge := intstr.FromString("25%")
+		obj.MaxSurge = &maxSurge
+	}
+
+	if obj.MaxUnavailable == nil && obj.MaxSurge != nil &&
+		(*obj.MaxSurge == intstr.FromInt(0) || *obj.MaxSurge == intstr.FromString("0%")) {
+		maxUnavailable := intstr.FromString("25%")
+		obj.MaxUnavailable = &maxUnavailable
+	}
+
+	if obj.MaxSurge == nil && obj.MaxUnavailable != nil &&
+		(*obj.MaxUnavailable == intstr.FromInt(0) || *obj.MaxUnavailable == intstr.FromString("0%")) {
 		maxSurge := intstr.FromString("25%")
 		obj.MaxSurge = &maxSurge
 	}

--- a/pkg/deploy/api/v1/defaults_test.go
+++ b/pkg/deploy/api/v1/defaults_test.go
@@ -232,6 +232,41 @@ func TestDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			original: &deployv1.DeploymentConfig{
+				Spec: deployv1.DeploymentConfigSpec{
+					Strategy: deployv1.DeploymentStrategy{
+						Type: deployv1.DeploymentStrategyTypeRolling,
+						RollingParams: &deployv1.RollingDeploymentStrategyParams{
+							UpdatePeriodSeconds: newInt64(5),
+							IntervalSeconds:     newInt64(6),
+							TimeoutSeconds:      newInt64(7),
+							MaxSurge:            newIntOrString(intstr.FromInt(0)),
+						},
+					},
+					Triggers: []deployv1.DeploymentTriggerPolicy{
+						{},
+					},
+				},
+			},
+			expected: &deployv1.DeploymentConfig{
+				Spec: deployv1.DeploymentConfigSpec{
+					Strategy: deployv1.DeploymentStrategy{
+						Type: deployv1.DeploymentStrategyTypeRolling,
+						RollingParams: &deployv1.RollingDeploymentStrategyParams{
+							UpdatePeriodSeconds: newInt64(5),
+							IntervalSeconds:     newInt64(6),
+							TimeoutSeconds:      newInt64(7),
+							MaxUnavailable:      newIntOrString(intstr.FromString("25%")),
+							MaxSurge:            newIntOrString(intstr.FromInt(0)),
+						},
+					},
+					Triggers: []deployv1.DeploymentTriggerPolicy{
+						{},
+					},
+				},
+			},
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -351,7 +351,7 @@ func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.De
 	if latestRC != nil {
 		switch deployutil.DeploymentStatusFor(latestRC) {
 		case deployapi.DeploymentStatusPending:
-			msg := fmt.Sprintf("Waiting on deployer pod for replication controller %q to be scheduled", latestRC.Name)
+			msg := fmt.Sprintf("Replication controller %q is waiting for pod %q to run", latestRC.Name, deployutil.DeployerPodNameForDeployment(latestRC.Name))
 			condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionUnknown, "", msg)
 			deployutil.SetDeploymentCondition(newStatus, *condition)
 		case deployapi.DeploymentStatusRunning:


### PR DESCRIPTION
Restores defaulting for maxSurge/maxUnavailable (regressed in https://github.com/openshift/origin/pull/11090)

@mfojtik ptal

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1389170