### PR TITLE
Update "no projects" warning in `oc status`

### DIFF
--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -50,6 +50,9 @@ func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *Forbid
 	}
 	messageResolver.addRootScopedForbiddenMessageMaker("create", "projectrequests", newTemplateForbiddenMessageMaker(projectRequestDeny))
 
+	// projects "get" request rejection
+	messageResolver.addNamespacedForbiddenMessageMaker("get", "projects", newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get project "{{.Namespace}}"`))
+
 	return messageResolver
 }
 

--- a/pkg/cmd/cli/cmd/login/loginoptions.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions.go
@@ -265,7 +265,7 @@ func (o *LoginOptions) gatherProjectInfo() error {
 	projectsList, err := oClient.Projects().List(kapi.ListOptions{})
 	// if we're running on kube (or likely kube), just set it to "default"
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
-		fmt.Fprintf(o.Out, "Using \"default\".  You can switch projects with '%s project <projectname>':\n\n", o.CommandName)
+		fmt.Fprintf(o.Out, "Using \"default\".  You can switch projects with:\n\n '%s project <projectname>'", o.CommandName)
 		o.Project = "default"
 		return nil
 	}

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -11,6 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
+	loginutil "github.com/openshift/origin/pkg/cmd/cli/cmd/login/util"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -108,6 +109,11 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseC
 		return err
 	}
 
+	rawConfig, err := f.OpenShiftClientConfig().RawConfig()
+	if err != nil {
+		return err
+	}
+
 	if o.allNamespaces {
 		o.namespace = kapi.NamespaceAll
 	} else {
@@ -122,15 +128,25 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseC
 		baseCLIName = "oc"
 	}
 
+	currentNamespace := ""
+	if currentContext, exists := rawConfig.Contexts[rawConfig.CurrentContext]; exists {
+		currentNamespace = currentContext.Namespace
+	}
+
+	nsFlag := kcmdutil.GetFlagString(cmd, "namespace")
+	canRequestProjects, _ := loginutil.CanRequestProjects(config, o.namespace)
+
 	o.describer = &describe.ProjectStatusDescriber{
 		K:       kclientset,
 		C:       client,
 		Server:  config.Host,
 		Suggest: o.verbose,
 
-		CommandBaseName: baseCLIName,
+		CommandBaseName:    baseCLIName,
+		RequestedNamespace: nsFlag,
+		CurrentNamespace:   currentNamespace,
 
-		Config: config,
+		CanRequestProjects: canRequestProjects,
 
 		// TODO: Remove these and reference them inside the markers using constants.
 		LogsCommandName:             o.logsCommandName,

--- a/test/cmd/login.sh
+++ b/test/cmd/login.sh
@@ -43,15 +43,9 @@ fi
 # remove self-provisioner role from user and test login prompt before creating any projects
 os::cmd::expect_success "oadm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
 os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. Contact your system administrator to request a project"
-# make sure `oc status` re-uses the correct "no projects" message from `oc login` with no self-provisioner role
-os::cmd::expect_success_and_text 'oc status' "You don't have any projects. Contact your system administrator to request a project"
-os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
 # make sure standard login prompt is printed once self-provisioner status is restored
 os::cmd::expect_success "oadm policy add-cluster-role-to-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
 os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. You can try to create a new project, by running"
-# make sure `oc status` re-uses the correct "no projects" message from `oc login`
-os::cmd::expect_success_and_text 'oc status' "You don't have any projects. You can try to create a new project, by running"
-os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
 os::cmd::expect_success 'oc logout'
 echo "login and status messages: ok"
 

--- a/test/cmd/status.sh
+++ b/test/cmd/status.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/lib/init.sh"
+os::log::stacktrace::install
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete project project-bar
+  exit 0
+) &>/dev/null
+
+login_kubeconfig="${ARTIFACT_DIR}/login.kubeconfig"
+cp "${KUBECONFIG}" "${login_kubeconfig}"
+
+os::test::junit::declare_suite_start "cmd/status"
+# login and ensure no current projects exist
+os::cmd::expect_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything"
+os::cmd::expect_success 'oc delete project --all'
+os::cmd::expect_success 'oc logout'
+
+# remove self-provisioner role from user and test login prompt before creating any projects
+os::cmd::expect_success "oadm policy remove-cluster-role-from-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
+
+# login as 'test-user'
+os::cmd::expect_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything"
+
+# make sure `oc status` re-uses the correct "no projects" message from `oc login` with no self-provisioner role
+os::cmd::expect_success_and_text 'oc status' "You don't have any projects. Contact your system administrator to request a project"
+os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
+# make sure standard login prompt is printed once self-provisioner status is restored
+os::cmd::expect_success "oc logout"
+os::cmd::expect_success "oadm policy add-cluster-role-to-group self-provisioner system:authenticated:oauth --config='${login_kubeconfig}'"
+os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. You can try to create a new project, by running"
+
+# make sure `oc status` re-uses the correct "no projects" message from `oc login`
+os::cmd::expect_success_and_text 'oc status' "You don't have any projects. You can try to create a new project, by running"
+os::cmd::expect_success_and_text 'oc status --all-namespaces' "Showing all projects on server"
+# make sure `oc status` does not re-use the "no projects" message from `oc login` if -n is specified
+os::cmd::expect_failure_and_text 'oc status -n forbidden' 'Error from server \(Forbidden\): User "test-user" cannot get project "forbidden"'
+
+# create a new project
+os::cmd::expect_success "oc new-project project-bar --display-name='my project' --description='test project'"
+os::cmd::expect_success_and_text "oc project" 'Using project "project-bar"'
+
+# make sure `oc status` does not use "no projects" message if there is a project created
+os::cmd::expect_success_and_text 'oc status' "In project my project \(project-bar\) on server"
+os::cmd::expect_failure_and_text 'oc status -n forbidden' 'Error from server \(Forbidden\): User "test-user" cannot get project "forbidden"'
+
+# create a second project
+os::cmd::expect_success "oc new-project project-bar-2 --display-name='my project 2' --description='test project 2'"
+os::cmd::expect_success_and_text "oc project" 'Using project "project-bar-2"'
+
+# delete the current project `project-bar-2` and make sure `oc status` does not return the "no projects"
+# message since `project-bar` still exists
+os::cmd::expect_success_and_text "oc delete project project-bar-2" 'project "project-bar-2" deleted'
+os::cmd::expect_failure_and_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar-2"'
+
+# delete "project-bar" and test that `oc status` still does not return the "no projects" message.
+# Although we are deleting the last remaining project, the current context's namespace is still set
+# to it, therefore `oc status` should simply return a forbidden error and not the "no projects" message
+# until the next time the user logs in.
+os::cmd::expect_success "oc project project-bar"
+os::cmd::expect_success "oc delete project project-bar"
+os::cmd::expect_failure_and_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar"'
+os::cmd::try_until_not_text "oc get projects" "project-bar"
+os::cmd::try_until_not_text "oc get projects" "project-bar-2"
+os::cmd::expect_success "oc logout"
+os::cmd::expect_success_and_text "oc login --server=${KUBERNETES_MASTER} --certificate-authority='${MASTER_CONFIG_DIR}/ca.crt' -u test-user -p anything" "You don't have any projects. You can try to create a new project, by running"
+os::cmd::expect_success_and_text 'oc status' "You don't have any projects. You can try to create a new project, by running"
+
+# logout
+os::cmd::expect_success "oc logout"
+
+echo "status: ok"
+os::test::junit::declare_suite_end

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -929,7 +929,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		localReview:    askCanValerieGetProject,
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   false,
-			Reason:    `User "valerie" cannot get projects in project "mallet-project"`,
+			Reason:    `User "valerie" cannot get project "mallet-project"`,
 			Namespace: "mallet-project",
 		},
 	}.run(t)


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1405636#c3
Related PR: https://github.com/openshift/origin/pull/12304

This patch only re-uses the `oc login` "no projects" warning in
`oc status` when a user cannot access the current default namespace
and has not yet created any projects and has not passed a namespace
value with the `--namespace` flag.

**Before**
```
$ oc login -u newuser -p any
$ oc status
You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>

$ oc status -n default
You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>
```

**After**
```
$ oc login -u newuser -p any
$ oc status
You don't have any projects. You can try to create a new project, by
running

    oc new-project <projectname>

$ oc status -n default
Error from server: User "newuser" cannot get projects in project "default"

$ oc new-project proj1
$ oc new-project proj2

$ oc status
In project proj2 on server https://10.13.137.149:8443

You have no services, deployment configs, or build configs.
Run 'oc new-app' to create an application.

$ oc delete project proj2
$ oc status
Error from server: User "newuser" cannot get projects in project "proj2"

$ oc logout
$ oc login -u newuser -p any
$ oc status
In project proj1 on server https://10.13.137.149:8443

You have no services, deployment configs, or build configs.
Run 'oc new-app' to create an application.
```

cc @openshift/cli-review 