### PR TITLE
update issue template from oadm

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@
 ##### Expected Result
 
 ##### Additional Information
-[try to run `$ oadm diagnostics` command if possible]
+[try to run `$ oadm diagnostics` or `oc adm diagnostics` command if possible]
 [if you are reporting issue related to builds, provide build logs with `BUILD_LOGLEVEL=5`]
 [consider attaching output of the `$ oc get all -o json -n <namespace>` command to the issue]
 [visit https://docs.openshift.org/latest/welcome/index.html]


### PR DESCRIPTION
`oadm` is replaced by `oc adm` in new version of `oc` so updating that in issue template.