### PR TITLE
Changes egress-router macvlan iface MTU size to 1450 by default.

### DIFF
--- a/images/router/egress/README.md
+++ b/images/router/egress/README.md
@@ -32,9 +32,8 @@ spec:
       value: 192.168.12.1
     - name: EGRESS_DESTINATION
       value: 203.0.113.25
-    # Set mtu size, optional, 1450 by default.
-    #- name: MTU_SIZE
-    #  value: 1400
+    - name: MTU_SIZE
+      value: 1450
   nodeSelector:
     site: springfield-1
 ```

--- a/images/router/egress/README.md
+++ b/images/router/egress/README.md
@@ -32,6 +32,9 @@ spec:
       value: 192.168.12.1
     - name: EGRESS_DESTINATION
       value: 203.0.113.25
+    # Set mtu size, optional, 1450 by default.
+    #- name: MTU_SIZE
+    #  value: 1400
   nodeSelector:
     site: springfield-1
 ```
@@ -58,6 +61,13 @@ pod's cluster IP address will be redirected to the same port on
 `EGRESS_DESTINATION`. In this example, connections to the pod will be
 redirected to **203.0.113.25**, with a source IP address of
 **192.168.12.99**.
+
+The macvlan network interface can be configured to use `MTU_SIZE`
+as its mtu size. Unlike the other environment variables, Its optional.
+If not set, the mtu size is set to 1450 by default.
+
+The mtu size must be set accordingly to the
+[pod network settings](https://docs.openshift.org/latest/install_config/configuring_sdn.html#configuring-the-pod-network-on-nodes).
 
 If only some of the nodes in your cluster are capable of claiming the
 specified source IP address and using the specified gateway, you can

--- a/images/router/egress/egress-router.sh
+++ b/images/router/egress/egress-router.sh
@@ -15,11 +15,16 @@ if [ -z "${EGRESS_GATEWAY}" ]; then
     exit 1
 fi
 
+# If MTU_SIZE is not defined, set 1450 as the default value.
+MTU=${MTU_SIZE:-1450}
+
 # The pod may die and get restarted; only try to add the
 # address/route/rules if they are not already there.
 if ! ip route get ${EGRESS_DESTINATION} | grep -q macvlan0; then
     ip addr add ${EGRESS_SOURCE}/32 dev macvlan0
     ip link set up dev macvlan0
+    ip link set macvlan0 mtu ${MTU}
+
     ip route add ${EGRESS_GATEWAY}/32 dev macvlan0
     ip route add ${EGRESS_DESTINATION}/32 via ${EGRESS_GATEWAY} dev macvlan0
 


### PR DESCRIPTION
Updates Readme too.

Now MTU can be changed using the env variable MTU_SIZE. Before, was 1500.

MTU size is a sensitive parameter, specially in some cloud environments,
such as Openstack. Allowing to change it using an env variable would
make Openshift more flexible and easy to use no matter the environment
where it runs.