### PR TITLE
update missing probe severity to info

### DIFF
--- a/pkg/api/graph/interfaces.go
+++ b/pkg/api/graph/interfaces.go
@@ -28,7 +28,7 @@ type Severity string
 
 const (
 	// InfoSeverity is interesting
-	// TODO: Consider what to do with this once we revisit the graph api - currently not used.
+	// Currently used in missing probe markers
 	InfoSeverity Severity = "info"
 	// WarningSeverity is probably wrong, but we aren't certain
 	WarningSeverity Severity = "warning"

--- a/pkg/api/kubegraph/analysis/podspec.go
+++ b/pkg/api/kubegraph/analysis/podspec.go
@@ -100,7 +100,7 @@ func FindMissingLivenessProbes(g osgraph.Graph, f osgraph.Namer, setProbeCommand
 			Node:         podSpecNode,
 			RelatedNodes: []graph.Node{topLevelNode},
 
-			Severity: osgraph.WarningSeverity,
+			Severity: osgraph.InfoSeverity,
 			Key:      MissingLivenessProbeWarning,
 			Message: fmt.Sprintf("%s has no liveness probe to verify pods are still running.",
 				topLevelString),

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -304,9 +304,38 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 		warningMarkers := allMarkers.BySeverity(osgraph.WarningSeverity)
 		if len(warningMarkers) > 0 {
 			if d.Suggest {
+				// add linebreak between Errors list and Warnings list
+				if len(errorMarkers) > 0 {
+					fmt.Fprintln(out)
+				}
 				fmt.Fprintln(out, "Warnings:")
 			}
 			for _, marker := range warningMarkers {
+				if d.Suggest {
+					fmt.Fprintln(out, indent+"* "+marker.Message)
+					switch s := marker.Suggestion.String(); {
+					case strings.Contains(s, "\n"):
+						fmt.Fprintln(out)
+						for _, line := range strings.Split(s, "\n") {
+							fmt.Fprintln(out, indent+"  "+line)
+						}
+					case len(s) > 0:
+						fmt.Fprintln(out, indent+"  try: "+s)
+					}
+				}
+			}
+		}
+
+		infoMarkers := allMarkers.BySeverity(osgraph.InfoSeverity)
+		if len(infoMarkers) > 0 {
+			if d.Suggest {
+				// add linebreak between Warnings list and Info List
+				if len(warningMarkers) > 0 || len(warningMarkers) > 0 {
+					fmt.Fprintln(out)
+				}
+				fmt.Fprintln(out, "Info:")
+			}
+			for _, marker := range infoMarkers {
 				if d.Suggest {
 					fmt.Fprintln(out, indent+"* "+marker.Message)
 					switch s := marker.Suggestion.String(); {

--- a/pkg/deploy/graph/analysis/dc.go
+++ b/pkg/deploy/graph/analysis/dc.go
@@ -118,7 +118,7 @@ Node:
 			// All of the containers in the deployment config lack a readiness probe
 			markers = append(markers, osgraph.Marker{
 				Node:     uncastDcNode,
-				Severity: osgraph.WarningSeverity,
+				Severity: osgraph.InfoSeverity,
 				Key:      MissingReadinessProbeWarning,
 				Message: fmt.Sprintf("%s has no readiness probe to verify pods are ready to accept traffic or ensure deployment is successful.",
 					f.ResourceName(dcNode)),


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/10294

This patch changes the marker severity of missing probes (liveness and readiness) from `osgraph.WarningSeverity` to `osgraph.InfoSeverity`. It also adds a linebreak between `Errors`, `Warnings`, and `Infos`.

**Example**
```
$ oc status -v
In project default on server https://10.13.137.149:8443

http://www.pictre.org (svc/frontend)

https://idling-echo-reencrypt-default.router.default.svc.cluster.local (reencrypt) (svc/idling-echo)
http://idling-echo-default.router.default.svc.cluster.local
  dc/idling-echo deploys docker.io/openshift/node:latest
    deployment #1 deployed 2 days ago - 3 pods

svc/kubernetes - 172.30.0.1 ports 443, 53->8053, 53->8053

dc/test-deployment-config deploys docker.io/openshift/origin-pod:latest
  deployment #1 deployed 2 days ago - 1 pod

bc/test-buildconfig source builds git://github.com/openshift/ruby-hello-world.git on docker.io/centos/ruby-22-centos7:latest
  not built yet

Errors:
  * route/foo is routing traffic to svc/foo, but either the administrator has not installed a router or the router is not selecting this route.
    try: oc adm router -h
  * route/idling-echo is routing traffic to svc/idling-echo, but either the administrator has not installed a router or the router is not selecting this route.
    try: oc adm router -h
  * route/idling-echo-reencrypt is routing traffic to svc/idling-echo, but either the administrator has not installed a router or the router is not selecting this route.
    try: oc adm router -h
  * route/my-route is routing traffic to svc/frontend, but either the administrator has not installed a router or the router is not selecting this route.
    try: oc adm router -h

Warnings:
  * route/foo is supposed to route traffic to svc/foo but svc/foo doesn't exist.
  * route/idling-echo doesn't have a port specified and is routing traffic to svc/idling-echo which uses multiple ports.
  * route/idling-echo-reencrypt doesn't have a port specified and is routing traffic to svc/idling-echo which uses multiple ports.

Infos:
  * dc/idling-echo has no readiness probe to verify pods are ready to accept traffic or ensure deployment is successful.
    try: oc set probe dc/idling-echo --readiness ...
  * dc/idling-echo has no liveness probe to verify pods are still running.
    try: oc set probe dc/idling-echo --liveness ...
  * dc/test-deployment-config has no readiness probe to verify pods are ready to accept traffic or ensure deployment is successful.
    try: oc set probe dc/test-deployment-config --readiness ...
  * dc/test-deployment-config has no liveness probe to verify pods are still running.
    try: oc set probe dc/test-deployment-config --liveness ...

View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.
```

cc @jwforres @deads2k @fabianofranz 