### PR TITLE
Allow to unlink deleted secrets from a service account

### DIFF
--- a/pkg/cmd/cli/secrets/link_secret_to_obj.go
+++ b/pkg/cmd/cli/secrets/link_secret_to_obj.go
@@ -127,7 +127,7 @@ func (o LinkSecretOptions) LinkSecrets() error {
 // linkSecretsToServiceAccount links secrets to the service account, either as pull secrets, mount secrets, or both.
 func (o LinkSecretOptions) linkSecretsToServiceAccount(serviceaccount *kapi.ServiceAccount) error {
 	updated := false
-	newSecrets, failLater, err := o.GetSecrets()
+	newSecrets, hasNotFound, err := o.GetSecrets(false)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (o LinkSecretOptions) linkSecretsToServiceAccount(serviceaccount *kapi.Serv
 		return err
 	}
 
-	if failLater {
+	if hasNotFound {
 		return errors.New("Some secrets could not be linked")
 	}
 

--- a/pkg/cmd/cli/secrets/options.go
+++ b/pkg/cmd/cli/secrets/options.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -144,9 +145,10 @@ func (o SecretOptions) GetOut() io.Writer {
 }
 
 // GetSecrets Return a list of secret objects in the default namespace
-func (o SecretOptions) GetSecrets() ([]*kapi.Secret, bool, error) {
+// If allowNonExisting is set to true, we will return the non-existing secrets as well.
+func (o SecretOptions) GetSecrets(allowNonExisting bool) ([]*kapi.Secret, bool, error) {
 	secrets := []*kapi.Secret{}
-	failLater := false
+	hasNotFound := false
 
 	for _, secretName := range o.SecretNames {
 		r := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper, kapi.Codecs.UniversalDecoder()).
@@ -159,11 +161,23 @@ func (o SecretOptions) GetSecrets() ([]*kapi.Secret, bool, error) {
 		}
 		obj, err := r.Object()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "secrets \"%s\" not found\n", secretName)
-			// Missing secrets are non-fatal but the command should not return
-			// success.
-			failLater = true
-			continue
+			// If the secret is not found it means it was deleted but we want still to allow to
+			// unlink a removed secret from the service account
+			if kerrors.IsNotFound(err) {
+				fmt.Fprintf(os.Stderr, "secret %q not found\n", secretName)
+				hasNotFound = true
+				if allowNonExisting {
+					obj = &kapi.Secret{
+						ObjectMeta: kapi.ObjectMeta{
+							Name: secretName,
+						},
+					}
+				} else {
+					continue
+				}
+			} else if err != nil {
+				return nil, false, err
+			}
 		}
 		switch t := obj.(type) {
 		case *kapi.Secret:
@@ -177,5 +191,5 @@ func (o SecretOptions) GetSecrets() ([]*kapi.Secret, bool, error) {
 		return nil, false, errors.New("No valid secrets found")
 	}
 
-	return secrets, failLater, nil
+	return secrets, hasNotFound, nil
 }

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -105,16 +105,16 @@ os::cmd::expect_failure 'oc get serviceaccounts/deployer -o yaml |grep -q basica
 os::cmd::expect_success 'oc secrets link deployer basicauth'
 
 # Removing a non-existent secret should warn but succeed and change nothing
-os::cmd::expect_failure_and_text 'oc secrets unlink deployer foobar' 'secrets "foobar" not found'
+os::cmd::expect_failure_and_text 'oc secrets unlink deployer foobar' 'secret "foobar" not found'
 
 # Make sure that removing an existent and non-existent secret succeeds but warns about the non-existent one
-os::cmd::expect_failure_and_text 'oc secrets unlink deployer foobar basicauth' 'secrets "foobar" not found'
+os::cmd::expect_failure_and_text 'oc secrets unlink deployer foobar basicauth' 'secret "foobar" not found'
 # Make sure that the existing secret is removed
 os::cmd::expect_failure 'oc get serviceaccounts/deployer -o yaml |grep -q basicauth'
 
 # Make sure that removing a real but unlinked secret succeeds
 # https://github.com/openshift/origin/pull/9234#discussion_r70832486
-os::cmd::expect_success 'oc secrets unlink deployer basicauth'
+os::cmd::expect_failure_and_text 'oc secrets unlink deployer basicauth', 'No valid secrets found or secrets not linked to service account'
 
 # Make sure that it succeeds if *any* of the secrets are linked
 # https://github.com/openshift/origin/pull/9234#discussion_r70832486


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/11851

@fabianofranz PTAL this improves a logic around linking/unlinking the secrets a little bit:

```console
[@dev] .../openshift/origin # oc create secret generic test --from-literal=foo=bar
secret "test" created
[@dev] .../openshift/origin # oc secrets unlink builder test
error: No valid secrets found or secrets not linked to service account
[@dev] .../openshift/origin # oc secrets link builder test
[@dev] .../openshift/origin # oc delete secret test
secret "test" deleted
[@dev] .../openshift/origin # oc secrets unlink builder test
secret "test" not found
error: Unlinked deleted secrets from test/builder service account
[@dev] .../openshift/origin # oc secrets unlink builder test
secret "test" not found
error: No valid secrets found or secrets not linked to service account
[@dev] .../openshift/origin # oc secrets link builder test
secret "test" not found
error: No valid secrets found
```