### PR TITLE
Fail hard when the commit checker finds no Git repo

### DIFF
--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -2,8 +2,8 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 if ! git status &> /dev/null; then
-  echo "SKIPPED: Not a Git repository"
-  exit 0
+  echo "FAILURE: Not a Git repository"
+  exit 1
 fi
 
 os::util::ensure::built_binary_exists 'commitchecker'


### PR DESCRIPTION
When someone invokes the commit checker but there is no repository to
check, the script should fail hard. Currently, a warning is emitted but
the script does not fail, which leads to the warning being ignored.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>