### PR TITLE
Add `request-timeout` val to `oc login` restclient

### DIFF
--- a/pkg/cmd/cli/cmd/login/login.go
+++ b/pkg/cmd/cli/cmd/login/login.go
@@ -11,6 +11,7 @@ import (
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/term"
@@ -104,6 +105,13 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 		// build a valid object to use if we failed on a non-existent file
 		o.StartingKubeConfig = kclientcmdapi.NewConfig()
 	}
+
+	unparsedTimeout := kcmdutil.GetFlagString(cmd, "request-timeout")
+	timeout, err := kclientcmd.ParseTimeout(unparsedTimeout)
+	if err != nil {
+		return err
+	}
+	o.RequestTimeout = timeout
 
 	o.CommandName = commandName
 	if o.CommandName == "" {

--- a/pkg/cmd/cli/cmd/login/loginoptions.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +67,8 @@ type LoginOptions struct {
 
 	PathOptions *kclientcmd.PathOptions
 
-	CommandName string
+	CommandName    string
+	RequestTimeout time.Duration
 }
 
 // Gather all required information in a comprehensive order.
@@ -99,6 +101,11 @@ func (o *LoginOptions) getClientConfig() (*restclient.Config, error) {
 	}
 
 	clientConfig := &restclient.Config{}
+
+	// ensure clientConfig has timeout option
+	if o.RequestTimeout > 0 {
+		clientConfig.Timeout = o.RequestTimeout
+	}
 
 	// normalize the provided server to a format expected by config
 	serverNormalized, err := config.NormalizeServerURL(o.Server)

--- a/test/cmd/timeout.sh
+++ b/test/cmd/timeout.sh
@@ -16,6 +16,7 @@ os::cmd::expect_success_and_text 'oc new-app node' 'Success'
 os::cmd::expect_success_and_text 'oc get dc node -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1s' 'node'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1' 'node'
+os::cmd::expect_failure_and_text 'oc login -u testuser -p test --request-timeout=1ns' 'Timeout exceeded while awaiting headers'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/37708
Fixes: https://github.com/openshift/origin/issues/12059

This patch adds a user-specified `request-timeout` flag value to the
restclient that is created by `oc login`. This allows `oc login` to
honor the `--request-timeout` flag.

```
$ oc login -u system:admin
Logged into "https://10.13.137.149:8443" as "system:admin" using
existing credentials.

You have access to the following projects and can switch between them
with 'oc project <projectname>':

  * default
  ...

$ oc login -u system:admin --request-timeout=1ms
Logged into "https://10.13.137.149:8443" as "system:admin" using
existing credentials.

Unable to connect to the server: net/http: request canceled
(Client.Timeout exceeded while awaiting headers)
```

cc @openshift/cli-review 