### PR TITLE
Removed reference to gssapi variable

### DIFF
--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -24,7 +24,7 @@ function cleanup()
 		# use the junitreport tool to generate us a report
 		os::util::ensure::built_binary_exists 'junitreport'
 
-		cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
+		cat "${JUNIT_REPORT_OUTPUT}" \
 			| junitreport --type oscmd \
 			--suites nested \
 			--roots github.com/openshift/origin \

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -27,7 +27,7 @@ function cleanup()
 		# use the junitreport tool to generate us a report
 		os::util::ensure::built_binary_exists 'junitreport'
 
-		cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
+		cat "${JUNIT_REPORT_OUTPUT}" \
 			| junitreport --type oscmd \
 			--suites nested \
 			--roots github.com/openshift/origin \

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -27,7 +27,7 @@ function cleanup()
 		# use the junitreport tool to generate us a report
 		os::util::ensure::built_binary_exists 'junitreport'
 
-		cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
+		cat "${JUNIT_REPORT_OUTPUT}" \
 			| junitreport --type oscmd \
 			--suites nested \
 			--roots github.com/openshift/origin \

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -25,7 +25,7 @@ function cleanup()
 		# use the junitreport tool to generate us a report
 		os::util::ensure::built_binary_exists 'junitreport'
 
-		cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
+		cat "${JUNIT_REPORT_OUTPUT}" \
 			| junitreport --type oscmd \
 			--suites nested \
 			--roots github.com/openshift/origin \

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -57,7 +57,7 @@ function os::test::extended::setup () {
 				# use the junitreport tool to generate us a report
 				os::util::ensure::built_binary_exists 'junitreport'
 
-				cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
+				cat "${JUNIT_REPORT_OUTPUT}" \
 					| junitreport --type oscmd \
 					--suites nested \
 					--roots github.com/openshift/origin \


### PR DESCRIPTION
junit_gssapi_output was incorrectly used in some of the extended tests.
This removes that reference.

@stevekuznetsov ptal?