### PR TITLE
Add comment pointing out incorrect SDN annotation naming

### DIFF
--- a/pkg/sdn/api/plugin.go
+++ b/pkg/sdn/api/plugin.go
@@ -9,11 +9,14 @@ const (
 	MultiTenantPluginName   = "redhat/openshift-ovs-multitenant"
 	NetworkPolicyPluginName = "redhat/openshift-ovs-networkpolicy"
 
+	// Pod annotations
 	IngressBandwidthAnnotation = "kubernetes.io/ingress-bandwidth"
 	EgressBandwidthAnnotation  = "kubernetes.io/egress-bandwidth"
 	AssignMacvlanAnnotation    = "pod.network.openshift.io/assign-macvlan"
+
+	// HostSubnet annotations. (Note: should be "hostsubnet.network.openshift.io/", but the incorrect name is now part of the API.)
 	AssignHostSubnetAnnotation = "pod.network.openshift.io/assign-subnet"
-	FixedVnidHost              = "pod.network.openshift.io/fixed-vnid-host"
+	FixedVNIDHostAnnotation    = "pod.network.openshift.io/fixed-vnid-host"
 )
 
 func IsOpenShiftNetworkPlugin(pluginName string) bool {

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -422,7 +422,7 @@ func (plugin *OsdnNode) AddHostSubnetRules(subnet *osapi.HostSubnet) {
 	otx := plugin.ovs.NewTransaction()
 
 	otx.AddFlow("table=10, priority=100, tun_src=%s, actions=goto_table:30", subnet.HostIP)
-	if vnid, ok := subnet.Annotations[osapi.FixedVnidHost]; ok {
+	if vnid, ok := subnet.Annotations[osapi.FixedVNIDHostAnnotation]; ok {
 		otx.AddFlow("table=50, priority=100, arp, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, vnid, subnet.HostIP)
 		otx.AddFlow("table=90, priority=100, ip, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, vnid, subnet.HostIP)
 	} else {

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -231,13 +231,13 @@ func (master *OsdnMaster) watchSubnets() {
 					return nil
 				}
 				var hsAnnotations map[string]string
-				if vnid, ok := hs.Annotations[osapi.FixedVnidHost]; ok {
+				if vnid, ok := hs.Annotations[osapi.FixedVNIDHostAnnotation]; ok {
 					vnidInt, err := strconv.Atoi(vnid)
 					if err == nil && vnidInt >= 0 && uint32(vnidInt) <= osapi.MaxVNID {
 						hsAnnotations = make(map[string]string)
-						hsAnnotations[osapi.FixedVnidHost] = strconv.Itoa(vnidInt)
+						hsAnnotations[osapi.FixedVNIDHostAnnotation] = strconv.Itoa(vnidInt)
 					} else {
-						log.Errorf("Vnid %s is an invalid value for annotation %s. Annotation will be ignored.", vnid, osapi.FixedVnidHost)
+						log.Errorf("Vnid %s is an invalid value for annotation %s. Annotation will be ignored.", vnid, osapi.FixedVNIDHostAnnotation)
 					}
 				}
 				err = master.addNode(name, hostIP, hsAnnotations)


### PR DESCRIPTION
In https://github.com/openshift/openshift-sdn/pull/271 we added the `pod.network.openshift.io/assign-macvlan` annotation, with the name based on comments from @smarterclayton (specifically https://github.com/openshift/openshift-sdn/pull/271#issuecomment-203003792).

Two later annotations copied the `pod.network.openshift.io/` part despite being HostSubnet annotations rather than Pod annotations. So it seems to me that those names were wrong, and while we can't fix them now (because API) we can at least clearly note that they're wrong so that people don't keep copying the wrongness.

I argue in the comment here that they should have the prefix `hostsubnet.openshift.io/`, because they're HostSubnet annotations, and because including `network` in there like with the macvlan annotation would be redundant, since HostSubnet, unlike Pod, is inherently networking-related. But then maybe it would be better with `network`, just for consistently namespacing sdn-related annotations?

(This came up while figuring out what to call the NetNamespace annotation for enabling multicast in the namespace, which, FTR, I'm planning to call `netnamespace.openshift.io/multicast-enabled`, by the same logic.)

@smarterclayton does this match your view of how annotation names should work?
