### PR TITLE
Configure `hack/test-cmd.sh` to run test libraries

### DIFF
--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -36,8 +36,7 @@ function os::test::junit::declare_suite_end() {
     local num_suites=${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}
     if [[ "${num_suites}" -lt "1" ]]; then
         # we can't end a suite if none have been started yet
-        echo "[ERROR] jUnit suite marker could not be placed, expected suites in flight, got ${num_suites}"
-        return 1
+        os::log::fatal "jUnit suite marker could not be placed, expected suites in flight, got ${num_suites}"
     fi
 
     echo "=== END TEST SUITE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
@@ -60,15 +59,13 @@ function os::test::junit::declare_test_start() {
     local num_tests=${NUM_OS_JUNIT_TESTS_IN_FLIGHT:-0}
     if [[ "${num_tests}" -ne "0" ]]; then
         # someone's declaring the starting of a test when a test is already in flight
-        echo "[ERROR] jUnit test marker could not be placed, expected no tests in flight, got ${num_tests}"
-        return 1
+        os::log::fatal "jUnit test marker could not be placed, expected no tests in flight, got ${num_tests}"
     fi
 
     local num_suites=${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}
     if [[ "${num_suites}" -lt "1" ]]; then
         # we can't end a test if no suites are in flight
-        echo "[ERROR] jUnit test marker could not be placed, expected suites in flight, got ${num_suites}"
-        return 1
+        os::log::fatal "jUnit test marker could not be placed, expected suites in flight, got ${num_suites}"
     fi
 
     echo "=== BEGIN TEST CASE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
@@ -91,8 +88,7 @@ function os::test::junit::declare_test_end() {
     local num_tests=${NUM_OS_JUNIT_TESTS_IN_FLIGHT:-0}
     if [[ "${num_tests}" -ne "1" ]]; then
         # someone's declaring the end of a test when a test is not in flight
-        echo "[ERROR] jUnit test marker could not be placed, expected one test in flight, got ${num_tests}"
-        return 1
+        os::log::fatal "jUnit test marker could not be placed, expected one test in flight, got ${num_tests}"
     fi
 
     echo "=== END TEST CASE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
@@ -114,11 +110,9 @@ readonly -f os::test::junit::declare_test_end
 #  None
 function os::test::junit::check_test_counters() {
     if [[ "${NUM_OS_JUNIT_SUITES_IN_FLIGHT-}" -ne "0" ]]; then
-        echo "[ERROR] Expected no test suites to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_SUITES_IN_FLIGHT-}"
-        return 1
+        os::log::fatal "Expected no test suites to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_SUITES_IN_FLIGHT-}"
     elif [[ "${NUM_OS_JUNIT_TESTS_IN_FLIGHT-}" -ne "0" ]]; then
-        echo "[ERROR] Expected no test cases to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_TESTS_IN_FLIGHT-}"
-        return 1
+        os::log::fatal "Expected no test cases to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_TESTS_IN_FLIGHT-}"
     fi
 }
 readonly -f os::test::junit::check_test_counters

--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
-trap os::test::junit::reconcile_output EXIT
+function os::test::suite() {
+	# This test validates the value of --image for oc run
+	os::cmd::expect_success_and_text 'oc run newdcforimage --image=validimagevalue' 'deploymentconfig "newdcforimage" created'
+	os::cmd::expect_failure_and_text 'oc run newdcforimage2 --image="InvalidImageValue0192"' 'error: Invalid image name "InvalidImageValue0192": invalid reference format'
+	os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --attach --dry-run' "dry-run can't be used with attached containers options"
+	os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --stdin --dry-run' "dry-run can't be used with attached containers options"
+}
 
-os::test::junit::declare_suite_start "cmd/run"
-# This test validates the value of --image for oc run
-os::cmd::expect_success_and_text 'oc run newdcforimage --image=validimagevalue' 'deploymentconfig "newdcforimage" created'
-os::cmd::expect_failure_and_text 'oc run newdcforimage2 --image="InvalidImageValue0192"' 'error: Invalid image name "InvalidImageValue0192": invalid reference format'
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --attach --dry-run' "dry-run can't be used with attached containers options"
-os::cmd::expect_failure_and_text 'oc run test1 --image=busybox --stdin --dry-run' "dry-run can't be used with attached containers options"
-echo "oc run: ok"
-os::test::junit::declare_suite_end
+function os::test::cleanup() {
+	return 0
+}


### PR DESCRIPTION
Refactor `test/cmd/run.sh` to be a library

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Configure `hack/test-cmd.sh` to run test libraries

The future of command tests is to declare test suites in functions and
have the test runner scripts execute those functions. Lots of complexity
surrounds the execution of nested Bash scripts and this complexity keeps
any refactoring from occurring that could minimize the setup preambles of
command test suite scripts or implement generic EXIT traps.

Currently, a very specific set of circumstances needs to occur for a
test script in `test/cmd` to be valuable by itself, so we lose basically
nothing by ensuring that those scripts are libraries and not executable.

As a library, each test script will be responsible for providing two
functions:

    os::test::suite()
    os::test::cleanup()

The suite should contain only `os::cmd` statements -- no jUnit suite
setup or teardown will be necessary, as it will be done in the runner.
The cleanup should contain cluster-level cleanup that is necessary for
the test to be re-entrant. The cleanup is best-effort.

The cleanup function should be written _after_ the suite in the file,
so that additional cleanup steps do not change the line numbers for any
tests in the suite. This is critical to a stable jUnit test name for
`os::cmd` tests.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Use `os::log::fatal` in jUnit helper functions

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
