### PR TITLE
Avoid reloads when route configuration hasn't changed

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -186,7 +186,7 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 	case watch.Added, watch.Modified:
 		p.Router.AddRoute(route)
 	case watch.Deleted:
-		glog.V(4).Infof("Deleting route %v", route)
+		glog.V(4).Infof("Deleting route %s/%s", route.Namespace, route.Name)
 		p.Router.RemoveRoute(route)
 	}
 	return nil

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -171,18 +171,22 @@ func (r *TestRouter) DeleteEndpoints(id string) {
 	}
 }
 
-// AddRoute adds a ServiceAliasConfig for the route with the ServiceUnit identified by id
-func (r *TestRouter) AddRoute(id string, weight int32, route *routeapi.Route, host string) {
-	su, _ := r.FindServiceUnit(id)
+// AddRoute adds a ServiceAliasConfig and associated ServiceUnits for the route
+func (r *TestRouter) AddRoute(route *routeapi.Route) {
 	routeKey := r.routeKey(route)
 
 	config := ServiceAliasConfig{
-		Host:             host,
+		Host:             route.Spec.Host,
 		Path:             route.Spec.Path,
 		ServiceUnitNames: make(map[string]int32),
 	}
 
-	config.ServiceUnitNames[su.Name] = weight
+	serviceKeys, weights := routeKeys(route)
+	for i, key := range serviceKeys {
+		config.ServiceUnitNames[key] = weights[i]
+		r.CreateServiceUnit(key)
+	}
+
 	r.State[routeKey] = config
 }
 

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -178,12 +178,10 @@ func (r *TestRouter) AddRoute(route *routeapi.Route) {
 	config := ServiceAliasConfig{
 		Host:             route.Spec.Host,
 		Path:             route.Spec.Path,
-		ServiceUnitNames: make(map[string]int32),
+		ServiceUnitNames: getServiceUnits(route),
 	}
 
-	serviceKeys, weights := routeKeys(route)
-	for i, key := range serviceKeys {
-		config.ServiceUnitNames[key] = weights[i]
+	for key := range config.ServiceUnitNames {
 		r.CreateServiceUnit(key)
 	}
 

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -569,88 +569,121 @@ func (r *templateRouter) routeKey(route *routeapi.Route) string {
 	return fmt.Sprintf("%s_%s", route.Namespace, route.Name)
 }
 
-// AddRoute adds a route for the given service id
-func (r *templateRouter) AddRoute(serviceID string, weight int32, route *routeapi.Route, host string) {
-	backendKey := r.routeKey(route)
+// createServiceAliasConfig creates a ServiceAliasConfig from a route and the router state.
+// The router state is not modified in the process, so referenced ServiceUnits may not exist.
+func (r *templateRouter) createServiceAliasConfig(route *routeapi.Route, routeKey string) *ServiceAliasConfig {
 	wantsWildcardSupport := (route.Spec.WildcardPolicy == routeapi.WildcardPolicySubdomain)
 
 	// The router config trumps what the route asks for/wants.
 	wildcard := r.allowWildcardRoutes && wantsWildcardSupport
 
-	config, ok := r.state[backendKey]
+	config := ServiceAliasConfig{
+		Name:             route.Name,
+		Namespace:        route.Namespace,
+		Host:             route.Spec.Host,
+		Path:             route.Spec.Path,
+		IsWildcard:       wildcard,
+		Annotations:      route.Annotations,
+		ServiceUnitNames: make(map[string]int32),
+	}
 
-	if !ok {
-		config = ServiceAliasConfig{
-			Name:             route.Name,
-			Namespace:        route.Namespace,
-			Host:             host,
-			Path:             route.Spec.Path,
-			IsWildcard:       wildcard,
-			Annotations:      route.Annotations,
-			ServiceUnitNames: make(map[string]int32),
-		}
+	if route.Spec.Port != nil {
+		config.PreferPort = route.Spec.Port.TargetPort.String()
+	}
 
-		if route.Spec.Port != nil {
-			config.PreferPort = route.Spec.Port.TargetPort.String()
-		}
+	tls := route.Spec.TLS
+	if tls != nil && len(tls.Termination) > 0 {
+		config.TLSTermination = tls.Termination
 
-		tls := route.Spec.TLS
-		if tls != nil && len(tls.Termination) > 0 {
-			config.TLSTermination = tls.Termination
+		config.InsecureEdgeTerminationPolicy = tls.InsecureEdgeTerminationPolicy
 
-			config.InsecureEdgeTerminationPolicy = tls.InsecureEdgeTerminationPolicy
+		if tls.Termination != routeapi.TLSTerminationPassthrough {
+			config.Certificates = make(map[string]Certificate)
 
-			if tls.Termination != routeapi.TLSTerminationPassthrough {
-				if config.Certificates == nil {
-					config.Certificates = make(map[string]Certificate)
+			if len(tls.Certificate) > 0 {
+				certKey := generateCertKey(&config)
+				cert := Certificate{
+					ID:         routeKey,
+					Contents:   tls.Certificate,
+					PrivateKey: tls.Key,
 				}
 
-				if len(tls.Certificate) > 0 {
-					certKey := generateCertKey(&config)
-					cert := Certificate{
-						ID:         backendKey,
-						Contents:   tls.Certificate,
-						PrivateKey: tls.Key,
-					}
+				config.Certificates[certKey] = cert
+			}
 
-					config.Certificates[certKey] = cert
+			if len(tls.CACertificate) > 0 {
+				caCertKey := generateCACertKey(&config)
+				caCert := Certificate{
+					ID:       routeKey,
+					Contents: tls.CACertificate,
 				}
 
-				if len(tls.CACertificate) > 0 {
-					caCertKey := generateCACertKey(&config)
-					caCert := Certificate{
-						ID:       backendKey,
-						Contents: tls.CACertificate,
-					}
+				config.Certificates[caCertKey] = caCert
+			}
 
-					config.Certificates[caCertKey] = caCert
+			if len(tls.DestinationCACertificate) > 0 {
+				destCertKey := generateDestCertKey(&config)
+				destCert := Certificate{
+					ID:       routeKey,
+					Contents: tls.DestinationCACertificate,
 				}
 
-				if len(tls.DestinationCACertificate) > 0 {
-					destCertKey := generateDestCertKey(&config)
-					destCert := Certificate{
-						ID:       backendKey,
-						Contents: tls.DestinationCACertificate,
-					}
-
-					config.Certificates[destCertKey] = destCert
-				}
+				config.Certificates[destCertKey] = destCert
 			}
 		}
 	}
 
-	key := fmt.Sprintf("%s %s", config.TLSTermination, backendKey)
+	key := fmt.Sprintf("%s %s", config.TLSTermination, routeKey)
 	config.RoutingKeyName = fmt.Sprintf("%x", md5.Sum([]byte(key)))
+
+	// Weight suggests the % of traffic that a given service will
+	// receive compared to other services pointed to by the route.
+	serviceKeys, weights := routeKeys(route)
+	for i, key := range serviceKeys {
+		config.ServiceUnitNames[key] = weights[i]
+	}
+
+	return &config
+}
+
+// AddRoute adds the given route to the router state if the route
+// hasn't been seen before or has changed since it was last seen.
+func (r *templateRouter) AddRoute(route *routeapi.Route) {
+	backendKey := r.routeKey(route)
+
+	newConfig := r.createServiceAliasConfig(route, backendKey)
+
+	if existingConfig, exists := r.state[backendKey]; exists {
+		if configsAreEqual(newConfig, &existingConfig) {
+			return
+		}
+
+		glog.V(4).Infof("Updating route %v", route)
+
+		// Delete the route first, because modify is to be treated as delete+add
+		r.RemoveRoute(route)
+
+		// TODO - clean up service units that are no longer
+		// referenced.  This may be challenging if a service unit can
+		// be referenced by more than one route, but the alternative
+		// is having stale service units accumulate with the attendant
+		// cost to router memory usage.
+	} else {
+		glog.V(4).Infof("Adding route %v", route)
+	}
+
+	// Add service units referred to by the config
+	for key := range newConfig.ServiceUnitNames {
+		if _, ok := r.FindServiceUnit(key); !ok {
+			glog.V(4).Infof("Creating new frontend for key: %v", key)
+			r.CreateServiceUnit(key)
+		}
+	}
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	frontend, _ := r.findMatchingServiceUnit(serviceID)
-
-	//create or replace
-	config.ServiceUnitNames[frontend.Name] = weight
-	r.state[backendKey] = config
-	r.serviceUnits[serviceID] = frontend
+	r.state[backendKey] = *newConfig
 	r.stateChanged = true
 }
 
@@ -789,4 +822,43 @@ func generateCACertKey(config *ServiceAliasConfig) string {
 
 func generateDestCertKey(config *ServiceAliasConfig) string {
 	return config.Host + destCertPostfix
+}
+
+// routeKeys returns the internal router keys to use for the given Route.
+// A route can have several services that it can point to, now
+func routeKeys(route *routeapi.Route) ([]string, []int32) {
+	keys := make([]string, 1+len(route.Spec.AlternateBackends))
+	weights := make([]int32, 1+len(route.Spec.AlternateBackends))
+	keys[0] = fmt.Sprintf("%s/%s", route.Namespace, route.Spec.To.Name)
+	if route.Spec.To.Weight != nil {
+		weights[0] = *route.Spec.To.Weight
+	}
+	for i, svc := range route.Spec.AlternateBackends {
+		keys[i+1] = fmt.Sprintf("%s/%s", route.Namespace, svc.Name)
+		if svc.Weight != nil {
+			weights[i+1] = *svc.Weight
+		}
+	}
+	return keys, weights
+}
+
+// configsAreEqual determines whether the given service alias configs can be considered equal.
+// This may be useful in determining whether a new service alias config is the same as an
+// existing one or represents an update to its state.
+func configsAreEqual(config1, config2 *ServiceAliasConfig) bool {
+	return config1.Name == config2.Name &&
+		config1.Namespace == config2.Namespace &&
+		config1.Host == config2.Host &&
+		config1.Path == config2.Path &&
+		config1.TLSTermination == config2.TLSTermination &&
+		reflect.DeepEqual(config1.Certificates, config2.Certificates) &&
+		// Status isn't compared since whether certs have been written
+		// to disk or not isn't relevant in determining whether a
+		// route needs to be updated.
+		config1.PreferPort == config2.PreferPort &&
+		config1.InsecureEdgeTerminationPolicy == config2.InsecureEdgeTerminationPolicy &&
+		config1.RoutingKeyName == config2.RoutingKeyName &&
+		config1.IsWildcard == config2.IsWildcard &&
+		reflect.DeepEqual(config1.Annotations, config2.Annotations) &&
+		reflect.DeepEqual(config1.ServiceUnitNames, config2.ServiceUnitNames)
 }

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -651,7 +651,7 @@ func (r *templateRouter) AddRoute(route *routeapi.Route) {
 			return
 		}
 
-		glog.V(4).Infof("Updating route %v", route)
+		glog.V(4).Infof("Updating route %s/%s", route.Namespace, route.Name)
 
 		// Delete the route first, because modify is to be treated as delete+add
 		r.RemoveRoute(route)
@@ -662,7 +662,7 @@ func (r *templateRouter) AddRoute(route *routeapi.Route) {
 		// is having stale service units accumulate with the attendant
 		// cost to router memory usage.
 	} else {
-		glog.V(4).Infof("Adding route %v", route)
+		glog.V(4).Infof("Adding route %s/%s", route.Namespace, route.Name)
 	}
 
 	// Add service units referred to by the config

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -3,10 +3,13 @@ package templaterouter
 import (
 	"crypto/md5"
 	"fmt"
+	"reflect"
 	"testing"
 
-	routeapi "github.com/openshift/origin/pkg/route/api"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/intstr"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 // TestCreateServiceUnit tests creating a service unit and finding it in router state
@@ -242,13 +245,6 @@ func TestRouteKey(t *testing.T) {
 		},
 	}
 
-	suKey := "test"
-	router.CreateServiceUnit(suKey)
-	_, ok := router.FindServiceUnit(suKey)
-	if !ok {
-		t.Fatalf("Unable to find created service unit %s", suKey)
-	}
-
 	startCount := len(router.state)
 	for _, tc := range testCases {
 		route := &routeapi.Route{
@@ -269,12 +265,7 @@ func TestRouteKey(t *testing.T) {
 			},
 		}
 
-		// add route always returns true
-		router.AddRoute(suKey, 100, route, route.Spec.Host)
-		if !router.stateChanged {
-			t.Fatalf("expected AddRoute to have changed router state")
-		}
-
+		router.AddRoute(route)
 		routeKey := router.routeKey(route)
 		_, ok := router.state[routeKey]
 		if !ok {
@@ -290,17 +281,29 @@ func TestRouteKey(t *testing.T) {
 	}
 }
 
-// TestAddRoute tests adding a service alias config to a service unit
-func TestAddRoute(t *testing.T) {
+// TestCreateServiceAliasConfig validates creation of a ServiceAliasConfig from a route and the router state
+func TestCreateServiceAliasConfig(t *testing.T) {
 	router := NewFakeTemplateRouter()
+
+	namespace := "foo"
+	serviceName := "TestService"
+	serviceWeight := int32(30)
+
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
-			Namespace: "foo",
+			Namespace: namespace,
 			Name:      "bar",
 		},
 		Spec: routeapi.RouteSpec{
 			Host: "host",
 			Path: "path",
+			Port: &routeapi.RoutePort{
+				TargetPort: intstr.FromInt(8080),
+			},
+			To: routeapi.RouteTargetReference{
+				Name:   serviceName,
+				Weight: &serviceWeight,
+			},
 			TLS: &routeapi.TLSConfig{
 				Termination:              routeapi.TLSTerminationEdge,
 				Certificate:              "abc",
@@ -310,28 +313,108 @@ func TestAddRoute(t *testing.T) {
 			},
 		},
 	}
-	suKey := "test"
-	router.CreateServiceUnit(suKey)
 
-	router.AddRoute(suKey, 100, route, route.Spec.Host)
-	if !router.stateChanged {
-		t.Fatalf("expected AddRoute to have changed router state")
+	config := *router.createServiceAliasConfig(route, "foo")
+
+	suName := fmt.Sprintf("%s/%s", namespace, serviceName)
+	expectedSUs := map[string]int32{
+		suName: serviceWeight,
 	}
 
-	_, ok := router.FindServiceUnit(suKey)
+	// Basic sanity, validate more fields as necessary
+	if config.Host != route.Spec.Host || config.Path != route.Spec.Path || !compareTLS(route, config, t) ||
+		config.PreferPort != route.Spec.Port.TargetPort.String() || !reflect.DeepEqual(expectedSUs, config.ServiceUnitNames) {
+		t.Errorf("Route %v did not match service alias config %v", route, config)
+	}
+}
 
-	if !ok {
-		t.Errorf("Unable to find created service unit %s", suKey)
-	} else {
-		routeKey := router.routeKey(route)
-		saCfg, ok := router.state[routeKey]
+// TestAddRoute validates that adding a route creates a service alias config and associated service units
+func TestAddRoute(t *testing.T) {
+	router := NewFakeTemplateRouter()
 
-		if !ok {
-			t.Errorf("Unable to find created service alias config for route %s", routeKey)
-		} else {
-			if saCfg.Host != route.Spec.Host || saCfg.Path != route.Spec.Path || !compareTLS(route, saCfg, t) {
-				t.Errorf("Route %v did not match serivce alias config %v", route, saCfg)
-			}
+	namespace := "foo"
+	serviceName := "TestService"
+
+	route := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: namespace,
+			Name:      "bar",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "host",
+			Path: "path",
+			To: routeapi.RouteTargetReference{
+				Name: serviceName,
+			},
+		},
+	}
+
+	router.AddRoute(route)
+	if !router.stateChanged {
+		t.Fatalf("router state not marked as changed")
+	}
+
+	suName := fmt.Sprintf("%s/%s", namespace, serviceName)
+	expectedSUs := map[string]ServiceUnit{
+		suName: {
+			Name:          suName,
+			EndpointTable: []Endpoint{},
+		},
+	}
+
+	if !reflect.DeepEqual(expectedSUs, router.serviceUnits) {
+		t.Fatalf("Expected %v service units, got %v", expectedSUs, router.serviceUnits)
+	}
+
+	routeKey := router.routeKey(route)
+
+	if config, ok := router.state[routeKey]; !ok {
+		t.Errorf("Unable to find created service alias config for route %s", routeKey)
+	} else if config.Host != route.Spec.Host {
+		// This test is not validating createServiceAliasConfig, so superficial validation should be good enough.
+		t.Errorf("Route %v did not match service alias config %v", route, config)
+	}
+}
+
+func TestUpdateRoute(t *testing.T) {
+	router := NewFakeTemplateRouter()
+
+	// Add a route that can be targeted for an update
+	route := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+		Spec: routeapi.RouteSpec{
+			Host: "host",
+			Path: "/foo",
+		},
+	}
+	router.AddRoute(route)
+
+	testCases := []struct {
+		name    string
+		path    string
+		updated bool
+	}{
+		{
+			name:    "Same route does not update state",
+			path:    "/foo",
+			updated: false,
+		},
+		{
+			name:    "Different route updates state",
+			path:    "/bar",
+			updated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		router.stateChanged = false
+		route.Spec.Path = tc.path
+		router.AddRoute(route)
+		if router.stateChanged != tc.updated {
+			t.Errorf("%s: expected stateChanged = %v, but got %v", tc.name, tc.updated, router.stateChanged)
 		}
 	}
 }
@@ -393,8 +476,8 @@ func TestRemoveRoute(t *testing.T) {
 	suKey := "test"
 
 	router.CreateServiceUnit(suKey)
-	router.AddRoute(suKey, 100, route, route.Spec.Host)
-	router.AddRoute(suKey, 100, route2, route2.Spec.Host)
+	router.AddRoute(route)
+	router.AddRoute(route2)
 
 	_, ok := router.FindServiceUnit(suKey)
 	if !ok {
@@ -569,31 +652,18 @@ func TestAddRouteEdgeTerminationInsecurePolicy(t *testing.T) {
 			},
 		}
 
-		suKey := fmt.Sprintf("%s-test", tc.Name)
-		router.CreateServiceUnit(suKey)
+		router.AddRoute(route)
 
-		router.AddRoute(suKey, 100, route, route.Spec.Host)
-		if !router.stateChanged {
-			t.Fatalf("InsecureEdgeTerminationPolicy test %s: expected AddRoute to have changed router state", tc.Name)
-		}
-
-		_, ok := router.FindServiceUnit(suKey)
+		routeKey := router.routeKey(route)
+		saCfg, ok := router.state[routeKey]
 
 		if !ok {
-			t.Errorf("InsecureEdgeTerminationPolicy test %s: unable to find created service unit %s",
-				tc.Name, suKey)
+			t.Errorf("InsecureEdgeTerminationPolicy test %s: unable to find created service alias config for route %s",
+				tc.Name, routeKey)
 		} else {
-			routeKey := router.routeKey(route)
-			saCfg, ok := router.state[routeKey]
-
-			if !ok {
-				t.Errorf("InsecureEdgeTerminationPolicy test %s: unable to find created service alias config for route %s",
-					tc.Name, routeKey)
-			} else {
-				if saCfg.Host != route.Spec.Host || saCfg.Path != route.Spec.Path || !compareTLS(route, saCfg, t) || saCfg.InsecureEdgeTerminationPolicy != tc.InsecurePolicy {
-					t.Errorf("InsecureEdgeTerminationPolicy test %s: route %v did not match serivce alias config %v",
-						tc.Name, route, saCfg)
-				}
+			if saCfg.Host != route.Spec.Host || saCfg.Path != route.Spec.Path || !compareTLS(route, saCfg, t) || saCfg.InsecureEdgeTerminationPolicy != tc.InsecurePolicy {
+				t.Errorf("InsecureEdgeTerminationPolicy test %s: route %v did not match serivce alias config %v",
+					tc.Name, route, saCfg)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, 'Added' and 'Modified' route events would always result in a router state change that required a reload.  This change ensures that the router computes the configuration of the route provided by an event and only makes a reload-requiring state change if the new configuration differs from the old.  Along with the changes from #12199, routers should no longer have to reload unless route and endpoint configuration changes.

Please review only https://github.com/openshift/origin/pull/12242/commits/c4636aa5da31760e50eeecebe14d0a2269021091 and https://github.com/openshift/origin/pull/12242/commits/93173fe816b9a6903ad6e64e76ace3ad4a1b2480.  The other commits are from #12199 and a necessary precursor to this work, but that PR may be close to merging and I didn't want to delay things by adding more code at the last minute.

cc: @openshift/networking @smarterclayton 