### PR TITLE
Update docs wrt multiple --env/--param arguments

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,7 +104,7 @@ The options are:
 |`--code` *dir*                | Use source code in *dir*                           |
 |`--context-dir` *dir*         | Use *dir* as context dir in the build              |
 |`--docker-image` *image*      | Include Docker image *image* in the app            |
-|`--env` (`-e`) *k1=v1,...*    | Set env vars *k1...* to values *v1...*             |
+|`--env` (`-e`) *k=v*          | Set env var *k* to value *v*                       |
 |`--file` *filename*           | Use template in *filename*                         |
 |`--group` *comp1*`+`*comp2*   | Group together components *comp1* and *comp2*      |
 |`--image-stream` (`-i`) *is*  | Use imagestream *is* in the app                    |
@@ -115,7 +115,7 @@ The options are:
 |`--output-template` *s*       | Template string (`-o template`) or path (`-o templatefile`) |
 |`--output-version` *version*  | Output with *version* (default api-version)        |
 |`--output` (`-o`) *format*    | *format* is one of: `json`, `yaml`, `template`, `templatefile` |
-|`--param` (`-p`) *k1=v1,...*  | Set/override parameters *k1...* with *v1...*       |
+|`--param` (`-p`) *k=v*        | Set/override parameter *k* with value *v*          |
 |`--strategy` *s*              | Use build strategy *s*, one of: `docker`, `source` |
 |`--template` *t*              | Use OpenShift stored template *t* in the app       |
 
@@ -160,7 +160,7 @@ Other options:
 
 | Name       |  Description                                                                                             |
 |:-----------|:---------------------------------------------------------------------------------------------------------|
-|`--env`, *(-e)* FOO=bar | Explicitly set or override environment variables for the current build. Does not change the BuildConfig. |
+|`--env`, *(-e)* FOO=bar | Explicitly set or override environment variable for the current build. Does not change the BuildConfig. |
 |`--build-loglevel` | Set or override the build log level output [0-5] during the build. |
 |`--commit`  | Specify the source code commit identifier the build should use; requires a build based on a Git repository. |
 |`--follow`  | Start a build and watch its logs until it completes or fails. |

--- a/docs/cli_hacking_guide.adoc
+++ b/docs/cli_hacking_guide.adoc
@@ -172,7 +172,7 @@ In case you need additional control over how flags behave in terms of code compl
 |=======
 |`cmd.MarkFlagFilename("my-flag-name")`                 |allows the given flag to autocomplete as a path to file or directory.
 |`cmd.MarkFlagFilename("my-flag-name", "yaml", "yml")`  |consider the given file extensions when doing autocomplete.
-|`MarkFlagRequired("my-flag-name")`                     |mark a flag as required. 
+|`cmd.MarkFlagRequired("my-flag-name")`                 |mark a flag as required.
 |=======
 
 === Automatically Generated Documentation


### PR DESCRIPTION
The following syntax is not supported anymore:
```
--env K1=V1,K2=V2,...
--param K1=V1,K2=V2,...
```

Fixes #12076 

@php-coder @bparees PTAL