### PR TITLE
UPSTREAM: <carry>: Pod deletion can be contended, causing test failure

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/pods.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/pods.go
@@ -160,7 +160,7 @@ var _ = framework.KubeDescribe("Pods Delete Grace Period", func() {
 		deleted := false
 		timeout := false
 		var lastPod *api.Pod
-		timer := time.After(30 * time.Second)
+		timer := time.After(2 * time.Minute)
 		for !deleted && !timeout {
 			select {
 			case event, _ := <-w.ResultChan():


### PR DESCRIPTION
Add a longer timeout to the test to deal with #11016.

[merge]