### PR TITLE
UPSTREAM: 36386: Avoid setting S_ISGID on files in volumes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/volume_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/volume_linux.go
@@ -71,7 +71,11 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 			mask = roMask
 		}
 
-		err = chmodRunner.Chmod(path, info.Mode()|mask|os.ModeSetgid)
+		if info.IsDir() {
+			mask |= os.ModeSetgid
+		}
+
+		err = chmodRunner.Chmod(path, info.Mode()|mask)
 		if err != nil {
 			glog.Errorf("Chmod failed on %v: %v", path, err)
 		}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/36386

xref https://bugzilla.redhat.com/show_bug.cgi?id=1387306

@ncdc @derekwaynecarr @pmorie 