### PR TITLE
[WIP] oc create clusterrole: new command

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -6404,6 +6404,53 @@ _oc_create_clusterresourcequota()
     noun_aliases=()
 }
 
+_oc_create_clusterrole()
+{
+    last_command="oc_create_clusterrole"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--resources=")
+    local_nonpersistent_flags+=("--resources=")
+    flags+=("--verbs=")
+    local_nonpersistent_flags+=("--verbs=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_create_configmap()
 {
     last_command="oc_create_configmap"
@@ -8025,6 +8072,7 @@ _oc_create()
     last_command="oc_create"
     commands=()
     commands+=("clusterresourcequota")
+    commands+=("clusterrole")
     commands+=("configmap")
     commands+=("deployment")
     commands+=("deploymentconfig")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -10987,6 +10987,54 @@ _openshift_cli_create_clusterresourcequota()
     noun_aliases=()
 }
 
+_openshift_cli_create_clusterrole()
+{
+    last_command="openshift_cli_create_clusterrole"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--resources=")
+    local_nonpersistent_flags+=("--resources=")
+    flags+=("--verbs=")
+    local_nonpersistent_flags+=("--verbs=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_cli_create_configmap()
 {
     last_command="openshift_cli_create_configmap"
@@ -12631,6 +12679,7 @@ _openshift_cli_create()
     last_command="openshift_cli_create"
     commands=()
     commands+=("clusterresourcequota")
+    commands+=("clusterrole")
     commands+=("configmap")
     commands+=("deployment")
     commands+=("deploymentconfig")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -6565,6 +6565,53 @@ _oc_create_clusterresourcequota()
     noun_aliases=()
 }
 
+_oc_create_clusterrole()
+{
+    last_command="oc_create_clusterrole"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--resources=")
+    local_nonpersistent_flags+=("--resources=")
+    flags+=("--verbs=")
+    local_nonpersistent_flags+=("--verbs=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_create_configmap()
 {
     last_command="oc_create_configmap"
@@ -8186,6 +8233,7 @@ _oc_create()
     last_command="oc_create"
     commands=()
     commands+=("clusterresourcequota")
+    commands+=("clusterrole")
     commands+=("configmap")
     commands+=("deployment")
     commands+=("deploymentconfig")

--- a/contrib/completions/zsh/openshift
+++ b/contrib/completions/zsh/openshift
@@ -11148,6 +11148,54 @@ _openshift_cli_create_clusterresourcequota()
     noun_aliases=()
 }
 
+_openshift_cli_create_clusterrole()
+{
+    last_command="openshift_cli_create_clusterrole"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--resources=")
+    local_nonpersistent_flags+=("--resources=")
+    flags+=("--verbs=")
+    local_nonpersistent_flags+=("--verbs=")
+    flags+=("--as=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--google-json-key=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--log-flush-frequency=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_cli_create_configmap()
 {
     last_command="openshift_cli_create_configmap"
@@ -12792,6 +12840,7 @@ _openshift_cli_create()
     last_command="openshift_cli_create"
     commands=()
     commands+=("clusterresourcequota")
+    commands+=("clusterrole")
     commands+=("configmap")
     commands+=("deployment")
     commands+=("deploymentconfig")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1165,6 +1165,19 @@ Create cluster resource quota resource.
 ====
 
 
+== oc create clusterrole
+Create a new cluster role
+
+====
+
+[options="nowrap"]
+----
+  # TODO
+  oc create clusterrole dev --resources a,b,c --verbs x,y,z
+----
+====
+
+
 == oc create configmap
 Create a configmap from a local file, directory or literal value
 

--- a/docs/man/man1/.files_generated_oc
+++ b/docs/man/man1/.files_generated_oc
@@ -113,6 +113,7 @@ oc-config-view.1
 oc-config.1
 oc-convert.1
 oc-create-clusterresourcequota.1
+oc-create-clusterrole.1
 oc-create-configmap.1
 oc-create-deployment.1
 oc-create-deploymentconfig.1

--- a/docs/man/man1/.files_generated_openshift
+++ b/docs/man/man1/.files_generated_openshift
@@ -202,6 +202,7 @@ openshift-cli-config-view.1
 openshift-cli-config.1
 openshift-cli-convert.1
 openshift-cli-create-clusterresourcequota.1
+openshift-cli-create-clusterrole.1
 openshift-cli-create-configmap.1
 openshift-cli-create-deployment.1
 openshift-cli-create-deploymentconfig.1

--- a/docs/man/man1/oc-create-clusterrole.1
+++ b/docs/man/man1/oc-create-clusterrole.1
@@ -1,0 +1,118 @@
+.TH "OC CREATE" "1" " Openshift CLI User Manuals" "Openshift" "June 2016"  ""
+
+
+.SH NAME
+.PP
+oc create clusterrole \- Create a new cluster role
+
+
+.SH SYNOPSIS
+.PP
+\fBoc create clusterrole\fP [OPTIONS]
+
+
+.SH DESCRIPTION
+.PP
+Create a new cluster role for specified resources and verbs.
+
+
+.SH OPTIONS
+.PP
+\fB\-\-resources\fP=[]
+    list of resources (separated by comma)
+
+.PP
+\fB\-\-verbs\fP=[]
+    list of verbs (separated by comma)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-version\fP=""
+    DEPRECATED: The API version to use when talking to the server
+
+.PP
+\fB\-\-as\fP=""
+    Username to impersonate for the operation
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client certificate file for TLS
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-config\fP=""
+    Path to the config file to use for CLI requests.
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-google\-json\-key\fP=""
+    The Google Cloud Platform Service Account JSON Key to use for authentication.
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+
+.PP
+\fB\-\-log\-flush\-frequency\fP=0
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-n\fP, \fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request
+
+.PP
+\fB\-\-request\-timeout\fP="0"
+    The length of time to wait before giving up on a single server request. Non\-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.
+
+.PP
+\fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+  # TODO
+  oc create clusterrole dev \-\-resources a,b,c \-\-verbs x,y,z
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBoc\-create(1)\fP,
+
+
+.SH HISTORY
+.PP
+June 2016, Ported from the Kubernetes man\-doc generator

--- a/docs/man/man1/oc-create.1
+++ b/docs/man/man1/oc-create.1
@@ -172,7 +172,7 @@ JSON and YAML formats are accepted.
 
 .SH SEE ALSO
 .PP
-\fBoc(1)\fP, \fBoc\-create\-clusterresourcequota(1)\fP, \fBoc\-create\-configmap(1)\fP, \fBoc\-create\-deployment(1)\fP, \fBoc\-create\-deploymentconfig(1)\fP, \fBoc\-create\-identity(1)\fP, \fBoc\-create\-imagestream(1)\fP, \fBoc\-create\-namespace(1)\fP, \fBoc\-create\-policybinding(1)\fP, \fBoc\-create\-quota(1)\fP, \fBoc\-create\-route(1)\fP, \fBoc\-create\-secret(1)\fP, \fBoc\-create\-service(1)\fP, \fBoc\-create\-serviceaccount(1)\fP, \fBoc\-create\-user(1)\fP, \fBoc\-create\-useridentitymapping(1)\fP,
+\fBoc(1)\fP, \fBoc\-create\-clusterresourcequota(1)\fP, \fBoc\-create\-clusterrole(1)\fP, \fBoc\-create\-configmap(1)\fP, \fBoc\-create\-deployment(1)\fP, \fBoc\-create\-deploymentconfig(1)\fP, \fBoc\-create\-identity(1)\fP, \fBoc\-create\-imagestream(1)\fP, \fBoc\-create\-namespace(1)\fP, \fBoc\-create\-policybinding(1)\fP, \fBoc\-create\-quota(1)\fP, \fBoc\-create\-route(1)\fP, \fBoc\-create\-secret(1)\fP, \fBoc\-create\-service(1)\fP, \fBoc\-create\-serviceaccount(1)\fP, \fBoc\-create\-user(1)\fP, \fBoc\-create\-useridentitymapping(1)\fP,
 
 
 .SH HISTORY

--- a/docs/man/man1/openshift-cli-create-clusterrole.1
+++ b/docs/man/man1/openshift-cli-create-clusterrole.1
@@ -1,0 +1,118 @@
+.TH "OPENSHIFT CLI CREATE" "1" " Openshift CLI User Manuals" "Openshift" "June 2016"  ""
+
+
+.SH NAME
+.PP
+openshift cli create clusterrole \- Create a new cluster role
+
+
+.SH SYNOPSIS
+.PP
+\fBopenshift cli create clusterrole\fP [OPTIONS]
+
+
+.SH DESCRIPTION
+.PP
+Create a new cluster role for specified resources and verbs.
+
+
+.SH OPTIONS
+.PP
+\fB\-\-resources\fP=[]
+    list of resources (separated by comma)
+
+.PP
+\fB\-\-verbs\fP=[]
+    list of verbs (separated by comma)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-api\-version\fP=""
+    DEPRECATED: The API version to use when talking to the server
+
+.PP
+\fB\-\-as\fP=""
+    Username to impersonate for the operation
+
+.PP
+\fB\-\-certificate\-authority\fP=""
+    Path to a cert. file for the certificate authority
+
+.PP
+\fB\-\-client\-certificate\fP=""
+    Path to a client certificate file for TLS
+
+.PP
+\fB\-\-client\-key\fP=""
+    Path to a client key file for TLS
+
+.PP
+\fB\-\-cluster\fP=""
+    The name of the kubeconfig cluster to use
+
+.PP
+\fB\-\-config\fP=""
+    Path to the config file to use for CLI requests.
+
+.PP
+\fB\-\-context\fP=""
+    The name of the kubeconfig context to use
+
+.PP
+\fB\-\-google\-json\-key\fP=""
+    The Google Cloud Platform Service Account JSON Key to use for authentication.
+
+.PP
+\fB\-\-insecure\-skip\-tls\-verify\fP=false
+    If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+
+.PP
+\fB\-\-log\-flush\-frequency\fP=0
+    Maximum number of seconds between log flushes
+
+.PP
+\fB\-\-match\-server\-version\fP=false
+    Require server version to match client version
+
+.PP
+\fB\-n\fP, \fB\-\-namespace\fP=""
+    If present, the namespace scope for this CLI request
+
+.PP
+\fB\-\-request\-timeout\fP="0"
+    The length of time to wait before giving up on a single server request. Non\-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests.
+
+.PP
+\fB\-\-server\fP=""
+    The address and port of the Kubernetes API server
+
+.PP
+\fB\-\-token\fP=""
+    Bearer token for authentication to the API server
+
+.PP
+\fB\-\-user\fP=""
+    The name of the kubeconfig user to use
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+  # TODO
+  openshift cli create clusterrole dev \-\-resources a,b,c \-\-verbs x,y,z
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBopenshift\-cli\-create(1)\fP,
+
+
+.SH HISTORY
+.PP
+June 2016, Ported from the Kubernetes man\-doc generator

--- a/docs/man/man1/openshift-cli-create.1
+++ b/docs/man/man1/openshift-cli-create.1
@@ -172,7 +172,7 @@ JSON and YAML formats are accepted.
 
 .SH SEE ALSO
 .PP
-\fBopenshift\-cli(1)\fP, \fBopenshift\-cli\-create\-clusterresourcequota(1)\fP, \fBopenshift\-cli\-create\-configmap(1)\fP, \fBopenshift\-cli\-create\-deployment(1)\fP, \fBopenshift\-cli\-create\-deploymentconfig(1)\fP, \fBopenshift\-cli\-create\-identity(1)\fP, \fBopenshift\-cli\-create\-imagestream(1)\fP, \fBopenshift\-cli\-create\-namespace(1)\fP, \fBopenshift\-cli\-create\-policybinding(1)\fP, \fBopenshift\-cli\-create\-quota(1)\fP, \fBopenshift\-cli\-create\-route(1)\fP, \fBopenshift\-cli\-create\-secret(1)\fP, \fBopenshift\-cli\-create\-service(1)\fP, \fBopenshift\-cli\-create\-serviceaccount(1)\fP, \fBopenshift\-cli\-create\-user(1)\fP, \fBopenshift\-cli\-create\-useridentitymapping(1)\fP,
+\fBopenshift\-cli(1)\fP, \fBopenshift\-cli\-create\-clusterresourcequota(1)\fP, \fBopenshift\-cli\-create\-clusterrole(1)\fP, \fBopenshift\-cli\-create\-configmap(1)\fP, \fBopenshift\-cli\-create\-deployment(1)\fP, \fBopenshift\-cli\-create\-deploymentconfig(1)\fP, \fBopenshift\-cli\-create\-identity(1)\fP, \fBopenshift\-cli\-create\-imagestream(1)\fP, \fBopenshift\-cli\-create\-namespace(1)\fP, \fBopenshift\-cli\-create\-policybinding(1)\fP, \fBopenshift\-cli\-create\-quota(1)\fP, \fBopenshift\-cli\-create\-route(1)\fP, \fBopenshift\-cli\-create\-secret(1)\fP, \fBopenshift\-cli\-create\-service(1)\fP, \fBopenshift\-cli\-create\-serviceaccount(1)\fP, \fBopenshift\-cli\-create\-user(1)\fP, \fBopenshift\-cli\-create\-useridentitymapping(1)\fP,
 
 
 .SH HISTORY

--- a/pkg/cmd/cli/cmd/create/clusterrole.go
+++ b/pkg/cmd/cli/cmd/create/clusterrole.go
@@ -1,0 +1,112 @@
+package create
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	authapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+// ClusterRoleRecommendedName is the recommended name for oc create clusterrole.
+const ClusterRoleRecommendedName = "clusterrole"
+
+var createClusterRoleExample = templates.Examples(`
+	# TODO
+	%[1]s dev --resources a,b,c --verbs x,y,z`)
+
+type CreateClusterRoleOptions struct {
+	ClusterRoleClient client.ClusterRoleInterface
+
+	Name      string
+	Resources []string
+	Verbs     []string
+}
+
+// NewCmdCreateClusterRole is a macro command to create a new cluster role.
+func NewCmdCreateClusterRole(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &CreateClusterRoleOptions{}
+
+	cmd := &cobra.Command{
+		Use:     name + " <role-name>",
+		Short:   "Create a new cluster role",
+		Long:    "Create a new cluster role for specified resources and verbs.",
+		Example: fmt.Sprintf(createClusterRoleExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+			if err := options.Validate(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			if err := options.CreateRole(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&options.Resources, "resources", "", options.Resources, "list of resources (separated by comma)")
+	cmd.Flags().StringSliceVarP(&options.Verbs, "verbs", "", options.Verbs, "list of verbs (separated by comma)")
+
+	return cmd
+}
+
+// Complete completes all the required options.
+func (o *CreateClusterRoleOptions) Complete(f *clientcmd.Factory, args []string) error {
+	if len(args) == 0 {
+		return errors.New("you must specify role name")
+	}
+
+	o.Name = args[0]
+
+	osClient, _, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.ClusterRoleClient = osClient.ClusterRoles()
+
+	return nil
+}
+
+// Validate validates all the required options.
+func (o *CreateClusterRoleOptions) Validate() error {
+	if len(o.Name) == 0 {
+		return errors.New("Name is required")
+	}
+	if len(o.Resources) == 0 {
+		return errors.New("Resources is required")
+	}
+	if len(o.Verbs) == 0 {
+		return errors.New("Verbs is required")
+	}
+	return nil
+}
+
+// CreateRole implements all the necessary functionality for creating cluster role.
+func (o *CreateClusterRoleOptions) CreateRole() error {
+	rule, err := authapi.NewRule(o.Verbs...).Resources(o.Resources...).Groups("").Rule()
+	if err != nil {
+		return err
+	}
+
+	role := &authapi.ClusterRole{}
+	role.Name = o.Name
+	role.Rules = []authapi.PolicyRule{rule}
+
+	_, err = o.ClusterRoleClient.Create(role)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("clusterrole %q created\n", role.Name)
+
+	return nil
+}

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -187,6 +187,7 @@ func NewCmdCreate(parentName string, f *clientcmd.Factory, out, errOut io.Writer
 	cmd.AddCommand(create.NewCmdCreatePolicyBinding(create.PolicyBindingRecommendedName, parentName+" create "+create.PolicyBindingRecommendedName, f, out))
 	cmd.AddCommand(create.NewCmdCreateDeploymentConfig(create.DeploymentConfigRecommendedName, parentName+" create "+create.DeploymentConfigRecommendedName, f, out))
 	cmd.AddCommand(create.NewCmdCreateClusterQuota(create.ClusterQuotaRecommendedName, parentName+" create "+create.ClusterQuotaRecommendedName, f, out))
+	cmd.AddCommand(create.NewCmdCreateClusterRole(create.ClusterRoleRecommendedName, parentName+" create "+create.ClusterRoleRecommendedName, f, out))
 
 	cmd.AddCommand(create.NewCmdCreateUser(create.UserRecommendedName, parentName+" create "+create.UserRecommendedName, f, out))
 	cmd.AddCommand(create.NewCmdCreateIdentity(create.IdentityRecommendedName, parentName+" create "+create.IdentityRecommendedName, f, out))


### PR DESCRIPTION
Add a new command `oc create clusterrole` that takes role name, list of actions, list of resources and creates a new cluster role.

Example:
```console
$ oc create clusterrole dockerbuilder --verbs create --resources builds/docker
clusterrole "dockerbuilder" created
$ oc get clusterrole dockerbuilder -o yaml
apiVersion: v1
kind: ClusterRole
metadata:
  creationTimestamp: 2016-11-16T18:06:28Z
  name: dockerbuilder
  resourceVersion: "42371"
  selfLink: /oapi/v1/clusterroles/dockerbuilder4
  uid: 65470a15-ac27-11e6-8811-080027242396
rules:
- apiGroups:
  - ""
  attributeRestrictions: null
  resources:
  - builds/docker
  verbs:
  - create
```

Fixes #3804

TODO:
- [x] rename to `oc create clusterrole`
- [ ] validate the actions and resources
- [ ] add `--force` option
- [ ] don't assume "" api group
- [ ] add example
- [ ] PR with the equivalent command upstream for rbac clusterroles
- [ ] add tests