### PR TITLE
provider recorder to attach detach controller

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -198,6 +198,10 @@ func (c *MasterConfig) RunPersistentVolumeController(client *client.Client, name
 
 func (c *MasterConfig) RunPersistentVolumeAttachDetachController(client *client.Client) {
 	s := c.ControllerManager
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(c.KubeClient.Events(""))
+	recorder := eventBroadcaster.NewRecorder(kapi.EventSource{Component: "controller-manager"})
+
 	attachDetachController, err :=
 		attachdetachcontroller.NewAttachDetachController(
 			clientadapter.FromUnversionedClient(client),
@@ -207,7 +211,7 @@ func (c *MasterConfig) RunPersistentVolumeAttachDetachController(client *client.
 			c.Informers.PersistentVolumes().Informer(),
 			c.CloudProvider,
 			kctrlmgr.ProbeAttachableVolumePlugins(s.VolumeConfiguration),
-			nil,
+			recorder,
 		)
 	if err != nil {
 		glog.Fatalf("Failed to start attach/detach controller: %v", err)

--- a/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/util/operationexecutor/operation_executor.go
@@ -504,15 +504,7 @@ func (oe *operationExecutor) generateAttachVolumeFunc(
 				volumeToAttach.NodeName,
 				attachErr)
 			for _, pod := range volumeToAttach.ScheduledPods {
-				// if pod is removed, reference to pod could be undefined
-				if pod != nil {
-					oe.recorder.Eventf(pod, v1.EventTypeWarning, kevents.FailedMountVolume, err.Error())
-				} else {
-					glog.Errorf("Pod is not found while attaching volume  %q on node %q. Attach error: %v",
-						volumeToAttach.VolumeSpec.Name(),
-						volumeToAttach.NodeName,
-						attachErr)
-				}
+				oe.recorder.Eventf(pod, v1.EventTypeWarning, kevents.FailedMountVolume, err.Error())
 			}
 			return err
 		}


### PR DESCRIPTION
@gnufied @childsb 

attach/detach controller uses recorder in operation_executor.go, but openshift forgets to provide one