### PR TITLE
Bug 1389213 - Fix join/isolate project network

### DIFF
--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -14,14 +14,12 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kcache "k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/fields"
+	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 func getPodContainerID(pod *kapi.Pod) string {
 	if len(pod.Status.ContainerStatuses) > 0 {
-		// Extract only container ID, pod.Status.ContainerStatuses[0].ContainerID is of the format: docker://<containerID>
-		if parts := strings.Split(pod.Status.ContainerStatuses[0].ContainerID, "://"); len(parts) > 1 {
-			return parts[1]
-		}
+		return kcontainer.ParseContainerID(pod.Status.ContainerStatuses[0].ContainerID).ID
 	}
 	return ""
 }

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -33,7 +33,6 @@ const (
 	sdnScript   = "openshift-sdn-ovs"
 	setUpCmd    = "setup"
 	tearDownCmd = "teardown"
-	statusCmd   = "status"
 	updateCmd   = "update"
 
 	AssignMacvlanAnnotation string = "pod.network.openshift.io/assign-macvlan"

--- a/pkg/sdn/plugin/vnids_node.go
+++ b/pkg/sdn/plugin/vnids_node.go
@@ -9,7 +9,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/container"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 	utilwait "k8s.io/kubernetes/pkg/util/wait"
@@ -167,7 +166,7 @@ func (node *OsdnNode) updatePodNetwork(namespace string, oldNetID, netID uint32)
 
 	// Update OF rules for the existing/old pods in the namespace
 	for _, pod := range pods {
-		err = node.UpdatePod(pod.Namespace, pod.Name, kubetypes.ContainerID{ID: getPodContainerID(&pod)})
+		err = node.UpdatePod(pod)
 		if err != nil {
 			errList = append(errList, err)
 		}


### PR DESCRIPTION
Pass kubeletTypes.ContainerID.ID instead of kubeletTypes.ContainerID.String() to UpdatePod(),
Otherwise docker client fails with error: no such container '://<id>'

Fixes bug 1389213