### PR TITLE
Add credentials to SA for docker-registry exposed by a route

### DIFF
--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -174,7 +174,8 @@ func (c *MasterConfig) RunServiceAccountPullSecretsControllers() {
 		DockercfgController:  dockercfgController,
 		DockerURLsIntialized: dockerURLsIntialized,
 	}
-	go serviceaccountcontrollers.NewDockerRegistryServiceController(c.KubeClientset(), dockerRegistryControllerOptions).Run(10, make(chan struct{}))
+	routeClient, _ := c.RouteAllocatorClients()
+	go serviceaccountcontrollers.NewDockerRegistryServiceController(c.KubeClientset(), routeClient, dockerRegistryControllerOptions).Run(10, make(chan struct{}))
 }
 
 // RunAssetServer starts the asset server for the OpenShift UI.

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -171,6 +172,7 @@ func (c *MasterConfig) RunServiceAccountPullSecretsControllers() {
 	dockerRegistryControllerOptions := serviceaccountcontrollers.DockerRegistryServiceControllerOptions{
 		RegistryNamespace:    "default",
 		RegistryServiceName:  "docker-registry",
+		RegistryDefaultHost:  os.Getenv("OPENSHIFT_DEFAULT_REGISTRY"),
 		DockercfgController:  dockercfgController,
 		DockerURLsIntialized: dockerURLsIntialized,
 	}


### PR DESCRIPTION
If a docker-registry service is exposed by a route, this PR will make sure we generate the dockercfg automatically when that route is created or changed.

```
# run openshift with OPENSHIFT_DEFAULT_REGISTRY=registry.local:80
$ oc expose service docker-registry --hostname=registry.local --as=system:admin
```

Now when pushing in build:

```
Pushing image registry.local:80/test/ruby-ex:latest ...
...
Push successful
```

Fixes: https://github.com/openshift/origin/issues/8581