### PR TITLE
Move kubelet e2e test to serial suite because it saturates nodes

### DIFF
--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -346,6 +346,7 @@ readonly SERIAL_TESTS=(
 	"\[Feature:ManualPerformance\]" # requires isolation
 	"Service endpoints latency" # requires low latency
 	"\[Feature:HighDensityPerformance\]" # requires no other namespaces
+	"Clean up pods on node" # schedules max pods per node
 )
 
 readonly CONFORMANCE_TESTS=(

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -182,7 +182,7 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		addRoleToE2EServiceAccounts(osClient, []kapi.Namespace{*ns}, bootstrappolicy.ViewRoleName)
 	}
 
-	if isPackage("/kubernetes/test/e2e/scheduler_predicates.go") || isPackage("/kubernetes/test/e2e/rescheduler.go") {
+	if isPackage("/kubernetes/test/e2e/scheduler_predicates.go") || isPackage("/kubernetes/test/e2e/rescheduler.go") || isPackage("/kubernetes/test/e2e/kubelet.go") {
 		allowAllNodeScheduling(c, ns.Name)
 	}
 


### PR DESCRIPTION
Results in scheduling failures in other pods.

[merge]