### PR TITLE
Bug 1388026 - Fix network diagnostics cleanup when test setup fails

### DIFF
--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -109,14 +109,14 @@ func (d *NetworkDiagnostic) runNetworkDiagnostic() {
 		d.Cleanup()
 	}()
 
+	defer func() {
+		d.Cleanup()
+	}()
 	// Setup test environment
 	if err := d.TestSetup(); err != nil {
 		d.res.Error("DNet2005", err, fmt.Sprintf("Setting up test environment for network diagnostics failed: %v", err))
 		return
 	}
-	defer func() {
-		d.Cleanup()
-	}()
 
 	// Need to show summary at least
 	loglevel := d.Level


### PR DESCRIPTION
Bug 1388026 [link](https://bugzilla.redhat.com/show_bug.cgi?id=1388026)

Diagnostics cleanup is called after completion of the network diagnostics tests
or anything goes wrong after the setup (launching test pods/services) is done.
But setup itself can fail if it is unable to deploy pods or services on the nodes.
So make cleanup to be called even if setup fails.