### PR TITLE
setup watches before creating the buildconfig

### DIFF
--- a/test/common/build/controllers.go
+++ b/test/common/build/controllers.go
@@ -320,18 +320,19 @@ func RunImageChangeTriggerTest(t testingT, clusterAdminClient *client.Client) {
 
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
+
 	config := imageChangeBuildConfig("sti-imagestreamtag", stiStrategy("ImageStreamTag", streamName+":"+tag))
-	created, err := clusterAdminClient.BuildConfigs(testutil.Namespace()).Create(config)
+	_, err := clusterAdminClient.BuildConfigs(testutil.Namespace()).Create(config)
 	if err != nil {
 		t.Fatalf("Couldn't create BuildConfig: %v", err)
 	}
 
-	watch, err := clusterAdminClient.Builds(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	watch, err := clusterAdminClient.Builds(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Builds %v", err)
 	}
 
-	watch2, err := clusterAdminClient.BuildConfigs(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	watch2, err := clusterAdminClient.BuildConfigs(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to BuildConfigs %v", err)
 	}
@@ -510,12 +511,12 @@ func RunBuildDeleteTest(t testingT, clusterAdminClient *client.Client, clusterAd
 	}
 	defer buildWatch.Stop()
 
-	created, err := clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
+	_, err = clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
 	if err != nil {
 		t.Fatalf("Couldn't create Build: %v", err)
 	}
 
-	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Pods %v", err)
 	}
@@ -575,12 +576,12 @@ func RunBuildRunningPodDeleteTest(t testingT, clusterAdminClient *client.Client,
 	}
 	defer buildWatch.Stop()
 
-	created, err := clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
+	_, err = clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
 	if err != nil {
 		t.Fatalf("Couldn't create Build: %v", err)
 	}
 
-	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Pods %v", err)
 	}
@@ -642,12 +643,12 @@ func RunBuildCompletePodDeleteTest(t testingT, clusterAdminClient *client.Client
 	}
 	defer buildWatch.Stop()
 
-	created, err := clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
+	_, err = clusterAdminClient.Builds(testutil.Namespace()).Create(mockBuild())
 	if err != nil {
 		t.Fatalf("Couldn't create Build: %v", err)
 	}
 
-	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	podWatch, err := clusterAdminKubeClientset.Core().Pods(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Pods %v", err)
 	}
@@ -705,7 +706,7 @@ func RunBuildConfigChangeControllerTest(t testingT, clusterAdminClient *client.C
 		t.Fatalf("Couldn't create BuildConfig: %v", err)
 	}
 
-	watch, err := clusterAdminClient.Builds(testutil.Namespace()).Watch(kapi.ListOptions{ResourceVersion: created.ResourceVersion})
+	watch, err := clusterAdminClient.Builds(testutil.Namespace()).Watch(kapi.ListOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Builds %v", err)
 	}


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/12017

between the fact that we were watching on builds based on the buildconfig resource version, and that we were starting the watches after the build was potentially created, there was probably a race condition here if the build got created really quickly.
