### PR TITLE
ipfailover keepalived split brain

### DIFF
--- a/images/ipfailover/keepalived/lib/failover-functions.sh
+++ b/images/ipfailover/keepalived/lib/failover-functions.sh
@@ -8,7 +8,7 @@ source "$mydir/utils.sh"
 source "$mydir/config-generators.sh"
 
 #  Constants.
-readonly KEEPALIVED_CONFIG="/etc/keepalived/keepalived.conf"
+readonly KEEPALIVED_CONFIG=${KEEPALIVED_CONFIG:-"/etc/keepalived/keepalived.conf"}
 readonly KEEPALIVED_DEFAULTS="/etc/sysconfig/keepalived"
 
 


### PR DESCRIPTION
All of the VIPs try to end up on the same node. The process doesn't
settle on a node. This fix places each VIP in a separete
vrrp_sync_group. The result is each VIP settles on a node and not all
appear on the same node.

There is some general coding style cleanup included as well.

Note: This may look like a script generating a script. It is not. The
script generates the keepalived.conf config file which is input by
keepalived when it starts.

Bug 1402536, 1405015
https://bugzilla.redhat.com/show_bug.cgi?id=1402536
https://bugzilla.redhat.com/show_bug.cgi?id=1405015

Signed-off-by: Phil Cameron <pcameron@redhat.com>