### PR TITLE
Pass no focus spec in `make test-extended` when unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,13 @@ endif
 #   make test-extended SUITE=core
 #   make test-extended SUITE=conformance FOCUS=pods
 SUITE ?= conformance
-FOCUS ?= .
+ifneq ($(strip $(FOCUS)),)
+	FOCUS_ARG=--ginkgo.focus="$(FOCUS)"
+else
+	FOCUS_ARG=
+endif
 test-extended:
-	test/extended/$(SUITE).sh --ginkgo.focus="$(FOCUS)"
+	test/extended/$(SUITE).sh $(FOCUS_ARG)
 .PHONY: test-extended
 
 # Build and run the complete test-suite.


### PR DESCRIPTION
The current implementation of the extended test setup and focus
mechanism is to honor user-provided `--ginkgo.focus` strings over
anything that can be inferred from which specific extended test bucket
is being run. This means that, for instance:

    $ make test-extended SUITE=conformance FOCUS=pods

Will run ALL Ginkgo tests that relate to `pods`, not just conformance
tests that do. This means that:

    $ make test-extended SUITE=conformance FOCUS="."

Cannot be used as a no-op focus to grab all conformance tests. We can't
default the focus to `.`, then, and need to entirely omit the argument
if no test focus is requested.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>