### PR TITLE
Add a nil check to Container.SecurityContext

### DIFF
--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -68,7 +68,7 @@ func getBandwidth(pod *kapi.Pod) (string, string, error) {
 func wantsMacvlan(pod *kapi.Pod) (bool, error) {
 	privileged := false
 	for _, container := range pod.Spec.Containers {
-		if container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
+		if container.SecurityContext != nil && container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
 			privileged = true
 			break
 		}


### PR DESCRIPTION
We were panicing sometimes when we dereferenced a nil pointer when
looking at the Container.SecurityContext which is defined as optional.

This fix adds a check to see if it is not nil before dereferencing.

Fixes bug 1412087 (https://bugzilla.redhat.com/show_bug.cgi?id=1412087)