### PR TITLE
Add DisableAttachDetachReconcilerSync new flag to master_config_test

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config_test.go
+++ b/pkg/cmd/server/kubernetes/master_config_test.go
@@ -144,10 +144,11 @@ func TestCMServerDefaults(t *testing.T) {
 				RenewDeadline: unversioned.Duration{Duration: 10 * time.Second},
 				RetryPeriod:   unversioned.Duration{Duration: 2 * time.Second},
 			},
-			ClusterSigningCertFile:   "/etc/kubernetes/ca/ca.pem",
-			ClusterSigningKeyFile:    "/etc/kubernetes/ca/ca.key",
-			EnableGarbageCollector:   true,
-			ReconcilerSyncLoopPeriod: unversioned.Duration{Duration: 5 * time.Second},
+			ClusterSigningCertFile:            "/etc/kubernetes/ca/ca.pem",
+			ClusterSigningKeyFile:             "/etc/kubernetes/ca/ca.key",
+			EnableGarbageCollector:            true,
+			DisableAttachDetachReconcilerSync: false,
+			ReconcilerSyncLoopPeriod:          unversioned.Duration{Duration: 5 * time.Second},
 		},
 	}
 


### PR DESCRIPTION
This is a followup to #12481, the new flag wasn't added to tests, so we won't know when it changes during next rebase.

@deads2k we've spoke about it on IRC, ptal