### PR TITLE
Fix SDN startup ordering (again)

### DIFF
--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -207,6 +207,14 @@ func (node *OsdnNode) Start() error {
 	// Wait for kubelet to init the plugin so we get a knetwork.Host
 	log.V(5).Infof("Waiting for kubelet network plugin initialization")
 	<-node.kubeletInitReady
+	// Wait for kubelet itself to finish initializing
+	kwait.PollInfinite(100*time.Millisecond,
+		func() (bool, error) {
+			if node.host.GetRuntime() == nil {
+				return false, nil
+			}
+			return true, nil
+		})
 
 	log.V(5).Infof("Creating and initializing openshift-sdn pod manager")
 	node.podManager, err = newPodManager(node.host, node.multitenant, node.localSubnetCIDR, node.networkInfo, node.kClient, node.vnids, node.mtu)


### PR DESCRIPTION
Network plugin Init() is called from the middle of kubelet initialization, which happens in parallel with SDN startup... So, it's possible that when SDN startup reaches the point where it wants to update the existing pods, Init() will have been called and node.host will be set, but node.host.GetRuntime() will return nil, because the kubelet hasn't created the containerRuntime object yet over in its own goroutine.

We may want to make this nicer later but for 3.4 this seemed simplest.

@openshift/networking especially @dcbw PTAL

[test][testextended][extended:networking]