### PR TITLE
cluster up: use serverIP on Mac when public host is not specified

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -276,7 +276,11 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 			}
 			nodeHost = internalIP
 			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--master=%s", internalIP))
-			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--public-master=https://%s:8443", h.publicHost))
+			publicHost := h.publicHost
+			if len(publicHost) == 0 {
+				publicHost = opt.ServerIP
+			}
+			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--public-master=https://%s:8443", publicHost))
 		} else {
 			nodeHost = opt.ServerIP
 			createConfigCmd = append(createConfigCmd, fmt.Sprintf("--master=%s", opt.ServerIP))


### PR DESCRIPTION
Follow up to https://github.com/openshift/origin/pull/12398

When public-hostname is not specified, we need to keep previous behavior.