### PR TITLE
Short-circuit path shortening logic when possible

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -78,10 +78,13 @@ function os::util::repository_relative_path() {
 	local directory; directory="$( dirname "${filename}" )"
 	filename="$( basename "${filename}" )"
 
-	pushd "${OS_ORIGINAL_WD}" >/dev/null 2>&1
-	directory="$( os::util::absolute_path "${directory}" )"
+	if [[ "${directory}" != "${OS_ROOT}"* ]]; then
+		pushd "${OS_ORIGINAL_WD}" >/dev/null 2>&1
+		directory="$( os::util::absolute_path "${directory}" )"
+		popd >/dev/null 2>&1
+	fi
+
 	directory="${directory##*${OS_ROOT}/}"
-	popd >/dev/null 2>&1
 
 	echo "${directory}/${filename}"
 }


### PR DESCRIPTION
When `os::util::repository_relative_path` is given a path that already
starts with `$OS_ROOT` we can simply truncate the path string to get the
relative path.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>