### PR TITLE
Fix manifest verification if pullthrough enabled

### DIFF
--- a/pkg/dockerregistry/server/manifestschema1handler.go
+++ b/pkg/dockerregistry/server/manifestschema1handler.go
@@ -110,8 +110,12 @@ func (h *manifestSchema1Handler) Payload() (mediaType string, payload []byte, ca
 func (h *manifestSchema1Handler) Verify(ctx context.Context, skipDependencyVerification bool) error {
 	var errs distribution.ErrManifestVerification
 
-	// we want to verify that referenced blobs exist locally - thus using upstream repository object directly
-	repo := h.repo.Repository
+	// we want to verify that referenced blobs exist locally or accessible over
+	// pullthroughBlobStore. The base image of this image can be remote repository
+	// and since we use pullthroughBlobStore all the layer existence checks will be
+	// successful. This means that the docker client will not attempt to send them
+	// to us as it will assume that the registry has them.
+	repo := h.repo
 
 	if len(path.Join(h.repo.registryAddr, h.manifest.Name)) > reference.NameTotalLengthMax {
 		errs = append(errs,

--- a/pkg/dockerregistry/server/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifestschema2handler.go
@@ -65,8 +65,12 @@ func (h *manifestSchema2Handler) Verify(ctx context.Context, skipDependencyVerif
 		return nil
 	}
 
-	// we want to verify that referenced blobs exist locally - thus using upstream repository object directly
-	repo := h.repo.Repository
+	// we want to verify that referenced blobs exist locally or accessible over
+	// pullthroughBlobStore. The base image of this image can be remote repository
+	// and since we use pullthroughBlobStore all the layer existence checks will be
+	// successful. This means that the docker client will not attempt to send them
+	// to us as it will assume that the registry has them.
+	repo := h.repo
 
 	target := h.manifest.Target()
 	_, err := repo.Blobs(ctx).Stat(ctx, target.Digest)

--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -118,6 +118,10 @@ func (r *pullthroughBlobStore) proxyStat(ctx context.Context, retriever importer
 }
 
 // ServeBlob attempts to serve the requested digest onto w, using a remote proxy store if necessary.
+// Important! This function is called for GET and HEAD requests. Docker client uses[1] HEAD request
+// to check existence of a layer. If the layer with the digest is available, this function MUST return
+// success response with no actual body content.
+// [1] https://docs.docker.com/registry/spec/api/#existing-layers
 func (pbs *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
 	store, ok := pbs.digestToStore[dgst.String()]
 	if !ok {


### PR DESCRIPTION
Allow to use pullthrough for manifest verification.

Fix #12329 #12389 
https://bugzilla.redhat.com/show_bug.cgi?id=1408661
https://bugzilla.redhat.com/show_bug.cgi?id=1408374

@miminar @mfojtik @pweil- please review.
