### PR TITLE
Wait for old pods to terminate before proceeding to Recreate

### DIFF
--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -276,6 +276,7 @@ func TestRecreate_acceptorSuccess(t *testing.T) {
 		out:          &bytes.Buffer{},
 		errOut:       &bytes.Buffer{},
 		eventClient:  fake.NewSimpleClientset().Core(),
+		podClient:    fake.NewSimpleClientset().Core(),
 		decoder:      kapi.Codecs.UniversalDecoder(),
 		retryTimeout: 1 * time.Second,
 		retryPeriod:  1 * time.Millisecond,
@@ -326,6 +327,7 @@ func TestRecreate_acceptorFail(t *testing.T) {
 		retryPeriod:  1 * time.Millisecond,
 		scaler:       scaler,
 		eventClient:  fake.NewSimpleClientset().Core(),
+		podClient:    fake.NewSimpleClientset().Core(),
 	}
 
 	acceptor := &testAcceptor{


### PR DESCRIPTION
@mfojtik should fix https://bugzilla.redhat.com/show_bug.cgi?id=1369644 

cc: @smarterclayton opted for this instead of having a TerminatingReplicas field in the replication controller.

Upstream equivalent PR is https://github.com/kubernetes/kubernetes/pull/36748