### PR TITLE
UPSTREAM: 38339: Exponential back off when volume delete fails

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -192,6 +192,7 @@ func (c *MasterConfig) RunPersistentVolumeController(client *client.Client, name
 		nil, nil, nil,
 		nil, // event recorder
 		s.VolumeConfiguration.EnableDynamicProvisioning,
+		true, // enableExpBackoff
 	)
 	volumeController.Run(utilwait.NeverStop)
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -435,6 +435,7 @@ func StartControllers(s *options.CMServer, kubeClient *client.Client, kubeconfig
 		nil, // classSource
 		nil, // eventRecorder
 		s.VolumeConfiguration.EnableDynamicProvisioning,
+		true, //enable Exponential backoff on errors
 	)
 	volumeController.Run(wait.NeverStop)
 	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/framework_test.go
@@ -606,6 +606,7 @@ func newTestController(kubeClient clientset.Interface, volumeSource, claimSource
 		classSource,
 		record.NewFakeRecorder(1000), // event recorder
 		enableDynamicProvisioning,
+		false, // enableExpBackoff
 	)
 
 	// Speed up the test

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -68,7 +68,7 @@ func NewPersistentVolumeController(
 		claims:            cache.NewStore(framework.DeletionHandlingMetaNamespaceKeyFunc),
 		kubeClient:        kubeClient,
 		eventRecorder:     eventRecorder,
-		runningOperations: goroutinemap.NewGoRoutineMap(false /* exponentialBackOffOnError */),
+		runningOperations: goroutinemap.NewGoRoutineMap(true/* exponentialBackOffOnError */),
 		cloud:             cloud,
 		enableDynamicProvisioning:     enableDynamicProvisioning,
 		clusterName:                   clusterName,

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -55,6 +55,7 @@ func NewPersistentVolumeController(
 	volumeSource, claimSource, classSource cache.ListerWatcher,
 	eventRecorder record.EventRecorder,
 	enableDynamicProvisioning bool,
+	enableExpBackoff bool,
 ) *PersistentVolumeController {
 
 	if eventRecorder == nil {
@@ -68,7 +69,7 @@ func NewPersistentVolumeController(
 		claims:            cache.NewStore(framework.DeletionHandlingMetaNamespaceKeyFunc),
 		kubeClient:        kubeClient,
 		eventRecorder:     eventRecorder,
-		runningOperations: goroutinemap.NewGoRoutineMap(true/* exponentialBackOffOnError */),
+		runningOperations: goroutinemap.NewGoRoutineMap(enableExpBackoff),
 		cloud:             cloud,
 		enableDynamicProvisioning:     enableDynamicProvisioning,
 		clusterName:                   clusterName,

--- a/vendor/k8s.io/kubernetes/test/integration/persistentvolumes/persistent_volumes_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/persistentvolumes/persistent_volumes_test.go
@@ -1132,12 +1132,13 @@ func createClients(ns *api.Namespace, t *testing.T, s *httptest.Server, syncPeri
 		nil, // alpha provisioner
 		plugins,
 		cloud,
-		"",   // cluster name
-		nil,  // volumeSource
-		nil,  // claimSource
-		nil,  // classSource
-		nil,  // eventRecorder
-		true) // enableDynamicProvisioning
+		"",    // cluster name
+		nil,   // volumeSource
+		nil,   // claimSource
+		nil,   // classSource
+		nil,   // eventRecorder
+		true,  // enableDynamicProvisioning
+		false) // enableExpBackoff
 
 	watchPV, err := testClient.PersistentVolumes().Watch(api.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
This implements pv_controller to exponentially backoff
when deleting a volume fails in Cloud API. It ensures that
we aren't making too many calls to Cloud API