### PR TITLE
Clarify the messages generated when we call pod cleanup twice

### DIFF
--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -69,13 +69,11 @@ add_ovs_flows() {
 }
 
 del_ovs_flows() {
-    if [ "$ipaddr" != "" ]; then
+    if [ -n "$ipaddr" ]; then
         ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_dst=${ipaddr}"
         ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_src=${ipaddr}"
         ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
         ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
-    else
-        echo "No ip address given for teardown of ${veth_host}, could have been called twice.  Skipping flow deletion"
     fi
 
     qos=$(ovs-vsctl get port ${veth_host} qos)

--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs
@@ -69,10 +69,14 @@ add_ovs_flows() {
 }
 
 del_ovs_flows() {
-    ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_dst=${ipaddr}"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_src=${ipaddr}"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
+    if [ "$ipaddr" != "" ]; then
+        ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_dst=${ipaddr}"
+        ovs-ofctl -O OpenFlow13 del-flows br0 "ip,nw_src=${ipaddr}"
+        ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
+        ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
+    else
+        echo "No ip address given for teardown of ${veth_host}, could have been called twice.  Skipping flow deletion"
+    fi
 
     qos=$(ovs-vsctl get port ${veth_host} qos)
     if [ "$qos" != "[]" ]; then
@@ -84,8 +88,8 @@ del_ovs_flows() {
 add_macvlan() {
     default_dev=$(ip route show | sed -ne 's/^default .* dev \([^ ]*\) .*/\1/p')
     if [ -z "$default_dev" ]; then
-	echo "Could not find default network interface"
-	exit 1
+        echo "Could not find default network interface"
+        exit 1
     fi
     ip link add link $default_dev name macvlan0 type macvlan mode private
     ip link set macvlan0 netns $pid


### PR DESCRIPTION
Before this change we emitted dire messages when pod cleanup was
called twice.  Calling it twice can happen because of coordination
problems, but should not be an error.  Fortunately, we handled it
correctly.  Unfortunately, we printed a message that confused people.

This changes the code so that we don't bother trying to delete the
flows when we don't have the IP address, and instead prints an
informative message that (hopefully) doesn't confuse people.

Fixes bug 1359240 [link](https://bugzilla.redhat.com/show_bug.cgi?id=1359240)