### PR TITLE
sdn: fix multi-master race by getting HostSubnets from event queue store

### DIFF
--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -39,7 +39,7 @@ func (plugin *OsdnNode) SetupEgressNetworkPolicy() error {
 }
 
 func (plugin *OsdnNode) watchEgressNetworkPolicies() {
-	RunEventQueue(plugin.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(nil, plugin.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 
 		vnid, err := plugin.vnids.GetVNID(policy.Namespace)

--- a/pkg/sdn/plugin/eventqueue_test.go
+++ b/pkg/sdn/plugin/eventqueue_test.go
@@ -504,7 +504,7 @@ func TestEventQueueCompress(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		queue := NewEventQueue(testKeyFunc)
+		queue, _ := NewEventQueue(testKeyFunc)
 
 		panicked, msg := addInitialDeltas(queue, test.initial)
 		if panicked != test.expectPanic {
@@ -546,7 +546,7 @@ func TestEventQueueUncompressed(t *testing.T) {
 	obj := "obj1"
 
 	for _, dtype := range []cache.DeltaType{cache.Added, cache.Updated, cache.Deleted, cache.Sync} {
-		queue := NewEventQueue(testKeyFunc)
+		queue, _ := NewEventQueue(testKeyFunc)
 
 		// Deleted requires the object to already be in the known objects
 		// list, and we must pop that cache.Added off before testing
@@ -600,7 +600,7 @@ func TestEventQueueUncompressed(t *testing.T) {
 
 // Test that DeletedFinalStateUnknown objects are handled correctly
 func TestEventQueueDeletedFinalStateUnknown(t *testing.T) {
-	queue := NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
+	queue, _ := NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
 
 	obj1 := &api.ObjectMeta{Name: "obj1", Namespace: "namespace1"}
 	obj2 := &api.ObjectMeta{Name: "obj2", Namespace: "namespace1"}
@@ -635,7 +635,7 @@ func TestEventQueueDeletedFinalStateUnknown(t *testing.T) {
 	}
 
 	// Repeat but this time make sure we get the objects we want, not DeletedFinalStateUnknown
-	queue = NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
+	queue, _ = NewEventQueue(DeletionHandlingMetaNamespaceKeyFunc)
 	queue.knownObjects.Add(obj1)
 	queue.knownObjects.Add(obj2)
 

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -13,16 +13,20 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiunversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	kcache "k8s.io/kubernetes/pkg/client/cache"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 type OsdnMaster struct {
-	kClient         *kclientset.Clientset
-	osClient        *osclient.Client
-	networkInfo     *NetworkInfo
+	kClient     *kclientset.Clientset
+	osClient    *osclient.Client
+	networkInfo *NetworkInfo
+	vnids       *masterVNIDMap
+
 	subnetAllocator *netutils.SubnetAllocator
-	vnids           *masterVNIDMap
+	subnetQueue     *EventQueue
+	subnetStore     kcache.Store
 }
 
 func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclient.Client, kClient *kclientset.Clientset) error {

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -69,7 +69,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsConfigHandler) error 
 }
 
 func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
-	RunEventQueue(proxy.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
+	RunEventQueue(nil, proxy.osClient, EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*osapi.EgressNetworkPolicy)
 		if delta.Type == cache.Deleted {
 			policy.Spec.Egress = nil

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -41,19 +41,39 @@ func (master *OsdnMaster) SubnetStartMaster(clusterNetwork *net.IPNet, hostSubne
 		return err
 	}
 
+	master.subnetQueue, master.subnetStore = NewSDNEventQueue()
+
 	go utilwait.Forever(master.watchNodes, 0)
 	go utilwait.Forever(master.watchSubnets, 0)
 	return nil
 }
 
-func (master *OsdnMaster) addNode(nodeName string, nodeIP string, hsAnnotations map[string]string) error {
+func (master *OsdnMaster) getHostSubnetFromStore(nodeName string) (*osapi.HostSubnet, error) {
+	// Neither nodes or HostSubnets are namespaced, so we can abuse
+	// the fact that the Store's keyFunc uses only the name as the key
+	item, exists, err := master.subnetStore.GetByKey(nodeName)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, fmt.Errorf("no HostSubnet found for node %s", nodeName)
+	}
+
+	subnet, ok := item.(*osapi.HostSubnet)
+	if !ok {
+		return nil, fmt.Errorf("expected HostSubnet %s but got %t %v", nodeName, item, item)
+	}
+
+	return subnet, nil
+}
+
+func (master *OsdnMaster) addHostSubnet(nodeName string, nodeIP string, hsAnnotations map[string]string) error {
 	// Validate node IP before proceeding
 	if err := master.networkInfo.validateNodeIP(nodeIP); err != nil {
 		return err
 	}
 
 	// Check if subnet needs to be created or updated
-	sub, err := master.osClient.HostSubnets().Get(nodeName)
+	sub, err := master.getHostSubnetFromStore(nodeName)
 	if err == nil {
 		if sub.HostIP == nodeIP {
 			return nil
@@ -91,17 +111,23 @@ func (master *OsdnMaster) addNode(nodeName string, nodeIP string, hsAnnotations 
 	return nil
 }
 
-func (master *OsdnMaster) deleteNode(nodeName string) error {
-	sub, err := master.osClient.HostSubnets().Get(nodeName)
-	if err != nil {
-		return fmt.Errorf("Error fetching subnet for node %q for deletion: %v", nodeName, err)
-	}
-	err = master.osClient.HostSubnets().Delete(nodeName)
-	if err != nil {
-		return fmt.Errorf("Error deleting subnet %v for node %q: %v", sub, nodeName, err)
+func (master *OsdnMaster) deleteHostSubnet(nodeName string) error {
+	var subnet string
+
+	if hs, _ := master.getHostSubnetFromStore(nodeName); hs != nil {
+		// Remove from event queue store to ensure it doesn't exist locally
+		// after it's been deleted remotely
+		master.subnetStore.Delete(hs)
+		subnet = hostSubnetToString(hs)
 	}
 
-	log.Infof("Deleted HostSubnet %s", hostSubnetToString(sub))
+	// Even if we didn't have the subnet locally, still try to delete it
+	// from the API as clustered apiservers have different views of the world
+	if err := master.osClient.HostSubnets().Delete(nodeName); err != nil {
+		return fmt.Errorf("error deleting subnet %s for node %q: %v", subnet, nodeName, err)
+	}
+
+	log.Infof("Deleted HostSubnet %s for node %q", subnet, nodeName)
 	return nil
 }
 
@@ -155,7 +181,7 @@ func (master *OsdnMaster) clearInitialNodeNetworkUnavailableCondition(node *kapi
 
 func (master *OsdnMaster) watchNodes() {
 	nodeAddressMap := map[types.UID]string{}
-	RunEventQueue(master.kClient.CoreClient, Nodes, func(delta cache.Delta) error {
+	RunEventQueue(nil, master.kClient.CoreClient, Nodes, func(delta cache.Delta) error {
 		node := delta.Object.(*kapi.Node)
 		name := node.ObjectMeta.Name
 		uid := node.ObjectMeta.UID
@@ -175,7 +201,7 @@ func (master *OsdnMaster) watchNodes() {
 			// Node status is frequently updated by kubelet, so log only if the above condition is not met
 			log.V(5).Infof("Watch %s event for Node %q", delta.Type, name)
 
-			err = master.addNode(name, nodeIP, nil)
+			err = master.addHostSubnet(name, nodeIP, nil)
 			if err != nil {
 				return fmt.Errorf("error creating subnet for node %s, ip %s: %v", name, nodeIP, err)
 			}
@@ -184,9 +210,9 @@ func (master *OsdnMaster) watchNodes() {
 			log.V(5).Infof("Watch %s event for Node %q", delta.Type, name)
 			delete(nodeAddressMap, uid)
 
-			err = master.deleteNode(name)
+			err = master.deleteHostSubnet(name)
 			if err != nil {
-				return fmt.Errorf("Error deleting node %s: %v", name, err)
+				return fmt.Errorf("Error deleting node %s subnet: %v", name, err)
 			}
 		}
 		return nil
@@ -201,7 +227,7 @@ func (node *OsdnNode) SubnetStartNode() error {
 // Only run on the master
 // Watch for all hostsubnet events and if one is found with the right annotation, use the SubnetAllocator to dole a real subnet
 func (master *OsdnMaster) watchSubnets() {
-	RunEventQueue(master.osClient, HostSubnets, func(delta cache.Delta) error {
+	RunEventQueue(master.subnetQueue, master.osClient, HostSubnets, func(delta cache.Delta) error {
 		hs := delta.Object.(*osapi.HostSubnet)
 		name := hs.ObjectMeta.Name
 		hostIP := hs.HostIP
@@ -216,11 +242,10 @@ func (master *OsdnMaster) watchSubnets() {
 				// will skip the event if it finds that the hostsubnet has the same host
 				// And we cannot fix the watchSubnets code for node because it will break migration if
 				// nodes are upgraded after the master
-				err := master.osClient.HostSubnets().Delete(name)
-				if err != nil {
-					log.Errorf("Error in deleting annotated subnet from master, name: %s, ip %s: %v", name, hostIP, err)
-					return nil
+				if err := master.deleteHostSubnet(name); err != nil {
+					return err
 				}
+
 				var hsAnnotations map[string]string
 				if vnid, ok := hs.Annotations[osapi.FixedVnidHost]; ok {
 					vnidInt, err := strconv.Atoi(vnid)
@@ -231,10 +256,8 @@ func (master *OsdnMaster) watchSubnets() {
 						log.Errorf("Vnid %s is an invalid value for annotation %s. Annotation will be ignored.", vnid, osapi.FixedVnidHost)
 					}
 				}
-				err = master.addNode(name, hostIP, hsAnnotations)
-				if err != nil {
-					log.Errorf("Error creating subnet for node %s, ip %s: %v", name, hostIP, err)
-					return nil
+				if err := master.addHostSubnet(name, hostIP, hsAnnotations); err != nil {
+					return err
 				}
 			}
 		case cache.Deleted:
@@ -254,7 +277,7 @@ func (master *OsdnMaster) watchSubnets() {
 // Only run on the nodes
 func (node *OsdnNode) watchSubnets() {
 	subnets := make(map[string]*osapi.HostSubnet)
-	RunEventQueue(node.osClient, HostSubnets, func(delta cache.Delta) error {
+	RunEventQueue(nil, node.osClient, HostSubnets, func(delta cache.Delta) error {
 		hs := delta.Object.(*osapi.HostSubnet)
 		if hs.HostIP == node.localIP {
 			return nil

--- a/pkg/sdn/plugin/vnids_master.go
+++ b/pkg/sdn/plugin/vnids_master.go
@@ -274,7 +274,7 @@ func (master *OsdnMaster) VnidStartMaster() error {
 }
 
 func (master *OsdnMaster) watchNamespaces() {
-	RunEventQueue(master.kClient.CoreClient, Namespaces, func(delta cache.Delta) error {
+	RunEventQueue(nil, master.kClient.CoreClient, Namespaces, func(delta cache.Delta) error {
 		ns := delta.Object.(*kapi.Namespace)
 		name := ns.ObjectMeta.Name
 
@@ -294,7 +294,7 @@ func (master *OsdnMaster) watchNamespaces() {
 }
 
 func (master *OsdnMaster) watchNetNamespaces() {
-	RunEventQueue(master.osClient, NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(nil, master.osClient, NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 		name := netns.ObjectMeta.Name
 

--- a/pkg/sdn/plugin/vnids_node.go
+++ b/pkg/sdn/plugin/vnids_node.go
@@ -195,7 +195,7 @@ func (node *OsdnNode) updatePodNetwork(namespace string, oldNetID, netID uint32)
 }
 
 func (node *OsdnNode) watchNetNamespaces() {
-	RunEventQueue(node.osClient, NetNamespaces, func(delta cache.Delta) error {
+	RunEventQueue(nil, node.osClient, NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*osapi.NetNamespace)
 
 		log.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, netns.ObjectMeta.Name)
@@ -240,7 +240,7 @@ func isServiceChanged(oldsvc, newsvc *kapi.Service) bool {
 
 func (node *OsdnNode) watchServices() {
 	services := make(map[string]*kapi.Service)
-	RunEventQueue(node.kClient.CoreClient, Services, func(delta cache.Delta) error {
+	RunEventQueue(nil, node.kClient.CoreClient, Services, func(delta cache.Delta) error {
 		serv := delta.Object.(*kapi.Service)
 
 		// Ignore headless services


### PR DESCRIPTION
An event queue watches a single master/etcd (due to its persistent HTTP
connection), but explicit Get/List/etc calls may be directed to a different
master/etcd since they initiate a new connection.  This means the
explicit HostSubnet Get() calls in the SDN master object's addNode/deleteNode
calls might retrieve an inconsistent state.  Fix that by using the object
from th event queue's internal store.

No other parts of the SDN code explicitly call Get(), and those that
call List() do so before any of the event queues have started, so only
the HostSubnet code needs this adjustment.

Fixes: https://github.com/openshift/origin/issues/11740