### PR TITLE
Fix blank image in redis example templates

### DIFF
--- a/examples/db-templates/redis-ephemeral-template.json
+++ b/examples/db-templates/redis-ephemeral-template.json
@@ -89,7 +89,7 @@
             "containers": [
               {
                 "name": "redis",
-                "image": " ",
+                "image": "redis:${REDIS_VERSION}",
                 "ports": [
                   {
                     "containerPort": 6379,

--- a/examples/db-templates/redis-persistent-template.json
+++ b/examples/db-templates/redis-persistent-template.json
@@ -106,7 +106,7 @@
             "containers": [
               {
                 "name": "redis",
-                "image": " ",
+                "image": "redis:${REDIS_VERSION}",
                 "ports": [
                   {
                     "containerPort": 6379,


### PR DESCRIPTION
Replace the " " image name with an image name and tag based on the version specified as a parameter.

Without this change, redis does not actually start because the `" "` image can't be pulled.