### PR TITLE
Use default cert dir for oc cluster up engine API client if DOCKER_TLS_VERIFY is set

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"github.com/blang/semver"
+	"github.com/docker/docker/cliconfig"
 	dockerclient "github.com/docker/engine-api/client"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
@@ -423,10 +424,15 @@ func getDockerClient(out io.Writer, dockerMachine string, canStartDockerMachine 
 		return dockerClient, engineAPIClient, nil
 	}
 
+	dockerTLSVerify := os.Getenv("DOCKER_TLS_VERIFY")
+	dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
+	if len(dockerTLSVerify) > 0 && len(dockerCertPath) == 0 {
+		dockerCertPath = cliconfig.ConfigDir()
+		os.Setenv("DOCKER_CERT_PATH", dockerCertPath)
+	}
+
 	if glog.V(4) {
 		dockerHost := os.Getenv("DOCKER_HOST")
-		dockerTLSVerify := os.Getenv("DOCKER_TLS_VERIFY")
-		dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
 		if len(dockerHost) == 0 && len(dockerTLSVerify) == 0 && len(dockerCertPath) == 0 {
 			glog.Infof("No Docker environment variables found. Will attempt default socket.")
 		}


### PR DESCRIPTION
If DOCKER_TLS_VERIFY env var is set and DOCKER_CERT_PATH is not set, this uses the default cert path for the engine API client of $HOME/.docker to be consistent with https://github.com/fsouza/go-dockerclient/blob/e374214216d867f2c16b84972ad3bb22b56b47c3/client.go#L992-L1019.

If we could upgrade fsouza/go-dockerclient then this could drop the engine API client completely to use one consistent client, however upgrading fsouza client would require upgrading docker dependency too which is probably undesirable atm (plus being additional work).