### PR TITLE
Move test case TestGenerateGateway to common_test.go

### DIFF
--- a/pkg/util/netutils/common_test.go
+++ b/pkg/util/netutils/common_test.go
@@ -20,3 +20,23 @@ func TestConversion(t *testing.T) {
 		t.Fatal("Conversion back and forth failed")
 	}
 }
+
+func TestGenerateGateway(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/24" {
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
+	}
+
+	gatewayIP := GenerateDefaultGateway(sn)
+	if gatewayIP.String() != "10.1.0.1" {
+		t.Fatalf("Did not get expected gateway IP Address (gatewayIP=%s)", gatewayIP.String())
+	}
+}

--- a/pkg/util/netutils/subnet_allocator_test.go
+++ b/pkg/util/netutils/subnet_allocator_test.go
@@ -248,23 +248,3 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 		t.Fatalf("Unexpectedly succeeded in getting network (sn=%s)", sn.String())
 	}
 }
-
-func TestGenerateGateway(t *testing.T) {
-	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
-	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
-	}
-
-	sn, err := sna.GetNetwork()
-	if err != nil {
-		t.Fatal("Failed to get network: ", err)
-	}
-	if sn.String() != "10.1.0.0/24" {
-		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
-	}
-
-	gatewayIP := GenerateDefaultGateway(sn)
-	if gatewayIP.String() != "10.1.0.1" {
-		t.Fatalf("Did not get expected gateway IP Address (gatewayIP=%s)", gatewayIP.String())
-	}
-}


### PR DESCRIPTION
The purpose of test case `TestGenerateGateway` is to test func `GenerateDefaultGateway` in common.go, so move `TestGenerateGateway` to common_test.go would be clearer? Just a nit.