### PR TITLE
UPSTREAM: google/cadvisor: 1573: Ignore any .mount cgroup in docker

### DIFF
--- a/vendor/github.com/google/cadvisor/container/docker/factory.go
+++ b/vendor/github.com/google/cadvisor/container/docker/factory.go
@@ -141,17 +141,21 @@ func ContainerNameToDockerId(name string) string {
 	return id
 }
 
+// isContainerName returns true if the cgroup with associated name
+// corresponds to a docker container.
 func isContainerName(name string) bool {
+	// always ignore .mount cgroup even if associated with docker and delegate to systemd
+	if strings.HasSuffix(name, ".mount") {
+		return false
+	}
 	return dockerCgroupRegexp.MatchString(path.Base(name))
 }
 
 // Docker handles all containers under /docker
 func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
-	// docker factory accepts all containers it can handle.
-	canAccept := true
-
+	// if the container is not associated with docker, we can't handle it or accept it.
 	if !isContainerName(name) {
-		return false, canAccept, fmt.Errorf("invalid container name")
+		return false, false, nil
 	}
 
 	// Check if the container is known to docker and it is active.
@@ -160,10 +164,10 @@ func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	// We assume that if Inspect fails then the container is not known to docker.
 	ctnr, err := self.client.ContainerInspect(context.Background(), id)
 	if err != nil || !ctnr.State.Running {
-		return false, canAccept, fmt.Errorf("error inspecting container: %v", err)
+		return false, true, fmt.Errorf("error inspecting container: %v", err)
 	}
 
-	return true, canAccept, nil
+	return true, true, nil
 }
 
 func (self *dockerFactory) DebugInfo() map[string][]string {


### PR DESCRIPTION
If you are using docker 1.12, you now get .mounts for anything associated with the dockershim, and we need to ignore them in favor of the usage associated with the .scope suffix for the container.

For example, cadvisor should ignore mounts of the following form:

```
/system.slice/var-lib-docker-containers-72e5a5ff5eef3c4222a6551b992b9360a99122f77d2229783f0ee0946dfd800e-shm.mount
```

