### PR TITLE
fix extended argument parsing to config building for etcd

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -23,11 +23,9 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/authorizer"
-	genericapiserveroptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
-	"k8s.io/kubernetes/pkg/storage/storagebackend"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	knet "k8s.io/kubernetes/pkg/util/net"
@@ -122,16 +120,13 @@ func BuildDefaultAPIServer(options configapi.MasterConfig) (*apiserveroptions.AP
 		return nil, nil, err
 	}
 
-	etcdConfig := storagebackend.Config{
-		Type:       server.StorageConfig.Type,
-		Prefix:     options.EtcdStorageConfig.KubernetesStoragePrefix,
-		ServerList: options.EtcdClientInfo.URLs,
-		KeyFile:    options.EtcdClientInfo.ClientCert.KeyFile,
-		CertFile:   options.EtcdClientInfo.ClientCert.CertFile,
-		CAFile:     options.EtcdClientInfo.CA,
-		DeserializationCacheSize: genericapiserveroptions.DefaultDeserializationCacheSize,
-		Quorum: server.StorageConfig.Quorum,
-	}
+	// use the stock storage config based on args, but override bits from our config where appropriate
+	etcdConfig := server.StorageConfig
+	etcdConfig.Prefix = options.EtcdStorageConfig.KubernetesStoragePrefix
+	etcdConfig.ServerList = options.EtcdClientInfo.URLs
+	etcdConfig.KeyFile = options.EtcdClientInfo.ClientCert.KeyFile
+	etcdConfig.CertFile = options.EtcdClientInfo.ClientCert.CertFile
+	etcdConfig.CAFile = options.EtcdClientInfo.CA
 
 	storageFactory, err := genericapiserver.BuildDefaultStorageFactory(
 		etcdConfig,


### PR DESCRIPTION
Building the storage config ignored API arguments passed in via config.  This undoes that, which makes it possible to tune the deserialization cache size default as a whole.

@mfojtik @liggitt ptal

@dinhxuanvu @abhgupta Might impact you.  After this change, you can set 
```yaml
kubernetesMasterConfig:
  apiServerArguments:
    watch-cache-sizes:
    - clusterresourcequotas#0
    deserialization-cache-size:
    - "10"
    storage-backend:
    - etcd2
```
in `master-config.yaml` to make the deserialization cache tiny for all objects.  Its not very granular, but its something I'd like to test.