### PR TITLE
deploy: revert proportional recreate timeout and default to 10m

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -11,7 +11,7 @@ const (
 	// DefaultRollingTimeoutSeconds is the default TimeoutSeconds for RollingDeploymentStrategyParams.
 	DefaultRollingTimeoutSeconds int64 = 10 * 60
 	// DefaultRecreateTimeoutSeconds is the default TimeoutSeconds for RecreateDeploymentStrategyParams.
-	DefaultRecreateTimeoutSeconds int64 = 2 * 60
+	DefaultRecreateTimeoutSeconds int64 = 10 * 60
 	// DefaultRollingIntervalSeconds is the default IntervalSeconds for RollingDeploymentStrategyParams.
 	DefaultRollingIntervalSeconds int64 = 1
 	// DefaultRollingUpdatePeriodSeconds is the default PeriodSeconds for RollingDeploymentStrategyParams.

--- a/pkg/deploy/api/v1/defaults.go
+++ b/pkg/deploy/api/v1/defaults.go
@@ -68,7 +68,7 @@ func SetDefaults_DeploymentStrategy(obj *DeploymentStrategy) {
 
 func SetDefaults_RecreateDeploymentStrategyParams(obj *RecreateDeploymentStrategyParams) {
 	if obj.TimeoutSeconds == nil {
-		obj.TimeoutSeconds = mkintp(deployapi.DefaultRollingTimeoutSeconds)
+		obj.TimeoutSeconds = mkintp(deployapi.DefaultRecreateTimeoutSeconds)
 	}
 }
 


### PR DESCRIPTION
This PR reverts the proportional timeout (accounting the deployer pod start time) as we don't need that since we count timeout for each operation that makes progress. Also this bumps the default timeout for this in recreate from 2m to 10m.