### PR TITLE
dind: fix /run mount prop for docker 1.12 compat

### DIFF
--- a/images/dind/dind-setup.sh
+++ b/images/dind/dind-setup.sh
@@ -42,4 +42,5 @@ function enable-overlay-storage() {
 }
 
 mount --make-shared /
+mount --make-shared /run
 enable-overlay-storage


### PR DESCRIPTION
As per #11707, docker 1.12 requires the /run volume to have shared mount propagation enabled. 