### PR TITLE
Fix ordering of SDN startup threads

### DIFF
--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -204,6 +204,10 @@ func (node *OsdnNode) Start() error {
 		}
 	}
 
+	// Wait for kubelet to init the plugin so we get a knetwork.Host
+	log.V(5).Infof("Waiting for kubelet network plugin initialization")
+	<-node.kubeletInitReady
+
 	log.V(5).Infof("Creating and initializing openshift-sdn pod manager")
 	node.podManager, err = newPodManager(node.host, node.multitenant, node.localSubnetCIDR, node.networkInfo, node.kClient, node.vnids, node.mtu)
 	if err != nil {
@@ -212,10 +216,6 @@ func (node *OsdnNode) Start() error {
 	if err := node.podManager.Start(cniserver.CNIServerSocketPath); err != nil {
 		return err
 	}
-
-	// Wait for kubelet to init the plugin so we get a knetwork.Host
-	log.V(5).Infof("Waiting for kubelet network plugin initialization")
-	<-node.kubeletInitReady
 
 	if networkChanged {
 		var pods []kapi.Pod


### PR DESCRIPTION
We could end up passing node.host to newPodManager() before node.host was set, resulting in:

    atomic-openshift-node: I1108 01:34:42.995163   36626 pod.go:170] Processing pod network request &{UPDATE default docker-registry-2-l1y4w 7f012f6f4e74627fecc8fe365f4b7777f073de44a05a955ecb9d7d3526a50e63  0xc42129bec0}
    atomic-openshift-node: panic: runtime error: invalid memory address or nil pointer dereference
    atomic-openshift-node: [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1808c2a]
    atomic-openshift-node: goroutine 294 [running]:
    atomic-openshift-node: panic(0x3caa240, 0xc420010040)
    atomic-openshift-node: /usr/lib/golang/src/runtime/panic.go:500 +0x1a1 fp=0xc4207b2be8 sp=0xc4207b2b58
    atomic-openshift-node: runtime.panicmem()
    atomic-openshift-node: /usr/lib/golang/src/runtime/panic.go:62 +0x6d fp=0xc4207b2c18 sp=0xc4207b2be8
    atomic-openshift-node: runtime.sigpanic()
    atomic-openshift-node: /usr/lib/golang/src/runtime/sigpanic_unix.go:24 +0x214 fp=0xc4207b2c70 sp=0xc4207b2c18
    atomic-openshift-node: github.com/openshift/origin/pkg/sdn/plugin.(*podManager).getContainerNetnsPath(0xc4212a3500, 0xc42117f319, 0x40, 0x78ed530, 0xc4207b2d88, 0x4bdc35, 0x790f888)
    atomic-openshift-node: /builddir/build/BUILD/atomic-openshift-git-0.24b1a58/_output/local/go/src/github.com/openshift/origin/pkg/sdn/plugin/pod_linux.go:351 +0x2a fp=0xc4207b2cc8 sp=0xc4207b2c70

@openshift/networking, @dcbw PTAL

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1389212