### PR TITLE
Don't mention internal error when docker registry is unreachable

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -214,7 +214,14 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 			glog.V(4).Infof("image import failed: %#v", image)
 			switch image.Status.Reason {
 			case unversioned.StatusReasonInternalError:
-				glog.Warningf("Docker registry lookup failed: %s", image.Status.Message)
+				// try to find the cause of the internal error
+				if image.Status.Details != nil && len(image.Status.Details.Causes) > 0 {
+					for _, c := range image.Status.Details.Causes {
+						glog.Warningf("Docker registry lookup failed: %s", c.Message)
+					}
+				} else {
+					glog.Warningf("Docker registry lookup failed: %s", image.Status.Message)
+				}
 			case unversioned.StatusReasonInvalid, unversioned.StatusReasonUnauthorized, unversioned.StatusReasonNotFound:
 			default:
 				errs = append(errs, fmt.Errorf("can't look up Docker image %q: %s", term, image.Status.Message))


### PR DESCRIPTION
Should make oc new-app output slightly less scary when used in disconnected environment.

Before:
```
$ oc new-app somegitrepo
...dockerimagelookup.go:220] Docker registry lookup failed: Internal error occurred: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```
After:
```
$ oc new-app somegitrepo
...dockerimagelookup.go:220] Docker registry lookup failed: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```
Fixes bug [1398330](https://bugzilla.redhat.com/show_bug.cgi?id=1398330).