### PR TITLE
fix typo and  drop = nil drop []string

### DIFF
--- a/pkg/auth/ldaputil/query_test.go
+++ b/pkg/auth/ldaputil/query_test.go
@@ -21,8 +21,8 @@ const (
 	DefaultQueryAttribute string       = "uid"
 )
 
-var DefaultAttributes []string = []string{"dn", "cn", "uid"}
-var DefaultControls []ldap.Control = nil
+var DefaultAttributes = []string{"dn", "cn", "uid"}
+var DefaultControls []ldap.Control
 
 func TestNewSearchRequest(t *testing.T) {
 	var testCases = []struct {

--- a/pkg/auth/ldaputil/url.go
+++ b/pkg/auth/ldaputil/url.go
@@ -205,7 +205,7 @@ func SplitLDAPQuery(query string) (attributes, scope, filter, extensions string,
 	}
 }
 
-// DeterminmeLDAPScope determines the LDAP search scope. Scope is one of "sub", "one", or "base"
+// DetermineLDAPScope determines the LDAP search scope. Scope is one of "sub", "one", or "base"
 // Default to "sub" to match mod_auth_ldap
 func DetermineLDAPScope(scope string) (Scope, error) {
 	switch scope {


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

drop = nil from declaration of var DefaultControls; it is the zero value
drop []string;it will be inferred from the right-hand side
