### PR TITLE
Registry manifest extended test is local only

### DIFF
--- a/test/extended/registry/registry.go
+++ b/test/extended/registry/registry.go
@@ -35,7 +35,7 @@ var _ = g.Describe("[registry][migration] manifest migration from etcd to regist
 		deleteTestImages(oc)
 	}
 
-	g.It("registry can get access to manifest", func() {
+	g.It("registry can get access to manifest [local]", func() {
 		oc.SetOutputDir(exutil.TestContext.OutputDir)
 		defer tearDown(oc)
 


### PR DESCRIPTION
[merge] addresses part of #12475 failing on GCE clusters