### PR TITLE
Fixed Bashisms and temporary directory use in kubeconfig tests

### DIFF
--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -137,7 +137,7 @@ echo "secrets: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/serviceaccounts-create-kubeconfig"
-os::cmd::expect_success 'oc serviceaccounts create-kubeconfig default > ${TMPDIR}/generated_default.kubeconfig'
-os::cmd::expect_success_and_text 'KUBECONFIG=${TMPDIR}/generated_default.kubeconfig oc whoami' "system:serviceaccount:$(oc project -q):default"
+os::cmd::expect_success "oc serviceaccounts create-kubeconfig default > '${BASETMPDIR}/generated_default.kubeconfig'"
+os::cmd::expect_success_and_text "KUBECONFIG='${BASETMPDIR}/generated_default.kubeconfig' oc whoami" "system:serviceaccount:$(oc project -q):default"
 echo "serviceaccounts: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>