### PR TITLE
UPSTREAM: 38525: Prevent json decoder panic

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/runtime/serializer/json/json.go
+++ b/vendor/k8s.io/kubernetes/pkg/runtime/serializer/json/json.go
@@ -194,7 +194,7 @@ func (s *Serializer) RecognizesData(peek io.Reader) (ok, unknown bool, err error
 		// we could potentially look for '---'
 		return false, true, nil
 	}
-	_, ok = utilyaml.GuessJSONStream(peek, 2048)
+	_, _, ok = utilyaml.GuessJSONStream(peek, 2048)
 	return ok, false, nil
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/util/yaml/decoder.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/yaml/decoder.go
@@ -181,6 +181,7 @@ type YAMLOrJSONDecoder struct {
 	bufferSize int
 
 	decoder decoder
+	rawData []byte
 }
 
 // NewYAMLOrJSONDecoder returns a decoder that will process YAML documents
@@ -198,10 +199,11 @@ func NewYAMLOrJSONDecoder(r io.Reader, bufferSize int) *YAMLOrJSONDecoder {
 // provide object, or returns an error.
 func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	if d.decoder == nil {
-		buffer, isJSON := GuessJSONStream(d.r, d.bufferSize)
+		buffer, origData, isJSON := GuessJSONStream(d.r, d.bufferSize)
 		if isJSON {
 			glog.V(4).Infof("decoding stream as JSON")
 			d.decoder = json.NewDecoder(buffer)
+			d.rawData = origData
 		} else {
 			glog.V(4).Infof("decoding stream as YAML")
 			d.decoder = NewYAMLToJSONDecoder(buffer)
@@ -215,6 +217,13 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 				glog.V(4).Infof("reading stream failed: %v", readErr)
 			}
 			js := string(data)
+
+			// if contents from io.Reader are not complete,
+			// use the original raw data to prevent panic
+			if int64(len(js)) <= syntax.Offset {
+				js = string(d.rawData)
+			}
+
 			start := strings.LastIndex(js[:syntax.Offset], "\n") + 1
 			line := strings.Count(js[:start], "\n")
 			return fmt.Errorf("json: line %d: %s", line, syntax.Error())
@@ -284,10 +293,10 @@ func (r *LineReader) Read() ([]byte, error) {
 // GuessJSONStream scans the provided reader up to size, looking
 // for an open brace indicating this is JSON. It will return the
 // bufio.Reader it creates for the consumer.
-func GuessJSONStream(r io.Reader, size int) (io.Reader, bool) {
+func GuessJSONStream(r io.Reader, size int) (io.Reader, []byte, bool) {
 	buffer := bufio.NewReaderSize(r, size)
 	b, _ := buffer.Peek(size)
-	return buffer, hasJSONPrefix(b)
+	return buffer, b, hasJSONPrefix(b)
 }
 
 var jsonPrefix = []byte("{")

--- a/vendor/k8s.io/kubernetes/pkg/util/yaml/decoder_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/yaml/decoder_test.go
@@ -65,7 +65,7 @@ func TestSplitYAMLDocument(t *testing.T) {
 }
 
 func TestGuessJSON(t *testing.T) {
-	if r, isJSON := GuessJSONStream(bytes.NewReader([]byte(" \n{}")), 100); !isJSON {
+	if r, _, isJSON := GuessJSONStream(bytes.NewReader([]byte(" \n{}")), 100); !isJSON {
 		t.Fatalf("expected stream to be JSON")
 	} else {
 		b := make([]byte, 30)


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/38525
Fixes: https://github.com/openshift/origin/issues/12132

This patch addresses an issue where json object data from a user input
would not persist when being decoded. This resulted in a panic when a
syntax error + line number were calculated.

**After**
```
> create filename with content:
{
"apiVersion": "v1",
"groupNames": null,
"kind": "RoleBinding",
"metadata": {
"labels": {
"group": "cicd",
"template": "cicd"
},
"name": "bkpadm_edit"
},
"roleRef": {
"name": "edit"
},
"subjects": [
{
"kind": "ServiceAccount",
"name": "bkpadm"
}
]
},

$ oc create -f filename.json
json: line 20: invalid character ',' looking for beginning of value
```

@openshift/cli-review 