### PR TITLE
Made build webhooks return new Build name.

### DIFF
--- a/pkg/build/registry/buildconfig/webhook_test.go
+++ b/pkg/build/registry/buildconfig/webhook_test.go
@@ -1,8 +1,10 @@
 package buildconfig
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -14,7 +16,9 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 
+	_ "github.com/openshift/origin/pkg/api/install"
 	"github.com/openshift/origin/pkg/build/api"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 	"github.com/openshift/origin/pkg/build/registry/test"
 	"github.com/openshift/origin/pkg/build/webhook"
 	"github.com/openshift/origin/pkg/build/webhook/github"
@@ -29,7 +33,15 @@ type buildConfigInstantiator struct {
 
 func (i *buildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
 	i.Request = request
-	return i.Build, i.Err
+	if i.Build != nil {
+		return i.Build, i.Err
+	}
+	return &api.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      request.Name,
+			Namespace: namespace,
+		},
+	}, i.Err
 }
 
 type plugin struct {
@@ -48,7 +60,7 @@ func (p *plugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *ht
 func newStorage() (*rest.WebHook, *buildConfigInstantiator, *test.BuildConfigRegistry) {
 	mockRegistry := &test.BuildConfigRegistry{}
 	bci := &buildConfigInstantiator{}
-	hook := NewWebHookREST(mockRegistry, bci, map[string]webhook.Plugin{
+	hook := NewWebHookREST(mockRegistry, bci, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{
 		"ok": &plugin{Proceed: true},
 		"okenv": &plugin{
 			Env: []kapi.EnvVar{
@@ -145,7 +157,18 @@ func TestConnectWebHook(t *testing.T) {
 			Obj:   &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn: func(err error) bool { return err == nil },
 			WFn: func(w *httptest.ResponseRecorder) bool {
-				return w.Code == http.StatusOK
+				body, _ := ioutil.ReadAll(w.Body)
+				// We want to make sure that we return the created build in the body.
+				if w.Code == http.StatusOK && len(body) > 0 {
+					// The returned json needs to be a v1 Build specifically
+					newBuild := &buildapiv1.Build{}
+					err := json.Unmarshal(body, newBuild)
+					if err == nil {
+						return true
+					}
+					return false
+				}
+				return false
 			},
 			Instantiate: true,
 		},
@@ -209,7 +232,12 @@ func TestConnectWebHook(t *testing.T) {
 type okBuildConfigInstantiator struct{}
 
 func (*okBuildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
-	return &api.Build{}, nil
+	return &api.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: namespace,
+			Name:      request.Name,
+		},
+	}, nil
 }
 
 type errorBuildConfigInstantiator struct{}
@@ -278,7 +306,7 @@ var mockBuildStrategy = api.BuildStrategy{
 func TestParseUrlError(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"github": github.New()}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"github": github.New()}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: ""}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -296,7 +324,7 @@ func TestParseUrlError(t *testing.T) {
 func TestParseUrlOK(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: "secret101/pathplugin"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -314,7 +342,7 @@ func TestParseUrlLong(t *testing.T) {
 	plugin := &pathPlugin{}
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"pathplugin": plugin}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"pathplugin": plugin}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: "secret101/pathplugin/some/more/args"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -332,7 +360,7 @@ func TestParseUrlLong(t *testing.T) {
 func TestInvokeWebhookMissingPlugin(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: "secret101/missingplugin"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -350,7 +378,7 @@ func TestInvokeWebhookMissingPlugin(t *testing.T) {
 func TestInvokeWebhookErrorBuildConfigInstantiate(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &errorBuildConfigInstantiator{}, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
+	handler, _ := NewWebHookREST(bcRegistry, &errorBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: "secret101/pathplugin"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -368,7 +396,7 @@ func TestInvokeWebhookErrorBuildConfigInstantiate(t *testing.T) {
 func TestInvokeWebhookErrorGetConfig(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"pathplugin": &pathPlugin{}}).
 		Connect(kapi.NewDefaultContext(), "badbuild100", &kapi.PodProxyOptions{Path: "secret101/pathplugin"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -388,7 +416,7 @@ func TestInvokeWebhookErrorGetConfig(t *testing.T) {
 func TestInvokeWebhookErrorCreateBuild(t *testing.T) {
 	bcRegistry := &test.BuildConfigRegistry{BuildConfig: testBuildConfig}
 	responder := &fakeResponder{}
-	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, map[string]webhook.Plugin{"errPlugin": &errPlugin{}}).
+	handler, _ := NewWebHookREST(bcRegistry, &okBuildConfigInstantiator{}, buildapiv1.SchemeGroupVersion, map[string]webhook.Plugin{"errPlugin": &errPlugin{}}).
 		Connect(kapi.NewDefaultContext(), "build100", &kapi.PodProxyOptions{Path: "secret101/errPlugin"}, responder)
 	server := httptest.NewServer(handler)
 	defer server.Close()

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -43,6 +43,7 @@ import (
 
 	authzcache "github.com/openshift/origin/pkg/authorization/authorizer/cache"
 	authzremote "github.com/openshift/origin/pkg/authorization/authorizer/remote"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildgenerator "github.com/openshift/origin/pkg/build/generator"
 	buildregistry "github.com/openshift/origin/pkg/build/registry/build"
@@ -727,6 +728,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	buildConfigWebHooks := buildconfigregistry.NewWebHookREST(
 		buildConfigRegistry,
 		buildclient.NewOSClientBuildConfigInstantiatorClient(bcClient),
+		// We use the buildapiv1 schemegroup to encode the Build that gets
+		// returned. As such, we need to make sure that the GroupVersion we use
+		// is the same API version that the storage is going to be used for.
+		buildapiv1.SchemeGroupVersion,
 		map[string]webhook.Plugin{
 			"generic": generic.New(),
 			"github":  github.New(),

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -97,7 +97,10 @@ os::cmd::expect_success_and_text 'oc start-build --list-webhooks=all bc/ruby-sam
 os::cmd::expect_success_and_text 'oc start-build --list-webhooks=all ruby-sample-build' 'github'
 os::cmd::expect_success_and_text 'oc start-build --list-webhooks=github ruby-sample-build' 'secret101'
 os::cmd::expect_failure 'oc start-build --list-webhooks=blah'
-os::cmd::expect_success "oc start-build --from-webhook='$(oc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1 | head -n 1)'"
+os::cmd::expect_success_and_text "oc start-build --from-webhook='$(oc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1 | head -n 1)'" "build \"ruby-sample-build-[0-9]\" started"
+os::cmd::expect_failure_and_text "oc start-build --from-webhook='$(oc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1 | head -n 1)/foo'" "error: server rejected our request"
+os::cmd::expect_success "oc patch bc/ruby-sample-build -p '{\"spec\":{\"strategy\":{\"dockerStrategy\":{\"from\":{\"name\":\"asdf:7\"}}}}}'"
+os::cmd::expect_failure_and_text "oc start-build --from-webhook='$(oc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1 | head -n 1)'" "Error resolving ImageStreamTag asdf:7"
 os::cmd::expect_success 'oc get builds'
 os::cmd::expect_success 'oc delete all -l build=docker'
 echo "buildConfig: ok"

--- a/test/integration/webhookgeneric_test.go
+++ b/test/integration/webhookgeneric_test.go
@@ -1,0 +1,87 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestWebhookGeneric(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unable to start master: %v", err)
+	}
+
+	kubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unable to get kubeClient: %v", err)
+	}
+	osClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unable to get osClient: %v", err)
+	}
+
+	kubeClient.Core().Namespaces().Create(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{Name: testutil.Namespace()},
+	})
+
+	if err := testserver.WaitForServiceAccounts(kubeClient, testutil.Namespace(), []string{bootstrappolicy.BuilderServiceAccountName, bootstrappolicy.DefaultServiceAccountName}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// create buildconfig
+	buildConfig := mockBuildConfigImageParms("originalimage", "imagestream", "validtag")
+	if _, err := osClient.BuildConfigs(testutil.Namespace()).Create(buildConfig); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	watch, err := osClient.Builds(testutil.Namespace()).Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't subscribe to builds: %v", err)
+	}
+	defer watch.Stop()
+
+	for _, s := range []string{
+		"/oapi/v1/namespaces/" + testutil.Namespace() + "/buildconfigs/pushbuild/webhooks/secret103/generic",
+	} {
+		// trigger build event sending push notification
+		clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		body := postFile(osClient.RESTClient.Client, "", "../../generic/testdata/push-generic.json", clusterAdminClientConfig.Host+s, http.StatusOK, t)
+		if len(body) == 0 {
+			t.Fatalf("Webhook did not return expected Build object.")
+		}
+
+		returnedBuild := &buildapiv1.Build{}
+		err = json.Unmarshal(body, returnedBuild)
+		if err != nil {
+			t.Fatalf("Unable to unmarshal returned body into a Build object.")
+		}
+
+		// TODO: improve negative testing
+		timer := time.NewTimer(time.Minute * 1)
+		select {
+		case <-timer.C:
+			t.Fatalf("Did not receive created build.")
+		case event := <-watch.ResultChan():
+			build := event.Object.(*buildapi.Build)
+			if build.Name != returnedBuild.Name {
+				t.Fatalf("Webhook returned incorrect build.")
+			}
+		}
+	}
+}


### PR DESCRIPTION
We now write the name of builds created with webhooks to the body of the
response, which was previously unused. This allows the client to alert
the user of the new build, similarly to if it was created through
non-webhook methods.

Old output:
```
$ oc start-build --from-webhook https://10.192.217.252:8443/oapi/v1/namespaces/myproject/buildconfigs/ruby-sample-build/webhooks/secret101/generic
```
New output:
```
$ oc start-build --from-webhook https://10.192.217.252:8443/oapi/v1/namespaces/myproject/buildconfigs/ruby-sample-build/webhooks/secret101/generic
build "ruby-sample-build-2" started
```

Fixes [bz1373441](https://bugzilla.redhat.com/show_bug.cgi?id=1373441)

@csrwng @wanghaoran1988 ptal?