### PR TITLE
Bug 1393716 - Fix network diagnostics on containerized openshift env

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -140,6 +140,7 @@ image "${tag_prefix}-docker-builder"        images/builder/docker/docker-builder
 image "${tag_prefix}-sti-builder"           images/builder/docker/sti-builder
 image "${tag_prefix}-f5-router"             images/router/f5
 image openshift/node                        images/node
+image openshift/diagnostics-deployer        images/diagnostics
 
 # extra images (not part of infrastructure)
 image openshift/hello-openshift       examples/hello-openshift

--- a/images/diagnostics/Dockerfile
+++ b/images/diagnostics/Dockerfile
@@ -1,0 +1,9 @@
+#
+# OpenShift diagnostics image
+# Used by network diagnostics (oadm diagnostics NetworkCheck)
+#
+# The standard name for this image is openshift/diagnostics-deployer
+
+FROM openshift/origin-base
+
+COPY scripts/openshift-network-debug /usr/bin/

--- a/images/diagnostics/scripts/openshift-network-debug
+++ b/images/diagnostics/scripts/openshift-network-debug
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# This script is used by network diagnostics.
+# Based on containerized/non-containerized openshift install,
+# it sets the environment so that docker, openshift, iptables, etc.
+# binaries are availble for network diagnostics.
+#
+set -o nounset
+set -o pipefail
+
+node_rootfs=$1
+shift
+cmd=$@
+
+# Origin image: openshift/node, OSE image: openshift3/node
+node_image_regex="^openshift.*/node"
+
+node_container_id="$(chroot "${node_rootfs}" docker ps --format='{{.Image}} {{.ID}}' | grep "${node_image_regex}" | cut -d' ' -f2)"
+
+if [[ -z "${node_container_id}" ]]; then # non-containerized openshift env
+
+    chroot "${node_rootfs}" ${cmd}
+
+else # containerized env
+
+    # On containerized install, docker on the host is used by node container,
+    # For the privileged network diagnostics pod to use all the binaries on the node:
+    # - Copy kubeconfig secret to node mount namespace
+    # - Run openshift under the mount namespace of node
+
+    node_docker_pid="$(chroot "${node_rootfs}" docker inspect --format='{{.State.Pid}}' "${node_container_id}")"
+    kubeconfig="/etc/origin/node/kubeconfig"
+    cp "${node_rootfs}/secrets/kubeconfig" "${node_rootfs}/${kubeconfig}"
+
+    chroot "${node_rootfs}" nsenter -m -t "${node_docker_pid}" -- sh -c 'KUBECONFIG='"${kubeconfig} ${cmd}"''
+
+fi


### PR DESCRIPTION
Added openshift/diagnostics-deployer image to set the environment needed for network diagnostics in case of containerized and non-containerized openshift.
This solution doesn't depend on docker storage driver on the node host.

Thanks @mrunalp for the help.