### PR TITLE
leave oauth on jenkins extended test, use token for http-level access

### DIFF
--- a/test/extended/util/jenkins/monitor.go
+++ b/test/extended/util/jenkins/monitor.go
@@ -1,11 +1,15 @@
 package jenkins
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
+	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
@@ -16,6 +20,14 @@ type JobMon struct {
 	buildNumber     string
 	jobName         string
 }
+
+const (
+	DisableJenkinsMemoryStats = "DISABLE_JENKINS_MEMORY_MONITORING"
+	DisableJenkinsGCSTats     = "DISABLE_JENKINS_GC_MONITORING"
+)
+
+// Designed to match if RSS memory is greater than 500000000  (i.e. > 476MB)
+var memoryOverragePattern = regexp.MustCompile(`\s+rss\s+5\d\d\d\d\d\d\d\d`)
 
 // Await waits for the timestamp on the Jenkins job to change. Returns
 // and error if the timeout expires.
@@ -52,4 +64,58 @@ func (jmon *JobMon) Await(timeout time.Duration) error {
 		return true, nil
 	})
 	return err
+}
+
+func StartJenkinsGCTracking(oc *exutil.CLI, jenkinsNamespace string) *time.Ticker {
+	jenkinsPod := FindJenkinsPod(oc)
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for t := range ticker.C {
+			stats, err := oc.Run("rsh").Args("--namespace", jenkinsNamespace, jenkinsPod.Name, "jstat", "-gcutil", "1").Output()
+			if err == nil {
+				fmt.Fprintf(g.GinkgoWriter, "\n\nJenkins gc stats %v\n%s\n\n", t, stats)
+			} else {
+				fmt.Fprintf(g.GinkgoWriter, "Unable to acquire Jenkins gc stats: %v", err)
+			}
+		}
+	}()
+	return ticker
+}
+
+func StartJenkinsMemoryTracking(oc *exutil.CLI, jenkinsNamespace string) *time.Ticker {
+	jenkinsPod := FindJenkinsPod(oc)
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for t := range ticker.C {
+			memstats, err := oc.Run("exec").Args("--namespace", jenkinsNamespace, jenkinsPod.Name, "--", "cat", "/sys/fs/cgroup/memory/memory.stat").Output()
+			if err != nil {
+				fmt.Fprintf(g.GinkgoWriter, "\nUnable to acquire Jenkins cgroup memory.stat")
+			}
+			ps, err := oc.Run("exec").Args("--namespace", jenkinsNamespace, jenkinsPod.Name, "--", "ps", "faux").Output()
+			if err != nil {
+				fmt.Fprintf(g.GinkgoWriter, "\nUnable to acquire Jenkins ps information")
+			}
+			fmt.Fprintf(g.GinkgoWriter, "\nJenkins memory statistics at %v\n%s\n%s\n\n", t, ps, memstats)
+
+			// This is likely a temporary measure in place to extract diagnostic information during unexpectedly
+			// high memory utilization within the Jenkins image. If Jenkins is using
+			// a large amount of RSS, extract JVM information from the pod.
+			if memoryOverragePattern.MatchString(memstats) {
+				histogram, err := oc.Run("rsh").Args("--namespace", jenkinsNamespace, jenkinsPod.Name, "jmap", "-histo", "1").Output()
+				if err == nil {
+					fmt.Fprintf(g.GinkgoWriter, "\n\nJenkins histogram:\n%s\n\n", histogram)
+				} else {
+					fmt.Fprintf(g.GinkgoWriter, "Unable to acquire Jenkins histogram: %v", err)
+				}
+				stack, err := oc.Run("exec").Args("--namespace", jenkinsNamespace, jenkinsPod.Name, "--", "jstack", "1").Output()
+				if err == nil {
+					fmt.Fprintf(g.GinkgoWriter, "\n\nJenkins thread dump:\n%s\n\n", stack)
+				} else {
+					fmt.Fprintf(g.GinkgoWriter, "Unable to acquire Jenkins thread dump: %v", err)
+				}
+			}
+
+		}
+	}()
+	return ticker
 }


### PR DESCRIPTION
@bparees PTAL

of course, this should not merge until the jenkins centos image is updated, but I'm assuming that happens before we finish reviewing this change and the merge queue frees up from the rebase.