### PR TITLE
Refactor startbuild cli cmd and create new unit tests

### DIFF
--- a/pkg/client/testclient/fake_buildconfigs.go
+++ b/pkg/client/testclient/fake_buildconfigs.go
@@ -77,23 +77,17 @@ func (c *FakeBuildConfigs) WebHookURL(name string, trigger *buildapi.BuildTrigge
 }
 
 func (c *FakeBuildConfigs) Instantiate(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
+	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
 	action.Subresource = "instantiate"
-	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
-	if obj == nil {
-		return nil, err
-	}
+	_, _ = c.Fake.Invokes(action, &buildapi.Build{})
 
-	return obj.(*buildapi.Build), err
+	return &buildapi.Build{}, err
 }
 
 func (c *FakeBuildConfigs) InstantiateBinary(request *buildapi.BinaryBuildRequestOptions, r io.Reader) (result *buildapi.Build, err error) {
-	action := ktestclient.NewCreateAction("builds", c.Namespace, request)
+	action := ktestclient.NewCreateAction("buildconfigs", c.Namespace, request)
 	action.Subresource = "instantiatebinary"
-	obj, err := c.Fake.Invokes(action, &buildapi.Build{})
-	if obj == nil {
-		return nil, err
-	}
+	_, _ = c.Fake.Invokes(action, &buildapi.Build{})
 
-	return obj.(*buildapi.Build), err
+	return &buildapi.Build{}, err
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -111,7 +111,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdDeploy(fullName, f, out),
 				cmd.NewCmdRollback(fullName, f, out),
 				cmd.NewCmdNewBuild(cmd.NewBuildRecommendedCommandName, fullName, f, in, out, errout),
-				cmd.NewCmdStartBuild(fullName, f, in, out, errout),
+				cmd.NewCmdStartBuild(cmd.StartBuildRecommendedCommandName, fullName, f, in, out, errout),
 				cmd.NewCmdCancelBuild(cmd.CancelBuildRecommendedCommandName, fullName, f, in, out, errout),
 				cmd.NewCmdImportImage(fullName, f, out, errout),
 				cmd.NewCmdTag(fullName, f, out),

--- a/pkg/cmd/cli/cmd/cancelbuild_test.go
+++ b/pkg/cmd/cli/cmd/cancelbuild_test.go
@@ -124,7 +124,8 @@ func TestCancelBuildRun(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		client := testclient.NewSimpleFake(genBuild(test.phase))
+
+		client := testclient.NewSimpleFake(genBuild("ruby-ex", "test", test.phase))
 		buildClient := NewFakeTestBuilds(client, test.opts.Namespace)
 
 		test.opts.Client = client
@@ -187,11 +188,11 @@ func (c *FakeTestBuilds) Update(inObj *buildapi.Build) (*buildapi.Build, error) 
 	return c.Obj, err
 }
 
-func genBuild(phase buildapi.BuildPhase) *buildapi.Build {
+func genBuild(name, ns string, phase buildapi.BuildPhase) *buildapi.Build {
 	build := buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "ruby-ex",
-			Namespace: "test",
+			Name:      name,
+			Namespace: ns,
 		},
 		Status: buildapi.BuildStatus{
 			Phase: phase,

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -37,6 +37,9 @@ import (
 	"github.com/openshift/source-to-image/pkg/tar"
 )
 
+// StartBuildRecommendedCommandName is the recommended command name.
+const StartBuildRecommendedCommandName = "start-build"
+
 var (
 	startBuildLong = templates.LongDesc(`
 		Start a build
@@ -54,63 +57,27 @@ var (
 
 	startBuildExample = templates.Examples(`
 		# Starts build from build config "hello-world"
-	  %[1]s start-build hello-world
+	  %[1]s %[2]s hello-world
 
 	  # Starts build from a previous build "hello-world-1"
-	  %[1]s start-build --from-build=hello-world-1
+	  %[1]s %[2]s --from-build=hello-world-1
 
 	  # Use the contents of a directory as build input
-	  %[1]s start-build hello-world --from-dir=src/
+	  %[1]s %[2]s hello-world --from-dir=src/
 
 	  # Send the contents of a Git repository to the server from tag 'v2'
-	  %[1]s start-build hello-world --from-repo=../hello-world --commit=v2
+	  %[1]s %[2]s hello-world --from-repo=../hello-world --commit=v2
 
 	  # Start a new build for build config "hello-world" and watch the logs until the build
 	  # completes or fails.
-	  %[1]s start-build hello-world --follow
+	  %[1]s %[2]s hello-world --follow
 
 	  # Start a new build for build config "hello-world" and wait until the build completes. It
 	  # exits with a non-zero return code if the build fails.
-	  %[1]s start-build hello-world --wait`)
+	  %[1]s %[2]s hello-world --wait`)
 )
 
-// NewCmdStartBuild implements the OpenShift cli start-build command
-func NewCmdStartBuild(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
-	o := &StartBuildOptions{}
-
-	cmd := &cobra.Command{
-		Use:        "start-build (BUILDCONFIG | --from-build=BUILD)",
-		Short:      "Start a new build",
-		Long:       startBuildLong,
-		Example:    fmt.Sprintf(startBuildExample, fullName),
-		SuggestFor: []string{"build", "builds"},
-		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(f, in, out, errout, cmd, fullName, args))
-			kcmdutil.CheckErr(o.Run())
-		},
-	}
-	cmd.Flags().StringVar(&o.LogLevel, "build-loglevel", o.LogLevel, "Specify the log level for the build log output")
-	cmd.Flags().StringArrayVarP(&o.Env, "env", "e", o.Env, "Specify a key-value pair for an environment variable to set for the build container.")
-	cmd.Flags().StringVar(&o.FromBuild, "from-build", o.FromBuild, "Specify the name of a build which should be re-run")
-
-	cmd.Flags().BoolVarP(&o.Follow, "follow", "F", o.Follow, "Start a build and watch its logs until it completes or fails")
-	cmd.Flags().BoolVarP(&o.WaitForComplete, "wait", "w", o.WaitForComplete, "Wait for a build to complete and exit with a non-zero return code if the build fails")
-
-	cmd.Flags().StringVar(&o.FromFile, "from-file", o.FromFile, "A file to use as the binary input for the build; example a pom.xml or Dockerfile. Will be the only file in the build source.")
-	cmd.Flags().StringVar(&o.FromDir, "from-dir", o.FromDir, "A directory to archive and use as the binary input for a build.")
-	cmd.Flags().StringVar(&o.FromRepo, "from-repo", o.FromRepo, "The path to a local source code repository to use as the binary input for a build.")
-	cmd.Flags().StringVar(&o.Commit, "commit", o.Commit, "Specify the source code commit identifier the build should use; requires a build based on a Git repository")
-
-	cmd.Flags().StringVar(&o.ListWebhooks, "list-webhooks", o.ListWebhooks, "List the webhooks for the specified build config or build; accepts 'all', 'generic', or 'github'")
-	cmd.Flags().StringVar(&o.FromWebhook, "from-webhook", o.FromWebhook, "Specify a generic webhook URL for an existing build config to trigger")
-
-	cmd.Flags().StringVar(&o.GitPostReceive, "git-post-receive", o.GitPostReceive, "The contents of the post-receive hook to trigger a build")
-	cmd.Flags().StringVar(&o.GitRepository, "git-repository", o.GitRepository, "The path to the git repository for post-receive; defaults to the current directory")
-
-	kcmdutil.AddOutputFlagsForMutation(cmd)
-	return cmd
-}
-
+// StartBuildOptions contains all the options for running the StartBuild cli command.
 type StartBuildOptions struct {
 	In          io.Reader
 	Out, ErrOut io.Writer
@@ -145,7 +112,44 @@ type StartBuildOptions struct {
 	Namespace   string
 }
 
-func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *cobra.Command, cmdFullName string, args []string) error {
+// NewCmdStartBuild implements the OpenShift cli start-build command
+func NewCmdStartBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+	o := &StartBuildOptions{}
+
+	cmd := &cobra.Command{
+		Use:        fmt.Sprintf("%s  (BUILDCONFIG | --from-build=BUILD)", name),
+		Short:      "Start a new build",
+		Long:       startBuildLong,
+		Example:    fmt.Sprintf(startBuildExample, baseName, name),
+		SuggestFor: []string{"build", "builds"},
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(baseName, f, cmd, args, in, out, errout))
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+	cmd.Flags().StringVar(&o.LogLevel, "build-loglevel", o.LogLevel, "Specify the log level for the build log output")
+	cmd.Flags().StringArrayVarP(&o.Env, "env", "e", o.Env, "Specify a key-value pair for an environment variable to set for the build container.")
+	cmd.Flags().StringVar(&o.FromBuild, "from-build", o.FromBuild, "Specify the name of a build which should be re-run")
+
+	cmd.Flags().BoolVarP(&o.Follow, "follow", "F", o.Follow, "Start a build and watch its logs until it completes or fails")
+	cmd.Flags().BoolVarP(&o.WaitForComplete, "wait", "w", o.WaitForComplete, "Wait for a build to complete and exit with a non-zero return code if the build fails")
+
+	cmd.Flags().StringVar(&o.FromFile, "from-file", o.FromFile, "A file to use as the binary input for the build; example a pom.xml or Dockerfile. Will be the only file in the build source.")
+	cmd.Flags().StringVar(&o.FromDir, "from-dir", o.FromDir, "A directory to archive and use as the binary input for a build.")
+	cmd.Flags().StringVar(&o.FromRepo, "from-repo", o.FromRepo, "The path to a local source code repository to use as the binary input for a build.")
+	cmd.Flags().StringVar(&o.Commit, "commit", o.Commit, "Specify the source code commit identifier the build should use; requires a build based on a Git repository")
+
+	cmd.Flags().StringVar(&o.ListWebhooks, "list-webhooks", o.ListWebhooks, "List the webhooks for the specified build config or build; accepts 'all', 'generic', or 'github'")
+	cmd.Flags().StringVar(&o.FromWebhook, "from-webhook", o.FromWebhook, "Specify a generic webhook URL for an existing build config to trigger")
+
+	cmd.Flags().StringVar(&o.GitPostReceive, "git-post-receive", o.GitPostReceive, "The contents of the post-receive hook to trigger a build")
+	cmd.Flags().StringVar(&o.GitRepository, "git-repository", o.GitRepository, "The path to the git repository for post-receive; defaults to the current directory")
+
+	kcmdutil.AddOutputFlagsForMutation(cmd)
+	return cmd
+}
+
+func (o *StartBuildOptions) Complete(baseName string, f *clientcmd.Factory, cmd *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	o.In = in
 	o.Out = out
 	o.ErrOut = errout
@@ -153,39 +157,33 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 	o.ClientConfig = f.OpenShiftClientConfig
 	o.Mapper, _ = f.Object(false)
 
-	webhook := o.FromWebhook
-	buildName := o.FromBuild
-	fromFile := o.FromFile
-	fromDir := o.FromDir
-	fromRepo := o.FromRepo
-	buildLogLevel := o.LogLevel
-
 	outputFormat := kcmdutil.GetFlagString(cmd, "output")
 	if outputFormat != "name" && outputFormat != "" {
 		return kcmdutil.UsageError(cmd, "Unsupported output format: %s", outputFormat)
 	}
 	o.ShortOutput = outputFormat == "name"
 
-	switch {
-	case len(webhook) > 0:
-		if len(args) > 0 || len(buildName) > 0 || len(fromFile) > 0 || len(fromDir) > 0 || len(fromRepo) > 0 {
+	if len(o.FromWebhook) > 0 {
+		if len(args) > 0 || len(o.FromBuild) > 0 || len(o.FromFile) > 0 || len(o.FromDir) > 0 || len(o.FromRepo) > 0 {
 			return kcmdutil.UsageError(cmd, "The '--from-webhook' flag is incompatible with arguments and all '--from-*' flags")
 		}
-		if !strings.HasSuffix(webhook, "/generic") {
+		if !strings.HasSuffix(o.FromWebhook, "/generic") {
 			fmt.Fprintf(errout, "warning: the '--from-webhook' flag should be called with a generic webhook URL.\n")
 		}
 		return nil
-
-	case len(args) != 1 && len(buildName) == 0:
-		return kcmdutil.UsageError(cmd, "Must pass a name of a build config or specify build name with '--from-build' flag.\nUse \"%s get bc\" to list all available build configs.", cmdFullName)
 	}
 
-	if len(buildName) != 0 && (len(fromFile) != 0 || len(fromDir) != 0 || len(fromRepo) != 0) {
+	if len(args) != 1 && len(o.FromBuild) == 0 {
+		return kcmdutil.UsageError(cmd, "Must pass a name of a build config or specify build name with '--from-build' flag.\nUse \"%s get bc\" to list all available build configs.", baseName)
+	}
+
+	if len(o.FromBuild) != 0 && (len(o.FromFile) != 0 || len(o.FromDir) != 0 || len(o.FromRepo) != 0) {
 		// TODO: we should support this, it should be possible to clone a build to run again with new uploaded artifacts.
 		// Doing so requires introducing a new clonebinary endpoint.
 		return kcmdutil.UsageError(cmd, "Cannot use '--from-build' flag with binary builds")
 	}
-	o.AsBinary = len(fromFile) > 0 || len(fromDir) > 0 || len(fromRepo) > 0
+
+	o.AsBinary = len(o.FromFile) > 0 || len(o.FromDir) > 0 || len(o.FromRepo) > 0
 
 	namespace, _, err := f.DefaultNamespace()
 	if err != nil {
@@ -199,7 +197,7 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 	o.Client = client
 
 	var (
-		name     = buildName
+		name     = o.FromBuild
 		resource = buildapi.Resource("builds")
 	)
 
@@ -220,6 +218,7 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 			return fmt.Errorf("invalid resource provided: %v", resource)
 		}
 	}
+
 	// when listing webhooks, allow --from-build to lookup a build config
 	if resource == buildapi.Resource("builds") && len(o.ListWebhooks) > 0 {
 		build, err := client.Builds(namespace).Get(name)
@@ -248,8 +247,8 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 	if err != nil {
 		return err
 	}
-	if len(buildLogLevel) > 0 {
-		env = append(env, kapi.EnvVar{Name: "BUILD_LOGLEVEL", Value: buildLogLevel})
+	if len(o.LogLevel) > 0 {
+		env = append(env, kapi.EnvVar{Name: "BUILD_LOGLEVEL", Value: o.LogLevel})
 	}
 	o.EnvVar = env
 


### PR DESCRIPTION
Refactor StartBuild command based on openshift cmd guidelines and added new test.

This PR have parts subtracted from #11290 to make the PR more clean.
