### PR TITLE
Patch: AWS - extend list of known reqions

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/credentialprovider/aws/aws_credentials.go
+++ b/vendor/k8s.io/kubernetes/pkg/credentialprovider/aws/aws_credentials.go
@@ -34,15 +34,18 @@ import (
 // and credentialprovider.
 var AWSRegions = [...]string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",
+	"eu-west-2",
 	"eu-central-1",
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ca-central-1,"
 	"cn-north-1",
 	"us-gov-west-1",
 	"sa-east-1",


### PR DESCRIPTION
This is a patch created from kubernetes v1.4 and v1.5 commits:
  80d4391 - AWS: recognize us-east-2 region: https://github.com/kubernetes/kubernetes/pull/35013
  e8b4875 - AWS: recognize eu-west-2 region: https://github.com/kubernetes/kubernetes/pull/38746
  e2342eb - AWS: Recognize ca-central-1 region: https://github.com/kubernetes/kubernetes/pull/38410