### PR TITLE
UPSTREAM: <carry>: Increase service endpoint test timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -112,7 +112,7 @@ const (
 	slowPodStartTimeout = 15 * time.Minute
 
 	// How long to wait for a service endpoint to be resolvable.
-	ServiceStartTimeout = 1 * time.Minute
+	ServiceStartTimeout = 3 * time.Minute
 
 	// How often to Poll pods, nodes and claims.
 	Poll = 2 * time.Second


### PR DESCRIPTION
Until #11016 is fixed, this reduces flakiness in extended suites where
long start delays result in this test failing.

[merge]