### PR TITLE
etcd3, unidling controller

### DIFF
--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -346,13 +346,13 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 
 	// Default storage backend to etcd3 with protobuf storage for our innate config when starting both
 	// Kubernetes and etcd.
-	if km := config.KubernetesMasterConfig; km != nil && config.EtcdConfig != nil {
-		if len(km.APIServerArguments) == 0 {
-			km.APIServerArguments = configapi.ExtendedArguments{}
-			km.APIServerArguments["storage-media-type"] = []string{"application/vnd.kubernetes.protobuf"}
-			km.APIServerArguments["storage-backend"] = []string{"etcd3"}
-		}
-	}
+	// if km := config.KubernetesMasterConfig; km != nil && config.EtcdConfig != nil {
+	// 	if len(km.APIServerArguments) == 0 {
+	// 		km.APIServerArguments = configapi.ExtendedArguments{}
+	// 		km.APIServerArguments["storage-media-type"] = []string{"application/vnd.kubernetes.protobuf"}
+	// 		km.APIServerArguments["storage-backend"] = []string{"etcd3"}
+	// 	}
+	// }
 
 	return config, nil
 }

--- a/pkg/unidling/controller/controller.go
+++ b/pkg/unidling/controller/controller.go
@@ -94,7 +94,8 @@ func NewUnidlingController(scaleNS kextclient.ScalesGetter, endptsNS kclient.End
 		&cache.ListWatch{
 			// No need to list -- we only care about new events
 			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
-				return &kapi.EventList{}, nil
+				options.FieldSelector = fieldSelector
+				return evtNS.Events(kapi.NamespaceAll).List(options)
 			},
 			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
 				options.FieldSelector = fieldSelector


### PR DESCRIPTION
* changes default storage backend to etcd2 (upstream is still defaulting to etcd2, etcd3 backend has fan-out issues calling Get() when processing delete/modify watch events)
* lists events for unidling controller

Fixes #10773 