### PR TITLE
HAProxy Router: Add option to use PROXY protocol

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -96,7 +96,7 @@ listen stats :1936
 
 {{ if .BindPorts }}
 frontend public
-  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
+  bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}{{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
   mode http
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
@@ -145,7 +145,7 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
-  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}
+  bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}{{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
   tcp-request  inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
 


### PR DESCRIPTION
Configure HAProxy to expect incoming connections on port 443 to use the PROXY protocol if the `ROUTER_USE_PROXY_PROTOCOL` environment variable is set to "true" or "TRUE".

This commit fixes bug 1385421.

https://bugzilla.redhat.com/show_bug.cgi?id=1385421

---

openshift-bot, please [test]!