### PR TITLE
Migrate scripts to use `os::log::info`

### DIFF
--- a/hack/lib/log/system.sh
+++ b/hack/lib/log/system.sh
@@ -186,7 +186,7 @@ function os::log::system::internal::plot() {
         printf '\n\n'
     } >> "${LOG_DIR}/gnuplot.log"
 
-    echo "[INFO] Stacked plot for log subset \"${plotname}\" written to ${LOG_DIR}/${plotname}.pdf"
+    os::log::info "Stacked plot for log subset \"${plotname}\" written to ${LOG_DIR}/${plotname}.pdf"
 }
 readonly -f os::log::system::internal::plot
 

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -192,7 +192,7 @@ function os::start::internal::patch_master_config() {
 	export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 	CLUSTER_ADMIN_CONTEXT=$(oc config view --config="${ADMIN_KUBECONFIG}" --flatten -o template --template='{{index . "current-context"}}'); export CLUSTER_ADMIN_CONTEXT
 	${sudo} chmod -R a+rwX "${ADMIN_KUBECONFIG}"
-	echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
+	os::log::info "To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
 }
 readonly -f os::start::internal::patch_master_config
 
@@ -230,7 +230,7 @@ function os::start::server() {
 	local controllers_version="${2:-}"
 	local skip_node="${3:-}"
 
-	echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
+	os::log::info "Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 	ps -ef | grep openshift
 
 	mkdir -p "${LOG_DIR}"
@@ -278,10 +278,10 @@ function os::start::master() {
 
 	mkdir -p "${LOG_DIR}"
 
-	echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
+	os::log::info "Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 	ps -ef | grep openshift
 
-	echo "[INFO] Starting OpenShift server"
+	os::log::info "Starting OpenShift server"
 	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
 	$(os::start::internal::openshift_executable) start master \
 		--config="${MASTER_CONFIG_DIR}/master-config.yaml" \
@@ -289,7 +289,7 @@ function os::start::master() {
 	&>"${LOG_DIR}/openshift.log" &
 	export OS_PID=$!
 
-	echo "[INFO] OpenShift server start at: "
+	os::log::info "OpenShift server start at: "
 	date
 
 	os::test::junit::declare_suite_start "setup/start-master"
@@ -297,7 +297,7 @@ function os::start::master() {
 	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 
-	echo "[INFO] OpenShift server health checks done at: "
+	os::log::info "OpenShift server health checks done at: "
 	date
 }
 readonly -f os::start::master
@@ -331,7 +331,7 @@ function os::start::all_in_one() {
 		use_latest_images="false"
 	fi
 
-	echo "[INFO] Starting OpenShift server"
+	os::log::info "Starting OpenShift server"
 	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable)"
@@ -344,7 +344,7 @@ function os::start::all_in_one() {
 		                      &>"${LOG_DIR}/openshift.log" &
 	export OS_PID=$!
 
-	echo "[INFO] OpenShift server start at: "
+	os::log::info "OpenShift server start at: "
 	date
 
 	os::test::junit::declare_suite_start "setup/start-all_in_one"
@@ -354,7 +354,7 @@ function os::start::all_in_one() {
 	os::cmd::try_until_success "oc get --raw /api/v1/nodes/${KUBELET_HOST} --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 80 * second )) 0.25
 	os::test::junit::declare_suite_end
 
-	echo "[INFO] OpenShift server health checks done at: "
+	os::log::info "OpenShift server health checks done at: "
 	date
 }
 readonly -f os::start::all_in_one
@@ -372,7 +372,7 @@ readonly -f os::start::all_in_one
 # Returns:
 #  - export ETCD_PID
 function os::start::etcd() {
-	echo "[INFO] Starting etcd"
+	os::log::info "Starting etcd"
 	local openshift_env=( "OPENSHIFT_ON_PANIC=crash" )
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable)"
@@ -380,14 +380,14 @@ function os::start::etcd() {
 		--config="${MASTER_CONFIG_DIR}/master-config.yaml" &>"${LOG_DIR}/etcd.log" &
 	export ETCD_PID=$!
 
-	echo "[INFO] etcd server start at: "
+	os::log::info "etcd server start at: "
 	date
 
 	os::test::junit::declare_suite_start "setup/start-etcd"
 	os::cmd::try_until_success "os::util::curl_etcd '/version'" $(( 10 * second ))
 	os::test::junit::declare_suite_end
 
-	echo "[INFO] etcd server health checks done at: "
+	os::log::info "etcd server health checks done at: "
 	date
 }
 readonly -f os::start::etcd
@@ -421,7 +421,7 @@ function os::start::api_server() {
 
 	export API_SERVER_PID=$!
 
-	echo "[INFO] OpenShift API server start at: "
+	os::log::info "OpenShift API server start at: "
 	date
 
 	os::test::junit::declare_suite_start "setup/start-api_server"
@@ -429,7 +429,7 @@ function os::start::api_server() {
 	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 
-	echo "[INFO] OpenShift API server health checks done at: "
+	os::log::info "OpenShift API server health checks done at: "
 	date
 }
 readonly -f os::start::api_server
@@ -456,7 +456,7 @@ function os::start::controllers() {
 
 	export CONTROLLERS_PID=$!
 
-	echo "[INFO] OpenShift controllers start at: "
+	os::log::info "OpenShift controllers start at: "
 	date
 }
 readonly -f os::start::controllers
@@ -485,7 +485,7 @@ function os::start::internal::start_node() {
 
 	mkdir -p "${LOG_DIR}"
 
-	echo "[INFO] Starting OpenShift node"
+	os::log::info "Starting OpenShift node"
 	local openshift_env=( "OPENSHIFT_ON_PANIC=crash" )
 	$(os::start::internal::openshift_executable) openshift start node \
 		--config="${NODE_CONFIG_DIR}/node-config.yaml" \
@@ -494,14 +494,14 @@ function os::start::internal::start_node() {
 	&>"${LOG_DIR}/node.log" &
 	export NODE_PID=$!
 
-	echo "[INFO] OpenShift node start at: "
+	os::log::info "OpenShift node start at: "
 	date
 
 	os::test::junit::declare_suite_start "setup/start-node"
 	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
 	os::test::junit::declare_suite_end
 
-	echo "[INFO] OpenShift node health checks done at: "
+	os::log::info "OpenShift node health checks done at: "
 	date
 }
 readonly -f os::start::internal::start_node
@@ -589,9 +589,9 @@ readonly -f os::start::internal::determine_hostnames
 function os::start::internal::print_server_info() {
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable)"
-	echo "[INFO] $(${openshift_executable} version)"
-	echo "[INFO] Server logs will be at:   ${LOG_DIR}"
-	echo "[INFO] Config dir is:            ${SERVER_CONFIG_DIR}"
-	echo "[INFO] Using images:             ${USE_IMAGES}"
-	echo "[INFO] MasterIP is:              ${MASTER_ADDR}"
+	os::log::info "$(${openshift_executable} version)"
+	os::log::info "Server logs will be at:   ${LOG_DIR}"
+	os::log::info "Config dir is:            ${SERVER_CONFIG_DIR}"
+	os::log::info "Using images:             ${USE_IMAGES}"
+	os::log::info "MasterIP is:              ${MASTER_ADDR}"
 }

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -32,7 +32,7 @@ function cleanup()
         echo -------------------------------------
         echo
     elif go tool -n pprof >/dev/null 2>&1; then
-        echo "[INFO] \`pprof\` output logged to ${LOG_DIR}/pprof.out"
+        os::log::info "\`pprof\` output logged to ${LOG_DIR}/pprof.out"
         go tool pprof -text "./_output/local/bin/$(os::util::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
     fi
 
@@ -65,7 +65,7 @@ function cleanup()
     fi
 
     ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
-    echo "[INFO] Exiting with ${out}"
+    os::log::info "Exiting with ${out}"
     exit $out
 }
 
@@ -147,7 +147,7 @@ oc version
 export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 
 # Specify the scheme and port for the listen address, but let the IP auto-discover. Set --public-master to localhost, for a stable link to the console.
-echo "[INFO] Create certificates for the OpenShift server to ${MASTER_CONFIG_DIR}"
+os::log::info "Create certificates for the OpenShift server to ${MASTER_CONFIG_DIR}"
 # find the same IP that openshift start will bind to.  This allows access from pods that have to talk back to master
 SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},$(openshift start --print-ip),localhost"
 
@@ -355,6 +355,6 @@ for test in "${tests[@]}"; do
   cp ${KUBECONFIG}{.bak,}  # since nothing ever gets deleted from kubeconfig, reset it
 done
 
-echo "[INFO] Metrics information logged to ${LOG_DIR}/metrics.log"
+os::log::info "Metrics information logged to ${LOG_DIR}/metrics.log"
 oc get --raw /metrics > "${LOG_DIR}/metrics.log"
 echo "test-cmd: ok"

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -5,7 +5,7 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "[INFO] Starting containerized end-to-end test"
+os::log::info "Starting containerized end-to-end test"
 
 unset KUBECONFIG
 
@@ -19,7 +19,7 @@ function cleanup()
 	if [ $out -ne 0 ]; then
 		echo "[FAIL] !!!!! Test Failed !!!!"
 	else
-		echo "[INFO] Test Succeeded"
+		os::log::info "Test Succeeded"
 	fi
 	echo
 
@@ -33,13 +33,13 @@ function cleanup()
 	os::cleanup::dump_etcd
 
 	if [[ -z "${SKIP_TEARDOWN-}" ]]; then
-		echo "[INFO] remove the openshift container"
+		os::log::info "remove the openshift container"
 		docker stop origin
 		docker rm origin
 
-		echo "[INFO] Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop
+		os::log::info "Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop
 		if [[ -z "${SKIP_IMAGE_CLEANUP-}" ]]; then
-			echo "[INFO] Removing k8s docker containers"; docker ps -a | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker rm
+			os::log::info "Removing k8s docker containers"; docker ps -a | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker rm
 		fi
 		set -u
 	fi
@@ -50,7 +50,7 @@ function cleanup()
 	truncate_large_logs
 	set -e
 
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
 	exit $out
 }
@@ -67,11 +67,11 @@ out=$(
 )
 
 # Setup
-echo "[INFO] openshift version: `openshift version`"
-echo "[INFO] oc version:        `oc version`"
-echo "[INFO] Using images:							${USE_IMAGES}"
+os::log::info "openshift version: `openshift version`"
+os::log::info "oc version:        `oc version`"
+os::log::info "Using images:							${USE_IMAGES}"
 
-echo "[INFO] Starting OpenShift containerized server"
+os::log::info "Starting OpenShift containerized server"
 oc cluster up --server-loglevel=4 --version="${TAG}" \
         --host-data-dir="${VOLUME_DIR}/etcd" \
         --host-volumes-dir="${VOLUME_DIR}"
@@ -85,7 +85,7 @@ export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template --template='{{index . "current-context"}}')
 sudo chmod -R a+rwX "${ADMIN_KUBECONFIG}"
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
-echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
+os::log::info "To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
 
 
 ${OS_ROOT}/test/end-to-end/core.sh

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -18,7 +18,7 @@ fi
 
 ensure_iptables_or_die
 
-echo "[INFO] Starting end-to-end test"
+os::log::info "Starting end-to-end test"
 
 function cleanup()
 {
@@ -27,12 +27,12 @@ function cleanup()
 	if [ $out -ne 0 ]; then
 		echo "[FAIL] !!!!! Test Failed !!!!"
 	else
-		echo "[INFO] Test Succeeded"
+		os::log::info "Test Succeeded"
 	fi
 	echo
 
 	cleanup_openshift
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
 	exit $out
 }

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -215,7 +215,7 @@ if [[ -n "${junit_report}" ]]; then
     test_error_file="${LOG_DIR}/test-go-err.log"
     junit_report_file="${ARTIFACT_DIR}/report.xml"
 
-    echo "[INFO] Running \`go test\`..."
+    os::log::info "Running \`go test\`..."
     # we don't care if the `go test` fails in this pipe, as we want to generate the report and summarize the output anyway
     set +o pipefail
 
@@ -258,8 +258,8 @@ if [[ -n "${junit_report}" ]]; then
         fi
     fi
 
-    echo "[INFO] Full output from \`go test\` logged at ${test_output_file}"
-    echo "[INFO] jUnit XML report placed at ${junit_report_file}"
+    os::log::info "Full output from \`go test\` logged at ${test_output_file}"
+    os::log::info "jUnit XML report placed at ${junit_report_file}"
     exit "${test_return_code}"
 
 elif [[ -n "${coverage_output_dir}" ]]; then
@@ -276,7 +276,7 @@ elif [[ -n "${coverage_output_dir}" ]]; then
     find "${coverage_output_dir}" -name profile.out | xargs sed '/^mode: atomic$/d' >> "${coverage_output_dir}/profiles.out"
 
     go tool cover "-html=${coverage_output_dir}/profiles.out" -o "${coverage_output_dir}/coverage.html"
-    echo "[INFO] Coverage profile written to ${coverage_output_dir}/coverage.html"
+    os::log::info "Coverage profile written to ${coverage_output_dir}/coverage.html"
 
     # clean up all of the individual coverage reports as they have been subsumed into the report at ${coverage_output_dir}/coverage.html
     # we can clean up all of the coverage reports at once as they all exist in subdirectories of ${coverage_output_dir}/${OS_GO_PACKAGE}

--- a/hack/update-generated-swagger-descriptions.sh
+++ b/hack/update-generated-swagger-descriptions.sh
@@ -62,11 +62,11 @@ for file in ${source_files}; do
 				echo "[ERROR] Generated Swagger documentation at \"${swagger_file}\" is out of date."
 				failed='true'
 			else
-				echo "[INFO] Verified that generated Swagger documentation at \"${swagger_file}\" is up to date."
+				os::log::info "Verified that generated Swagger documentation at \"${swagger_file}\" is up to date."
 			fi
 		else
 			mv "${tmp_output_file}" "${swagger_file}"
-			echo "[INFO] Generated Swagger documentation written for \"${file}\" to \"${swagger_file}\""
+			os::log::info "Generated Swagger documentation written for \"${file}\" to \"${swagger_file}\""
 		fi
 	fi
 done

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -7,4 +7,4 @@ pushd "${OS_ROOT}/hack/swagger-doc" > /dev/null
 gradle gendocs --info
 popd > /dev/null
 
-echo "[INFO] Swagger doc generation successful"
+os::log::info "Swagger doc generation successful"

--- a/hack/verify-open-ports.sh
+++ b/hack/verify-open-ports.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # Open port scanning
-echo "[INFO] Checking open ports ('sudo openshift start' should already be running)"
+os::log::info "Checking open ports ('sudo openshift start' should already be running)"
 
 # 53 (DNS)
 # 4001,7001 (etcd)

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -11,7 +11,7 @@ function cleanup()
 {
 	out=$?
     kill $OS_PID
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	exit $out
 }
 
@@ -19,15 +19,15 @@ trap "exit" INT TERM
 trap "cleanup" EXIT
 
 
-echo "[INFO] Starting server as distinct processes"
-echo "[INFO] `openshift version`"
-echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
-echo "[INFO] Test artifacts will be in: ${ARTIFACT_DIR}"
-echo "[INFO] Config dir is:             ${SERVER_CONFIG_DIR}"
+os::log::info "Starting server as distinct processes"
+os::log::info "`openshift version`"
+os::log::info "Server logs will be at:    ${LOG_DIR}/openshift.log"
+os::log::info "Test artifacts will be in: ${ARTIFACT_DIR}"
+os::log::info "Config dir is:             ${SERVER_CONFIG_DIR}"
 
 mkdir -p ${LOG_DIR}
 
-echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
+os::log::info "Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 ps -ef | grep openshift
 
 mkdir -p "${SERVER_CONFIG_DIR}"

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -14,7 +14,7 @@ function cleanup()
 	out=$?
   pgrep -f "openshift" | xargs -r sudo kill
 	cleanup_openshift
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	exit $out
 }
 
@@ -22,30 +22,30 @@ trap "exit" INT TERM
 trap "cleanup" EXIT
 
 
-echo "[INFO] Starting server as distinct processes"
+os::log::info "Starting server as distinct processes"
 ensure_iptables_or_die
 os::start::configure_server
 
-echo "[INFO] `openshift version`"
-echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
-echo "[INFO] Test artifacts will be in: ${ARTIFACT_DIR}"
-echo "[INFO] Volumes dir is:            ${VOLUME_DIR}"
-echo "[INFO] Config dir is:             ${SERVER_CONFIG_DIR}"
-echo "[INFO] Using images:              ${USE_IMAGES}"
-echo "[INFO] MasterIP is:               ${MASTER_ADDR}"
+os::log::info "`openshift version`"
+os::log::info "Server logs will be at:    ${LOG_DIR}/openshift.log"
+os::log::info "Test artifacts will be in: ${ARTIFACT_DIR}"
+os::log::info "Volumes dir is:            ${VOLUME_DIR}"
+os::log::info "Config dir is:             ${SERVER_CONFIG_DIR}"
+os::log::info "Using images:              ${USE_IMAGES}"
+os::log::info "MasterIP is:               ${MASTER_ADDR}"
 
 mkdir -p ${LOG_DIR}
 
-echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
+os::log::info "Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 ps -ef | grep openshift
 
-echo "[INFO] Starting etcdserver"
+os::log::info "Starting etcdserver"
 sudo env "PATH=${PATH}" OPENSHIFT_ON_PANIC=crash openshift start etcd \
  --config=${MASTER_CONFIG_DIR}/master-config.yaml \
  --loglevel=4 \
 &>"${LOG_DIR}/os-etcdserver.log" &
 
-echo "[INFO] Starting api server"
+os::log::info "Starting api server"
 sudo env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master api \
  --config=${MASTER_CONFIG_DIR}/master-config.yaml \
  --loglevel=4 \
@@ -53,11 +53,11 @@ sudo env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift
 
 os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
 os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
-echo "[INFO] OpenShift API server up at: "
+os::log::info "OpenShift API server up at: "
 date
 
 # test alternate node level launches
-echo "[INFO] Testing alternate node configurations"
+os::log::info "Testing alternate node configurations"
 
 # proxy only
 sudo env "PATH=${PATH}" TEST_CALL=1 OPENSHIFT_ON_PANIC=crash openshift start network --enable=proxy \
@@ -111,25 +111,25 @@ os::cmd::expect_success_and_not_text 'cat ${LOG_DIR}/os-node-3.log' 'Starting no
 os::cmd::expect_success_and_not_text 'cat ${LOG_DIR}/os-node-3.log' 'Started Kubernetes Proxy on'
 
 
-echo "[INFO] Starting controllers"
+os::log::info "Starting controllers"
 sudo env "PATH=${PATH}"  OPENSHIFT_ON_PANIC=crash openshift start master controllers \
  --config=${MASTER_CONFIG_DIR}/master-config.yaml \
  --loglevel=4 \
 &>"${LOG_DIR}/os-controllers.log" &
 
-echo "[INFO] Starting node"
+os::log::info "Starting node"
 sudo env "PATH=${PATH}"  OPENSHIFT_ON_PANIC=crash openshift start node \
  --config=${NODE_CONFIG_DIR}/node-config.yaml \
  --loglevel=4 \
 &>"${LOG_DIR}/os-node.log" &
 export OS_PID=$!
 
-echo "[INFO] OpenShift server start at: "
+os::log::info "OpenShift server start at: "
 date
 
 os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' minute 0.5
 os::cmd::try_until_success "oc get --raw /api/v1/nodes/${KUBELET_HOST} --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 80 * second )) 0.25
-echo "[INFO] OpenShift node health checks done at: "
+os::log::info "OpenShift node health checks done at: "
 date
 
 # set our default KUBECONFIG location

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -14,14 +14,14 @@ function cleanup()
 	out=$?
 	docker rmi test/scratchimage
 	cleanup_openshift
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	return "${out}"
 }
 
 trap "exit" INT TERM
 trap "cleanup" EXIT
 
-echo "[INFO] Starting server"
+os::log::info "Starting server"
 
 os::util::environment::use_sudo
 os::util::environment::setup_all_server_vars "test-extended/cmd/"
@@ -44,7 +44,7 @@ docker_registry="$( oc get service/docker-registry -n default -o jsonpath='{.spe
 os::test::junit::declare_suite_start "extended/cmd"
 
 os::test::junit::declare_suite_start "extended/cmd/new-app"
-echo "[INFO] Running newapp extended tests"
+os::log::info "Running newapp extended tests"
 oc login "${MASTER_ADDR}" -u new-app -p password --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt"
 oc new-project new-app
 oc delete all --all
@@ -73,11 +73,11 @@ VERBOSE=true os::cmd::expect_success "oc project new-app"
 os::cmd::expect_failure_and_text "oc new-app test/scratchimage2 -o yaml" "partial match"
 # success with exact match
 os::cmd::expect_success "oc new-app test/scratchimage"
-echo "[INFO] newapp: ok"
+os::log::info "newapp: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "extended/cmd/variable-expansion"
-echo "[INFO] Running env variable expansion tests"
+os::log::info "Running env variable expansion tests"
 VERBOSE=true os::cmd::expect_success "oc new-project envtest"
 os::cmd::expect_success "oc create -f test/extended/testdata/test-env-pod.json"
 os::cmd::try_until_text "oc get pods" "Running"
@@ -86,11 +86,11 @@ os::cmd::expect_success_and_text "oc exec test-pod env" "podname_composed=test-p
 os::cmd::expect_success_and_text "oc exec test-pod env" "var1=value1"
 os::cmd::expect_success_and_text "oc exec test-pod env" "var2=value1"
 os::cmd::expect_success_and_text "oc exec test-pod ps ax" "sleep 120"
-echo "[INFO] variable-expansion: ok"
+os::log::info "variable-expansion: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "extended/cmd/image-pull-secrets"
-echo "[INFO] Running image pull secrets tests"
+os::log::info "Running image pull secrets tests"
 VERBOSE=true os::cmd::expect_success "oc login '${MASTER_ADDR}' -u pull-secrets-user -p password --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt'"
 
 # create a new project and push a busybox image in there

--- a/test/extended/compatibility.sh
+++ b/test/extended/compatibility.sh
@@ -18,5 +18,5 @@ os::test::extended::setup
 os::test::extended::focus "$@"
 
 
-echo "[INFO] Running compatibility tests"
+os::log::info "Running compatibility tests"
 FOCUS="\[Compatibility\]" SKIP="${SKIP_TESTS:-}" TEST_REPORT_FILE_NAME=compatibility os::test::extended::run -- -ginkgo.v -test.timeout 2h

--- a/test/extended/conformance.sh
+++ b/test/extended/conformance.sh
@@ -20,7 +20,7 @@ sf=$(join '|' "${serial_only[@]}")
 ss=$(join '|' "${serial_exclude[@]}")
 
 
-echo "[INFO] Running the following tests:"
+os::log::info "Running the following tests:"
 TEST_REPORT_DIR= TEST_OUTPUT_QUIET=true ${EXTENDEDTEST} "--ginkgo.focus=${pf}" "--ginkgo.skip=${ps}" --ginkgo.dryRun --ginkgo.noColor | grep ok | grep -v skip | cut -c 20- | sort
 TEST_REPORT_DIR= TEST_OUTPUT_QUIET=true ${EXTENDEDTEST} "--ginkgo.focus=${sf}" "--ginkgo.skip=${ss}" --ginkgo.dryRun --ginkgo.noColor | grep ok | grep -v skip | cut -c 20- | sort
 echo
@@ -29,11 +29,11 @@ exitstatus=0
 
 # run parallel tests
 nodes="${PARALLEL_NODES:-5}"
-echo "[INFO] Running parallel tests N=${nodes}"
+os::log::info "Running parallel tests N=${nodes}"
 TEST_REPORT_FILE_NAME=conformance_parallel ${GINKGO} -v "-focus=${pf}" "-skip=${ps}" -p -nodes "${nodes}" ${EXTENDEDTEST} -- -ginkgo.v -test.timeout 6h || exitstatus=$?
 
 # run tests in serial
-echo "[INFO] Running serial tests"
+os::log::info "Running serial tests"
 TEST_REPORT_FILE_NAME=conformance_serial ${GINKGO} -v "-focus=${sf}" "-skip=${ss}" ${EXTENDEDTEST} -- -ginkgo.v -test.timeout 2h || exitstatus=$?
 
 exit $exitstatus

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -12,14 +12,14 @@ function cleanup()
 {
 	out=$?
 	cleanup_openshift
-	echo "[INFO] Exiting"
+	os::log::info "Exiting"
 	return $out
 }
 
 trap "exit" INT TERM
 trap "cleanup" EXIT
 
-echo "[INFO] Starting server"
+os::log::info "Starting server"
 
 ensure_iptables_or_die
 os::util::environment::use_sudo
@@ -94,13 +94,13 @@ function compare_and_cleanup() {
 
 oc login -u system:admin -n default
 
-echo "[INFO] Running extended tests"
+os::log::info "Running extended tests"
 
 schema=('rfc2307' 'ad' 'augmented-ad')
 
 for (( i=0; i<${#schema[@]}; i++ )); do
 	current_schema=${schema[$i]}
-	echo "[INFO] Testing schema: ${current_schema}"
+	os::log::info "Testing schema: ${current_schema}"
 
 	WORKINGDIR=${BASETMPDIR}/${current_schema}
 	mkdir ${WORKINGDIR}


### PR DESCRIPTION
Instead of using `echo "[INFO]..."` scripts should instead
be using the logging utility function `os::log::info`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

This commit was generated with the following script:
```sh
#!/bin/bash

for file in $( find /home/skuznets/Documents/go/src/github.com/openshift/origin -type f -name '*.sh' ); do
	if grep -q 'lib/init.sh' "${file}" ||
		[[
			"${file}" == *'hack/lib/'* ||
			"${file}" == *'hack/common.sh' ||
			"${file}" == *'hack/util.sh'
		]] && [[
			! "${file}" == *'hack/lib/log/output.sh'
		]]; then
		sed -i "s/echo '\[INFO\] /os::log::info '/g" "${file}"
		sed -i 's/echo "\[INFO\] /os::log::info "/g'  "${file}"
	fi
done
```

@smarterclayton PTAL