### PR TITLE
add some optimiztion for new-build command

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -597,12 +597,12 @@ func (c *AppConfig) Run() (*AppResult, error) {
 	repositories := resolved.Repositories
 	components := resolved.Components
 
-	if err := c.validateBuilders(components); err != nil {
-		return nil, err
-	}
-
 	if len(repositories) == 0 && len(components) == 0 {
 		return nil, ErrNoInputs
+	}
+
+	if err := c.validateBuilders(components); err != nil {
+		return nil, err
 	}
 
 	if len(c.Name) > 0 {
@@ -647,9 +647,6 @@ func (c *AppConfig) Run() (*AppResult, error) {
 
 	pipelines, err := c.buildPipelines(components.ImageComponentRefs(), env)
 	if err != nil {
-		if err == app.ErrNameRequired {
-			return nil, errors.New("can't suggest a valid name, please specify a name with --name")
-		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<br />1. Checking of `repositories `and `components `should be called at before of calling `validateBuilders`<br /><br />2.  `err == app.ErrNameRequired ` is redundant, because `buildPipelines` will never return a error that equals 5to `ErrNameRequired `