### PR TITLE
Make the OS_RELEASE=n ./hack/build-images.sh work again

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -16,7 +16,10 @@ if [[ "${OS_RELEASE:-}" == "n" ]]; then
 	# identical to build-cross.sh
 	os::build::os_version_vars
 	OS_RELEASE_COMMIT="${OS_GIT_VERSION//+/-}"
-	OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
+	platform="$(os::build::host_platform)"
+	OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]:-${platform}}")
+	OS_IMAGE_COMPILE_TARGETS=("${OS_IMAGE_COMPILE_TARGETS[@]:-${OS_IMAGE_COMPILE_TARGETS_LINUX[@]}}")
+	OS_SCRATCH_IMAGE_COMPILE_TARGETS=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS[@]:-${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]}}")
 
 	echo "Building images from source ${OS_RELEASE_COMMIT}:"
 	echo


### PR DESCRIPTION
Make the `OS_RELEASE=n ./hack/build-images.sh` work again

Without this patch, I get:

    $ OS_RELEASE=n ./hack/build-images.sh
    Building images from source v1.5.0-alpha.2-78d8140-6-dirty:

    ++ temporarily enabling swap space to assist in building in limited memory - use OS_BUILD_SWAP_DISABLE=1 to bypass
    /data/src/github.com/openshift/origin/hack/common.sh: line 295: platforms[@]: unbound variable


    $ OS_RELEASE=n ./hack/build-images.sh
    Building images from source v1.5.0-alpha.2-78d8140-6-dirty:

    OS_IMAGE_COMPILE_TARGETS:
    ++ temporarily enabling swap space to assist in building in limited memory - use OS_BUILD_SWAP_DISABLE=1 to bypass
    ++ Building go targets for linux/amd64:
    ++ Placing binaries

    ln: failed to access '/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/pod': No such file or directory