### PR TITLE
Add check for empty directory to recycler

### DIFF
--- a/pkg/cmd/recycle/recycle_test.go
+++ b/pkg/cmd/recycle/recycle_test.go
@@ -1,12 +1,66 @@
 package recycle
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 )
+
+var testFilenames = []string{
+	string([]byte{3}), // Ctrl+C
+	string([]byte{4}), // Ctrl+D
+
+	`white space`,
+	`new
+line`,
+
+	`*`,
+	`~`,
+	`\`,
+	`\\`,
+
+	` && touch and-escape`,
+	` || touch or-escape`,
+	` ; touch semi-escape`,
+	` " touch quote-escape`,
+	` ' touch apos-escape`,
+	` }"; touch brace-escape`,
+
+	`env x='() { :;}; echo vulnerable'`, // shellshock
+
+	`$USER`,
+
+	`...`,
+	`.file`,
+
+	`中文`,                   // utf-8
+	`κόσμε`,                // utf-8
+	`Iñtërnâtiônàlizætiøn`, // utf-8
+}
+
+func prepareTestDir(root string, filenames []string) error {
+	for _, dir := range filenames {
+		dirpath := path.Join(root, dir)
+		if err := os.Mkdir(dirpath, os.FileMode(0755)); err != nil {
+			return fmt.Errorf("Error writing dir %s\n%v", dirpath, err)
+		}
+
+		for _, file := range filenames {
+			filepath := path.Join(dirpath, file)
+			if err := ioutil.WriteFile(filepath, []byte(filepath), os.FileMode(0755)); err != nil {
+				return fmt.Errorf("Error writing file %s\n%v", filepath, err)
+			}
+
+			if _, err := os.Stat(filepath); err != nil {
+				return fmt.Errorf("Error verifying file %s\n%v", filepath, err)
+			}
+		}
+	}
+	return nil
+}
 
 func TestRecycle(t *testing.T) {
 	root, err := ioutil.TempDir("", "recycler-test-")
@@ -19,56 +73,7 @@ func TestRecycle(t *testing.T) {
 		}
 	}()
 
-	filenames := []string{
-		string([]byte{3}), // Ctrl+C
-		string([]byte{4}), // Ctrl+D
-
-		`white space`,
-		`new
-	line`,
-
-		`*`,
-		`~`,
-		`\`,
-		`\\`,
-
-		` && touch and-escape`,
-		` || touch or-escape`,
-		` ; touch semi-escape`,
-		` " touch quote-escape`,
-		` ' touch apos-escape`,
-		` }"; touch brace-escape`,
-
-		`env x='() { :;}; echo vulnerable'`, // shellshock
-
-		`$USER`,
-
-		`...`,
-		`.file`,
-
-		`中文`,                   // utf-8
-		`κόσμε`,                // utf-8
-		`Iñtërnâtiônàlizætiøn`, // utf-8
-	}
-
-	for _, dir := range filenames {
-		dirpath := path.Join(root, dir)
-		if err := os.Mkdir(dirpath, os.FileMode(0755)); err != nil {
-			t.Errorf("Error writing dir %s\n%v", dirpath, err)
-			continue
-		}
-
-		for _, file := range filenames {
-			filepath := path.Join(dirpath, file)
-			if err := ioutil.WriteFile(filepath, []byte(filepath), os.FileMode(0755)); err != nil {
-				t.Errorf("Error writing file %s\n%v", filepath, err)
-			}
-
-			if _, err := os.Stat(filepath); err != nil {
-				t.Errorf("Error verifying file %s\n%v", filepath, err)
-			}
-		}
-	}
+	prepareTestDir(root, testFilenames)
 
 	err = Recycle(root)
 	if err != nil {
@@ -85,5 +90,57 @@ func TestRecycle(t *testing.T) {
 	}
 	if len(remaining) != 1 || remaining[0] != root {
 		t.Errorf("Unexpected files left after recycling: %#v", remaining)
+	}
+}
+
+func TestCheckEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		filenames     []string
+		expectedError bool
+	}{
+		{
+			name:          "EmptyDir",
+			expectedError: false,
+		},
+		{
+			name:          "File",
+			filenames:     []string{"file"},
+			expectedError: true,
+		},
+		{
+			name:          "HiddenFile",
+			filenames:     []string{".file"},
+			expectedError: true,
+		},
+		{
+			name:          "TestFilenames",
+			filenames:     testFilenames,
+			expectedError: true,
+		},
+	}
+	for _, test := range tests {
+		root, err := ioutil.TempDir("", "recycler-test-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := os.RemoveAll(root); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		if err := prepareTestDir(root, test.filenames); err != nil {
+			t.Errorf("Failed to prepare files for test %q: %v", test.name, err)
+			continue
+		}
+
+		err = CheckEmpty(root)
+		if test.expectedError && err == nil {
+			t.Errorf("Test %q expected an error and did not get any", test.name)
+		}
+		if !test.expectedError && err != nil {
+			t.Errorf("Test %q: unexpected error: %v", test.name, err)
+		}
 	}
 }


### PR DESCRIPTION
Recycler should return an error when a recycled volume is not empty - another pod might have written some data into it. This directory should be recycled again (and Kubernetes will do that in few seconds).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1395271