### PR TITLE
Add hack/build-dind-images.sh

### DIFF
--- a/hack/build-dind-images.sh
+++ b/hack/build-dind-images.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script builds the dind images so they can be baked into the ami
+# to reduce minimize the potential for dnf flakes in ci.
+#
+# Reference: https://github.com/openshift/origin/issues/11452
+
+STARTTIME=$(date +%s)
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+os::build::image "${OS_ROOT}/images/dind"        openshift/dind
+os::build::image "${OS_ROOT}/images/dind/node"   openshift/dind-node
+os::build::image "${OS_ROOT}/images/dind/master" openshift/dind-master
+
+ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -72,7 +72,8 @@ RUN systemctl enable docker.service
 RUN echo "DOCKER_STORAGE_OPTIONS=--storage-driver vfs" >\
  /etc/sysconfig/docker-storage
 
-COPY dind-setup.sh /usr/local/bin
+RUN mkdir -p /usr/local/bin
+COPY dind-setup.sh /usr/local/bin/
 COPY dind-setup.service /etc/systemd/system/
 RUN systemctl enable dind-setup.service
 


### PR DESCRIPTION
Building the dind images as part of a ci job is a frequent source of flakes caused by package installation failure via dnf.  This change ensures the dind images are built by hack/build-base-images.sh so they can be baked into the ami.

Intended to help with #11452.

cc: @stevekuznetsov @openshift/networking 