### PR TITLE
Fail new builds that can't start build pod because it already exists

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -309,6 +309,10 @@ const (
 	// StatusReasonDockerBuildFailed indicates that the docker build strategy has
 	// failed.
 	StatusReasonDockerBuildFailed StatusReason = "DockerBuildFailed"
+
+	// StatusReasonBuildPodExists indicates that the build tried to create a
+	// build pod but one was already present.
+	StatusReasonBuildPodExists = "BuildPodExists"
 )
 
 // NOTE: These messages might change.
@@ -326,6 +330,7 @@ const (
 	StatusMessageFetchSourceFailed         = "Failed to fetch the input source"
 	StatusMessageCancelledBuild            = "The build was cancelled by the user"
 	StatusMessageDockerBuildFailed         = "Docker build strategy has failed"
+	StatusMessageBuildPodExists            = "The pod for this build already exists and is older than the build"
 )
 
 // BuildSource is the input used for the build.


### PR DESCRIPTION
Consider following scenario:

- build is started by user
- build controller creates build pod
- build is deleted by user
- build pod is killed but remains Terminating during grace period
- build with same name as in first step is started by user

Previously the new build stayed in New phase until the old build pod finished and then went into Failed after the pod terminated. This commit causes the new build to go into Error phase when it first tries creating build pod and fails because pod with the same name exists.

Slightly improves bug 1300949 (the described behavior is still very similar).