### PR TITLE
normalize server url before writing to config

### DIFF
--- a/pkg/cmd/server/admin/create_kubeconfig.go
+++ b/pkg/cmd/server/admin/create_kubeconfig.go
@@ -15,6 +15,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/cert"
 
+	"github.com/openshift/origin/pkg/cmd/cli/config"
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/templates"
@@ -174,6 +175,12 @@ func (o CreateKubeConfigOptions) CreateKubeConfig() (*clientcmdapi.Config, error
 	credentials[userNick] = &clientcmdapi.AuthInfo{
 		ClientCertificateData: certData,
 		ClientKeyData:         keyData,
+	}
+
+	// normalize the provided server to a format expected by config
+	o.APIServerURL, err = config.NormalizeServerURL(o.APIServerURL)
+	if err != nil {
+		return nil, err
 	}
 
 	clusters := make(map[string]*clientcmdapi.Cluster)


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1393943

This patch updates `$ openshift admin create-api-client-config` command to normalize the specified server url before creating the client kubeconfig.

cc @openshift/cli-review 