### PR TITLE
UPSTREAM: 34831: cloudprovider/gce: canonicalize instance name when returning instance array

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
@@ -2787,6 +2787,7 @@ func (gce *GCECloud) getInstancesByNames(names []string) ([]*gceInstance, error)
 
 	instanceArray := make([]*gceInstance, len(names))
 	for i, name := range names {
+		name = canonicalizeInstanceName(name)
 		instance := instances[name]
 		if instance == nil {
 			glog.Errorf("Failed to retrieve instance: %q", name)


### PR DESCRIPTION
@knobunc @liggitt @soltysh 