### PR TITLE
Make use of `os::util::absolute_path` over `realpath`

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -75,17 +75,15 @@ fi
 #  None
 function os::util::repository_relative_path() {
 	local filename=$1
+	local directory; directory="$( dirname "${filename}" )"
+	filename="$( basename "${filename}" )"
 
-	if which realpath >/dev/null 2>&1; then
-		pushd "${OS_ORIGINAL_WD}" >/dev/null 2>&1
-		local trim_path
-		trim_path="$( realpath "${OS_ROOT}" )/"
-		filename="$( realpath "${filename}" )"
-		filename="${filename##*${trim_path}}"
-		popd >/dev/null 2>&1
-	fi
+	pushd "${OS_ORIGINAL_WD}" >/dev/null 2>&1
+	directory="$( os::util::absolute_path "${directory}" )"
+	directory="${directory##*${OS_ROOT}/}"
+	popd >/dev/null 2>&1
 
-	echo "${filename}"
+	echo "${directory}/${filename}"
 }
 readonly -f os::util::repository_relative_path
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]