### PR TITLE
Allow PATCH in an API CORS setup

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/apiserver/handlers.go
+++ b/vendor/k8s.io/kubernetes/pkg/apiserver/handlers.go
@@ -396,7 +396,7 @@ func CORS(handler http.Handler, allowedOriginPatterns []*regexp.Regexp, allowedM
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				// Set defaults for methods and headers if nothing was passed
 				if allowedMethods == nil {
-					allowedMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE"}
+					allowedMethods = []string{"POST", "GET", "OPTIONS", "PUT", "DELETE", "PATCH"}
 				}
 				if allowedHeaders == nil {
 					allowedHeaders = []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "X-Requested-With", "If-Modified-Since"}


### PR DESCRIPTION
Allows the PATCH method to be used in a REST API CORS setup.

Upstream: https://github.com/kubernetes/kubernetes/pull/35978

@jwforres 