### PR TITLE
WIP: Updated test fixtures to point to a specific tag instead of latest

### DIFF
--- a/test/extended/testdata/deployments/deployment-with-ref-env.yaml
+++ b/test/extended/testdata/deployments/deployment-with-ref-env.yaml
@@ -27,7 +27,6 @@ spec:
         name: deployment-simple
     spec:
       containers:
-      - image: "openshift/origin-base:latest"
+      - image: openshift/origin-base:v1.3.1
         args: [ "sleep 120" ]
-        imagePullPolicy: IfNotPresent
         name: myapp

--- a/test/extended/testdata/deployments/tag-images-deployment.yaml
+++ b/test/extended/testdata/deployments/tag-images-deployment.yaml
@@ -24,8 +24,7 @@ spec:
         name: tag-images
     spec:
       containers:
-      - image: openshift/origin-pod
-        imagePullPolicy: IfNotPresent
+      - image: openshift/origin-pod:v1.3.1
         name: sample-name
         ports:
         - containerPort: 8080

--- a/test/extended/testdata/idling-echo-server-rc.yaml
+++ b/test/extended/testdata/idling-echo-server-rc.yaml
@@ -17,7 +17,7 @@ items:
           replicationcontroller: idling-echo
       spec:
         containers:
-        - image: openshift/node
+        - image: openshift/node:v1.3.1
           name: idling-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -20,7 +20,7 @@ items:
           deploymentconfig: idling-echo
       spec:
         containers:
-        - image: openshift/node
+        - image: openshift/node:v1.3.1
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -29,7 +29,7 @@ items:
           ports:
           - containerPort: 8675
             protocol: TCP
-        - image: openshift/node
+        - image: openshift/node:v1.3.1
           name: idling-udp-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/jobs/v1.yaml
+++ b/test/extended/testdata/jobs/v1.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: simplev1
-        image: gcr.io/google_containers/busybox
+        image: gcr.io/google_containers/busybox:1.24
         command: ["/bin/sh", "-c", "exit 0"]
       restartPolicy: Never

--- a/test/extended/testdata/jobs/v1beta1.yaml
+++ b/test/extended/testdata/jobs/v1beta1.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: simplev1beta1
-        image: gcr.io/google_containers/busybox
+        image: gcr.io/google_containers/busybox:1.24
         command: ["/bin/sh", "-c", "exit 0"]
       restartPolicy: Never

--- a/test/extended/testdata/scoped-router.yaml
+++ b/test/extended/testdata/scoped-router.yaml
@@ -11,7 +11,7 @@ items:
   spec:
     containers:
     - name: router
-      image: openshift/origin-haproxy-router
+      image: openshift/origin-haproxy-router:v1.3.1
       env:
       - name: POD_NAMESPACE
         valueFrom:
@@ -37,7 +37,7 @@ items:
   spec:
     containers:
     - name: router
-      image: openshift/origin-haproxy-router
+      image: openshift/origin-haproxy-router:v1.3.1
       env:
       - name: POD_NAMESPACE
         valueFrom:
@@ -117,7 +117,7 @@ items:
   spec:
     containers:
     - name: test
-      image: openshift/hello-openshift
+      image: openshift/hello-openshift:v1.3.1
       # image: openshift/deployment-example:v1
       ports:
       - containerPort: 8080

--- a/test/extended/testdata/weighted-router.yaml
+++ b/test/extended/testdata/weighted-router.yaml
@@ -11,7 +11,7 @@ items:
   spec:
     containers:
     - name: router
-      image: openshift/origin-haproxy-router
+      image: openshift/origin-haproxy-router:v1.3.1
       env:
       - name: POD_NAMESPACE
         valueFrom:
@@ -120,7 +120,7 @@ items:
   spec:
     containers:
     - name: test
-      image: openshift/hello-openshift
+      image: openshift/hello-openshift:v1.3.1
       ports:
       - containerPort: 8080
         name: http
@@ -136,7 +136,7 @@ items:
   spec:
     containers:
     - name: test
-      image: openshift/hello-openshift
+      image: openshift/hello-openshift:v1.3.1
       ports:
       - containerPort: 8080
         name: http


### PR DESCRIPTION
First require to pre-pull v1.3.1 images via https://github.com/openshift/origin/pull/9622
Then all fixtures should be `IfNotPresent` and they should not pull the latest image from DockerHub.