### PR TITLE
Uses patch instead of update to mark nodes (un)schedulable

### DIFF
--- a/pkg/cmd/admin/node/schedulable.go
+++ b/pkg/cmd/admin/node/schedulable.go
@@ -1,6 +1,9 @@
 package node
 
 import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 )
@@ -22,8 +25,8 @@ func (s *SchedulableOptions) Run() error {
 	unschedulable := !s.Schedulable
 	for _, node := range nodes {
 		if node.Spec.Unschedulable != unschedulable {
-			node.Spec.Unschedulable = unschedulable
-			node, err = s.Options.KubeClient.Core().Nodes().Update(node)
+			patch := fmt.Sprintf(`{"spec":{"unschedulable":%t}}`, unschedulable)
+			node, err = s.Options.KubeClient.Core().Nodes().Patch(node.Name, api.MergePatchType, []byte(patch))
 			if err != nil {
 				errList = append(errList, err)
 				continue


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1279303

Avoid race conditions when using `oadm manage-node --schedulable` by applying a PATCH in the desired attribute instead of a full update of the node object.