### PR TITLE
set automatic to false for the dev DC deployment

### DIFF
--- a/examples/jenkins/application-template.json
+++ b/examples/jenkins/application-template.json
@@ -246,7 +246,7 @@
           {
             "type": "ImageChange",
             "imageChangeParams": {
-              "automatic": true,
+              "automatic": false,
               "containerNames": [
                 "nodejs-helloworld"
               ],


### PR DESCRIPTION
don't allow the dev image to be auto deployed by the ICT, it should only be deployed by the pipeline deploy stage.  This will keep us from having 2 deployments each time the pipeline runs.

@jwforres fyi

bug 1393695