### PR TITLE
Restore custom etcd prefix for user-identities

### DIFF
--- a/pkg/cmd/server/origin/rest/storage_options.go
+++ b/pkg/cmd/server/origin/rest/storage_options.go
@@ -26,12 +26,14 @@ func StorageOptions(options configapi.MasterConfig) restoptions.Getter {
 			{Resource: "oauthclients"}:              "oauth/clients",
 			{Resource: "oauthclientauthorizations"}: "oauth/clientauthorizations",
 
+			{Resource: "identities"}: "useridentities",
+
 			{Resource: "clusterresourcequotas"}: quotaapi.GroupName + "/clusterresourcequotas",
 
-			{Resource: "clusternetworks"}:     "registry/sdnnetworks",
-			{Resource: "egressnetworkpolicy"}: "registry/egressnetworkpolicy",
-			{Resource: "hostsubnets"}:         "registry/sdnsubnets",
-			{Resource: "netnamespaces"}:       "registry/sdnnetnamespaces",
+			{Resource: "clusternetworks"}:       "registry/sdnnetworks",
+			{Resource: "egressnetworkpolicies"}: "registry/egressnetworkpolicy",
+			{Resource: "hostsubnets"}:           "registry/sdnsubnets",
+			{Resource: "netnamespaces"}:         "registry/sdnnetnamespaces",
 		},
 		map[unversioned.GroupResource]struct{}{
 			{Resource: "oauthauthorizetokens"}: {},

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -410,7 +410,7 @@ func TestUserInitialization(t *testing.T) {
 		if _, err := etcdClient.Delete(context.Background(), path.Join(masterConfig.EtcdStorageConfig.OpenShiftStoragePrefix, "/users"), &etcdclient.DeleteOptions{Recursive: true}); err != nil && !etcdutil.IsEtcdNotFound(err) {
 			t.Fatalf("Could not clean up users: %v", err)
 		}
-		if _, err := etcdClient.Delete(context.Background(), path.Join(masterConfig.EtcdStorageConfig.OpenShiftStoragePrefix, "/identities"), &etcdclient.DeleteOptions{Recursive: true}); err != nil && !etcdutil.IsEtcdNotFound(err) {
+		if _, err := etcdClient.Delete(context.Background(), path.Join(masterConfig.EtcdStorageConfig.OpenShiftStoragePrefix, "/useridentities"), &etcdclient.DeleteOptions{Recursive: true}); err != nil && !etcdutil.IsEtcdNotFound(err) {
 			t.Fatalf("Could not clean up identities: %v", err)
 		}
 


### PR DESCRIPTION
The prefix was accidentally changed in during 1.4 development. This reverts to the 1.3 prefix.

Fixes https://github.com/openshift/origin/issues/12598

Cherry-pick of https://github.com/openshift/origin/pull/12607