### PR TITLE
Fix test-go.sh for directories with "-" in their names

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -136,7 +136,7 @@ function list_test_packages_under() {
 # Break up the positional arguments into packages that need to be tested and arguments that need to be passed to `go test`
 package_args=
 for arg in "$@"; do
-    if [[ "${arg}" =~ -.* ]]; then
+    if [[ "${arg}" =~ ^-.* ]]; then
         # we found an arg that begins with a dash, so we stop interpreting arguments
         # henceforth as packages and instead interpret them as flags to give to `go test`
         break


### PR DESCRIPTION
You can't currently run tests in a single directory if that directory has a "-" in its name. Eg:

    danw@w541:origin (master)> ./hack/test-go.sh pkg/sdn/plugin/sdn-cni-plugin
    can't load package: package pkg/sdn/plugin/sdn-cni-plugin: cannot find package "pkg/sdn/plugin/sdn-cni-plugin" in any of:
    	/usr/lib/golang/src/pkg/sdn/plugin/sdn-cni-plugin (from $GOROOT)
    	/home/danw/rh/go/src/github.com/openshift/origin/_output/local/go/src/pkg/sdn/plugin/sdn-cni-plugin (from $GOPATH)
    ./hack/test-go.sh failed after 2 seconds

with the fix:

    danw@w541:origin (master)> git checkout test-dash-fix 
    Switched to branch 'test-dash-fix'
    Your branch is up-to-date with 'danw/test-dash-fix'.
    danw@w541:origin (test-dash-fix)> ./hack/test-go.sh pkg/sdn/plugin/sdn-cni-plugin
    ok  	github.com/openshift/origin/pkg/sdn/plugin/sdn-cni-plugin	1.016s	coverage: 71.1% of statements
    ./hack/test-go.sh succeeded after 1 seconds
