### PR TITLE
Keep the action name of geting REST storage consistent

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
@@ -16,8 +16,8 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against ClusterPolicy.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+// NewREST returns a RESTStorage object that will work against ClusterPolicy.
+func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.ClusterPolicy{} },

--- a/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
@@ -16,8 +16,8 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against ClusterPolicyBinding.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+// NewREST returns a RESTStorage object that will work against ClusterPolicyBinding.
+func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.ClusterPolicyBinding{} },

--- a/pkg/authorization/registry/policy/etcd/etcd.go
+++ b/pkg/authorization/registry/policy/etcd/etcd.go
@@ -16,8 +16,8 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against Policy objects.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+// NewREST returns a RESTStorage object that will work against Policy objects.
+func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.Policy{} },
 		NewListFunc:       func() runtime.Object { return &authorizationapi.PolicyList{} },

--- a/pkg/authorization/registry/policybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/policybinding/etcd/etcd.go
@@ -16,8 +16,8 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against PolicyBinding objects.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+// NewREST returns a RESTStorage object that will work against PolicyBinding objects.
+func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:           func() runtime.Object { return &authorizationapi.PolicyBinding{} },
 		NewListFunc:       func() runtime.Object { return &authorizationapi.PolicyBindingList{} },

--- a/pkg/authorization/registry/rolebindingrestriction/etcd.go
+++ b/pkg/authorization/registry/rolebindingrestriction/etcd.go
@@ -16,7 +16,7 @@ type REST struct {
 }
 
 // NewStorage returns a RESTStorage object that will work against nodes.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store, err := makeStore(optsGetter)
 	if err != nil {
 		return nil, err

--- a/pkg/build/registry/buildclone/rest.go
+++ b/pkg/build/registry/buildclone/rest.go
@@ -9,24 +9,24 @@ import (
 	"github.com/openshift/origin/pkg/build/generator"
 )
 
-// NewStorage creates a new storage object for build generation
-func NewStorage(generator *generator.BuildGenerator) *CloneREST {
-	return &CloneREST{generator: generator}
+// NewREST creates a new storage object for build generation
+func NewREST(generator *generator.BuildGenerator) *REST {
+	return &REST{generator: generator}
 }
 
 // CloneREST is a RESTStorage implementation for a BuildGenerator which supports only
 // the Get operation (as the generator has no underlying storage object).
-type CloneREST struct {
+type REST struct {
 	generator *generator.BuildGenerator
 }
 
 // New creates a new build clone request
-func (s *CloneREST) New() runtime.Object {
+func (s *REST) New() runtime.Object {
 	return &buildapi.BuildRequest{}
 }
 
 // Create instantiates a new build from an existing build
-func (s *CloneREST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
 	if err := rest.BeforeCreate(Strategy, ctx, obj); err != nil {
 		return nil, err
 	}

--- a/pkg/build/registry/buildclone/rest_test.go
+++ b/pkg/build/registry/buildclone/rest_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCreateClone(t *testing.T) {
-	rest := CloneREST{&generator.BuildGenerator{Client: generator.Client{
+	rest := REST{&generator.BuildGenerator{Client: generator.Client{
 		CreateBuildFunc: func(ctx kapi.Context, build *buildapi.Build) error {
 			return nil
 		},
@@ -27,7 +27,7 @@ func TestCreateClone(t *testing.T) {
 }
 
 func TestCreateCloneValidationError(t *testing.T) {
-	rest := CloneREST{&generator.BuildGenerator{}}
+	rest := REST{&generator.BuildGenerator{}}
 	_, err := rest.Create(kapi.NewDefaultContext(), &buildapi.BuildRequest{})
 	if err == nil {
 		t.Error("Expected object got none!")

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -130,25 +130,25 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 		return r.Err()
 	}
 
-	policyStorage, err := policyetcd.NewStorage(optsGetter)
+	policyStorage, err := policyetcd.NewREST(optsGetter)
 	if err != nil {
 		return err
 	}
 	policyRegistry := policyregistry.NewRegistry(policyStorage)
 
-	policyBindingStorage, err := policybindingetcd.NewStorage(optsGetter)
+	policyBindingStorage, err := policybindingetcd.NewREST(optsGetter)
 	if err != nil {
 		return err
 	}
 	policyBindingRegistry := policybindingregistry.NewRegistry(policyBindingStorage)
 
-	clusterPolicyStorage, err := clusterpolicyetcd.NewStorage(optsGetter)
+	clusterPolicyStorage, err := clusterpolicyetcd.NewREST(optsGetter)
 	if err != nil {
 		return err
 	}
 	clusterPolicyRegistry := clusterpolicyregistry.NewRegistry(clusterPolicyStorage)
 
-	clusterPolicyBindingStorage, err := clusterpolicybindingetcd.NewStorage(optsGetter)
+	clusterPolicyBindingStorage, err := clusterpolicybindingetcd.NewREST(optsGetter)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/origin/ensure.go
+++ b/pkg/cmd/server/origin/ensure.go
@@ -210,7 +210,7 @@ func (c *MasterConfig) ensureDefaultSecurityContextConstraints() {
 
 // ensureComponentAuthorizationRules initializes the cluster policies
 func (c *MasterConfig) ensureComponentAuthorizationRules() {
-	clusterPolicyStorage, err := clusterpolicystorage.NewStorage(c.RESTOptionsGetter)
+	clusterPolicyStorage, err := clusterpolicystorage.NewREST(c.RESTOptionsGetter)
 	if err != nil {
 		glog.Errorf("Error creating policy storage: %v", err)
 		return

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -514,6 +514,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	buildStorage, buildDetailsStorage, err := buildetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	buildRegistry := buildregistry.NewRegistry(buildStorage)
+	buildLogStorage := buildlogregistry.NewREST(buildStorage, buildStorage, c.BuildLogClient().Core(), nodeConnectionInfoGetter)
 
 	buildConfigStorage, err := buildconfigetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
@@ -557,17 +558,17 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	groupStorage, err := groupetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 
-	policyStorage, err := policyetcd.NewStorage(c.RESTOptionsGetter)
+	policyStorage, err := policyetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	policyRegistry := policyregistry.NewRegistry(policyStorage)
-	policyBindingStorage, err := policybindingetcd.NewStorage(c.RESTOptionsGetter)
+	policyBindingStorage, err := policybindingetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	policyBindingRegistry := policybindingregistry.NewRegistry(policyBindingStorage)
 
-	clusterPolicyStorage, err := clusterpolicystorage.NewStorage(c.RESTOptionsGetter)
+	clusterPolicyStorage, err := clusterpolicystorage.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	clusterPolicyRegistry := clusterpolicyregistry.NewRegistry(clusterPolicyStorage)
-	clusterPolicyBindingStorage, err := clusterpolicybindingstorage.NewStorage(c.RESTOptionsGetter)
+	clusterPolicyBindingStorage, err := clusterpolicybindingstorage.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewRegistry(clusterPolicyBindingStorage)
 
@@ -578,6 +579,12 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver, nil, authorizationapi.Resource("rolebinding"))
 	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
 	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
+
+	clusterResourceQuotasStorage, clusterResourceQuotasStatusStorage, err := clusterresourcequotaregistry.NewREST(c.RESTOptionsGetter)
+	checkStorageErr(err)
+	appliedClusterResourceQuotaStorage := appliedclusterresourcequotaregistry.NewREST(c.ClusterQuotaMappingController.GetClusterQuotaMapper(),
+		c.Informers.ClusterResourceQuotas().Lister(),
+		c.Informers.KubernetesInformers().Namespaces().Lister())
 
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)
@@ -627,7 +634,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		ServiceAccounts: c.KubeClientset(),
 		Secrets:         c.KubeClientset(),
 	}
-
+	buildCloneStorage := buildclone.NewREST(buildGenerator)
+	buildConfigInstantiateStorage, buildConfigInstantiateBinaryStorage := buildconfiginstantiate.NewREST(buildGenerator, buildStorage, c.BuildLogClient(), nodeConnectionInfoGetter)
 	// TODO: with sharding, this needs to be changed
 	deployConfigGenerator := &deployconfiggenerator.DeploymentConfigGenerator{
 		Client: deployconfiggenerator.Client{
@@ -643,6 +651,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		GRFn: deployrollback.NewRollbackGenerator().GenerateRollback,
 	}
 	deployConfigRollbackStorage := deployrollback.NewREST(configClient, kclient, c.ExternalVersionCodec)
+
+	deployConfigLogStorage := deploylogregistry.NewREST(configClient, kclient, c.DeploymentLogClient(), nodeConnectionInfoGetter)
+	generateDeploymentConfigStorage := deployconfiggenerator.NewREST(deployConfigGenerator, c.ExternalVersionCodec)
+	deploymentConfigRollbackStorage := deployrollback.NewDeprecatedREST(deployRollbackClient, c.ExternalVersionCodec)
 
 	projectStorage := projectproxy.NewREST(c.PrivilegedLoopbackKubernetesClientset.Core().Namespaces(), c.ProjectAuthorizationCache, c.ProjectAuthorizationCache, c.ProjectCache)
 
@@ -685,6 +697,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 	templateStorage, err := templateetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
+	processedTemplateStorage := templateregistry.NewREST()
 
 	storage := map[string]rest.Storage{
 		"images":               imageStorage,
@@ -701,14 +714,14 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"deploymentConfigs/scale":       deployConfigScaleStorage,
 		"deploymentConfigs/status":      deployConfigStatusStorage,
 		"deploymentConfigs/rollback":    deployConfigRollbackStorage,
-		"deploymentConfigs/log":         deploylogregistry.NewREST(configClient, kclient, c.DeploymentLogClient(), nodeConnectionInfoGetter),
+		"deploymentConfigs/log":         deployConfigLogStorage,
 		"deploymentConfigs/instantiate": dcInstantiateStorage,
 
 		// TODO: Deprecate these
-		"generateDeploymentConfigs": deployconfiggenerator.NewREST(deployConfigGenerator, c.ExternalVersionCodec),
-		"deploymentConfigRollbacks": deployrollback.NewDeprecatedREST(deployRollbackClient, c.ExternalVersionCodec),
+		"generateDeploymentConfigs": generateDeploymentConfigStorage,
+		"deploymentConfigRollbacks": deploymentConfigRollbackStorage,
 
-		"processedTemplates": templateregistry.NewREST(),
+		"processedTemplates": processedTemplateStorage,
 		"templates":          templateStorage,
 
 		"routes":        routeStorage,
@@ -753,24 +766,23 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"clusterRoleBindings":   clusterRoleBindingStorage,
 		"clusterRoles":          clusterRoleStorage,
 
-		"clusterResourceQuotas":        restInPeace(clusterresourcequotaregistry.NewStorage(c.RESTOptionsGetter)),
-		"clusterResourceQuotas/status": updateInPeace(clusterresourcequotaregistry.NewStatusStorage(c.RESTOptionsGetter)),
-		"appliedClusterResourceQuotas": appliedclusterresourcequotaregistry.NewREST(
-			c.ClusterQuotaMappingController.GetClusterQuotaMapper(), c.Informers.ClusterResourceQuotas().Lister(), c.Informers.KubernetesInformers().Namespaces().Lister()),
+		"clusterResourceQuotas":        clusterResourceQuotasStorage,
+		"clusterResourceQuotas/status": clusterResourceQuotasStatusStorage,
+		"appliedClusterResourceQuotas": appliedClusterResourceQuotaStorage,
 
-		"roleBindingRestrictions": restInPeace(rolebindingrestrictionregistry.NewStorage(c.RESTOptionsGetter)),
+		"roleBindingRestrictions": restInPeace(rolebindingrestrictionregistry.NewREST(c.RESTOptionsGetter)),
 	}
 
 	if configapi.IsBuildEnabled(&c.Options) {
 		storage["builds"] = buildStorage
-		storage["builds/clone"] = buildclone.NewStorage(buildGenerator)
-		storage["builds/log"] = buildlogregistry.NewREST(buildStorage, buildStorage, c.BuildLogClient().Core(), nodeConnectionInfoGetter)
+		storage["builds/clone"] = buildCloneStorage
+		storage["builds/log"] = buildLogStorage
 		storage["builds/details"] = buildDetailsStorage
 
 		storage["buildConfigs"] = buildConfigStorage
 		storage["buildConfigs/webhooks"] = buildConfigWebHooks
-		storage["buildConfigs/instantiate"] = buildconfiginstantiate.NewStorage(buildGenerator)
-		storage["buildConfigs/instantiatebinary"] = buildconfiginstantiate.NewBinaryStorage(buildGenerator, buildStorage, c.BuildLogClient(), nodeConnectionInfoGetter)
+		storage["buildConfigs/instantiate"] = buildConfigInstantiateStorage
+		storage["buildConfigs/instantiatebinary"] = buildConfigInstantiateBinaryStorage
 	}
 
 	return storage

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -712,7 +712,7 @@ func addAuthorizationListerWatchers(customListerWatchers shared.DefaultListerWat
 func newClusterPolicyLW(optsGetter restoptions.Getter) (cache.ListerWatcher, error) {
 	ctx := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
 
-	storage, err := clusterpolicyetcd.NewStorage(optsGetter)
+	storage, err := clusterpolicyetcd.NewREST(optsGetter)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +731,7 @@ func newClusterPolicyLW(optsGetter restoptions.Getter) (cache.ListerWatcher, err
 func newClusterPolicyBindingLW(optsGetter restoptions.Getter) (cache.ListerWatcher, error) {
 	ctx := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
 
-	storage, err := clusterpolicybindingetcd.NewStorage(optsGetter)
+	storage, err := clusterpolicybindingetcd.NewREST(optsGetter)
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +750,7 @@ func newClusterPolicyBindingLW(optsGetter restoptions.Getter) (cache.ListerWatch
 func newPolicyLW(optsGetter restoptions.Getter) (cache.ListerWatcher, error) {
 	ctx := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
 
-	storage, err := policyetcd.NewStorage(optsGetter)
+	storage, err := policyetcd.NewREST(optsGetter)
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +769,7 @@ func newPolicyLW(optsGetter restoptions.Getter) (cache.ListerWatcher, error) {
 func newPolicyBindingLW(optsGetter restoptions.Getter) (cache.ListerWatcher, error) {
 	ctx := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
 
-	storage, err := policybindingetcd.NewStorage(optsGetter)
+	storage, err := policybindingetcd.NewREST(optsGetter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/quota/registry/clusterresourcequota/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd.go
@@ -17,26 +17,22 @@ type REST struct {
 	*registry.Store
 }
 
-// NewStorage returns a RESTStorage object that will work against ClusterResourceQuota objects.
-func NewStorage(optsGetter restoptions.Getter) (*REST, error) {
+// NewREST returns a RESTStorage object that will work against nodes.
+func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 	store, err := makeStore(optsGetter)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	REST := REST{Store: store}
 
-	return &REST{Store: store}, nil
-}
+	statusStore := *store
+	statusStore.CreateStrategy = nil
+	statusStore.DeleteStrategy = nil
+	statusStore.UpdateStrategy = StatusStrategy
 
-func NewStatusStorage(optsGetter restoptions.Getter) (*StatusREST, error) {
-	store, err := makeStore(optsGetter)
-	if err != nil {
-		return nil, err
-	}
-	store.CreateStrategy = nil
-	store.DeleteStrategy = nil
-	store.UpdateStrategy = StatusStrategy
+	StatusREST := StatusREST{store: &statusStore}
 
-	return &StatusREST{store: store}, nil
+	return &REST, &StatusREST, nil
 }
 
 // StatusREST implements the REST endpoint for changing the status of a resourcequota.


### PR DESCRIPTION
**what this PR mainly does?**

1.in pkg/cmd/server/origin/master.go, i found that when geting REST objects, we use NewREST or NewStorage, i think we'd better keep the name consistent. this PR i use NewREST since most of them named NewREST. 

2.if two REST objects in a same file(same package), I wrap it in one method just like invocation `deployconfigetcd.NewREST` does.

3.when save all REST objects to `storage` map, use a variable instead of using a calling process just like most of them does which make the code clean.