### PR TITLE
Fix the command to restart docker on 1.3->1.4 upgrade

### DIFF
--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -126,10 +126,10 @@ func (node *OsdnNode) dockerPreCNICleanup() error {
 	// "systemctl restart" will bail out (unnecessarily) in the
 	// OpenShift-in-a-container case, so we work around that by sending
 	// the messages by hand.
-	if err := osexec.Command("dbus-send", "--system", "--print-reply", "--reply-timeout=2000", "--type=method_call", "--dest=org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager.Reload"); err != nil {
+	if _, err := osexec.Command("dbus-send", "--system", "--print-reply", "--reply-timeout=2000", "--type=method_call", "--dest=org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager.Reload").CombinedOutput(); err != nil {
 		log.Error(err)
 	}
-	if err := osexec.Command("dbus-send", "--system", "--print-reply", "--reply-timeout=2000", "--type=method_call", "--dest=org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager.RestartUnit", "string:'docker.service' string:'replace'"); err != nil {
+	if _, err := osexec.Command("dbus-send", "--system", "--print-reply", "--reply-timeout=2000", "--type=method_call", "--dest=org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager.RestartUnit", "string:'docker.service' string:'replace'").CombinedOutput(); err != nil {
 		log.Error(err)
 	}
 


### PR DESCRIPTION
We were creating an `osexec.Command` object to restart docker but then not executing it. Oops.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1395069; without this fix, upgrading a 3.3 system to 3.4 without rebooting will not work correctly.

@openshift/networking PTAL