### PR TITLE
prevent test/cmd/config.sh from writing config to working dir

### DIFF
--- a/test/cmd/config.sh
+++ b/test/cmd/config.sh
@@ -35,10 +35,13 @@ os::cmd::expect_success_and_not_text 'oc get bc' 'does not exist'
 
   os::cmd::expect_failure_and_text 'oc get bc --config=missing' 'missing: no such file or directory'
 
+  # define temp location for new config
+  NEW_CONFIG_LOC="${BASETMPDIR}/new-config.yaml"
+
   # make sure non-existing --cluster and --user can still be set
-  os::cmd::expect_success_and_text 'oc config set-context new-context-name --cluster=missing-cluster --user=missing-user --namespace=default --config=new-config.yaml' 'context "new-context-name" set'
-  # os::cmd::expect_failure_and_text "env -u KUBECONFIG -u KUBERNETES_MASTER oc get bc --config=new-config.yaml" 'Missing or incomplete configuration info'
-  os::cmd::expect_failure_and_text "oc get bc --config=new-config.yaml" 'Missing or incomplete configuration info'
+  os::cmd::expect_success_and_text "oc config set-context new-context-name --cluster=missing-cluster --user=missing-user --namespace=default --config='${NEW_CONFIG_LOC}'" 'context "new-context-name" set'
+  os::cmd::expect_failure_and_text "env -u KUBECONFIG -u KUBERNETES_MASTER oc get bc --config='${NEW_CONFIG_LOC}'" 'Missing or incomplete configuration info'
+  os::cmd::expect_failure_and_text "oc get bc --config='${NEW_CONFIG_LOC}'" 'Missing or incomplete configuration info'
 )
 echo "config error handling: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
this patch writes temporary test config to `/tmp/openshift/new-config.yaml` instead of the working directory.

cc @stevekuznetsov @fabianofranz 