### PR TITLE
add login warning if cannot list or create projectrequests

### DIFF
--- a/pkg/cmd/cli/cmd/login/loginoptions.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions.go
@@ -252,17 +252,30 @@ func (o *LoginOptions) canRequestProjects() (bool, error) {
 	sar := &authorizationapi.SubjectAccessReview{
 		Action: authorizationapi.Action{
 			Namespace: o.DefaultNamespace,
+			Verb:      "list",
+			Resource:  "projectrequests",
+		},
+	}
+
+	listResponse, err := oClient.SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return false, err
+	}
+
+	sar = &authorizationapi.SubjectAccessReview{
+		Action: authorizationapi.Action{
+			Namespace: o.DefaultNamespace,
 			Verb:      "create",
 			Resource:  "projectrequests",
 		},
 	}
 
-	response, err := oClient.SubjectAccessReviews().Create(sar)
+	createResponse, err := oClient.SubjectAccessReviews().Create(sar)
 	if err != nil {
 		return false, err
 	}
 
-	return response.Allowed, nil
+	return (listResponse.Allowed && createResponse.Allowed), nil
 }
 
 // Discover the projects available for the established session and take one to use. It


### PR DESCRIPTION
Related PR: https://github.com/openshift/origin/pull/11904/files
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1262696

This patch adds a check to see if the user cannot list `projectrequests`,
in addition to create `projectrequests`. This warning showed up previously
only when a user did not have a `self-provisioner` role, however, it
faield to show up if the user did have a `self-provisioner` role but
was unable to list `projectrequests`.

**Before**
```
$ oc login -u system:admin
# make sure auth users have ability to create projectrequests
$ oadm policy add-cluster-role-to-group self-provisioner system:authenticated:oauth
$ oc edit clusterrole basic-user
- apiGroups: null
  attributeRestrictions: null
  resources:
  - projectrequests
  verbs:
  - list # remove this verb (user will be able to create projectrequests, but not list them)  
$ oc login -u test -p test
Login successful.

You don't have any projects. You can try to create a new project, by running

    oc new-project <projectname>
```

**After**
```
$ oc login -u system:admin
# make sure auth users have ability to create projectrequests
$ oadm policy add-cluster-role-to-group self-provisioner system:authenticated:oauth
$ oc edit clusterrole basic-user
- apiGroups: null
  attributeRestrictions: null
  resources:
  - projectrequests
  verbs:
  - list # remove this verb (user will be able to create projectrequests, but not list them)  
$ oc login -u test -p test
Login successful.

You do not have access to create new projects, contact your system administrator to request a project.
```

cc @xiaocwan @fabianofranz 