### PR TITLE
allow special hostsubnets to force a vnid on egress packets

### DIFF
--- a/pkg/sdn/api/plugin.go
+++ b/pkg/sdn/api/plugin.go
@@ -12,6 +12,7 @@ const (
 	EgressBandwidthAnnotation  = "kubernetes.io/egress-bandwidth"
 	AssignMacvlanAnnotation    = "pod.network.openshift.io/assign-macvlan"
 	AssignHostSubnetAnnotation = "pod.network.openshift.io/assign-subnet"
+	FixedVnidHost              = "pod.network.openshift.io/fixed-vnid-host"
 )
 
 func IsOpenShiftNetworkPlugin(pluginName string) bool {


### PR DESCRIPTION
Fixes the multi-tenant networking for F5 vxlan. The return packets are forced to have a vnid that is preselected for that host (based on an annotation). This is required for F5 configuration to be able to communicate with pods outside of the default vnid in a multitenant sdn installation.
https://bugzilla.redhat.com/show_bug.cgi?id=1389706#c13

@danwinship Please review.
cc @openshift/networking 