### PR TITLE
oc cluster up: fix hang on cat of host tcp ports

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -49,6 +49,7 @@ var (
 	RouterPorts           = []int{80, 443}
 	DefaultPorts          = append(BasePorts, DefaultDNSPort)
 	PortsWithAlternateDNS = append(BasePorts, AlternateDNSPort)
+	AllPorts              = append(append(RouterPorts, DefaultPorts...), AlternateDNSPort)
 	SocatPidFile          = filepath.Join(homedir.HomeDir(), cliconfig.OpenShiftConfigHomeDir, "socat-8443.pid")
 )
 


### PR DESCRIPTION
Adds an input stream to the call to run the container that will
output the tcp connection information from the host. This prevents
a hang when the attach occurs after the container has completed.

Fixes #9470