### PR TITLE
only set CGO_ENABLED=0 for tests

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -171,8 +171,6 @@ os::build::internal::build_binaries() {
     # Use eval to preserve embedded quoted strings.
     local goflags
     eval "goflags=(${OS_GOFLAGS:-})"
-    local gotags
-    eval "gotags=(${OS_GOFLAGS_TAGS:-})"
 
     local arg
     for arg; do
@@ -213,6 +211,7 @@ os::build::internal::build_binaries() {
       fi
 
       local platform_gotags_envvar=OS_GOFLAGS_TAGS_$(echo ${platform} | tr '[:lower:]/' '[:upper:]_')
+      local platform_gotags_test_envvar=OS_GOFLAGS_TAGS_TEST_$(echo ${platform} | tr '[:lower:]/' '[:upper:]_')
 
       if [[ ${#nonstatics[@]} -gt 0 ]]; then
         GOOS=${platform%/*} GOARCH=${platform##*/} go install \
@@ -231,9 +230,10 @@ os::build::internal::build_binaries() {
 
       for test in "${tests[@]:+${tests[@]}}"; do
         local outfile="${OS_OUTPUT_BINPATH}/${platform}/$(basename ${test})"
-        GOOS=${platform%/*} GOARCH=${platform##*/} go test \
+        # disabling cgo allows use of delve
+        CGO_ENABLED=0 GOOS=${platform%/*} GOARCH=${platform##*/} go test \
           -pkgdir "${OS_OUTPUT_PKGDIR}/${platform}" \
-          -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-}" \
+          -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_test_envvar:-}" \
           -ldflags "${version_ldflags}" \
           -i -c -o "${outfile}" \
           "${goflags[@]:+${goflags[@]}}" \

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -26,11 +26,11 @@ name="$(basename ${package})"
 dlv_debug="${DLV_DEBUG:-}"
 verbose="${VERBOSE:-}"
 
-# build the test executable (cgo must be disabled to have the symbol table available)
+# build the test executable
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
   os::log::warn "Skipping build due to OPENSHIFT_SKIP_BUILD"
 else
-	CGO_ENABLED=0 "${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test" -installsuffix=cgo
+	"${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test"
 fi
 testexec="$(os::util::find::built_binary "${name}.test")"
 

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -5,9 +5,6 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 source "${OS_ROOT}/test/extended/setup.sh"
 
-# cgo must be disabled to have the symbol table available
-export CGO_ENABLED=0
-
 os::test::extended::setup
 os::test::extended::focus "$@"
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -269,8 +269,7 @@ if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]] &&
      os::util::find::built_binary 'extended.test' >/dev/null 2>&1; then
   os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=1"
 else
-  # cgo must be disabled to have the symbol table available
-  CGO_ENABLED=0 hack/build-go.sh test/extended/extended.test
+  hack/build-go.sh test/extended/extended.test
 fi
 
 # enable-selinux/disable-selinux use the shared control variable


### PR DESCRIPTION
#11044 accidentally caused the openshift binary to be built with CGO_ENABLED=0 if it had not been built by the time test/extended/core.sh was run.  The openshift binary cannot run correctly with CGO_ENABLED=0 as cgo is used by kubelet.

This change centralises the setting of CGO_ENABLED to hack/common.sh for all .test executables.

I believe that this setting is wanted so that delve can be used against these executables.