### PR TITLE
Improve `hack/env`

### DIFF
--- a/hack/env
+++ b/hack/env
@@ -26,6 +26,9 @@
 #   $ hack/env make # slow
 #   $ hack/env make # fast!
 #
+#   # force a new volume to get created from the current source
+#   $ OS_BUILD_ENV_VOLUME_FORCE_NEW=TRUE hack/env
+#
 
 # NOTE:   only committed code is built.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -124,7 +124,10 @@ function os::build::environment::start() {
         mkdir -p "${parent}"
       fi
       os::log::debug "Copying from ${container}:${workingdir}/${path} to ${parent}"
-      docker cp "${container}:${workingdir}/${path}" "${parent}"
+      if ! output="$( docker cp "${container}:${workingdir}/${path}" "${parent}" 2>&1 )"; then
+        os::log::warn "Copying ${path} from the container failed!"
+        os::log::warn "${output}"
+      fi
     done
     IFS="${oldIFS}"
   fi


### PR DESCRIPTION
Added an option to `hack/env` to use a new volume

When doing iteration on `hack/env`, especially with `tito` builds that
change the state of the git repository on the local volume used with
`hack/env` without changing the git state of the repository on the local
system, it is necessary to force `hack/env` to use a new volume.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Don't give up copying from `hack/env` on failure

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Don't require `hack/env` users to end their flags with spaces

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

