### PR TITLE
Fix extended tests

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -230,7 +230,9 @@ func init() {
 				},
 				{
 					APIGroups: []string{""},
-					Verbs:     sets.NewString("get", "list", "watch"),
+					// TODO: remove "update" once
+					// https://github.com/kubernetes/kubernetes/issues/36897 is resolved.
+					Verbs:     sets.NewString("get", "list", "watch", "update"),
 					Resources: sets.NewString("pods"),
 				},
 				{

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -276,6 +276,9 @@ readonly EXCLUDED_TESTS=(
 	# Inordinately slow tests
 	"should create and stop a working application"
 	"should always delete fast" # will be uncommented in etcd3
+
+	# tested by networking.sh and requires the environment that script sets up
+	"\[networking\] OVS"
 )
 
 readonly SERIAL_TESTS=(

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -226,6 +226,7 @@ readonly EXCLUDED_TESTS=(
 	"^Kubernetes Dashboard"  # Not installed by default (also probbaly slow image pull)
 
 	"\[Feature:Federation\]"   # Not enabled yet
+	"\[Feature:Federation12\]"   # Not enabled yet
 	"\[Feature:PodAffinity\]"  # Not enabled yet
 	Ingress                    # Not enabled yet
 	"Cinder"                   # requires an OpenStack cluster

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -214,6 +214,9 @@ readonly EXCLUDED_TESTS=(
 
 	"\[Feature:Performance\]"
 
+	# not enabled in Origin yet
+	"\[Feature:GarbageCollector\]"
+
 	# Depends on external components, may not need yet
 	Monitoring              # Not installed, should be
 	"Cluster level logging" # Not installed yet

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2565,6 +2565,7 @@ items:
     verbs:
     - get
     - list
+    - update
     - watch
   - apiGroups:
     - ""


### PR DESCRIPTION
- allow deployment controller to update pods
- disable kube garbage collector tests since the kube garbage collector isn't enabled in origin yet
- excluded 1 federation test that wasn't caught by our existing filter
- skip networking OVS tests in core.sh because they need a special network configuration that's set up by test/extended/networking.sh

Fixes #11903