### PR TITLE
add some test code to verify urlpattern

### DIFF
--- a/pkg/util/urlpattern/urlpattern_test.go
+++ b/pkg/util/urlpattern/urlpattern_test.go
@@ -211,4 +211,52 @@ func TestMatchPatterns(t *testing.T) {
 	} else if match.Cookie.(string) != "pattern2" {
 		t.Errorf("Match() returned %q", match.Cookie.(string))
 	}
+
+	pattern3, err := NewURLPattern("*://*.test.com/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern3.Cookie = "pattern3"
+
+	pattern4, err := NewURLPattern("ssh://*.test.com/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern4.Cookie = "pattern4"
+
+	url, err = url.Parse("ssh://git@test.com/test/test.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	match = Match([]*URLPattern{pattern3, pattern4}, url)
+	if match == nil {
+		t.Errorf("Match() returned nil")
+	} else if match.Cookie.(string) != "pattern4" {
+		t.Errorf("Match() returned %q", match.Cookie.(string))
+	}
+
+	pattern5, err := NewURLPattern("ssh://*.test.com/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern5.Cookie = "pattern5"
+
+	pattern6, err := NewURLPattern("ssh://git@test.com/test/test.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern6.Cookie = "pattern6"
+
+	url, err = url.Parse("ssh://git@test.com/test/test.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	match = Match([]*URLPattern{pattern5, pattern6}, url)
+	if match == nil {
+		t.Errorf("Match() returned nil")
+	} else if match.Cookie.(string) != "pattern6" {
+		t.Errorf("Match() returned %q", match.Cookie.(string))
+	}
 }


### PR DESCRIPTION
@jim-minter 
when I testing this [trello card](https://trello.com/c/NoVpS2OS), I execute:
`oc new-app git@gitlab.com:shiywang/ruby-hello-world.git`
`oc patch secret test -p '{"metadata":{"annotations":{"build.openshift.io/source-secret-match-uri-1" : "https://git@gitlab.com/shiywang/*"}}}'  `
the bc cannot find the correct sshauth secret
I guess urlpartten deal with token `@` have some problem, so the return hosts doesn't match.

I add two set of tests to verify this problem, partten3,partten4 pass
but partten5,partten6 failed due to the url contain `@`