### PR TITLE
adapt secret key names of database example templates

### DIFF
--- a/examples/db-templates/mariadb-ephemeral-template.json
+++ b/examples/db-templates/mariadb-ephemeral-template.json
@@ -22,9 +22,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -115,7 +115,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -124,7 +124,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -133,7 +133,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },

--- a/examples/db-templates/mariadb-persistent-template.json
+++ b/examples/db-templates/mariadb-persistent-template.json
@@ -22,9 +22,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -132,7 +132,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -141,7 +141,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -150,7 +150,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },

--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -23,9 +23,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MONGODB_USER}",
-        "databasePassword" : "${MONGODB_PASSWORD}",
-        "databaseAdminPassword" : "${MONGODB_ADMIN_PASSWORD}"
+        "database-user" : "${MONGODB_USER}",
+        "database-password" : "${MONGODB_PASSWORD}",
+        "database-admin-password" : "${MONGODB_ADMIN_PASSWORD}"
       }
     },
     {
@@ -128,7 +128,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -137,7 +137,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -146,7 +146,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseAdminPassword"
+                        "key" : "database-admin-password"
                       }
                     }
                   },

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -23,9 +23,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MONGODB_USER}",
-        "databasePassword" : "${MONGODB_PASSWORD}",
-        "databaseAdminPassword" : "${MONGODB_ADMIN_PASSWORD}"
+        "database-user" : "${MONGODB_USER}",
+        "database-password" : "${MONGODB_PASSWORD}",
+        "database-admin-password" : "${MONGODB_ADMIN_PASSWORD}"
       }
     },
     {
@@ -145,7 +145,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -154,7 +154,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -163,7 +163,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseAdminPassword"
+                        "key" : "database-admin-password"
                       }
                     }
                   },

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -22,9 +22,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -128,7 +128,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -137,7 +137,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -146,7 +146,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },

--- a/examples/db-templates/mysql-persistent-template.json
+++ b/examples/db-templates/mysql-persistent-template.json
@@ -22,9 +22,9 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -132,7 +132,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -141,7 +141,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -150,7 +150,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -23,8 +23,8 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${POSTGRESQL_USER}",
-        "databasePassword" : "${POSTGRESQL_PASSWORD}"
+        "database-user" : "${POSTGRESQL_USER}",
+        "database-password" : "${POSTGRESQL_PASSWORD}"
       }
     },
     {
@@ -127,7 +127,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -136,7 +136,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -23,8 +23,8 @@
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${POSTGRESQL_USER}",
-        "databasePassword" : "${POSTGRESQL_PASSWORD}"
+        "database-user" : "${POSTGRESQL_USER}",
+        "database-password" : "${POSTGRESQL_PASSWORD}"
       }
     },
     {
@@ -144,7 +144,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -153,7 +153,7 @@
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -1691,9 +1691,9 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -1784,7 +1784,7 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -1793,7 +1793,7 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -1802,7 +1802,7 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },
@@ -1933,9 +1933,9 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -2043,7 +2043,7 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -2052,7 +2052,7 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -2061,7 +2061,7 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },
@@ -2200,9 +2200,9 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MONGODB_USER}",
-        "databasePassword" : "${MONGODB_PASSWORD}",
-        "databaseAdminPassword" : "${MONGODB_ADMIN_PASSWORD}"
+        "database-user" : "${MONGODB_USER}",
+        "database-password" : "${MONGODB_PASSWORD}",
+        "database-admin-password" : "${MONGODB_ADMIN_PASSWORD}"
       }
     },
     {
@@ -2305,7 +2305,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -2314,7 +2314,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -2323,7 +2323,7 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseAdminPassword"
+                        "key" : "database-admin-password"
                       }
                     }
                   },
@@ -2470,9 +2470,9 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MONGODB_USER}",
-        "databasePassword" : "${MONGODB_PASSWORD}",
-        "databaseAdminPassword" : "${MONGODB_ADMIN_PASSWORD}"
+        "database-user" : "${MONGODB_USER}",
+        "database-password" : "${MONGODB_PASSWORD}",
+        "database-admin-password" : "${MONGODB_ADMIN_PASSWORD}"
       }
     },
     {
@@ -2592,7 +2592,7 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -2601,7 +2601,7 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -2610,7 +2610,7 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseAdminPassword"
+                        "key" : "database-admin-password"
                       }
                     }
                   },
@@ -2763,9 +2763,9 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -2869,7 +2869,7 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -2878,7 +2878,7 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -2887,7 +2887,7 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },
@@ -3033,9 +3033,9 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${MYSQL_USER}",
-        "databasePassword" : "${MYSQL_PASSWORD}",
-        "databaseRootPassword" : "${MYSQL_ROOT_PASSWORD}"
+        "database-user" : "${MYSQL_USER}",
+        "database-password" : "${MYSQL_PASSWORD}",
+        "database-root-password" : "${MYSQL_ROOT_PASSWORD}"
       }
     },
     {
@@ -3143,7 +3143,7 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -3152,7 +3152,7 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -3161,7 +3161,7 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseRootPassword"
+                        "key" : "database-root-password"
                       }
                     }
                   },
@@ -3307,8 +3307,8 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${POSTGRESQL_USER}",
-        "databasePassword" : "${POSTGRESQL_PASSWORD}"
+        "database-user" : "${POSTGRESQL_USER}",
+        "database-password" : "${POSTGRESQL_PASSWORD}"
       }
     },
     {
@@ -3411,7 +3411,7 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -3420,7 +3420,7 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },
@@ -3559,8 +3559,8 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
         "name": "${DATABASE_SERVICE_NAME}"
       },
       "stringData" : {
-        "databaseUser" : "${POSTGRESQL_USER}",
-        "databasePassword" : "${POSTGRESQL_PASSWORD}"
+        "database-user" : "${POSTGRESQL_USER}",
+        "database-password" : "${POSTGRESQL_PASSWORD}"
       }
     },
     {
@@ -3680,7 +3680,7 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databaseUser"
+                        "key" : "database-user"
                       }
                     }
                   },
@@ -3689,7 +3689,7 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
                     "valueFrom": {
                       "secretKeyRef" : {
                         "name" : "${DATABASE_SERVICE_NAME}",
-                        "key" : "databasePassword"
+                        "key" : "database-password"
                       }
                     }
                   },


### PR DESCRIPTION
There is a new policy for secret key names.
No uppercase letters are allowed since version 3.2, see [release notes](https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#api-changes)

Changed key names of database example templates from camel to snake case. 