### PR TITLE
Update 1.4 for CentOS docker and tito builds

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 
 from tito.common import (
+    debug,
     find_git_root,
     get_latest_commit,
     run_command,

--- a/images/dind/Dockerfile.centos7
+++ b/images/dind/Dockerfile.centos7
@@ -18,7 +18,7 @@
 #      $ docker run -d --privileged openshift/dind
 #
 
-FROM centos:systemd
+FROM centos:centos7
 
 # Fix 'WARNING: terminal is not fully functional' when TERM=dumb
 ENV TERM=xterm
@@ -49,10 +49,18 @@ RUN systemctl mask\
 RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
  sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 
+# Remove non-english translations for glibc to reduce image size by 100mb.
+# docker-v1.10-migrator is unnecessary for a new docker installation
+# selinux-policy-minimum is unnecessary since selinux won't be enabled
 RUN yum -y update && yum -y install\
  docker\
  iptables\
+ openssh-clients\
  openssh-server\
+ && yum -y remove\
+ docker-v1.10-migrator\
+ glibc-all-langpacks\
+ selinux-policy-minimum\
  && yum clean all
 
 ## Configure docker

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -20,7 +20,7 @@ RUN INSTALL_PKGS="origin-sdn-ovs libmnl libnetfilter_conntrack openvswitch \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /usr/lib/systemd/system/origin-node.service.d /usr/lib/systemd/system/docker.service.d && \
-    chmod +x /usr/local/bin/* /usr/bin/openshift-*
+    chmod +x /usr/local/bin/* /usr/bin/openshift-* /opt/cni/bin/*
 
 LABEL io.k8s.display-name="OpenShift Origin Node" \
       io.k8s.description="This is a component of OpenShift Origin and contains the software for individual nodes when using SDN."

--- a/images/origin/Dockerfile.centos7
+++ b/images/origin/Dockerfile.centos7
@@ -21,7 +21,6 @@ LABEL io.k8s.display-name="OpenShift Origin Application Platform" \
 ENV HOME=/root \
     OPENSHIFT_CONTAINERIZED=true \
     KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig
-VOLUME /var/lib/origin
 WORKDIR /var/lib/origin
 EXPOSE 8443 53
 ENTRYPOINT ["/usr/bin/openshift"]


### PR DESCRIPTION
Update Dockerfile.centos7 files
Fix missing import breaking tito customization.