### PR TITLE
note about net.ipv4.ip_forward=1 in the docs/cluster_up_down.md 

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -40,6 +40,7 @@ a URL to access the management console for your cluster.
 | WARNING |
 | ------- |
 | In some cases, networking for pods will not work for containers in your cluster, especially in Fedora 24. To fix this, flush your iptables rules by running `$ sudo iptables -F` before running `oc cluster up`. |
+| Check that `sysctl net.ipv4.ip_forward` is set to 1. |
 
 1. Install Docker with your platform's package manager.
 2. Configure the Docker daemon with an insecure registry parameter of `172.30.0.0/16`


### PR DESCRIPTION
`oc cluster up` doesn't check this (openshift-origin-client-tools-v1.3.2-ac1d579-linux-64bit.tar.gz) and without forwarding cluster ends in half-working state (commands works but pods aren't run)

``` > oc adm diagnostics
ERROR: [DCli2012 from diagnostic DiagnosticPod@openshift/origin/pkg/diagnostics/client/run_diagnostics_pod.go:155]
       See the errors below in the output from the diagnostic pod:
       [Note] Running diagnostic: PodCheckAuth
              Description: Check that service account credentials authenticate as expected
              
       Info:  Service account token successfully authenticated to master
       
       ERROR: [DP1014 from diagnostic PodCheckAuth@openshift/origin/pkg/diagnostics/pod/auth.go:173]
              Request to integrated registry timed out; this typically indicates network or SDN problems.
              
       [Note] Running diagnostic: PodCheckDns
              Description: Check that DNS within a pod works as expected
              
       [Note] Summary of diagnostics execution (version v1.3.2):
       [Note] Errors seen: 1

ERROR: [DClu1006 from diagnostic ClusterRegistry@openshift/origin/pkg/diagnostics/cluster/registry.go:208]
       The "docker-registry" service exists but has no associated pods, so it
       is not available. Builds and deployments that use the registry will fail.
       
ERROR: [DClu1001 from diagnostic ClusterRegistry@openshift/origin/pkg/diagnostics/cluster/registry.go:178]
       The "docker-registry" service exists but no pods currently running, so it
       is not available. Builds and deployments that use the registry will fail.
```