### PR TITLE
Bug 1348174 - error on non-existing tag when importing from .spec.dockerImageRepository

### DIFF
--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -17,10 +19,8 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	imageapi "github.com/openshift/origin/pkg/image/api"
-	"github.com/spf13/cobra"
-
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 var (
@@ -383,7 +383,7 @@ func (o *ImportImageOptions) importTag(stream *imageapi.ImageStream) (*imageapi.
 
 	} else {
 		// create a new tag
-		if len(from) == 0 {
+		if len(from) == 0 && tag == imageapi.DefaultImageTag {
 			from = stream.Spec.DockerImageRepository
 		}
 		// if the from is still empty this means there's no such tag defined

--- a/pkg/cmd/cli/cmd/importimage_test.go
+++ b/pkg/cmd/cli/cmd/importimage_test.go
@@ -59,6 +59,17 @@ func TestCreateImageImport(t *testing.T) {
 				To:   &kapi.LocalObjectReference{Name: "latest"},
 			}},
 		},
+		"import from .spec.dockerImageRepository non-existing tag": {
+			name: "testis:nonexisting",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{Name: "testis", Namespace: "other"},
+				Spec: imageapi.ImageStreamSpec{
+					DockerImageRepository: "repo.com/somens/someimage",
+					Tags: make(map[string]imageapi.TagReference),
+				},
+			},
+			err: `"nonexisting" does not exist on the image stream`,
+		},
 		"import all from .spec.dockerImageRepository": {
 			name: "testis",
 			all:  true,


### PR DESCRIPTION
Fixes [bug 1348174](https://bugzilla.redhat.com/show_bug.cgi?id=1348174).

We were blindly creating a tag from non-existing ones when `.spec.dockerImageRepository` was passed. This limits it only to use-cases where you specify full IS name or latest, which will point to actual `.spec.dockerImageRepository`.

@miminar ptal

