### PR TITLE
build extended tests: don't use large Jenkins image unnecessarily

### DIFF
--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[builds][Slow] build can have Docker image source", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for imagestreams to be imported")
-		err = exutil.WaitForAnImageStream(oc.AdminClient().ImageStreams("openshift"), "jenkins", exutil.CheckImageStreamLatestTagPopulatedFn, exutil.CheckImageStreamTagNotFoundFn)
+		err = exutil.WaitForAnImageStream(oc.AdminClient().ImageStreams("openshift"), "ruby", exutil.CheckImageStreamLatestTagPopulatedFn, exutil.CheckImageStreamTagNotFoundFn)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
@@ -48,7 +48,7 @@ var _ = g.Describe("[builds][Slow] build can have Docker image source", func() {
 			g.By("expecting the pod to contain the file from the input image")
 			out, err := oc.Run("exec").Args(pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "ls", "injected/dir").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(out).To(o.ContainSubstring("jenkins.war"))
+			o.Expect(out).To(o.ContainSubstring("ruby"))
 		})
 	})
 	g.Describe("build with image docker", func() {
@@ -71,7 +71,7 @@ var _ = g.Describe("[builds][Slow] build can have Docker image source", func() {
 			g.By("expecting the pod to contain the file from the input image")
 			out, err := oc.Run("exec").Args(pod.Name, "-c", pod.Spec.Containers[0].Name, "--", "ls", "injected/dir").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(out).To(o.ContainSubstring("jenkins.war"))
+			o.Expect(out).To(o.ContainSubstring("ruby"))
 		})
 
 	})

--- a/test/extended/testdata/test-imagesource-build.yaml
+++ b/test/extended/testdata/test-imagesource-build.yaml
@@ -19,15 +19,15 @@ items:
       images:
       - from:
           kind: ImageStreamTag
-          name: jenkins:latest
+          name: ruby:2.3
           namespace: openshift
         paths:
         - destinationDir: injected/dir
-          sourcePath: /usr/lib/jenkins/jenkins.war
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
     strategy:
-      sourceStrategy: 
+      sourceStrategy:
         forcePull: true
-        from: 
+        from:
           kind: ImageStreamTag
           name: ruby:latest
           namespace: openshift
@@ -48,11 +48,11 @@ items:
       images:
       - from:
           kind: ImageStreamTag
-          name: jenkins:latest
+          name: ruby:2.3
           namespace: openshift
         paths:
         - destinationDir: injected/dir
-          sourcePath: /usr/lib/jenkins/jenkins.war
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
     strategy:
       dockerStrategy: {}
 - apiVersion: v1
@@ -99,7 +99,6 @@ items:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
     triggers:
     - imageChangeParams:
         automatic: true
@@ -144,7 +143,6 @@ items:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
     triggers:
     - imageChangeParams:
         automatic: true


### PR DESCRIPTION
No need to pull openshift/jenkins-1-centos7 or do yum install -y httpd - save time & bandwidth!