### PR TITLE
Remove `$TERM` export from our Bash library

### DIFF
--- a/hack/lib/util/text.sh
+++ b/hack/lib/util/text.sh
@@ -81,10 +81,6 @@ function os::text::clear_string() {
     fi
 }
 
-# If $TERM is set but not exported, we will not be able to call
-# tput. Therefore, we export whatever is present in $TERM.
-export TERM
-
 # os::text::internal::is_tty determines if we are outputting to a TTY
 function os::text::internal::is_tty() {
 	[[ -t 1 && -n "${TERM:-}" ]]


### PR DESCRIPTION
The Travis team has responded to the issues with `$TERM` being set but
not exported, so we should be able to stop carrying this hack and still
get correct execution on Travis CI.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>