### PR TITLE
cluster up: do not ignore public-hostname on Mac with Docker for Mac

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -276,7 +276,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 			}
 			nodeHost = internalIP
 			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--master=%s", internalIP))
-			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--public-master=https://%s:8443", opt.ServerIP))
+			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--public-master=https://%s:8443", h.publicHost))
 		} else {
 			nodeHost = opt.ServerIP
 			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--master=%s", opt.ServerIP))

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -767,9 +767,13 @@ func (c *ClientStartConfig) ServerInfo(out io.Writer) error {
 		loggingInfo = fmt.Sprintf("The kibana logging UI is available at:\n"+
 			"    https://%s\n\n", openshift.LoggingHost(c.RoutingSuffix, c.ServerIP))
 	}
+	masterURL := c.OpenShiftHelper().Master(c.ServerIP)
+	if len(c.PublicHostname) > 0 {
+		masterURL = fmt.Sprintf("https://%s:8443", c.PublicHostname)
+	}
 	msg := fmt.Sprintf("OpenShift server started.\n"+
 		"The server is accessible via web console at:\n"+
-		"    %s\n\n%s%s", c.OpenShiftHelper().Master(c.ServerIP), metricsInfo, loggingInfo)
+		"    %s\n\n%s%s", masterURL, metricsInfo, loggingInfo)
 
 	if c.ShouldCreateUser() {
 		msg += fmt.Sprintf("You are logged in as:\n"+


### PR DESCRIPTION
When forwarding ports (ie. running on Mac with Docker for Mac), use the specified public-hostname argument as the cluster's public host name.

Also fixes command information output. It should display the public hostname and not the ip address of the cluster.

Fixes #12369