### PR TITLE
ipfailover - fix typo in script

### DIFF
--- a/images/ipfailover/keepalived/conf/settings.sh
+++ b/images/ipfailover/keepalived/conf/settings.sh
@@ -41,7 +41,7 @@ HA_REPLICA_COUNT="${OPENSHIFT_HA_REPLICA_COUNT:-"1"}"
 #  same cluster. Range 1..255
 #     HA_VRRP_ID_OFFSET=30
 #
-HA_VRRP_ID_OFFSET="${OPENSHIFT_HA_VRRP_ID_OFFSET:-"0""}"
+HA_VRRP_ID_OFFSET="${OPENSHIFT_HA_VRRP_ID_OFFSET:-"0"}"
 
 # When the DC supplies an (non null) iptables chain
 # (OPENSHIFT_HA_IPTABLES_CHAIN) make sure the rule to pass keepalived


### PR DESCRIPTION
Breaks ipfailover keepalived.conf in pod.

Bug: 1407003
https://bugzilla.redhat.com/show_bug.cgi?id=1407003

Signed-off-by: Phil Cameron <pcameron@redhat.com>