### PR TITLE
set a default size for ClusterResourceQuota watch cache size

### DIFF
--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -117,6 +117,15 @@ func (g *configRESTOptionsGetter) loadSettings() error {
 
 		g.cacheSizes[resource] = size
 	}
+
+	// set some hardcoded defaults
+	// assuming each CRQ controls two resources for 100 projects, these are about 500k in memory each
+	// the default would take about 500MB of RAM, which doesn't sound too bad to me, but it is an awful lot
+	// to hold very little since these are updated a lot, but there are very few of them.
+	if _, ok := g.cacheSizes[unversioned.GroupResource{Resource: "clusterresourcequotas"}]; !ok {
+		g.cacheSizes[unversioned.GroupResource{Resource: "clusterresourcequotas"}] = 50
+	}
+
 	return kerrors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
ClusterResourceQuota objects are really big and we cache 1000 of them by default.  This takes about 500 megs of RAM for CRQs covering two resources on 100 projects for comparatively little gain since its not a commonly watched thing.

@dinhxuanvu @abhgupta this stops the "leak"
@liggitt alternatives?