### PR TITLE
Do not require findmnt on OSX

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -145,12 +145,14 @@ function os::util::environment::setup_tmpdir_vars() {
     HOME="${FAKE_HOME_DIR}"
     export HOME
 
-    # ensure that the directories are clean
-    for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
-        if [[ "${target}" == "${BASETMPDIR}"* ]]; then
-            ${USE_SUDO:+sudo} umount "${target}"
-        fi
-    done
+		if [[ "$(uname)" != "Darwin" ]]; then
+			# ensure that the directories are clean
+			for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
+				if [[ "${target}" == "${BASETMPDIR}"* ]]; then
+					${USE_SUDO:+sudo} umount "${target}"
+				fi
+			done
+		fi
 
     for directory in "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"; do
         ${USE_SUDO:+sudo} rm -rf "${directory}"


### PR DESCRIPTION
On Mac:

```
# ./hack/test-go.sh pkg/client
.../util/environment.sh: line 130: findmnt: command not found
```