### PR TITLE
Wait for the token to be added to serviceaccount before running command

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -356,6 +356,7 @@ os::cmd::expect_success 'oc whoami'
 
 os::log::info "Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
+os::cmd::try_until_success "oc sa get-token default"
 oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
 # TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
 #os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'


### PR DESCRIPTION
Apparently between line 358 and 359 it takes a bit longer, sometime to get the token available in the serviceaccount. I'm adding there a small wait time to bypass the problem. 

Fixes #12558

@deads2k @ncdc @smarterclayton ptal