### PR TITLE
Use - instead of + in tar filenames because GitHub changes them

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -377,7 +377,7 @@ function os::build::place_bins() {
 readonly -f os::build::place_bins
 
 function os::build::archive_name() {
-  echo "${OS_RELEASE_ARCHIVE}-${OS_GIT_VERSION}-$1"
+  echo "${OS_RELEASE_ARCHIVE}-${OS_GIT_VERSION}-$1" | tr '+' '-'
 }
 readonly -f os::build::archive_name
 


### PR DESCRIPTION
GitHub silently replaces + with - on upload, meaning everything is wrong.  Give in to the inevitable.

[test]