### PR TITLE
Prevent jenkins from being killed prematurely

### DIFF
--- a/examples/jenkins/jenkins-ephemeral-template.json
+++ b/examples/jenkins/jenkins-ephemeral-template.json
@@ -89,7 +89,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 120,
+                    "initialDelaySeconds": 420,
                     "failureThreshold" : 30,
                     "httpGet": {
                         "path": "/login",

--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -106,7 +106,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 120,
+                    "initialDelaySeconds": 420,
                     "failureThreshold" : 30,
                     "httpGet": {
                         "path": "/login",

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -3724,7 +3724,7 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 120,
+                    "initialDelaySeconds": 420,
                     "failureThreshold" : 30,
                     "httpGet": {
                         "path": "/login",
@@ -4033,7 +4033,7 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 120,
+                    "initialDelaySeconds": 420,
                     "failureThreshold" : 30,
                     "httpGet": {
                         "path": "/login",


### PR DESCRIPTION
## What was done

Changed initialDelaySeconds for livenessProbe in openshift-persistent template

## Definition of the problem

Jenkins template livenessProbe initial delay is too small and it's killing jenkins before it starts. 
Recent jenkins image requires lots of time to start on PV.
On my machine (MacPro 2015) it takes up to 6 minutes.

```
Dec 04, 2016 11:20:33 PM jenkins.InitReactorRunner$1 onAttained
INFO: Started initialization
Dec 04, 2016 11:26:05 PM jenkins.InitReactorRunner$1 onAttained
INFO: Listed all plugins
```
## Steps to replicate
```
oc cluster up
oc new-app -f ./jenkins-persistent-template.json
```

`livenessProbe` with only 2 minutes `initialDelaySeconds` is IMHO to small. I tested this on different machines etc. 

