### PR TITLE
UPSTREAM: 38538: output "not patched" on object unchanged

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
@@ -17,11 +17,13 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -167,8 +169,9 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		}
 
 		if !options.Local {
+			dataChangeMsg := "not patched"
 			helper := resource.NewHelper(client, mapping)
-			_, err := helper.Patch(namespace, name, patchType, patchBytes)
+			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes)
 			if err != nil {
 				return err
 			}
@@ -184,8 +187,20 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			}
 			count++
 
+			oldData, err := json.Marshal(info.Object)
+			if err != nil {
+				return err
+			}
+			newData, err := json.Marshal(patchedObj)
+			if err != nil {
+				return err
+			}
+			if !reflect.DeepEqual(oldData, newData) {
+				dataChangeMsg = "patched"
+			}
+
 			if options.OutputFormat == "name" || len(options.OutputFormat) == 0 {
-				cmdutil.PrintSuccess(mapper, options.OutputFormat == "name", out, "", name, false, "patched")
+				cmdutil.PrintSuccess(mapper, options.OutputFormat == "name", out, "", name, false, dataChangeMsg)
 			}
 			return nil
 		}


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1311786
Related Upstream: https://github.com/kubernetes/kubernetes/pull/38538

This patch compares an original object against a patched object returned
from the server and only announces that the object was successfully
patched if the object returned from the server does not equal the
original object.

cc @openshift/cli-review 