### PR TITLE
Removed `--force` flag from `docker tag` invocations

### DIFF
--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -66,7 +66,7 @@ if [[ "${tag}" == ":latest" ]]; then
   if [[ "${OS_PUSH_BASE_IMAGES-}" != "" ]]; then
     for image in "${base_images[@]}"; do
       if [[ "${OS_PUSH_BASE_REGISTRY-}" != "" ]]; then
-        docker tag -f "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY}${image}${tag}"
+        docker tag "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY}${image}${tag}"
       fi
       docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
     done
@@ -90,7 +90,7 @@ fi
 
 if [[ "${OS_PUSH_BASE_REGISTRY-}" != "" || "${tag}" != "" ]]; then
   for image in "${images[@]}"; do
-    docker tag -f "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
+    docker tag "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
   done
 fi
 

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -100,7 +100,7 @@ token="$( oc sa get-token builder )"
 os::cmd::expect_success "docker login -u imagensbuilder -p ${token} -e fake@example.org ${docker_registry}"
 os::cmd::expect_success "oc import-image busybox:latest --confirm"
 os::cmd::expect_success "docker pull busybox"
-os::cmd::expect_success "docker tag -f docker.io/busybox:latest ${docker_registry}/image-ns/busybox:latest"
+os::cmd::expect_success "docker tag docker.io/busybox:latest ${docker_registry}/image-ns/busybox:latest"
 os::cmd::expect_success "docker push ${docker_registry}/image-ns/busybox:latest"
 os::cmd::expect_success "docker rmi -f ${docker_registry}/image-ns/busybox:latest"
 

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -336,7 +336,7 @@ docker login -u e2e-user -p ${token} -e e2e-user@openshift.com ${DOCKER_REGISTRY
 echo "[INFO] Docker login successful"
 
 echo "[INFO] Tagging and pushing ruby-22-centos7 to ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest"
-docker tag -f centos/ruby-22-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
+docker tag centos/ruby-22-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
 docker push ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
 echo "[INFO] Pushed ruby-22-centos7"
 


### PR DESCRIPTION
In Docker 1.12, the `--force` flag on the `docker tag` CLI
endpoint is removed and that behavior is default. We don't
need to use the flag any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>