### PR TITLE
Proposal to  enable all service accounts in PodSecurityPolicyReview REST endpoint

### DIFF
--- a/pkg/security/api/types.go
+++ b/pkg/security/api/types.go
@@ -80,16 +80,17 @@ type PodSecurityPolicyReview struct {
 // PodSecurityPolicyReviewSpec defines specification for PodSecurityPolicyReview
 type PodSecurityPolicyReviewSpec struct {
 	// Template is the PodTemplateSpec to check. The PodTemplateSpec.Spec.ServiceAccountName field is used
-	// if ServiceAccountNames is empty, unless the PodTemplateSpec.Spec.ServiceAccountName is empty,
+	// if ServiceAccountNames is not nil and empty, unless the PodTemplateSpec.Spec.ServiceAccountName is empty,
 	// in which case "default" is used.
-	// If ServiceAccountNames is specified, PodTemplateSpec.Spec.ServiceAccountName is ignored.
+	// If ServiceAccountNames is specified or nil, PodTemplateSpec.Spec.ServiceAccountName is ignored.
 	Template kapi.PodTemplateSpec
 
 	// ServiceAccountNames is an optional set of ServiceAccounts to run the check with.
-	// If ServiceAccountNames is empty, the PodTemplateSpec.Spec.ServiceAccountName is used,
+	// If ServiceAccountNames is nil all ServiceAccounts are taken in account
+	// If ServiceAccountNames is not nil but empty, the PodTemplateSpec.Spec.ServiceAccountName is used,
 	// unless it's empty, in which case "default" is used instead.
-	// If ServiceAccountNames is specified, PodTemplateSpec.Spec.ServiceAccountName is ignored.
-	ServiceAccountNames []string // TODO: find a way to express 'all service accounts'
+	// If ServiceAccountNames is specified or nil, PodTemplateSpec.Spec.ServiceAccountName is ignored.
+	ServiceAccountNames []string
 }
 
 // PodSecurityPolicyReviewStatus represents the status of PodSecurityPolicyReview.

--- a/pkg/security/api/v1/types.go
+++ b/pkg/security/api/v1/types.go
@@ -80,16 +80,17 @@ type PodSecurityPolicyReview struct {
 // PodSecurityPolicyReviewSpec defines specification for PodSecurityPolicyReview
 type PodSecurityPolicyReviewSpec struct {
 	// template is the PodTemplateSpec to check. The template.spec.serviceAccountName field is used
-	// if serviceAccountNames is empty, unless the template.spec.serviceAccountName is empty,
+	// if serviceAccountNames is not nil and empty, unless the template.spec.serviceAccountName is empty,
 	// in which case "default" is used.
-	// If serviceAccountNames is specified, template.spec.serviceAccountName is ignored.
+	// If serviceAccountNames is specified or nil, template.spec.serviceAccountName is ignored.
 	Template kapi.PodTemplateSpec `json:"template" protobuf:"bytes,1,opt,name=template"`
 
 	// serviceAccountNames is an optional set of ServiceAccounts to run the check with.
-	// If serviceAccountNames is empty, the template.spec.serviceAccountName is used,
+	// If serviceAccountNames is nil all ServiceAccounts are considered
+	// If serviceAccountNames is not nil but empty, the template.spec.serviceAccountName is used,
 	// unless it's empty, in which case "default" is used instead.
-	// If serviceAccountNames is specified, template.spec.serviceAccountName is ignored.
-	ServiceAccountNames []string `json:"serviceAccountNames,omitempty" protobuf:"bytes,2,rep,name=serviceAccountNames"` // TODO: find a way to express 'all service accounts'
+	// If serviceAccountNames is specified or nil, template.spec.serviceAccountName is ignored.
+	ServiceAccountNames []string `json:"serviceAccountNames" protobuf:"bytes,2,rep,name=serviceAccountNames"`
 }
 
 // PodSecurityPolicyReviewStatus represents the status of PodSecurityPolicyReview.

--- a/pkg/security/registry/podsecuritypolicyreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicyreview/rest.go
@@ -10,6 +10,7 @@ import (
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/cache"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	kscc "k8s.io/kubernetes/pkg/securitycontextconstraints"
 	"k8s.io/kubernetes/pkg/serviceaccount"
@@ -101,11 +102,13 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 
 func getServiceAccounts(psprSpec securityapi.PodSecurityPolicyReviewSpec, saCache *cache.StoreToServiceAccountLister, namespace string) ([]*kapi.ServiceAccount, error) {
 	serviceAccounts := []*kapi.ServiceAccount{}
-	//  TODO: express 'all service accounts'
-	//if serviceAccountList, err := client.Core().ServiceAccounts(namespace).List(kapi.ListOptions{}); err == nil {
-	//	serviceAccounts = serviceAccountList.Items
-	//	return serviceAccounts, fmt.Errorf("unable to retrieve service accounts: %v", err)
-	//}
+	if psprSpec.ServiceAccountNames == nil {
+		serviceAccountList, err := saCache.ServiceAccounts(namespace).List(labels.Everything())
+		if err != nil {
+			return serviceAccounts, fmt.Errorf("unable to retrieve service accounts: %v", err)
+		}
+		return serviceAccountList, nil
+	}
 
 	if len(psprSpec.ServiceAccountNames) > 0 {
 		errs := []error{}


### PR DESCRIPTION
@openshift/api-review  goal of this is to propose a way to handle all service accounts in PodSecurityPolicyReview REST endpoint.

@soltysh FYI

No generated files to keep it simple. Thanks for your feedback.