### PR TITLE
Fix a multiple-pointers-to-single-loop-variable bug in EgressNetworkPolicy

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -332,7 +332,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	return true, nil
 }
 
-func policyNames(policies []*osapi.EgressNetworkPolicy) string {
+func policyNames(policies []osapi.EgressNetworkPolicy) string {
 	names := make([]string, len(policies))
 	for i, policy := range policies {
 		names[i] = policy.Namespace + ":" + policy.Name

--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -24,7 +24,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 			glog.Warningf("Could not find netid for namespace %q: %v", policy.Namespace, err)
 			continue
 		}
-		plugin.egressPolicies[vnid] = append(plugin.egressPolicies[vnid], &policy)
+		plugin.egressPolicies[vnid] = append(plugin.egressPolicies[vnid], policy)
 	}
 
 	for vnid := range plugin.egressPolicies {
@@ -55,7 +55,7 @@ func (plugin *OsdnNode) watchEgressNetworkPolicies() {
 			}
 		}
 		if delta.Type != cache.Deleted && len(policy.Spec.Egress) > 0 {
-			policies = append(policies, policy)
+			policies = append(policies, *policy)
 		}
 		plugin.egressPolicies[vnid] = policies
 
@@ -73,7 +73,7 @@ func (plugin *OsdnNode) UpdateEgressNetworkPolicyVNID(namespace string, oldVnid,
 	policies := plugin.egressPolicies[oldVnid]
 	for i, oldPolicy := range policies {
 		if oldPolicy.Namespace == namespace {
-			policy = oldPolicy
+			policy = &oldPolicy
 			plugin.egressPolicies[oldVnid] = append(policies[:i], policies[i+1:]...)
 			err := plugin.updateEgressNetworkPolicyRules(oldVnid)
 			if err != nil {
@@ -84,7 +84,7 @@ func (plugin *OsdnNode) UpdateEgressNetworkPolicyVNID(namespace string, oldVnid,
 	}
 
 	if policy != nil {
-		plugin.egressPolicies[newVnid] = append(plugin.egressPolicies[newVnid], policy)
+		plugin.egressPolicies[newVnid] = append(plugin.egressPolicies[newVnid], *policy)
 		err := plugin.updateEgressNetworkPolicyRules(newVnid)
 		if err != nil {
 			return err

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -44,7 +44,7 @@ type OsdnNode struct {
 	vnids              *nodeVNIDMap
 	iptablesSyncPeriod time.Duration
 	mtu                uint32
-	egressPolicies     map[uint32][]*osapi.EgressNetworkPolicy
+	egressPolicies     map[uint32][]osapi.EgressNetworkPolicy
 
 	host             knetwork.Host
 	kubeletCniPlugin knetwork.NetworkPlugin
@@ -99,7 +99,7 @@ func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient *kclien
 		kubeletInitReady:   make(chan struct{}),
 		iptablesSyncPeriod: iptablesSyncPeriod,
 		mtu:                mtu,
-		egressPolicies:     make(map[uint32][]*osapi.EgressNetworkPolicy),
+		egressPolicies:     make(map[uint32][]osapi.EgressNetworkPolicy),
 	}
 
 	if err := plugin.dockerPreCNICleanup(); err != nil {


### PR DESCRIPTION
The EgressNetworkPolicy code was doing the same thing as in https://github.com/openshift/ose/pull/420 where we were trying to store pointers to various objects in an array but ended up storing multiple pointers to the same object instead.

(I guess I was imagining [and maybe others were too since this bug passed code review twice] that since `policy` was a local variable, but `&policy` survives after the function returns, then that must mean that `&` in this context copies the local variable to a new heap object. But in fact, all that happens is that the compiler sees that `&policy` needs to survive after the function returns, and so allocates `policy` on the heap rather than the stack to begin with, and so `&policy` is the same address each time through the loop.)

Fixes #12038.

@openshift/networking PTAL