### PR TITLE
sdn: add support for multicast traffic for simple and multitenant plugins

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -241,8 +241,10 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	// vxlan0
 	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
 	otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
+	otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, nw_dst=224.0.0.0/3, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR)
 	otx.AddFlow("table=0, priority=150, in_port=1, actions=drop")
 	// tun0
+	otx.AddFlow("table=0, priority=250, in_port=2, ip, nw_dst=224.0.0.0/3, actions=drop")
 	otx.AddFlow("table=0, priority=200, in_port=2, arp, nw_src=%s, nw_dst=%s, actions=goto_table:30", localSubnetGateway, clusterNetworkCIDR)
 	otx.AddFlow("table=0, priority=200, in_port=2, ip, actions=goto_table:30")
 	otx.AddFlow("table=0, priority=150, in_port=2, actions=drop")
@@ -272,6 +274,12 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:60", serviceNetworkCIDR)
 	otx.AddFlow("table=30, priority=200, ip, nw_dst=%s, actions=goto_table:70", localSubnetCIDR)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:90", clusterNetworkCIDR)
+
+	// Multicast coming from the VXLAN
+	otx.AddFlow("table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/3, actions=goto_table:120")
+	// Multicast coming from local pods
+	otx.AddFlow("table=30, priority=25, ip, nw_dst=224.0.0.0/3, actions=goto_table:110")
+
 	otx.AddFlow("table=30, priority=0, ip, actions=goto_table:100")
 	otx.AddFlow("table=30, priority=0, arp, actions=drop")
 
@@ -304,6 +312,12 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	// Table 100: egress network policy dispatch; edited by UpdateEgressNetworkPolicy()
 	// eg, "table=100, reg0=${tenant_id}, priority=2, ip, nw_dst=${external_cidr}, actions=drop
 	otx.AddFlow("table=100, priority=0, actions=output:2")
+
+	// Table 110: multicast delivery from local pods to the VXLAN
+	otx.AddFlow("table=110, priority=0, actions=drop")
+
+	// Table 120: multicast delivery to local pods (either from VXLAN or local pods)
+	otx.AddFlow("table=120, priority=0, actions=drop")
 
 	err = otx.EndTransaction()
 	if err != nil {

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -238,7 +238,7 @@ func (node *OsdnNode) Start() error {
 		})
 
 	log.V(5).Infof("Creating and initializing openshift-sdn pod manager")
-	node.podManager, err = newPodManager(node.host, node.localSubnetCIDR, node.networkInfo, node.kClient, node.policy, node.mtu)
+	node.podManager, err = newPodManager(node.host, node.localSubnetCIDR, node.networkInfo, node.kClient, node.policy, node.mtu, node.ovs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/openshift/origin/pkg/sdn/plugin/cniserver"
 	"github.com/openshift/origin/pkg/util/netutils"
+	"github.com/openshift/origin/pkg/util/ovs"
 
 	"github.com/golang/glog"
 
@@ -26,6 +28,7 @@ type podHandler interface {
 type runningPod struct {
 	activePod *kubehostport.ActivePod
 	vnid      uint32
+	ofport    int
 }
 
 type podManager struct {
@@ -44,16 +47,18 @@ type podManager struct {
 	mtu             uint32
 	hostportHandler kubehostport.HostportHandler
 	host            knetwork.Host
+	ovs             *ovs.Interface
 }
 
 // Creates a new live podManager; used by node code
-func newPodManager(host knetwork.Host, localSubnetCIDR string, netInfo *NetworkInfo, kClient *kclientset.Clientset, policy osdnPolicy, mtu uint32) (*podManager, error) {
+func newPodManager(host knetwork.Host, localSubnetCIDR string, netInfo *NetworkInfo, kClient *kclientset.Clientset, policy osdnPolicy, mtu uint32, ovs *ovs.Interface) (*podManager, error) {
 	pm := newDefaultPodManager(host)
 	pm.kClient = kClient
 	pm.policy = policy
 	pm.mtu = mtu
 	pm.hostportHandler = kubehostport.NewHostportHandler()
 	pm.podHandler = pm
+	pm.ovs = ovs
 
 	var err error
 	pm.ipamConfig, err = getIPAMConfig(netInfo.ClusterNetwork, localSubnetCIDR)
@@ -94,6 +99,7 @@ func getIPAMConfig(clusterNetwork *net.IPNet, localSubnet string) ([]byte, error
 		IPAM *hostLocalIPAM `json:"ipam"`
 	}
 
+	mcaddr := net.ParseIP("224.0.0.0")
 	return json.Marshal(&cniNetworkConfig{
 		Name: "openshift-sdn",
 		Type: "openshift-sdn",
@@ -112,6 +118,13 @@ func getIPAMConfig(clusterNetwork *net.IPNet, localSubnet string) ([]byte, error
 					GW: netutils.GenerateDefaultGateway(nodeNet),
 				},
 				{Dst: *clusterNetwork},
+				{
+					// Multicast
+					Dst: net.IPNet{
+						IP:   mcaddr,
+						Mask: net.IPMask(mcaddr),
+					},
+				},
 			},
 		},
 	})
@@ -166,6 +179,73 @@ func (m *podManager) handleCNIRequest(request *cniserver.PodRequest) ([]byte, er
 	return result.Response, result.Err
 }
 
+type runningPodsSlice []*runningPod
+
+func (l runningPodsSlice) Len() int           { return len(l) }
+func (l runningPodsSlice) Less(i, j int) bool { return l[i].ofport < l[j].ofport }
+func (l runningPodsSlice) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+
+// FIXME: instead of calculating all this ourselves, figure out a way to pass
+// the old VNID through the Update() call (or get it from somewhere else).
+func updateMulticastFlows(runningPods map[string]*runningPod, ovs *ovs.Interface, podKey string, changedPod *runningPod) error {
+	// FIXME: prevents TestPodUpdate() from crashing. (We separately test this function anyway.)
+	if ovs == nil {
+		return nil
+	}
+
+	// Build map of pods by their VNID, excluding the changed pod
+	podsByVNID := make(map[uint32]runningPodsSlice)
+	for key, runningPod := range runningPods {
+		if key != podKey {
+			podsByVNID[runningPod.vnid] = append(podsByVNID[runningPod.vnid], runningPod)
+		}
+	}
+
+	// Figure out what two VNIDs changed so we can update only those two flows
+	changedVNIDs := make([]uint32, 0)
+	oldPod, exists := runningPods[podKey]
+	if changedPod != nil {
+		podsByVNID[changedPod.vnid] = append(podsByVNID[changedPod.vnid], changedPod)
+		changedVNIDs = append(changedVNIDs, changedPod.vnid)
+		if exists {
+			// VNID changed
+			changedVNIDs = append(changedVNIDs, oldPod.vnid)
+		}
+	} else if exists {
+		// Pod deleted
+		changedVNIDs = append(changedVNIDs, oldPod.vnid)
+	}
+
+	if len(changedVNIDs) == 0 {
+		// Shouldn't happen, but whatever
+		return fmt.Errorf("Multicast update requested but not required!")
+	}
+
+	otx := ovs.NewTransaction()
+	for _, vnid := range changedVNIDs {
+		// Sort pod array to ensure consistent ordering for testcases and readability
+		pods := podsByVNID[vnid]
+		sort.Sort(pods)
+
+		// build up list of ports on this VNID
+		outputs := ""
+		for _, pod := range pods {
+			if len(outputs) > 0 {
+				outputs += ","
+			}
+			outputs += fmt.Sprintf("output:%d", pod.ofport)
+		}
+
+		// Update or delete the flows for the vnid
+		if len(outputs) > 0 {
+			otx.AddFlow("table=120, priority=100, reg0=%d, actions=%s", vnid, outputs)
+		} else {
+			otx.DeleteFlows("table=120, reg0=%d", vnid)
+		}
+	}
+	return otx.EndTransaction()
+}
+
 // Process all CNI requests from the request queue serially.  Our OVS interaction
 // and scripts currently cannot run in parallel, and doing so greatly complicates
 // setup/teardown logic
@@ -173,32 +253,36 @@ func (m *podManager) processCNIRequests() {
 	for request := range m.requests {
 		pk := getPodKey(request)
 
+		var pod *runningPod
+		var ipamResult *cnitypes.Result
+
 		glog.V(5).Infof("Processing pod network request %v", request)
 		result := &cniserver.PodResult{}
 		switch request.Command {
 		case cniserver.CNI_ADD:
-			ipamResult, runningPod, err := m.podHandler.setup(request)
+			ipamResult, pod, result.Err = m.podHandler.setup(request)
 			if ipamResult != nil {
-				result.Response, err = json.Marshal(ipamResult)
-				if result.Err == nil {
-					m.runningPods[pk] = runningPod
-				}
-			}
-			if err != nil {
-				result.Err = err
+				result.Response, result.Err = json.Marshal(ipamResult)
 			}
 		case cniserver.CNI_UPDATE:
-			runningPod, err := m.podHandler.update(request)
-			if err == nil {
-				m.runningPods[pk] = runningPod
-			}
-			result.Err = err
+			pod, result.Err = m.podHandler.update(request)
 		case cniserver.CNI_DEL:
-			delete(m.runningPods, pk)
 			result.Err = m.podHandler.teardown(request)
 		default:
 			result.Err = fmt.Errorf("unhandled CNI request %v", request.Command)
 		}
+
+		if result.Err == nil {
+			if err := updateMulticastFlows(m.runningPods, m.ovs, pk, pod); err != nil {
+				glog.Warningf("Failed to update multicast flows: %v", err)
+			}
+			if pod != nil {
+				m.runningPods[pk] = pod
+			} else {
+				delete(m.runningPods, pk)
+			}
+		}
+
 		glog.V(5).Infof("Processed pod network request %v, result %s err %v", request, string(result.Response), result.Err)
 		request.Result <- result
 	}

--- a/pkg/sdn/plugin/pod_unsupported.go
+++ b/pkg/sdn/plugin/pod_unsupported.go
@@ -12,12 +12,12 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
-func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *kubehostport.ActivePod, error) {
+func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runningPod, error) {
 	return nil, nil, fmt.Errorf("openshift-sdn is unsupported on this OS!")
 }
 
-func (m *podManager) update(req *cniserver.PodRequest) error {
-	return fmt.Errorf("openshift-sdn is unsupported on this OS!")
+func (m *podManager) update(req *cniserver.PodRequest) (*runningPod, error) {
+	return nil, fmt.Errorf("openshift-sdn is unsupported on this OS!")
 }
 
 // Clean up all pod networking (clear OVS flows, release IPAM lease, remove host/container veth)


### PR DESCRIPTION
Multicast pings don't work, but there doesn't seem to be much of a point to that.  They could be added easily by:
```
echo "0" > /proc/sys/net/ipv4/icmp_echo_ignore_all
echo "0" > /proc/sys/net/ipv4/icmp_echo_ignore_broadcasts 
```
in the pods.

but other than all that, open for comments on the approach.  A refinement may be to use groups and buckets instead of building up flows for every port in a VNID and every node on the VXLAN.

Testing: use https://github.com/troglobit/mcjoin/ and in one pod run "mcjoin -s" and in another run "mcjoin" and you should see the "mcjoin" process printing out '.' every time it receives a multicast packet from the "-s" process.

@openshift/networking 