### PR TITLE
UPSTREAM: 35013: AWS: recognize us-east-2 region

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/credentialprovider/aws/aws_credentials.go
+++ b/vendor/k8s.io/kubernetes/pkg/credentialprovider/aws/aws_credentials.go
@@ -34,6 +34,7 @@ import (
 // and credentialprovider.
 var AWSRegions = [...]string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",


### PR DESCRIPTION
This is a patch cherry-picked from kubernetes v1.4 commit:
80d4391 - AWS: recognize us-east-2 region: kubernetes/kubernetes#35013

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1400746