### PR TITLE
sdn: better warning when non-restarted 3.3 node process calls updated 3.4 script

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -303,6 +303,7 @@ pushd pkg/sdn/plugin/sdn-cni-plugin
 popd
 pushd pkg/sdn/plugin/bin
    install -p -m 0755 openshift-sdn-ovs %{buildroot}%{_bindir}/openshift-sdn-ovs
+   install -p -m 0755 openshift-sdn-ovs-33 %{buildroot}%{_bindir}/openshift-sdn-ovs-33
 popd
 install -d -m 0755 %{buildroot}/opt/cni/bin
 install -p -m 0755 _output/local/bin/linux/amd64/sdn-cni-plugin %{buildroot}/opt/cni/bin/openshift-sdn
@@ -475,6 +476,7 @@ fi
 %dir %{_sysconfdir}/cni/net.d
 %dir /opt/cni/bin
 %{_bindir}/openshift-sdn-ovs
+%{_bindir}/openshift-sdn-ovs-33
 %{_unitdir}/%{name}-node.service.d/openshift-sdn-ovs.conf
 %{_sysconfdir}/cni/net.d/80-openshift-sdn.conf
 /opt/cni/bin/*

--- a/pkg/sdn/plugin/bin/openshift-sdn-ovs-33
+++ b/pkg/sdn/plugin/bin/openshift-sdn-ovs-33
@@ -4,12 +4,11 @@ set -ex
 lock_file=/var/lock/openshift-sdn.lock
 
 action=$1
-veth_host=$2
-macaddr=$3
-ipaddr=$4
-tenant_id=$5
-ingress_bw=$6
-egress_bw=$7
+net_container=$2
+tenant_id=$3
+ingress_bw=$4
+egress_bw=$5
+macvlan=$6
 
 lockwrap() {
     (
@@ -18,7 +17,43 @@ lockwrap() {
     ) 200>${lock_file}
 }
 
+# Retrieve the name of the host-local member of the veth pair that
+# connects the container (identified by pid) to the docker bridge.
+get_veth_host() {
+    local pid=$1
+
+    local veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
+    # Strip a suffix starting with '@' from the interface name.
+    # The suffixed interface name won't be recognized by brctl or ovs-*
+    ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
+}
+
+get_ipaddr_pid_veth() {
+    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
+    if [ "${network_mode}" == "host" ]; then
+      # quit, nothing for the SDN here
+      exit 0
+    elif [[ "${network_mode}" =~ container:.* ]]; then
+      # Get pod infra container
+      net_container=$(echo ${network_mode} | cut -d ":" -f 2)
+    fi
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+
+    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
+    if [ -z "$ipaddr" ]; then
+	echo "Could not find IP address for container ${net_container}"
+	exit 1
+    fi
+
+    veth_host=$(get_veth_host $pid)
+    if [ -z "$veth_host" ]; then
+	echo "Could not find host veth interface for container ${net_container}"
+	exit 1
+    fi
+}
+
 add_ovs_port() {
+    brctl delif lbr0 $veth_host
     ovs-vsctl add-port br0 ${veth_host}
 }
 
@@ -34,6 +69,11 @@ add_ovs_flows() {
     ovs_port=$(ovs-vsctl get Interface ${veth_host} ofport)
     if [ -z "$ovs_port" ]; then
 	echo "Could not find OVS port for veth device ${veth_host} of container ${net_container}"
+	exit 1
+    fi
+    macaddr=$(nsenter -n -t $pid -- ip link show dev eth0 | sed -n -e 's/.*link.ether \([^ ]*\).*/\1/p')
+    if [ -z "$macaddr" ]; then
+	echo "Could not find MAC address for container ${net_container}"
 	exit 1
     fi
 
@@ -73,31 +113,51 @@ del_ovs_flows() {
     ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_dst=${ipaddr}"
     ovs-ofctl -O OpenFlow13 del-flows br0 "arp,nw_src=${ipaddr}"
 
-    qos=$(ovs-vsctl get port ${veth_host} qos || true)
-    if [ -n "${qos}" -a "${qos}" != "[]" ]; then
+    qos=$(ovs-vsctl get port ${veth_host} qos)
+    if [ "$qos" != "[]" ]; then
         ovs-vsctl clear port ${veth_host} qos
         ovs-vsctl --if-exists destroy qos ${qos}
     fi
 }
 
-run() {
-    # With openshift 3.3 $2 was the netns path; check for that
-    if [[ "${veth_host}" =~ "/proc" ]]; then
-      echo "Old openshift calling new script; upgrade or restart the openshift node process!"
-      openshift-sdn-ovs-33 $@
-      exit 0
+add_subnet_route() {
+    nsenter -n -t $pid -- ip route add $OPENSHIFT_CLUSTER_SUBNET dev eth0 proto kernel scope link src $ipaddr
+}
+
+ensure_subnet_route() {
+    nsenter -n -t $pid -- ip route del $OPENSHIFT_CLUSTER_SUBNET dev eth0 || true
+    add_subnet_route
+}
+
+add_macvlan() {
+    default_dev=$(ip route show | sed -ne 's/^default .* dev \([^ ]*\) .*/\1/p')
+    if [ -z "$default_dev" ]; then
+	echo "Could not find default network interface"
+	exit 1
     fi
+    ip link add link $default_dev name macvlan0 type macvlan mode private
+    ip link set macvlan0 netns $pid
+}
+
+run() {
+    get_ipaddr_pid_veth
+    source /run/openshift-sdn/config.env
 
     case "$action" in
 	setup)
 	    add_ovs_port
 	    add_ovs_flows
+	    add_subnet_route
+	    if [ "$macvlan" = true ]; then
+		add_macvlan
+	    fi
 	    ;;
 
 	update)
 	    ensure_ovs_port
 	    del_ovs_flows
 	    add_ovs_flows
+	    ensure_subnet_route
 	    ;;
 
 	teardown)


### PR DESCRIPTION
When the openshift-sdn RPM gets updated, that drops a new
/usr/bin/openshift-sdn-ovs script on disk.  But if the openshift-node
process hasn't been restarted yet for whatever reason, openshift-sdn-ovs
will print unhelpful error messages due to argument mismatches between
the 3.3 and 3.4 versions of that script.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1396919

@openshift/networking @sdodson 