### PR TITLE
Turn on jUnit output by default for `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ export OS_OUTPUT_GOPATH
 # mounting secrets specific to a build environment.
 export OS_BUILD_IMAGE_ARGS
 
+# Tests run using `make` are most often run by the CI system, so we are OK to
+# assume the user wants jUnit output and will turn it off if they don't.
+JUNIT_REPORT ?= true
+
 # Build code.
 #
 # Args:


### PR DESCRIPTION
Developers run tests using scripts. The CI runs tests using `make`. jUnit output takes infinitesimally less time to generate than our tests take to run, and sits on top cleanly. If a developer is using `make` to run tests and for some reason can't live with jUnit output for free, they can use scripts. I'd rather just turn this one in one place by default than exposing it as a parameter (and adding doc) for pretty much every single `make` target.

@smarterclayton @deads2k @liggitt @csrwng @bparees @pweil- any last thoughts before merge?

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>