### PR TITLE
Remove manifest from Image

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -556,7 +556,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule("get", "delete").Groups(imageGroup).Resources("images", "imagestreamtags").RuleOrDie(),
 				authorizationapi.NewRule("get").Groups(imageGroup).Resources("imagestreamimages", "imagestreams/secrets").RuleOrDie(),
-				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("imagestreams").RuleOrDie(),
+				authorizationapi.NewRule("get", "update").Groups(imageGroup).Resources("images", "imagestreams").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(imageGroup).Resources("imagestreammappings").RuleOrDie(),
 			},
 		},

--- a/pkg/dockerregistry/client_test.go
+++ b/pkg/dockerregistry/client_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift/origin/pkg/dockerregistry/testutil"
 )
 
 // tests of running registries are done in the integration client test
@@ -298,7 +300,7 @@ func TestGetTagFallback(t *testing.T) {
 		endpoint: *uri,
 	}
 	// Case when tag is found
-	img, err := repo.getTaggedImage(c, "test", "")
+	img, _, err := repo.getTaggedImage(c, "test", "")
 	if err != nil {
 		t.Errorf("unexpected error getting tag: %v", err)
 		return
@@ -307,8 +309,54 @@ func TestGetTagFallback(t *testing.T) {
 		t.Errorf("unexpected image for tag: %v", img)
 	}
 	// Case when tag is not found
-	img, err = repo.getTaggedImage(c, "test2", "")
+	img, _, err = repo.getTaggedImage(c, "test2", "")
 	if err == nil {
 		t.Errorf("expected error")
 	}
+}
+
+func TestImageManifest(t *testing.T) {
+	manifestDigest := "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238"
+
+	called := make(chan struct{}, 2)
+	var uri *url.URL
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called <- struct{}{}
+		t.Logf("got %s %s", r.Method, r.URL.Path)
+		switch r.URL.Path {
+		case "/v2/":
+			w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+			w.Write([]byte(`{}`))
+		case "/v2/test/image/manifests/latest", "/v2/test/image/manifests/" + manifestDigest:
+			if r.Method == "HEAD" {
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testutil.SampleImageManifestSchema1)))
+				w.Header().Set("Docker-Content-Digest", manifestDigest)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.Write([]byte(testutil.SampleImageManifestSchema1))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
+			return
+		}
+	}))
+	uri, _ = url.Parse(server.URL)
+	conn, err := NewClient(10*time.Second, true).Connect(uri.Host, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, manifest, err := conn.ImageManifest("test", "image", "latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest) == 0 {
+		t.Errorf("empty manifest")
+	}
+
+	if string(manifest) != testutil.SampleImageManifestSchema1 {
+		t.Errorf("unexpected manifest: %#v", manifest)
+	}
+
+	<-called
+	<-called
 }

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/middleware/registry"
 	"github.com/docker/distribution/registry/storage"
 
@@ -182,6 +183,12 @@ func imageHasBlob(
 		return false
 	}
 
+	// someone asks for manifest
+	if imageName == blobDigest {
+		r.rememberLayersOfImage(image, cacheName)
+		return true
+	}
+
 	if len(image.DockerImageLayers) == 0 {
 		if len(image.DockerImageManifestMediaType) > 0 {
 			// If the media type is set, we can safely assume that the best effort to fill the image layers
@@ -204,7 +211,8 @@ func imageHasBlob(
 	}
 
 	// only manifest V2 schema2 has docker image config filled where dockerImage.Metadata.id is its digest
-	if len(image.DockerImageConfig) > 0 && image.DockerImageMetadata.ID == blobDigest {
+	if image.DockerImageManifestMediaType == schema2.MediaTypeManifest &&
+		image.DockerImageMetadata.ID == blobDigest {
 		// remember manifest config reference of schema 2 as well
 		r.rememberLayersOfImage(image, cacheName)
 		return true

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -177,7 +177,7 @@ func imageHasBlob(
 
 	// in case of pullthrough disabled, client won't be able to download a blob belonging to not managed image
 	// (image stored in external registry), thus don't consider them as candidates
-	if managed := image.Annotations[imageapi.ManagedByOpenShiftAnnotation]; requireManaged && managed != "true" {
+	if requireManaged && !isImageManaged(image) {
 		context.GetLogger(r.ctx).Debugf("skipping not managed image")
 		return false
 	}

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -198,10 +198,10 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 				"reference", "latest",
 			},
 			unsetRepository: true,
-			// succeed because blob store is not involved
-			expectedStatus: http.StatusOK,
-			// manifest is retrieved from etcd
-			expectedMethodInvocations: map[string]int{"Stat": 0},
+			// failed because we trying to get manifest from storage driver first.
+			expectedStatus: http.StatusNotFound,
+			// manifest can't be retrieved from etcd
+			expectedMethodInvocations: map[string]int{"Stat": 1},
 		},
 
 		{
@@ -214,7 +214,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			// manifest is retrieved from etcd
-			expectedMethodInvocations: map[string]int{"Stat": 0},
+			expectedMethodInvocations: map[string]int{"Stat": 3},
 		},
 
 		{

--- a/pkg/dockerregistry/server/errormanifestservice.go
+++ b/pkg/dockerregistry/server/errormanifestservice.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+)
+
+// errorManifestService wraps a distribution.ManifestService for a particular repo.
+// before delegating, it ensures auth completed and there were no errors relevant to the repo.
+type errorManifestService struct {
+	manifests distribution.ManifestService
+	repo      *repository
+}
+
+var _ distribution.ManifestService = &errorManifestService{}
+
+func (em *errorManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	if err := em.repo.checkPendingErrors(ctx); err != nil {
+		return false, err
+	}
+	return em.manifests.Exists(ctx, dgst)
+}
+
+func (em *errorManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	if err := em.repo.checkPendingErrors(ctx); err != nil {
+		return nil, err
+	}
+	return em.manifests.Get(ctx, dgst, options...)
+}
+
+func (em *errorManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	if err := em.repo.checkPendingErrors(ctx); err != nil {
+		return "", err
+	}
+	return em.manifests.Put(ctx, manifest, options...)
+}
+
+func (em *errorManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := em.repo.checkPendingErrors(ctx); err != nil {
+		return err
+	}
+	return em.manifests.Delete(ctx, dgst)
+}

--- a/pkg/dockerregistry/server/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 
@@ -28,6 +29,9 @@ type ManifestHandler interface {
 
 	// Verify returns an error if the contained manifest is not valid or has missing dependencies.
 	Verify(ctx context.Context, skipDependencyVerification bool) error
+
+	// Digest returns manifest's digest
+	Digest() (manifestDigest digest.Digest, err error)
 }
 
 // NewManifestHandler creates a manifest handler for the given manifest.

--- a/pkg/dockerregistry/server/manifestschema1handler.go
+++ b/pkg/dockerregistry/server/manifestschema1handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/libtrust"
@@ -171,4 +172,8 @@ func (h *manifestSchema1Handler) Verify(ctx context.Context, skipDependencyVerif
 		return errs
 	}
 	return nil
+}
+
+func (h *manifestSchema1Handler) Digest() (digest.Digest, error) {
+	return digest.FromBytes(h.manifest.Canonical), nil
 }

--- a/pkg/dockerregistry/server/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifestschema2handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -109,4 +110,12 @@ func (h *manifestSchema2Handler) Verify(ctx context.Context, skipDependencyVerif
 		return errs
 	}
 	return nil
+}
+
+func (h *manifestSchema2Handler) Digest() (digest.Digest, error) {
+	_, p, err := h.manifest.Payload()
+	if err != nil {
+		return "", err
+	}
+	return digest.FromBytes(p), nil
 }

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema2"
+	regapi "github.com/docker/distribution/registry/api/v2"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	quotautil "github.com/openshift/origin/pkg/quota/util"
+)
+
+var _ distribution.ManifestService = &manifestService{}
+
+type manifestService struct {
+	ctx       context.Context
+	repo      *repository
+	manifests distribution.ManifestService
+
+	// acceptschema2 allows to refuse the manifest schema version 2
+	acceptschema2 bool
+}
+
+// Exists returns true if the manifest specified by dgst exists.
+func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	context.GetLogger(ctx).Debugf("(*manifestService).Exists")
+
+	image, err := m.repo.getImage(dgst)
+	if err != nil {
+		return false, err
+	}
+	return image != nil, nil
+}
+
+// Get retrieves the manifest with digest `dgst`.
+func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	context.GetLogger(ctx).Debugf("(*manifestService).Get")
+
+	if _, err := m.repo.getImageStreamImage(dgst); err != nil {
+		context.GetLogger(ctx).Errorf("error retrieving ImageStreamImage %s/%s@%s: %v", m.repo.namespace, m.repo.name, dgst.String(), err)
+		return nil, err
+	}
+
+	image, err := m.repo.getImage(dgst)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("error retrieving image %s: %v", dgst.String(), err)
+		return nil, err
+	}
+
+	ref := imageapi.DockerImageReference{
+		Namespace: m.repo.namespace,
+		Name:      m.repo.name,
+		Registry:  m.repo.registryAddr,
+	}
+	if isImageManaged(image) {
+		// Reference without a registry part refers to repository containing locally managed images.
+		// Such an entry is retrieved, checked and set by blobDescriptorService operating only on local blobs.
+		ref.Registry = ""
+	} else {
+		// Repository with a registry points to remote repository. This is used by pullthrough middleware.
+		ref = ref.DockerClientDefaults().AsRepository()
+	}
+
+	manifest, err := m.repo.manifestFromImageWithCachedLayers(image, ref.Exact())
+
+	return manifest, err
+}
+
+// Put creates or updates the named manifest.
+func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	context.GetLogger(ctx).Debugf("(*manifestService).Put")
+
+	mh, err := NewManifestHandler(m.repo, manifest)
+	if err != nil {
+		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
+	}
+	mediaType, payload, canonical, err := mh.Payload()
+	if err != nil {
+		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
+	}
+
+	// this is fast to check, let's do it before verification
+	if !m.acceptschema2 && mediaType == schema2.MediaTypeManifest {
+		return "", regapi.ErrorCodeManifestInvalid.WithDetail(fmt.Errorf("manifest V2 schema 2 not allowed"))
+	}
+
+	// in order to stat the referenced blobs, repository need to be set on the context
+	if err := mh.Verify(WithRepository(ctx, m.repo), false); err != nil {
+		return "", err
+	}
+
+	// Calculate digest
+	dgst := digest.FromBytes(canonical)
+
+	// Upload to openshift
+	ism := imageapi.ImageStreamMapping{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: m.repo.namespace,
+			Name:      m.repo.name,
+		},
+		Image: imageapi.Image{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: dgst.String(),
+				Annotations: map[string]string{
+					imageapi.ManagedByOpenShiftAnnotation: "true",
+				},
+			},
+			DockerImageReference:         fmt.Sprintf("%s/%s/%s@%s", m.repo.registryAddr, m.repo.namespace, m.repo.name, dgst.String()),
+			DockerImageManifest:          string(payload),
+			DockerImageManifestMediaType: mediaType,
+		},
+	}
+
+	for _, option := range options {
+		if opt, ok := option.(distribution.WithTagOption); ok {
+			ism.Tag = opt.Tag
+			break
+		}
+	}
+
+	if err = mh.FillImageMetadata(ctx, &ism.Image); err != nil {
+		return "", err
+	}
+
+	if err = m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
+		// if the error was that the image stream wasn't found, try to auto provision it
+		statusErr, ok := err.(*kerrors.StatusError)
+		if !ok {
+			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
+			return "", err
+		}
+
+		if quotautil.IsErrorQuotaExceeded(statusErr) {
+			context.GetLogger(ctx).Errorf("denied creating ImageStreamMapping: %v", statusErr)
+			return "", distribution.ErrAccessDenied
+		}
+
+		status := statusErr.ErrStatus
+		if status.Code != http.StatusNotFound ||
+			(strings.ToLower(status.Details.Kind) != "imagestream" /*pre-1.2*/ && strings.ToLower(status.Details.Kind) != "imagestreams") ||
+			status.Details.Name != m.repo.name {
+			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
+			return "", err
+		}
+
+		stream := imageapi.ImageStream{}
+		stream.Name = m.repo.name
+
+		uclient, ok := UserClientFrom(m.ctx)
+		if !ok {
+			context.GetLogger(ctx).Errorf("error creating user client to auto provision image stream: Origin user client unavailable")
+			return "", statusErr
+		}
+
+		if _, err := uclient.ImageStreams(m.repo.namespace).Create(&stream); err != nil {
+			if quotautil.IsErrorQuotaExceeded(err) {
+				context.GetLogger(ctx).Errorf("denied creating ImageStream: %v", err)
+				return "", distribution.ErrAccessDenied
+			}
+			context.GetLogger(ctx).Errorf("error auto provisioning ImageStream: %s", err)
+			return "", statusErr
+		}
+
+		// try to create the ISM again
+		if err := m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
+			if quotautil.IsErrorQuotaExceeded(err) {
+				context.GetLogger(ctx).Errorf("denied a creation of ImageStreamMapping: %v", err)
+				return "", distribution.ErrAccessDenied
+			}
+			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
+			return "", err
+		}
+	}
+
+	return dgst, nil
+}
+
+// Delete deletes the manifest with digest `dgst`. Note: Image resources
+// in OpenShift are deleted via 'oadm prune images'. This function deletes
+// the content related to the manifest in the registry's storage (signatures).
+func (m *manifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	context.GetLogger(ctx).Debugf("(*manifestService).Delete")
+	return m.manifests.Delete(WithRepository(ctx, m.repo), dgst)
+}

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// pullthroughManifestService wraps a distribution.ManifestService
+// repositories. Since the manifest is no longer stored in the Image
+// the docker-registry must pull through requests to manifests as well
+// as to blobs.
+type pullthroughManifestService struct {
+	distribution.ManifestService
+
+	repo                       *repository
+	pullFromInsecureRegistries bool
+}
+
+var _ distribution.ManifestService = &pullthroughManifestService{}
+
+func (m *pullthroughManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	manifest, err := m.ManifestService.Get(ctx, dgst, options...)
+	switch err.(type) {
+	case distribution.ErrManifestUnknownRevision:
+		break
+	case nil:
+		return manifest, nil
+	default:
+		return nil, err
+	}
+
+	return m.remoteGet(ctx, dgst, options...)
+}
+
+func (m *pullthroughManifestService) remoteGet(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	isi, err := m.repo.getImageStreamImage(dgst)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("error retrieving ImageStreamImage %s/%s@%s: %v", m.repo.namespace, m.repo.name, dgst.String(), err)
+		return nil, err
+	}
+
+	m.pullFromInsecureRegistries = false
+
+	if insecure, ok := isi.Annotations[imageapi.InsecureRepositoryAnnotation]; ok {
+		m.pullFromInsecureRegistries = insecure == "true"
+	}
+
+	ref, err := imageapi.ParseDockerImageReference(isi.Image.DockerImageReference)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("bad DockerImageReference in Image %s/%s@%s: %v", m.repo.namespace, m.repo.name, dgst.String(), err)
+		return nil, err
+	}
+	ref = ref.DockerClientDefaults()
+
+	retriever := m.repo.importContext()
+
+	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), m.pullFromInsecureRegistries)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("error getting remote repository for image %q: %v", ref.Exact(), err)
+		return nil, err
+	}
+
+	pullthroughManifestService, err := repo.Manifests(ctx)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("error getting remote manifests for image %q: %v", ref.Exact(), err)
+		return nil, err
+	}
+
+	manifest, err := pullthroughManifestService.Get(ctx, dgst)
+	switch err.(type) {
+	case nil:
+		m.repo.rememberLayersOfManifest(dgst, manifest, ref.Exact())
+	case distribution.ErrManifestUnknownRevision:
+		break
+	default:
+		context.GetLogger(ctx).Errorf("error getting manifest from remote location %q: %v", ref.Exact(), err)
+	}
+
+	return manifest, err
+}

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/registry/handlers"
+	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
+	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func TestPullthroughManifests(t *testing.T) {
+	ctx := context.Background()
+
+	installFakeAccessController(t)
+
+	testImage, err := registrytest.NewImageForManifest("user/app", registrytest.SampleImageManifestSchema1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testImage.DockerImageManifest = ""
+
+	client := &testclient.Fake{}
+	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *testImage))
+
+	// TODO: get rid of those nasty global vars
+	backupRegistryClient := DefaultRegistryClient
+	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
+	defer func() {
+		// set it back once this test finishes to make other unit tests working again
+		DefaultRegistryClient = backupRegistryClient
+	}()
+
+	// pullthrough middleware will attempt to pull from this registry instance
+	remoteRegistryApp := handlers.NewApp(ctx, &configuration.Configuration{
+		Loglevel: "debug",
+		Auth: map[string]configuration.Parameters{
+			fakeAuthorizerName: {"realm": fakeAuthorizerName},
+		},
+		Storage: configuration.Storage{
+			"inmemory": configuration.Parameters{},
+			"cache": configuration.Parameters{
+				"blobdescriptor": "inmemory",
+			},
+			"delete": configuration.Parameters{
+				"enabled": true,
+			},
+		},
+		Middleware: map[string][]configuration.Middleware{
+			"registry":   {{Name: "openshift"}},
+			"repository": {{Name: "openshift"}},
+			"storage":    {{Name: "openshift"}},
+		},
+	})
+	remoteRegistryServer := httptest.NewServer(remoteRegistryApp)
+	defer remoteRegistryServer.Close()
+
+	serverURL, err := url.Parse(remoteRegistryServer.URL)
+	if err != nil {
+		t.Fatalf("error parsing server url: %v", err)
+	}
+	os.Setenv("DOCKER_REGISTRY_URL", serverURL.Host)
+	testImage.DockerImageReference = fmt.Sprintf("%s/%s@%s", serverURL.Host, "user/app", testImage.Name)
+
+	testImageStream := registrytest.TestNewImageStreamObject("user", "app", "latest", testImage.Name, testImage.DockerImageReference)
+	if testImageStream.Annotations == nil {
+		testImageStream.Annotations = make(map[string]string)
+	}
+	testImageStream.Annotations[imageapi.InsecureRepositoryAnnotation] = "true"
+
+	client.AddReactor("get", "imagestreams", imagetest.GetFakeImageStreamGetHandler(t, *testImageStream))
+
+	signedManifest := &schema1.SignedManifest{}
+	if err := json.Unmarshal([]byte(etcdManifest), signedManifest); err != nil {
+		t.Fatalf("error unmarshaling signed manifest: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name                  string
+		method                string
+		manifestDigest        digest.Digest
+		localData             map[digest.Digest]distribution.Manifest
+		expectedLocalCalls    map[string]int
+		expectedError         bool
+		expectedNotFoundError bool
+	}{
+		{
+			name:           "manifest digest",
+			method:         "GET",
+			manifestDigest: etcdDigest,
+			localData: map[digest.Digest]distribution.Manifest{
+				etcdDigest: signedManifest,
+			},
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+		{
+			name:                  "unknown manifest digest",
+			method:                "GET",
+			manifestDigest:        unknownBlobDigest,
+			expectedNotFoundError: true,
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+	} {
+		localManifestService := newTestManifestService(tc.localData)
+
+		cachedLayers, err := newDigestToRepositoryCache(10)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ptms := &pullthroughManifestService{
+			ManifestService: localManifestService,
+			repo: &repository{
+				ctx:              ctx,
+				namespace:        "user",
+				name:             "app",
+				pullthrough:      true,
+				cachedLayers:     cachedLayers,
+				registryOSClient: client,
+			},
+		}
+
+		manifestResult, err := ptms.Get(ctx, tc.manifestDigest)
+		switch err.(type) {
+		case distribution.ErrManifestUnknownRevision:
+			if !tc.expectedNotFoundError {
+				t.Fatalf("[%s] unexpected error: %#+v", tc.name, err)
+			}
+		case nil:
+			if tc.expectedError || tc.expectedNotFoundError {
+				t.Fatalf("[%s] unexpected successful response", tc.name)
+			}
+		default:
+			if tc.expectedError {
+				break
+			}
+			if tc.expectedNotFoundError && err == distribution.ErrBlobUnknown {
+				break
+			}
+			t.Fatalf("[%s] unexpected error: %#+v", tc.name, err)
+		}
+
+		if manifestResult != nil && manifestResult != tc.localData[tc.manifestDigest] {
+			t.Fatalf("[%s] unexpected retult returned", tc.name)
+		}
+
+		for name, count := range localManifestService.calls {
+			expectCount, exists := tc.expectedLocalCalls[name]
+			if !exists {
+				t.Errorf("[%s] expected no calls to method %s of local manifest service, got %d", tc.name, name, count)
+			}
+			if count != expectCount {
+				t.Errorf("[%s] unexpected number of calls to method %s of local manifest service, got %d", tc.name, name, count)
+			}
+		}
+	}
+}
+
+type testManifestService struct {
+	data  map[digest.Digest]distribution.Manifest
+	calls map[string]int
+}
+
+var _ distribution.ManifestService = &testManifestService{}
+
+func newTestManifestService(data map[digest.Digest]distribution.Manifest) *testManifestService {
+	b := make(map[digest.Digest]distribution.Manifest)
+	for d, content := range data {
+		b[d] = content
+	}
+	return &testManifestService{
+		data:  b,
+		calls: make(map[string]int),
+	}
+}
+
+func (t *testManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	t.calls["Exists"]++
+	_, exists := t.data[dgst]
+	return exists, nil
+}
+
+func (t *testManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	t.calls["Get"]++
+	content, exists := t.data[dgst]
+	if !exists {
+		return nil, distribution.ErrBlobUnknown
+	}
+	return content, nil
+}
+
+func (t *testManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	t.calls["Put"]++
+	return "", fmt.Errorf("method not implemented")
+}
+
+func (t *testManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	t.calls["Delete"]++
+	return fmt.Errorf("method not implemented")
+}
+
+const etcdDigest = "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238"
+const etcdManifest = `{
+   "schemaVersion": 1, 
+   "tag": "latest", 
+   "name": "coreos/etcd", 
+   "architecture": "amd64", 
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }, 
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }, 
+      {
+         "blobSum": "sha256:2560187847cadddef806eaf244b7755af247a9dbabb90ca953dd2703cf423766"
+      }, 
+      {
+         "blobSum": "sha256:744b46d0ac8636c45870a03830d8d82c20b75fbfb9bc937d5e61005d23ad4cfe"
+      }
+   ], 
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"fe50ac14986497fa6b5d2cc24feb4a561d01767bc64413752c0988cb70b0b8b9\",\"parent\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"created\":\"2015-12-30T22:29:13.967754365Z\",\"container\":\"c8d0f1a274b5f52fa5beb280775ef07cf18ec0f95e5ae42fbad01157e2614d42\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ENTRYPOINT \\u0026{[\\\"/etcd\\\"]}\"],\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"parent\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"created\":\"2015-12-30T22:29:13.504159783Z\",\"container\":\"080708d544f85052a46fab72e701b4358c1b96cb4b805a5b2d66276fc2aaf85d\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) EXPOSE 2379/tcp 2380/tcp 4001/tcp 7001/tcp\"],\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"parent\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.912813629Z\",\"container\":\"f28be899c9b8680d4cf8585e663ad20b35019db062526844e7cfef117ce9037f\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:e330b1da49d993059975e46560b3bd360691498b0f2f6e00f39fc160cf8d4ec3 in /\"],\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":13502144}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.346834862Z\",\"container\":\"1b97abade59e4b5b935aede236980a54fb500cd9ee5bd4323c832c6d7b3ffc6e\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:74912593c6783292c4520514f5cc9313acbd1da0f46edee0fdbed2a24a264d6f in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":15141568}"
+      }
+   ], 
+   "signatures": [
+      {
+         "header": {
+            "alg": "RS256", 
+            "jwk": {
+               "e": "AQAB", 
+               "kty": "RSA", 
+               "n": "yB40ou1GMvIxYs1jhxWaeoDiw3oa0_Q2UJThUPtArvO0tRzaun9FnSphhOEHIGcezfq95jy-3MN-FIjmsWgbPHY8lVDS38fF75aCw6qkholwqjmMtUIgPNYoMrg0rLUE5RRyJ84-hKf9Fk7V3fItp1mvCTGKaS3ze-y5dTTrfbNGE7qG638Dla2Fuz-9CNgRQj0JH54o547WkKJC-pG-j0jTDr8lzsXhrZC7lJas4yc-vpt3D60iG4cW_mkdtIj52ZFEgHZ56sUj7AhnNVly0ZP9W1hmw4xEHDn9WLjlt7ivwARVeb2qzsNdguUitcI5hUQNwpOVZ_O3f1rUIL_kRw"
+            }
+         }, 
+         "protected": "eyJmb3JtYXRUYWlsIjogIkNuMCIsICJmb3JtYXRMZW5ndGgiOiA1OTI2LCAidGltZSI6ICIyMDE2LTAxLTAyVDAyOjAxOjMzWiJ9", 
+         "signature": "DrQ43UWeit-thDoRGTCP0Gd2wL5K2ecyPhHo_au0FoXwuKODja0tfwHexB9ypvFWngk-ijXuwO02x3aRIZqkWpvKLxxzxwkrZnPSje4o_VrFU4z5zwmN8sJw52ODkQlW38PURIVksOxCrb0zRl87yTAAsUAJ_4UUPNltZSLnhwy-qPb2NQ8ghgsONcBxRQrhPFiWNkxDKZ3kjvzYyrXDxTcvwK3Kk_YagZ4rCOhH1B7mAdVSiSHIvvNV5grPshw_ipAoqL2iNMsxWxLjYZl9xSJQI2asaq3fvh8G8cZ7T-OahDUos_GyhnIj39C-9ouqdJqMUYFETqbzRCR6d36CpQ"
+      }
+   ]
+}`

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -308,6 +308,11 @@ func (r *repository) getImageStreamImage(dgst digest.Digest) (*imageapi.ImageStr
 	return r.registryOSClient.ImageStreamImages(r.namespace).Get(r.name, dgst.String())
 }
 
+// updateImage modifies the Image.
+func (r *repository) updateImage(image *imageapi.Image) (*imageapi.Image, error) {
+	return r.registryOSClient.Images().Update(image)
+}
+
 // rememberLayersOfImage caches the layer digests of given image
 func (r *repository) rememberLayersOfImage(image *imageapi.Image, cacheName string) {
 	if len(image.DockerImageLayers) == 0 && len(image.DockerImageManifestMediaType) > 0 && len(image.DockerImageConfig) == 0 {

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -11,18 +11,15 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
-	regapi "github.com/docker/distribution/registry/api/v2"
 	repomw "github.com/docker/distribution/registry/middleware/repository"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/importer"
-	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
 
 const (
@@ -150,8 +147,6 @@ type repository struct {
 	cachedLayers digestToRepositoryCache
 }
 
-var _ distribution.ManifestService = &repository{}
-
 // newRepositoryWithClient returns a new repository middleware.
 func newRepositoryWithClient(
 	registryOSClient client.Interface,
@@ -208,12 +203,24 @@ func newRepositoryWithClient(
 
 // Manifests returns r, which implements distribution.ManifestService.
 func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
-	if r.ctx == ctx {
-		return r, nil
+	ms, err := r.Repository.Manifests(WithRepository(ctx, r))
+	if err != nil {
+		return nil, err
 	}
-	repo := repository(*r)
-	repo.ctx = ctx
-	return &repo, nil
+
+	ms = &manifestService{
+		ctx:           WithRepository(ctx, r),
+		repo:          r,
+		manifests:     ms,
+		acceptschema2: r.acceptschema2,
+	}
+
+	ms = &errorManifestService{
+		manifests: ms,
+		repo:      r,
+	}
+
+	return ms, nil
 }
 
 // Blobs returns a blob store which can delegate to remote repositories.
@@ -264,181 +271,6 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 	}
 
 	return ts
-}
-
-// Exists returns true if the manifest specified by dgst exists.
-func (r *repository) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
-	if err := r.checkPendingErrors(ctx); err != nil {
-		return false, err
-	}
-
-	image, err := r.getImage(dgst)
-	if err != nil {
-		return false, err
-	}
-	return image != nil, nil
-}
-
-// Get retrieves the manifest with digest `dgst`.
-func (r *repository) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
-	if err := r.checkPendingErrors(ctx); err != nil {
-		return nil, err
-	}
-
-	if _, err := r.getImageStreamImage(dgst); err != nil {
-		context.GetLogger(r.ctx).Errorf("error retrieving ImageStreamImage %s/%s@%s: %v", r.namespace, r.name, dgst.String(), err)
-		return nil, err
-	}
-
-	image, err := r.getImage(dgst)
-	if err != nil {
-		context.GetLogger(r.ctx).Errorf("error retrieving image %s: %v", dgst.String(), err)
-		return nil, err
-	}
-
-	ref := imageapi.DockerImageReference{Namespace: r.namespace, Name: r.name, Registry: r.registryAddr}
-	if managed := image.Annotations[imageapi.ManagedByOpenShiftAnnotation]; managed == "true" {
-		// Repository without a registry part is refers to repository containing locally managed images.
-		// Such an entry is retrieved, checked and set by blobDescriptorService operating only on local blobs.
-		ref.Registry = ""
-	} else {
-		// Repository with a registry points to remote repository. This is used by pullthrough middleware.
-		ref = ref.DockerClientDefaults().AsRepository()
-	}
-
-	manifest, err := r.manifestFromImageWithCachedLayers(image, ref.Exact())
-
-	return manifest, err
-}
-
-// Put creates or updates the named manifest.
-func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
-	if err := r.checkPendingErrors(ctx); err != nil {
-		return "", err
-	}
-
-	mh, err := NewManifestHandler(r, manifest)
-	if err != nil {
-		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
-	}
-	mediaType, payload, canonical, err := mh.Payload()
-	if err != nil {
-		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
-	}
-
-	// this is fast to check, let's do it before verification
-	if !r.acceptschema2 && mediaType == schema2.MediaTypeManifest {
-		err = fmt.Errorf("manifest V2 schema 2 not allowed")
-		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
-	}
-
-	// in order to stat the referenced blobs, repository need to be set on the context
-	ctx = WithRepository(ctx, r)
-	if err := mh.Verify(ctx, false); err != nil {
-		return "", err
-	}
-
-	// Calculate digest
-	dgst := digest.FromBytes(canonical)
-
-	// Upload to openshift
-	ism := imageapi.ImageStreamMapping{
-		ObjectMeta: kapi.ObjectMeta{
-			Namespace: r.namespace,
-			Name:      r.name,
-		},
-		Image: imageapi.Image{
-			ObjectMeta: kapi.ObjectMeta{
-				Name: dgst.String(),
-				Annotations: map[string]string{
-					imageapi.ManagedByOpenShiftAnnotation: "true",
-				},
-			},
-			DockerImageReference:         fmt.Sprintf("%s/%s/%s@%s", r.registryAddr, r.namespace, r.name, dgst.String()),
-			DockerImageManifest:          string(payload),
-			DockerImageManifestMediaType: mediaType,
-		},
-	}
-
-	for _, option := range options {
-		if opt, ok := option.(distribution.WithTagOption); ok {
-			ism.Tag = opt.Tag
-			break
-		}
-	}
-
-	if err = mh.FillImageMetadata(ctx, &ism.Image); err != nil {
-		return "", err
-	}
-
-	if err = r.registryOSClient.ImageStreamMappings(r.namespace).Create(&ism); err != nil {
-		// if the error was that the image stream wasn't found, try to auto provision it
-		statusErr, ok := err.(*kerrors.StatusError)
-		if !ok {
-			context.GetLogger(r.ctx).Errorf("error creating ImageStreamMapping: %s", err)
-			return "", err
-		}
-
-		if quotautil.IsErrorQuotaExceeded(statusErr) {
-			context.GetLogger(r.ctx).Errorf("denied creating ImageStreamMapping: %v", statusErr)
-			return "", distribution.ErrAccessDenied
-		}
-
-		status := statusErr.ErrStatus
-		if status.Code != http.StatusNotFound || (strings.ToLower(status.Details.Kind) != "imagestream" /*pre-1.2*/ && strings.ToLower(status.Details.Kind) != "imagestreams") || status.Details.Name != r.name {
-			context.GetLogger(r.ctx).Errorf("error creating ImageStreamMapping: %s", err)
-			return "", err
-		}
-
-		stream := imageapi.ImageStream{
-			ObjectMeta: kapi.ObjectMeta{
-				Name: r.name,
-			},
-		}
-
-		uclient, ok := UserClientFrom(r.ctx)
-		if !ok {
-			context.GetLogger(r.ctx).Errorf("error creating user client to auto provision image stream: Origin user client unavailable")
-			return "", statusErr
-		}
-
-		if _, err := uclient.ImageStreams(r.namespace).Create(&stream); err != nil {
-			if quotautil.IsErrorQuotaExceeded(err) {
-				context.GetLogger(r.ctx).Errorf("denied creating ImageStream: %v", err)
-				return "", distribution.ErrAccessDenied
-			}
-			context.GetLogger(r.ctx).Errorf("error auto provisioning ImageStream: %s", err)
-			return "", statusErr
-		}
-
-		// try to create the ISM again
-		if err := r.registryOSClient.ImageStreamMappings(r.namespace).Create(&ism); err != nil {
-			if quotautil.IsErrorQuotaExceeded(err) {
-				context.GetLogger(r.ctx).Errorf("denied a creation of ImageStreamMapping: %v", err)
-				return "", distribution.ErrAccessDenied
-			}
-			context.GetLogger(r.ctx).Errorf("error creating ImageStreamMapping: %s", err)
-			return "", err
-		}
-	}
-
-	return dgst, nil
-}
-
-// Delete deletes the manifest with digest `dgst`. Note: Image resources
-// in OpenShift are deleted via 'oadm prune images'. This function deletes
-// the content related to the manifest in the registry's storage (signatures).
-func (r *repository) Delete(ctx context.Context, dgst digest.Digest) error {
-	if err := r.checkPendingErrors(ctx); err != nil {
-		return err
-	}
-
-	ms, err := r.Repository.Manifests(r.ctx)
-	if err != nil {
-		return err
-	}
-	ctx = WithRepository(ctx, r)
-	return ms.Delete(ctx, dgst)
 }
 
 // importContext loads secrets for this image stream and returns a context for getting distribution

--- a/pkg/dockerregistry/server/tagservice.go
+++ b/pkg/dockerregistry/server/tagservice.go
@@ -212,8 +212,3 @@ func (t tagService) Untag(ctx context.Context, tag string) error {
 
 	return t.repo.registryOSClient.ImageStreamTags(imageStream.Namespace).Delete(imageStream.Name, tag)
 }
-
-func isImageManaged(image *imageapi.Image) bool {
-	managed, ok := image.ObjectMeta.Annotations[imageapi.ManagedByOpenShiftAnnotation]
-	return ok && managed == "true"
-}

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -135,3 +135,8 @@ func effectiveCreateOptions(options []distribution.BlobCreateOption) (*distribut
 	}
 	return opts, nil
 }
+
+func isImageManaged(image *imageapi.Image) bool {
+	managed, ok := image.ObjectMeta.Annotations[imageapi.ManagedByOpenShiftAnnotation]
+	return ok && managed == "true"
+}

--- a/pkg/image/controller/controller_test.go
+++ b/pkg/image/controller/controller_test.go
@@ -65,6 +65,10 @@ func (f *fakeDockerRegistryClient) ImageByTag(namespace, name, tag string) (*doc
 	return nil, dockerregistry.NewImageNotFoundError(fmt.Sprintf("%s/%s", namespace, name), tag, tag)
 }
 
+func (f *fakeDockerRegistryClient) ImageManifest(namespace, name, tag string) (string, []byte, error) {
+	return "", nil, dockerregistry.NewImageNotFoundError(fmt.Sprintf("%s/%s", namespace, name), tag, tag)
+}
+
 func (f *fakeDockerRegistryClient) ImageByID(namespace, name, id string) (*dockerregistry.Image, error) {
 	f.Called = true
 	f.Namespace, f.Name, f.ID = namespace, name, id

--- a/pkg/image/registry/image/etcd/etcd_test.go
+++ b/pkg/image/registry/image/etcd/etcd_test.go
@@ -301,8 +301,8 @@ func TestUpdateResetsMetadata(t *testing.T) {
 		// existing manifest is preserved, and unpacked
 		{
 			expect: func(image *api.Image) bool {
-				if image.DockerImageManifest != etcdManifest {
-					t.Errorf("unexpected manifest: %s", image.DockerImageManifest)
+				if len(image.DockerImageManifest) != 0 {
+					t.Errorf("unexpected not empty manifest")
 					return false
 				}
 				if image.DockerImageMetadata.ID != "fe50ac14986497fa6b5d2cc24feb4a561d01767bc64413752c0988cb70b0b8b9" {

--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -76,6 +76,7 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 			Namespace:         kapi.NamespaceValue(ctx),
 			Name:              api.MakeImageStreamImageName(name, imageID),
 			CreationTimestamp: image.ObjectMeta.CreationTimestamp,
+			Annotations:       repo.Annotations,
 		},
 		Image: *image,
 	}

--- a/pkg/image/registry/imagestreamimport/strategy.go
+++ b/pkg/image/registry/imagestreamimport/strategy.go
@@ -37,6 +37,10 @@ func (s *strategy) PrepareImageForCreate(obj runtime.Object) {
 
 	// signatures can be added using "images" or "imagesignatures" resources
 	image.Signatures = nil
+
+	// Remove the raw manifest as it's very big and this leads to a large memory consumption in etcd.
+	image.DockerImageManifest = ""
+	image.DockerImageConfig = ""
 }
 
 func (s *strategy) Validate(ctx kapi.Context, obj runtime.Object) field.ErrorList {

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -156,7 +156,12 @@ os::cmd::try_until_success "oc exec --context='${CLUSTER_ADMIN_CONTEXT}' -n defa
 
 os::log::info "Docker registry refuses manifest with missing dependencies"
 os::cmd::expect_success 'oc new-project verify-manifest'
-os::cmd::expect_success "oc get -o jsonpath=$'{.dockerImageManifest}\n' 'image/${rubyimagedigest}' --context="${CLUSTER_ADMIN_CONTEXT}" >'${ARTIFACT_DIR}/rubyimagemanifest.json'"
+os::cmd::expect_success "curl \
+    --location                                                                      \
+    --header 'Content-Type: application/vnd.docker.distribution.manifest.v1+json'   \
+    --user 'e2e_user:${e2e_user_token}'                                             \
+    --output '${ARTIFACT_DIR}/rubyimagemanifest.json'                               \
+    'http://${DOCKER_REGISTRY}/v2/cache/ruby-22-centos7/manifests/latest'"
 os::cmd::expect_success "curl --head                                                \
     --silent                                                                        \
     --request PUT                                                                   \
@@ -245,13 +250,10 @@ os::cmd::expect_success "oc import-image --confirm --from=hello-world:latest hel
 os::cmd::expect_success_and_text "oc get -o jsonpath='{.image.dockerImageManifestMediaType}' istag hello-world:pullthrough" 'application/vnd\.docker\.distribution\.manifest\.v2\+json'
 hello_world_name="$(oc get -o 'jsonpath={.image.metadata.name}' istag hello-world:pullthrough)"
 os::cmd::expect_success_and_text "echo '${hello_world_name}'" '.+'
-# dockerImageManifest is retrievable only with "images" resource
+# dockerImageManifest isn't retrievable only with "images" resource
 hello_world_config_name="$(oc get -o 'jsonpath={.dockerImageManifest}' image "${hello_world_name}" --context="${CLUSTER_ADMIN_CONTEXT}" | jq -r '.config.digest')"
 hello_world_config_image="$(oc get -o 'jsonpath={.image.dockerImageConfig}' istag hello-world:pullthrough | jq -r '.container_config.Image')"
-os::cmd::expect_success_and_text "echo '${hello_world_config_name},${hello_world_config_image}'" '.+,.+'
-# verify we can fetch the config
-os::cmd::expect_success_and_text "curl -u 'schema2-user:${schema2_user_token}' -v -s -o '${ARTIFACT_DIR}/hello-world-config.json' '${DOCKER_REGISTRY}/v2/schema2/hello-world/blobs/${hello_world_config_name}' 2>&1" "Docker-Content-Digest:\s*${hello_world_config_name}"
-os::cmd::expect_success_and_text "jq -r '.container_config.Image' '${ARTIFACT_DIR}/hello-world-config.json'" "${hello_world_config_image}"
+os::cmd::expect_success_and_text "echo '${hello_world_config_name},${hello_world_config_image}'" '^,$'
 # no accept header provided, the registry will convert schema 2 to schema 1 on-the-fly
 hello_world_schema1_digest="$(curl -u "schema2-user:${schema2_user_token}" -s -v -o "${ARTIFACT_DIR}/hello-world-manifest.json" "${DOCKER_REGISTRY}/v2/schema2/hello-world/manifests/pullthrough" |& sed -n 's/.*Docker-Content-Digest:\s*\(\S\+\).*/\1/p')"
 # ensure the manifest was converted to schema 1
@@ -615,10 +617,8 @@ os::cmd::expect_success_and_text "curl -I -u 'schema2-user:${schema2_user_token}
 os::log::info "Manifest V2 schema 2 successfully converted to schema 1"
 
 os::log::info "Verify image size calculation"
-busybox_expected_size="$(oc get -o 'jsonpath={.dockerImageManifest}' image "${busybox_name}" --context="${CLUSTER_ADMIN_CONTEXT}" | jq -r '[.. | .size?] | add')"
 busybox_calculated_size="$(oc get -o go-template='{{.dockerImageMetadata.Size}}' image "${busybox_name}" --context="${CLUSTER_ADMIN_CONTEXT}")"
-os::cmd::expect_success_and_text "echo '${busybox_expected_size}:${busybox_calculated_size}'" '^[1-9][0-9]*:[1-9][0-9]*$'
-os::cmd::expect_success_and_text "echo '${busybox_expected_size}'" "${busybox_calculated_size}"
+os::cmd::expect_success_and_text "echo '${busybox_calculated_size}'" '^[1-9][0-9]*$'
 os::log::info "Image size matches"
 
 os::test::junit::declare_suite_end

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/registry"
 	_ "github.com/openshift/origin/test/extended/router"
 	_ "github.com/openshift/origin/test/extended/security"
 

--- a/test/extended/registry/registry.go
+++ b/test/extended/registry/registry.go
@@ -1,0 +1,158 @@
+package registry
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	dockerClient "github.com/fsouza/go-dockerclient"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	regclient "github.com/openshift/origin/pkg/dockerregistry"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	imagesutil "github.com/openshift/origin/test/extended/images"
+	exutil "github.com/openshift/origin/test/extended/util"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+const (
+	repoName  = "app"
+	tagName   = "latest"
+	imageSize = 1024
+)
+
+var _ = g.Describe("[registry][migration] manifest migration from etcd to registry storage", func() {
+	defer g.GinkgoRecover()
+	var oc = exutil.NewCLI("registry-migration", exutil.KubeConfigPath())
+
+	// needs to be run at the top of each It; cannot be run in AfterEach which is run after the project
+	// is destroyed
+	tearDown := func(oc *exutil.CLI) {
+		deleteTestImages(oc)
+	}
+
+	g.It("registry can get access to manifest", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+		defer tearDown(oc)
+
+		g.By("set up policy for registry to have anonymous access to images")
+		err := oc.Run("policy").Args("add-role-to-user", "registry-viewer", "system:anonymous").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		dClient, err := testutil.NewDockerClient()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		registryURL, err := imagesutil.GetDockerRegistryURL(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("pushing image...")
+		imageDigest, err := imagesutil.BuildAndPushImageOfSizeWithDocker(oc, dClient, repoName, tagName, imageSize, 1, g.GinkgoWriter, true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("checking that the image converted...")
+		image, err := oc.AsAdmin().Client().Images().Get(imageDigest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(image.DockerImageManifest)).Should(o.Equal(0))
+		imageMetadataNotEmpty(image)
+
+		g.By("getting image manifest from docker-registry...")
+		conn, err := regclient.NewClient(10*time.Second, true).Connect(registryURL, true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, manifest, err := conn.ImageManifest(oc.Namespace(), repoName, tagName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(manifest)).Should(o.BeNumerically(">", 0))
+
+		g.By("restoring manifest...")
+		image, err = oc.AsAdmin().Client().Images().Get(imageDigest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		imageMetadataNotEmpty(image)
+
+		image.DockerImageManifest = string(manifest)
+
+		newImage, err := oc.AsAdmin().Client().Images().Update(image)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		imageMetadataNotEmpty(newImage)
+
+		g.By("checking that the manifest is present in the image...")
+		image, err = oc.AsAdmin().Client().Images().Get(imageDigest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(image.DockerImageManifest)).Should(o.BeNumerically(">", 0))
+		o.Expect(image.DockerImageManifest).Should(o.Equal(string(manifest)))
+		imageMetadataNotEmpty(image)
+
+		g.By("getting image manifest from docker-registry one more time...")
+		_, manifest, err = conn.ImageManifest(oc.Namespace(), repoName, tagName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(manifest)).Should(o.BeNumerically(">", 0))
+
+		g.By("waiting until image is updated...")
+		err = waitForImageUpdate(oc, image)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("checking that the manifest was removed from the image...")
+		image, err = oc.AsAdmin().Client().Images().Get(imageDigest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(image.DockerImageManifest)).Should(o.Equal(0))
+		imageMetadataNotEmpty(image)
+
+		g.By("getting image manifest from docker-registry to check if he's available...")
+		_, manifest, err = conn.ImageManifest(oc.Namespace(), repoName, tagName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(manifest)).Should(o.BeNumerically(">", 0))
+
+		g.By("pulling image...")
+		authCfg, err := exutil.BuildAuthConfiguration(registryURL, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		opts := dockerClient.PullImageOptions{
+			Repository: authCfg.ServerAddress + "/" + oc.Namespace() + "/" + repoName,
+			Tag:        tagName,
+		}
+		err = dClient.PullImage(opts, *authCfg)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("removing image...")
+		err = dClient.RemoveImage(opts.Repository)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})
+
+func imageMetadataNotEmpty(image *imageapi.Image) {
+	o.Expect(len(image.DockerImageMetadata.ID)).Should(o.BeNumerically(">", 0))
+	o.Expect(len(image.DockerImageMetadata.Container)).Should(o.BeNumerically(">", 0))
+	o.Expect(len(image.DockerImageMetadata.DockerVersion)).Should(o.BeNumerically(">", 0))
+	o.Expect(len(image.DockerImageMetadata.Architecture)).Should(o.BeNumerically(">", 0))
+}
+
+func waitForImageUpdate(oc *exutil.CLI, image *imageapi.Image) error {
+	return wait.Poll(200*time.Millisecond, 2*time.Minute, func() (bool, error) {
+		newImage, err := oc.AsAdmin().Client().Images().Get(image.Name)
+		if err != nil {
+			return false, err
+		}
+
+		return (image.ResourceVersion < newImage.ResourceVersion), nil
+	})
+}
+
+// deleteTestImages deletes test images built in current and shared
+// namespaces. It also deletes shared projects.
+func deleteTestImages(oc *exutil.CLI) {
+	g.By(fmt.Sprintf("Deleting images and image streams in project %q", oc.Namespace()))
+	iss, err := oc.AdminClient().ImageStreams(oc.Namespace()).List(kapi.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, is := range iss.Items {
+		for _, history := range is.Status.Tags {
+			for i := range history.Items {
+				oc.AdminClient().Images().Delete(history.Items[i].Image)
+			}
+		}
+	}
+}

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -376,4 +376,5 @@ readonly CONFORMANCE_TESTS=(
 	"\[Feature\:PodDisruptionbudget\]"
 	"should create a pod that reads a secret"
 	"should create a pod that prints his name and namespace"
+	"manifest migration from etcd to registry storage"
 )

--- a/test/integration/dockerregistry_pullthrough_test.go
+++ b/test/integration/dockerregistry_pullthrough_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -31,6 +32,10 @@ var gzippedEmptyTar = []byte{
 	31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 98, 24, 5, 163, 96, 20, 140, 88,
 	0, 8, 0, 0, 255, 255, 46, 175, 181, 239, 0, 4, 0, 0,
 }
+
+// digestSHA256GzippedEmptyTar is the canonical sha256 digest of
+// gzippedEmptyTar
+const digestSHA256GzippedEmptyTar = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
 
 func runRegistry() error {
 	config := `version: 0.1

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1884,6 +1884,7 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - images
     - imagestreams
     verbs:
     - get


### PR DESCRIPTION
We need to remove manifest from `Image` to reduce the amount of occupied etcd data. The docker-registry will store the manifest in the storage (where it stores the blobs). It removes the manifest from the `Image` after fills in  all metadata fields. The manifest will be removed when importing the image from an external `docker/distribution`.

@miminar @soltysh @mfojtik please review.