### PR TITLE
Fix oauth redirect ref in jenkins service account

### DIFF
--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -175,7 +175,7 @@
         "metadata": {
             "name": "${JENKINS_SERVICE_NAME}",
             "annotations": {
-                  "serviceaccounts.openshift.io/oauth-redirectref.jenkins": "{\"kind\": \"Route\", \"name\": \"${JENKINS_SERVICE_NAME}\", \"group\": \"\"}"
+		"serviceaccounts.openshift.io/oauth-redirectreference.jenkins": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"${JENKINS_SERVICE_NAME}\"}}"
             }
         }
     },

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -3844,7 +3844,7 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
         "metadata": {
             "name": "${JENKINS_SERVICE_NAME}",
             "annotations": {
-                  "serviceaccounts.openshift.io/oauth-redirectref.jenkins": "{\"kind\": \"Route\", \"name\": \"${JENKINS_SERVICE_NAME}\", \"group\": \"\"}"
+		"serviceaccounts.openshift.io/oauth-redirectreference.jenkins": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"${JENKINS_SERVICE_NAME}\"}}"
             }
         }
     },


### PR DESCRIPTION
Makes the redirect reference annotation for the Jenkins service account in the persistent template the same as the one in the ephemeral template:

https://github.com/openshift/origin/blob/master/examples/jenkins/jenkins-ephemeral-template.json#L161