### PR TITLE
Router improvement

### DIFF
--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -19,6 +19,11 @@ import (
 	"github.com/openshift/origin/pkg/router"
 )
 
+// RejectionRecorder is an object capable of recording why a route was rejected
+type RejectionRecorder interface {
+	RecordRouteRejection(route *routeapi.Route, reason, message string)
+}
+
 // StatusAdmitter ensures routes added to the plugin have status set.
 type StatusAdmitter struct {
 	plugin     router.Plugin
@@ -73,7 +78,7 @@ func findOrCreateIngress(route *routeapi.Route, name string) (_ *routeapi.RouteI
 			continue
 		}
 		updated = append(updated, *existing)
-		position = i
+		position = len(updated) - 1
 	}
 	switch {
 	case position == -1:

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -25,11 +25,6 @@ func HostForRoute(route *routeapi.Route) string {
 type HostToRouteMap map[string][]*routeapi.Route
 type RouteToHostMap map[string]string
 
-// RejectionRecorder is an object capable of recording why a route was rejected
-type RejectionRecorder interface {
-	RecordRouteRejection(route *routeapi.Route, reason, message string)
-}
-
 var LogRejections = logRecorder{}
 
 type logRecorder struct{}


### PR DESCRIPTION
This PR introduces two minor changes to the router:
1. Move the definition of ```RejectionRecorder``` interface into ``status.go``` from ```unique_host.go```, as the latter one may be depracted one day.
2. In the ```findOrCreateIngress``` function inside ```status.go```, change the statement ```position = i``` into ```position = len(updated) -1``` for a more correct semantic. And such change can support further different logic in choosing the matching item other than just using the first one.