### PR TITLE
Update build logic to support more flexibility in startup

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -5,15 +5,7 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-os::util::ensure::built_binary_exists 'oc'
-
-function build() {
-  eval "oc ex dockerbuild $2 $1 ${OS_BUILD_IMAGE_ARGS:-}"
-}
-
-# Build the images
-build openshift/origin-base                   "${OS_ROOT}/images/base"
-build openshift/origin-haproxy-router-base    "${OS_ROOT}/images/router/haproxy-base"
-build openshift/origin-release                "${OS_ROOT}/images/release"
+# Build the base image without the default image args
+OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" openshift/origin-base
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"


### PR DESCRIPTION
Allows OS_BUILD_IMAGE_ARGS= to be specified for everything except openshift/origin-base. Parallelizes build output. Remove building origin/haproxy-base which is no longer used, and also the core release image (we use external builds now).

Also ensure that hack/build-base-images.sh builds the release image to the correct local tag (which it was not doing before).

[test]