### PR TITLE
Ensure router reload on initial sync

### DIFF
--- a/pkg/router/controller/controller.go
+++ b/pkg/router/controller/controller.go
@@ -79,12 +79,6 @@ func (c *RouterController) handleFirstSync() bool {
 		return false
 	}
 
-	err := c.Plugin.SetSyncedAtLeastOnce()
-	if err != nil {
-		utilruntime.HandleError(err)
-		return false
-	}
-
 	// If either of the event queues were empty after the initial
 	// List, the tracking listConsumed variable's default value of
 	// 'false' may prevent the router from committing the readiness

--- a/pkg/router/controller/controller.go
+++ b/pkg/router/controller/controller.go
@@ -36,6 +36,7 @@ type RouterController struct {
 	routesListConsumed    bool
 	endpointsListConsumed bool
 	filteredByNamespace   bool
+	syncing               bool
 
 	RoutesListSuccessfulAtLeastOnce    func() bool
 	EndpointsListSuccessfulAtLeastOnce func() bool
@@ -78,25 +79,26 @@ func (c *RouterController) handleFirstSync() bool {
 		return false
 	}
 
+	err := c.Plugin.SetSyncedAtLeastOnce()
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false
+	}
+
 	// If either of the event queues were empty after the initial
 	// List, the tracking listConsumed variable's default value of
-	// 'false' may prevent the router from reloading to indicate the
-	// readiness status.  Set the value to 'true' to ensure that a
-	// reload will be performed if necessary.
+	// 'false' may prevent the router from committing the readiness
+	// status.  Set the value to 'true' to ensure that state will be
+	// committed if necessary.
 	if c.RoutesListCount() == 0 {
 		c.routesListConsumed = true
 	}
 	if c.EndpointsListCount() == 0 {
 		c.endpointsListConsumed = true
 	}
-	c.updateLastSyncProcessed()
+	c.commit()
 
-	err := c.Plugin.SetSyncedAtLeastOnce()
-	if err == nil {
-		return true
-	}
-	utilruntime.HandleError(err)
-	return false
+	return true
 }
 
 // watchForFirstSync loops until the first sync has been handled.
@@ -116,16 +118,17 @@ func (c *RouterController) HandleNamespaces() {
 			c.lock.Lock()
 			defer c.lock.Unlock()
 
-			// Namespace filtering is assumed to be have been
-			// performed so long as the plugin event handler is called
-			// at least once.
-			c.filteredByNamespace = true
-			c.updateLastSyncProcessed()
-
 			glog.V(4).Infof("Updating watched namespaces: %v", namespaces)
 			if err := c.Plugin.HandleNamespaces(namespaces); err != nil {
 				utilruntime.HandleError(err)
 			}
+
+			// Namespace filtering is assumed to be have been
+			// performed so long as the plugin event handler is called
+			// at least once.
+			c.filteredByNamespace = true
+			c.commit()
+
 			return
 		}
 		utilruntime.HandleError(fmt.Errorf("unable to find namespaces for router: %v", err))
@@ -164,11 +167,6 @@ func (c *RouterController) HandleRoute() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	// Change the local sync state within the lock to ensure that all
-	// event handlers have the same view of sync state.
-	c.routesListConsumed = c.RoutesListConsumed()
-	c.updateLastSyncProcessed()
-
 	glog.V(4).Infof("Processing Route: %s -> %s", route.Name, route.Spec.To.Name)
 	glog.V(4).Infof("           Alias: %s", route.Spec.Host)
 	glog.V(4).Infof("           Event: %s", eventType)
@@ -176,6 +174,11 @@ func (c *RouterController) HandleRoute() {
 	if err := c.Plugin.HandleRoute(eventType, route); err != nil {
 		utilruntime.HandleError(err)
 	}
+
+	// Change the local sync state within the lock to ensure that all
+	// event handlers have the same view of sync state.
+	c.routesListConsumed = c.RoutesListConsumed()
+	c.commit()
 }
 
 // HandleEndpoints handles a single Endpoints event and refreshes the router backend.
@@ -189,22 +192,36 @@ func (c *RouterController) HandleEndpoints() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	if err := c.Plugin.HandleEndpoints(eventType, endpoints); err != nil {
+		utilruntime.HandleError(err)
+	}
+
 	// Change the local sync state within the lock to ensure that all
 	// event handlers have the same view of sync state.
 	c.endpointsListConsumed = c.EndpointsListConsumed()
-	c.updateLastSyncProcessed()
+	c.commit()
+}
 
-	if err := c.Plugin.HandleEndpoints(eventType, endpoints); err != nil {
+// commit notifies the plugin that it is safe to commit state.
+func (c *RouterController) commit() {
+	syncing := !(c.endpointsListConsumed && c.routesListConsumed &&
+		(c.Namespaces == nil || c.filteredByNamespace))
+	c.logSyncState(syncing)
+	if syncing {
+		return
+	}
+	if err := c.Plugin.Commit(); err != nil {
 		utilruntime.HandleError(err)
 	}
 }
 
-// updateLastSyncProcessed notifies the plugin if the most recent sync
-// of router resources has been completed.
-func (c *RouterController) updateLastSyncProcessed() {
-	lastSyncProcessed := c.endpointsListConsumed && c.routesListConsumed &&
-		(c.Namespaces == nil || c.filteredByNamespace)
-	if err := c.Plugin.SetLastSyncProcessed(lastSyncProcessed); err != nil {
-		utilruntime.HandleError(err)
+func (c *RouterController) logSyncState(syncing bool) {
+	if c.syncing != syncing {
+		c.syncing = syncing
+		if c.syncing {
+			glog.V(4).Infof("Router sync in progress")
+		} else {
+			glog.V(4).Infof("Router sync complete")
+		}
 	}
 }

--- a/pkg/router/controller/controller_test.go
+++ b/pkg/router/controller/controller_test.go
@@ -32,10 +32,6 @@ func (p *fakeRouterPlugin) Commit() error {
 	return nil
 }
 
-func (p *fakeRouterPlugin) SetSyncedAtLeastOnce() error {
-	return nil
-}
-
 type fakeNamespaceLister struct {
 }
 

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -79,8 +79,8 @@ func (p *ExtendedValidator) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
-func (p *ExtendedValidator) SetLastSyncProcessed(processed bool) error {
-	return p.plugin.SetLastSyncProcessed(processed)
+func (p *ExtendedValidator) Commit() error {
+	return p.plugin.Commit()
 }
 
 func (p *ExtendedValidator) SetSyncedAtLeastOnce() error {

--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -82,7 +82,3 @@ func (p *ExtendedValidator) HandleNamespaces(namespaces sets.String) error {
 func (p *ExtendedValidator) Commit() error {
 	return p.plugin.Commit()
 }
-
-func (p *ExtendedValidator) SetSyncedAtLeastOnce() error {
-	return p.plugin.SetSyncedAtLeastOnce()
-}

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -152,10 +152,6 @@ func (p *HostAdmitter) Commit() error {
 	return p.plugin.Commit()
 }
 
-func (p *HostAdmitter) SetSyncedAtLeastOnce() error {
-	return p.plugin.SetSyncedAtLeastOnce()
-}
-
 // addRoute admits routes based on subdomain ownership - returns errors if the route is not admitted.
 func (p *HostAdmitter) addRoute(route *routeapi.Route) error {
 	// Find displaced routes (or error if an existing route displaces us)

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -148,8 +148,8 @@ func (p *HostAdmitter) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
-func (p *HostAdmitter) SetLastSyncProcessed(processed bool) error {
-	return p.plugin.SetLastSyncProcessed(processed)
+func (p *HostAdmitter) Commit() error {
+	return p.plugin.Commit()
 }
 
 func (p *HostAdmitter) SetSyncedAtLeastOnce() error {

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -312,8 +312,8 @@ func (a *StatusAdmitter) HandleNamespaces(namespaces sets.String) error {
 	return a.plugin.HandleNamespaces(namespaces)
 }
 
-func (a *StatusAdmitter) SetLastSyncProcessed(processed bool) error {
-	return a.plugin.SetLastSyncProcessed(processed)
+func (a *StatusAdmitter) Commit() error {
+	return a.plugin.Commit()
 }
 
 func (a *StatusAdmitter) SetSyncedAtLeastOnce() error {

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -315,7 +315,3 @@ func (a *StatusAdmitter) HandleNamespaces(namespaces sets.String) error {
 func (a *StatusAdmitter) Commit() error {
 	return a.plugin.Commit()
 }
-
-func (a *StatusAdmitter) SetSyncedAtLeastOnce() error {
-	return a.plugin.SetSyncedAtLeastOnce()
-}

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -43,10 +43,6 @@ func (p *fakePlugin) Commit() error {
 	return fmt.Errorf("not expected")
 }
 
-func (p *fakePlugin) SetSyncedAtLeastOnce() error {
-	return fmt.Errorf("not expected")
-}
-
 func TestStatusNoOp(t *testing.T) {
 	now := nowFn()
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -39,7 +39,7 @@ func (p *fakePlugin) HandleEndpoints(watch.EventType, *kapi.Endpoints) error {
 func (p *fakePlugin) HandleNamespaces(namespaces sets.String) error {
 	return fmt.Errorf("not expected")
 }
-func (p *fakePlugin) SetLastSyncProcessed(processed bool) error {
+func (p *fakePlugin) Commit() error {
 	return fmt.Errorf("not expected")
 }
 

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -259,10 +259,6 @@ func (p *UniqueHost) Commit() error {
 	return p.plugin.Commit()
 }
 
-func (p *UniqueHost) SetSyncedAtLeastOnce() error {
-	return p.plugin.SetSyncedAtLeastOnce()
-}
-
 // routeKeys returns the internal router key to use for the given Route.
 func routeKeys(route *routeapi.Route) []string {
 	keys := make([]string, 1+len(route.Spec.AlternateBackends))

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -255,8 +255,8 @@ func (p *UniqueHost) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
-func (p *UniqueHost) SetLastSyncProcessed(processed bool) error {
-	return p.plugin.SetLastSyncProcessed(processed)
+func (p *UniqueHost) Commit() error {
+	return p.plugin.Commit()
 }
 
 func (p *UniqueHost) SetSyncedAtLeastOnce() error {

--- a/pkg/router/f5/plugin.go
+++ b/pkg/router/f5/plugin.go
@@ -630,7 +630,7 @@ func (p *F5Plugin) HandleRoute(eventType watch.EventType,
 }
 
 // No-op since f5 configuration can be updated piecemeal
-func (p *F5Plugin) SetLastSyncProcessed(processed bool) error {
+func (p *F5Plugin) Commit() error {
 	return nil
 }
 

--- a/pkg/router/f5/plugin.go
+++ b/pkg/router/f5/plugin.go
@@ -633,8 +633,3 @@ func (p *F5Plugin) HandleRoute(eventType watch.EventType,
 func (p *F5Plugin) Commit() error {
 	return nil
 }
-
-// No-op since f5 has its own concept of what 'ready' means
-func (p *F5Plugin) SetSyncedAtLeastOnce() error {
-	return nil
-}

--- a/pkg/router/interfaces.go
+++ b/pkg/router/interfaces.go
@@ -17,5 +17,4 @@ type Plugin interface {
 	HandleNamespaces(namespaces sets.String) error
 	HandleNode(watch.EventType, *kapi.Node) error
 	Commit() error
-	SetSyncedAtLeastOnce() error
 }

--- a/pkg/router/interfaces.go
+++ b/pkg/router/interfaces.go
@@ -16,6 +16,6 @@ type Plugin interface {
 	// If sent, filter the list of accepted routes and endpoints to this set
 	HandleNamespaces(namespaces sets.String) error
 	HandleNode(watch.EventType, *kapi.Node) error
-	SetLastSyncProcessed(processed bool) error
+	Commit() error
 	SetSyncedAtLeastOnce() error
 }

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -83,9 +83,6 @@ type routerInterface interface {
 	// Commit applies the changes in the background. It kicks off a rate-limited
 	// commit (persist router state + refresh the backend) that coalesces multiple changes.
 	Commit()
-
-	// SetSyncedAtLeastOnce indicates to the router that state has been read from the api at least once
-	SetSyncedAtLeastOnce()
 }
 
 func env(name, defaultValue string) string {
@@ -224,11 +221,6 @@ func (p *TemplatePlugin) HandleNamespaces(namespaces sets.String) error {
 
 func (p *TemplatePlugin) Commit() error {
 	p.Router.Commit()
-	return nil
-}
-
-func (p *TemplatePlugin) SetSyncedAtLeastOnce() error {
-	p.Router.SetSyncedAtLeastOnce()
 	return nil
 }
 

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -60,10 +60,6 @@ type routerInterface interface {
 	// frontend key is used; all call sites make certain the frontend
 	// is created.
 
-	// HasServiceUnit indicates whether the router has a service unit
-	// for the given key.
-	HasServiceUnit(key string) bool
-
 	// CreateServiceUnit creates a new service named with the given id.
 	CreateServiceUnit(id string)
 	// FindServiceUnit finds the service with the given id.
@@ -82,6 +78,8 @@ type routerInterface interface {
 	AddRoute(id string, weight int32, route *routeapi.Route, host string) bool
 	// RemoveRoute removes the given route
 	RemoveRoute(route *routeapi.Route)
+	// HasRoute indicates whether the router is configured with the given route
+	HasRoute(route *routeapi.Route) bool
 	// Reduce the list of routes to only these namespaces
 	FilterNamespaces(namespaces sets.String)
 	// Commit applies the changes in the background. It kicks off a rate-limited

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -65,17 +65,15 @@ type routerInterface interface {
 	// FindServiceUnit finds the service with the given id.
 	FindServiceUnit(id string) (v ServiceUnit, ok bool)
 
-	// AddEndpoints adds new Endpoints for the given id. Returns true if a change was made
-	// and the state should be stored with Commit().
-	AddEndpoints(id string, endpoints []Endpoint) bool
+	// AddEndpoints adds new Endpoints for the given id.
+	AddEndpoints(id string, endpoints []Endpoint)
 	// DeleteEndpoints deletes the endpoints for the frontend with the given id.
 	DeleteEndpoints(id string)
 
 	// AddRoute adds a route for the given id and the calculated host. Weight
 	// suggests the weightage attached to it with respect to other services
-	// pointed to by the route. Returns true if a
-	// change was made and the state should be stored with Commit().
-	AddRoute(id string, weight int32, route *routeapi.Route, host string) bool
+	// pointed to by the route.
+	AddRoute(id string, weight int32, route *routeapi.Route, host string)
 	// RemoveRoute removes the given route
 	RemoveRoute(route *routeapi.Route)
 	// HasRoute indicates whether the router is configured with the given route
@@ -85,9 +83,6 @@ type routerInterface interface {
 	// Commit applies the changes in the background. It kicks off a rate-limited
 	// commit (persist router state + refresh the backend) that coalesces multiple changes.
 	Commit()
-
-	// SetSkipCommit indicates to the router whether commits should be skipped
-	SetSkipCommit(skipCommit bool)
 
 	// SetSyncedAtLeastOnce indicates to the router that state has been read from the api at least once
 	SetSyncedAtLeastOnce()
@@ -171,14 +166,10 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 		glog.V(4).Infof("Modifying endpoints for %s", key)
 		routerEndpoints := createRouterEndpoints(endpoints, !p.IncludeUDP, p.ServiceFetcher)
 		key := endpointsKey(endpoints)
-		commit := p.Router.AddEndpoints(key, routerEndpoints)
-		if commit {
-			p.Router.Commit()
-		}
+		p.Router.AddEndpoints(key, routerEndpoints)
 	case watch.Deleted:
 		glog.V(4).Infof("Deleting endpoints for %s", key)
 		p.Router.DeleteEndpoints(key)
-		p.Router.Commit()
 	}
 
 	return nil
@@ -206,7 +197,6 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 		p.Router.RemoveRoute(route)
 
 		// Now add the route back again
-		commit := false
 		for i := range serviceKeys {
 			key := serviceKeys[i]
 			weight := weights[i]
@@ -216,16 +206,11 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 			}
 
 			glog.V(4).Infof("Modifying routes for %s", key)
-			commitRoute := p.Router.AddRoute(key, weight, route, host)
-			commit = (map[bool]bool{true: true, false: commit})[commitRoute]
-		}
-		if commit {
-			p.Router.Commit()
+			p.Router.AddRoute(key, weight, route, host)
 		}
 	case watch.Deleted:
 		glog.V(4).Infof("Deleting route %v", route)
 		p.Router.RemoveRoute(route)
-		p.Router.Commit()
 	}
 	return nil
 }
@@ -234,18 +219,16 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 // the provided namespace list.
 func (p *TemplatePlugin) HandleNamespaces(namespaces sets.String) error {
 	p.Router.FilterNamespaces(namespaces)
-	p.Router.Commit()
 	return nil
 }
 
-func (p *TemplatePlugin) SetLastSyncProcessed(processed bool) error {
-	p.Router.SetSkipCommit(!processed)
+func (p *TemplatePlugin) Commit() error {
+	p.Router.Commit()
 	return nil
 }
 
 func (p *TemplatePlugin) SetSyncedAtLeastOnce() error {
 	p.Router.SetSyncedAtLeastOnce()
-	p.Router.Commit()
 	return nil
 }
 

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -235,9 +235,6 @@ func (r *TestRouter) Commit() {
 	// No op
 }
 
-func (r *TestRouter) SetSyncedAtLeastOnce() {
-}
-
 // TestHandleEndpoints test endpoint watch events
 func TestHandleEndpoints(t *testing.T) {
 	testCases := []struct {

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -123,8 +123,6 @@ bGvtpjWA4r9WASIDPFsxk/cDEEEO6iPxgMOf5MdpQC2y2MU0rzF/Gg==
 type TestRouter struct {
 	State        map[string]ServiceAliasConfig
 	ServiceUnits map[string]ServiceUnit
-
-	Committed bool
 }
 
 // NewTestRouter creates a new TestRouter and registers the initial state.
@@ -132,7 +130,6 @@ func newTestRouter(state map[string]ServiceAliasConfig) *TestRouter {
 	return &TestRouter{
 		State:        state,
 		ServiceUnits: make(map[string]ServiceUnit),
-		Committed:    false,
 	}
 }
 
@@ -153,22 +150,19 @@ func (r *TestRouter) FindServiceUnit(id string) (v ServiceUnit, ok bool) {
 }
 
 // AddEndpoints adds the endpoints to the service unit identified by id
-func (r *TestRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
-	r.Committed = false //expect any call to this method to subsequently call commit
+func (r *TestRouter) AddEndpoints(id string, endpoints []Endpoint) {
 	su, _ := r.FindServiceUnit(id)
 
 	// simulate the logic that compares endpoints
 	if reflect.DeepEqual(su.EndpointTable, endpoints) {
-		return false
+		return
 	}
 	su.EndpointTable = endpoints
 	r.ServiceUnits[id] = su
-	return true
 }
 
 // DeleteEndpoints removes all endpoints from the service unit
 func (r *TestRouter) DeleteEndpoints(id string) {
-	r.Committed = false //expect any call to this method to subsequently call commit
 	if su, ok := r.FindServiceUnit(id); !ok {
 		return
 	} else {
@@ -178,8 +172,7 @@ func (r *TestRouter) DeleteEndpoints(id string) {
 }
 
 // AddRoute adds a ServiceAliasConfig for the route with the ServiceUnit identified by id
-func (r *TestRouter) AddRoute(id string, weight int32, route *routeapi.Route, host string) bool {
-	r.Committed = false //expect any call to this method to subsequently call commit
+func (r *TestRouter) AddRoute(id string, weight int32, route *routeapi.Route, host string) {
 	su, _ := r.FindServiceUnit(id)
 	routeKey := r.routeKey(route)
 
@@ -191,12 +184,10 @@ func (r *TestRouter) AddRoute(id string, weight int32, route *routeapi.Route, ho
 
 	config.ServiceUnitNames[su.Name] = weight
 	r.State[routeKey] = config
-	return true
 }
 
 // RemoveRoute removes the service alias config for Route
 func (r *TestRouter) RemoveRoute(route *routeapi.Route) {
-	r.Committed = false //expect any call to this method to subsequently call commit
 	routeKey := r.routeKey(route)
 	_, ok := r.State[routeKey]
 	if !ok {
@@ -240,12 +231,8 @@ func (r *TestRouter) routeKey(route *routeapi.Route) string {
 	return route.Spec.Host + "-" + route.Spec.Path
 }
 
-// Commit saves router state
 func (r *TestRouter) Commit() {
-	r.Committed = true
-}
-
-func (r *TestRouter) SetSkipCommit(skipCommit bool) {
+	// No op
 }
 
 func (r *TestRouter) SetSyncedAtLeastOnce() {
@@ -336,10 +323,6 @@ func TestHandleEndpoints(t *testing.T) {
 
 	for _, tc := range testCases {
 		plugin.HandleEndpoints(tc.eventType, tc.endpoints)
-
-		if !router.Committed {
-			t.Errorf("Expected router to be committed after HandleEndpoints call")
-		}
 
 		su, ok := router.FindServiceUnit(tc.expectedServiceUnit.Name)
 
@@ -451,10 +434,6 @@ func TestHandleTCPEndpoints(t *testing.T) {
 	for _, tc := range testCases {
 		plugin.HandleEndpoints(tc.eventType, tc.endpoints)
 
-		if !router.Committed {
-			t.Errorf("Expected router to be committed after HandleEndpoints call")
-		}
-
 		su, ok := router.FindServiceUnit(tc.expectedServiceUnit.Name)
 
 		if !ok {
@@ -514,10 +493,6 @@ func TestHandleRoute(t *testing.T) {
 	serviceUnitKey := fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
 
 	plugin.HandleRoute(watch.Added, route)
-
-	if !router.Committed {
-		t.Errorf("Expected router to be committed after HandleRoute call")
-	}
 
 	_, ok := router.FindServiceUnit(serviceUnitKey)
 
@@ -614,9 +589,6 @@ func TestHandleRoute(t *testing.T) {
 	if err := plugin.HandleRoute(watch.Modified, route); err != nil {
 		t.Fatal("unexpected error")
 	}
-	if !router.Committed {
-		t.Errorf("Expected router to be committed after HandleRoute call")
-	}
 	_, ok = router.FindServiceUnit(serviceUnitKey)
 	if !ok {
 		t.Errorf("TestHandleRoute was unable to find the service unit %s after HandleRoute was called", route.Spec.To.Name)
@@ -641,9 +613,6 @@ func TestHandleRoute(t *testing.T) {
 	//delete
 	if err := plugin.HandleRoute(watch.Deleted, route); err != nil {
 		t.Fatal("unexpected error")
-	}
-	if !router.Committed {
-		t.Errorf("Expected router to be committed after HandleRoute call")
 	}
 	_, ok = router.FindServiceUnit(serviceUnitKey)
 	if !ok {
@@ -693,10 +662,6 @@ func TestHandleRouteExtendedValidation(t *testing.T) {
 	serviceUnitKey := fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
 
 	plugin.HandleRoute(watch.Added, route)
-
-	if !router.Committed {
-		t.Errorf("Expected router to be committed after HandleRoute call")
-	}
 
 	_, ok := router.FindServiceUnit(serviceUnitKey)
 
@@ -1076,73 +1041,5 @@ func TestNamespaceScopingFromEmpty(t *testing.T) {
 	plugin.HandleRoute(watch.Added, route)
 	if _, ok := router.FindServiceUnit("foo/TestService"); ok || plugin.HostLen() != 0 {
 		t.Errorf("unexpected router state %#v", router)
-	}
-}
-
-func TestUnchangingEndpointsDoesNotCommit(t *testing.T) {
-	router := newTestRouter(make(map[string]ServiceAliasConfig))
-	plugin := newDefaultTemplatePlugin(router, true, nil)
-	endpoints := &kapi.Endpoints{
-		ObjectMeta: kapi.ObjectMeta{
-			Namespace: "foo",
-			Name:      "test",
-		},
-		Subsets: []kapi.EndpointSubset{{
-			Addresses: []kapi.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}},
-			Ports:     []kapi.EndpointPort{{Port: 0}},
-		}},
-	}
-	changedEndpoints := &kapi.Endpoints{
-		ObjectMeta: kapi.ObjectMeta{
-			Namespace: "foo",
-			Name:      "test",
-		},
-		Subsets: []kapi.EndpointSubset{{
-			Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3"}, {IP: "2.2.2.2"}},
-			Ports:     []kapi.EndpointPort{{Port: 0}},
-		}},
-	}
-
-	testCases := []struct {
-		name         string
-		event        watch.EventType
-		endpoints    *kapi.Endpoints
-		expectCommit bool
-	}{
-		{
-			name:         "initial add",
-			event:        watch.Added,
-			endpoints:    endpoints,
-			expectCommit: true,
-		},
-		{
-			name:         "mod with no change",
-			event:        watch.Modified,
-			endpoints:    endpoints,
-			expectCommit: false,
-		},
-		{
-			name:         "add with change",
-			event:        watch.Added,
-			endpoints:    changedEndpoints,
-			expectCommit: true,
-		},
-		{
-			name:         "add with no change",
-			event:        watch.Added,
-			endpoints:    changedEndpoints,
-			expectCommit: false,
-		},
-	}
-
-	for _, v := range testCases {
-		err := plugin.HandleEndpoints(v.event, v.endpoints)
-		if err != nil {
-			t.Errorf("%s had unexpected error in handle endpoints %v", v.name, err)
-			continue
-		}
-		if router.Committed != v.expectCommit {
-			t.Errorf("%s expected router commit to be %v but found %v", v.name, v.expectCommit, router.Committed)
-		}
 	}
 }

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -206,6 +206,11 @@ func (r *TestRouter) RemoveRoute(route *routeapi.Route) {
 	}
 }
 
+func (r *TestRouter) HasRoute(route *routeapi.Route) bool {
+	// Not used
+	return false
+}
+
 func (r *TestRouter) FilterNamespaces(namespaces sets.String) {
 	if len(namespaces) == 0 {
 		r.State = make(map[string]ServiceAliasConfig)
@@ -244,10 +249,6 @@ func (r *TestRouter) SetSkipCommit(skipCommit bool) {
 }
 
 func (r *TestRouter) SetSyncedAtLeastOnce() {
-}
-
-func (r *TestRouter) HasServiceUnit(key string) bool {
-	return false
 }
 
 // TestHandleEndpoints test endpoint watch events

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -186,7 +186,9 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		return nil, err
 	}
 	glog.V(4).Infof("Committing state")
-	router.Commit()
+	// Bypass the rate limiter to ensure the first sync will be
+	// committed without delay.
+	router.commitAndReload()
 	return router, nil
 }
 

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -84,12 +84,12 @@ type templateRouter struct {
 	rateLimitedCommitStopChannel chan struct{}
 	// lock is a mutex used to prevent concurrent router reloads.
 	lock sync.Mutex
-	// the router should only reload when the value is false
-	skipCommit bool
 	// If true, haproxy should only bind ports when it has route and endpoint state
 	bindPortsAfterSync bool
 	// whether the router state has been read from the api at least once
 	syncedAtLeastOnce bool
+	// whether a state change has occurred
+	stateChanged bool
 }
 
 // templateRouterCfg holds all configuration items required to initialize the template router
@@ -348,10 +348,12 @@ func (r *templateRouter) readState() error {
 // the state and refresh the backend. This is all done in the background
 // so that we can rate limit + coalesce multiple changes.
 func (r *templateRouter) Commit() {
-	if r.skipCommit {
-		glog.V(4).Infof("Skipping router commit until last sync has been processed")
-	} else {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.stateChanged {
 		r.rateLimitedCommitFunction.Invoke(r.rateLimitedCommitFunction)
+		r.stateChanged = false
 	}
 }
 
@@ -453,6 +455,8 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	r.stateChanged = true
+
 	if len(namespaces) == 0 {
 		r.state = make(map[string]ServiceAliasConfig)
 		r.serviceUnits = make(map[string]ServiceUnit)
@@ -487,6 +491,7 @@ func (r *templateRouter) CreateServiceUnit(id string) {
 	defer r.lock.Unlock()
 
 	r.serviceUnits[id] = service
+	r.stateChanged = true
 }
 
 // findMatchingServiceUnit finds the service with the given id - internal
@@ -515,12 +520,15 @@ func (r *templateRouter) DeleteServiceUnit(id string) {
 	}
 
 	delete(r.serviceUnits, id)
+	r.stateChanged = true
 }
 
 // DeleteEndpoints deletes the endpoints for the service with the given id.
 func (r *templateRouter) DeleteEndpoints(id string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	r.stateChanged = true
 
 	service, ok := r.findMatchingServiceUnit(id)
 	if !ok {
@@ -555,7 +563,7 @@ func (r *templateRouter) routeKey(route *routeapi.Route) string {
 }
 
 // AddRoute adds a route for the given service id
-func (r *templateRouter) AddRoute(serviceID string, weight int32, route *routeapi.Route, host string) bool {
+func (r *templateRouter) AddRoute(serviceID string, weight int32, route *routeapi.Route, host string) {
 	backendKey := r.routeKey(route)
 	wantsWildcardSupport := (route.Spec.WildcardPolicy == routeapi.WildcardPolicySubdomain)
 
@@ -636,14 +644,15 @@ func (r *templateRouter) AddRoute(serviceID string, weight int32, route *routeap
 	config.ServiceUnitNames[frontend.Name] = weight
 	r.state[backendKey] = config
 	r.serviceUnits[serviceID] = frontend
-	//r.cleanUpdates(serviceID, backendKey)
-	return true
+	r.stateChanged = true
 }
 
 // RemoveRoute removes the given route
 func (r *templateRouter) RemoveRoute(route *routeapi.Route) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	r.stateChanged = true
 
 	routeKey := r.routeKey(route)
 	serviceAliasConfig, ok := r.state[routeKey]
@@ -656,7 +665,7 @@ func (r *templateRouter) RemoveRoute(route *routeapi.Route) {
 }
 
 // AddEndpoints adds new Endpoints for the given id.
-func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
+func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	frontend, _ := r.findMatchingServiceUnit(id)
@@ -664,7 +673,7 @@ func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
 	//only make the change if there is a difference
 	if reflect.DeepEqual(frontend.EndpointTable, endpoints) {
 		glog.V(4).Infof("Ignoring change for %s, endpoints are the same", id)
-		return false
+		return
 	}
 
 	frontend.EndpointTable = endpoints
@@ -675,7 +684,7 @@ func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
 		glog.V(4).Infof("Peer endpoints updated to: %#v", r.peerEndpoints)
 	}
 
-	return true
+	r.stateChanged = true
 }
 
 // cleanUpServiceAliasConfig performs any necessary steps to clean up a service alias config before deleting it from
@@ -741,20 +750,15 @@ func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
 	return false
 }
 
-// SetSkipCommit indicates to the router whether requests to
-// commit/reload should be skipped.
-func (r *templateRouter) SetSkipCommit(skipCommit bool) {
-	if r.skipCommit != skipCommit {
-		glog.V(4).Infof("Updating skip commit to: %t", skipCommit)
-		r.skipCommit = skipCommit
-	}
-}
-
 // SetSyncedAtLeastOnce indicates to the router that state has been
 // read from the api.
 func (r *templateRouter) SetSyncedAtLeastOnce() {
-	r.syncedAtLeastOnce = true
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	glog.V(4).Infof("Router state synchronized for the first time")
+	r.syncedAtLeastOnce = true
+	r.stateChanged = true
 }
 
 // HasRoute indicates whether the given route is known to this router.

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -87,7 +87,7 @@ type templateRouter struct {
 	// If true, haproxy should only bind ports when it has route and endpoint state
 	bindPortsAfterSync bool
 	// whether the router state has been read from the api at least once
-	syncedAtLeastOnce bool
+	synced bool
 	// whether a state change has occurred
 	stateChanged bool
 }
@@ -351,6 +351,12 @@ func (r *templateRouter) Commit() {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	if !r.synced {
+		glog.V(4).Infof("Router state synchronized for the first time")
+		r.synced = true
+		r.stateChanged = true
+	}
+
 	if r.stateChanged {
 		r.rateLimitedCommitFunction.Invoke(r.rateLimitedCommitFunction)
 		r.stateChanged = false
@@ -418,7 +424,7 @@ func (r *templateRouter) writeConfig() error {
 			StatsUser:          r.statsUser,
 			StatsPassword:      r.statsPassword,
 			StatsPort:          r.statsPort,
-			BindPorts:          !r.bindPortsAfterSync || r.syncedAtLeastOnce,
+			BindPorts:          !r.bindPortsAfterSync || r.synced,
 		}
 		if err := template.Execute(file, data); err != nil {
 			file.Close()
@@ -748,17 +754,6 @@ func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
 		return false
 	}
 	return false
-}
-
-// SetSyncedAtLeastOnce indicates to the router that state has been
-// read from the api.
-func (r *templateRouter) SetSyncedAtLeastOnce() {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	glog.V(4).Infof("Router state synchronized for the first time")
-	r.syncedAtLeastOnce = true
-	r.stateChanged = true
 }
 
 // HasRoute indicates whether the given route is known to this router.

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -755,12 +755,12 @@ func (r *templateRouter) SetSyncedAtLeastOnce() {
 	glog.V(4).Infof("Router state synchronized for the first time")
 }
 
-// HasServiceUnit attempts to retrieve a service unit for the given
-// key, returning a boolean indication of whether the key is known.
-func (r *templateRouter) HasServiceUnit(key string) bool {
+// HasRoute indicates whether the given route is known to this router.
+func (r *templateRouter) HasRoute(route *routeapi.Route) bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	_, ok := r.findMatchingServiceUnit(key)
+	key := r.routeKey(route)
+	_, ok := r.state[key]
 	return ok
 }
 

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -461,11 +461,10 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.stateChanged = true
-
 	if len(namespaces) == 0 {
 		r.state = make(map[string]ServiceAliasConfig)
 		r.serviceUnits = make(map[string]ServiceUnit)
+		r.stateChanged = true
 	}
 	for k := range r.serviceUnits {
 		// TODO: the id of a service unit should be defined inside this class, not passed in from the outside
@@ -475,6 +474,7 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 			continue
 		}
 		delete(r.serviceUnits, k)
+		r.stateChanged = true
 	}
 
 	for k := range r.state {
@@ -483,6 +483,7 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 			continue
 		}
 		delete(r.state, k)
+		r.stateChanged = true
 	}
 }
 
@@ -534,8 +535,6 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.stateChanged = true
-
 	service, ok := r.findMatchingServiceUnit(id)
 	if !ok {
 		return
@@ -551,6 +550,8 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 		r.peerEndpoints = []Endpoint{}
 		glog.V(4).Infof("Peer endpoint table has been cleared")
 	}
+
+	r.stateChanged = true
 }
 
 // routeKey generates route key in form of Namespace_Name.  This is NOT the normal key structure of ns/name because
@@ -658,8 +659,6 @@ func (r *templateRouter) RemoveRoute(route *routeapi.Route) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.stateChanged = true
-
 	routeKey := r.routeKey(route)
 	serviceAliasConfig, ok := r.state[routeKey]
 	if !ok {
@@ -668,6 +667,7 @@ func (r *templateRouter) RemoveRoute(route *routeapi.Route) {
 
 	r.cleanUpServiceAliasConfig(&serviceAliasConfig)
 	delete(r.state, routeKey)
+	r.stateChanged = true
 }
 
 // AddEndpoints adds new Endpoints for the given id.

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -288,13 +288,6 @@ func (p *DelayPlugin) Commit() error {
 	return p.plugin.Commit()
 }
 
-func (p *DelayPlugin) SetSyncedAtLeastOnce() error {
-	if p.committed {
-		return nil
-	}
-	return p.plugin.SetSyncedAtLeastOnce()
-}
-
 // launchRouter launches a template router that communicates with the
 // api via the provided clients.
 func launchRouter(oc osclient.Interface, kc kclientset.Interface, maxDelay int32, name string, reloadInterval int, reloadedMap map[string]bool) (templatePlugin *templateplugin.TemplatePlugin) {

--- a/test/integration/router_stress_test.go
+++ b/test/integration/router_stress_test.go
@@ -33,7 +33,7 @@ func TestRouterReloadSuppressionOnSync(t *testing.T) {
 		// Allow the test to be configured to enable experimentation
 		// without a costly (~60s+) go build.
 		cmdutil.EnvInt("OS_TEST_NAMESPACE_COUNT", 1, 1),
-		cmdutil.EnvInt("OS_TEST_ROUTES_PER_NAMESPACE", 10, 10),
+		cmdutil.EnvInt("OS_TEST_ROUTES_PER_NAMESPACE", 5, 5),
 		cmdutil.EnvInt("OS_TEST_ROUTER_COUNT", 1, 1),
 		cmdutil.EnvInt("OS_TEST_MAX_ROUTER_DELAY", 10, 10),
 	)
@@ -85,6 +85,17 @@ func stressRouter(t *testing.T, namespaceCount, routesPerNamespace, routerCount,
 				t.Fatalf("unexpected error: %v", err)
 			}
 			routes = append(routes, route)
+
+		}
+		// Create a final route that uses the same host as the
+		// previous route to create a conflict.  This will validate
+		// that a router still reloads if the last item in the initial
+		// list is rejected.
+		host := routes[len(routes)-1].Spec.Host
+		routeProperties := createRouteProperties("invalid-service", host)
+		_, err = oc.Routes(namespace.Name).Create(routeProperties)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	}
 
@@ -96,38 +107,44 @@ func stressRouter(t *testing.T, namespaceCount, routesPerNamespace, routerCount,
 	reloadInterval := 0
 
 	// Track reload counts indexed by router name.
-	reloadCounts := make(map[string]int)
+	reloadedMap := make(map[string]bool)
 
 	// Create the routers
 	for i := int32(0); i < routerCount; i++ {
 		routerName := fmt.Sprintf("router_%d", i)
-		router := launchRouter(oc, kc, maxRouterDelay, routerName, reloadInterval, reloadCounts)
+		router := launchRouter(oc, kc, maxRouterDelay, routerName, reloadInterval, reloadedMap)
 		plugins = append(plugins, router)
 	}
 
-	// Wait until the routers have processed all the routes.  The test
-	// runner is assumed enforce a timeout that ensures termination in
-	// the event of a failure.
-	expectedRouteCount := len(routes)
+	// Wait for the routers to reload
 	for {
-		routeCount := 0
-		for _, plugin := range plugins {
-			for _, route := range routes {
-				if plugin.Router.HasRoute(route) {
-					routeCount++
-				}
+		allReloaded := true
+		for _, reloaded := range reloadedMap {
+			if !reloaded {
+				allReloaded = false
+				break
 			}
 		}
-		if routeCount == expectedRouteCount {
+		if allReloaded {
 			break
 		} else {
-			time.Sleep(1)
+			time.Sleep(time.Second)
 		}
 	}
 
-	for _, reloadCount := range reloadCounts {
-		if reloadCount > 1 {
-			t.Fatalf("One or more routers reloaded more than once")
+	// Check that the routers have processed all routes.  The delay
+	// plugin should ensure that router state reflects only the
+	// initial sync and not subsequent watch events.
+	expectedRouteCount := len(routes)
+	for _, plugin := range plugins {
+		routeCount := 0
+		for _, route := range routes {
+			if plugin.Router.HasRoute(route) {
+				routeCount++
+			}
+		}
+		if routeCount != expectedRouteCount {
+			t.Fatalf("Expected %v routes, got %v", expectedRouteCount, routeCount)
 		}
 	}
 }
@@ -210,10 +227,13 @@ func launchApi() (osclient.Interface, kclientset.Interface, error) {
 
 // DelayPlugin implements the router.Plugin interface to introduce
 // random delay into plugin handlers to simulate variation in
-// processing time when a router is under load.
+// processing time when a router is under load.  It also limits the
+// router to a single commit to enable validation of initial sync
+// behavior.
 type DelayPlugin struct {
-	plugin   router.Plugin
-	maxDelay int32
+	plugin    router.Plugin
+	maxDelay  int32
+	committed bool
 }
 
 func NewDelayPlugin(plugin router.Plugin, maxDelay int32) *DelayPlugin {
@@ -229,41 +249,60 @@ func (p *DelayPlugin) delay() {
 }
 
 func (p *DelayPlugin) HandleRoute(eventType watch.EventType, route *routeapi.Route) error {
+	if p.committed {
+		return nil
+	}
 	p.delay()
 	return p.plugin.HandleRoute(eventType, route)
 }
 
 func (p *DelayPlugin) HandleNode(eventType watch.EventType, node *kapi.Node) error {
+	if p.committed {
+		return nil
+	}
 	p.delay()
 	return p.plugin.HandleNode(eventType, node)
 }
 
 func (p *DelayPlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
+	if p.committed {
+		return nil
+	}
 	p.delay()
 	return p.plugin.HandleEndpoints(eventType, endpoints)
 }
 
 func (p *DelayPlugin) HandleNamespaces(namespaces sets.String) error {
+	if p.committed {
+		return nil
+	}
 	p.delay()
 	return p.plugin.HandleNamespaces(namespaces)
 }
 
-func (p *DelayPlugin) SetLastSyncProcessed(processed bool) error {
-	return p.plugin.SetLastSyncProcessed(processed)
+func (p *DelayPlugin) Commit() error {
+	if p.committed {
+		return nil
+	}
+	p.committed = true
+	return p.plugin.Commit()
 }
 
 func (p *DelayPlugin) SetSyncedAtLeastOnce() error {
+	if p.committed {
+		return nil
+	}
 	return p.plugin.SetSyncedAtLeastOnce()
 }
 
 // launchRouter launches a template router that communicates with the
 // api via the provided clients.
-func launchRouter(oc osclient.Interface, kc kclientset.Interface, maxDelay int32, name string, reloadInterval int, reloadCounts map[string]int) (templatePlugin *templateplugin.TemplatePlugin) {
+func launchRouter(oc osclient.Interface, kc kclientset.Interface, maxDelay int32, name string, reloadInterval int, reloadedMap map[string]bool) (templatePlugin *templateplugin.TemplatePlugin) {
 	r := templateplugin.NewFakeTemplateRouter()
 
-	reloadCounts[name] = 0
+	reloadedMap[name] = false
 	r.EnableRateLimiter(reloadInterval, func() error {
-		reloadCounts[name]++
+		reloadedMap[name] = true
 		return nil
 	})
 
@@ -281,8 +320,8 @@ func launchRouter(oc osclient.Interface, kc kclientset.Interface, maxDelay int32
 	}
 
 	factory := controllerfactory.NewDefaultRouterControllerFactory(oc, kc)
-	controller := factory.Create(plugin, false)
-	controller.Run()
+	ctrl := factory.Create(plugin, false)
+	ctrl.Run()
 
 	return
 }


### PR DESCRIPTION
Previously, the router wouldn't reload HAProxy after the initial sync if the last item of the initial list of any of the watched resources didn't reach the router to trigger the commit.  This could be caused by  a route being rejected for any reason (e.g. specifying a host claimed by another namespace). The router could be left in its initial state until another commit-triggering event occurred (e.g. a watch event).  

This PR ensures that the router will always reload after the initial sync.

Reference: [bz1383663](https://bugzilla.redhat.com/show_bug.cgi?id=1383663)

cc: @openshift/networking, @smarterclayton