### PR TITLE
Print clearer messages in `oc status` when user has no projects

### DIFF
--- a/pkg/cmd/cli/cmd/errors/login.go
+++ b/pkg/cmd/cli/cmd/errors/login.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/openshift/origin/pkg/cmd/errors"
@@ -50,4 +51,16 @@ func kubeConfigSolution(isExplicitFile bool) string {
 		}
 		return KubeConfigSolutionUnix
 	}
+}
+
+// NoProjectsExistMessage returns a message indicating that no projects have been created by the current user.
+func NoProjectsExistMessage(canRequestProjects bool, commandName string) string {
+	if !canRequestProjects {
+		return fmt.Sprintf("You don't have any projects. Contact your system administrator to request a project.\n")
+	}
+	return fmt.Sprintf(`You don't have any projects. You can try to create a new project, by running
+
+    %s new-project <projectname>
+
+`, commandName)
 }

--- a/pkg/cmd/cli/cmd/login/util/util.go
+++ b/pkg/cmd/cli/cmd/login/util/util.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"k8s.io/kubernetes/pkg/client/restclient"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+)
+
+func CanRequestProjects(config *restclient.Config, defaultNamespace string) (bool, error) {
+	oClient, err := client.New(config)
+	if err != nil {
+		return false, err
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Action: authorizationapi.Action{
+			Namespace: defaultNamespace,
+			Verb:      "list",
+			Resource:  "projectrequests",
+		},
+	}
+
+	listResponse, err := oClient.SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return false, err
+	}
+
+	sar = &authorizationapi.SubjectAccessReview{
+		Action: authorizationapi.Action{
+			Namespace: defaultNamespace,
+			Verb:      "create",
+			Resource:  "projectrequests",
+		},
+	}
+
+	createResponse, err := oClient.SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return false, err
+	}
+
+	return (listResponse.Allowed && createResponse.Allowed), nil
+}

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -131,6 +131,8 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseC
 
 		CommandBaseName: baseCLIName,
 
+		Config: config,
+
 		// TODO: Remove these and reference them inside the markers using constants.
 		LogsCommandName:             o.logsCommandName,
 		SecurityPolicyCommandFormat: o.securityPolicyCommandFormat,

--- a/test/cmd/login.sh
+++ b/test/cmd/login.sh
@@ -40,6 +40,21 @@ if [[ "${API_SCHEME}" == "https" ]]; then
     os::cmd::expect_failure_and_text "oc get services" 'certificate signed by unknown authority'
 fi
 
+# remove self-provisioner role from user and test login prompt before creating any projects
+os::cmd::expect_success "oadm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
+os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. Contact your system administrator to request a project"
+# make sure `oc status` re-uses the correct "no projects" message from `oc login` with no self-provisioner role
+os::cmd::expect_success_and_text 'oc status' "You don't have any projects. Contact your system administrator to request a project"
+os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
+# make sure standard login prompt is printed once self-provisioner status is restored
+os::cmd::expect_success "oadm policy add-cluster-role-to-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
+os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. You can try to create a new project, by running"
+# make sure `oc status` re-uses the correct "no projects" message from `oc login`
+os::cmd::expect_success_and_text 'oc status' "You don't have any projects. You can try to create a new project, by running"
+os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
+os::cmd::expect_success 'oc logout'
+echo "login and status messages: ok"
+
 # login and logout tests
 # bad token should error
 os::cmd::expect_failure_and_text "oc login ${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' --token=badvalue" 'The token provided is invalid or expired'


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1405636

This patch re-uses the "No projects" message from `oc login` in `oc
status` if a user attempts to use the command without first creating any
projects. This message suggests to the user a way to request a new
project rather than returning an error to the user which warns that they
cannot "get" projects in project "default".

**Before**

```
$ oc login -u newuser -p any
Login successful.

You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>

$ oc status
Error from server: User "newuser" cannot get projects in project
"default"
```

**After**

```
$ oc login -u newuser -p any
Login successful.

You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>

$ oc status
You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>

```

Additionally, since the same message from `oc login` is re-used, if a
user does not have access to request new projects, the following message
is printed instead:

```
$ oc status
You don't have any projects. Contact your system administrator to
request a project.
```

@openshift/cli-review 