### PR TITLE
Warn about the right thing on double-pod-teardown

### DIFF
--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -393,6 +393,13 @@ func (m *podManager) update(req *cniserver.PodRequest) error {
 
 // Clean up all pod networking (clear OVS flows, release IPAM lease, remove host/container veth)
 func (m *podManager) teardown(req *cniserver.PodRequest) error {
+	if err := ns.IsNSorErr(req.Netns); err != nil {
+		if _, ok := err.(ns.NSPathNotExistErr); ok {
+			glog.V(3).Infof("teardown called on already-destroyed pod %s/%s", req.PodNamespace, req.PodName)
+			return nil
+		}
+	}
+
 	hostVethName, contVethMac, podIP, err := getVethInfo(req.Netns, podInterfaceName)
 	if err != nil {
 		return err


### PR DESCRIPTION
We still don't know why this is happening, but apparently it's happening even more in 3.4 (Bug 1359240 [link](https://bugzilla.redhat.com/show_bug.cgi?id=1359240#c22))

@openshift/networking PTAL