### PR TITLE
Verify manifest before accepting

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -90,7 +90,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	}
 	os.Setenv("DOCKER_REGISTRY_URL", serverURL.Host)
 
-	desc, _, err := registrytest.UploadTestBlob(serverURL, "user/app")
+	desc, _, err := registrytest.UploadTestBlob(serverURL, nil, "user/app")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dockerregistry/server/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler.go
@@ -25,6 +25,9 @@ type ManifestHandler interface {
 	// Payload returns manifest's media type, complete payload with signatures and canonical payload without
 	// signatures or an error if the information could not be fetched.
 	Payload() (mediaType string, payload []byte, canonical []byte, err error)
+
+	// Verify returns an error if the contained manifest is not valid or has missing dependencies.
+	Verify(ctx context.Context, skipDependencyVerification bool) error
 }
 
 // NewManifestHandler creates a manifest handler for the given manifest.

--- a/pkg/dockerregistry/server/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+// A ManifestHandler defines a common set of operations on all versions of manifest schema.
+type ManifestHandler interface {
+	// FillImageMetadata fills a given image with metadata parsed from manifest. It also corrects layer sizes
+	// with blob sizes. Newer Docker client versions don't set layer sizes in the manifest schema 1 at all.
+	// Origin master needs correct layer sizes for proper image quota support. That's why we need to fill the
+	// metadata in the registry.
+	FillImageMetadata(ctx context.Context, image *imageapi.Image) error
+
+	// Manifest returns a deserialized manifest object.
+	Manifest() distribution.Manifest
+
+	// Payload returns manifest's media type, complete payload with signatures and canonical payload without
+	// signatures or an error if the information could not be fetched.
+	Payload() (mediaType string, payload []byte, canonical []byte, err error)
+}
+
+// NewManifestHandler creates a manifest handler for the given manifest.
+func NewManifestHandler(repo *repository, manifest distribution.Manifest) (ManifestHandler, error) {
+	switch t := manifest.(type) {
+	case *schema1.SignedManifest:
+		return &manifestSchema1Handler{repo: repo, manifest: t}, nil
+	case *schema2.DeserializedManifest:
+		return &manifestSchema2Handler{repo: repo, manifest: t}, nil
+	default:
+		return nil, fmt.Errorf("unsupported manifest type %T", manifest)
+	}
+}
+
+// NewManifestHandlerFromImage creates a new manifest handler for a manifest stored in the given image.
+func NewManifestHandlerFromImage(repo *repository, image *imageapi.Image) (ManifestHandler, error) {
+	var (
+		manifest distribution.Manifest
+		err      error
+	)
+
+	switch image.DockerImageManifestMediaType {
+	case "", schema1.MediaTypeManifest:
+		manifest, err = unmarshalManifestSchema1([]byte(image.DockerImageManifest), image.DockerImageSignatures)
+	case schema2.MediaTypeManifest:
+		manifest, err = unmarshalManifestSchema2([]byte(image.DockerImageManifest))
+	default:
+		return nil, fmt.Errorf("unsupported manifest media type %s", image.DockerImageManifestMediaType)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewManifestHandler(repo, manifest)
+}

--- a/pkg/dockerregistry/server/manifestschema1handler.go
+++ b/pkg/dockerregistry/server/manifestschema1handler.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
+	"path"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/libtrust"
 
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -102,4 +105,70 @@ func (h *manifestSchema1Handler) Manifest() distribution.Manifest {
 func (h *manifestSchema1Handler) Payload() (mediaType string, payload []byte, canonical []byte, err error) {
 	mt, payload, err := h.manifest.Payload()
 	return mt, payload, h.manifest.Canonical, err
+}
+
+func (h *manifestSchema1Handler) Verify(ctx context.Context, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	// we want to verify that referenced blobs exist locally - thus using upstream repository object directly
+	repo := h.repo.Repository
+
+	if len(path.Join(h.repo.registryAddr, h.manifest.Name)) > reference.NameTotalLengthMax {
+		errs = append(errs,
+			distribution.ErrManifestNameInvalid{
+				Name:   h.manifest.Name,
+				Reason: fmt.Errorf("<registry-host>/<manifest-name> must not be more than %d characters", reference.NameTotalLengthMax),
+			})
+	}
+
+	if !reference.NameRegexp.MatchString(h.manifest.Name) {
+		errs = append(errs,
+			distribution.ErrManifestNameInvalid{
+				Name:   h.manifest.Name,
+				Reason: fmt.Errorf("invalid manifest name format"),
+			})
+	}
+
+	if len(h.manifest.History) != len(h.manifest.FSLayers) {
+		errs = append(errs, fmt.Errorf("mismatched history and fslayer cardinality %d != %d",
+			len(h.manifest.History), len(h.manifest.FSLayers)))
+	}
+
+	if _, err := schema1.Verify(h.manifest); err != nil {
+		switch err {
+		case libtrust.ErrMissingSignatureKey, libtrust.ErrInvalidJSONContent, libtrust.ErrMissingSignatureKey:
+			errs = append(errs, distribution.ErrManifestUnverified{})
+		default:
+			if err.Error() == "invalid signature" {
+				errs = append(errs, distribution.ErrManifestUnverified{})
+			} else {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	if skipDependencyVerification {
+		if len(errs) > 0 {
+			return errs
+		}
+		return nil
+	}
+
+	for _, fsLayer := range h.manifest.References() {
+		_, err := repo.Blobs(ctx).Stat(ctx, fsLayer.Digest)
+		if err != nil {
+			if err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+				continue
+			}
+
+			// On error here, we always append unknown blob errors.
+			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: fsLayer.Digest})
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
 }

--- a/pkg/dockerregistry/server/manifestschema1handler.go
+++ b/pkg/dockerregistry/server/manifestschema1handler.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"encoding/json"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/libtrust"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func unmarshalManifestSchema1(content []byte, signatures [][]byte) (distribution.Manifest, error) {
+	// prefer signatures from the manifest
+	if _, err := libtrust.ParsePrettySignature(content, "signatures"); err == nil {
+		sm := schema1.SignedManifest{Canonical: content}
+		if err = json.Unmarshal(content, &sm); err == nil {
+			return &sm, nil
+		}
+	}
+
+	jsig, err := libtrust.NewJSONSignature(content, signatures...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the pretty JWS
+	content, err = jsig.PrettySignature("signatures")
+	if err != nil {
+		return nil, err
+	}
+
+	var sm schema1.SignedManifest
+	if err = json.Unmarshal(content, &sm); err != nil {
+		return nil, err
+	}
+	return &sm, nil
+}
+
+type manifestSchema1Handler struct {
+	repo     *repository
+	manifest *schema1.SignedManifest
+}
+
+var _ ManifestHandler = &manifestSchema1Handler{}
+
+func (h *manifestSchema1Handler) FillImageMetadata(ctx context.Context, image *imageapi.Image) error {
+	signatures, err := h.manifest.Signatures()
+	if err != nil {
+		return err
+	}
+
+	for _, signDigest := range signatures {
+		image.DockerImageSignatures = append(image.DockerImageSignatures, signDigest)
+	}
+
+	if err := imageapi.ImageWithMetadata(image); err != nil {
+		return err
+	}
+
+	refs := h.manifest.References()
+
+	blobSet := sets.NewString()
+	image.DockerImageMetadata.Size = int64(0)
+
+	blobs := h.repo.Blobs(ctx)
+	for i := range image.DockerImageLayers {
+		layer := &image.DockerImageLayers[i]
+		// DockerImageLayers represents h.manifest.Manifest.FSLayers in reversed order
+		desc, err := blobs.Stat(ctx, refs[len(image.DockerImageLayers)-i-1].Digest)
+		if err != nil {
+			context.GetLogger(ctx).Errorf("failed to stat blob %s of image %s", layer.Name, image.DockerImageReference)
+			return err
+		}
+		// The MediaType appeared in manifest schema v2. We need to fill it
+		// manually in the old images if it is not already filled.
+		if len(layer.MediaType) == 0 {
+			if len(desc.MediaType) > 0 {
+				layer.MediaType = desc.MediaType
+			} else {
+				layer.MediaType = schema1.MediaTypeManifestLayer
+			}
+		}
+		layer.LayerSize = desc.Size
+		// count empty layer just once (empty layer may actually have non-zero size)
+		if !blobSet.Has(layer.Name) {
+			image.DockerImageMetadata.Size += desc.Size
+			blobSet.Insert(layer.Name)
+		}
+	}
+
+	return nil
+}
+
+func (h *manifestSchema1Handler) Manifest() distribution.Manifest {
+	return h.manifest
+}
+
+func (h *manifestSchema1Handler) Payload() (mediaType string, payload []byte, canonical []byte, err error) {
+	mt, payload, err := h.manifest.Payload()
+	return mt, payload, h.manifest.Canonical, err
+}

--- a/pkg/dockerregistry/server/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifestschema2handler.go
@@ -2,12 +2,18 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema2"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+var (
+	errMissingURL    = errors.New("missing URL on layer")
+	errUnexpectedURL = errors.New("unexpected URL on layer")
 )
 
 func unmarshalManifestSchema2(content []byte) (distribution.Manifest, error) {
@@ -50,4 +56,57 @@ func (h *manifestSchema2Handler) Manifest() distribution.Manifest {
 func (h *manifestSchema2Handler) Payload() (mediaType string, payload []byte, canonical []byte, err error) {
 	mt, p, err := h.manifest.Payload()
 	return mt, p, p, err
+}
+
+func (h *manifestSchema2Handler) Verify(ctx context.Context, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	if skipDependencyVerification {
+		return nil
+	}
+
+	// we want to verify that referenced blobs exist locally - thus using upstream repository object directly
+	repo := h.repo.Repository
+
+	target := h.manifest.Target()
+	_, err := repo.Blobs(ctx).Stat(ctx, target.Digest)
+	if err != nil {
+		if err != distribution.ErrBlobUnknown {
+			errs = append(errs, err)
+		}
+
+		// On error here, we always append unknown blob errors.
+		errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: target.Digest})
+	}
+
+	for _, fsLayer := range h.manifest.References() {
+		var err error
+		if fsLayer.MediaType != schema2.MediaTypeForeignLayer {
+			if len(fsLayer.URLs) == 0 {
+				_, err = repo.Blobs(ctx).Stat(ctx, fsLayer.Digest)
+			} else {
+				err = errUnexpectedURL
+			}
+		} else {
+			// Clients download this layer from an external URL, so do not check for
+			// its presense.
+			if len(fsLayer.URLs) == 0 {
+				err = errMissingURL
+			}
+		}
+		if err != nil {
+			if err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+				continue
+			}
+
+			// On error here, we always append unknown blob errors.
+			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: fsLayer.Digest})
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
 }

--- a/pkg/dockerregistry/server/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifestschema2handler.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"encoding/json"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/schema2"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func unmarshalManifestSchema2(content []byte) (distribution.Manifest, error) {
+	var deserializedManifest schema2.DeserializedManifest
+	if err := json.Unmarshal(content, &deserializedManifest); err != nil {
+		return nil, err
+	}
+
+	return &deserializedManifest, nil
+}
+
+type manifestSchema2Handler struct {
+	repo     *repository
+	manifest *schema2.DeserializedManifest
+}
+
+var _ ManifestHandler = &manifestSchema2Handler{}
+
+func (h *manifestSchema2Handler) FillImageMetadata(ctx context.Context, image *imageapi.Image) error {
+	// The manifest.Config references a configuration object for a container by its digest.
+	// It needs to be fetched in order to fill an image object metadata below.
+	configBytes, err := h.repo.Blobs(ctx).Get(ctx, h.manifest.Config.Digest)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("failed to get image config %s: %v", h.manifest.Config.Digest.String(), err)
+		return err
+	}
+	image.DockerImageConfig = string(configBytes)
+
+	if err := imageapi.ImageWithMetadata(image); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *manifestSchema2Handler) Manifest() distribution.Manifest {
+	return h.manifest
+}
+
+func (h *manifestSchema2Handler) Payload() (mediaType string, payload []byte, canonical []byte, err error) {
+	mt, p, err := h.manifest.Payload()
+	return mt, p, p, err
+}

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -88,11 +88,11 @@ func TestPullthroughServeBlob(t *testing.T) {
 
 	client.AddReactor("get", "imagestreams", imagetest.GetFakeImageStreamGetHandler(t, *testImageStream))
 
-	blob1Desc, blob1Content, err := registrytest.UploadTestBlob(serverURL, "user/app")
+	blob1Desc, blob1Content, err := registrytest.UploadTestBlob(serverURL, nil, "user/app")
 	if err != nil {
 		t.Fatal(err)
 	}
-	blob2Desc, blob2Content, err := registrytest.UploadTestBlob(serverURL, "user/app")
+	blob2Desc, blob2Content, err := registrytest.UploadTestBlob(serverURL, nil, "user/app")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -326,9 +326,16 @@ func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, op
 		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
 	}
 
+	// this is fast to check, let's do it before verification
 	if !r.acceptschema2 && mediaType == schema2.MediaTypeManifest {
 		err = fmt.Errorf("manifest V2 schema 2 not allowed")
 		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
+	}
+
+	// in order to stat the referenced blobs, repository need to be set on the context
+	ctx = WithRepository(ctx, r)
+	if err := mh.Verify(ctx, false); err != nil {
+		return "", err
 	}
 
 	// Calculate digest

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,17 +10,14 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	regapi "github.com/docker/distribution/registry/api/v2"
 	repomw "github.com/docker/distribution/registry/middleware/repository"
-	"github.com/docker/libtrust"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -321,29 +317,18 @@ func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, op
 		return "", err
 	}
 
-	var canonical []byte
-
-	// Resolve the payload in the manifest.
-	mediatype, payload, err := manifest.Payload()
+	mh, err := NewManifestHandler(r, manifest)
 	if err != nil {
-		return "", err
+		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
 	}
-
-	switch manifest.(type) {
-	case *schema1.SignedManifest:
-		canonical = manifest.(*schema1.SignedManifest).Canonical
-	case *schema2.DeserializedManifest:
-		canonical = payload
-	default:
-		err = fmt.Errorf("unrecognized manifest type %T", manifest)
+	mediaType, payload, canonical, err := mh.Payload()
+	if err != nil {
 		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
 	}
 
-	if !r.acceptschema2 {
-		if _, ok := manifest.(*schema1.SignedManifest); !ok {
-			err = fmt.Errorf("schema version 2 disabled")
-			return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
-		}
+	if !r.acceptschema2 && mediaType == schema2.MediaTypeManifest {
+		err = fmt.Errorf("manifest V2 schema 2 not allowed")
+		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
 	}
 
 	// Calculate digest
@@ -364,7 +349,7 @@ func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, op
 			},
 			DockerImageReference:         fmt.Sprintf("%s/%s/%s@%s", r.registryAddr, r.namespace, r.name, dgst.String()),
 			DockerImageManifest:          string(payload),
-			DockerImageManifestMediaType: mediatype,
+			DockerImageManifestMediaType: mediaType,
 		},
 	}
 
@@ -375,7 +360,7 @@ func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, op
 		}
 	}
 
-	if err = r.fillImageWithMetadata(manifest, &ism.Image); err != nil {
+	if err = mh.FillImageMetadata(ctx, &ism.Image); err != nil {
 		return "", err
 	}
 
@@ -431,89 +416,6 @@ func (r *repository) Put(ctx context.Context, manifest distribution.Manifest, op
 	}
 
 	return dgst, nil
-}
-
-// fillImageWithMetadata fills a given image with metadata.
-func (r *repository) fillImageWithMetadata(manifest distribution.Manifest, image *imageapi.Image) error {
-	if deserializedManifest, ok := manifest.(*schema2.DeserializedManifest); ok {
-		r.deserializedManifestFillImageMetadata(deserializedManifest, image)
-	} else if signedManifest, ok := manifest.(*schema1.SignedManifest); ok {
-		r.signedManifestFillImageMetadata(signedManifest, image)
-	} else {
-		return fmt.Errorf("unrecognized manifest type %T", manifest)
-	}
-
-	context.GetLogger(r.ctx).Infof("total size of image %s with docker ref %s: %d", image.Name, image.DockerImageReference, image.DockerImageMetadata.Size)
-	return nil
-}
-
-// signedManifestFillImageMetadata fills a given image with metadata. It also corrects layer sizes with blob sizes. Newer
-// Docker client versions don't set layer sizes in the manifest at all. Origin master needs correct layer
-// sizes for proper image quota support. That's why we need to fill the metadata in the registry.
-func (r *repository) signedManifestFillImageMetadata(manifest *schema1.SignedManifest, image *imageapi.Image) error {
-	signatures, err := manifest.Signatures()
-	if err != nil {
-		return err
-	}
-
-	for _, signDigest := range signatures {
-		image.DockerImageSignatures = append(image.DockerImageSignatures, signDigest)
-	}
-
-	if err := imageapi.ImageWithMetadata(image); err != nil {
-		return err
-	}
-
-	refs := manifest.References()
-
-	blobSet := sets.NewString()
-	image.DockerImageMetadata.Size = int64(0)
-
-	blobs := r.Blobs(r.ctx)
-	for i := range image.DockerImageLayers {
-		layer := &image.DockerImageLayers[i]
-		// DockerImageLayers represents manifest.Manifest.FSLayers in reversed order
-		desc, err := blobs.Stat(r.ctx, refs[len(image.DockerImageLayers)-i-1].Digest)
-		if err != nil {
-			context.GetLogger(r.ctx).Errorf("failed to stat blobs %s of image %s", layer.Name, image.DockerImageReference)
-			return err
-		}
-		if layer.MediaType == "" {
-			if desc.MediaType != "" {
-				layer.MediaType = desc.MediaType
-			} else {
-				layer.MediaType = schema1.MediaTypeManifestLayer
-			}
-		}
-		layer.LayerSize = desc.Size
-		// count empty layer just once (empty layer may actually have non-zero size)
-		if !blobSet.Has(layer.Name) {
-			image.DockerImageMetadata.Size += desc.Size
-			blobSet.Insert(layer.Name)
-		}
-	}
-	if len(image.DockerImageConfig) > 0 && !blobSet.Has(image.DockerImageMetadata.ID) {
-		blobSet.Insert(image.DockerImageMetadata.ID)
-		image.DockerImageMetadata.Size += int64(len(image.DockerImageConfig))
-	}
-
-	return nil
-}
-
-// deserializedManifestFillImageMetadata fills a given image with metadata.
-func (r *repository) deserializedManifestFillImageMetadata(manifest *schema2.DeserializedManifest, image *imageapi.Image) error {
-	configBytes, err := r.Blobs(r.ctx).Get(r.ctx, manifest.Config.Digest)
-	if err != nil {
-		context.GetLogger(r.ctx).Errorf("failed to get image config %s: %v", manifest.Config.Digest.String(), err)
-		return err
-	}
-	image.DockerImageConfig = string(configBytes)
-
-	if err := imageapi.ImageWithMetadata(image); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Delete deletes the manifest with digest `dgst`. Note: Image resources
@@ -578,12 +480,12 @@ func (r *repository) rememberLayersOfImage(image *imageapi.Image, cacheName stri
 		return
 	}
 
-	manifest, err := r.getManifestFromImage(image)
+	mh, err := NewManifestHandlerFromImage(r, image)
 	if err != nil {
 		context.GetLogger(r.ctx).Errorf("cannot remember layers of image %q: %v", image.Name, err)
 		return
 	}
-	r.rememberLayersOfManifest(manifest, cacheName)
+	r.rememberLayersOfManifest(mh.Manifest(), cacheName)
 }
 
 // rememberLayersOfManifest caches the layer digests of given manifest
@@ -596,74 +498,14 @@ func (r *repository) rememberLayersOfManifest(manifest distribution.Manifest, ca
 
 // manifestFromImageWithCachedLayers loads the image and then caches any located layers
 func (r *repository) manifestFromImageWithCachedLayers(image *imageapi.Image, cacheName string) (manifest distribution.Manifest, err error) {
-	manifest, err = r.getManifestFromImage(image)
+	mh, err := NewManifestHandlerFromImage(r, image)
 	if err != nil {
 		return
 	}
 
+	manifest = mh.Manifest()
 	r.rememberLayersOfManifest(manifest, cacheName)
 	return
-}
-
-// getManifestFromImage returns a manifest object constructed from a blob stored in the given image.
-func (r *repository) getManifestFromImage(image *imageapi.Image) (manifest distribution.Manifest, err error) {
-	switch image.DockerImageManifestMediaType {
-	case schema2.MediaTypeManifest:
-		manifest, err = deserializedManifestFromImage(image)
-	case schema1.MediaTypeManifest, "":
-		manifest, err = r.signedManifestFromImage(image)
-	default:
-		err = regapi.ErrorCodeManifestInvalid.WithDetail(fmt.Errorf("unknown manifest media type %q", image.DockerImageManifestMediaType))
-	}
-	return
-}
-
-// signedManifestFromImage converts an Image to a SignedManifest.
-func (r *repository) signedManifestFromImage(image *imageapi.Image) (*schema1.SignedManifest, error) {
-	if image.DockerImageManifestMediaType == schema2.MediaTypeManifest {
-		context.GetLogger(r.ctx).Errorf("old client pulling new image %s", image.DockerImageReference)
-		return nil, fmt.Errorf("unable to convert new image to old one")
-	}
-
-	raw := []byte(image.DockerImageManifest)
-	// prefer signatures from the manifest
-	if _, err := libtrust.ParsePrettySignature(raw, "signatures"); err == nil {
-		sm := schema1.SignedManifest{Canonical: raw}
-		if err = json.Unmarshal(raw, &sm); err == nil {
-			return &sm, nil
-		}
-	}
-
-	var signBytes [][]byte
-	for _, sign := range image.DockerImageSignatures {
-		signBytes = append(signBytes, sign)
-	}
-
-	jsig, err := libtrust.NewJSONSignature(raw, signBytes...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Extract the pretty JWS
-	raw, err = jsig.PrettySignature("signatures")
-	if err != nil {
-		return nil, err
-	}
-
-	var sm schema1.SignedManifest
-	if err = json.Unmarshal(raw, &sm); err != nil {
-		return nil, err
-	}
-	return &sm, err
-}
-
-// deserializedManifestFromImage converts an Image to a DeserializedManifest.
-func (r *repository) deserializedManifestFromImage(image *imageapi.Image) (*schema2.DeserializedManifest, error) {
-	var manifest schema2.DeserializedManifest
-	if err := json.Unmarshal([]byte(image.DockerImageManifest), &manifest); err != nil {
-		return nil, err
-	}
-	return &manifest, nil
 }
 
 func (r *repository) checkPendingErrors(ctx context.Context) error {

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -139,10 +139,10 @@ os::log::info "Pushed ruby-22-centos7"
 
 # get image's digest
 rubyimagedigest="$(oc get -o jsonpath='{.status.tags[?(@.tag=="latest")].items[0].image}' is/ruby-22-centos7)"
-os::log::info "Ruby image digest: $rubyimagedigest"
+os::log::info "Ruby image digest: ${rubyimagedigest}"
 # get a random, non-empty blob
 rubyimageblob="$(oc get isimage -o go-template='{{range .image.dockerImageLayers}}{{if gt .size 1024.}}{{.name}},{{end}}{{end}}' "ruby-22-centos7@${rubyimagedigest}" | cut -d , -f 1)"
-os::log::info "Ruby's testing blob digest: $rubyimageblob"
+os::log::info "Ruby's testing blob digest: ${rubyimageblob}"
 
 # verify remote images can be pulled directly from the local registry
 os::log::info "Docker pullthrough"
@@ -153,6 +153,24 @@ mysqlblob="$(oc get istag -o go-template='{{range .image.dockerImageLayers}}{{if
 os::cmd::expect_success "curl -H 'Authorization: bearer $(oc whoami -t)' 'http://${DOCKER_REGISTRY}/v2/cache/mysql/blobs/${mysqlblob}' 1>/dev/null"
 # verify the blob exists on disk in the registry due to mirroring under .../blobs/sha256/<2 char prefix>/<sha value>
 os::cmd::try_until_success "oc exec --context='${CLUSTER_ADMIN_CONTEXT}' -n default -p '${registry_pod}' du /registry | tee '${LOG_DIR}/registry-images.txt' | grep '${mysqlblob:7:100}' | grep blobs"
+
+os::log::info "Docker registry refuses manifest with missing dependencies"
+os::cmd::expect_success 'oc new-project verify-manifest'
+os::cmd::expect_success "oc get -o jsonpath=$'{.dockerImageManifest}\n' 'image/${rubyimagedigest}' --context="${CLUSTER_ADMIN_CONTEXT}" >'${ARTIFACT_DIR}/rubyimagemanifest.json'"
+os::cmd::expect_success "curl --head                                                \
+    --silent                                                                        \
+    --request PUT                                                                   \
+    --header 'Content-Type: application/vnd.docker.distribution.manifest.v1+json'   \
+    --user 'e2e_user:${e2e_user_token}'                                             \
+    --upload-file '${ARTIFACT_DIR}/rubyimagemanifest.json'                          \
+    'http://${DOCKER_REGISTRY}/v2/verify-manifest/ruby-22-centos7/manifests/latest' \
+    >'${ARTIFACT_DIR}/curl-ruby-manifest-put.txt'"
+os::cmd::expect_success_and_text "cat '${ARTIFACT_DIR}/curl-ruby-manifest-put.txt'" '400 Bad Request'
+os::cmd::expect_success_and_text "cat '${ARTIFACT_DIR}/curl-ruby-manifest-put.txt'" '"errors":.*MANIFEST_BLOB_UNKNOWN'
+os::cmd::expect_success_and_text "cat '${ARTIFACT_DIR}/curl-ruby-manifest-put.txt'" '"errors":.*blob unknown to registry'
+os::log::info "Docker registry successfuly refused manifest with missing dependencies"
+
+os::cmd::expect_success 'oc project cache'
 
 os::log::info "Docker registry start with GCS"
 os::cmd::expect_failure_and_text "docker run -e REGISTRY_STORAGE=\"gcs: {}\" openshift/origin-docker-registry:${TAG}" "No bucket parameter provided"

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -22,15 +23,23 @@ import (
 	"github.com/openshift/origin/pkg/cmd/dockerregistry"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	registryutil "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
-func signedManifest(name string) ([]byte, digest.Digest, error) {
+func signedManifest(name string, blobs []digest.Digest) ([]byte, digest.Digest, error) {
 	key, err := libtrust.GenerateECP256PrivateKey()
 	if err != nil {
 		return []byte{}, "", fmt.Errorf("error generating EC key: %s", err)
+	}
+
+	history := make([]schema1.History, 0, len(blobs))
+	fsLayers := make([]schema1.FSLayer, 0, len(blobs))
+	for _, b := range blobs {
+		history = append(history, schema1.History{V1Compatibility: `{"id": "foo"}`})
+		fsLayers = append(fsLayers, schema1.FSLayer{BlobSum: b})
 	}
 
 	mappingManifest := schema1.Manifest{
@@ -40,11 +49,8 @@ func signedManifest(name string) ([]byte, digest.Digest, error) {
 		Name:         name,
 		Tag:          imageapi.DefaultImageTag,
 		Architecture: "amd64",
-		History: []schema1.History{
-			{
-				V1Compatibility: `{"id": "foo"}`,
-			},
-		},
+		History:      history,
+		FSLayers:     fsLayers,
 	}
 
 	manifestBytes, err := json.MarshalIndent(mappingManifest, "", "    ")
@@ -264,8 +270,14 @@ middleware:
 }
 
 func putManifest(name, user, token string) (digest.Digest, error) {
+	creds := registryutil.NewBasicCredentialStore(user, token)
+	desc, _, err := registryutil.UploadTestBlob(&url.URL{Host: "127.0.0.1:5000", Scheme: "http"}, creds, testutil.Namespace()+"/"+name)
+	if err != nil {
+		return "", err
+	}
+
 	putUrl := fmt.Sprintf("http://127.0.0.1:5000/v2/%s/%s/manifests/%s", testutil.Namespace(), name, imageapi.DefaultImageTag)
-	signedManifest, dgst, err := signedManifest(fmt.Sprintf("%s/%s", testutil.Namespace(), name))
+	signedManifest, dgst, err := signedManifest(fmt.Sprintf("%s/%s", testutil.Namespace(), name), []digest.Digest{desc.Digest})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Referenced blobs need to be checked for presence in a destination repository before accepting incoming manifest. Otherwise, user will be able to pull image without previous access to its blobs.

Resolves [bz#1388018](https://bugzilla.redhat.com/show_bug.cgi?id=1388018)

Blocked on #11925 