### PR TITLE
UPSTREAM: 39496: Use privileged containers for host path e2e tests

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/host_path.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/host_path.go
@@ -132,6 +132,7 @@ func mount(source *api.HostPathVolumeSource) []api.Volume {
 //TODO: To merge this with the emptyDir tests, we can make source a lambda.
 func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod {
 	podName := "pod-host-path-test"
+	privileged := true
 
 	return &api.Pod{
 		TypeMeta: unversioned.TypeMeta{
@@ -152,6 +153,9 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 							MountPath: path,
 						},
 					},
+					SecurityContext: &api.SecurityContext{
+						Privileged: &privileged,
+					},
 				},
 				{
 					Name:  containerName2,
@@ -161,6 +165,9 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 							Name:      volumeName,
 							MountPath: path,
 						},
+					},
+					SecurityContext: &api.SecurityContext{
+						Privileged: &privileged,
 					},
 				},
 			},


### PR DESCRIPTION
Test containers need to run as spc_t in order to interact with the host
filesystem under /tmp, as the tests for HostPath are doing. Docker will
transition the container into this domain when running the container as
privileged.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>