### PR TITLE
Clean up OpenShift SDN network artifacts when using third party network plugin

### DIFF
--- a/pkg/client/clusternetwork.go
+++ b/pkg/client/clusternetwork.go
@@ -14,6 +14,7 @@ type ClusterNetworkInterface interface {
 	Get(name string) (*sdnapi.ClusterNetwork, error)
 	Create(sub *sdnapi.ClusterNetwork) (*sdnapi.ClusterNetwork, error)
 	Update(sub *sdnapi.ClusterNetwork) (*sdnapi.ClusterNetwork, error)
+	Delete(name string) error
 }
 
 // clusterNetwork implements ClusterNetworkInterface interface
@@ -47,4 +48,9 @@ func (c *clusterNetwork) Update(cn *sdnapi.ClusterNetwork) (result *sdnapi.Clust
 	result = &sdnapi.ClusterNetwork{}
 	err = c.r.Put().Resource("clusterNetworks").Name(cn.Name).Body(cn).Do().Into(result)
 	return
+}
+
+// Delete takes the name of the ClusterNetwork, and returns an error if one occurs during deletion of the ClusterNetwork
+func (c *clusterNetwork) Delete(name string) error {
+	return c.r.Delete().Resource("clusterNetworks").Name(name).Do().Error()
 }


### PR DESCRIPTION
If users forget to clean up OpenShift SDN network artifacts when [migrating between SDN plugins](https://docs.openshift.org/latest/install_config/configuring_sdn.html#migrating-between-sdn-plugins), CLI functionality `oadm pod-network` validation #11880 will get incorrect result due to the existed clusternetwork info. This PR cleans up OpenShift SDN network artifacts if exist when using third party network plugin. Then users don't need to clean up manually.

cc @knobunc @pravisankar 