### PR TITLE
Migrated SELinux utility functions to the networking suite

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -183,31 +183,6 @@ function install_registry() {
 }
 readonly -f install_registry
 
-# enable-selinux/disable-selinux use the shared control variable
-# SELINUX_DISABLED to determine whether to re-enable selinux after it
-# has been disabled.  The goal is to allow temporary disablement of
-# selinux enforcement while avoiding enabling enforcement in an
-# environment where it is not already enabled.
-SELINUX_DISABLED=0
-
-function enable-selinux() {
-	if [ "${SELINUX_DISABLED}" = "1" ]; then
-		os::log::info "Re-enabling selinux enforcement"
-		sudo setenforce 1
-		SELINUX_DISABLED=0
-	fi
-}
-readonly -f enable-selinux
-
-function disable-selinux() {
-	if selinuxenabled && [ "$(getenforce)" = "Enforcing" ]; then
-		os::log::info "Temporarily disabling selinux enforcement"
-		sudo setenforce 0
-		SELINUX_DISABLED=1
-	fi
-}
-readonly -f disable-selinux
-
 ######
 # end of common functions for extended test group's run.sh scripts
 ######

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -269,6 +269,29 @@ else
 fi
 TEST_BINARY="${OS_ROOT}/$(os::build::find-binary extended.test)"
 
+# enable-selinux/disable-selinux use the shared control variable
+# SELINUX_DISABLED to determine whether to re-enable selinux after it
+# has been disabled.  The goal is to allow temporary disablement of
+# selinux enforcement while avoiding enabling enforcement in an
+# environment where it is not already enabled.
+SELINUX_DISABLED=0
+
+function enable-selinux() {
+  if [ "${SELINUX_DISABLED}" = "1" ]; then
+    os::log::info "Re-enabling selinux enforcement"
+    sudo setenforce 1
+    SELINUX_DISABLED=0
+  fi
+}
+
+function disable-selinux() {
+  if selinuxenabled && [ "$(getenforce)" = "Enforcing" ]; then
+    os::log::info "Temporarily disabling selinux enforcement"
+    sudo setenforce 0
+    SELINUX_DISABLED=1
+  fi
+}
+
 os::log::info "Starting 'networking' extended tests"
 if [[ -n "${CONFIG_ROOT}" ]]; then
   KUBECONFIG="$(get-kubeconfig-from-root "${CONFIG_ROOT}")"


### PR DESCRIPTION
As none of the other test suites are touching SELinux (and
should NOT be doing so), we do not need to contain these
utilities for enabling and disabling SELinux in a shared
Bash library.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @marun

[test]