### PR TITLE
update port validation message

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/validation/validation.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/validation/validation.go
@@ -207,7 +207,7 @@ func IsValidUserId(uid int64) []string {
 }
 
 var portNameCharsetRegex = regexp.MustCompile("^[-a-z0-9]+$")
-var portNameOneLetterRegexp = regexp.MustCompile("[a-z]")
+var portNameOneLetterRegexp = regexp.MustCompile("[a-z0-9]")
 
 // IsValidPortName check that the argument is valid syntax. It must be
 // non-empty and no more than 15 characters long. It may contain only [-a-z0-9]
@@ -225,7 +225,7 @@ func IsValidPortName(port string) []string {
 		errs = append(errs, "must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)")
 	}
 	if !portNameOneLetterRegexp.MatchString(port) {
-		errs = append(errs, "must contain at least one letter (a-z)")
+		errs = append(errs, "must contain at least one letter or number (a-z, 0-9)")
 	}
 	if strings.Contains(port, "--") {
 		errs = append(errs, "must not contain consecutive hyphens")


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1355703#c2

Port validation when doing commands such as:
```
$ oc set probe dc/mydc --liveness --get-url="https://www.google.com:"
```

result in a multi-line error message:
```
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain at least one letter (a-z)
```

which suggests that ports can only be at minimum one letter.

Per [this bugzilla comment](https://bugzilla.redhat.com/show_bug.cgi?id=1355703#c2), this patch updates the second bullet point on the error message to be clearer:

```
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain at least one letter or number (a-z, 0-9)
```

@openshift/cli-review 