### PR TITLE
Add prometheus metrics for dockerregistry

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -35,3 +35,8 @@ middleware:
         blobrepositorycachettl: 10m
   storage:
     - name: openshift
+openshift:
+  version: 1.0
+  metrics:
+    enabled: false
+    secret: TopSecretToken

--- a/pkg/dockerregistry/server/api/doc.go
+++ b/pkg/dockerregistry/server/api/doc.go
@@ -1,0 +1,2 @@
+// Package api describes routes and urls that extends the Registry JSON HTTP API.
+package api

--- a/pkg/dockerregistry/server/api/routes.go
+++ b/pkg/dockerregistry/server/api/routes.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"github.com/docker/distribution/reference"
+)
+
+var (
+	AdminPrefix      = "/admin/"
+	ExtensionsPrefix = "/extensions/v2/"
+
+	AdminPath      = "/blobs/{digest:" + reference.DigestRegexp.String() + "}"
+	SignaturesPath = "/{name:" + reference.NameRegexp.String() + "}/signatures/{digest:" + reference.DigestRegexp.String() + "}"
+	MetricsPath    = "/metrics"
+)

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -25,6 +25,8 @@ import (
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
 	"github.com/openshift/origin/pkg/client"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 )
 
 // TestVerifyImageStreamAccess mocks openshift http request/response and
@@ -405,6 +407,7 @@ func TestAccessController(t *testing.T) {
 		}
 		ctx := context.Background()
 		ctx = context.WithRequest(ctx, req)
+		ctx = WithConfiguration(ctx, &configuration.Configuration{})
 		authCtx, err := accessController.Authorized(ctx, test.access...)
 		server.Close()
 

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/distribution/registry/middleware/registry"
 	"github.com/docker/distribution/registry/storage"
 
+	srvconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -62,6 +63,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *testImage))
 
 	ctx := context.Background()
+	ctx = WithConfiguration(ctx, &srvconfig.Configuration{})
 	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, nil))
 	app := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -1,0 +1,140 @@
+package configuration
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/docker/distribution/configuration"
+)
+
+var (
+	// CurrentVersion is the most recent Version that can be parsed.
+	CurrentVersion = configuration.MajorMinorVersion(1, 0)
+
+	ErrUnsupportedVersion = errors.New("Unsupported openshift configuration version")
+)
+
+type openshiftConfig struct {
+	Openshift Configuration
+}
+
+type Configuration struct {
+	Version configuration.Version `yaml:"version"`
+	Metrics Metrics               `yaml:"metrics"`
+}
+
+type Metrics struct {
+	Enabled bool   `yaml:"enabled"`
+	Secret  string `yaml:"secret"`
+}
+
+type versionInfo struct {
+	Openshift struct {
+		Version *configuration.Version
+	}
+}
+
+// Parse parses an input configuration and returns docker configuration structure and
+// openshift specific configuration.
+// Environment variables may be used to override configuration parameters.
+func Parse(rd io.Reader) (*configuration.Configuration, *Configuration, error) {
+	in, err := ioutil.ReadAll(rd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// We don't want to change the version from the environment variables.
+	os.Unsetenv("REGISTRY_OPENSHIFT_VERSION")
+
+	openshiftEnv, err := popEnv("REGISTRY_OPENSHIFT_")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dockerConfig, err := configuration.Parse(bytes.NewBuffer(in))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dockerEnv, err := popEnv("REGISTRY_")
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := pushEnv(openshiftEnv); err != nil {
+		return nil, nil, err
+	}
+
+	config := openshiftConfig{}
+
+	vInfo := &versionInfo{}
+	if err := yaml.Unmarshal(in, &vInfo); err != nil {
+		return nil, nil, err
+	}
+
+	if vInfo.Openshift.Version != nil {
+		if *vInfo.Openshift.Version != CurrentVersion {
+			return nil, nil, ErrUnsupportedVersion
+		}
+	} else {
+		return dockerConfig, &config.Openshift, nil
+	}
+
+	p := configuration.NewParser("registry", []configuration.VersionedParseInfo{
+		{
+			Version: dockerConfig.Version,
+			ParseAs: reflect.TypeOf(config),
+			ConversionFunc: func(c interface{}) (interface{}, error) {
+				return c, nil
+			},
+		},
+	})
+
+	if err = p.Parse(in, &config); err != nil {
+		return nil, nil, err
+	}
+	if err := pushEnv(dockerEnv); err != nil {
+		return nil, nil, err
+	}
+
+	return dockerConfig, &config.Openshift, nil
+}
+
+type envVar struct {
+	name  string
+	value string
+}
+
+func popEnv(prefix string) ([]envVar, error) {
+	var envVars []envVar
+
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, prefix) {
+			continue
+		}
+		envParts := strings.SplitN(env, "=", 2)
+		err := os.Unsetenv(envParts[0])
+		if err != nil {
+			return nil, err
+		}
+
+		envVars = append(envVars, envVar{envParts[0], envParts[1]})
+	}
+
+	return envVars, nil
+}
+
+func pushEnv(environ []envVar) error {
+	for _, env := range environ {
+		if err := os.Setenv(env.name, env.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/dockerregistry/server/configuration/configuration_test.go
+++ b/pkg/dockerregistry/server/configuration/configuration_test.go
@@ -1,0 +1,136 @@
+package configuration
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+var configYamlV0_1 = `
+version: 0.1
+http:
+  addr: :5000
+  relativeurls: true
+storage:
+  inmemory: {}
+openshift:
+  version: 1.0
+  metrics:
+    enabled: true
+    secret: TopSecretToken
+`
+
+func TestConfigurationParser(t *testing.T) {
+	configFile := bytes.NewBufferString(configYamlV0_1)
+
+	dockerConfig, extraConfig, err := Parse(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error parsing configuration file: %s", err)
+	}
+
+	if !dockerConfig.HTTP.RelativeURLs {
+		t.Fatalf("unexpected value: dockerConfig.HTTP.RelativeURLs != true")
+	}
+
+	if extraConfig.Version.Major() != 1 || extraConfig.Version.Minor() != 0 {
+		t.Fatalf("unexpected value: extraConfig.Version: %s", extraConfig.Version)
+	}
+
+	if !extraConfig.Metrics.Enabled {
+		t.Fatalf("unexpected value: extraConfig.Metrics.Enabled != true")
+	}
+
+	if extraConfig.Metrics.Secret != "TopSecretToken" {
+		t.Fatalf("unexpected value: extraConfig.Metrics.Secret: %s", extraConfig.Metrics.Secret)
+	}
+}
+
+func TestConfigurationOverwriteEnv(t *testing.T) {
+	os.Setenv("REGISTRY_OPENSHIFT_METRICS_ENABLED", "false")
+	defer os.Unsetenv("REGISTRY_OPENSHIFT_METRICS_ENABLED")
+
+	configFile := bytes.NewBufferString(configYamlV0_1)
+
+	_, extraConfig, err := Parse(configFile)
+	if err != nil {
+		t.Fatalf("unexpected error parsing configuration file: %s", err)
+	}
+	if extraConfig.Metrics.Enabled {
+		t.Fatalf("unexpected value: extraConfig.Metrics.Enabled != false")
+	}
+}
+
+func TestDockerConfigurationError(t *testing.T) {
+	var badDockerConfigYamlV0_1 = `
+version: 0.1
+http:
+  addr: :5000
+  relativeurls: "true"
+storage:
+  inmemory: {}
+`
+	configFile := bytes.NewBufferString(badDockerConfigYamlV0_1)
+
+	_, _, err := Parse(configFile)
+	if err == nil {
+		t.Fatalf("unexpected parser success")
+	}
+}
+
+func TestExtraConfigurationError(t *testing.T) {
+	var badExtraConfigYaml = `
+version: 0.1
+http:
+  addr: :5000
+storage:
+  inmemory: {}
+openshift:
+  version: 1.0
+  metrics:
+    enabled: "true"
+`
+	configFile := bytes.NewBufferString(badExtraConfigYaml)
+
+	_, _, err := Parse(configFile)
+	if err == nil {
+		t.Fatalf("unexpected parser success")
+	}
+}
+
+func TestEmptyExtraConfigurationError(t *testing.T) {
+	var emptyExtraConfigYaml = `
+version: 0.1
+http:
+  addr: :5000
+storage:
+  inmemory: {}
+`
+	configFile := bytes.NewBufferString(emptyExtraConfigYaml)
+
+	_, _, err := Parse(configFile)
+	if err != nil {
+		t.Fatalf("unexpected parser error: %s", err)
+	}
+}
+
+func TestExtraConfigurationVersionError(t *testing.T) {
+	var badExtraConfigYaml = `
+version: 0.1
+http:
+  addr: :5000
+storage:
+  inmemory: {}
+openshift:
+  version: 2.0
+`
+	configFile := bytes.NewBufferString(badExtraConfigYaml)
+
+	_, _, err := Parse(configFile)
+	if err == nil {
+		t.Fatalf("unexpected parser success")
+	}
+
+	if err != ErrUnsupportedVersion {
+		t.Fatalf("unexpected parser error: %v", err)
+	}
+}

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/distribution/context"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 )
 
 type contextKey string
@@ -29,6 +30,9 @@ const (
 
 	// deferredErrorsKey is the key for deferred errors in Contexts.
 	deferredErrorsKey contextKey = "deferredErrors"
+
+	// configurationKey is the key for Configuration in Context.
+	configurationKey contextKey = "configuration"
 )
 
 // withRepository returns a new Context that carries value repo.
@@ -101,4 +105,15 @@ func withDeferredErrors(parent context.Context, errs deferredErrors) context.Con
 func deferredErrorsFrom(ctx context.Context) (deferredErrors, bool) {
 	errs, ok := ctx.Value(deferredErrorsKey).(deferredErrors)
 	return errs, ok
+}
+
+// WithConfiguration returns a new Context with provided configuration.
+func WithConfiguration(ctx context.Context, config *configuration.Configuration) context.Context {
+	return context.WithValue(ctx, configurationKey, config)
+}
+
+// ConfigurationFrom returns the configuration stored in ctx if present.
+// It will panic otherwise.
+func ConfigurationFrom(ctx context.Context) *configuration.Configuration {
+	return ctx.Value(configurationKey).(*configuration.Configuration)
 }

--- a/pkg/dockerregistry/server/manifestservice_test.go
+++ b/pkg/dockerregistry/server/manifestservice_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	"github.com/openshift/origin/pkg/dockerregistry/testutil"
 )
 
@@ -85,6 +86,7 @@ func TestManifestServicePut(t *testing.T) {
 	ctx := context.Background()
 	ctx = withAuthPerformed(ctx)
 	ctx = withUserClient(ctx, client)
+	ctx = WithConfiguration(ctx, &configuration.Configuration{})
 	dgst, err := ms.Put(ctx, manifest)
 	if err != nil {
 		t.Fatalf("ms.Put(ctx, manifest): %s", err)

--- a/pkg/dockerregistry/server/metrichandler.go
+++ b/pkg/dockerregistry/server/metrichandler.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution/registry/auth"
+	"github.com/docker/distribution/registry/handlers"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/api"
+	"github.com/openshift/origin/pkg/dockerregistry/server/metrics"
+)
+
+func RegisterMetricHandler(app *handlers.App) {
+	metrics.Register()
+	getMetricsAccess := func(r *http.Request) []auth.Access {
+		return []auth.Access{
+			{
+				Resource: auth.Resource{
+					Type: "metrics",
+				},
+				Action: "get",
+			},
+		}
+	}
+	extensionsRouter := app.NewRoute().PathPrefix(api.ExtensionsPrefix).Subrouter()
+	app.RegisterRoute(
+		extensionsRouter.Path(api.MetricsPath).Methods("GET"),
+		metrics.Dispatcher,
+		handlers.NameNotRequired,
+		getMetricsAccess,
+	)
+}

--- a/pkg/dockerregistry/server/metrics/dispatcher.go
+++ b/pkg/dockerregistry/server/metrics/dispatcher.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/docker/distribution/registry/handlers"
+
+	gorillahandlers "github.com/gorilla/handlers"
+)
+
+// Dispatcher handles the GET requests for metrics endpoint.
+func Dispatcher(ctx *handlers.Context, r *http.Request) http.Handler {
+	return gorillahandlers.MethodHandler{
+		"GET": prometheus.Handler(),
+	}
+}

--- a/pkg/dockerregistry/server/metrics/doc.go
+++ b/pkg/dockerregistry/server/metrics/doc.go
@@ -1,0 +1,3 @@
+// Package metrics provides functions to collect runtime registry statistics and
+// expose the registered metrics via HTTP.
+package metrics

--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	registryNamespace = "openshift"
+	registrySubsystem = "registry"
+)
+
+var (
+	RegistryAPIRequests *prometheus.SummaryVec
+)
+
+// Register the metrics.
+func Register() {
+	RegistryAPIRequests = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: registryNamespace,
+			Subsystem: registrySubsystem,
+			Name:      "request_duration_seconds",
+			Help:      "Request latency summary in microseconds for each operation",
+		},
+		[]string{"operation", "name"},
+	)
+	prometheus.MustRegister(RegistryAPIRequests)
+}
+
+// NewTimer wraps the SummaryVec and used to track amount of time passed since the Timer was created.
+func NewTimer(collector *prometheus.SummaryVec, labels []string) *metricTimer {
+	return &metricTimer{
+		collector: collector,
+		labels:    labels,
+		startTime: time.Now(),
+	}
+}
+
+type metricTimer struct {
+	collector *prometheus.SummaryVec
+	labels    []string
+	startTime time.Time
+}
+
+// Stop records the duration passed since the Timer was created with NewTimer.
+func (m *metricTimer) Stop() {
+	m.collector.WithLabelValues(m.labels...).Observe(float64(time.Since(m.startTime) / time.Second))
+}

--- a/pkg/dockerregistry/server/metrics/metricsblobstore.go
+++ b/pkg/dockerregistry/server/metrics/metricsblobstore.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+)
+
+// BlobStore wraps a distribution.BlobStore to collect statistics
+type BlobStore struct {
+	Store    distribution.BlobStore
+	Reponame string
+}
+
+var _ distribution.BlobStore = &BlobStore{}
+
+func (b *BlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.stat", b.Reponame}).Stop()
+	return b.Store.Stat(ctx, dgst)
+}
+
+func (b *BlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.get", b.Reponame}).Stop()
+	return b.Store.Get(ctx, dgst)
+}
+
+func (b *BlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.open", b.Reponame}).Stop()
+	return b.Store.Open(ctx, dgst)
+}
+
+func (b *BlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.put", b.Reponame}).Stop()
+	return b.Store.Put(ctx, mediaType, p)
+}
+
+func (b *BlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.create", b.Reponame}).Stop()
+
+	writer, err := b.Store.Create(ctx, options...)
+
+	return &metricsBlobWriter{
+		BlobWriter: writer,
+		reponame:   b.Reponame,
+	}, err
+}
+
+func (b *BlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.resume", b.Reponame}).Stop()
+	return b.Store.Resume(ctx, id)
+}
+
+func (b *BlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.serveblob", b.Reponame}).Stop()
+	return b.Store.ServeBlob(ctx, w, req, dgst)
+}
+
+func (b *BlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	defer NewTimer(RegistryAPIRequests, []string{"blobstore.delete", b.Reponame}).Stop()
+	return b.Store.Delete(ctx, dgst)
+}
+
+type metricsBlobWriter struct {
+	distribution.BlobWriter
+	reponame string
+}
+
+func (bw *metricsBlobWriter) Commit(ctx context.Context, provisional distribution.Descriptor) (canonical distribution.Descriptor, err error) {
+	defer NewTimer(RegistryAPIRequests, []string{"blobwriter.commit", bw.reponame}).Stop()
+	return bw.BlobWriter.Commit(ctx, provisional)
+}
+
+func (bw *metricsBlobWriter) Cancel(ctx context.Context) error {
+	defer NewTimer(RegistryAPIRequests, []string{"blobwriter.cancel", bw.reponame}).Stop()
+	return bw.BlobWriter.Cancel(ctx)
+}

--- a/pkg/dockerregistry/server/metrics/metricsmanifestservice.go
+++ b/pkg/dockerregistry/server/metrics/metricsmanifestservice.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+)
+
+// ManifestService wraps a distribution.ManifestService to collect statistics
+type ManifestService struct {
+	Manifests distribution.ManifestService
+	Reponame  string
+}
+
+var _ distribution.ManifestService = &ManifestService{}
+
+func (m *ManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"manifestservice.exists", m.Reponame}).Stop()
+	return m.Manifests.Exists(ctx, dgst)
+}
+
+func (m *ManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"manifestservice.get", m.Reponame}).Stop()
+	return m.Manifests.Get(ctx, dgst, options...)
+}
+
+func (m *ManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"manifestservice.put", m.Reponame}).Stop()
+	return m.Manifests.Put(ctx, manifest, options...)
+}
+
+func (m *ManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	defer NewTimer(RegistryAPIRequests, []string{"manifestservice.delete", m.Reponame}).Stop()
+	return m.Manifests.Delete(ctx, dgst)
+}

--- a/pkg/dockerregistry/server/metrics/metricstagservice.go
+++ b/pkg/dockerregistry/server/metrics/metricstagservice.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+)
+
+// TagService wraps a distribution.TagService to collect statistics
+type TagService struct {
+	Tags     distribution.TagService
+	Reponame string
+}
+
+var _ distribution.TagService = &TagService{}
+
+func (t *TagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"tagservice.get", t.Reponame}).Stop()
+	return t.Tags.Get(ctx, tag)
+}
+
+func (t *TagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	defer NewTimer(RegistryAPIRequests, []string{"tagservice.tag", t.Reponame}).Stop()
+	return t.Tags.Tag(ctx, tag, desc)
+}
+
+func (t *TagService) Untag(ctx context.Context, tag string) error {
+	defer NewTimer(RegistryAPIRequests, []string{"tagservice.untag", t.Reponame}).Stop()
+	return t.Tags.Untag(ctx, tag)
+}
+
+func (t *TagService) All(ctx context.Context) ([]string, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"tagservice.all", t.Reponame}).Stop()
+	return t.Tags.All(ctx)
+}
+
+func (t *TagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	defer NewTimer(RegistryAPIRequests, []string{"tagservice.lookup", t.Reponame}).Stop()
+	return t.Tags.Lookup(ctx, digest)
+}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+	"github.com/openshift/origin/pkg/dockerregistry/server/metrics"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
@@ -264,6 +265,15 @@ func (r *repository) Manifests(ctx context.Context, options ...distribution.Mani
 		}
 	}
 
+	config := ConfigurationFrom(ctx)
+
+	if config.Metrics.Enabled {
+		ms = &metrics.ManifestService{
+			Manifests: ms,
+			Reponame:  r.Named().Name(),
+		}
+	}
+
 	return ms, nil
 }
 
@@ -299,6 +309,15 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		}
 	}
 
+	config := ConfigurationFrom(ctx)
+
+	if config.Metrics.Enabled {
+		bs = &metrics.BlobStore{
+			Store:    bs,
+			Reponame: r.Named().Name(),
+		}
+	}
+
 	return bs
 }
 
@@ -319,6 +338,15 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 	if audit.LoggerExists(ctx) {
 		ts = &auditTagService{
 			tags: ts,
+		}
+	}
+
+	config := ConfigurationFrom(ctx)
+
+	if config.Metrics.Enabled {
+		ts = &metrics.TagService{
+			Tags:     ts,
+			Reponame: r.Named().Name(),
 		}
 	}
 

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -284,6 +285,7 @@ func TestRepositoryBlobStat(t *testing.T) {
 		}
 
 		ctx := context.Background()
+		ctx = WithConfiguration(ctx, &configuration.Configuration{})
 		if !tc.skipAuth {
 			ctx = withAuthPerformed(ctx)
 		}
@@ -333,6 +335,7 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 
 	quotaEnforcing = &quotaEnforcingConfig{}
 	ctx := withAuthPerformed(context.Background())
+	ctx = WithConfiguration(ctx, &configuration.Configuration{})
 
 	// this driver holds all the testing blobs in memory during the whole test run
 	driver := inmemory.New()

--- a/pkg/dockerregistry/server/signaturehandler.go
+++ b/pkg/dockerregistry/server/signaturehandler.go
@@ -4,15 +4,16 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution/context"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/auth"
 	"github.com/docker/distribution/registry/handlers"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 )
 
 // RegisterSignatureHandler registers the Docker image signature extension to Docker
 // registry.
 func RegisterSignatureHandler(app *handlers.App) {
-	extensionsRouter := app.NewRoute().PathPrefix("/extensions/v2/").Subrouter()
+	extensionsRouter := app.NewRoute().PathPrefix(api.ExtensionsPrefix).Subrouter()
 	var (
 		getSignatureAccess = func(r *http.Request) []auth.Access {
 			return []auth.Access{
@@ -38,13 +39,13 @@ func RegisterSignatureHandler(app *handlers.App) {
 		}
 	)
 	app.RegisterRoute(
-		extensionsRouter.Path("/{name:"+reference.NameRegexp.String()+"}/signatures/{digest:"+reference.DigestRegexp.String()+"}").Methods("GET"),
+		extensionsRouter.Path(api.SignaturesPath).Methods("GET"),
 		SignatureDispatcher,
 		handlers.NameRequired,
 		getSignatureAccess,
 	)
 	app.RegisterRoute(
-		extensionsRouter.Path("/{name:"+reference.NameRegexp.String()+"}/signatures/{digest:"+reference.DigestRegexp.String()+"}").Methods("PUT"),
+		extensionsRouter.Path(api.SignaturesPath).Methods("PUT"),
 		SignatureDispatcher,
 		handlers.NameRequired,
 		putSignatureAccess,


### PR DESCRIPTION
Example:
```

# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
# TYPE http_request_duration_microseconds summary
http_request_duration_microseconds{handler="openshift",quantile="0.5"} 12060.892
http_request_duration_microseconds{handler="openshift",quantile="0.9"} 26831.134
http_request_duration_microseconds{handler="openshift",quantile="0.99"} 92603.647
http_request_duration_microseconds_sum{handler="openshift"} 817404.5250000001
http_request_duration_microseconds_count{handler="openshift"} 52

# HELP http_request_size_bytes The HTTP request sizes in bytes.
# TYPE http_request_size_bytes summary
http_request_size_bytes{handler="openshift",quantile="0.5"} 345
http_request_size_bytes{handler="openshift",quantile="0.9"} 583
http_request_size_bytes{handler="openshift",quantile="0.99"} 3114
http_request_size_bytes_sum{handler="openshift"} 25907
http_request_size_bytes_count{handler="openshift"} 52

# HELP http_response_size_bytes The HTTP response sizes in bytes.
# TYPE http_response_size_bytes summary
http_response_size_bytes{handler="openshift",quantile="0.5"} 87
http_response_size_bytes{handler="openshift",quantile="0.9"} 2739
http_response_size_bytes{handler="openshift",quantile="0.99"} 2740
http_response_size_bytes_sum{handler="openshift"} 25128
http_response_size_bytes_count{handler="openshift"} 52

# HELP http_requests_total Total number of HTTP requests made.
# TYPE http_requests_total counter
http_requests_total{code="200",handler="openshift",method="get"} 19
http_requests_total{code="200",handler="openshift",method="head"} 6
http_requests_total{code="201",handler="openshift",method="post"} 1
http_requests_total{code="201",handler="openshift",method="put"} 4
http_requests_total{code="202",handler="openshift",method="patch"} 2
http_requests_total{code="202",handler="openshift",method="post"} 2
http_requests_total{code="400",handler="openshift",method="put"} 2
http_requests_total{code="401",handler="openshift",method="get"} 14
http_requests_total{code="404",handler="openshift",method="head"} 2

# HELP openshift_registry_request_duration_microseconds Request latency summary in microseconds for each operation
# TYPE openshift_registry_request_duration_microseconds summary
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.serveblob",quantile="0.5"} 316
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.serveblob",quantile="0.9"} 385
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.serveblob",quantile="0.99"} 385
openshift_registry_request_duration_microseconds_sum{name="tmp/busybox",operation="blobstore.serveblob"} 1180
openshift_registry_request_duration_microseconds_count{name="tmp/busybox",operation="blobstore.serveblob"} 3
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.stat",quantile="0.5"} 466
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.stat",quantile="0.9"} 632
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="blobstore.stat",quantile="0.99"} 632
openshift_registry_request_duration_microseconds_sum{name="tmp/busybox",operation="blobstore.stat"} 6633
openshift_registry_request_duration_microseconds_count{name="tmp/busybox",operation="blobstore.stat"} 7
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="manifestservice.get",quantile="0.5"} 10427
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="manifestservice.get",quantile="0.9"} 10427
openshift_registry_request_duration_microseconds{name="tmp/busybox",operation="manifestservice.get",quantile="0.99"} 10427
openshift_registry_request_duration_microseconds_sum{name="tmp/busybox",operation="manifestservice.get"} 22958
openshift_registry_request_duration_microseconds_count{name="tmp/busybox",operation="manifestservice.get"} 2
```

This is only one part of implemented metrics. Currently collected metrics about the process state, memstats, the garbage collector metrics.