### PR TITLE
sdn/eventqueue: handle DeletedFinalStateUnknown delta objects

### DIFF
--- a/pkg/sdn/plugin/eventqueue.go
+++ b/pkg/sdn/plugin/eventqueue.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/kubernetes/pkg/client/cache"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
@@ -23,6 +24,13 @@ type EventQueue struct {
 	// Private store if not intitialized with one to ensure deletion
 	// events are always recognized.
 	knownObjects cache.Store
+}
+
+func DeletionHandlingMetaNamespaceKeyFunc(obj interface{}) (string, error) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		return d.Key, nil
+	}
+	return cache.MetaNamespaceKeyFunc(obj)
 }
 
 func NewEventQueue(keyFunc cache.KeyFunc) *EventQueue {
@@ -66,6 +74,10 @@ func (queue *EventQueue) updateKnownObjects(delta cache.Delta) {
 	}
 }
 
+// Function should process one object delta, which represents a change notification
+// for a single object. Function is passed the delta, which contains the
+// changed object or the deleted final object state. The deleted final object
+// state is extracted from the DeletedFinalStateUnknown passed by DeltaFIFO.
 type ProcessEventFunc func(delta cache.Delta) error
 
 // Process queued changes for an object.  The 'process' function is called
@@ -73,7 +85,7 @@ type ProcessEventFunc func(delta cache.Delta) error
 // for that object. If the process function returns an error queued changes
 // for that object are dropped but processing continues with the next available
 // object's cache.Deltas.  The error is logged with call stack information.
-func (queue *EventQueue) Pop(process ProcessEventFunc) (interface{}, error) {
+func (queue *EventQueue) Pop(process ProcessEventFunc, expectedType interface{}) (interface{}, error) {
 	return queue.DeltaFIFO.Pop(func(obj interface{}) error {
 		// Oldest to newest delta lists
 		for _, delta := range obj.(cache.Deltas) {
@@ -82,14 +94,39 @@ func (queue *EventQueue) Pop(process ProcessEventFunc) (interface{}, error) {
 				queue.updateKnownObjects(delta)
 			}
 
+			// Handle DeletedFinalStateUnknown delta objects
+			var err error
+			if expectedType != nil {
+				delta.Object, err = extractDeltaObject(delta, expectedType)
+				if err != nil {
+					utilruntime.HandleError(err)
+					return nil
+				}
+			}
+
 			// Process one delta for the object
-			if err := process(delta); err != nil {
+			if err = process(delta); err != nil {
 				utilruntime.HandleError(fmt.Errorf("event processing failed: %v", err))
 				return nil
 			}
 		}
 		return nil
 	})
+}
+
+// Helper function to extract the object from a Delta (including special handling
+// of DeletedFinalStateUnknown delta objects) and check its type against
+// an expected type.  The contained object is only returned if it matches the
+// expected type, otherwise an error is returned.
+func extractDeltaObject(delta cache.Delta, expectedType interface{}) (interface{}, error) {
+	deltaObject := delta.Object
+	if deleted, ok := deltaObject.(cache.DeletedFinalStateUnknown); ok {
+		deltaObject = deleted.Obj
+	}
+	if reflect.TypeOf(deltaObject) != reflect.TypeOf(expectedType) {
+		return nil, fmt.Errorf("event processing failed: got delta object type %T but wanted type %T", deltaObject, expectedType)
+	}
+	return deltaObject, nil
 }
 
 // Describes the action to take for a given combination of deltas

--- a/pkg/sdn/plugin/eventqueue_test.go
+++ b/pkg/sdn/plugin/eventqueue_test.go
@@ -2,9 +2,11 @@ package plugin
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 )
 
@@ -19,6 +21,266 @@ func testKeyFunc(obj interface{}) (string, error) {
 	return key, nil
 }
 
+func deltaCompress(deltas cache.Deltas, keyFunc cache.KeyFunc) (newDeltas cache.Deltas, panicked bool, msg string) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			msg = fmt.Sprintf("%#v", r)
+		}
+	}()
+
+	newDeltas = deltaCompressor(deltas, keyFunc)
+	return
+}
+
+func compressTestDesc(test compressTest) string {
+	var start, result []string
+	for _, delta := range test.initial {
+		start = append(start, string(delta.Type))
+	}
+	for _, delta := range test.compressed {
+		result = append(result, string(delta.Type))
+	}
+	return strings.Join(start, "+") + "=" + strings.Join(result, "+")
+}
+
+type compressTest struct {
+	initial     cache.Deltas
+	compressed  cache.Deltas
+	expectPanic bool
+}
+
+// Test the delta compressor on its own
+func TestEventQueueDeltaCompressor(t *testing.T) {
+	tests := []compressTest{
+		// 1.  If a cache.Added/cache.Sync is enqueued with state X and a cache.Updated with state Y
+		//     is received, these are compressed into (Added/Sync, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+			},
+		},
+
+		// 1.  If a cache.Added/cache.Sync is enqueued with state X and a cache.Updated with state Y
+		//     is received, these are compressed into (Added/Sync, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+				// test that a second object doesn't affect compression of the first
+				{Type: cache.Added, Object: "obj2"},
+				{Type: cache.Updated, Object: "obj2"},
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Added, Object: "obj2"},
+				{Type: cache.Added, Object: "obj1"},
+			},
+		},
+
+		// 1.  If a cache.Added/cache.Sync is enqueued with state X and a cache.Updated with state Y
+		//     is received, these are compressed into (Added/Sync, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+			},
+		},
+
+		// 1.  If a cache.Added/cache.Sync is enqueued with state X and a cache.Updated with state Y
+		//     is received, these are compressed into (Added/Sync, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+				// test that a second object doesn't affect compression of the first
+				{Type: cache.Added, Object: "obj2"},
+				{Type: cache.Updated, Object: "obj2"},
+				{Type: cache.Updated, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Added, Object: "obj2"},
+				{Type: cache.Sync, Object: "obj1"},
+			},
+		},
+
+		// 2.  If a cache.Added is enqueued with state X and a cache.Deleted is received with state Y,
+		//     these are dropped and consumers will not see either event
+		{
+			initial: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+				// test that a second object doesn't affect compression of the first
+				{Type: cache.Added, Object: "obj2"},
+				{Type: cache.Deleted, Object: "obj2"},
+				{Type: cache.Deleted, Object: "obj1"},
+			},
+			compressed: cache.Deltas{},
+		},
+
+		// 3.  If a cache.Sync/cache.Updated is enqueued with state X and a cache.Deleted
+		//     is received with state Y, these are compressed into (Deleted, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+				// test that a second object doesn't affect compression of the first
+				{Type: cache.Sync, Object: "obj2"},
+				{Type: cache.Updated, Object: "obj2"},
+				{Type: cache.Deleted, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Sync, Object: "obj2"},
+				{Type: cache.Deleted, Object: "obj1"},
+			},
+		},
+
+		// 3.  If a cache.Sync/cache.Updated is enqueued with state X and a cache.Deleted
+		//     is received with state Y, these are compressed into (Deleted, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Deleted, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Deleted, Object: "obj1"},
+			},
+		},
+
+		// 4.  If a cache.Updated is enqueued with state X and a cache.Updated with state Y is received,
+		//     these two events are compressed into (Updated, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Updated, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Updated, Object: "obj1"},
+			},
+		},
+
+		// 5.  If a cache.Added is enqueued with state X and a cache.Sync with state Y is received,
+		//     these are compressed into (Added, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+				{Type: cache.Sync, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Added, Object: "obj1"},
+			},
+		},
+
+		// 6.  If a cache.Sync is enqueued with state X and a cache.Sync with state Y is received,
+		//     these are compressed into (Sync, Y)
+		{
+			initial: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+				{Type: cache.Sync, Object: "obj1"},
+			},
+			compressed: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+			},
+		},
+
+		// 7.  Invalid combinations (eg, Sync + Added or Updated + Added) result in a panic.
+		{
+			initial: cache.Deltas{
+				{Type: cache.Sync, Object: "obj1"},
+				{Type: cache.Added, Object: "obj1"},
+			},
+			compressed:  cache.Deltas{},
+			expectPanic: true,
+		},
+
+		// 7.  Invalid combinations (eg, Sync + Added or Updated + Added) result in a panic.
+		{
+			initial: cache.Deltas{
+				{Type: cache.Updated, Object: "obj1"},
+				{Type: cache.Added, Object: "obj1"},
+			},
+			compressed:  cache.Deltas{},
+			expectPanic: true,
+		},
+	}
+
+	for _, test := range tests {
+		newDeltas, panicked, msg := deltaCompress(test.initial, testKeyFunc)
+		if panicked != test.expectPanic {
+			t.Fatalf("(%s) unexpected panic result %v (expected %v): %v", compressTestDesc(test), panicked, test.expectPanic, msg)
+		}
+		if test.expectPanic {
+			continue
+		}
+
+		if len(newDeltas) != len(test.compressed) {
+			t.Fatalf("(%s) wrong number of compressed deltas (got %d, expected %d): %v", compressTestDesc(test), len(newDeltas), len(test.compressed), newDeltas)
+		}
+		for j, expected := range test.compressed {
+			have := newDeltas[j]
+			if expected.Type != have.Type {
+				t.Fatalf("(%s) wrong delta type (got %s, expected %s): %v", compressTestDesc(test), have.Type, expected.Type, newDeltas)
+			}
+			if expected.Object.(string) != have.Object.(string) {
+				t.Fatalf("(%s) wrong delta object key (got %s, expected %s)", compressTestDesc(test), have.Object.(string), expected.Object.(string))
+			}
+		}
+	}
+}
+
+func TestEventQueueDeltaCompressorDeletedFinalStateUnknown(t *testing.T) {
+	deletedObj := cache.DeletedFinalStateUnknown{
+		Key: "namespace1/obj1",
+		Obj: &api.ObjectMeta{Name: "obj1", Namespace: "namespace1"},
+	}
+	initial := cache.Deltas{
+		{
+			Type:   cache.Deleted,
+			Object: deletedObj,
+		},
+	}
+
+	newDeltas, panicked, msg := deltaCompress(initial, DeletionHandlingMetaNamespaceKeyFunc)
+	if panicked {
+		t.Fatalf("unexpected panic: %v", msg)
+	}
+
+	if len(newDeltas) != 1 {
+		t.Fatalf("wrong number of compressed deltas (got %d, expected 1): %v", len(newDeltas), newDeltas)
+	}
+	if newDeltas[0].Type != cache.Deleted {
+		t.Fatalf("unexpected delta type %v (expected Deleted)", newDeltas[0].Type)
+	}
+	if !reflect.DeepEqual(newDeltas[0].Object, deletedObj) {
+		t.Fatalf("unexpected delta object %v (expected %v)", newDeltas[0].Object, deletedObj)
+	}
+}
+
+// Ensure the compressor panics when its given a keyFunc that can't handle the delta object
+func TestEventQueueDeltaCompressorDeletedFinalStateUnknown2(t *testing.T) {
+	initial := cache.Deltas{
+		{
+			Type: cache.Deleted,
+			Object: cache.DeletedFinalStateUnknown{
+				Key: "namespace1/obj1",
+				Obj: &api.ObjectMeta{Name: "obj1", Namespace: "namespace1"},
+			},
+		},
+	}
+
+	_, panicked, _ := deltaCompress(initial, cache.MetaNamespaceKeyFunc)
+	if !panicked {
+		t.Fatalf("expected panic but didn't get one")
+	}
+}
+
 type initialDelta struct {
 	deltaType cache.DeltaType
 	object    interface{}
@@ -28,7 +290,7 @@ type initialDelta struct {
 
 type eventQueueTest struct {
 	initial      []initialDelta
-	compressed   []cache.Delta
+	compressed   cache.Deltas
 	knownObjects []interface{}
 	expectPanic  bool
 }
@@ -45,10 +307,10 @@ func testDesc(test eventQueueTest) string {
 }
 
 // Returns false on success, true on panic
-func addInitialDeltas(queue *EventQueue, deltas []initialDelta) (paniced bool, msg string) {
+func addInitialDeltas(queue *EventQueue, deltas []initialDelta) (panicked bool, msg string) {
 	defer func() {
 		if r := recover(); r != nil {
-			paniced = true
+			panicked = true
 			msg = fmt.Sprintf("%#v", r)
 		}
 	}()
@@ -65,10 +327,16 @@ func addInitialDeltas(queue *EventQueue, deltas []initialDelta) (paniced bool, m
 			// knownObjects should be valid for Sync operations
 			queue.Replace(initial.knownObjects, "123")
 		}
+		if initial.object != nil {
+			queue.updateKnownObjects(cache.Delta{Type: initial.deltaType, Object: initial.object})
+		}
 	}
 	return
 }
 
+// Test the whole event queue, not just the compressor itself; this will exercise
+// DeltaFIFO constructs like DeletedFinalStateUnknown, the EventQueue internal
+// store, the DeltaFIFO deletion compression, and the DeltaFIFO knownObjects array
 func TestEventQueueCompress(t *testing.T) {
 	tests := []eventQueueTest{
 		// 1.  If a cache.Added/cache.Sync is enqueued with state X and a cache.Updated with state Y
@@ -79,7 +347,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Updated, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Added, Object: "obj1"},
 			},
 		},
@@ -95,7 +363,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Updated, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Added, Object: "obj1"},
 			},
 		},
@@ -108,7 +376,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Updated, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Sync, Object: "obj1"},
 			},
 		},
@@ -124,7 +392,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj2"},
 				{deltaType: cache.Updated, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Sync, Object: "obj1"},
 			},
 		},
@@ -139,7 +407,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Deleted, object: "obj2"},
 				{deltaType: cache.Deleted, object: "obj1"},
 			},
-			compressed: []cache.Delta{},
+			compressed: cache.Deltas{},
 		},
 
 		// 3.  If a cache.Sync/cache.Updated is enqueued with state X and a cache.Deleted
@@ -152,7 +420,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj2"},
 				{deltaType: cache.Deleted, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Deleted, Object: "obj1"},
 			},
 		},
@@ -164,7 +432,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Deleted, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Deleted, Object: "obj1"},
 			},
 		},
@@ -176,7 +444,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Updated, object: "obj1"},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Updated, Object: "obj1"},
 			},
 		},
@@ -188,7 +456,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Added, object: "obj1"},
 				{deltaType: cache.Sync, object: "obj1", knownObjects: []interface{}{"obj1"}},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Added, Object: "obj1"},
 			},
 		},
@@ -200,7 +468,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Sync, object: "obj1", knownObjects: []interface{}{"obj1"}},
 				{deltaType: cache.Sync, object: "obj1", knownObjects: []interface{}{"obj1"}},
 			},
-			compressed: []cache.Delta{
+			compressed: cache.Deltas{
 				{Type: cache.Sync, Object: "obj1"},
 			},
 		},
@@ -211,7 +479,7 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Sync, object: "obj1", knownObjects: []interface{}{"obj1"}},
 				{deltaType: cache.Added, object: "obj1"},
 			},
-			compressed:  []cache.Delta{},
+			compressed:  cache.Deltas{},
 			expectPanic: true,
 		},
 
@@ -221,17 +489,26 @@ func TestEventQueueCompress(t *testing.T) {
 				{deltaType: cache.Updated, object: "obj1"},
 				{deltaType: cache.Added, object: "obj1"},
 			},
-			compressed:  []cache.Delta{},
+			compressed:  cache.Deltas{},
 			expectPanic: true,
+		},
+
+		// Ensure DeletedFinalStateUnknown objects can be compressed
+		{
+			initial: []initialDelta{
+				{deltaType: cache.Added, object: "obj1"},
+				{deltaType: cache.Sync, knownObjects: []interface{}{}},
+			},
+			compressed: cache.Deltas{},
 		},
 	}
 
 	for _, test := range tests {
 		queue := NewEventQueue(testKeyFunc)
 
-		paniced, msg := addInitialDeltas(queue, test.initial)
-		if paniced != test.expectPanic {
-			t.Fatalf("(%s) unexpected panic result %v (expected %v): %v", testDesc(test), paniced, test.expectPanic, msg)
+		panicked, msg := addInitialDeltas(queue, test.initial)
+		if panicked != test.expectPanic {
+			t.Fatalf("(%s) unexpected panic result %v (expected %v): %v", testDesc(test), panicked, test.expectPanic, msg)
 		}
 		if test.expectPanic {
 			continue
@@ -259,7 +536,7 @@ func TestEventQueueCompress(t *testing.T) {
 				}
 			}
 		} else if ok {
-			t.Fatalf("(%s) unexpected object", testDesc(test))
+			t.Fatalf("(%s) unexpected object %v", testDesc(test), items)
 		}
 	}
 }
@@ -279,7 +556,7 @@ func TestEventQueueUncompressed(t *testing.T) {
 			queue.Add(obj)
 			items, err := queue.Pop(func(delta cache.Delta) error {
 				return nil
-			})
+			}, nil)
 			if err != nil {
 				t.Fatalf("(%s) unexpected error popping initial Added delta: %v", dtype, err)
 			}
@@ -307,7 +584,7 @@ func TestEventQueueUncompressed(t *testing.T) {
 		// And pop the expected item out of the queue
 		items, err := queue.Pop(func(delta cache.Delta) error {
 			return nil
-		})
+		}, nil)
 		if err != nil {
 			t.Fatalf("(%s) unexpected error popping delta: %v", dtype, err)
 		}
@@ -318,5 +595,71 @@ func TestEventQueueUncompressed(t *testing.T) {
 		if deltas[0].Type != dtype {
 			t.Fatalf("(%s) expected same delta, got %v", dtype, deltas[0].Type)
 		}
+	}
+}
+
+// Test that DeletedFinalStateUnknown objects are handled correctly
+func TestEventQueueDeletedFinalStateUnknown(t *testing.T) {
+	queue := NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
+
+	obj1 := &api.ObjectMeta{Name: "obj1", Namespace: "namespace1"}
+	obj2 := &api.ObjectMeta{Name: "obj2", Namespace: "namespace1"}
+
+	// Make sure objects are in knownObjects but not in the delta queue,
+	// to ensure we get DeletedFinalStateUnknown delta objects
+	queue.knownObjects.Add(obj1)
+	queue.knownObjects.Add(obj2)
+
+	// This should create two DeletedFinalStateUnknown objects
+	queue.Replace([]interface{}{}, "123")
+
+	// First test that we get actual DeletedFinalStateUnknown objects
+	var called bool
+	var processErr error
+	if _, err := queue.Pop(func(delta cache.Delta) error {
+		called = true
+		if _, ok := delta.Object.(cache.DeletedFinalStateUnknown); !ok {
+			// Capture error that Pop() logs the error but doesn't return
+			processErr = fmt.Errorf("Unexpected item type %T", delta.Object)
+			return processErr
+		}
+		return nil
+	}, nil); err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+	if !called {
+		t.Fatalf("Delta pop function wasn't called")
+	}
+	if processErr != nil {
+		t.Fatalf("Delta pop function returned error %v", processErr)
+	}
+
+	// Repeat but this time make sure we get the objects we want, not DeletedFinalStateUnknown
+	queue = NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
+	queue.knownObjects.Add(obj1)
+	queue.knownObjects.Add(obj2)
+
+	// This should create two DeletedFinalStateUnknown objects
+	queue.Replace([]interface{}{}, "123")
+
+	// Now test that we only get api.ObjectMeta objects since we passed that
+	// as the expected type
+	called = false
+	if _, err := queue.Pop(func(delta cache.Delta) error {
+		called = true
+		if _, ok := delta.Object.(*api.ObjectMeta); !ok {
+			// Capture error that Pop() logs the error but doesn't return
+			processErr = fmt.Errorf("Unexpected item type %T", delta.Object)
+			return processErr
+		}
+		return nil
+	}, &api.ObjectMeta{}); err != nil {
+		t.Fatalf(fmt.Sprintf("%v", err))
+	}
+	if !called {
+		t.Fatalf("Delta pop function wasn't called")
+	}
+	if processErr != nil {
+		t.Fatalf("Delta pop function returned error %v", processErr)
 	}
 }


### PR DESCRIPTION
We'll get DeletedFinalStateUnknown objects instead of our expected
dela object when the object used to exist but whatever stocks the
queue calls Replace() because it doesn't have the final object state
at deletion.  DeltaFIFO generates a DeletedFinalStateUnknown with
the current object state (which may be stale) but the key function
we were using (MetaNamespaceKeyFunc) and the processing functions
in the SDN modules weren't handling them.

None of our processing functions seem to care that the state may
be stale, so fix up the key function to handle DeletedFinalStateUnknown
and try to extract the expected object out of it when we get one.

Fixes bug 1389770 [link](https://bugzilla.redhat.com/show_bug.cgi?id=1389770)

fixes https://github.com/openshift/origin/issues/11794

@openshift/networking 