### PR TITLE
Add missing arguments to glog.Infof

### DIFF
--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -74,7 +74,7 @@ func BuildRunPolicy(build *buildapi.Build) buildapi.BuildRunPolicy {
 			return buildapi.BuildRunPolicySerialLatestOnly
 		}
 	}
-	glog.V(5).Infof("Build %s/%s does not have start policy label set, using default (Serial)")
+	glog.V(5).Infof("Build %s/%s does not have start policy label set, using default (Serial)", build.Namespace, build.Name)
 	return buildapi.BuildRunPolicySerial
 }
 


### PR DESCRIPTION
Fixes following message appearing in the logs:
```
util.go:94] Build %!s(MISSING)/%!s(MISSING) does not have start policy label set, using default (Serial)
```

@bparees PTAL