### PR TITLE
Prune manifest config of schema 2 images

### DIFF
--- a/pkg/image/prune/prune.go
+++ b/pkg/image/prune/prune.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/golang/glog"
 	gonum "github.com/gonum/graph"
@@ -329,7 +330,7 @@ func addImagesToGraph(g graph.Graph, images *imageapi.ImageList, algorithm prune
 		glog.V(4).Infof("Adding image %q to graph", image.Name)
 		imageNode := imagegraph.EnsureImageNode(g, image)
 
-		if len(image.DockerImageConfig) > 0 {
+		if image.DockerImageManifestMediaType == schema2.MediaTypeManifest && len(image.DockerImageMetadata.ID) > 0 {
 			configName := image.DockerImageMetadata.ID
 			glog.V(4).Infof("Adding image config %q to graph", configName)
 			configNode := imagegraph.EnsureImageComponentConfigNode(g, configName)

--- a/pkg/image/prune/prune_test.go
+++ b/pkg/image/prune/prune_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -84,7 +87,8 @@ func imageWithLayers(id, ref string, configName *string, layers ...string) image
 				imageapi.ManagedByOpenShiftAnnotation: "true",
 			},
 		},
-		DockerImageReference: ref,
+		DockerImageReference:         ref,
+		DockerImageManifestMediaType: schema1.MediaTypeManifest,
 	}
 
 	if configName != nil {
@@ -92,6 +96,7 @@ func imageWithLayers(id, ref string, configName *string, layers ...string) image
 			ID: *configName,
 		}
 		image.DockerImageConfig = fmt.Sprintf("{Digest: %s}", *configName)
+		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
 	}
 
 	image.DockerImageLayers = []imageapi.ImageLayer{}


### PR DESCRIPTION
The Config is no longer stored in the image object. We need to check
manifest media type instead.

Since #11925 the Config object is unset on newly created images and images
served by registry.

Resolves #12499