### PR TITLE
UPSTREAM: 38112: Add json,yaml output format support to `oc create`, `oc apply`

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
@@ -174,18 +174,7 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 
 			count++
 			if len(output) > 0 && !shortOutput {
-				printer, generic, err := cmdutil.PrinterForCommand(cmd)
-				if err != nil {
-					return err
-				}
-				if !generic || printer == nil {
-					printer, err := f.PrinterForMapping(cmd, nil, false)
-					if err != nil {
-						return err
-					}
-					return printer.PrintObj(info.Object, out)
-				}
-				return printer.PrintObj(info.Object, out)
+				return cmdutil.PrintResourceInfoForCommand(cmd, info, f, out)
 			}
 			cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
 			return nil
@@ -215,18 +204,7 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 
 		count++
 		if len(output) > 0 && !shortOutput {
-			printer, generic, err := cmdutil.PrinterForCommand(cmd)
-			if err != nil {
-				return err
-			}
-			if !generic || printer == nil {
-				printer, err := f.PrinterForMapping(cmd, nil, false)
-				if err != nil {
-					return err
-				}
-				return printer.PrintObj(info.Object, out)
-			}
-			return printer.PrintObj(info.Object, out)
+			return cmdutil.PrintResourceInfoForCommand(cmd, info, f, out)
 		}
 		cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "configured")
 		return nil

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
@@ -77,7 +77,6 @@ func NewCmdApply(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: apply_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(validateArgs(cmd, args))
-			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
 			cmdutil.CheckErr(RunApply(f, cmd, out, options))
 		},
 	}
@@ -104,7 +103,6 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 }
 
 func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *ApplyOptions) error {
-	shortOutput := cmdutil.GetFlagString(cmd, "output") == "name"
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"), cmdutil.GetFlagString(cmd, "schema-cache-dir"))
 	if err != nil {
 		return err
@@ -129,6 +127,8 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 	}
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
+	output := cmdutil.GetFlagString(cmd, "output")
+	shortOutput := output == "name"
 
 	encoder := f.JSONEncoder()
 	decoder := f.Decoder(false)
@@ -173,6 +173,20 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 			}
 
 			count++
+			if len(output) > 0 && !shortOutput {
+				printer, generic, err := cmdutil.PrinterForCommand(cmd)
+				if err != nil {
+					return err
+				}
+				if !generic || printer == nil {
+					printer, err := f.PrinterForMapping(cmd, nil, false)
+					if err != nil {
+						return err
+					}
+					return printer.PrintObj(info.Object, out)
+				}
+				return printer.PrintObj(info.Object, out)
+			}
 			cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
 			return nil
 		}
@@ -200,6 +214,20 @@ func RunApply(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *Ap
 		}
 
 		count++
+		if len(output) > 0 && !shortOutput {
+			printer, generic, err := cmdutil.PrinterForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if !generic || printer == nil {
+				printer, err := f.PrinterForMapping(cmd, nil, false)
+				if err != nil {
+					return err
+				}
+				return printer.PrintObj(info.Object, out)
+			}
+			return printer.PrintObj(info.Object, out)
+		}
 		cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "configured")
 		return nil
 	})

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
@@ -65,7 +65,6 @@ func NewCmdCreate(f *cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 				return
 			}
 			cmdutil.CheckErr(ValidateArgs(cmd, args))
-			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
 			cmdutil.CheckErr(RunCreate(f, cmd, out, options))
 		},
 	}
@@ -127,6 +126,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 	}
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
+	output := cmdutil.GetFlagString(cmd, "output")
 
 	count := 0
 	err = r.Visit(func(info *resource.Info, err error) error {
@@ -150,7 +150,17 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		}
 
 		count++
-		shortOutput := cmdutil.GetFlagString(cmd, "output") == "name"
+		shortOutput := output == "name"
+		if len(output) > 0 && !shortOutput {
+			printer, generic, err := cmdutil.PrinterForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if !generic {
+				return fmt.Errorf("That output format is not supoported")
+			}
+			return printer.PrintObj(info.Object, out)
+		}
 		if !shortOutput {
 			f.PrintObjectSpecificMessage(info.Object, out)
 		}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
@@ -152,18 +152,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		count++
 		shortOutput := output == "name"
 		if len(output) > 0 && !shortOutput {
-			printer, generic, err := cmdutil.PrinterForCommand(cmd)
-			if err != nil {
-				return err
-			}
-			if !generic || printer == nil {
-				printer, err := f.PrinterForMapping(cmd, nil, false)
-				if err != nil {
-					return err
-				}
-				return printer.PrintObj(info.Object, out)
-			}
-			return printer.PrintObj(info.Object, out)
+			return cmdutil.PrintResourceInfoForCommand(cmd, info, f, out)
 		}
 		if !shortOutput {
 			f.PrintObjectSpecificMessage(info.Object, out)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
@@ -23,9 +23,7 @@ import (
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -158,12 +156,12 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 			if err != nil {
 				return err
 			}
-			if !generic {
-				decodedObj, decoded := decodeUnstructuredObject(info.Object)
-				if !decoded {
-					return fmt.Errorf("Unsupported output format for the current object")
+			if !generic || printer == nil {
+				printer, err := f.PrinterForMapping(cmd, nil, false)
+				if err != nil {
+					return err
 				}
-				return f.PrintObject(cmd, registered.RESTMapper(), decodedObj, out)
+				return printer.PrintObj(info.Object, out)
 			}
 			return printer.PrintObj(info.Object, out)
 		}
@@ -181,20 +179,6 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 		return fmt.Errorf("no objects passed to create")
 	}
 	return nil
-}
-
-// decodeUnstructuredObject attempts to convert an unstructured object into a known type
-// If the object fails to be converted or printed, an error is returned.
-func decodeUnstructuredObject(obj runtime.Object) (runtime.Object, bool) {
-	switch obj.(type) {
-	case *runtime.UnstructuredList, *runtime.Unstructured, *runtime.Unknown:
-		if objBytes, err := runtime.Encode(api.Codecs.LegacyCodec(), obj); err == nil {
-			if decodedObj, err := runtime.Decode(api.Codecs.UniversalDecoder(), objBytes); err == nil {
-				return decodedObj, true
-			}
-		}
-	}
-	return nil, false
 }
 
 // createAndRefresh creates an object from input info and refreshes info with that object

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/spf13/cobra"
 )
@@ -131,6 +132,24 @@ func PrinterForCommand(cmd *cobra.Command) (kubectl.ResourcePrinter, bool, error
 	}
 
 	return maybeWrapSortingPrinter(cmd, printer), generic, nil
+}
+
+// PrintResourceInfoForCommand receives a *cobra.Command and a *resource.Info and
+// attempts to print an info object based on the specified output format. If the
+// object passed is non-generic, it attempts to print the object using a HumanReadablePrinter.
+// Requires that printer flags have been added to cmd (see AddPrinterFlags).
+func PrintResourceInfoForCommand(cmd *cobra.Command, info *resource.Info, f *Factory, out io.Writer) error {
+	printer, generic, err := PrinterForCommand(cmd)
+	if err != nil {
+		return err
+	}
+	if !generic || printer == nil {
+		printer, err = f.PrinterForMapping(cmd, nil, false)
+		if err != nil {
+			return err
+		}
+	}
+	return printer.PrintObj(info.Object, out)
 }
 
 func maybeWrapSortingPrinter(cmd *cobra.Command, printer kubectl.ResourcePrinter) kubectl.ResourcePrinter {


### PR DESCRIPTION
Upstream: https://github.com/kubernetes/kubernetes/pull/38112
Related upstream issue: https://github.com/kubernetes/kubernetes/issues/37390

This patch adds the ability to specify an output format other than
"name" to `oc create ...`. It can be used in conjunction with the
`--dry-run` option.

Will add upstream PR

Due to the `mapper` being an [UnstructuredObject](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/create.go#L114), using a `wide` format option results in the error:
```
error: unknown type &runtime.Unstructured{Object:map[string]interface {}{"status":map[string]interface {}{"lastVersion":1}, "kind":"BuildConfig", "apiVersion":"v1", "metadata":map[string]interface {}{"name":"gitauthtest", "namespace":"default", "selfLink":"/oapi/v1/namespaces/default/buildconfigs/gitauthtest", "uid":"39b2c5a1-b1b3-11e6-9a01-507b9dac96e1", "resourceVersion":"800167", "creationTimestamp":"2016-11-23T19:30:00Z", "labels":map[string]interface {}{"app":"gitauthtest", "template":"gitserver"}, "annotations":map[string]interface {}{"openshift.io/generated-by":"OpenShiftNewApp"}}, "spec":map[string]interface {}{"runPolicy":"Serial", "source":map[string]interface {}{"type":"Git", "git":map[string]interface {}{"uri":"http://gitserver-tokenauth.linux.xip.io/ruby-hello-world"}, "sourceSecret":map[string]interface {}{"name":"builder-token-nbme5"}}, "strategy":map[string]interface {}{"type":"Source", "sourceStrategy":map[string]interface {}{"from":map[string]interface {}{"kind":"ImageStreamTag", "namespace":"openshift", "name":"ruby:latest"}}}, "output":map[string]interface {}{}, "resources":map[string]interface {}{}, "postCommit":map[string]interface {}{}, "nodeSelector":interface {}(nil), "triggers":[]interface {}{}}}}
```

To mitigate this, an `unsupported output format` error message is printed when a format like this one is specified.

**Example**
```
$ oc create -f pkg/api/graph/test/bc-missing-output.yaml --dry-run -o yaml
apiVersion: v1
kind: BuildConfig
metadata:
  annotations:
    openshift.io/generated-by: OpenShiftNewApp
  creationTimestamp: 2015-11-18T14:41:17Z
  labels:
    app: gitauthtest
    template: gitserver
  name: gitauthtest
  namespace: default
spec:
  output: {}
  resources: {}
  source:
    git:
      uri: http://gitserver-tokenauth.linux.xip.io/ruby-hello-world
    sourceSecret:
      name: builder-token-nbme5
    type: Git
  strategy:
    sourceStrategy:
      from:
        kind: ImageStreamTag
        name: ruby:latest
        namespace: openshift
    type: Source
  triggers: []
status:
  lastVersion: 1
```

```
$ oc create -f pkg/api/graph/test/bc-missing-output.yaml --dry-run -o wide
error: That output format is not supoported
```

cc @openshift/cli-review 