### PR TITLE
Node should default to controller attach detach

### DIFF
--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -160,8 +160,6 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	server.CPUCFSQuota = true // enable cpu cfs quota enforcement by default
 	server.MaxPods = 250
 	server.PodsPerCore = 10
-	server.SerializeImagePulls = false          // disable serialized image pulls by default
-	server.EnableControllerAttachDetach = false // stay consistent with existing config, but admins should enable it
 	if enableDNS {
 		// if we are running local DNS, skydns will load the default recursive nameservers for us
 		server.ResolverConfig = ""


### PR DESCRIPTION
This should have been changed in 1.4, and I don't see anything in the ansible setup that would set it to true.  This means that 1.4 installs are probably running with both kubelet attach/detach and controller attach/detach...

@derekwaynecarr

[test]