### PR TITLE
make invocation generateBuildFromConfig more readable

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
@@ -17,7 +17,7 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against nodes.
+// NewStorage returns a RESTStorage object that will work against ClusterPolicy.
 func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 
 	store := &registry.Store{

--- a/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
@@ -17,7 +17,7 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against nodes.
+// NewStorage returns a RESTStorage object that will work against ClusterPolicyBinding.
 func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 
 	store := &registry.Store{

--- a/pkg/authorization/registry/policy/etcd/etcd.go
+++ b/pkg/authorization/registry/policy/etcd/etcd.go
@@ -17,7 +17,7 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against nodes.
+// NewStorage returns a RESTStorage object that will work against Policy objects.
 func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.Policy{} },

--- a/pkg/authorization/registry/policybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/policybinding/etcd/etcd.go
@@ -17,7 +17,7 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against nodes.
+// NewStorage returns a RESTStorage object that will work against PolicyBinding objects.
 func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.PolicyBinding{} },

--- a/pkg/quota/registry/clusterresourcequota/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd.go
@@ -18,7 +18,7 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against nodes.
+// NewStorage returns a RESTStorage object that will work against ClusterResourceQuota objects.
 func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
 	store, err := makeStore(optsGetter)
 	if err != nil {


### PR DESCRIPTION
it is reasonable to use bccopy all the time since we have make a deep copy (bccopy) for buildconfig in invocation generateBuildFromConfig.  In this PR I also wrapper some code to make it more readable and add some small modifications for comment. <br />/cc @bparees