### PR TITLE
UPSTREAM: <carry>: Double container probe timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/container_probe.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/container_probe.go
@@ -34,7 +34,7 @@ const (
 	probTestContainerName       = "test-webserver"
 	probTestInitialDelaySeconds = 15
 
-	defaultObservationTimeout = time.Minute * 2
+	defaultObservationTimeout = time.Minute * 4
 )
 
 var _ = framework.KubeDescribe("Probing container", func() {


### PR DESCRIPTION
Until #11016 is resolved, we suspect that a combination of start latency
and the corresponding effect on sync pod latency is causing status
manager to fail to report within the 2 minute window. Double for now

[merge] @ncdc