### PR TITLE
ipfailover - user check script overrides default

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -44,6 +44,8 @@ function generate_global_config() {
 
 #
 #  Generate VRRP checker script configuration section.
+#    When a check script is provided use it instead of default script
+#    The default script is suppressed When port is 0
 #
 #  Example:
 #      generate_script_config
@@ -56,13 +58,14 @@ function generate_script_config() {
   echo ""
   echo "vrrp_script ${CHECK_SCRIPT_NAME} {"
 
-  if [[ "${port}" == "0" ]]; then
-    echo "   script \"true\""
+  if [[ -n "${HA_CHECK_SCRIPT}" ]]; then
+    echo "   script \"${HA_CHECK_SCRIPT}\""
   else
-    if [[ -n "${HA_CHECK_SCRIPT}" ]]; then
-      echo "   script \"${HA_CHECK_SCRIPT}\""
+    if [[ "${port}" == "0" ]]; then
+      echo "   script \"true\""
+    else
+      echo "   script \"</dev/tcp/${serviceip}/${port}\""
     fi
-    echo "   script \"</dev/tcp/${serviceip}/${port}\""
   fi
 
   echo "   interval ${CHECK_INTERVAL_SECS}"
@@ -165,8 +168,6 @@ function generate_vip_section() {
 
 #
 #  Generate vrrpd instance configuration section.
-#    This generates the vrrp_sync_group and vrrp_instance
-#    There is one VIP per vrrp_sync_group
 #
 #  Examples:
 #      generate_vrrpd_instance_config arp 1 "10.1.2.3" enp0s8 "252" "master"


### PR DESCRIPTION
When the user supplies a check script, that check script replaces the
default check script.

See openshift-docs PR 3501

bug bz1410721
https://bugzilla.redhat.com/show_bug.cgi?id=1410721

Signed-off-by: Phil Cameron <pcameron@redhat.com>