### PR TITLE
Migrate scripts to use `os::log::warn`

### DIFF
--- a/hack/lib/log/system.sh
+++ b/hack/lib/log/system.sh
@@ -51,7 +51,7 @@ function os::log::system::clean_up() {
     fi
 
     if ! which sadf  >/dev/null 2>&1; then
-        echo "[WARNING] System logger data could not be unpacked and graphed, 'sadf' binary not found in this environment."
+        os::log::warn "System logger data could not be unpacked and graphed, 'sadf' binary not found in this environment."
         return 0
     fi
 
@@ -201,7 +201,7 @@ readonly -f os::log::system::internal::plot
 #  - export SAR_LOGFILE
 function os::log::system::start() {
     if ! which sar >/dev/null 2>&1; then
-        echo "[WARNING] System logger could not be started, 'sar' binary not found in this environment."
+        os::log::warn "System logger could not be started, 'sar' binary not found in this environment."
         return 0
     fi
 

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -80,7 +80,7 @@ if [[ "${tag}" != ":latest" ]]; then
       docker pull "${OS_PUSH_BASE_REGISTRY-}${image}:${source_tag}"
     done
   else
-    echo "WARNING: Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}*${tag}"
+    os::log::warn "Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}*${tag}"
     if [[ -z "${OS_PUSH_ALWAYS:-}" ]]; then
       echo "  CTRL+C to cancel, or any other key to continue"
       read

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -44,27 +44,27 @@ os::util::environment::setup_tmpdir_vars "test-go"
 # TODO(skuznets): remove these once we've migrated all tools to the new vars
 if [[ -n "${KUBE_TIMEOUT+x}" ]]; then
     TIMEOUT="${KUBE_TIMEOUT}"
-    echo "[WARNING] The flag \$KUBE_TIMEOUT for $0 is deprecated, use \$TIMEOUT instead."
+    os::log::warn "The flag \$KUBE_TIMEOUT for $0 is deprecated, use \$TIMEOUT instead."
 fi
 
 if [[ -n "${KUBE_COVER+x}" ]]; then
     COVERAGE_SPEC="${KUBE_COVER}"
-    echo "[WARNING] The flag \$KUBE_COVER for $0 is deprecated, use \$COVERAGE_SPEC instead."
+    os::log::warn "The flag \$KUBE_COVER for $0 is deprecated, use \$COVERAGE_SPEC instead."
 fi
 
 if [[ -n "${OUTPUT_COVERAGE+x}" ]]; then
     COVERAGE_OUTPUT_DIR="${OUTPUT_COVERAGE}"
-    echo "[WARNING] The flag \$OUTPUT_COVERAGE for $0 is deprecated, use \$COVERAGE_OUTPUT_DIR instead."
+    os::log::warn "The flag \$OUTPUT_COVERAGE for $0 is deprecated, use \$COVERAGE_OUTPUT_DIR instead."
 fi
 
 if [[ -n "${KUBE_RACE+x}" ]]; then
     DETECT_RACES="${KUBE_RACE}"
-    echo "[WARNING] The flag \$KUBE_RACE for $0 is deprecated, use \$DETECT_RACES instead."
+    os::log::warn "The flag \$KUBE_RACE for $0 is deprecated, use \$DETECT_RACES instead."
 fi
 
 if [[ -n "${PRINT_PACKAGES+x}" ]]; then
     DRY_RUN="${PRINT_PACKAGES}"
-    echo "[WARNING] The flag \$PRINT_PACKAGES for $0 is deprecated, use \$DRY_RUN instead."
+    os::log::warn "The flag \$PRINT_PACKAGES for $0 is deprecated, use \$DRY_RUN instead."
 fi
 
 # Internalize environment variables we consume and default if they're not set
@@ -237,24 +237,24 @@ if [[ -n "${junit_report}" ]]; then
 
     if echo "${summary}" | grep -q ', 0 failed,'; then
         if [[ "${test_return_code}" -ne "0" ]]; then
-            echo "[WARNING] While the jUnit report found no failed tests, the \`go test\` process failed."
-            echo "[WARNING] This usually means that the unit test suite failed to compile."
+            os::log::warn "While the jUnit report found no failed tests, the \`go test\` process failed."
+            os::log::warn "This usually means that the unit test suite failed to compile."
         fi
     fi
 
     if [[ -s "${test_error_file}" ]]; then
-        echo "[WARNING] \`go test\` had the following output to stderr:"
+        os::log::warn "\`go test\` had the following output to stderr:"
         cat "${test_error_file}"
     fi
 
     if grep -q 'WARNING: DATA RACE' "${test_output_file}"; then
         locations=( $( sed -n '/WARNING: DATA RACE/=' "${test_output_file}") )
         if [[ "${#locations[@]}" -gt 1 ]]; then
-            echo "[WARNING] \`go test\` detected data races."
-            echo "[WARNING] Details can be found in the full output file at lines ${locations[*]}."
+            os::log::warn "\`go test\` detected data races."
+            os::log::warn "Details can be found in the full output file at lines ${locations[*]}."
         else
-            echo "[WARNING] \`go test\` detected a data race."
-            echo "[WARNING] Details can be found in the full output file at line ${locations[*]}."
+            os::log::warn "\`go test\` detected a data race."
+            os::log::warn "Details can be found in the full output file at line ${locations[*]}."
         fi
     fi
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -28,7 +28,7 @@ verbose="${VERBOSE:-}"
 
 # build the test executable (cgo must be disabled to have the symbol table available)
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
-  echo "WARNING: Skipping build due to OPENSHIFT_SKIP_BUILD"
+  os::log::warn "Skipping build due to OPENSHIFT_SKIP_BUILD"
 else
 	CGO_ENABLED=0 "${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test" -installsuffix=cgo
 fi

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -9,7 +9,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 platform="$(os::build::host_platform)"
 if [[ "${platform}" != "linux/amd64" ]]; then
-  echo "WARNING: Generating completions on ${platform} may not be identical to running on linux/amd64 due to conditional compilation."
+  os::log::warn "Generating completions on ${platform} may not be identical to running on linux/amd64 due to conditional compilation."
 fi
 
 OUTPUT_REL_DIR=${1:-""}

--- a/hack/verify-generated-completions.sh
+++ b/hack/verify-generated-completions.sh
@@ -5,7 +5,7 @@ echo "===== Verifying Generated Completions ====="
 
 platform="$(os::build::host_platform)"
 if [[ "${platform}" != "linux/amd64" ]]; then
-  echo "WARNING: Completions cannot be verified on non-Linux systems (${platform})"
+  os::log::warn "Completions cannot be verified on non-Linux systems (${platform})"
   exit 0
 fi
 


### PR DESCRIPTION
Instead of using `echo "[WARNING]..."` scripts should instead
be using the logging utility function `os::log::warn`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton also generated with a script