### PR TITLE
Non redistributable does not build everything, plus aarch64

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -12,17 +12,20 @@ if [[ -n "${OS_ONLY_BUILD_PLATFORMS-}" ]]; then
       filtered+=("${platform}")
     fi
   done
+  if [[ ${OS_ONLY_BUILD_PLATFORMS} == "linux/ppc64le" ]]; then
+    filtered+=("${OS_ONLY_BUILD_PLATFORMS}")
+  elif [[ ${OS_ONLY_BUILD_PLATFORMS} == "linux/arm64" ]]; then
+    filtered+=("${OS_ONLY_BUILD_PLATFORMS}")
+  fi
   platforms=("${filtered[@]}")
 fi
 
 # Build the primary client/server for all platforms
 OS_BUILD_PLATFORMS=("${platforms[@]}")
 host_platform=$(os::build::host_platform)
-if [[ $host_platform == "linux/ppc64le" ]]; then
-  OS_GOFLAGS_LINUX_PPC64LE="-tags=gssapi" os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
-else
-  OS_GOFLAGS_LINUX_AMD64="-tags=gssapi" os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
-fi
+platform_goflags_envvar="OS_GOFLAGS_$(echo ${host_platform} | tr '[:lower:]/' '[:upper:]_')"
+declare "${platform_goflags_envvar}=-tags=gssapi"
+os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 
 # Build image binaries for a subset of platforms. Image binaries are currently
 # linux-only, and are compiled with flags to make them static for use in Docker

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -468,6 +468,9 @@ function os::build::place_bins() {
         elif [[ $platform == "linux/ppc64le" ]]; then
           platform="linux/ppc64le" OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
           platform="linux/ppc64le" OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
+        elif [[ $platform == "linux/arm64" ]]; then
+          platform="linux/arm64" OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
+          platform="linux/arm64" OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
         else
           echo "++ ERROR: No release type defined for $platform"
         fi
@@ -476,6 +479,8 @@ function os::build::place_bins() {
           platform="linux/64bit" os::build::archive_tar "./*"
         elif [[ $platform == "linux/ppc64le" ]]; then
           platform="linux/ppc64le" os::build::archive_tar "./*"
+        elif [[ $platform == "linux/arm64" ]]; then
+          platform="linux/arm64" os::build::archive_tar "./*"
         else
           echo "++ ERROR: No release type defined for $platform"
         fi

--- a/origin.spec
+++ b/origin.spec
@@ -206,8 +206,25 @@ of docker.  Exclude those versions of docker.
 %setup -q
 
 %build
-# Create Binaries
+%if 0%{make_redistributable}
+# Create Binaries for all supported arches
 %{os_git_vars} hack/build-cross.sh
+%else
+# Create Binaries only for building arch
+%ifarch x86_64
+  BUILD_PLATFORM="linux/amd64"
+%endif
+%ifarch %{ix86}
+  BUILD_PLATFORM="linux/386"
+%endif
+%ifarch ppc64le
+  BUILD_PLATFORM="linux/ppc64le"
+%endif
+%ifarch %{arm} aarch64
+  BUILD_PLATFORM="linux/arm64"
+%endif
+OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} hack/build-cross.sh
+%endif
 
 %if 0%{build_tests}
 # Create extended.test


### PR DESCRIPTION
If you set the non-redistributable bit to 0, it will not build everything.
This not only saves time, but helps for multi-arches that might not be able to do cross compiling.
This also allows origin rpms to be built on aarch64