### PR TITLE
Refactor uses of `wait_for_command` to use `os::cmd::try_until*`

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -25,51 +25,6 @@ function ensure_iptables_or_die() {
 }
 readonly -f ensure_iptables_or_die
 
-# wait_for_command executes a command and waits for it to
-# complete or times out after max_wait.
-#
-# $1 - The command to execute (e.g. curl -fs http://redhat.com)
-# $2 - Optional maximum time to wait in ms before giving up (Default: 10000ms)
-# $3 - Optional alternate command to determine if the wait should
-#		exit before the max_wait
-function wait_for_command() {
-	STARTTIME=$(date +%s)
-	cmd=$1
-	msg="Waiting for command to finish: '${cmd}'..."
-	max_wait=${2:-10*TIME_SEC}
-	fail=${3:-""}
-	wait=0.2
-
-	echo "[INFO] $msg"
-	expire=$(($(time_now) + $max_wait))
-	set +e
-	while [[ $(time_now) -lt $expire ]]; do
-		eval $cmd
-		if [ $? -eq 0 ]; then
-			set -e
-			ENDTIME=$(date +%s)
-			echo "[INFO] Success running command: '$cmd' after $(($ENDTIME - $STARTTIME)) seconds"
-			return 0
-		fi
-		#check a failure condition where the success
-		#command may never be evaluated before timing
-		#out
-		if [[ ! -z $fail ]]; then
-			eval $fail
-			if [ $? -eq 0 ]; then
-				set -e
-				echo "[FAIL] Returning early. Command Failed '$cmd'"
-				return 1
-			fi
-		fi
-		sleep $wait
-	done
-	echo "[ ERR] Gave up waiting for: '$cmd'"
-	set -e
-	return 1
-}
-readonly -f wait_for_command
-
 # kill_all_processes function will kill all
 # all processes created by the test script.
 function kill_all_processes() {

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -8,7 +8,6 @@ trap os::test::junit::reconcile_output EXIT
   oc delete all,templates --all
   oc delete template/ruby-helloworld-sample -n openshift
   oc delete project test-template-project
-  wait_for_command '! oc get project test-template-project'
   exit 0
 ) &>/dev/null
 

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -50,8 +50,9 @@ is_event_template=(               \
 )
 is_event_template=$(IFS=""; echo "${is_event_template[*]}") # re-formats template for use
 
+os::test::junit::declare_suite_start "extended/ldap-groups/setup"
 # wait until the last event that occurred on the imagestream was the successful pull of the latest image
-wait_for_command 'oc get imagestream openldap --template="${is_event_template}" | grep latest' $((60*TIME_SEC))
+os::cmd::try_until_text "oc get imagestream openldap --template='${is_event_template}'" 'latest' "$((60*TIME_SEC))"
 
 # kick off a build and wait for it to finish
 oc start-build openldap --follow
@@ -73,10 +74,10 @@ server_ready_template=(                                  \
 server_ready_template=$(IFS=$""; echo "${server_ready_template[*]}") # re-formats template for use
 
 # wait for LDAP server to be ready
-wait_for_command 'oc get pods -l deploymentconfig=openldap-server --template="${server_ready_template}" | grep "ReadyTrue "' $((60*TIME_SEC))
+os::cmd::try_until_text "oc get pods -l deploymentconfig=openldap-server --template='${server_ready_template}'" "ReadyTrue " "$((60*TIME_SEC))"
 
 oc login -u system:admin -n openldap
-
+os::test::junit::declare_suite_end
 
 LDAP_SERVICE_IP=$(oc get --output-version=v1 --template="{{ .spec.clusterIP }}" service openldap-server)
 


### PR DESCRIPTION
The old `wait_for_command` utility is obsoleted by the newer functions
in the `os::cmd` suite. Scripts should not use the old `wait_for_command`
function any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 
depends on #11780 