### PR TITLE
Run all verification in Makefile rather than exiting early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - make install-travis
 
 script:
-  - PERMISSIVE_GO=y make verify
+  - PROTO_OPTIONAL=1 PERMISSIVE_GO=y make verify
   - make verify-commits
 
 notifications:


### PR DESCRIPTION
Tried to find the minimal change that is not overly hard to read and
still linear. All verification steps will run before failing.

[test]