### PR TITLE
Allow to use selector when listing clusterroles

### DIFF
--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -47,7 +47,7 @@ func (m *VirtualStorage) NewList() runtime.Object {
 }
 
 func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runtime.Object, error) {
-	policyList, err := m.PolicyStorage.ListPolicies(ctx, options)
+	policyList, err := m.PolicyStorage.ListPolicies(ctx, &kapi.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -54,7 +54,7 @@ func (m *VirtualStorage) NewList() runtime.Object {
 }
 
 func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runtime.Object, error) {
-	policyBindingList, err := m.BindingRegistry.ListPolicyBindings(ctx, options)
+	policyBindingList, err := m.BindingRegistry.ListPolicyBindings(ctx, &kapi.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -267,6 +267,20 @@ os::cmd::expect_success "oadm policy reconcile-cluster-role-bindings --confirm"
 echo "admin-role-reapers: ok"
 os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/admin/role-selectors"
+os::cmd::expect_success "oc create -f test/extended/testdata/roles/policy-clusterroles.yaml"
+os::cmd::expect_success "oc get clusterrole/basic-user2"
+os::cmd::expect_success "oc label clusterrole/basic-user2 foo=bar"
+os::cmd::expect_success_and_not_text "oc get clusterroles --selector=foo=bar" "No resources found"
+os::cmd::expect_success_and_text "oc get clusterroles --selector=foo=unknown" "No resources found"
+os::cmd::expect_success "oc get clusterrolebinding/basic-users2"
+os::cmd::expect_success "oc label clusterrolebinding/basic-users2 foo=bar"
+os::cmd::expect_success_and_not_text "oc get clusterrolebindings --selector=foo=bar" "No resources found"
+os::cmd::expect_success_and_text "oc get clusterroles --selector=foo=unknown" "No resources found"
+os::cmd::expect_success "oc delete clusterrole/basic-user2"
+os::test::junit::declare_suite_end
+echo "admin-role-selectors: ok"
+
 os::test::junit::declare_suite_start "cmd/admin/ui-project-commands"
 # Test the commands the UI projects page tells users to run
 # These should match what is described in projects.html


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/12450

Basically pass the ListOptions when filtering the policies.