### PR TITLE
new-app: appropriately warn/error on circular builds

### DIFF
--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -264,6 +264,10 @@ os::cmd::expect_success_and_text 'oc new-build --name mybuild --binary --strateg
 os::cmd::expect_failure_and_text 'oc new-build mysql --source-image centos' 'error: --source-image-path must be specified when --source-image is specified.'
 os::cmd::expect_failure_and_text 'oc new-build mysql --source-image-path foo' 'error: --source-image must be specified when --source-image-path is specified.'
 
+# ensure circular ref flagged but allowed for template
+os::cmd::expect_success 'oc create -f test/testdata/circular-is.yaml'
+os::cmd::expect_success_and_text 'oc new-app -f test/testdata/circular.yaml' 'should be different than input'
+
 # do not allow use of non-existent image (should fail)
 os::cmd::expect_failure_and_text 'oc new-app  openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml' "no match for"
 # allow use of non-existent image (should succeed)

--- a/test/testdata/circular-is.yaml
+++ b/test/testdata/circular-is.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: newapp-circular-template
+  spec: {}
+kind: List
+metadata: {}

--- a/test/testdata/circular.yaml
+++ b/test/testdata/circular.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: circular
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: newapp-circular-template
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: newapp-circular-template:latest
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: newapp-circular-template:latest
+      type: Docker
+    triggers:
+    - github:
+        secret: faSaQS1VY-gdRMwge4eV
+      type: GitHub
+    - generic:
+        secret: u-_J-vtKR5K3GykKwCuK
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0


### PR DESCRIPTION
Bug 1393549
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1393549
Detailed explanation
Citing of cirular builds were performed for new-build but not new-app;
With new-app, if template, simply warn, if not template fail command

@csrwng PTAL