### PR TITLE
Only one ipfailover container can be run on a node

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -178,7 +178,7 @@ function generate_vip_section() {
 #
 function generate_vrrpd_instance_config() {
   local servicename=$1
-  local iid=${2:-"0"}
+  local iid=${2:-"1"}
   local vips=$3
   local interface=$4
   local priority=${5:-"10"}

--- a/pkg/ipfailover/keepalived/plugin.go
+++ b/pkg/ipfailover/keepalived/plugin.go
@@ -116,7 +116,7 @@ func (p *KeepalivedPlugin) Generate() (*kapi.List, error) {
 	}
 
 	if len(p.Options.VirtualIPs) == 0 {
-		return nil, fmt.Errorf("you must specify at least one virtual IP address for keepalived to expose")
+		return nil, fmt.Errorf("you must specify at least one virtual IP address (--virtual-ips=) for keepalived to expose")
 	}
 
 	dc, err := GenerateDeploymentConfig(p.Name, p.Options, selector)

--- a/pkg/ipfailover/types.go
+++ b/pkg/ipfailover/types.go
@@ -12,8 +12,9 @@ const (
 	// DefaultType is the default IP Failover type.
 	DefaultType = "keepalived"
 
-	// DefaultServicePort is the default service port.
-	DefaultServicePort = 1985
+	// DefaultServicePort is the port associated with the ipfailover config.
+	// Each ipfailover config has a different ServicePort.
+	DefaultServicePort = 63000
 
 	// DefaultWatchPort is the default IP Failover watched port number.
 	DefaultWatchPort = 80

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -78,7 +78,10 @@ os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --ipta
 os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --check-interval=1177 --dry-run -o yaml' 'value: "1177"'
 os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --check-script="ChkScript.sh" --dry-run -o yaml' 'value: ChkScript.sh'
 os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --notify-script="NotScript.sh" --dry-run -o yaml' 'value: NotScript.sh'
+os::cmd::expect_success_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run -o yaml --vrrp-id-offset=56' 'hostPort: 63056'
+os::cmd::expect_failure_and_text 'oadm ipfailover --virtual-ips="1.2.3.4" --dry-run -o yaml --vrrp-id-offset=255' 'error: The vrrp-id-offset must be in the range 0..254'
 os::cmd::expect_success 'oadm policy remove-scc-from-user privileged -z ipfailover'
+
 # TODO add tests for normal ipfailover creation
 # os::cmd::expect_success_and_text 'oadm ipfailover' 'deploymentconfig "ipfailover" created'
 # os::cmd::expect_failure_and_text 'oadm ipfailover' 'Error from server: deploymentconfig "ipfailover" already exists'


### PR DESCRIPTION
The ipfailover pods for a given configuration must run on
different nodes.  We are using the ServicePort as a mechanism
to prevent multiple pods for same configuration from starting
on the same node. Since pods for different configurations can
run on the same node a different ServicePort is used for each
configuration.

In the future, this may be changed to pod anti-affinity.

bug 1411501
https://bugzilla.redhat.com/show_bug.cgi?id=1411501

Signed-off-by: Phil Cameron <pcameron@redhat.com>