### PR TITLE
improve output of `oc idle`

### DIFF
--- a/test/cmd/idle.sh
+++ b/test/cmd/idle.sh
@@ -60,27 +60,27 @@ EOF
 os::test::junit::declare_suite_start "cmd/idle/by-name"
 setup_idling_resources
 os::cmd::expect_failure "oc idle dc/${dc_name}" # make sure manually passing non-endpoints resources fails
-os::cmd::expect_success_and_text 'oc idle idling-echo' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/${dc_name} \(unidle to 2 replicas\)"
+os::cmd::expect_success_and_text 'oc idle idling-echo' "The service will unidle DeploymentConfig \"${project}/${dc_name}\" to 2 replicas once it receives traffic"
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${idled_at_template}'" '.'
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${unidle_target_template}' | jq '.[] | select(.name == \"${dc_name}\") | (.replicas == 2 and .kind == \"DeploymentConfig\")'" 'true'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/idle/by-label"
 setup_idling_resources
-os::cmd::expect_success_and_text 'oc idle -l app=idling-echo' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/${dc_name} \(unidle to 2 replicas\)"
+os::cmd::expect_success_and_text 'oc idle -l app=idling-echo' "The service will unidle DeploymentConfig \"${project}/${dc_name}\" to 2 replicas once it receives traffic"
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${idled_at_template}'" '.'
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${unidle_target_template}' | jq '.[] | select(.name == \"${dc_name}\") | (.replicas == 2 and .kind == \"DeploymentConfig\")'" 'true'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/idle/all"
 setup_idling_resources
-os::cmd::expect_success_and_text 'oc idle --all' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/${dc_name} \(unidle to 2 replicas\)"
+os::cmd::expect_success_and_text 'oc idle --all' "The service will unidle DeploymentConfig \"${project}/${dc_name}\" to 2 replicas once it receives traffic"
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${idled_at_template}'" '.'
 os::cmd::expect_success_and_text "oc get endpoints idling-echo -o go-template='${unidle_target_template}' | jq '.[] | select(.name == \"${dc_name}\") | (.replicas == 2 and .kind == \"DeploymentConfig\")'" 'true'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/idle/check-previous-scale"
 setup_idling_resources  # scales up to 2 replicas
-os::cmd::expect_success_and_text 'oc idle idling-echo' "Marked service ${project}/idling-echo to unidle resource DeploymentConfig ${project}/${dc_name} \(unidle to 2 replicas\)"
+os::cmd::expect_success_and_text 'oc idle idling-echo' "The service will unidle DeploymentConfig \"${project}/${dc_name}\" to 2 replicas once it receives traffic"
 os::cmd::expect_success_and_text "oc get dc ${dc_name}  -o go-template='${prev_scale_template}'" '2'  # we see the result of the initial scale as the previous scale
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1402356

Improves the output of `oc idle` when idling a service with one or more scalable refs, no scalable refs (or a service that has already been idled), and when idling a service with the `--dry-run` flag.

**Before**
```
$ oc idle database
Marked service test-oc-idle/database to unidle resource DeploymentConfig test-oc-idle/database (unidle to 1 replicas)
Idled DeploymentConfig test-oc-idle/database

# idle a svc that has already been marked as idled
$ oc idle database
error: no scalable resources marked as idled for service test-oc-idle/database, not marking as idled

# with --dry-run, the (dry run) text did not appear if the service was already idled
$ oc idle database --dry-run
Marked service test-oc-idle/database to unidle resource DeploymentConfig test-oc-idle/database (unidle to 1 replicas)
```

**After**
```
$ oc idle database
The service "test-oc-idle/database" has been marked as idled
The service will unidle DeploymentConfig "test-oc-idle/database" to 1 replicas once it receives traffic
DeploymentConfig "test-oc-idle/database" has been idled

$ oc idle database
error: unable to mark the service "test-oc-idle/database" as idled.
Make sure that the service is not already marked as idled, and that it is associated with resources that can be scaled.
See 'oc idle -h' for help and examples.

$ oc idle database --dry-run
The service "test-oc-idle/database" has been marked as idled (dry run)
The service will unidle DeploymentConfig "test-oc-idle/database" to 1 replicas once it receives traffic (dry run)
```

cc @fabianofranz @DirectXMan12 @openshift/cli-review 