### PR TITLE
Bug 1415440: Check image history for zero size

### DIFF
--- a/pkg/cmd/admin/top/images.go
+++ b/pkg/cmd/admin/top/images.go
@@ -213,7 +213,7 @@ func getImageStreamTags(g graph.Graph, node *imagegraph.ImageNode) []string {
 func getTags(stream *imageapi.ImageStream, image *imageapi.Image) []string {
 	tags := []string{}
 	for tag, history := range stream.Status.Tags {
-		if history.Items[0].Image == image.Name {
+		if len(history.Items) > 0 && history.Items[0].Image == image.Name {
 			tags = append(tags, tag)
 		}
 	}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1415440

@soltysh PTAL (I dunno what the case is when the history items is zero but this should prevent the panic. I will do more investigation.