### PR TITLE
UPSTREAM: 0000: remove "no resource" warning when getting resources is

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get.go
@@ -325,7 +325,7 @@ func RunGet(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args 
 			}
 			errs = append(errs, err)
 		}
-		if len(infos) == 0 {
+		if len(infos) == 0 && err == nil {
 			outputEmptyListWarning(errOut)
 		}
 
@@ -380,7 +380,7 @@ func RunGet(f *cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args 
 	if err != nil {
 		allErrs = append(allErrs, err)
 	}
-	if len(infos) == 0 {
+	if len(infos) == 0 && err == nil {
 		outputEmptyListWarning(errOut)
 	}
 


### PR DESCRIPTION
Related Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1393289

This patch removes the `No resources found.` warning when attempting to
get resources from the server results in any kind of error.

**Before**
```
$ oc login -u unauthorizeduser
$ oc get users
No resources found.
Error from server: User "unauthorizeduser" cannot list all users in the
cluster
```

**After**
```
$ oc login -u unauthorizeduser
$ oc get users
Error from server: User "unauthorizeduser" cannot list all users in the
cluster
```

@openshift/cli-review 