### PR TITLE
Extended deployment timeout

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -152,7 +152,8 @@ var _ = g.Describe("deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By(fmt.Sprintf("by checking that the second deployment exists"))
-			err = wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+			// TODO when #11016 gets fixed this can be reverted to 30seconds
+			err = wait.PollImmediate(500*time.Millisecond, 1*time.Minute, func() (bool, error) {
 				_, rcs, _, err := deploymentInfo(oc, name)
 				if err != nil {
 					return false, nil


### PR DESCRIPTION
This extended one of the timeouts we have in our deployment tests, I've noticed at least one occurrence, where the pod got into ready state right after we've timed out. Not sure how much this will help with #10228, but it's worth the shot at this point in time to decrease the level of flakes.

@mfojtik fyi