### PR TITLE
Break out `os::cmd` framework tests from `hack/test-cmd.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test-integration:
 # Example:
 #   make test-cmd
 test-cmd: build
+	hack/test-util.sh
 	hack/test-cmd.sh
 .PHONY: test-cmd
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -103,9 +103,6 @@ os::log::system::start
 # Prevent user environment from colliding with the test setup
 unset KUBECONFIG
 
-# test wrapper functions
-${OS_ROOT}/hack/test-util.sh > ${LOG_DIR}/wrappers_test.log 2>&1
-
 # handle profiling defaults
 profile="${OPENSHIFT_PROFILE-}"
 unset OPENSHIFT_PROFILE

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -3,10 +3,8 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
-BASETMPDIR="${TMPDIR:-/tmp}/openshift/test-tools"
-JUNIT_REPORT_OUTPUT="${BASETMPDIR}/junit_output.txt"
-mkdir -p "${BASETMPDIR}"
-touch "${JUNIT_REPORT_OUTPUT}"
+os::util::environment::setup_all_server_vars "test-os-cmd/"
+export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 
 # set verbosity so we can see that command output renders correctly
 VERBOSE=1


### PR DESCRIPTION
Upcoming trap framework refactoring will rely on entrypoint scripts not
executing other scripts in our directories, as that practice makes
thinking about traps very difficult. This set of tests does not
necessarily need to live within `hack/test-cmd.sh` and can live instead
within the `make test-cmd` target that is executed in the test job.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>