### PR TITLE
Add vendor HTTP header to docker registry

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -223,6 +223,8 @@ func alive(path string, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == path {
 			w.Header().Set("Cache-Control", "no-cache")
+			// TODO: Make this a special version endpoint?
+			w.Header().Set("Docker-Registry-Vendor", "openshift")
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
@miminar @mtrmac PTAL

@smarterclayton I can add a separate endpoint for the version information. We might also need to advertise the "public master API URL" for the Docker daemon, so it knows where to route the HTTP request to get the image signature from. I guess we can't just use the kubeconfig value and this will need to be a new option for the registry.

We also discussed with @legionus that it should not be that hard to add a completely new endpoint in the registry to serve the Image signatures. Basically, the Docker daemon will have to talk just to registry then. Registry will forward the request to OpenShift API and return the Image signature.

I'm open to both approaches (the registry serving signatures seems easier for Docker guys).