### PR TITLE
Refactor logic for OSX etcd cURL statement

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -183,11 +183,10 @@ function os::util::curl_etcd() {
 
 		curl --fail --silent --cacert "${ca_bundle}" \
 		     --cert "${etcd_client_cert_p12}:${etcd_client_cert_p12_password}" "${full_url}"
+	else
+		curl --fail --silent --cacert "${ca_bundle}" \
+		     --cert "${etcd_client_cert}" --key "${etcd_client_key}" "${full_url}"
 	fi
-
-
-	curl --fail --silent --cacert "${ca_bundle}" \
-	     --cert "${etcd_client_cert}" --key "${etcd_client_key}" "${full_url}"
 }
 
 # os::util::host_platform determines what the host OS and architecture


### PR DESCRIPTION
The previous implementation of this statement would have caused two cURL
executions on MacOS.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>