### PR TITLE
Bug 1390173 - Test more pod to pod connectivity test combinations

### DIFF
--- a/pkg/diagnostics/network/results.go
+++ b/pkg/diagnostics/network/results.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (d *NetworkDiagnostic) CollectNetworkPodLogs() error {
-	podList, err := d.getPodList(d.nsName, util.NetworkDiagPodNamePrefix)
+	podList, err := d.getPodList(d.nsName1, util.NetworkDiagPodNamePrefix)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (d *NetworkDiagnostic) CollectNetworkInfo(diagsFailed bool) error {
 		l.LogMaster()
 	}
 
-	podList, err := d.getPodList(d.nsName, util.NetworkDiagPodNamePrefix)
+	podList, err := d.getPodList(d.nsName1, util.NetworkDiagPodNamePrefix)
 	if err != nil {
 		return err
 	}

--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -76,7 +76,7 @@ func (d *NetworkDiagnostic) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if !ok {
-		d.res.Warn("DNet2002", nil, fmt.Sprintf("Skipping network diagnostics check. Reason: Not using openshift network plugin."))
+		d.res.Warn("DNet2002", nil, "Skipping network diagnostics check. Reason: Not using openshift network plugin.")
 		return d.res
 	}
 
@@ -86,7 +86,7 @@ func (d *NetworkDiagnostic) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if len(d.nodes) == 0 {
-		d.res.Warn("DNet2004", nil, fmt.Sprint("Skipping network checks. Reason: No schedulable/ready nodes found."))
+		d.res.Warn("DNet2004", nil, "Skipping network checks. Reason: No schedulable/ready nodes found.")
 		return d.res
 	}
 

--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -31,11 +31,13 @@ type NetworkDiagnostic struct {
 	PreventModification bool
 	LogDir              string
 
-	pluginName   string
-	nodes        []kapi.Node
-	nsName       string
-	globalnsName string
-	res          types.DiagnosticResult
+	pluginName    string
+	nodes         []kapi.Node
+	nsName1       string
+	nsName2       string
+	globalnsName1 string
+	globalnsName2 string
+	res           types.DiagnosticResult
 }
 
 // Name is part of the Diagnostic interface and just returns name.
@@ -118,7 +120,7 @@ func (d *NetworkDiagnostic) runNetworkDiagnostic() {
 		return
 	}
 	// Wait for network diagnostic pod completion
-	if err := d.waitForNetworkPod(d.nsName, util.NetworkDiagPodNamePrefix, []kapi.PodPhase{kapi.PodSucceeded, kapi.PodFailed}); err != nil {
+	if err := d.waitForNetworkPod(d.nsName1, util.NetworkDiagPodNamePrefix, []kapi.PodPhase{kapi.PodSucceeded, kapi.PodFailed}); err != nil {
 		d.res.Error("DNet2007", err, err.Error())
 		return
 	}
@@ -137,7 +139,7 @@ func (d *NetworkDiagnostic) runNetworkDiagnostic() {
 	}
 
 	// Wait for network diagnostic pod to start
-	if err := d.waitForNetworkPod(d.nsName, util.NetworkDiagPodNamePrefix, []kapi.PodPhase{kapi.PodRunning, kapi.PodFailed, kapi.PodSucceeded}); err != nil {
+	if err := d.waitForNetworkPod(d.nsName1, util.NetworkDiagPodNamePrefix, []kapi.PodPhase{kapi.PodRunning, kapi.PodFailed, kapi.PodSucceeded}); err != nil {
 		d.res.Error("DNet2010", err, err.Error())
 		// Do not bail out here, collect what ever info is available from all valid nodes
 	}
@@ -157,7 +159,7 @@ func (d *NetworkDiagnostic) runNetworkPod(command []string) error {
 		podName := kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagPodNamePrefix))
 
 		pod := GetNetworkDiagnosticsPod(command, podName, node.Name)
-		_, err := d.KubeClient.Pods(d.nsName).Create(pod)
+		_, err := d.KubeClient.Pods(d.nsName1).Create(pod)
 		if err != nil {
 			return fmt.Errorf("Creating network diagnostic pod %q on node %q with command %q failed: %v", podName, node.Name, strings.Join(command, " "), err)
 		}

--- a/pkg/diagnostics/network/setup.go
+++ b/pkg/diagnostics/network/setup.go
@@ -20,12 +20,15 @@ import (
 )
 
 func (d *NetworkDiagnostic) TestSetup() error {
-	d.nsName = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagNamespacePrefix))
+	d.nsName1 = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagNamespacePrefix))
+	d.nsName2 = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagNamespacePrefix))
 
-	nsList := []string{d.nsName}
+	nsList := []string{d.nsName1, d.nsName2}
 	if sdnapi.IsOpenShiftMultitenantNetworkPlugin(d.pluginName) {
-		d.globalnsName = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagGlobalNamespacePrefix))
-		nsList = append(nsList, d.globalnsName)
+		d.globalnsName1 = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagGlobalNamespacePrefix))
+		nsList = append(nsList, d.globalnsName1)
+		d.globalnsName2 = kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", util.NetworkDiagGlobalNamespacePrefix))
+		nsList = append(nsList, d.globalnsName2)
 	}
 
 	for _, name := range nsList {
@@ -49,7 +52,7 @@ func (d *NetworkDiagnostic) TestSetup() error {
 	secret := &kapi.Secret{}
 	secret.Name = util.NetworkDiagSecretName
 	secret.Data = map[string][]byte{strings.ToLower(kclientcmd.RecommendedConfigPathEnvVar): kconfigData}
-	if _, err = d.KubeClient.Secrets(d.nsName).Create(secret); err != nil {
+	if _, err = d.KubeClient.Secrets(d.nsName1).Create(secret); err != nil {
 		return fmt.Errorf("Creating secret %q failed: %v", secret.Name, err)
 	}
 
@@ -67,8 +70,10 @@ func (d *NetworkDiagnostic) TestSetup() error {
 
 func (d *NetworkDiagnostic) Cleanup() {
 	// Deleting namespaces will delete corresponding service accounts/pods in the namespace automatically.
-	d.KubeClient.Namespaces().Delete(d.nsName)
-	d.KubeClient.Namespaces().Delete(d.globalnsName)
+	d.KubeClient.Namespaces().Delete(d.nsName1)
+	d.KubeClient.Namespaces().Delete(d.nsName2)
+	d.KubeClient.Namespaces().Delete(d.globalnsName1)
+	d.KubeClient.Namespaces().Delete(d.globalnsName2)
 }
 
 func (d *NetworkDiagnostic) getPodList(nsName, prefix string) (*kapi.PodList, error) {

--- a/pkg/diagnostics/networkpod/pod.go
+++ b/pkg/diagnostics/networkpod/pod.go
@@ -92,31 +92,31 @@ func (d CheckPodNetwork) Check() types.DiagnosticResult {
 
 func (d CheckPodNetwork) checkDifferentNodePodToPodConnection(localGlobalPods, localNonGlobalPods, nonlocalGlobalPods, nonlocalNonGlobalPods []kapi.Pod) {
 	// Applicable to flat and multitenant networks
-	d.checkConnection(localGlobalPods, nonlocalGlobalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on different nodes. Reason: Couldn't find 2 global pods."))
+	d.checkConnection(localGlobalPods, nonlocalGlobalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on different nodes. Reason: Couldn't find 2 global pods."), true)
 
 	// Applicable to multitenant network
 	isMultitenant := (d.vnidMap != nil)
 	if isMultitenant {
-		d.checkConnection(localNonGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on different nodes. Reason: Couldn't find 2 non-global pods."))
+		d.checkConnection(localNonGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on different nodes. Reason: Couldn't find 2 non-global pods."), true)
 
-		d.checkConnection(localGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on different nodes. Reason: Couldn't find global and/or non-global pod."))
+		d.checkConnection(localGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on different nodes. Reason: Couldn't find global and/or non-global pod."), false)
 	}
 }
 
 func (d CheckPodNetwork) checkSameNodePodToPodConnection(globalPods, nonGlobalPods []kapi.Pod) {
 	// Applicable to both flat and multitenant networks
-	d.checkConnection(globalPods, globalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on the same node. Reason: Couldn't find 2 global pods."))
+	d.checkConnection(globalPods, globalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on the same node. Reason: Couldn't find 2 global pods."), true)
 
 	// Applicable to multitenant network
 	isMultitenant := (d.vnidMap != nil)
 	if isMultitenant {
-		d.checkConnection(nonGlobalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on the same node. Reason: Couldn't find 2 non-global pods."))
+		d.checkConnection(nonGlobalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on the same node. Reason: Couldn't find 2 non-global pods."), true)
 
-		d.checkConnection(globalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on the same node. Reason: Couldn't find global and/or non-global pod."))
+		d.checkConnection(globalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on the same node. Reason: Couldn't find global and/or non-global pod."), false)
 	}
 }
 
-func (d CheckPodNetwork) checkConnection(pods1, pods2 []kapi.Pod, warnMsg string) {
+func (d CheckPodNetwork) checkConnection(pods1, pods2 []kapi.Pod, warnMsg string, checkSameNamespace bool) {
 	minCount := 1
 	if len(pods1) > 0 && len(pods2) > 0 && (pods1[0].UID == pods2[0].UID) {
 		minCount += 1
@@ -147,6 +147,13 @@ func (d CheckPodNetwork) checkConnection(pods1, pods2 []kapi.Pod, warnMsg string
 				d.checkPodToPodConnection(&pod1, &pod2)
 			}
 		}
+	}
+
+	if checkSameNamespace && !sameNamespace {
+		d.res.Warn("DPodNet1010", nil, fmt.Sprintf("Same Namespace: %s", warnMsg))
+	}
+	if !diffNamespace {
+		d.res.Warn("DPodNet1011", nil, fmt.Sprintf("Different namespaces: %s", warnMsg))
 	}
 }
 

--- a/pkg/diagnostics/networkpod/pod.go
+++ b/pkg/diagnostics/networkpod/pod.go
@@ -59,7 +59,7 @@ func (d CheckPodNetwork) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if !ok {
-		d.res.Warn("DPodNet1002", nil, fmt.Sprintf("Skipping pod connectivity test. Reason: Not using openshift network plugin."))
+		d.res.Warn("DPodNet1002", nil, "Skipping pod connectivity test. Reason: Not using openshift network plugin.")
 		return d.res
 	}
 
@@ -92,27 +92,27 @@ func (d CheckPodNetwork) Check() types.DiagnosticResult {
 
 func (d CheckPodNetwork) checkDifferentNodePodToPodConnection(localGlobalPods, localNonGlobalPods, nonlocalGlobalPods, nonlocalNonGlobalPods []kapi.Pod) {
 	// Applicable to flat and multitenant networks
-	d.checkConnection(localGlobalPods, nonlocalGlobalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on different nodes. Reason: Couldn't find 2 global pods."), true)
+	d.checkConnection(localGlobalPods, nonlocalGlobalPods, "Skipping pod connectivity test for global projects on different nodes. Reason: Couldn't find 2 global pods.", true)
 
 	// Applicable to multitenant network
 	isMultitenant := (d.vnidMap != nil)
 	if isMultitenant {
-		d.checkConnection(localNonGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on different nodes. Reason: Couldn't find 2 non-global pods."), true)
+		d.checkConnection(localNonGlobalPods, nonlocalNonGlobalPods, "Skipping pod connectivity test for non-global projects on different nodes. Reason: Couldn't find 2 non-global pods.", true)
 
-		d.checkConnection(localGlobalPods, nonlocalNonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on different nodes. Reason: Couldn't find global and/or non-global pod."), false)
+		d.checkConnection(localGlobalPods, nonlocalNonGlobalPods, "Skipping pod connectivity test between global to non-global projects on different nodes. Reason: Couldn't find global and/or non-global pod.", false)
 	}
 }
 
 func (d CheckPodNetwork) checkSameNodePodToPodConnection(globalPods, nonGlobalPods []kapi.Pod) {
 	// Applicable to both flat and multitenant networks
-	d.checkConnection(globalPods, globalPods, fmt.Sprintf("Skipping pod connectivity test for global projects on the same node. Reason: Couldn't find 2 global pods."), true)
+	d.checkConnection(globalPods, globalPods, "Skipping pod connectivity test for global projects on the same node. Reason: Couldn't find 2 global pods.", true)
 
 	// Applicable to multitenant network
 	isMultitenant := (d.vnidMap != nil)
 	if isMultitenant {
-		d.checkConnection(nonGlobalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test for non-global projects on the same node. Reason: Couldn't find 2 non-global pods."), true)
+		d.checkConnection(nonGlobalPods, nonGlobalPods, "Skipping pod connectivity test for non-global projects on the same node. Reason: Couldn't find 2 non-global pods.", true)
 
-		d.checkConnection(globalPods, nonGlobalPods, fmt.Sprintf("Skipping pod connectivity test between global to non-global projects on the same node. Reason: Couldn't find global and/or non-global pod."), false)
+		d.checkConnection(globalPods, nonGlobalPods, "Skipping pod connectivity test between global to non-global projects on the same node. Reason: Couldn't find global and/or non-global pod.", false)
 	}
 }
 

--- a/pkg/diagnostics/networkpod/service.go
+++ b/pkg/diagnostics/networkpod/service.go
@@ -132,6 +132,13 @@ func (d CheckServiceNetwork) checkConnection(pods []kapi.Pod, services []kapi.Se
 			}
 		}
 	}
+
+	if !sameNamespace {
+		d.res.Warn("DSvcNet1012", nil, fmt.Sprintf("Same Namespace: %s", warnMsg))
+	}
+	if !diffNamespace {
+		d.res.Warn("DSvcNet1013", nil, fmt.Sprintf("Different namespaces: %s", warnMsg))
+	}
 }
 
 func getAllServices(kubeClient *kclient.Client) ([]kapi.Service, error) {

--- a/pkg/diagnostics/networkpod/service.go
+++ b/pkg/diagnostics/networkpod/service.go
@@ -59,7 +59,7 @@ func (d CheckServiceNetwork) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if !ok {
-		d.res.Warn("DSvcNet1002", nil, fmt.Sprintf("Skipping service connectivity test. Reason: Not using openshift network plugin."))
+		d.res.Warn("DSvcNet1002", nil, "Skipping service connectivity test. Reason: Not using openshift network plugin.")
 		return d.res
 	}
 
@@ -69,7 +69,7 @@ func (d CheckServiceNetwork) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if len(services) == 0 {
-		d.res.Warn("DSvcNet1004", nil, fmt.Sprintf("Skipping service connectivity test. Reason: No services found."))
+		d.res.Warn("DSvcNet1004", nil, "Skipping service connectivity test. Reason: No services found.")
 		return d.res
 	}
 
@@ -96,13 +96,13 @@ func (d CheckServiceNetwork) Check() types.DiagnosticResult {
 
 	// Applicable to flat and multitenant networks
 	if len(localGlobalPods) > 0 {
-		d.checkConnection(localGlobalPods, services, fmt.Sprintf("Skipping service connectivity test for global projects. Reason: Couldn't find a global pod."))
+		d.checkConnection(localGlobalPods, services, "Skipping service connectivity test for global projects. Reason: Couldn't find a global pod.")
 	}
 
 	// Applicable to multitenant network
 	isMultitenant := (d.vnidMap != nil)
 	if isMultitenant {
-		d.checkConnection(localNonGlobalPods, services, fmt.Sprintf("Skipping service connectivity test for non-global projects. Reason: Couldn't find a non-global pod."))
+		d.checkConnection(localNonGlobalPods, services, "Skipping service connectivity test for non-global projects. Reason: Couldn't find a non-global pod.")
 	}
 	return d.res
 }


### PR DESCRIPTION
Created 2 isolated and 2 global namespaces on every node, so that pod to pod connectivity
tests can be performed among same/different namespaces, same/different nodes and global/non-global pods.