### PR TITLE
Multicast fixes and enable/disable annotation

### DIFF
--- a/pkg/sdn/api/plugin.go
+++ b/pkg/sdn/api/plugin.go
@@ -17,6 +17,9 @@ const (
 	// HostSubnet annotations. (Note: should be "hostsubnet.network.openshift.io/", but the incorrect name is now part of the API.)
 	AssignHostSubnetAnnotation = "pod.network.openshift.io/assign-subnet"
 	FixedVNIDHostAnnotation    = "pod.network.openshift.io/fixed-vnid-host"
+
+	// NetNamespace annotations
+	MulticastEnabledAnnotation = "netnamespace.network.openshift.io/multicast-enabled"
 )
 
 func IsOpenShiftNetworkPlugin(pluginName string) bool {

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -313,9 +313,13 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	// eg, "table=100, reg0=${tenant_id}, priority=2, ip, nw_dst=${external_cidr}, actions=drop
 	otx.AddFlow("table=100, priority=0, actions=output:2")
 
-	// Table 110: multicast delivery from local pods to the VXLAN; only one rule, updated by updateVXLANMulticastRules() in subnets.go
-	// eg, "table=110, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:${remote_node_ip_1}->tun_dst,output:1,set_field:${remote_node_ip_2}->tun_dst,output:1,goto_table:120"
+	// Table 110: outbound multicast filtering, updated by updateLocalMulticastFlows() in pod.go
+	// eg, "table=110, priority=100, reg0=${tenant_id}, actions=goto_table:111
 	otx.AddFlow("table=110, priority=0, actions=drop")
+
+	// Table 111: multicast delivery from local pods to the VXLAN; only one rule, updated by updateVXLANMulticastRules() in subnets.go
+	// eg, "table=111, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:${remote_node_ip_1}->tun_dst,output:1,set_field:${remote_node_ip_2}->tun_dst,output:1,goto_table:120"
+	otx.AddFlow("table=111, priority=0, actions=drop")
 
 	// Table 120: multicast delivery to local pods (either from VXLAN or local pods); updated by updateLocalMulticastFlows() in pod.go
 	// eg, "table=120, priority=100, reg0=${tenant_id}, actions=output:${ovs_port_1},output:${ovs_port_2}"

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -317,7 +317,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	// eg, "table=110, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:${remote_node_ip_1}->tun_dst,output:1,set_field:${remote_node_ip_2}->tun_dst,output:1,goto_table:120"
 	otx.AddFlow("table=110, priority=0, actions=drop")
 
-	// Table 120: multicast delivery to local pods (either from VXLAN or local pods); updated by updateMulticastFlows() in pod.go
+	// Table 120: multicast delivery to local pods (either from VXLAN or local pods); updated by updateLocalMulticastFlows() in pod.go
 	// eg, "table=120, priority=100, reg0=${tenant_id}, actions=output:${ovs_port_1},output:${ovs_port_2}"
 	otx.AddFlow("table=120, priority=0, actions=drop")
 

--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -313,10 +313,12 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	// eg, "table=100, reg0=${tenant_id}, priority=2, ip, nw_dst=${external_cidr}, actions=drop
 	otx.AddFlow("table=100, priority=0, actions=output:2")
 
-	// Table 110: multicast delivery from local pods to the VXLAN
+	// Table 110: multicast delivery from local pods to the VXLAN; only one rule, updated by updateVXLANMulticastRules() in subnets.go
+	// eg, "table=110, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:${remote_node_ip_1}->tun_dst,output:1,set_field:${remote_node_ip_2}->tun_dst,output:1,goto_table:120"
 	otx.AddFlow("table=110, priority=0, actions=drop")
 
-	// Table 120: multicast delivery to local pods (either from VXLAN or local pods)
+	// Table 120: multicast delivery to local pods (either from VXLAN or local pods); updated by updateMulticastFlows() in pod.go
+	// eg, "table=120, priority=100, reg0=${tenant_id}, actions=output:${ovs_port_1},output:${ovs_port_2}"
 	otx.AddFlow("table=120, priority=0, actions=drop")
 
 	err = otx.EndTransaction()

--- a/pkg/sdn/plugin/multitenant.go
+++ b/pkg/sdn/plugin/multitenant.go
@@ -93,6 +93,10 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 
 	// Update namespace references in egress firewall rules
 	mp.node.UpdateEgressNetworkPolicyVNID(namespace, oldNetID, netID)
+
+	// Update local multicast rules
+	mp.node.podManager.UpdateLocalMulticastRules(oldNetID)
+	mp.node.podManager.UpdateLocalMulticastRules(netID)
 }
 
 func (mp *multiTenantPlugin) AddNetNamespace(netns *osapi.NetNamespace) {

--- a/pkg/sdn/plugin/multitenant.go
+++ b/pkg/sdn/plugin/multitenant.go
@@ -64,35 +64,37 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 		services = &kapi.ServiceList{}
 	}
 
-	movedVNIDRefs := 0
+	if oldNetID != netID {
+		movedVNIDRefs := 0
 
-	// Update OF rules for the existing/old pods in the namespace
-	for _, pod := range pods {
-		err = mp.node.UpdatePod(pod)
-		if err == nil {
+		// Update OF rules for the existing/old pods in the namespace
+		for _, pod := range pods {
+			err = mp.node.UpdatePod(pod)
+			if err == nil {
+				movedVNIDRefs++
+			} else {
+				glog.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err)
+			}
+		}
+
+		// Update OF rules for the old services in the namespace
+		for _, svc := range services.Items {
+			if !kapi.IsServiceIPSet(&svc) {
+				continue
+			}
+
+			mp.node.DeleteServiceRules(&svc)
+			mp.node.AddServiceRules(&svc, netID)
 			movedVNIDRefs++
-		} else {
-			glog.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err)
-		}
-	}
-
-	// Update OF rules for the old services in the namespace
-	for _, svc := range services.Items {
-		if !kapi.IsServiceIPSet(&svc) {
-			continue
 		}
 
-		mp.node.DeleteServiceRules(&svc)
-		mp.node.AddServiceRules(&svc, netID)
-		movedVNIDRefs++
-	}
+		if movedVNIDRefs > 0 {
+			mp.moveVNIDRefs(movedVNIDRefs, oldNetID, netID)
+		}
 
-	if movedVNIDRefs > 0 {
-		mp.moveVNIDRefs(movedVNIDRefs, oldNetID, netID)
+		// Update namespace references in egress firewall rules
+		mp.node.UpdateEgressNetworkPolicyVNID(namespace, oldNetID, netID)
 	}
-
-	// Update namespace references in egress firewall rules
-	mp.node.UpdateEgressNetworkPolicyVNID(namespace, oldNetID, netID)
 
 	// Update local multicast rules
 	mp.node.podManager.UpdateLocalMulticastRules(oldNetID)
@@ -117,6 +119,13 @@ func (mp *multiTenantPlugin) GetVNID(namespace string) (uint32, error) {
 
 func (mp *multiTenantPlugin) GetNamespaces(vnid uint32) []string {
 	return mp.vnids.GetNamespaces(vnid)
+}
+
+func (mp *multiTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
+	if vnid == osapi.GlobalVNID {
+		return false
+	}
+	return mp.vnids.GetMulticastEnabled(vnid)
 }
 
 func (mp *multiTenantPlugin) RefVNID(vnid uint32) {

--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -160,7 +160,11 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *osapi.NetNamespace) {
 }
 
 func (np *networkPolicyPlugin) UpdateNetNamespace(netns *osapi.NetNamespace, oldNetID uint32) {
-	glog.Warning("Got UpdateNetNamespace for namespace %s (%d) while using %s plugin", netns.NetName, netns.NetID, osapi.NetworkPolicyPluginName)
+	if netns.NetID != oldNetID {
+		glog.Warning("Got VNID change for namespace %s while using %s plugin", netns.NetName, osapi.NetworkPolicyPluginName)
+	}
+
+	np.node.podManager.UpdateLocalMulticastRules(netns.NetID)
 }
 
 func (np *networkPolicyPlugin) DeleteNetNamespace(netns *osapi.NetNamespace) {
@@ -176,6 +180,10 @@ func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {
 
 func (np *networkPolicyPlugin) GetNamespaces(vnid uint32) []string {
 	return np.vnids.GetNamespaces(vnid)
+}
+
+func (np *networkPolicyPlugin) GetMulticastEnabled(vnid uint32) bool {
+	return np.vnids.GetMulticastEnabled(vnid)
 }
 
 func (np *networkPolicyPlugin) syncNamespace(npns *npNamespace) {

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -40,6 +40,7 @@ type osdnPolicy interface {
 
 	GetVNID(namespace string) (uint32, error)
 	GetNamespaces(vnid uint32) []string
+	GetMulticastEnabled(vnid uint32) bool
 
 	RefVNID(vnid uint32)
 	UnrefVNID(vnid uint32)

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -209,6 +209,9 @@ func (m *podManager) updateLocalMulticastRulesWithLock(vnid uint32) {
 	otx := m.ovs.NewTransaction()
 	if m.policy.GetMulticastEnabled(vnid) {
 		outputs = localMulticastOutputs(m.runningPods, vnid)
+		otx.AddFlow("table=110, reg0=%d, actions=goto_table:111", vnid)
+	} else {
+		otx.DeleteFlows("table=110, reg0=%d", vnid)
 	}
 	if len(outputs) > 0 {
 		otx.AddFlow("table=120, priority=100, reg0=%d, actions=%s", vnid, outputs)

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -22,7 +22,7 @@ import (
 
 type podHandler interface {
 	setup(req *cniserver.PodRequest) (*cnitypes.Result, *runningPod, error)
-	update(req *cniserver.PodRequest) (*runningPod, error)
+	update(req *cniserver.PodRequest) (uint32, error)
 	teardown(req *cniserver.PodRequest) error
 }
 
@@ -259,9 +259,11 @@ func (m *podManager) processRequest(request *cniserver.PodRequest) *cniserver.Po
 			result.Err = err
 		}
 	case cniserver.CNI_UPDATE:
-		runningPod, err := m.podHandler.update(request)
+		vnid, err := m.podHandler.update(request)
 		if err == nil {
-			m.runningPods[pk] = runningPod
+			if runningPod, exists := m.runningPods[pk]; exists {
+				runningPod.vnid = vnid
+			}
 		}
 		result.Err = err
 	case cniserver.CNI_DEL:

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -99,7 +99,7 @@ func getIPAMConfig(clusterNetwork *net.IPNet, localSubnet string) ([]byte, error
 		IPAM *hostLocalIPAM `json:"ipam"`
 	}
 
-	mcaddr := net.ParseIP("224.0.0.0")
+	_, mcnet, _ := net.ParseCIDR("224.0.0.0/3")
 	return json.Marshal(&cniNetworkConfig{
 		Name: "openshift-sdn",
 		Type: "openshift-sdn",
@@ -111,19 +111,20 @@ func getIPAMConfig(clusterNetwork *net.IPNet, localSubnet string) ([]byte, error
 			},
 			Routes: []cnitypes.Route{
 				{
+					// Default route
 					Dst: net.IPNet{
 						IP:   net.IPv4zero,
 						Mask: net.IPMask(net.IPv4zero),
 					},
 					GW: netutils.GenerateDefaultGateway(nodeNet),
 				},
-				{Dst: *clusterNetwork},
+				{
+					// Cluster network
+					Dst: *clusterNetwork,
+				},
 				{
 					// Multicast
-					Dst: net.IPNet{
-						IP:   mcaddr,
-						Mask: net.IPMask(mcaddr),
-					},
+					Dst: *mcnet,
 				},
 			},
 		},

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"sync"
 
 	"github.com/openshift/origin/pkg/sdn/plugin/cniserver"
 	"github.com/openshift/origin/pkg/util/netutils"
@@ -38,7 +39,8 @@ type podManager struct {
 	// Request queue for pod operations incoming from the CNIServer
 	requests chan (*cniserver.PodRequest)
 	// Tracks pod :: IP address for hostport handling
-	runningPods map[string]*runningPod
+	runningPods     map[string]*runningPod
+	runningPodsLock sync.Mutex
 
 	// Live pod setup/teardown stuff not used in testing code
 	kClient         *kclientset.Clientset
@@ -180,71 +182,46 @@ func (m *podManager) handleCNIRequest(request *cniserver.PodRequest) ([]byte, er
 	return result.Response, result.Err
 }
 
-type runningPodsSlice []*runningPod
-
-func (l runningPodsSlice) Len() int           { return len(l) }
-func (l runningPodsSlice) Less(i, j int) bool { return l[i].ofport < l[j].ofport }
-func (l runningPodsSlice) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-
-// FIXME: instead of calculating all this ourselves, figure out a way to pass
-// the old VNID through the Update() call (or get it from somewhere else).
-func updateMulticastFlows(runningPods map[string]*runningPod, ovs *ovs.Interface, podKey string, changedPod *runningPod) error {
-	// FIXME: prevents TestPodUpdate() from crashing. (We separately test this function anyway.)
-	if ovs == nil {
-		return nil
-	}
-
-	// Build map of pods by their VNID, excluding the changed pod
-	podsByVNID := make(map[uint32]runningPodsSlice)
-	for key, runningPod := range runningPods {
-		if key != podKey {
-			podsByVNID[runningPod.vnid] = append(podsByVNID[runningPod.vnid], runningPod)
+func localMulticastOutputs(runningPods map[string]*runningPod, vnid uint32) string {
+	var ofports []int
+	for _, pod := range runningPods {
+		if pod.vnid == vnid {
+			ofports = append(ofports, pod.ofport)
 		}
 	}
-
-	// Figure out what two VNIDs changed so we can update only those two flows
-	changedVNIDs := make([]uint32, 0)
-	oldPod, exists := runningPods[podKey]
-	if changedPod != nil {
-		podsByVNID[changedPod.vnid] = append(podsByVNID[changedPod.vnid], changedPod)
-		changedVNIDs = append(changedVNIDs, changedPod.vnid)
-		if exists {
-			// VNID changed
-			changedVNIDs = append(changedVNIDs, oldPod.vnid)
-		}
-	} else if exists {
-		// Pod deleted
-		changedVNIDs = append(changedVNIDs, oldPod.vnid)
+	if len(ofports) == 0 {
+		return ""
 	}
 
-	if len(changedVNIDs) == 0 {
-		// Shouldn't happen, but whatever
-		return fmt.Errorf("Multicast update requested but not required!")
-	}
-
-	otx := ovs.NewTransaction()
-	for _, vnid := range changedVNIDs {
-		// Sort pod array to ensure consistent ordering for testcases and readability
-		pods := podsByVNID[vnid]
-		sort.Sort(pods)
-
-		// build up list of ports on this VNID
-		outputs := ""
-		for _, pod := range pods {
-			if len(outputs) > 0 {
-				outputs += ","
-			}
-			outputs += fmt.Sprintf("output:%d", pod.ofport)
-		}
-
-		// Update or delete the flows for the vnid
+	sort.Ints(ofports)
+	outputs := ""
+	for _, ofport := range ofports {
 		if len(outputs) > 0 {
-			otx.AddFlow("table=120, priority=100, reg0=%d, actions=%s", vnid, outputs)
-		} else {
-			otx.DeleteFlows("table=120, reg0=%d", vnid)
+			outputs += ","
 		}
+		outputs += fmt.Sprintf("output:%d", ofport)
 	}
-	return otx.EndTransaction()
+	return outputs
+}
+
+func (m *podManager) updateLocalMulticastRulesWithLock(vnid uint32) {
+	outputs := localMulticastOutputs(m.runningPods, vnid)
+	otx := m.ovs.NewTransaction()
+	if len(outputs) > 0 {
+		otx.AddFlow("table=120, priority=100, reg0=%d, actions=%s", vnid, outputs)
+	} else {
+		otx.DeleteFlows("table=120, reg0=%d", vnid)
+	}
+	if err := otx.EndTransaction(); err != nil {
+		glog.Errorf("Error updating OVS multicast flows for VNID %d: %v", vnid, err)
+	}
+}
+
+// Update multicast OVS rules for the given vnid
+func (m *podManager) UpdateLocalMulticastRules(vnid uint32) {
+	m.runningPodsLock.Lock()
+	defer m.runningPodsLock.Unlock()
+	m.updateLocalMulticastRulesWithLock(vnid)
 }
 
 // Process all CNI requests from the request queue serially.  Our OVS interaction
@@ -252,40 +229,51 @@ func updateMulticastFlows(runningPods map[string]*runningPod, ovs *ovs.Interface
 // setup/teardown logic
 func (m *podManager) processCNIRequests() {
 	for request := range m.requests {
-		pk := getPodKey(request)
-
-		var pod *runningPod
-		var ipamResult *cnitypes.Result
-
 		glog.V(5).Infof("Processing pod network request %v", request)
-		result := &cniserver.PodResult{}
-		switch request.Command {
-		case cniserver.CNI_ADD:
-			ipamResult, pod, result.Err = m.podHandler.setup(request)
-			if ipamResult != nil {
-				result.Response, result.Err = json.Marshal(ipamResult)
-			}
-		case cniserver.CNI_UPDATE:
-			pod, result.Err = m.podHandler.update(request)
-		case cniserver.CNI_DEL:
-			result.Err = m.podHandler.teardown(request)
-		default:
-			result.Err = fmt.Errorf("unhandled CNI request %v", request.Command)
-		}
-
-		if result.Err == nil {
-			if err := updateMulticastFlows(m.runningPods, m.ovs, pk, pod); err != nil {
-				glog.Warningf("Failed to update multicast flows: %v", err)
-			}
-			if pod != nil {
-				m.runningPods[pk] = pod
-			} else {
-				delete(m.runningPods, pk)
-			}
-		}
-
+		result := m.processRequest(request)
 		glog.V(5).Infof("Processed pod network request %v, result %s err %v", request, string(result.Response), result.Err)
 		request.Result <- result
 	}
 	panic("stopped processing CNI pod requests!")
+}
+
+func (m *podManager) processRequest(request *cniserver.PodRequest) *cniserver.PodResult {
+	m.runningPodsLock.Lock()
+	defer m.runningPodsLock.Unlock()
+
+	pk := getPodKey(request)
+	result := &cniserver.PodResult{}
+	switch request.Command {
+	case cniserver.CNI_ADD:
+		ipamResult, runningPod, err := m.podHandler.setup(request)
+		if ipamResult != nil {
+			result.Response, err = json.Marshal(ipamResult)
+			if result.Err == nil {
+				m.runningPods[pk] = runningPod
+				if m.ovs != nil {
+					m.updateLocalMulticastRulesWithLock(runningPod.vnid)
+				}
+			}
+		}
+		if err != nil {
+			result.Err = err
+		}
+	case cniserver.CNI_UPDATE:
+		runningPod, err := m.podHandler.update(request)
+		if err == nil {
+			m.runningPods[pk] = runningPod
+		}
+		result.Err = err
+	case cniserver.CNI_DEL:
+		if runningPod, exists := m.runningPods[pk]; exists {
+			delete(m.runningPods, pk)
+			if m.ovs != nil {
+				m.updateLocalMulticastRulesWithLock(runningPod.vnid)
+			}
+		}
+		result.Err = m.podHandler.teardown(request)
+	default:
+		result.Err = fmt.Errorf("unhandled CNI request %v", request.Command)
+	}
+	return result
 }

--- a/pkg/sdn/plugin/pod.go
+++ b/pkg/sdn/plugin/pod.go
@@ -205,8 +205,11 @@ func localMulticastOutputs(runningPods map[string]*runningPod, vnid uint32) stri
 }
 
 func (m *podManager) updateLocalMulticastRulesWithLock(vnid uint32) {
-	outputs := localMulticastOutputs(m.runningPods, vnid)
+	var outputs string
 	otx := m.ovs.NewTransaction()
+	if m.policy.GetMulticastEnabled(vnid) {
+		outputs = localMulticastOutputs(m.runningPods, vnid)
+	}
 	if len(outputs) > 0 {
 		otx.AddFlow("table=120, priority=100, reg0=%d, actions=%s", vnid, outputs)
 	} else {

--- a/pkg/sdn/plugin/pod_test.go
+++ b/pkg/sdn/plugin/pod_test.go
@@ -146,13 +146,13 @@ func (pt *podTester) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 	return result, fakeRunningPod(req.PodNamespace, req.PodName, ip), nil
 }
 
-func (pt *podTester) update(req *cniserver.PodRequest) (*runningPod, error) {
+func (pt *podTester) update(req *cniserver.PodRequest) (uint32, error) {
 	pod, err := pt.getExpectedPod(req.PodNamespace, req.PodName, req.Command)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	pod.updated += 1
-	return fakeRunningPod(req.PodNamespace, req.PodName, net.ParseIP(pod.cidr)), nil
+	return 0, nil
 }
 
 func (pt *podTester) teardown(req *cniserver.PodRequest) error {

--- a/pkg/sdn/plugin/pod_test.go
+++ b/pkg/sdn/plugin/pod_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/openshift/origin/pkg/sdn/plugin/cniserver"
-	"github.com/openshift/origin/pkg/util/ovs"
 
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
@@ -21,7 +20,6 @@ import (
 	kcontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	khostport "k8s.io/kubernetes/pkg/kubelet/network/hostport"
-	kexec "k8s.io/kubernetes/pkg/util/exec"
 	utiltesting "k8s.io/kubernetes/pkg/util/testing"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -490,135 +488,19 @@ func TestDirectPodUpdate(t *testing.T) {
 	}
 }
 
-func normalSetup() *kexec.FakeExec {
-	return &kexec.FakeExec{
-		LookPathFunc: func(prog string) (string, error) {
-			if prog == "ovs-ofctl" || prog == "ovs-vsctl" {
-				return "/sbin/" + prog, nil
-			} else {
-				return "", fmt.Errorf("%s not found", prog)
-			}
-		},
-	}
-}
-
-func addTestResult(t *testing.T, fexec *kexec.FakeExec, command string, output string, err error) {
-	fcmd := kexec.FakeCmd{
-		CombinedOutputScript: []kexec.FakeCombinedOutputAction{
-			func() ([]byte, error) { return []byte(output), err },
-		},
-	}
-	fexec.CommandScript = append(fexec.CommandScript,
-		func(cmd string, args ...string) kexec.Cmd {
-			execCommand := strings.Join(append([]string{cmd}, args...), " ")
-			if execCommand != command {
-				t.Fatalf("Unexpected command: wanted %q got %q", command, execCommand)
-			}
-			return kexec.InitFakeCmd(&fcmd, cmd, args...)
-		})
-}
-
-func ensureTestResults(t *testing.T, fexec *kexec.FakeExec) {
-	if fexec.CommandCalls != len(fexec.CommandScript) {
-		t.Fatalf("Only used %d of %d expected commands", fexec.CommandCalls, len(fexec.CommandScript))
-	}
-}
-
-func TestUpdateMulticastFlowsAddOne(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=5, actions=output:2", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
-	}
-
-	newPod := &runningPod{vnid: 5, ofport: 2}
-	if err := updateMulticastFlows(make(map[string]*runningPod), ovsif, "foobar", newPod); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
-	}
-
-	ensureTestResults(t, fexec)
-}
-
-func TestUpdateMulticastFlowsAddMany(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=5, actions=output:2,output:7,output:8", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
-	}
-
-	pods := map[string]*runningPod{
-		"blah": {
-			vnid:   5,
-			ofport: 7,
-		},
-		"baz": {
-			vnid:   5,
-			ofport: 8,
-		},
-		// We don't expect a rule for this pod's VNID because it hasn't changed
-		"bork": {
-			vnid:   8,
-			ofport: 10,
-		},
-	}
-	newPod := &runningPod{vnid: 5, ofport: 2}
-	if err := updateMulticastFlows(pods, ovsif, "foobar", newPod); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
-	}
-
-	ensureTestResults(t, fexec)
-}
-
-func TestUpdateMulticastFlowsUpdateOne(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=6, actions=output:2", "", nil)
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 del-flows br0 table=120, reg0=5", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
-	}
-
-	pods := map[string]*runningPod{
-		"foobar": {
-			vnid:   5,
-			ofport: 2,
-		},
-	}
-	newPod := &runningPod{vnid: 6, ofport: 2}
-	if err := updateMulticastFlows(pods, ovsif, "foobar", newPod); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
-	}
-
-	ensureTestResults(t, fexec)
-}
-
-func TestUpdateMulticastFlowsUpdateMany(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=6, actions=output:3,output:7,output:9", "", nil)
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=5, actions=output:2,output:8", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
-	}
-
+func TestUpdateMulticastFlows(t *testing.T) {
 	pods := map[string]*runningPod{
 		"blah": {
 			vnid:   5,
 			ofport: 2,
 		},
-		"foobar": {
-			vnid:   5,
-			ofport: 7,
-		},
 		"baz": {
 			vnid:   5,
 			ofport: 8,
+		},
+		"foobar": {
+			vnid:   5,
+			ofport: 7,
 		},
 		"blah2": {
 			vnid:   6,
@@ -628,73 +510,26 @@ func TestUpdateMulticastFlowsUpdateMany(t *testing.T) {
 			vnid:   6,
 			ofport: 9,
 		},
-		// We don't expect a rule for this pod's VNID because it hasn't changed
 		"bork": {
 			vnid:   8,
 			ofport: 10,
 		},
 	}
-	newPod := &runningPod{vnid: 6, ofport: 7}
-	if err := updateMulticastFlows(pods, ovsif, "foobar", newPod); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
+
+	outputs := localMulticastOutputs(pods, 0)
+	if outputs != "" {
+		t.Fatalf("Unexpected outputs for vnid 0: %s", outputs)
 	}
-
-	ensureTestResults(t, fexec)
-}
-
-func TestUpdateMulticastFlowsDeleteOne(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 del-flows br0 table=120, reg0=5", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
+	outputs = localMulticastOutputs(pods, 5)
+	if outputs != "output:2,output:7,output:8" {
+		t.Fatalf("Unexpected outputs for vnid 5: %s", outputs)
 	}
-
-	pods := map[string]*runningPod{
-		"foobar": {
-			vnid:   5,
-			ofport: 2,
-		},
+	outputs = localMulticastOutputs(pods, 6)
+	if outputs != "output:3,output:9" {
+		t.Fatalf("Unexpected outputs for vnid 6: %s", outputs)
 	}
-	if err := updateMulticastFlows(pods, ovsif, "foobar", nil); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
+	outputs = localMulticastOutputs(pods, 8)
+	if outputs != "output:10" {
+		t.Fatalf("Unexpected outputs for vnid 0: %s", outputs)
 	}
-
-	ensureTestResults(t, fexec)
-}
-
-func TestUpdateMulticastFlowsDeleteMany(t *testing.T) {
-	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 add-flow br0 table=120, priority=100, reg0=5, actions=output:2,output:8", "", nil)
-
-	ovsif, err := ovs.New(fexec, "br0", "")
-	if err != nil {
-		t.Fatalf("Unexpected error from ovs.New(): %v", err)
-	}
-
-	pods := map[string]*runningPod{
-		"blah": {
-			vnid:   5,
-			ofport: 2,
-		},
-		"foobar": {
-			vnid:   5,
-			ofport: 7,
-		},
-		"baz": {
-			vnid:   5,
-			ofport: 8,
-		},
-		// We don't expect a rule for this pod's VNID because it hasn't changed
-		"bork": {
-			vnid:   8,
-			ofport: 10,
-		},
-	}
-	if err := updateMulticastFlows(pods, ovsif, "foobar", nil); err != nil {
-		t.Fatalf("Unexpected error from command: %v", err)
-	}
-
-	ensureTestResults(t, fexec)
 }

--- a/pkg/sdn/plugin/singletenant.go
+++ b/pkg/sdn/plugin/singletenant.go
@@ -37,6 +37,10 @@ func (sp *singleTenantPlugin) GetNamespaces(vnid uint32) []string {
 	return nil
 }
 
+func (sp *singleTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
+	return false
+}
+
 func (sp *singleTenantPlugin) RefVNID(vnid uint32) {
 }
 

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -272,7 +272,7 @@ func (plugin *OsdnNode) updateVXLANMulticastRules(subnets hostSubnetMap) {
 			tun_dsts += fmt.Sprintf(",set_field:%s->tun_dst,output:1", subnet.HostIP)
 		}
 	}
-	otx.AddFlow("table=110, ip, nw_dst=224.0.0.0/3, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31]%s,goto_table:120", tun_dsts)
+	otx.AddFlow("table=110, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31]%s,goto_table:120", tun_dsts)
 
 	if err := otx.EndTransaction(); err != nil {
 		log.Errorf("Error updating OVS VXLAN multicast flows: %v", err)

--- a/pkg/sdn/plugin/subnets.go
+++ b/pkg/sdn/plugin/subnets.go
@@ -272,7 +272,7 @@ func (plugin *OsdnNode) updateVXLANMulticastRules(subnets hostSubnetMap) {
 			tun_dsts += fmt.Sprintf(",set_field:%s->tun_dst,output:1", subnet.HostIP)
 		}
 	}
-	otx.AddFlow("table=110, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31]%s,goto_table:120", tun_dsts)
+	otx.AddFlow("table=111, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31]%s,goto_table:120", tun_dsts)
 
 	if err := otx.EndTransaction(); err != nil {
 		log.Errorf("Error updating OVS VXLAN multicast flows: %v", err)

--- a/pkg/sdn/plugin/vnids_node_test.go
+++ b/pkg/sdn/plugin/vnids_node_test.go
@@ -19,10 +19,10 @@ func TestNodeVNIDMap(t *testing.T) {
 
 	// set vnids, non-overlapping
 
-	vmap.setVNID("alpha", 1)
-	vmap.setVNID("bravo", 2)
-	vmap.setVNID("charlie", 3)
-	vmap.setVNID("delta", 4)
+	vmap.setVNID("alpha", 1, false)
+	vmap.setVNID("bravo", 2, false)
+	vmap.setVNID("charlie", 3, false)
+	vmap.setVNID("delta", 4, false)
 
 	checkExists(t, vmap, "alpha", 1)
 	checkExists(t, vmap, "bravo", 2)
@@ -71,8 +71,8 @@ func TestNodeVNIDMap(t *testing.T) {
 
 	// change vnids
 
-	vmap.setVNID("bravo", 1)
-	vmap.setVNID("delta", 2)
+	vmap.setVNID("bravo", 1, false)
+	vmap.setVNID("delta", 2, false)
 
 	checkExists(t, vmap, "bravo", 1)
 	checkExists(t, vmap, "delta", 2)
@@ -86,12 +86,12 @@ func TestNodeVNIDMap(t *testing.T) {
 
 	// overlapping vnids
 
-	vmap.setVNID("echo", 3)
-	vmap.setVNID("foxtrot", 5)
-	vmap.setVNID("golf", 1)
-	vmap.setVNID("hotel", 1)
-	vmap.setVNID("india", 1)
-	vmap.setVNID("juliet", 3)
+	vmap.setVNID("echo", 3, false)
+	vmap.setVNID("foxtrot", 5, false)
+	vmap.setVNID("golf", 1, false)
+	vmap.setVNID("hotel", 1, false)
+	vmap.setVNID("india", 1, false)
+	vmap.setVNID("juliet", 3, false)
 
 	checkExists(t, vmap, "bravo", 1)
 	checkExists(t, vmap, "delta", 2)


### PR DESCRIPTION
This cleans up the multicast code a bit and adds support for an annotation on NetNamespace to enable/disable multicast. (https://bugzilla.redhat.com/show_bug.cgi?id=1415318)

Um, was there some reason we decided on an annotation rather than adding a new NetNamespace field?

@openshift/networking PTAL (noting that dcbw is on PTO so don't expect him to review it :)

Oh, the first commit ("Add comment pointing out incorrect SDN annotation naming") is from #12627