### PR TITLE
oc new-app: do not fail when file exists with same name as image

### DIFF
--- a/pkg/generate/app/templatelookup.go
+++ b/pkg/generate/app/templatelookup.go
@@ -129,6 +129,8 @@ func (r *TemplateFileSearcher) Search(precise bool, terms ...string) (ComponentM
 			switch {
 			case strings.Contains(err.Error(), "does not exist") && strings.Contains(err.Error(), "the path"):
 				continue
+			case strings.Contains(err.Error(), "not a directory") && strings.Contains(err.Error(), "the path"):
+				continue
 			default:
 				if syntaxErr, ok := err.(*json.SyntaxError); ok {
 					err = fmt.Errorf("at offset %d: %v", syntaxErr.Offset, err)


### PR DESCRIPTION
When "oc new-app foo/bar" was run in a directory with regular file named "foo" it failed with:

```
error: unable to load template file "foo/bar": the path "foo/bar" cannot be accessed: stat foo/bar: not a directory
```

Fixes bug [1393003](https://bugzilla.redhat.com/show_bug.cgi?id=1347512).

----

The fix feels a bit wrong, any hints how to fix this better appreciated.

@bparees or @fabianofranz PTAL?