### PR TITLE
[3.4] UPSTREAM: docker/distribution: 2140: Add 'ca-central-1' region for registry S3 storage driver

### DIFF
--- a/vendor/github.com/docker/distribution/registry/storage/driver/s3-aws/s3.go
+++ b/vendor/github.com/docker/distribution/registry/storage/driver/s3-aws/s3.go
@@ -72,10 +72,13 @@ type DriverParameters struct {
 func init() {
 	for _, region := range []string{
 		"us-east-1",
+		"us-east-2",
 		"us-west-1",
 		"us-west-2",
 		"eu-west-1",
+		"eu-west-2",
 		"eu-central-1",
+		"ap-south-1",
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"ap-northeast-1",
@@ -83,6 +86,7 @@ func init() {
 		"sa-east-1",
 		"cn-north-1",
 		"us-gov-west-1",
+		"ca-central-1",
 	} {
 		validRegions[region] = struct{}{}
 	}


### PR DESCRIPTION


Signed-off-by: Michal Fojtik <mfojtik@redhat.com>