### PR TITLE
Using kubernetes API to construct metadata fields set

### DIFF
--- a/pkg/authorization/api/fields.go
+++ b/pkg/authorization/api/fields.go
@@ -1,65 +1,50 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // ClusterPolicyToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func ClusterPolicyToSelectableFields(policy *ClusterPolicy) fields.Set {
-	return fields.Set{
-		"metadata.name": policy.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&policy.ObjectMeta, false)
 }
 
 // ClusterPolicyBindingToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func ClusterPolicyBindingToSelectableFields(policyBinding *ClusterPolicyBinding) fields.Set {
-	return fields.Set{
-		"metadata.name": policyBinding.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&policyBinding.ObjectMeta, false)
 }
 
 // PolicyToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func PolicyToSelectableFields(policy *Policy) fields.Set {
-	return fields.Set{
-		"metadata.name":      policy.Name,
-		"metadata.namespace": policy.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&policy.ObjectMeta, true)
 }
 
 // PolicyBindingToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func PolicyBindingToSelectableFields(policyBinding *PolicyBinding) fields.Set {
-	return fields.Set{
-		"metadata.name":       policyBinding.Name,
-		"metadata.namespace":  policyBinding.Namespace,
+	return generic.AddObjectMetaFieldsSet(fields.Set{
 		"policyRef.namespace": policyBinding.PolicyRef.Namespace,
-	}
+	}, &policyBinding.ObjectMeta, true)
 }
 
 // RoleToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func RoleToSelectableFields(role *Role) fields.Set {
-	return fields.Set{
-		"metadata.name":      role.Name,
-		"metadata.namespace": role.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&role.ObjectMeta, true)
 }
 
 // RoleBindingToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func RoleBindingToSelectableFields(roleBinding *RoleBinding) fields.Set {
-	return fields.Set{
-		"metadata.name":      roleBinding.Name,
-		"metadata.namespace": roleBinding.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&roleBinding.ObjectMeta, true)
 }
 
 // RoleBindingRestrictionToSelectableFields returns a label set that be used to
 // identify a RoleBindingRestriction object.
 func RoleBindingRestrictionToSelectableFields(rbr *RoleBindingRestriction) fields.Set {
-	return fields.Set{
-		"metadata.name":      rbr.Name,
-		"metadata.namespace": rbr.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&rbr.ObjectMeta, true)
 }

--- a/pkg/authorization/api/v1/conversion_test.go
+++ b/pkg/authorization/api/v1/conversion_test.go
@@ -9,32 +9,32 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicy",
+	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicy", false,
 		// Ensure all currently returned labels are supported
 		api.ClusterPolicyToSelectableFields(&api.ClusterPolicy{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicyBinding",
+	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicyBinding", false,
 		// Ensure all currently returned labels are supported
 		api.ClusterPolicyBindingToSelectableFields(&api.ClusterPolicyBinding{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "Policy",
+	testutil.CheckFieldLabelConversions(t, "v1", "Policy", true,
 		// Ensure all currently returned labels are supported
 		api.PolicyToSelectableFields(&api.Policy{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "PolicyBinding",
+	testutil.CheckFieldLabelConversions(t, "v1", "PolicyBinding", true,
 		// Ensure all currently returned labels are supported
 		api.PolicyBindingToSelectableFields(&api.PolicyBinding{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "Role",
+	testutil.CheckFieldLabelConversions(t, "v1", "Role", true,
 		// Ensure all currently returned labels are supported
 		api.RoleToSelectableFields(&api.Role{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "RoleBinding",
+	testutil.CheckFieldLabelConversions(t, "v1", "RoleBinding", true,
 		// Ensure all currently returned labels are supported
 		api.RoleBindingToSelectableFields(&api.RoleBinding{}),
 	)

--- a/pkg/build/api/fields.go
+++ b/pkg/build/api/fields.go
@@ -1,23 +1,21 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // BuildToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func BuildToSelectableFields(build *Build) fields.Set {
-	return fields.Set{
-		"metadata.name":      build.Name,
-		"metadata.namespace": build.Namespace,
-		"status":             string(build.Status.Phase),
-		"podName":            GetBuildPodName(build),
-	}
+	return generic.AddObjectMetaFieldsSet(fields.Set{
+		"status":  string(build.Status.Phase),
+		"podName": GetBuildPodName(build),
+	}, &build.ObjectMeta, true)
 }
 
 // BuildConfigToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func BuildConfigToSelectableFields(buildConfig *BuildConfig) fields.Set {
-	return fields.Set{
-		"metadata.name":      buildConfig.Name,
-		"metadata.namespace": buildConfig.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&buildConfig.ObjectMeta, true)
 }

--- a/pkg/build/api/v1/conversion_test.go
+++ b/pkg/build/api/v1/conversion_test.go
@@ -16,14 +16,14 @@ import (
 var Convert = knewer.Scheme.Convert
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Build",
+	testutil.CheckFieldLabelConversions(t, "v1", "Build", true,
 		// Ensure all currently returned labels are supported
 		newer.BuildToSelectableFields(&newer.Build{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"name", "status", "podName",
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "BuildConfig",
+	testutil.CheckFieldLabelConversions(t, "v1", "BuildConfig", true,
 		// Ensure all currently returned labels are supported
 		newer.BuildConfigToSelectableFields(&newer.BuildConfig{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST

--- a/pkg/deploy/api/fields.go
+++ b/pkg/deploy/api/fields.go
@@ -1,11 +1,11 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // DeploymentConfigToSelectableFields returns a label set that represents the object
 func DeploymentConfigToSelectableFields(deploymentConfig *DeploymentConfig) fields.Set {
-	return fields.Set{
-		"metadata.name":      deploymentConfig.Name,
-		"metadata.namespace": deploymentConfig.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&deploymentConfig.ObjectMeta, true)
 }

--- a/pkg/deploy/api/v1/conversion_test.go
+++ b/pkg/deploy/api/v1/conversion_test.go
@@ -225,7 +225,7 @@ func newIntOrString(ios intstr.IntOrString) *intstr.IntOrString {
 }
 
 func TestFieldSelectors(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "DeploymentConfig",
+	testutil.CheckFieldLabelConversions(t, "v1", "DeploymentConfig", true,
 		// Ensure all currently returned labels are supported
 		newer.DeploymentConfigToSelectableFields(&newer.DeploymentConfig{}),
 	)

--- a/pkg/image/api/fields.go
+++ b/pkg/image/api/fields.go
@@ -1,21 +1,19 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // ImageToSelectableFields returns a label set that represents the object.
 func ImageToSelectableFields(image *Image) fields.Set {
-	return fields.Set{
-		"metadata.name":      image.Name,
-		"metadata.namespace": image.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&image.ObjectMeta, true)
 }
 
 // ImageStreamToSelectableFields returns a label set that represents the object.
 func ImageStreamToSelectableFields(ir *ImageStream) fields.Set {
-	return fields.Set{
-		"metadata.name":                ir.Name,
-		"metadata.namespace":           ir.Namespace,
+	return generic.AddObjectMetaFieldsSet(fields.Set{
 		"spec.dockerImageRepository":   ir.Spec.DockerImageRepository,
 		"status.dockerImageRepository": ir.Status.DockerImageRepository,
-	}
+	}, &ir.ObjectMeta, true)
 }

--- a/pkg/image/api/v1/conversion_test.go
+++ b/pkg/image/api/v1/conversion_test.go
@@ -49,11 +49,11 @@ func TestRoundTripVersionedObject(t *testing.T) {
 }
 
 func TestFieldSelectors(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Image",
+	testutil.CheckFieldLabelConversions(t, "v1", "Image", true,
 		// Ensure all currently returned labels are supported
 		newer.ImageToSelectableFields(&newer.Image{}),
 	)
-	testutil.CheckFieldLabelConversions(t, "v1", "ImageStream",
+	testutil.CheckFieldLabelConversions(t, "v1", "ImageStream", true,
 		// Ensure all currently returned labels are supported
 		newer.ImageStreamToSelectableFields(&newer.ImageStream{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST

--- a/pkg/oauth/api/fields.go
+++ b/pkg/oauth/api/fields.go
@@ -1,41 +1,39 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // OAuthAccessTokenToSelectableFields returns a label set that represents the object
 func OAuthAccessTokenToSelectableFields(obj *OAuthAccessToken) fields.Set {
-	return fields.Set{
-		"metadata.name":  obj.Name,
+	return generic.AddObjectMetaFieldsSet(fields.Set{
 		"clientName":     obj.ClientName,
 		"userName":       obj.UserName,
 		"userUID":        obj.UserUID,
 		"authorizeToken": obj.AuthorizeToken,
-	}
+	}, &obj.ObjectMeta, false)
 }
 
 // OAuthAuthorizeTokenToSelectableFields returns a label set that represents the object
 func OAuthAuthorizeTokenToSelectableFields(obj *OAuthAuthorizeToken) fields.Set {
-	return fields.Set{
-		"metadata.name": obj.Name,
-		"clientName":    obj.ClientName,
-		"userName":      obj.UserName,
-		"userUID":       obj.UserUID,
-	}
+	return generic.AddObjectMetaFieldsSet(fields.Set{
+		"clientName": obj.ClientName,
+		"userName":   obj.UserName,
+		"userUID":    obj.UserUID,
+	}, &obj.ObjectMeta, false)
 }
 
 // OAuthClientToSelectableFields returns a label set that represents the object
 func OAuthClientToSelectableFields(obj *OAuthClient) fields.Set {
-	return fields.Set{
-		"metadata.name": obj.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false)
 }
 
 // OAuthClientAuthorizationToSelectableFields returns a label set that represents the object
 func OAuthClientAuthorizationToSelectableFields(obj *OAuthClientAuthorization) fields.Set {
-	return fields.Set{
-		"metadata.name": obj.Name,
-		"clientName":    obj.ClientName,
-		"userName":      obj.UserName,
-		"userUID":       obj.UserUID,
-	}
+	return generic.AddObjectMetaFieldsSet(fields.Set{
+		"clientName": obj.ClientName,
+		"userName":   obj.UserName,
+		"userUID":    obj.UserUID,
+	}, &obj.ObjectMeta, false)
 }

--- a/pkg/oauth/api/v1/conversion_test.go
+++ b/pkg/oauth/api/v1/conversion_test.go
@@ -11,26 +11,26 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAccessToken",
+	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAccessToken", false,
 		// Ensure all currently returned labels are supported
 		api.OAuthAccessTokenToSelectableFields(&api.OAuthAccessToken{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"clientName", "userName", "userUID", "authorizeToken",
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAuthorizeToken",
+	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAuthorizeToken", false,
 		// Ensure all currently returned labels are supported
 		api.OAuthAuthorizeTokenToSelectableFields(&api.OAuthAuthorizeToken{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"clientName", "userName", "userUID",
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClient",
+	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClient", false,
 		// Ensure all currently returned labels are supported
 		api.OAuthClientToSelectableFields(&api.OAuthClient{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClientAuthorization",
+	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClientAuthorization", false,
 		// Ensure all currently returned labels are supported
 		api.OAuthClientAuthorizationToSelectableFields(&api.OAuthClientAuthorization{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST

--- a/pkg/project/api/v1/conversion_test.go
+++ b/pkg/project/api/v1/conversion_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Project",
+	testutil.CheckFieldLabelConversions(t, "v1", "Project", false,
 		// Ensure all currently returned labels are supported
 		namespace.NamespaceToSelectableFields(&kapi.Namespace{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST

--- a/pkg/quota/api/fields.go
+++ b/pkg/quota/api/fields.go
@@ -1,9 +1,10 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 func ClusterResourceQuotaToSelectableFields(quota *ClusterResourceQuota) fields.Set {
-	return fields.Set{
-		"metadata.name": quota.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&quota.ObjectMeta, false)
 }

--- a/pkg/route/api/fields.go
+++ b/pkg/route/api/fields.go
@@ -1,14 +1,15 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // RouteToSelectableFields returns a label set that represents the object
 func RouteToSelectableFields(route *Route) fields.Set {
-	return fields.Set{
-		"metadata.name":      route.Name,
-		"metadata.namespace": route.Namespace,
-		"spec.path":          route.Spec.Path,
-		"spec.host":          route.Spec.Host,
-		"spec.to.name":       route.Spec.To.Name,
-	}
+	return generic.AddObjectMetaFieldsSet(fields.Set{
+		"spec.path":    route.Spec.Path,
+		"spec.host":    route.Spec.Host,
+		"spec.to.name": route.Spec.To.Name,
+	}, &route.ObjectMeta, true)
 }

--- a/pkg/route/api/v1/conversion_test.go
+++ b/pkg/route/api/v1/conversion_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Route",
+	testutil.CheckFieldLabelConversions(t, "v1", "Route", true,
 		// Ensure all currently returned labels are supported
 		api.RouteToSelectableFields(&api.Route{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST

--- a/pkg/sdn/api/fields.go
+++ b/pkg/sdn/api/fields.go
@@ -1,32 +1,26 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // ClusterNetworkToSelectableFields returns a label set that represents the object
 func ClusterNetworkToSelectableFields(network *ClusterNetwork) fields.Set {
-	return fields.Set{
-		"metadata.name": network.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&network.ObjectMeta, false)
 }
 
 // HostSubnetToSelectableFields returns a label set that represents the object
 func HostSubnetToSelectableFields(obj *HostSubnet) fields.Set {
-	return fields.Set{
-		"metadata.name": obj.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false)
 }
 
 // NetNamespaceToSelectableFields returns a label set that represents the object
 func NetNamespaceToSelectableFields(obj *NetNamespace) fields.Set {
-	return fields.Set{
-		"metadata.name": obj.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false)
 }
 
 // EgressNetworkPolicyToSelectableFields returns a label set that represents the object
 func EgressNetworkPolicyToSelectableFields(obj *EgressNetworkPolicy) fields.Set {
-	return fields.Set{
-		"metadata.name":      obj.Name,
-		"metadata.namespace": obj.Namespace,
-	}
+	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
 }

--- a/pkg/sdn/api/v1/conversion_test.go
+++ b/pkg/sdn/api/v1/conversion_test.go
@@ -11,22 +11,22 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "ClusterNetwork",
+	testutil.CheckFieldLabelConversions(t, "v1", "ClusterNetwork", false,
 		// Ensure all currently returned labels are supported
 		api.ClusterNetworkToSelectableFields(&api.ClusterNetwork{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "HostSubnet",
+	testutil.CheckFieldLabelConversions(t, "v1", "HostSubnet", false,
 		// Ensure all currently returned labels are supported
 		api.HostSubnetToSelectableFields(&api.HostSubnet{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "NetNamespace",
+	testutil.CheckFieldLabelConversions(t, "v1", "NetNamespace", false,
 		// Ensure all currently returned labels are supported
 		api.NetNamespaceToSelectableFields(&api.NetNamespace{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "EgressNetworkPolicy",
+	testutil.CheckFieldLabelConversions(t, "v1", "EgressNetworkPolicy", true,
 		// Ensure all currently returned labels are supported
 		api.EgressNetworkPolicyToSelectableFields(&api.EgressNetworkPolicy{}),
 	)

--- a/pkg/template/api/fields.go
+++ b/pkg/template/api/fields.go
@@ -1,11 +1,12 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // TemplateToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func TemplateToSelectableFields(template *Template) fields.Set {
-	return fields.Set{
-		"metadata.name": template.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&template.ObjectMeta, false)
 }

--- a/pkg/template/api/v1/conversion_test.go
+++ b/pkg/template/api/v1/conversion_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Template",
+	testutil.CheckFieldLabelConversions(t, "v1", "Template", false,
 		// Ensure all currently returned labels are supported
 		api.TemplateToSelectableFields(&api.Template{}),
 	)

--- a/pkg/user/api/fields.go
+++ b/pkg/user/api/fields.go
@@ -1,31 +1,29 @@
 package api
 
-import "k8s.io/kubernetes/pkg/fields"
+import (
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/registry/generic"
+)
 
 // GroupToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func GroupToSelectableFields(group *Group) fields.Set {
-	return fields.Set{
-		"metadata.name": group.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&group.ObjectMeta, false)
 }
 
 // IdentityToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func IdentityToSelectableFields(identity *Identity) fields.Set {
-	return fields.Set{
-		"metadata.name":    identity.Name,
+	return generic.AddObjectMetaFieldsSet(fields.Set{
 		"providerName":     identity.ProviderName,
 		"providerUserName": identity.ProviderName,
 		"user.name":        identity.User.Name,
 		"user.uid":         string(identity.User.UID),
-	}
+	}, &identity.ObjectMeta, false)
 }
 
 // UserToSelectableFields returns a label set that represents the object
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func UserToSelectableFields(user *User) fields.Set {
-	return fields.Set{
-		"metadata.name": user.Name,
-	}
+	return generic.ObjectMetaFieldsSet(&user.ObjectMeta, false)
 }

--- a/pkg/user/api/v1/conversion_test.go
+++ b/pkg/user/api/v1/conversion_test.go
@@ -11,19 +11,19 @@ import (
 )
 
 func TestFieldSelectorConversions(t *testing.T) {
-	testutil.CheckFieldLabelConversions(t, "v1", "Group",
+	testutil.CheckFieldLabelConversions(t, "v1", "Group", false,
 		// Ensure all currently returned labels are supported
 		api.GroupToSelectableFields(&api.Group{}),
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "Identity",
+	testutil.CheckFieldLabelConversions(t, "v1", "Identity", false,
 		// Ensure all currently returned labels are supported
 		api.IdentityToSelectableFields(&api.Identity{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"providerName", "providerUserName", "user.name", "user.uid",
 	)
 
-	testutil.CheckFieldLabelConversions(t, "v1", "User",
+	testutil.CheckFieldLabelConversions(t, "v1", "User", false,
 		// Ensure all currently returned labels are supported
 		api.UserToSelectableFields(&api.User{}),
 	)

--- a/test/util/api/conversion.go
+++ b/test/util/api/conversion.go
@@ -6,7 +6,18 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
-func CheckFieldLabelConversions(t *testing.T, version, kind string, expectedLabels map[string]string, customLabels ...string) {
+func CheckFieldLabelConversions(t *testing.T, version, kind string, namespaceScoped bool, expectedLabels map[string]string, customLabels ...string) {
+	if _, ok := expectedLabels["metadata.namespace"]; namespaceScoped != ok {
+		if namespaceScoped {
+			t.Errorf("%s %s requires the 'metadata.namespace' field label", version, kind)
+		} else {
+			t.Errorf("%s %s should not contain the 'metadata.namespace' field label", version, kind)
+		}
+	}
+	if _, ok := expectedLabels["metadata.name"]; !ok {
+		t.Errorf("%s %s requires the 'metadata.name' field label", version, kind)
+	}
+
 	for label := range expectedLabels {
 		_, _, err := kapi.Scheme.ConvertFieldLabel(version, kind, label, "")
 		if err != nil {


### PR DESCRIPTION
The upstream kubrnetes provides two functions for making generic selectable fields set. This PR changes every 'metadata.name' and 'metadata.namespace' in each resource's ```fields.go``` to use these two functions.