### PR TITLE
Add `os::log::debug` and add statements to `hack/env`

### DIFF
--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -46,3 +46,15 @@ function os::log::fatal() {
 	return 1
 }
 readonly -f os::log::fatal
+
+# os::log::debug writes the message to stderr if
+# the ${OS_DEBUG} variable is set.
+#
+# Arguments:
+#  - all: message to write
+function os::log::debug() {
+	if [[ -n "${OS_DEBUG:-}" ]]; then
+		os::text::print_blue "[DEBUG] $*" 1>&2
+	fi
+}
+readonly -f os::log::debug


### PR DESCRIPTION
Run-time triggered debugging for complicated Bash scripts is necessary,
and today there is no simple way to do it other than to add `echo`
statements to the scripts themselves. By using `os::log::debug` we can
turn on debugging whenever we want with `$OS_DEBUG`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton PTAL