### PR TITLE
Fix SRV record lookup for ExternalName service

### DIFF
--- a/pkg/dns/serviceresolver.go
+++ b/pkg/dns/serviceresolver.go
@@ -141,8 +141,10 @@ func (b *ServiceResolver) Records(dnsName string, exact bool) ([]msg.Service, er
 		// if has a portal IP and looking at svc
 		if svc.Spec.ClusterIP != kapi.ClusterIPNone && !retrieveEndpoints {
 			hostValue := svc.Spec.ClusterIP
+			targetStripValue := 2
 			if svc.Spec.Type == kapi.ServiceTypeExternalName {
 				hostValue = svc.Spec.ExternalName
+				targetStripValue = 0
 			}
 
 			defaultService := msg.Service{
@@ -188,7 +190,7 @@ func (b *ServiceResolver) Records(dnsName string, exact bool) ([]msg.Service, er
 						Weight:   10,
 						Ttl:      30,
 
-						TargetStrip: 2,
+						TargetStrip: targetStripValue,
 
 						Key: msg.Path(keyName),
 					},


### PR DESCRIPTION
The current implementation sets `TargetStrip` field to 2 unconditionally when the client issuses a SRV record lookup. But for the ExternalName service, as its ExternalName field doesn't contain the SRV record's prefix, setting `TargetStrip` to 2 will cause a wrong A record lookup result. This PR fixes the bug by setting the field to 0 if the query is made for an ExternalName service.