### PR TITLE
dind: minor cleanup

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -359,9 +359,9 @@ case "${1:-""}" in
     build-images "${OS_ROOT}"
     ;;
   *)
-    >&2 echo "Usage: $0 {start|stop|wait-for-cluster|build-images}
+    >&2 echo "Usage: $0 {start|stop|wait-for-cluster|build-images} [options]
 
-start accepts the following arguments:
+start accepts the following options:
 
  -n [net plugin]   the name of the network plugin to deploy
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -265,9 +265,9 @@ esac
 
 TEST_EXTRA_ARGS="$@"
 
-if [[ "${OPENSHIFT_SKIP_BUILD:-false}" = "true" ]] &&
+if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]] &&
      os::util::find::built_binary 'extended.test' >/dev/null 2>&1; then
-  os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=true"
+  os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=1"
 else
   # cgo must be disabled to have the symbol table available
   CGO_ENABLED=0 hack/build-go.sh test/extended/extended.test


### PR DESCRIPTION
 - ``networking.sh``: ``OPENSHIFT_SKIP_BUILD`` previously required ``true``, now follows bash convention of a any value (e.g. ``1``)
 - ``dind-cluster.sh``: The help text now documents the order of command and options

cc: @openshift/networking 