### PR TITLE
Allow user to set autoProvisionEnabled with a ConfigMap

### DIFF
--- a/docs/proposals/dynamic-openshift-settings-configmaps.md
+++ b/docs/proposals/dynamic-openshift-settings-configmaps.md
@@ -1,0 +1,79 @@
+# Changing OpenShift settings dynamically through ConfigMaps
+
+## Problem
+
+Currently, there are settings contained within the master-config.yaml file that
+are of value to an unpriviledged user. Specifically, the `autoProvisionEnabled`
+boolean under `jenkinsPipelineConfig` is only available to users with the
+ability to write to the master-config.
+
+## Design proposal:
+
+- In each project there can exist one or more ConfigMaps annotated with
+  'project.openshift.io/configuration'
+
+- The ConfigMap will contain the key/value pair of setting(s) to be overridden
+  (key) and the value(s) to use.
+
+- Some cluster settings will be overridable at the project level using this
+  method, and other project specific settings can be introduced via the
+  ConfigMap as well.
+
+- For values with more than one entry, e.g. `corsAllowedOrigins`, yaml or json
+  array notation could be used.
+
+- (Optional) Have a utility function for consolidating settings over multiple
+  ConfigMaps. Have documentation to alert users that overlapping settings causes
+  nondeterministic or unsupported behavior.
+
+## Issues:
+
+- We will likely not be exposing all settings in this way, so there needs to be
+  an easy way for affected users to discover these.
+
+- Will admins be able to disable this feature, and if so, how?
+
+## Other solutions considered
+
+Handling settings like this through project annotations was explored, but
+because unpriviledged users cannot annotate their own projects, it was
+abandoned.
+
+We could use a specific name of a ConfigMap to designate a project-level
+configuration. This has the benefits of
+
+ 1.  Making the code to process the project settings simpler (do not need to
+     retrieve all ConfigMaps and filter down to the ones w/ the annotation, and merge
+     keys across ConfigMaps, deal w/ conflicts, etc).
+ 
+However, this 
+
+ 1.  Would prevent the user from ever using that name for anything else
+ 1.  Would not allow for grouping different settings into multiple ConfigMaps
+
+## Example
+
+For the setting `autoProvisionEnabled` under jenkinsPipelineConfig:
+
+```bash
+$ oc create configmap jenkins-pipeline-config --from-literal=autoProvisionEnabled=false
+configmap "jenkins-pipeline-config" created
+$ oc annotate configmap jenkins-pipeline-config project.openshift.io/configuration=true
+$ oc new-app jenkins-pipeline-example
+--> Deploying template "openshift/jenkins-pipeline-example" to project myproject
+...
+--> Creating resources ...
+    buildconfig "sample-pipeline" created
+    service "nodejs-mongodb-example" created
+    route "nodejs-mongodb-example" created
+    imagestream "nodejs-mongodb-example" created
+    buildconfig "nodejs-mongodb-example" created
+    deploymentconfig "nodejs-mongodb-example" created
+    service "mongodb" created
+    deploymentconfig "mongodb" created
+--> Success
+$ oc get pods
+NAME               READY     STATUS              RESTARTS   AGE
+mongodb-1-deploy   1/1       Running             0          57s
+mongodb-1-yasy3    0/1       ContainerCreating   0          55s
+```

--- a/examples/jenkins/pipeline/README.md
+++ b/examples/jenkins/pipeline/README.md
@@ -43,6 +43,13 @@ jenkins template represented by jenkinstemplate.json by running these commands a
 
     At this point if you run `oc get pods` you should see a jenkins pod, or at least a jenkins-deploy pod. (along with other items in your project)  This pod was created as a result of the new pipeline buildconfig being defined by the sample-pipeline template.
 
+    Note: If you use a centralized Jenkins server for your cluster, you can
+    stop the automatic Jenkins provisioning by creating a ConfigMap called
+    `jenkins-pipeline-config` with a key-value literal of
+    `autoProvisionEnabled=true`.
+
+        $ oc create configmap jenkins-pipeline-config --from-literal=autoProvisionEnabled=true
+
 5. View/Manage Jenkins (optional)
 
     You should not need to access the jenkins console for anything, but if you want to configure settings or watch the execution,

--- a/pkg/build/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission.go
@@ -28,6 +28,9 @@ import (
 	"github.com/openshift/origin/pkg/config/cmd"
 )
 
+// This name reflects the master-config.yaml subsection where the overridden value is
+var JenkinsPipelineConfigMap = "jenkins-pipeline-config"
+
 func init() {
 	admission.RegisterPlugin("openshift.io/JenkinsBootstrapper", func(c clientset.Interface, config io.Reader) (admission.Interface, error) {
 		return NewJenkinsBootstrapper(c.Core()), nil
@@ -74,6 +77,32 @@ func (a *jenkinsBootstrapper) Admit(attributes admission.Attributes) error {
 	}
 
 	// TODO pull this from a cache.
+
+	kcl, err := kclient.New(&a.privilegedRESTClientConfig)
+
+	if err != nil {
+		return err
+	}
+
+	configmaps, err := kcl.ConfigMaps(namespace).List(kapi.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	for _, configmap := range configmaps.Items {
+		// We look for the ConfigMap with the correct annotation
+		for k, _ := range configmap.Annotations {
+			// TODO: Convene  on a label for this
+			if k == "project.openshift.io/configuration" {
+				if configmap.Data["autoProvisionEnabled"] == "false" {
+					return nil
+				}
+				break
+			}
+		}
+	}
+
 	if _, err := a.serviceClient.Services(namespace).Get(svcName); !kapierrors.IsNotFound(err) {
 		// if it isn't a "not found" error, return the error.  Either its nil and there's nothing to do or something went really wrong
 		return err

--- a/pkg/build/admission/jenkinsbootstrapper/admission_test.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission_test.go
@@ -122,6 +122,21 @@ func TestAdmission(t *testing.T) {
 			},
 			expectedErr: "Jenkins pipeline template / not found",
 		},
+		{
+			name:           "autoProvisionEnabled false",
+			attributes:     admission.NewAttributesRecord(&kapi.Service{}, nil, unversioned.GroupVersionKind{}, "namespace", "name", buildapi.SchemeGroupVersion.WithResource("builds"), "", admission.Create, &user.DefaultInfo{}),
+			jenkinsEnabled: boolptr(true),
+			objects: []runtime.Object{
+				&kapi.ConfigMap{
+					ObjectMeta: kapi.ObjectMeta{
+						Annotations: map[string]string{"project.openshift.io/configuration": "true"},
+						Namespace:   "namespace",
+						Name:        "jenkins-pipeline-config",
+					},
+					Data: map[string]string{"autoProvisionEnabled": "false"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This enables users to stop the automatic creation of a Jenkins pod when
a JenkinsPipeline strategy is used. This new method overrides the global
setting when set to false.

Added a proposal for standardizing the ConfigMap approach.

Implements [(3) Block jenkins autoprovisioning in a project [pipeline_integration]](https://trello.com/c/pRTTyP42/1061-3-block-jenkins-autoprovisioning-in-a-project-pipeline-integration)

@bparees ptal?