### PR TITLE
Mark tests that require local access

### DIFF
--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[volumes] Test local storage quota", func() {
 		emptyDirPodFixture = exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
 	)
 
-	g.Describe("FSGroup local storage quota", func() {
+	g.Describe("FSGroup local storage quota [local]", func() {
 		g.It("should be applied to XFS filesystem when a pod is created", func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 			project := oc.Namespace()

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[security] supplemental groups", func() {
 	)
 
 	g.Describe("Ensure supplemental groups propagate to docker", func() {
-		g.It("should propagate requested groups to the docker host config", func() {
+		g.It("should propagate requested groups to the docker host config [local]", func() {
 			// Before running any of this test we need to first check that
 			// the docker version being used supports the supplemental groups feature
 			g.By("ensuring the feature is supported")


### PR DESCRIPTION
Mark tests that require local access appropriately for now (until they are fixed)

[merge]