### PR TITLE
Reuse test artifacts

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -146,11 +146,13 @@ function os::util::environment::setup_tmpdir_vars() {
     export HOME
 
     # ensure that the directories are clean
-    for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
-        if [[ "${target}" == "${BASETMPDIR}"* ]]; then
-            ${USE_SUDO:+sudo} umount "${target}"
-        fi
-    done
+    if os::util::find::system_binary "findmnt"; then
+        for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
+            if [[ "${target}" == "${BASETMPDIR}"* ]]; then
+                ${USE_SUDO:+sudo} umount "${target}"
+            fi
+        done
+    fi
 
     for directory in "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"; do
         ${USE_SUDO:+sudo} rm -rf "${directory}"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -210,6 +210,7 @@ if [[ -n "${junit_report}" ]]; then
     # we don't care if the `go test` fails in this pipe, as we want to generate the report and summarize the output anyway
     set +o pipefail
 
+    go test -i ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" \
         | tee "${test_output_file}"                                 \
         | junitreport --type gotest                                 \
@@ -255,6 +256,7 @@ if [[ -n "${junit_report}" ]]; then
 
 elif [[ -n "${coverage_output_dir}" ]]; then
     # we need to generate coverage reports
+    go test -i ${gotest_flags} ${test_packages}
     for test_package in ${test_packages}; do
         mkdir -p "${coverage_output_dir}/${test_package}"
         local_gotest_flags="${gotest_flags} -coverprofile=${coverage_output_dir}/${test_package}/profile.out"
@@ -279,5 +281,6 @@ elif [[ -n "${dlv_debug}" ]]; then
     dlv test ${test_packages}
 else
     # we need to generate neither jUnit XML nor coverage reports
+    go test -i ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages}
 fi

--- a/pkg/sdn/plugin/sdn-cni-plugin/doc.go
+++ b/pkg/sdn/plugin/sdn-cni-plugin/doc.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package sdnciplugin

--- a/pkg/sdn/plugin/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/pkg/sdn/plugin/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -1,4 +1,6 @@
-package plugin
+// +build linux
+
+package main
 
 import (
 	"encoding/json"
@@ -10,13 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/origin/pkg/sdn/plugin/cniserver"
-	cniplugin "github.com/openshift/origin/pkg/sdn/plugin/sdn-cni-plugin"
-
-	utiltesting "k8s.io/kubernetes/pkg/util/testing"
-
 	cniskel "github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+
+	"github.com/openshift/origin/pkg/sdn/plugin/cniserver"
+	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 )
 
 var expectedResult cnitypes.Result
@@ -68,7 +68,7 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
 
-	cniPlugin := cniplugin.NewCNIPlugin(path)
+	cniPlugin := NewCNIPlugin(path)
 
 	expectedIP, expectedNet, _ := net.ParseCIDR("10.0.0.2/24")
 	expectedResult = cnitypes.Result{


### PR DESCRIPTION
go test -i will put packages in the core GOPATH (users who have OS_OUTPUT_GOPATH set to empty will not share these packages). Also, the presence of race detection forces a recompile of the full package tree, which means we waste time recompiling everything.