### PR TITLE
improve oadm manage node output

### DIFF
--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -27,6 +27,8 @@ type EvacuateOptions struct {
 	DryRun      bool
 	Force       bool
 	GracePeriod int64
+
+	printPodHeaders bool
 }
 
 // NewEvacuateOptions creates a new EvacuateOptions with default values.
@@ -36,6 +38,8 @@ func NewEvacuateOptions(nodeOptions *NodeOptions) *EvacuateOptions {
 		DryRun:      false,
 		Force:       false,
 		GracePeriod: 30,
+
+		printPodHeaders: true,
 	}
 }
 
@@ -49,6 +53,11 @@ func (e *EvacuateOptions) AddFlags(cmd *cobra.Command) {
 }
 
 func (e *EvacuateOptions) Run() error {
+	if e.DryRun {
+		listpodsOp := ListPodsOptions{Options: e.Options, printPodHeaders: e.printPodHeaders}
+		return listpodsOp.Run()
+	}
+
 	nodes, err := e.Options.GetNodes()
 	if err != nil {
 		return err
@@ -66,11 +75,6 @@ func (e *EvacuateOptions) Run() error {
 }
 
 func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
-	if e.DryRun {
-		listpodsOp := ListPodsOptions{Options: e.Options}
-		return listpodsOp.Run()
-	}
-
 	// We do *not* automatically mark the node unschedulable to perform evacuation.
 	// Rationale: If we unschedule the node and later the operation is unsuccessful (stopped by user, network error, etc.),
 	// we may not be able to recover in some cases to mark the node back to schedulable. To avoid these cases, we recommend

--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -17,6 +17,8 @@ import (
 
 type ListPodsOptions struct {
 	Options *NodeOptions
+
+	printPodHeaders bool
 }
 
 func (l *ListPodsOptions) AddFlags(cmd *cobra.Command) {
@@ -71,6 +73,14 @@ func (l *ListPodsOptions) runListPods(node *kapi.Node, printer kprinters.Resourc
 	}
 
 	fmt.Fprint(l.Options.ErrWriter, "\nListing matched pods on node: ", node.ObjectMeta.Name, "\n\n")
+	if p, ok := printer.(*kprinters.HumanReadablePrinter); ok {
+		if l.printPodHeaders {
+			p.EnsurePrintHeaders()
+		}
+		p.PrintObj(pods, l.Options.Writer)
+		return err
+	}
+
 	printer.PrintObj(pods, l.Options.Writer)
 
 	return err

--- a/pkg/cmd/admin/node/node.go
+++ b/pkg/cmd/admin/node/node.go
@@ -58,7 +58,7 @@ func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, ou
 	opts := &NodeOptions{}
 	schedulableOp := &SchedulableOptions{Options: opts}
 	evacuateOp := NewEvacuateOptions(opts)
-	listpodsOp := &ListPodsOptions{Options: opts}
+	listpodsOp := &ListPodsOptions{Options: opts, printPodHeaders: true}
 
 	cmd := &cobra.Command{
 		Use:     commandName,
@@ -91,8 +91,10 @@ func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, ou
 				schedulableOp.Schedulable = schedulable
 				err = schedulableOp.Run()
 			} else if evacuate {
+				evacuateOp.printPodHeaders = !kcmdutil.GetFlagBool(c, "no-headers")
 				err = evacuateOp.Run()
 			} else if listpods {
+				listpodsOp.printPodHeaders = !kcmdutil.GetFlagBool(c, "no-headers")
 				err = listpodsOp.Run()
 			}
 			kcmdutil.CheckErr(err)


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/40111
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1390900

This patch ensures that headers are printed for each list of pods
that is printed in each node, as long as the --no-headers printer flag
has not been specified by the user.

##### Example
```
$ oadm manage-node --list-pods --selector=                             
Listing matched pods on node: <node_name>

NAME           READY     STATUS    RESTARTS   AGE
node-1-fg513   0/1       Unknown   126        1d

Listing matched pods on node: <node_name_2>

NAME           READY     STATUS    RESTARTS   AGE
node-1-424dd   0/1       CrashLoopBackOff   32        2h
```

It also ensures that the entire `--dry-run` output of `--evacuate` is
only printed once, rather than once per node on the cluster.

@openshift/cli-review 