### PR TITLE
Add username to every log message under the auth middleware

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -13,6 +13,8 @@ storage:
 auth:
   openshift:
     realm: openshift
+    audit:
+      enabled: false
 
     # tokenrealm is a base URL to use for the token-granting registry endpoint.
     # If unspecified, the scheme and host for the token redirect are determined from the incoming request.

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/dockerregistry/server"
+	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 )
 
 // Execute runs the Docker registry.
@@ -47,6 +48,7 @@ func Execute(configFile io.Reader) {
 		log.Fatalf("error parsing configuration file: %s", err)
 	}
 	setDefaultMiddleware(config)
+	setDefaultLogParameters(config)
 
 	ctx := context.Background()
 	ctx, err = configureLogging(ctx, config)
@@ -277,4 +279,11 @@ func setDefaultMiddleware(config *configuration.Configuration) {
 		log.Errorf("obsolete configuration detected, please add openshift %s middleware into registry config file", middlewareType)
 	}
 	return
+}
+
+func setDefaultLogParameters(config *configuration.Configuration) {
+	if len(config.Log.Fields) == 0 {
+		config.Log.Fields = make(map[string]interface{})
+	}
+	config.Log.Fields[audit.LogEntryType] = audit.DefaultLoggerType
 }

--- a/pkg/dockerregistry/server/audit/log.go
+++ b/pkg/dockerregistry/server/audit/log.go
@@ -1,0 +1,123 @@
+package audit
+
+import (
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/context"
+)
+
+const (
+	LogEntryType     = "openshift.logger"
+	AuditUserEntry   = "openshift.auth.user"
+	AuditUserIDEntry = "openshift.auth.userid"
+	AuditStatusEntry = "openshift.request.status"
+	AuditErrorEntry  = "openshift.request.error"
+
+	auditLoggerKey = "openshift.audit.logger"
+
+	DefaultLoggerType = "registry"
+	AuditLoggerType   = "audit"
+
+	OpStatusBegin = "begin"
+	OpStatusError = "error"
+	OpStatusOK    = "success"
+)
+
+// AuditLogger implements special audit log. We can't use the system logger because
+// the change of log level can hide the audit logs.
+type AuditLogger struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	logger *logrus.Logger
+}
+
+// MakeAuditLogger returns new audit logger which inherits fields from the system logger.
+func MakeAuditLogger(ctx context.Context) *AuditLogger {
+	logger := &AuditLogger{
+		logger: logrus.New(),
+		ctx:    ctx,
+	}
+	if entry, ok := context.GetLogger(ctx).(*logrus.Entry); ok {
+		logger.SetFormatter(entry.Logger.Formatter)
+	} else if lgr, ok := context.GetLogger(ctx).(*logrus.Logger); ok {
+		logger.SetFormatter(lgr.Formatter)
+	}
+	return logger
+}
+
+// SetFormatter sets the audit logger formatter.
+func (l *AuditLogger) SetFormatter(formatter logrus.Formatter) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.logger.Formatter = formatter
+}
+
+// Log logs record.
+func (l *AuditLogger) Log(args ...interface{}) {
+	auditFields := logrus.Fields{
+		LogEntryType:     AuditLoggerType,
+		AuditStatusEntry: OpStatusBegin,
+	}
+	l.getEntry().WithFields(auditFields).Info(args...)
+}
+
+// Logf formats record according to a format.
+func (l *AuditLogger) Logf(format string, args ...interface{}) {
+	auditFields := logrus.Fields{
+		LogEntryType: AuditLoggerType,
+	}
+	l.getEntry().WithFields(auditFields).Infof(format, args...)
+}
+
+// LogResult logs record with additional operation status.
+func (l *AuditLogger) LogResult(err error, args ...interface{}) {
+	auditFields := logrus.Fields{
+		LogEntryType:     AuditLoggerType,
+		AuditStatusEntry: OpStatusOK,
+	}
+	if err != nil {
+		auditFields[AuditErrorEntry] = err
+		auditFields[AuditStatusEntry] = OpStatusError
+	}
+	l.getEntry().WithFields(auditFields).Info(args...)
+}
+
+// LogResultf formats record according to a format with additional operation status.
+func (l *AuditLogger) LogResultf(err error, format string, args ...interface{}) {
+	auditFields := logrus.Fields{
+		LogEntryType:     AuditLoggerType,
+		AuditStatusEntry: OpStatusOK,
+	}
+	if err != nil {
+		auditFields[AuditErrorEntry] = err
+		auditFields[AuditStatusEntry] = OpStatusError
+	}
+	l.getEntry().WithFields(auditFields).Infof(format, args...)
+}
+
+func (l *AuditLogger) getEntry() *logrus.Entry {
+	if entry, ok := context.GetLogger(l.ctx).(*logrus.Entry); ok {
+		return l.logger.WithFields(entry.Data)
+	}
+	return logrus.NewEntry(l.logger)
+}
+
+// LoggerExists checks audit logger existence.
+func LoggerExists(ctx context.Context) (exists bool) {
+	_, exists = ctx.Value(auditLoggerKey).(*AuditLogger)
+	return
+}
+
+// GetLogger returns the logger from the current context, if present. It will be created otherwise.
+func GetLogger(ctx context.Context) *AuditLogger {
+	if logger, ok := ctx.Value(auditLoggerKey).(*AuditLogger); ok {
+		return logger
+	}
+	return MakeAuditLogger(ctx)
+}
+
+// WithLogger creates a new context with provided logger.
+func WithLogger(ctx context.Context, logger *AuditLogger) context.Context {
+	return context.WithValue(ctx, auditLoggerKey, logger)
+}

--- a/pkg/dockerregistry/server/auditblobstore.go
+++ b/pkg/dockerregistry/server/auditblobstore.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+)
+
+// auditBlobStore wraps a distribution.BlobStore to track operation result and
+// write it in the audit log.
+type auditBlobStore struct {
+	store distribution.BlobStore
+}
+
+var _ distribution.BlobStore = &auditBlobStore{}
+
+func (b *auditBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Stat")
+	desc, err := b.store.Stat(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Stat")
+	return desc, err
+}
+
+func (b *auditBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Get")
+	blob, err := b.store.Get(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Get")
+	return blob, err
+}
+
+func (b *auditBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Open")
+	reader, err := b.store.Open(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Open")
+	return reader, err
+}
+
+func (b *auditBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Put")
+	desc, err := b.store.Put(ctx, mediaType, p)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Put")
+	return desc, err
+}
+
+func (b *auditBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Create")
+	writer, err := b.store.Create(ctx, options...)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Create")
+	return &blobWriter{BlobWriter: writer}, err
+}
+
+func (b *auditBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	audit.GetLogger(ctx).Log("BlobStore.Resume")
+	writer, err := b.store.Resume(ctx, id)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Resume")
+	return writer, err
+}
+
+func (b *auditBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	audit.GetLogger(ctx).Log("BlobStore.ServeBlob")
+	err := b.store.ServeBlob(ctx, w, req, dgst)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.ServeBlob")
+	return err
+}
+
+func (b *auditBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	audit.GetLogger(ctx).Log("BlobStore.Delete")
+	err := b.store.Delete(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "BlobStore.Delete")
+	return err
+}
+
+type blobWriter struct {
+	distribution.BlobWriter
+}
+
+func (bw *blobWriter) Commit(ctx context.Context, provisional distribution.Descriptor) (canonical distribution.Descriptor, err error) {
+	audit.GetLogger(ctx).Log("BlobWriter.Commit")
+	desc, err := bw.BlobWriter.Commit(ctx, provisional)
+	audit.GetLogger(ctx).LogResult(err, "BlobWriter.Commit")
+	return desc, err
+}
+
+func (bw *blobWriter) Cancel(ctx context.Context) error {
+	audit.GetLogger(ctx).Log("BlobWriter.Cancel")
+	err := bw.BlobWriter.Cancel(ctx)
+	audit.GetLogger(ctx).LogResult(err, "BlobWriter.Cancel")
+	return err
+}

--- a/pkg/dockerregistry/server/auditmanifestservice.go
+++ b/pkg/dockerregistry/server/auditmanifestservice.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+)
+
+// auditManifestService wraps a distribution.ManifestService to track operation result and
+// write it in the audit log.
+type auditManifestService struct {
+	manifests distribution.ManifestService
+}
+
+var _ distribution.ManifestService = &auditManifestService{}
+
+func (m *auditManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	audit.GetLogger(ctx).Log("ManifestService.Exists")
+	exists, err := m.manifests.Exists(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "ManifestService.Exists")
+	return exists, err
+}
+
+func (m *auditManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	audit.GetLogger(ctx).Log("ManifestService.Get")
+	manifest, err := m.manifests.Get(ctx, dgst, options...)
+	audit.GetLogger(ctx).LogResult(err, "ManifestService.Get")
+	return manifest, err
+}
+
+func (m *auditManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	audit.GetLogger(ctx).Log("ManifestService.Put")
+	dgst, err := m.manifests.Put(ctx, manifest, options...)
+	audit.GetLogger(ctx).LogResult(err, "ManifestService.Put")
+	return dgst, err
+}
+
+func (m *auditManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	audit.GetLogger(ctx).Log("ManifestService.Delete")
+	err := m.manifests.Delete(ctx, dgst)
+	audit.GetLogger(ctx).LogResult(err, "ManifestService.Delete")
+	return err
+}

--- a/pkg/dockerregistry/server/audittagservice.go
+++ b/pkg/dockerregistry/server/audittagservice.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+)
+
+// auditTagService wraps a distribution.TagService to track operation result and
+// write it in the audit log.
+type auditTagService struct {
+	tags distribution.TagService
+}
+
+var _ distribution.TagService = &auditTagService{}
+
+func (t *auditTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	audit.GetLogger(ctx).Log("TagService.Get")
+	desc, err := t.tags.Get(ctx, tag)
+	audit.GetLogger(ctx).LogResult(err, "TagService.Get")
+	return desc, err
+}
+
+func (t *auditTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	audit.GetLogger(ctx).Log("TagService.Tag")
+	err := t.tags.Tag(ctx, tag, desc)
+	audit.GetLogger(ctx).LogResult(err, "TagService.Tag")
+	return err
+}
+
+func (t *auditTagService) Untag(ctx context.Context, tag string) error {
+	audit.GetLogger(ctx).Log("TagService.Untag")
+	err := t.tags.Untag(ctx, tag)
+	audit.GetLogger(ctx).LogResult(err, "TagService.Untag")
+	return err
+}
+
+func (t *auditTagService) All(ctx context.Context) ([]string, error) {
+	audit.GetLogger(ctx).Log("TagService.All")
+	list, err := t.tags.All(ctx)
+	audit.GetLogger(ctx).LogResult(err, "TagService.All")
+	return list, err
+}
+
+func (t *auditTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	audit.GetLogger(ctx).Log("TagService.Lookup")
+	list, err := t.tags.Lookup(ctx, digest)
+	audit.GetLogger(ctx).LogResult(err, "TagService.Lookup")
+	return list, err
+}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -20,6 +20,8 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/importer"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 )
 
 const (
@@ -227,6 +229,12 @@ func (r *repository) Manifests(ctx context.Context, options ...distribution.Mani
 		repo:      r,
 	}
 
+	if audit.LoggerExists(ctx) {
+		ms = &auditManifestService{
+			manifests: ms,
+		}
+	}
+
 	return ms, nil
 }
 
@@ -260,6 +268,12 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		repo:  &repo,
 	}
 
+	if audit.LoggerExists(ctx) {
+		bs = &auditBlobStore{
+			store: bs,
+		}
+	}
+
 	return bs
 }
 
@@ -275,6 +289,12 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 	ts = &errorTagService{
 		tags: ts,
 		repo: r,
+	}
+
+	if audit.LoggerExists(ctx) {
+		ts = &auditTagService{
+			tags: ts,
+		}
 	}
 
 	return ts

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -82,6 +82,17 @@ func getBoolOption(envVar string, optionName string, defval bool, options map[st
 	return value.(bool), err
 }
 
+func getStringOption(envVar string, optionName string, defval string, options map[string]interface{}) (string, error) {
+	value, err := getOptionValue(envVar, optionName, defval, options, func(value interface{}) (b interface{}, err error) {
+		s, ok := value.(string)
+		if !ok {
+			return defval, fmt.Errorf("expected string, not %T", value)
+		}
+		return s, err
+	})
+	return value.(string), err
+}
+
 func getDurationOption(envVar string, optionName string, defval time.Duration, options map[string]interface{}) (time.Duration, error) {
 	value, err := getOptionValue(envVar, optionName, defval, options, func(value interface{}) (d interface{}, err error) {
 		s, ok := value.(string)


### PR DESCRIPTION
New audit logger not depends on the logging level of the server.

Audit log contains information about the invocation of API functions. Record contains the status of operation (`openshift.request.status`) and error if the operation failed.

All server log entries have `openshift.log.entry` field to be able to split entries into categories (`message` and `audit`).

All log entries after authorization have the `openshift.auth.user` field with username (`openshift.auth.user`) and user ID (`openshift.auth.userid`).

Example:
```
ERRO[0012] error retrieving ImageStream tmp/busybox: imagestreams "busybox" not found  go.version=go1.6.2 http.request.host=10.34.129.41:5000 http.request.id=c736cc17-068f-40e3-b985-e55a8cac18a7 http.request.method=GET http.request.remoteaddr=10.34.129.41:38584 http.request.uri=/v2/tmp/busybox/manifests/latest http.request.useragent=docker/1.12.2 go/go1.7.1 kernel/4.8.16-300.fc25.x86_64 os/linux arch/amd64 UpstreamClient(Docker-Client/1.12.2 \(linux\)) instance.id=1456f002-dbdd-47f9-af5b-e9aa7d6e178c openshift.auth.user=tmp openshift.auth.userid=161e1705-e171-11e6-aae0-507b9d472d2b openshift.log.entry=message vars.name=tmp/busybox vars.reference=latest
INFO[0012] TagService.Get                                go.version=go1.6.2 http.request.host=10.34.129.41:5000 http.request.id=c736cc17-068f-40e3-b985-e55a8cac18a7 http.request.method=GET http.request.remoteaddr=10.34.129.41:38584 http.request.uri=/v2/tmp/busybox/manifests/latest http.request.useragent=docker/1.12.2 go/go1.7.1 kernel/4.8.16-300.fc25.x86_64 os/linux arch/amd64 UpstreamClient(Docker-Client/1.12.2 \(linux\)) instance.id=1456f002-dbdd-47f9-af5b-e9aa7d6e178c openshift.auth.user=tmp openshift.auth.userid=161e1705-e171-11e6-aae0-507b9d472d2b openshift.log.entry=audit openshift.request.error=unknown repository name=tmp/busybox openshift.request.status=error vars.name=tmp/busybox vars.reference=latest
ERRO[0012] response completed with error                 err.code=manifest unknown err.detail=unknown repository name=tmp/busybox err.message=manifest unknown go.version=go1.6.2 http.request.host=10.34.129.41:5000 http.request.id=c736cc17-068f-40e3-b985-e55a8cac18a7 http.request.method=GET http.request.remoteaddr=10.34.129.41:38584 http.request.uri=/v2/tmp/busybox/manifests/latest http.request.useragent=docker/1.12.2 go/go1.7.1 kernel/4.8.16-300.fc25.x86_64 os/linux arch/amd64 UpstreamClient(Docker-Client/1.12.2 \(linux\)) http.response.contenttype=application/json; charset=utf-8 http.response.duration=19.791297ms http.response.status=404 http.response.written=102 instance.id=1456f002-dbdd-47f9-af5b-e9aa7d6e178c openshift.auth.user=tmp openshift.auth.userid=161e1705-e171-11e6-aae0-507b9d472d2b openshift.log.entry=message vars.name=tmp/busybox vars.reference=latest
```

@miminar @mfojtik @smarterclayton PTAL
