### PR TITLE
UPSTREAM: 38196: fix mesos unit tests

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/client_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/client_test.go
@@ -56,9 +56,9 @@ const (
 				"cpus": 8
 			},
 			"registered_time": 1429456502.46999,
-			"pid": "slave(1)@mesos1.internal.company.com:5050",
+			"pid": "slave(1)@mesos1.internal.example.org.fail:5050",
 			"id": "20150419-081501-16777343-5050-16383-S2",
-			"hostname": "mesos1.internal.company.com",
+			"hostname": "mesos1.internal.example.org.fail",
 			"attributes": {},
 			"active": true
 		},
@@ -70,9 +70,9 @@ const (
 				"cpus": 8
 			},
 			"registered_time": 1429456502.4144,
-			"pid": "slave(1)@mesos2.internal.company.com:5050",
+			"pid": "slave(1)@mesos2.internal.example.org.fail:5050",
 			"id": "20150419-081501-16777343-5050-16383-S1",
-			"hostname": "mesos2.internal.company.com",
+			"hostname": "mesos2.internal.example.org.fail",
 			"attributes": {},
 			"active": true
 		},
@@ -84,17 +84,17 @@ const (
 				"cpus": 8
 			},
 			"registered_time": 1429456502.02879,
-			"pid": "slave(1)@mesos3.internal.company.com:5050",
+			"pid": "slave(1)@mesos3.internal.example.org.fail:5050",
 			"id": "20150419-081501-16777343-5050-16383-S0",
-			"hostname": "mesos3.internal.company.com",
+			"hostname": "mesos3.internal.example.org.fail",
 			"attributes": {},
 			"active": true
 		}
 		],
-		"pid": "master@mesos-master0.internal.company.com:5050",
+		"pid": "master@mesos-master0.internal.example.org.fail:5050",
 		"orphan_tasks": [],
 		"lost_tasks": 0,
-		"leader": "master@mesos-master0.internal.company.com:5050",
+		"leader": "master@mesos-master0.internal.example.org.fail:5050",
 		"killed_tasks": 0,
 		"failed_tasks": 0,
 		"elected_time": 1429456501.61638,
@@ -234,9 +234,9 @@ func Test_listSlaves(t *testing.T) {
 	}
 
 	expectedHostnames := map[string]struct{}{
-		"mesos1.internal.company.com": {},
-		"mesos2.internal.company.com": {},
-		"mesos3.internal.company.com": {},
+		"mesos1.internal.example.org.fail": {},
+		"mesos2.internal.example.org.fail": {},
+		"mesos3.internal.example.org.fail": {},
 	}
 
 	actualHostnames := make(map[string]struct{})

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/mesos_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/mesos_test.go
@@ -268,7 +268,7 @@ func Test_ExternalID(t *testing.T) {
 		t.Fatalf("ExternalID did not return InstanceNotFound on an unknown instance")
 	}
 
-	slaveName := "mesos3.internal.company.com"
+	slaveName := "mesos3.internal.example.org.fail"
 	id, err := mesosCloud.ExternalID(slaveName)
 	if id != "" {
 		t.Fatalf("ExternalID should not be able to resolve %q", slaveName)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/12157 which currently blocks the queue.
Upstream cherry-pick of https://github.com/kubernetes/kubernetes/pull/38196.

cc: @smarterclayton @mfojtik @deads2k @liggitt 

@ncdc I think the rebase will take a couple of days, or if you are so optimistic you can close this PR and pick the upstream change in yours. :)