### PR TITLE
Add `test-extended` target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,22 @@ ifeq ($(TEST_ASSETS),true)
 endif
 .PHONY: test-assets
 
+# Run extended tests.
+#
+# Args:
+#   SUITE: Which Bash entrypoint under test/extended/ to use. Don't include the
+#          ending `.sh`. Ex: `core`.
+#   FOCUS: Literal string to pass to `--ginkgo.focus=`
+#
+# Example:
+#   make test-extended SUITE=core
+#   make test-extended SUITE=conformance FOCUS=pods
+SUITE ?= conformance
+FOCUS ?= .
+test-extended:
+	test/extended/$(SUITE).sh --ginkgo.focus="$(FOCUS)"
+.PHONY: test-extended
+
 # Build and run the complete test-suite.
 #
 # Example:


### PR DESCRIPTION
In order to mirror the current API that exists with Rosie bot for
running the extended tests from GitHub comments, a new `make` target
is necessary with the ability to specify the Bash entrypoint to use
and the Ginkgo focus (if applicable). We can get away with passing
the Ginkgo focus even to entrypoints that don't use Ginkgo, as it will
simply be ignored.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>