### PR TITLE
Change Factory Clients method to return client interface

### DIFF
--- a/pkg/bootstrap/docker/status.go
+++ b/pkg/bootstrap/docker/status.go
@@ -104,7 +104,7 @@ func isHealthy(f *clientcmd.Factory) (bool, error) {
 	}
 
 	var statusCode int
-	osClient.Client.Timeout = 10 * time.Second
+	osClient.SetTimeout(10 * time.Second)
 	osClient.Get().AbsPath("/healthz").Do().StatusCode(&statusCode)
 	return statusCode == 200, nil
 }

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -795,7 +795,7 @@ func (c *ClientStartConfig) Factory() (*clientcmd.Factory, error) {
 }
 
 // Clients returns clients for OpenShift and Kube
-func (c *ClientStartConfig) Clients() (*client.Client, *kclient.Client, error) {
+func (c *ClientStartConfig) Clients() (client.Interface, *kclient.Client, error) {
 	f, err := c.Factory()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/build/cmd/reaper.go
+++ b/pkg/build/cmd/reaper.go
@@ -20,7 +20,7 @@ import (
 )
 
 // NewBuildConfigReaper returns a new reaper for buildConfigs
-func NewBuildConfigReaper(oc *client.Client) kubectl.Reaper {
+func NewBuildConfigReaper(oc client.Interface) kubectl.Reaper {
 	return &BuildConfigReaper{oc: oc, pollInterval: kubectl.Interval, timeout: kubectl.Timeout}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,11 +6,13 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/typed/discovery"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/version"
@@ -65,6 +67,11 @@ type Interface interface {
 	ClusterRoleBindingsInterface
 	ClusterResourceQuotasInterface
 	AppliedClusterResourceQuotasNamespacer
+	// Openshift specific methods.
+	Discovery() discovery.DiscoveryInterface
+	SetTimeout(d time.Duration)
+	// Implements kubectl RESTClient
+	resource.RESTClient
 }
 
 // Builds provides a REST client for Builds
@@ -311,10 +318,35 @@ func New(c *restclient.Config) (*Client, error) {
 	return &Client{client}, nil
 }
 
-// DiscoveryClient returns a discovery client.
+// Discovery returns a discovery client.
 func (c *Client) Discovery() discovery.DiscoveryInterface {
 	d := NewDiscoveryClient(c.RESTClient)
 	return d
+}
+
+func (c *Client) SetTimeout(d time.Duration) {
+	c.RESTClient.Client.Timeout = d
+}
+
+// Methods above implements RESTClient interface.
+func (c *Client) Post() *restclient.Request {
+	return c.RESTClient.Post()
+}
+
+func (c *Client) Put() *restclient.Request {
+	return c.RESTClient.Put()
+}
+
+func (c *Client) Patch(pt kapi.PatchType) *restclient.Request {
+	return c.RESTClient.Patch(pt)
+}
+
+func (c *Client) Get() *restclient.Request {
+	return c.RESTClient.Get()
+}
+
+func (c *Client) Delete() *restclient.Request {
+	return c.RESTClient.Delete()
 }
 
 // SetOpenShiftDefaults sets the default settings on the passed

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -3,9 +3,12 @@ package testclient
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
+	"k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/client/typed/discovery"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
@@ -346,4 +349,30 @@ func (c *Fake) ClusterResourceQuotas() client.ClusterResourceQuotaInterface {
 
 func (c *Fake) AppliedClusterResourceQuotas(namespace string) client.AppliedClusterResourceQuotaInterface {
 	return &FakeAppliedClusterResourceQuotas{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Discovery() discovery.DiscoveryInterface {
+	return nil
+}
+
+func (c *Fake) SetTimeout(time.Duration) {}
+
+func (c *Fake) Post() *restclient.Request {
+	return nil
+}
+
+func (c *Fake) Put() *restclient.Request {
+	return nil
+}
+
+func (c *Fake) Patch(pt kapi.PatchType) *restclient.Request {
+	return nil
+}
+
+func (c *Fake) Get() *restclient.Request {
+	return nil
+}
+
+func (c *Fake) Delete() *restclient.Request {
+	return nil
 }

--- a/pkg/cmd/admin/diagnostics/cluster.go
+++ b/pkg/cmd/admin/diagnostics/cluster.go
@@ -43,7 +43,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 	}
 
 	var (
-		clusterClient  *client.Client
+		clusterClient  client.Interface
 		kclusterClient *kclient.Client
 	)
 
@@ -84,7 +84,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 }
 
 // attempts to find which context in the config might be a cluster-admin for the server in the current context.
-func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*client.Client, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (client.Interface, *kclient.Client, bool, string, error) {
 	if o.ClientClusterContext != "" { // user has specified cluster context to use
 		if context, exists := rawConfig.Contexts[o.ClientClusterContext]; exists {
 			configErr := fmt.Errorf("Specified '%s' as cluster-admin context, but it was not found in your client configuration.", o.ClientClusterContext)
@@ -120,7 +120,7 @@ func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (
 }
 
 // makes the client from the specified context and determines whether it is a cluster-admin.
-func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*client.Client, *kclient.Client, bool, string, error) {
+func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (client.Interface, *kclient.Client, bool, string, error) {
 	overrides := &clientcmd.ConfigOverrides{Context: *context}
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, overrides)
 	serverUrl := rawConfig.Clusters[context.Cluster].Server

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -28,7 +28,7 @@ import (
 
 type ProjectOptions struct {
 	DefaultNamespace string
-	Oclient          *osclient.Client
+	Oclient          osclient.Interface
 	Kclient          *kclient.Client
 	Out              io.Writer
 

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -23,7 +23,7 @@ const WhoCanRecommendedName = "who-can"
 type whoCanOptions struct {
 	allNamespaces    bool
 	bindingNamespace string
-	client           *client.Client
+	client           client.Interface
 
 	verb         string
 	resource     unversioned.GroupVersionResource

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -424,7 +424,7 @@ func (p *describingManifestDeleter) DeleteManifest(registryClient *http.Client, 
 }
 
 // getClients returns a Kube client, OpenShift client, and registry client.
-func getClients(f *clientcmd.Factory, caBundle string) (*client.Client, *kclient.Client, *http.Client, error) {
+func getClients(f *clientcmd.Factory, caBundle string) (client.Interface, *kclient.Client, *http.Client, error) {
 	clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, nil, err
@@ -432,7 +432,7 @@ func getClients(f *clientcmd.Factory, caBundle string) (*client.Client, *kclient
 
 	var (
 		token          string
-		osClient       *client.Client
+		osClient       client.Interface
 		kClient        *kclient.Client
 		registryClient *http.Client
 	)

--- a/pkg/cmd/cli/cmd/idle.go
+++ b/pkg/cmd/cli/cmd/idle.go
@@ -532,7 +532,7 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 	}
 
 	delegScaleGetter := osclient.NewDelegatingScaleNamespacer(oclient, kclient)
-	dcGetter := deployclient.New(oclient.RESTClient)
+	dcGetter := deployclient.New(oclient)
 	rcGetter := clientset.FromUnversionedClient(kclient)
 
 	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, dcGetter, rcGetter, func(currentReplicas int32, annotations map[string]string) {

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -27,7 +27,7 @@ import (
 type ProjectOptions struct {
 	Config       clientcmdapi.Config
 	ClientConfig *restclient.Config
-	ClientFn     func() (*client.Client, kclient.Interface, error)
+	ClientFn     func() (client.Interface, kclient.Interface, error)
 	Out          io.Writer
 	PathOptions  *kclientcmd.PathOptions
 
@@ -107,7 +107,7 @@ func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Wr
 		return err
 	}
 
-	o.ClientFn = func() (*client.Client, kclient.Interface, error) {
+	o.ClientFn = func() (client.Interface, kclient.Interface, error) {
 		return f.Clients()
 	}
 
@@ -279,7 +279,7 @@ func (o ProjectOptions) RunProject() error {
 	return nil
 }
 
-func confirmProjectAccess(currentProject string, oClient *client.Client, kClient kclient.Interface) error {
+func confirmProjectAccess(currentProject string, oClient client.Interface, kClient kclient.Interface) error {
 	_, projectErr := oClient.Projects().Get(currentProject)
 	if !kapierrors.IsNotFound(projectErr) {
 		return projectErr
@@ -294,7 +294,7 @@ func confirmProjectAccess(currentProject string, oClient *client.Client, kClient
 	return projectErr
 }
 
-func getProjects(oClient *client.Client, kClient kclient.Interface) ([]api.Project, error) {
+func getProjects(oClient client.Interface, kClient kclient.Interface) ([]api.Project, error) {
 	projects, err := oClient.Projects().List(kapi.ListOptions{})
 	if err == nil {
 		return projects.Items, nil

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -23,7 +23,7 @@ import (
 type ProjectsOptions struct {
 	Config       clientcmdapi.Config
 	ClientConfig *restclient.Config
-	Client       *client.Client
+	Client       client.Interface
 	KubeClient   kclient.Interface
 	Out          io.Writer
 	PathOptions  *kclientcmd.PathOptions

--- a/pkg/cmd/cli/cmd/version.go
+++ b/pkg/cmd/cli/cmd/version.go
@@ -33,7 +33,7 @@ type VersionOptions struct {
 	Out      io.Writer
 
 	ClientConfig kclientcmd.ClientConfig
-	Clients      func() (*client.Client, *kclient.Client, error)
+	Clients      func() (client.Interface, *kclient.Client, error)
 
 	Timeout time.Duration
 

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -591,7 +591,7 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		if err != nil {
 			return nil, err
 		}
-		return w.OriginSwaggerSchema(oc.RESTClient, gvk.GroupVersion())
+		return w.OriginSwaggerSchema(oc, gvk.GroupVersion())
 	}
 
 	w.EditorEnvs = func() []string {
@@ -993,7 +993,7 @@ func podNameForJob(job *batch.Job, kc *kclient.Client, timeout time.Duration, so
 }
 
 // Clients returns an OpenShift and Kubernetes client.
-func (f *Factory) Clients() (*client.Client, *kclient.Client, error) {
+func (f *Factory) Clients() (client.Interface, *kclient.Client, error) {
 	kClient, err := f.Client()
 	if err != nil {
 		return nil, nil, err
@@ -1006,7 +1006,7 @@ func (f *Factory) Clients() (*client.Client, *kclient.Client, error) {
 }
 
 // OriginSwaggerSchema returns a swagger API doc for an Origin schema under the /oapi prefix.
-func (f *Factory) OriginSwaggerSchema(client *restclient.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
+func (f *Factory) OriginSwaggerSchema(client resource.RESTClient, version unversioned.GroupVersion) (*swagger.ApiDeclaration, error) {
 	if version.Empty() {
 		return nil, fmt.Errorf("groupVersion cannot be empty")
 	}

--- a/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
+++ b/pkg/deploy/client/clientset_generated/internalclientset/typed/core/unversioned/core_client.go
@@ -4,16 +4,17 @@ import (
 	api "k8s.io/kubernetes/pkg/api"
 	registered "k8s.io/kubernetes/pkg/apimachinery/registered"
 	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
 type CoreInterface interface {
-	GetRESTClient() *restclient.RESTClient
+	GetRESTClient() resource.RESTClient
 	DeploymentConfigsGetter
 }
 
 // CoreClient is used to interact with features provided by the Core group.
 type CoreClient struct {
-	*restclient.RESTClient
+	resource.RESTClient
 }
 
 func (c *CoreClient) DeploymentConfigs(namespace string) DeploymentConfigInterface {
@@ -44,7 +45,7 @@ func NewForConfigOrDie(c *restclient.Config) *CoreClient {
 }
 
 // New creates a new CoreClient for the given RESTClient.
-func New(c *restclient.RESTClient) *CoreClient {
+func New(c resource.RESTClient) *CoreClient {
 	return &CoreClient{c}
 }
 
@@ -77,9 +78,9 @@ func setConfigDefaults(config *restclient.Config) error {
 
 // GetRESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreClient) GetRESTClient() *restclient.RESTClient {
+func (c *CoreClient) GetRESTClient() resource.RESTClient {
 	if c == nil {
 		return nil
 	}
-	return c.RESTClient
+	return c
 }

--- a/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/diagnostic.go
@@ -26,7 +26,7 @@ import (
 type AggregatedLogging struct {
 	masterConfig     *configapi.MasterConfig
 	MasterConfigFile string
-	OsClient         *client.Client
+	OsClient         client.Interface
 	KubeClient       *kclient.Client
 	result           types.DiagnosticResult
 }
@@ -45,7 +45,7 @@ const (
 var loggingSelector = labels.Set{loggingInfraKey: "support"}
 
 //NewAggregatedLogging returns the AggregatedLogging Diagnostic
-func NewAggregatedLogging(masterConfigFile string, kclient *kclient.Client, osclient *client.Client) *AggregatedLogging {
+func NewAggregatedLogging(masterConfigFile string, kclient *kclient.Client, osclient client.Interface) *AggregatedLogging {
 	return &AggregatedLogging{nil, masterConfigFile, osclient, kclient, types.NewDiagnosticResult(AggregatedLoggingName)}
 }
 
@@ -158,7 +158,7 @@ and updating the annotation:
 
 `
 
-func retrieveLoggingProject(r types.DiagnosticResult, masterCfg *configapi.MasterConfig, osClient *client.Client) string {
+func retrieveLoggingProject(r types.DiagnosticResult, masterCfg *configapi.MasterConfig, osClient client.Interface) string {
 	r.Debug("AGL0010", fmt.Sprintf("masterConfig.AssetConfig.LoggingPublicURL: '%s'", masterCfg.AssetConfig.LoggingPublicURL))
 	projectName := ""
 	if len(masterCfg.AssetConfig.LoggingPublicURL) == 0 {

--- a/pkg/diagnostics/cluster/aggregated_logging/kibana.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/kibana.go
@@ -22,7 +22,7 @@ const (
 )
 
 //checkKibana verifies the various integration points between Kibana and logging
-func checkKibana(r types.DiagnosticResult, osClient *client.Client, kClient *kclient.Client, project string) {
+func checkKibana(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string) {
 	oauthclient, err := osClient.OAuthClients().Get(kibanaProxyOauthClientName)
 	if err != nil {
 		r.Error("AGL0115", err, fmt.Sprintf("Error retrieving the OauthClient '%s': %s. Unable to check Kibana", kibanaProxyOauthClientName, err))
@@ -33,7 +33,7 @@ func checkKibana(r types.DiagnosticResult, osClient *client.Client, kClient *kcl
 }
 
 //checkKibanaSecret confirms the secret used by kibana matches that configured in the oauth client
-func checkKibanaSecret(r types.DiagnosticResult, osClient *client.Client, kClient *kclient.Client, project string, oauthclient *oauthapi.OAuthClient) {
+func checkKibanaSecret(r types.DiagnosticResult, osClient client.Interface, kClient *kclient.Client, project string, oauthclient *oauthapi.OAuthClient) {
 	r.Debug("AGL0100", "Checking oauthclient secrets...")
 	secret, err := kClient.Secrets(project).Get(kibanaProxySecretName)
 	if err != nil {
@@ -54,7 +54,7 @@ func checkKibanaSecret(r types.DiagnosticResult, osClient *client.Client, kClien
 }
 
 //checkKibanaRoutesInOauthClient verifies the client contains the correct redirect uris
-func checkKibanaRoutesInOauthClient(r types.DiagnosticResult, osClient *client.Client, project string, oauthclient *oauthapi.OAuthClient) {
+func checkKibanaRoutesInOauthClient(r types.DiagnosticResult, osClient client.Interface, project string, oauthclient *oauthapi.OAuthClient) {
 	r.Debug("AGL0141", "Checking oauthclient redirectURIs for the logging routes...")
 	routeList, err := osClient.Routes(project).List(kapi.ListOptions{LabelSelector: loggingSelector.AsSelector()})
 	if err != nil {

--- a/pkg/diagnostics/cluster/master_node.go
+++ b/pkg/diagnostics/cluster/master_node.go
@@ -28,7 +28,7 @@ to proxy to pods over the Open vSwitch SDN.
 // with other nodes.
 type MasterNode struct {
 	KubeClient       *kclient.Client
-	OsClient         *osclient.Client
+	OsClient         osclient.Interface
 	ServerUrl        string
 	MasterConfigFile string // may often be empty if not being run on the host
 }

--- a/pkg/diagnostics/cluster/node_definitions.go
+++ b/pkg/diagnostics/cluster/node_definitions.go
@@ -48,7 +48,7 @@ other options for 'oadm manage-node').
 // NodeDefinitions is a Diagnostic for analyzing the nodes in a cluster.
 type NodeDefinitions struct {
 	KubeClient *kclient.Client
-	OsClient   *osclient.Client
+	OsClient   osclient.Interface
 }
 
 const NodeDefinitionsName = "NodeDefinitions"

--- a/pkg/diagnostics/cluster/registry.go
+++ b/pkg/diagnostics/cluster/registry.go
@@ -21,7 +21,7 @@ import (
 // ClusterRegistry is a Diagnostic to check that there is a working Docker registry.
 type ClusterRegistry struct {
 	KubeClient          *kclient.Client
-	OsClient            *osclient.Client
+	OsClient            osclient.Interface
 	PreventModification bool
 }
 

--- a/pkg/diagnostics/cluster/router.go
+++ b/pkg/diagnostics/cluster/router.go
@@ -23,7 +23,7 @@ import (
 // ClusterRouter is a Diagnostic to check that there is a working router.
 type ClusterRouter struct {
 	KubeClient *kclient.Client
-	OsClient   *osclient.Client
+	OsClient   osclient.Interface
 }
 
 const (

--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -27,7 +27,7 @@ const (
 // NetworkDiagnostic is a diagnostic that runs a network diagnostic pod and relays the results.
 type NetworkDiagnostic struct {
 	KubeClient          *kclient.Client
-	OSClient            *osclient.Client
+	OSClient            osclient.Interface
 	ClientFlags         *flag.FlagSet
 	Level               int
 	Factory             *osclientcmd.Factory

--- a/pkg/diagnostics/networkpod/pod.go
+++ b/pkg/diagnostics/networkpod/pod.go
@@ -23,7 +23,7 @@ const (
 // CheckPodNetwork is a Diagnostic to check communication between pods in the cluster.
 type CheckPodNetwork struct {
 	KubeClient *kclient.Client
-	OSClient   *osclient.Client
+	OSClient   osclient.Interface
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult

--- a/pkg/diagnostics/networkpod/service.go
+++ b/pkg/diagnostics/networkpod/service.go
@@ -23,7 +23,7 @@ const (
 // CheckServiceNetwork is a Diagnostic to check communication between services in the cluster.
 type CheckServiceNetwork struct {
 	KubeClient *kclient.Client
-	OSClient   *osclient.Client
+	OSClient   osclient.Interface
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult

--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -33,7 +33,7 @@ const (
 	NetworkDiagPodLogDirPrefix       = "/pods"
 )
 
-func GetOpenShiftNetworkPlugin(osClient *osclient.Client) (string, bool, error) {
+func GetOpenShiftNetworkPlugin(osClient osclient.Interface) (string, bool, error) {
 	cn, err := osClient.ClusterNetwork().Get(api.ClusterNetworkDefault)
 	if err != nil {
 		if kerrors.IsNotFound(err) {


### PR DESCRIPTION
This PR refactory openshift to use client.Interface instead of *client.Client on Factory.Clients(), for tests purpose.

This PR is part of #11290 and was subtracted for make the PR more clean.
