### PR TITLE
Router sets its dns name in admitted routes test

### DIFF
--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -49,15 +49,16 @@ func TestStatusNoOp(t *testing.T) {
 	touched := unversioned.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
 	c := testclient.NewSimpleFake()
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	admitter := NewStatusAdmitter(p, c, "test", "a.b.c.d")
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
 		Status: routeapi.RouteStatus{
 			Ingress: []routeapi.RouteIngress{
 				{
-					Host:       "route1.test.local",
-					RouterName: "test",
+					Host:                    "route1.test.local",
+					RouterName:              "test",
+					RouterCanonicalHostname: "a.b.c.d",
 					Conditions: []routeapi.RouteIngressCondition{
 						{
 							Type:               routeapi.RouteAdmitted,


### PR DESCRIPTION
This is a unit test case for code in PR12195

Signed-off-by: Phil Cameron <pcameron@redhat.com>