### PR TITLE
add namespace selector field to crq describe output

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -1494,8 +1494,16 @@ func DescribeClusterQuota(quota *quotaapi.ClusterResourceQuota) (string, error) 
 		return "", err
 	}
 
+	nsSelector := make([]interface{}, 0, quota.Status.Namespaces.OrderedKeys().Len())
+	ns := quota.Status.Namespaces.OrderedKeys().Front()
+	for ns != nil {
+		nsSelector = append(nsSelector, ns.Value)
+		ns = ns.Next()
+	}
+
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, quota.ObjectMeta)
+		fmt.Fprintf(out, "Namespace Selector: %q\n", nsSelector)
 		fmt.Fprintf(out, "Label Selector: %s\n", labelSelector)
 		fmt.Fprintf(out, "AnnotationSelector: %s\n", quota.Spec.Selector.AnnotationSelector)
 		if len(quota.Spec.Quota.Scopes) > 0 {


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1400912

This patch adds a `Namespace Selector` field to the describer output of `clusterresourcequota` to display the list of namespaces that are selected based on the `clusterresourcequota`'s `--project-anotation-selector`.

**Example**
```
$ oc create clusterresourcequota crq-1 --project-annotation-selector=openshift.io/requester=user --hard=secrets=50

$ oc new-project p-1 --as=user
$ oc new-project p-2 --as=user
$ oc new-project p-3 --as=dev

$ oc describe clusterresourcequota crq-1
Name:           crq-1
Namespace:      <none>
Created:        52 minutes ago
Labels:         <none>
Annotations:    <none>
Namespace Selector: ["p-1" "p-2"]
Label Selector: <null>
AnnotationSelector: map[openshift.io/requester:user]
Resource        Used    Hard
--------        ----    ----
secrets         18      50
```

@openshift/cli-review 