### PR TITLE
prevent Normalize from running twice on oadm drain

### DIFF
--- a/docs/man/man1/oadm-drain.1
+++ b/docs/man/man1/oadm-drain.1
@@ -27,7 +27,7 @@ When you are ready to put the node back into service, use kubectl uncordon, whic
 
 .PP
 ! 
-\[la]http://kubernetes.io/images/docs/kubectl\[ra] \_drain.svg
+\[la]http://kubernetes.io/images/docs/kubectl_drain.svg\[ra]
 
 
 .SH OPTIONS

--- a/docs/man/man1/oc-adm-drain.1
+++ b/docs/man/man1/oc-adm-drain.1
@@ -27,7 +27,7 @@ When you are ready to put the node back into service, use kubectl uncordon, whic
 
 .PP
 ! 
-\[la]http://kubernetes.io/images/docs/kubectl\[ra] \_drain.svg
+\[la]http://kubernetes.io/images/docs/kubectl_drain.svg\[ra]
 
 
 .SH OPTIONS

--- a/docs/man/man1/openshift-admin-drain.1
+++ b/docs/man/man1/openshift-admin-drain.1
@@ -27,7 +27,7 @@ When you are ready to put the node back into service, use kubectl uncordon, whic
 
 .PP
 ! 
-\[la]http://kubernetes.io/images/docs/kubectl\[ra] \_drain.svg
+\[la]http://kubernetes.io/images/docs/kubectl_drain.svg\[ra]
 
 
 .SH OPTIONS

--- a/docs/man/man1/openshift-cli-adm-drain.1
+++ b/docs/man/man1/openshift-cli-adm-drain.1
@@ -27,7 +27,7 @@ When you are ready to put the node back into service, use kubectl uncordon, whic
 
 .PP
 ! 
-\[la]http://kubernetes.io/images/docs/kubectl\[ra] \_drain.svg
+\[la]http://kubernetes.io/images/docs/kubectl_drain.svg\[ra]
 
 
 .SH OPTIONS

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -76,7 +76,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 				node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out, errout),
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubecmd.NewCmdCordon(f, out))),
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubecmd.NewCmdUncordon(f, out))),
-				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubecmd.NewCmdDrain(f, out, errout))),
+				cmdutil.ReplaceCommandName("kubectl", fullName, kubecmd.NewCmdDrain(f, out, errout)),
 				cmdutil.ReplaceCommandName("kubectl", fullName, templates.Normalize(kubecmd.NewCmdTaint(f, out))),
 				network.NewCmdPodNetwork(network.PodNetworkCommandName, fullName+" "+network.PodNetworkCommandName, f, out, errout),
 			},


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1415985

This patch avoids running template#Normalize twice on the description
and example text of the `oadm drain` command. This fixes the broken link
in the command's long description.

**Before**
```
$ oadm drain -h
...
! http://kubernetes.io/images/docs/kubectl _drain.svg
...
```

**After**
```
$ oadm drain -h
...
! http://kubernetes.io/images/docs/kubectl_drain.svg
...
```

@openshift/cli-review 