### PR TITLE
Fix bugz 1392395 - make regexp match more precise with ^$.

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -218,10 +218,10 @@ func genSubdomainWildcardRegexp(hostname, path string, exactPath bool) string {
 
 	expr := regexp.QuoteMeta(fmt.Sprintf(".%s%s", subdomain, path))
 	if exactPath {
-		return fmt.Sprintf("[^\\.]*%s", expr)
+		return fmt.Sprintf("^[^\\.]*%s$", expr)
 	}
 
-	return fmt.Sprintf("[^\\.]*%s(|/.*)", expr)
+	return fmt.Sprintf("^[^\\.]*%s(|/.*)$", expr)
 }
 
 func endpointsForAlias(alias ServiceAliasConfig, svc ServiceUnit) []Endpoint {


### PR DESCRIPTION
fixes bug 1392395 (https://bugzilla.redhat.com/show_bug.cgi?id=1392395)

@knobunc  missing precise match "^$" - I could have sworn this was there initially. PTAL Thx