### PR TITLE
Remove temporary files after tests execution

### DIFF
--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/generate/git"
 	"github.com/openshift/origin/pkg/util/docker/dockerfile"
+	"github.com/openshift/origin/test/util"
 	"github.com/openshift/source-to-image/pkg/tar"
 )
 
@@ -136,7 +137,7 @@ RUN echo "hello world"
 	}
 }
 
-// TestDockerfilePath validates that we can use a Dockefile with a custom name, and in a sub-directory
+// TestDockerfilePath validates that we can use a Dockerfile with a custom name, and in a sub-directory
 func TestDockerfilePath(t *testing.T) {
 	tests := []struct {
 		contextDir     string
@@ -174,7 +175,7 @@ func TestDockerfilePath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		buildDir, err := ioutil.TempDir("", "dockerfile-path")
+		buildDir, err := ioutil.TempDir(util.GetBaseDir(), "dockerfile-path")
 		if err != nil {
 			t.Errorf("failed to create tmpdir: %v", err)
 			continue
@@ -251,6 +252,7 @@ func TestDockerfilePath(t *testing.T) {
 			t.Errorf("failed to build: %v", err)
 			continue
 		}
+		os.RemoveAll(buildDir)
 	}
 }
 
@@ -309,7 +311,7 @@ RUN echo "hello world"
 		},
 	}
 	for i, test := range tests {
-		buildDir, err := ioutil.TempDir("", "dockerfile-path")
+		buildDir, err := ioutil.TempDir(util.GetBaseDir(), "dockerfile-path")
 		if err != nil {
 			t.Errorf("failed to create tmpdir: %v", err)
 			continue
@@ -337,5 +339,6 @@ RUN echo "hello world"
 				break
 			}
 		}
+		os.RemoveAll(buildDir)
 	}
 }

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/test"
 
 	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/test/util"
 )
 
 func skipExternalGit(t *testing.T) {
@@ -1827,7 +1828,7 @@ func TestNewAppSourceAuthRequired(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		url := setupLocalGitRepo(t, test.passwordProtected, test.useProxy)
+		url, tempRepoDir := setupLocalGitRepo(t, test.passwordProtected, test.useProxy)
 
 		sourceRepo, err := app.NewSourceRepository(url, generate.StrategySource)
 		if err != nil {
@@ -1852,6 +1853,7 @@ func TestNewAppSourceAuthRequired(t *testing.T) {
 		if test.expectAuthRequired != sourceRef.RequiresAuth {
 			t.Errorf("%s: unexpected auth required result. Expected: %v. Actual: %v", test.name, test.expectAuthRequired, sourceRef.RequiresAuth)
 		}
+		os.RemoveAll(tempRepoDir)
 	}
 }
 
@@ -1902,9 +1904,9 @@ func TestNewAppListAndSearch(t *testing.T) {
 	}
 }
 
-func setupLocalGitRepo(t *testing.T, passwordProtected bool, requireProxy bool) string {
+func setupLocalGitRepo(t *testing.T, passwordProtected bool, requireProxy bool) (string, string) {
 	// Create test directories
-	testDir, err := ioutil.TempDir("", "gitauth")
+	testDir, err := ioutil.TempDir(util.GetBaseDir(), "gitauth")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -2016,7 +2018,7 @@ insteadOf = %s
 	os.Setenv("HOME", userHomeDir)
 	os.Setenv("GIT_ASKPASS", "true")
 
-	return gitURLString
+	return gitURLString, testDir
 
 }
 


### PR DESCRIPTION
Some tests left temporary files after its execution. I attempted to fix some of them.

Example:
```console
$ ls -ld /tmp/gitauth*
ls: cannot access /tmp/gitauth*: No such file or directory
$ ./hack/test-integration.sh TestNewAppSourceAuthRequired
ok      TestNewAppSourceAuthRequired
./hack/test-integration.sh took 19 seconds
Complete
$ ls -ld /tmp/gitauth*
drwx------. 5 coder coder 100 Nov  9 16:42 /tmp/gitauth003198106
drwx------. 5 coder coder 100 Nov  9 16:42 /tmp/gitauth776832470
drwx------. 5 coder coder 100 Nov  9 16:42 /tmp/gitauth968712578
drwx------. 5 coder coder 100 Nov  9 16:42 /tmp/gitauth993381998
```

PTAL @mfojtik 