### PR TITLE
UPSTREAM: <carry>: Wait longer for pods to stop

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -100,7 +100,7 @@ const (
 	PodStartTimeout = 5 * time.Minute
 
 	// How long to wait for the pod to no longer be running
-	podNoLongerRunningTimeout = 30 * time.Second
+	podNoLongerRunningTimeout = 2 * time.Minute
 
 	// If there are any orphaned namespaces to clean up, this test is running
 	// on a long lived cluster. A long wait here is preferably to spurious test


### PR DESCRIPTION
Until #11016 is fixed, pods can take longer to terminate due to other
cascading delays.

[merge]