### PR TITLE
Replace old build utility functions with `os::cmd::try_until_text`

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -247,30 +247,6 @@ function install_registry() {
 }
 readonly -f install_registry
 
-# Wait for builds to start
-# $1 namespace
-function os::build:wait_for_start() {
-	echo "[INFO] Waiting for $1 namespace build to start"
-	wait_for_command "oc get -n $1 builds | grep -i running" $((10*TIME_MIN)) "oc get -n $1 builds | grep -i -e failed -e error"
-	BUILD_ID=`oc get -n $1 builds  --output-version=v1 --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
-	echo "[INFO] Build ${BUILD_ID} started"
-}
-readonly -f os::build:wait_for_start
-
-# Wait for builds to complete
-# $1 namespace
-function os::build:wait_for_end() {
-	echo "[INFO] Waiting for $1 namespace build to complete"
-	wait_for_command "oc get -n $1 builds | grep -i complete" $((10*TIME_MIN)) "oc get -n $1 builds | grep -i -e failed -e error"
-	BUILD_ID=`oc get -n $1 builds --output-version=v1 --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
-	echo "[INFO] Build ${BUILD_ID} finished"
-	# TODO: fix
-	set +e
-	oc build-logs -n $1 $BUILD_ID > $LOG_DIR/$1build.log
-	set -e
-}
-readonly -f os::build:wait_for_end
-
 # enable-selinux/disable-selinux use the shared control variable
 # SELINUX_DISABLED to determine whether to re-enable selinux after it
 # has been disabled.  The goal is to allow temporary disablement of


### PR DESCRIPTION
With the advent of `os::cmd::try_until_text` and simple object indexing
with jsonpath, there is no need for cusom polling utility function impls
anymore. We can collapse on polling with `os::cmd` and the correct index
instead. We _do_ lose the early-exit functionality of these functions as
`os::cmd` doesn't support that, but the loss is worth it as we simplify
our Bash scripts.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@bparees for correctness PTAL