### PR TITLE
cluster up: add pod networking check

### DIFF
--- a/pkg/bootstrap/docker/openshift/cnetwork.go
+++ b/pkg/bootstrap/docker/openshift/cnetwork.go
@@ -1,0 +1,31 @@
+package openshift
+
+import (
+	"fmt"
+)
+
+// TestContainerNetworking launches a container that will check whether the container
+// can communicate with the master API and DNS endpoints.
+func (h *Helper) TestContainerNetworking(ip string) error {
+	// Skip check if the server ip is the localhost
+	if ip == "127.0.0.1" {
+		return nil
+	}
+	testCmd := fmt.Sprintf("echo 'Testing connectivity to master API' && "+
+		"curl -s -S -k https://%s:8443 && "+
+		"echo 'Testing connectivity to master DNS server' && "+
+		"for i in {1..5}; do "+
+		"   if curl -s -S -k https://kubernetes.default.svc.cluster.local; then "+
+		"      exit 0;"+
+		"   fi; "+
+		"   sleep 1; "+
+		"done; "+
+		"exit 1", ip)
+	_, err := h.runHelper.New().Image(h.image).
+		DiscardContainer().
+		DNS(ip).
+		Entrypoint("/bin/bash").
+		Command("-c", testCmd).
+		Run()
+	return err
+}

--- a/pkg/bootstrap/docker/printer.go
+++ b/pkg/bootstrap/docker/printer.go
@@ -73,13 +73,12 @@ func PrintError(err error, out io.Writer) {
 	if d, ok := err.(hasDetails); ok && len(d.Details()) > 0 {
 		fmt.Fprintf(out, "Details:\n")
 		w := prefixwriter.New("  ", out)
-		fmt.Fprintf(w, d.Details())
+		fmt.Fprintf(w, "%s\n", d.Details())
 	}
 	if s, ok := err.(hasSolution); ok && len(s.Solution()) > 0 {
 		fmt.Fprintf(out, "Solution:\n")
 		w := prefixwriter.New("  ", out)
-		fmt.Fprintf(w, s.Solution())
-		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "%s\n", s.Solution())
 	}
 	if c, ok := err.(hasCause); ok && c.Cause() != nil {
 		fmt.Fprintf(out, "Caused By:\n")

--- a/pkg/bootstrap/docker/run/run.go
+++ b/pkg/bootstrap/docker/run/run.go
@@ -115,6 +115,11 @@ func (h *Runner) DiscardContainer() *Runner {
 	return h
 }
 
+func (h *Runner) DNS(address ...string) *Runner {
+	h.hostConfig.DNS = address
+	return h
+}
+
 // Start starts the container as a daemon and returns
 func (h *Runner) Start() (string, error) {
 	id, err := h.Create()
@@ -244,6 +249,12 @@ func printHostConfig(c *docker.HostConfig) string {
 	out := &bytes.Buffer{}
 	fmt.Fprintf(out, "  pid mode: %s\n", c.PidMode)
 	fmt.Fprintf(out, "  network mode: %s\n", c.NetworkMode)
+	if len(c.DNS) > 0 {
+		fmt.Fprintf(out, "  DNS:\n")
+		for _, h := range c.DNS {
+			fmt.Fprintf(out, "    %s\n", h)
+		}
+	}
 	if len(c.Binds) > 0 {
 		fmt.Fprintf(out, "  volume binds:\n")
 		for _, b := range c.Binds {

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -205,6 +205,8 @@ type ClientStartConfig struct {
 
 	shouldInitializeData *bool
 	shouldCreateUser     *bool
+
+	containerNetworkErr chan error
 }
 
 func (c *ClientStartConfig) addTask(name string, fn taskFunc) {
@@ -306,6 +308,9 @@ func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 
 	// Remove temporary directory
 	c.addTask("Removing temporary directory", c.RemoveTemporaryDirectory)
+
+	// Check container networking
+	c.addTask("Checking container networking", c.CheckContainerNetworking)
 
 	// Display server information
 	c.addTask("Server Information", c.ServerInfo)
@@ -668,7 +673,29 @@ func (c *ClientStartConfig) StartOpenShift(out io.Writer) error {
 		opt.LoggingHost = openshift.LoggingHost(c.RoutingSuffix, c.ServerIP)
 	}
 	c.LocalConfigDir, err = c.OpenShiftHelper().Start(opt, out)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Start a container networking test
+	c.containerNetworkErr = make(chan error)
+	go func() {
+		c.containerNetworkErr <- c.OpenShiftHelper().TestContainerNetworking(c.ServerIP)
+	}()
+	return nil
+}
+
+func (c *ClientStartConfig) CheckContainerNetworking(out io.Writer) error {
+	networkErr := <-c.containerNetworkErr
+	if networkErr != nil {
+		return errors.NewError("containers cannot communicate with the OpenShift master").
+			WithDetails("The cluster was started. However, the container networking test failed.").
+			WithSolution(
+				fmt.Sprintf("Ensure that access to ports tcp/8443 and udp/53 is allowed on %s.\n"+
+					"You may need to open these ports on your machine's firewall.", c.ServerIP)).
+			WithCause(networkErr)
+	}
+	return nil
 }
 
 func (c *ClientStartConfig) imageFormat() string {


### PR DESCRIPTION
Check container communication with api master and DNS server. Otherwise print an error message.

When an error occurs:
```
-- Checking container networking ... FAIL
   Error: containers cannot communicate with the OpenShift master
   Details:
     The cluster was started. However, the container networking test failed.
   Solution:
     Ensure that access to ports tcp/8443 and udp/53 is allowed on 10.0.2.15.
     You may need to open these ports on your machine's firewall.
   Caused By:
     Error: Docker run error rc=1
     Details:
       Image: openshift/origin:v1.5.0-alpha.1
       Entrypoint: [/bin/bash]
       Command: [-c echo 'Testing connectivity to master API' && curl -s -S -k https://10.0.2.15:8443 && echo 'Testing connectivity to master DNS server' && for i in {1..5}; do    if curl -s -S -k https://kubernetes.default.svc.cluster.local; then       exit 0;	fi;    sleep 1; done; exit 1]
       Output:
         Testing connectivity to master API
       Error Output:
         curl: (7) Failed connect to 10.0.2.15:8443; No route to host
```

When no error occurs:

```
-- Starting OpenShift container ...
   Creating initial OpenShift configuration
   Starting OpenShift using container 'origin'
   Waiting for API server to start listening
   OpenShift server started
-- Adding default OAuthClient redirect URIs ... OK
-- Installing registry ... OK
-- Installing router ... OK
-- Importing image streams ... OK
-- Importing templates ... OK
-- Login to server ... OK
-- Creating initial project "myproject" ... OK
-- Removing temporary directory ... OK
-- Checking container networking ... OK
-- Server Information ...
   OpenShift server started.
   The server is accessible via web console at:
       https://1.2.3.4:8443

   You are logged in as:
       User:     developer
       Password: developer

   To login as administrator:
       oc login -u system:admin
```

Fixes https://github.com/openshift/origin/issues/10139