### PR TITLE
Fix ip range check condition

### DIFF
--- a/pkg/ipfailover/validator.go
+++ b/pkg/ipfailover/validator.go
@@ -27,12 +27,12 @@ func ValidateIPAddressRange(iprange string) error {
 		return fmt.Errorf("invalid IP range format: %s", iprange)
 	}
 
-	// Its an IP range of the form: n.n.n.n-n
+	// It's an IP range of the form: n.n.n.n-n
 	rangeLimits := strings.Split(iprange, "-")
 	startIP := rangeLimits[0]
 	parts := strings.Split(startIP, ".")
-	if len(parts) < 4 {
-		return fmt.Errorf("invalid IP range start fomat: %s", startIP)
+	if len(parts) != 4 {
+		return fmt.Errorf("invalid IP range start format: %s", startIP)
 	}
 	rangeStart := parts[3]
 	rangeEnd := rangeLimits[1]

--- a/pkg/ipfailover/validator_test.go
+++ b/pkg/ipfailover/validator_test.go
@@ -30,7 +30,7 @@ func TestValidateIPAddress(t *testing.T) {
 func TestValidateIPAddressRange(t *testing.T) {
 	validRanges := []string{"1.1.1.1-1", "1.1.1.1-7", "1.1.1.250-255",
 		"255.255.255.255-255", "8.8.8.4-8", "0.1.2.3-255",
-		"255.254.253.252-255",
+		"255.254.253.252-255", "1.1.1.1", "   1.1.1.1-2   ",
 	}
 
 	for _, iprange := range validRanges {
@@ -43,6 +43,7 @@ func TestValidateIPAddressRange(t *testing.T) {
 		"1.1.1.5-1", "255.255.255.255-259", "1024.512.256.128-255",
 		"a.b.c.d-e", "1.2.3.4.abc-def", "5.6.7.8def-1.2.3.4abc",
 		"a.12.13.14-55", "9999.888.77.6-66", "1.2.3.4-5-6", "1.2.3-4",
+		"1,2.3.4.5-6", "-", "1.1.1.    1-2",
 	}
 
 	for _, iprange := range invalidRanges {


### PR DESCRIPTION
IP ranges like 1.2.3.4.5-6 are also invalid. The last PR https://github.com/openshift/origin/pull/10204 missed this condition, sorry.

Also fix other nit and add some range instances in test case.