### PR TITLE
Update release images to configure git client and install tito from source

### DIFF
--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -23,7 +23,9 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    touch /os-build-image
+    touch /os-build-image && \
+    git config --global user.name origin-release-container && \
+    git config --global user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -23,6 +23,8 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
+    git clone https://github.com/dgoodwin/tito.git && \
+    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -24,7 +24,9 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    touch /os-build-image
+    touch /os-build-image && \
+    git config --global user.name origin-release-container && \
+    git config --global user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -24,6 +24,8 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    git clone https://github.com/dgoodwin/tito.git && \
+    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -24,7 +24,9 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    touch /os-build-image
+    touch /os-build-image && \
+    git config --global user.name origin-release-container && \
+    git config --global user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -24,6 +24,8 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    git clone https://github.com/dgoodwin/tito.git && \
+    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.8/Dockerfile
+++ b/images/release/golang-1.8/Dockerfile
@@ -24,7 +24,9 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    touch /os-build-image
+    touch /os-build-image && \
+    git config --global user.name origin-release-container && \
+    git config --global user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.8/Dockerfile
+++ b/images/release/golang-1.8/Dockerfile
@@ -24,6 +24,8 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    git clone https://github.com/dgoodwin/tito.git && \
+    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com


### PR DESCRIPTION
Install tito from source in `openshift/origin-release`

Updates from `tito` are often blockers for working on the RPM build
process; waiting for new versions of `tito` to be released through the
normal channels is slow. Installing `tito` from source allows us to
iterate more quickly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Configure global git options in the release images

Actions like `tito tag` that interact with the git state of the
repository mounted into the release image when used with `hack/env`
require that the `git` global configuration contain the commiter name
and email.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
