### PR TITLE
Accept docker0 traffic regardless of firewall

### DIFF
--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -93,7 +93,8 @@ func (n *NodeIPTables) getStaticNodeIPTablesRules() []FirewallRule {
 	return []FirewallRule{
 		{"nat", "POSTROUTING", []string{"-s", n.clusterNetworkCIDR, "-j", "MASQUERADE"}},
 		{"filter", "INPUT", []string{"-p", "udp", "-m", "multiport", "--dports", VXLAN_PORT, "-m", "comment", "--comment", "001 vxlan incoming", "-j", "ACCEPT"}},
-		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "traffic from docker for internet", "-j", "ACCEPT"}},
+		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "traffic from SDN", "-j", "ACCEPT"}},
+		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "traffic from docker", "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
 	}


### PR DESCRIPTION
Since docker traffic isn't getting routed through OVS any more, the existing firewall-bypassing rule we had no longer applies, so plain docker containers (eg, builds) can't reach the node's IP address, which is a problem if that's what they're supposed to be using for DNS.

Fixes the second half of https://bugzilla.redhat.com/show_bug.cgi?id=1390835

@openshift/networking PTAL