### PR TITLE
Extract duplicated code between new-build and new-app

### DIFF
--- a/pkg/cmd/cli/cmd/newapp_test.go
+++ b/pkg/cmd/cli/cmd/newapp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/origin/pkg/generate/app"
 	kapi "k8s.io/kubernetes/pkg/api"
 
+	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	newcmd "github.com/openshift/origin/pkg/generate/app/cmd"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
@@ -207,8 +208,10 @@ func TestNewAppRunFailure(t *testing.T) {
 	}
 
 	opts := &NewAppOptions{
-		BaseName:    "oc",
-		CommandName: NewAppRecommendedCommandName,
+		ObjectGeneratorOptions: &ObjectGeneratorOptions{
+			BaseName:    "oc",
+			CommandName: NewAppRecommendedCommandName,
+		},
 	}
 
 	for testName, test := range tests {
@@ -318,9 +321,13 @@ func TestNewAppRunQueryActions(t *testing.T) {
 	}
 
 	o := &NewAppOptions{
-		Out:         ioutil.Discard,
-		BaseName:    "oc",
-		CommandName: NewAppRecommendedCommandName,
+		ObjectGeneratorOptions: &ObjectGeneratorOptions{
+			Action: configcmd.BulkAction{
+				Out: ioutil.Discard,
+			},
+			BaseName:    "oc",
+			CommandName: NewAppRecommendedCommandName,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/cmd/cli/cmd/newbuild_test.go
+++ b/pkg/cmd/cli/cmd/newbuild_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/openshift/origin/pkg/client/testclient"
+	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	"github.com/openshift/origin/pkg/generate/app"
 	newcmd "github.com/openshift/origin/pkg/generate/app/cmd"
-
-	"github.com/openshift/origin/pkg/client/testclient"
 )
 
 // TestNewBuildRun ensures that Run command calls the right actions
@@ -52,10 +52,14 @@ func TestNewBuildRun(t *testing.T) {
 	}
 
 	o := &NewBuildOptions{
-		Out:         ioutil.Discard,
-		CommandPath: "oc new-build",
-		BaseName:    "oc",
-		CommandName: "new-build",
+		ObjectGeneratorOptions: &ObjectGeneratorOptions{
+			Action: configcmd.BulkAction{
+				Out: ioutil.Discard,
+			},
+			CommandPath: "oc new-build",
+			BaseName:    "oc",
+			CommandName: "new-build",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/cmd/util/cmd.go
+++ b/pkg/cmd/util/cmd.go
@@ -153,6 +153,9 @@ func VersionedPrintObject(fn func(*cobra.Command, meta.RESTMapper, runtime.Objec
 }
 
 func WarnAboutCommaSeparation(errout io.Writer, values []string, flag string) {
+	if errout == nil {
+		return
+	}
 	for _, value := range values {
 		if commaSepVarsPattern.MatchString(value) {
 			fmt.Fprintf(errout, "warning: %s no longer accepts comma-separated lists of values. %q will be treated as a single key-value pair.\n", flag, value)

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -1865,28 +1865,30 @@ func TestNewAppListAndSearch(t *testing.T) {
 		{
 			name: "search, no oldversion",
 			options: clicmd.NewAppOptions{
-				Config: &cmd.AppConfig{
-					ComponentInputs: cmd.ComponentInputs{
-						ImageStreams: []string{"ruby"},
-					},
-					AsSearch: true,
-				},
+				ObjectGeneratorOptions: &clicmd.ObjectGeneratorOptions{
+					Config: &cmd.AppConfig{
+						ComponentInputs: cmd.ComponentInputs{
+							ImageStreams: []string{"ruby"},
+						},
+						AsSearch: true,
+					}},
 			},
 			expectedOutput: "Image streams (oc new-app --image-stream=<image-stream> [--code=<source>])\n-----\nruby\n  Project: default\n  Tags:    latest\n\n",
 		},
 		{
 			name: "list, no oldversion",
 			options: clicmd.NewAppOptions{
-				Config: &cmd.AppConfig{
-					AsList: true,
-				},
+				ObjectGeneratorOptions: &clicmd.ObjectGeneratorOptions{
+					Config: &cmd.AppConfig{
+						AsList: true,
+					}},
 			},
 			expectedOutput: "Image streams (oc new-app --image-stream=<image-stream> [--code=<source>])\n-----\nruby\n  Project: default\n  Tags:    latest\n\n",
 		},
 	}
 	for _, test := range tests {
 		stdout, stderr := PrepareAppConfig(test.options.Config)
-		test.options.Out, test.options.ErrOut = stdout, stderr
+		test.options.Action.Out, test.options.ErrOut = stdout, stderr
 		test.options.BaseName = "oc"
 		test.options.CommandName = "new-app"
 


### PR DESCRIPTION
**What this PR does?**

In command **new-app** and **new-build**, the implementation  of `Complete` (`NewAppOptions `and `NewBuildOptions`) are almost same. So in this PR I use a BaseOptions struct that implement the `Complete `function that can be called both by `NewAppOptions  `and `NewBuildOptions`. And also update the origin definition of struct `NewBuildOptions `and `NewAppOptions`, grab all items instead by a new struct named `BaseOptions `.