### PR TITLE
Store Jobs under batch/v1 instead of deprecated extensions/v1beta1

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -184,7 +184,7 @@ func BuildDefaultAPIServer(options configapi.MasterConfig) (*apiserveroptions.Se
 		master.DefaultAPIResourceConfigSource(),
 	)*/
 	// the order here is important, it defines which version will be used for storage
-	storageFactory.AddCohabitatingResources(extensions.Resource("jobs"), batch.Resource("jobs"))
+	storageFactory.AddCohabitatingResources(batch.Resource("jobs"), extensions.Resource("jobs"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("horizontalpodautoscalers"), autoscaling.Resource("horizontalpodautoscalers"))
 
 	return server, storageFactory, nil

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -356,6 +356,7 @@ os::cmd::expect_success 'oc whoami'
 
 os::log::info "Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
+os::cmd::try_until_success "oc sa get-token default"
 oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
 # TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
 #os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'


### PR DESCRIPTION
Fixes #10950. This only changes the version under jobs are stored in etcd, the location stays the same.

@deads2k @liggitt ptal