### PR TITLE
Update version regex to handle longer dot-versions

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -578,7 +578,7 @@ function os::build::os_version_vars() {
       # Try to match the "git describe" output to a regex to try to extract
       # the "major" and "minor" versions and whether this is the exact tagged
       # version or whether the tree is between two tagged versions.
-      if [[ "${OS_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$ ]]; then
+      if [[ "${OS_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)+?([-].*)?$ ]]; then
         OS_GIT_MAJOR=${BASH_REMATCH[1]}
         OS_GIT_MINOR=${BASH_REMATCH[2]}
         if [[ -n "${BASH_REMATCH[4]}" ]]; then
@@ -626,7 +626,7 @@ function os::build::kube_version_vars() {
   # Try to match the "git describe" output to a regex to try to extract
   # the "major" and "minor" versions and whether this is the exact tagged
   # version or whether the tree is between two tagged versions.
-  if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$ ]]; then
+  if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)+?([-].*)?$ ]]; then
     KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
     KUBE_GIT_MINOR=${BASH_REMATCH[2]}
     if [[ -n "${BASH_REMATCH[4]}" ]]; then


### PR DESCRIPTION
The current regex for parsing the output of `git describe` fails to
capture output when parsing a tag that has more than three sections
to the numerical dot-version, e.g. `W.X.Y.Z`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>