### PR TITLE
Check for 'in-cluster configuration' in both oc logs and output from oc run

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -358,23 +358,24 @@ os::log::info "Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
 os::cmd::try_until_success "oc sa get-token default"
 oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
-#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-os::cmd::expect_success_and_text "oc logs cli-with-token" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "oc logs cli-with-token" 'In project test'
+# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+set +o errexit
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+set -o errexit
 os::cmd::expect_success 'oc delete pod cli-with-token'
 oc run cli-with-token-2 --attach --image="openshift/origin:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
-#os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
-os::cmd::expect_success_and_text "oc logs cli-with-token-2" 'system:serviceaccount:test:default'
+# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+set +o errexit
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+set -o errexit
 os::cmd::expect_success 'oc delete pod cli-with-token-2'
 oc run kubectl-with-token --attach --image="openshift/origin:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-# TODO Switch back to using cat once https://github.com/docker/docker/pull/26718 is in our Godeps
-#os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
-#os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
-os::cmd::expect_success_and_text "oc logs kubectl-with-token" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "oc logs kubectl-with-token" 'kubectl-with-token'
+# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+set +o errexit
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
+set -o errexit
 
 os::log::info "Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors


### PR DESCRIPTION
Another approach to #12558.

I'm checking for `in-cluster configuration` text in both `oc logs` and `oc run` output.

@smarterclayton @ncdc @liggitt @stevekuznetsov ptal