### PR TITLE
Fix stub interface so Mac compilations work

### DIFF
--- a/pkg/sdn/plugin/pod_unsupported.go
+++ b/pkg/sdn/plugin/pod_unsupported.go
@@ -14,8 +14,8 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 	return nil, nil, fmt.Errorf("openshift-sdn is unsupported on this OS!")
 }
 
-func (m *podManager) update(req *cniserver.PodRequest) (*runningPod, error) {
-	return nil, fmt.Errorf("openshift-sdn is unsupported on this OS!")
+func (m *podManager) update(req *cniserver.PodRequest) (uint32, error) {
+	return 0, fmt.Errorf("openshift-sdn is unsupported on this OS!")
 }
 
 // Clean up all pod networking (clear OVS flows, release IPAM lease, remove host/container veth)


### PR DESCRIPTION
The stub "unsupported" interface had the wrong signature.  This
corrects it to prevent a compilation error on Macs.

Fixes bug 1417747 https://bugzilla.redhat.com/show_bug.cgi?id=1417747