### PR TITLE
Add wildfly image stream to maven pipeline example

### DIFF
--- a/examples/jenkins/pipeline/maven-pipeline.yaml
+++ b/examples/jenkins/pipeline/maven-pipeline.yaml
@@ -41,6 +41,27 @@ objects:
   status:
     dockerImageRepository: ""
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: wildfly
+  spec:
+    tags:
+    - annotations:
+        supports: wildfly:10.1,jee,java
+        tags: builder,wildfly,java
+        version: "10.1"
+      from:
+        kind: DockerImage
+        name: openshift/wildfly-101-centos7:latest
+      name: "10.1"
+    - annotations:
+        supports: jee,java
+        tags: builder,wildfly,java
+      from:
+        kind: ImageStreamTag
+        name: "10.1"
+      name: latest
+- apiVersion: v1
   kind: BuildConfig
   metadata:
     annotations:
@@ -116,7 +137,6 @@ objects:
         from:
           kind: ImageStreamTag
           name: wildfly:latest
-          namespace: openshift
       type: Docker
     triggers: {}
 - apiVersion: v1

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -4935,6 +4935,27 @@ objects:
   status:
     dockerImageRepository: ""
 - apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: wildfly
+  spec:
+    tags:
+    - annotations:
+        supports: wildfly:10.1,jee,java
+        tags: builder,wildfly,java
+        version: "10.1"
+      from:
+        kind: DockerImage
+        name: openshift/wildfly-101-centos7:latest
+      name: "10.1"
+    - annotations:
+        supports: jee,java
+        tags: builder,wildfly,java
+      from:
+        kind: ImageStreamTag
+        name: "10.1"
+      name: latest
+- apiVersion: v1
   kind: BuildConfig
   metadata:
     annotations:
@@ -5010,7 +5031,6 @@ objects:
         from:
           kind: ImageStreamTag
           name: wildfly:latest
-          namespace: openshift
       type: Docker
     triggers: {}
 - apiVersion: v1


### PR DESCRIPTION
As it is, the example cannot be instantiated in an OCP cluster because the wildfly image stream is not present by default. This creates a local image stream in the namespace of the pipeline.