### PR TITLE
WIP: [DO_NOT_MERGE]: Image Index

### DIFF
--- a/pkg/client/images.go
+++ b/pkg/client/images.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -18,6 +19,7 @@ type ImageInterface interface {
 	Create(image *imageapi.Image) (*imageapi.Image, error)
 	Update(image *imageapi.Image) (*imageapi.Image, error)
 	Delete(name string) error
+	Watch(opts kapi.ListOptions) (watch.Interface, error)
 }
 
 // images implements ImagesInterface.
@@ -69,4 +71,13 @@ func (c *images) Update(image *imageapi.Image) (result *imageapi.Image, err erro
 func (c *images) Delete(name string) (err error) {
 	err = c.r.Delete().Resource("images").Name(name).Do().Error()
 	return
+}
+
+// Watch returns a watch.Interface that watches the requested images.
+func (c *images) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Resource("images").
+		VersionedParams(&opts, kapi.ParameterCodec).
+		Watch()
 }

--- a/pkg/client/testclient/fake_images.go
+++ b/pkg/client/testclient/fake_images.go
@@ -3,6 +3,7 @@ package testclient
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -56,4 +57,8 @@ func (c *FakeImages) Update(inObj *imageapi.Image) (*imageapi.Image, error) {
 func (c *FakeImages) Delete(name string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("images", name), &imageapi.Image{})
 	return err
+}
+
+func (c *FakeImages) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(ktestclient.NewWatchAction("images", kapi.NamespaceAll, opts))
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/policy"
 	"github.com/openshift/origin/pkg/cmd/cli/sa"
 	"github.com/openshift/origin/pkg/cmd/cli/secrets"
+	"github.com/openshift/origin/pkg/cmd/experimental/images"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -197,6 +198,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	}
 	experimental.AddCommand(
 		dockerbuild.NewCmdDockerbuild(fullName, f, out, errout),
+		images.NewCmdImages(fullName, f, out, errout),
 	)
 	cmds.AddCommand(experimental)
 

--- a/pkg/cmd/experimental/images/index.go
+++ b/pkg/cmd/experimental/images/index.go
@@ -1,0 +1,113 @@
+package images
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/index"
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+type ImageIndexOptions struct {
+	Out io.Writer
+
+	Client osclient.Interface
+
+	ImageName   string
+	Ancestors   bool
+	Descendants bool
+	Siblings    bool
+	Printer     kubectl.ResourcePrinter
+}
+
+const imagesLong = `TBD`
+
+func NewCmdImages(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+	o := &ImageIndexOptions{Out: out}
+
+	cmd := &cobra.Command{
+		Use:   "images IMAGE [--ancestors|--descendants|--siblings]",
+		Short: "Query images",
+		Long:  imagesLong,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Validate())
+			cmdutil.CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().BoolVarP(&o.Ancestors, "ancestors", "a", false, "Query the given image ancestors")
+	cmd.Flags().BoolVarP(&o.Descendants, "descendants", "d", false, "Query the given image descendants")
+	cmd.Flags().BoolVarP(&o.Siblings, "siblings", "s", false, "Query the given image siblings")
+
+	return cmd
+}
+
+func (o *ImageIndexOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("exactly one IMAGE is allowed")
+	}
+	o.ImageName = args[0]
+
+	client, _, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.Client = client
+	o.Printer, _ = f.Printer(nil, kubectl.PrintOptions{})
+
+	return nil
+}
+
+func (o *ImageIndexOptions) Validate() error {
+	if !strings.HasPrefix(o.ImageName, "sha256:") {
+		return fmt.Errorf(`the image must start with "sha256:" prefix`)
+	}
+	return nil
+}
+
+func (o *ImageIndexOptions) Run() error {
+	image, err := o.Client.Images().Get(o.ImageName)
+	if err != nil {
+		return err
+	}
+
+	stopChan := make(chan struct{})
+	i := index.NewImageIndex(o.Client.Images(), stopChan)
+	i.WaitForSyncedStores()
+
+	list := imageapi.ImageList{Items: []imageapi.Image{}}
+	var items []*imageapi.Image
+
+	if o.Ancestors {
+		items, err = i.Ancestors(image)
+		for _, i := range items {
+			list.Items = append(list.Items, *i)
+		}
+	}
+	if o.Descendants {
+		items, err = i.Descendants(image)
+		for _, i := range items {
+			list.Items = append(list.Items, *i)
+		}
+	}
+	if o.Siblings {
+		items, err = i.Siblings(image)
+		for _, i := range items {
+			list.Items = append(list.Items, *i)
+		}
+	}
+	if err != nil || len(items) == 0 {
+		return err
+	}
+
+	o.Printer.PrintObj(&list, o.Out)
+
+	return nil
+}

--- a/pkg/image/index/index.go
+++ b/pkg/image/index/index.go
@@ -1,0 +1,197 @@
+package index
+
+import (
+	"time"
+
+	"github.com/docker/distribution/digest"
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller/framework"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type ImageIndex struct {
+	client client.ImageInterface
+
+	imageController  *framework.Controller
+	imageIndex       cache.Indexer
+	imageStoreSynced func() bool
+}
+
+var (
+	ChainIndexName     = "chain"
+	LastChainIndexName = "last-chain"
+	// TODO: Re-listing images might be expensive on large clusters, this should be
+	// configurable?
+	ResyncInterval = 10 * time.Minute
+)
+
+// NewImageIndex returns a new image index.
+func NewImageIndex(client client.ImageInterface, stopChan <-chan struct{}) *ImageIndex {
+	c := &ImageIndex{
+		client: client,
+	}
+	c.imageIndex, c.imageController = framework.NewIndexerInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+				return c.client.List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return c.client.Watch(options)
+			},
+		},
+		&imageapi.Image{},
+		ResyncInterval,
+		framework.ResourceEventHandlerFuncs{
+			AddFunc:    c.addImage,
+			UpdateFunc: c.updateImage,
+			DeleteFunc: c.deleteImage,
+		},
+		cache.Indexers{
+			ChainIndexName:     chainIndexFunc,
+			LastChainIndexName: lastChainIndexFunc,
+		},
+	)
+
+	go c.imageController.Run(stopChan)
+	return c
+}
+
+func (c *ImageIndex) WaitForSyncedStores() {
+	for !c.imageController.HasSynced() {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// Ancestors provides a list of images that are based in the provideed image.
+func (c *ImageIndex) Ancestors(image *imageapi.Image) ([]*imageapi.Image, error) {
+	imageChains := getImageLayerChain(image)
+	result := &uniqueImageList{}
+	for _, chain := range imageChains {
+		objects, err := c.imageIndex.ByIndex(LastChainIndexName, chain)
+		if err != nil {
+			return nil, err
+		}
+		for _, obj := range objects {
+			if i := obj.(*imageapi.Image); i.Name != image.Name {
+				result.Append(i)
+			}
+		}
+	}
+	return result.Images, nil
+}
+
+// Descendants provides a list of images that the provided image is based on.
+// Note that if a base image is tagged multiple times, this will return all the matching
+// images.
+func (c *ImageIndex) Descendants(image *imageapi.Image) ([]*imageapi.Image, error) {
+	chains := getImageLayerChain(image)
+	objects, err := c.imageIndex.ByIndex(ChainIndexName, chains[len(chains)-1])
+	if err != nil {
+		return nil, err
+	}
+	result := &uniqueImageList{}
+	for _, obj := range objects {
+		i := obj.(*imageapi.Image)
+		imageChain := getImageLayerChain(i)
+		// Remove the image itself from the result
+		if imageChain[len(imageChain)-1] != chains[len(chains)-1] {
+			result.Append(i)
+		}
+	}
+	return result.Images, nil
+}
+
+// Siblings returns a list of images that represents the same image but under different
+// tag or name.
+func (c *ImageIndex) Siblings(image *imageapi.Image) ([]*imageapi.Image, error) {
+	chains := getImageLayerChain(image)
+	objects, err := c.imageIndex.ByIndex(LastChainIndexName, chains[len(chains)-1])
+	if err != nil {
+		return nil, err
+	}
+	result := []*imageapi.Image{}
+	for _, obj := range objects {
+		i := obj.(*imageapi.Image)
+		if i.Name != image.Name {
+			result = append(result, i)
+		}
+	}
+	return result, nil
+}
+
+func (c *ImageIndex) addImage(obj interface{}) {
+	if err := c.imageIndex.Add(obj); err != nil {
+		glog.Errorf("failed to add image %+v to index: %v", obj, err)
+	}
+}
+
+func (c *ImageIndex) updateImage(_, newObj interface{}) {
+	if err := c.imageIndex.Update(newObj); err != nil {
+		glog.Errorf("failed to update image %+v in index: %v", newObj, err)
+	}
+}
+
+func (c *ImageIndex) deleteImage(obj interface{}) {
+	i, ok := obj.(*imageapi.Image)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("couldn't get object from tombstone %#v", obj)
+			return
+		}
+		i, ok = tombstone.Obj.(*imageapi.Image)
+		if !ok {
+			glog.Errorf("tombstone contained object that is not a Deployment %#v", obj)
+			return
+		}
+	}
+	c.imageIndex.Delete(i)
+}
+
+type uniqueImageList struct {
+	Images []*imageapi.Image
+	index  map[string]struct{}
+}
+
+func (l *uniqueImageList) Append(image *imageapi.Image) {
+	if l.index == nil {
+		l.index = map[string]struct{}{}
+	}
+	if _, exists := l.index[image.Name]; exists {
+		return
+	}
+	l.Images = append(l.Images, image)
+	l.index[image.Name] = struct{}{}
+}
+
+// getImageLayerChain recalculates the digest from each layer and return a sequence that
+// represents the image.
+func getImageLayerChain(image *imageapi.Image) []string {
+	chain := []string{}
+	for i, layer := range image.DockerImageLayers {
+		if i > 0 {
+			chain = append(chain, digest.FromBytes([]byte(chain[i-1]+"/"+layer.Name)).String())
+		} else {
+			chain = append(chain, layer.Name)
+		}
+	}
+	return chain
+}
+
+// chainIndexFunc provides an index function that indexes the images by the chains that the
+// images are build from.
+func chainIndexFunc(obj interface{}) ([]string, error) {
+	return getImageLayerChain(obj.(*imageapi.Image)), nil
+}
+
+// lastChainIndexFunc provides an index function that indexes the images by the last chain
+// that indentifies the image itself.
+func lastChainIndexFunc(obj interface{}) ([]string, error) {
+	chains := getImageLayerChain(obj.(*imageapi.Image))
+	return []string{chains[len(chains)-1]}, nil
+}

--- a/pkg/image/index/index_test.go
+++ b/pkg/image/index/index_test.go
@@ -1,0 +1,151 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+func addImage(name string, layers []string) imageapi.Image {
+	image := imageapi.Image{}
+	image.Name = name
+	image.DockerImageLayers = []imageapi.ImageLayer{}
+	for _, l := range layers {
+		image.DockerImageLayers = append(image.DockerImageLayers, imageapi.ImageLayer{Name: l, LayerSize: int64(100)})
+	}
+	return image
+}
+
+func simpleImageChain() []imageapi.Image {
+	result := []imageapi.Image{}
+	result = append(result, addImage("base", []string{
+		"sha256:9c3823d8bc18257d5552703135c2222d2c083a296064ed2b151eaa21e819770e",
+		"sha256:8f045733649f36ff037148858463355dca8f224da31835baf153b391eb915adb",
+		"sha256:2da06dc69380add7862cf69f0b66cb9a2873023e901e7e024e2107cef3351b6e",
+	}))
+	result = append(result, addImage("s2i-base", []string{
+		"sha256:9c3823d8bc18257d5552703135c2222d2c083a296064ed2b151eaa21e819770e",
+		"sha256:8f045733649f36ff037148858463355dca8f224da31835baf153b391eb915adb",
+		"sha256:2da06dc69380add7862cf69f0b66cb9a2873023e901e7e024e2107cef3351b6e",
+		"sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+	}))
+	result = append(result, addImage("s2i-python", []string{
+		"sha256:9c3823d8bc18257d5552703135c2222d2c083a296064ed2b151eaa21e819770e",
+		"sha256:8f045733649f36ff037148858463355dca8f224da31835baf153b391eb915adb",
+		"sha256:2da06dc69380add7862cf69f0b66cb9a2873023e901e7e024e2107cef3351b6e",
+		"sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+		"sha256:d9b34ea2353dc308b7e9b1d7c8a40344691dc0801332004fef8960a026f869ed",
+	}))
+	result = append(result, addImage("app", []string{
+		"sha256:9c3823d8bc18257d5552703135c2222d2c083a296064ed2b151eaa21e819770e",
+		"sha256:8f045733649f36ff037148858463355dca8f224da31835baf153b391eb915adb",
+		"sha256:2da06dc69380add7862cf69f0b66cb9a2873023e901e7e024e2107cef3351b6e",
+		"sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+		"sha256:d9b34ea2353dc308b7e9b1d7c8a40344691dc0801332004fef8960a026f869ed",
+		"sha256:11111112353dc308b7e9b1d7c8a40344691dc0801332004fef8960a026f869ed",
+	}))
+	return result
+}
+
+func getImage(list []imageapi.Image, name string) *imageapi.Image {
+	for _, i := range list {
+		if i.Name == name {
+			return &i
+		}
+	}
+	return nil
+}
+
+func TestSimpleImageIndexAncestors(t *testing.T) {
+	fake := &testclient.Fake{}
+	fake.AddReactor("list", "images", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		result := imageapi.ImageList{Items: simpleImageChain()}
+		return true, &result, nil
+	})
+	fake.AddWatchReactor("images", ktestclient.DefaultWatchReactor(watch.NewFake(), nil))
+
+	index := NewImageIndex(fake.Images(), make(chan struct{}))
+
+	index.WaitForSyncedStores()
+	simpleChain := simpleImageChain()
+
+	descendantsTable := map[string][]string{
+		"base":       []string{},
+		"s2i-python": []string{"s2i-base", "base"},
+		"app":        []string{"s2i-python", "s2i-base", "base"},
+	}
+
+	for imageName, expect := range descendantsTable {
+		images, err := index.Ancestors(getImage(simpleChain, imageName))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(expect) != len(images) {
+			imageNameList := []string{}
+			for _, i := range images {
+				imageNameList = append(imageNameList, i.Name)
+			}
+			t.Errorf("[%s] expected %v, got %#+v", imageName, expect, imageNameList)
+			continue
+		}
+		for _, e := range expect {
+			found := false
+			for _, got := range images {
+				if got.Name == e {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected %q in the descendants", e)
+			}
+		}
+	}
+}
+
+func TestSimpleImageIndexDescendants(t *testing.T) {
+	fake := &testclient.Fake{}
+	fake.AddReactor("list", "images", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		result := imageapi.ImageList{Items: simpleImageChain()}
+		return true, &result, nil
+	})
+	fake.AddWatchReactor("images", ktestclient.DefaultWatchReactor(watch.NewFake(), nil))
+
+	index := NewImageIndex(fake.Images(), make(chan struct{}))
+
+	index.WaitForSyncedStores()
+	simpleChain := simpleImageChain()
+
+	ancestorTable := map[string][]string{
+		"base":       []string{"s2i-base", "s2i-python", "app"},
+		"s2i-python": []string{"app"},
+		"app":        []string{},
+	}
+
+	for imageName, expect := range ancestorTable {
+		images, err := index.Descendants(getImage(simpleChain, imageName))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(expect) != len(images) {
+			t.Errorf("expected %v, got %#+v", expect, images)
+			continue
+		}
+		for _, e := range expect {
+			found := false
+			for _, got := range images {
+				if got.Name == e {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected %q in the ancestors", e)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This code provides a fast access index for listing image ancestors and descentants.
@legionus will provide util package to access the image "chains" with explanation how they works.

Caveats:

* Since a single image can be tagged multiple times, but having the same layers it means ancestors and descentants might return all these images.
* In v2 schema the empty layers (ENV,  LABEL, etc.) are omited from the layer list because they don't serve any purpose (except providing configuration ;-). 

