### PR TITLE
Do not use whoami inside of start scripts

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -34,7 +34,7 @@
 function os::start::configure_server() {
 	local version="${1:-}"
 	local current_user
-	current_user="$( whoami )"
+	current_user="$( id -u )"
 
 	os::start::internal::create_master_certs     "${version}"
 	os::start::internal::configure_node          "${version}"


### PR DESCRIPTION
Use something that works when the user isn't in /etc/passwd for running
in a container.

[merge] to unblock containerized tests