### PR TITLE
router: differentiate router integration tests

### DIFF
--- a/test/integration/router_controller_test.go
+++ b/test/integration/router_controller_test.go
@@ -1,3 +1,10 @@
+// This file is intended to contain tests of the behavior of the
+// router controller interacting with the api.  Docker and a router
+// image are not required to run the tests.
+//
+// Tests intended to validate router-configured HAProxy belong in
+// router_test.go instead.
+
 package integration
 
 import (

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1,3 +1,12 @@
+// This file is intended to contain tests of the behavior of
+// router-configured instances of HAProxy.  Such tests require docker
+// and a router image.  Validating a change to the router code with
+// these tests requires that the code and the router image be rebuilt
+// before the tests are run.
+//
+// Tests that do not need to validate how the router configures
+// HAProxy belong in router_controller_test.go instead.
+
 package integration
 
 import (


### PR DESCRIPTION
There are 2 router files containing integration tests.  This change renames router_stress_test.go to router_controller_test.go to better communicate its purpose and adds docs at the top of both files to aid in future test development.