### PR TITLE
UPSTREAM: <carry>: Increase pod deletion test timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
@@ -234,7 +234,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		deleted := false
 		timeout := false
 		var lastPod *api.Pod
-		timer := time.After(30 * time.Second)
+		timer := time.After(2 * time.Minute)
 		for !deleted && !timeout {
 			select {
 			case event, _ := <-w.ResultChan():

--- a/vendor/k8s.io/kubernetes/test/e2e/generated_clientset.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/generated_clientset.go
@@ -100,7 +100,7 @@ func observeCreation(w watch.Interface) {
 func observeObjectDeletion(w watch.Interface) (obj runtime.Object) {
 	deleted := false
 	timeout := false
-	timer := time.After(60 * time.Second)
+	timer := time.After(2 * time.Minute)
 	for !deleted && !timeout {
 		select {
 		case event, _ := <-w.ResultChan():


### PR DESCRIPTION
As a result of #11016, we do not see deletes within the existing short
window.

[merge]