### PR TITLE
Allow setting patchStrategy for maps

### DIFF
--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -27,7 +27,7 @@ type Image struct {
 	// DockerImageReference is the string that can be used to pull this image.
 	DockerImageReference string `json:"dockerImageReference,omitempty" protobuf:"bytes,2,opt,name=dockerImageReference"`
 	// DockerImageMetadata contains metadata about this image
-	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty" protobuf:"bytes,3,opt,name=dockerImageMetadata"`
+	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty" patchStrategy:"replace" protobuf:"bytes,3,opt,name=dockerImageMetadata"`
 	// DockerImageMetadataVersion conveys the version of the object, which if empty defaults to "1.0"
 	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty" protobuf:"bytes,4,opt,name=dockerImageMetadataVersion"`
 	// DockerImageManifest is the raw JSON of the manifest

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -22,5 +22,17 @@ os::cmd::expect_success_and_not_text 'OC_EDITOR=cat oc edit --windows-line-endin
 
 os::cmd::expect_success 'oc create -f test/testdata/services.yaml'
 os::cmd::expect_success_and_text 'OC_EDITOR=cat oc edit svc' 'kind: List'
+
+os::cmd::expect_success 'oc create imagestream test'
+os::cmd::expect_success 'oc create -f test/testdata/mysql-image-stream-mapping.yaml'
+os::cmd::expect_success_and_not_text 'oc get istag/test:new -o jsonpath={.metadata.annotations}' "tags:hidden"
+editorfile="$(mktemp -d)/tmp-editor.sh"
+echo '#!/bin/bash' > ${editorfile}
+echo 'sed -i "s/^tag: null/tag:\n  referencePolicy:\n    type: Source/g" $1' >> ${editorfile}
+echo 'sed -i "s/^metadata:$/metadata:\n  annotations:\n    tags: hidden/g" $1' >> ${editorfile}
+chmod +x ${editorfile}
+os::cmd::expect_success "EDITOR=${editorfile} oc edit istag/test:new"
+os::cmd::expect_success_and_text 'oc get istag/test:new -o jsonpath={.metadata.annotations}' "tags:hidden"
+
 echo "edit: ok"
 os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/util/strategicpatch/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/strategicpatch/patch.go
@@ -225,9 +225,16 @@ func diffMaps(original, modified map[string]interface{}, t reflect.Type, ignoreC
 		switch originalValueTyped := originalValue.(type) {
 		case map[string]interface{}:
 			modifiedValueTyped := modifiedValue.(map[string]interface{})
-			fieldType, _, _, err := forkedjson.LookupPatchMetadata(t, key)
+			fieldType, fieldPatchStrategy, _, err := forkedjson.LookupPatchMetadata(t, key)
 			if err != nil {
 				return nil, err
+			}
+
+			if fieldPatchStrategy == replaceDirective {
+				if !ignoreChangesAndAdditions {
+					patch[key] = modifiedValue
+				}
+				continue
 			}
 
 			patchValue, err := diffMaps(originalValueTyped, modifiedValueTyped, fieldType, ignoreChangesAndAdditions, ignoreDeletions)
@@ -1035,6 +1042,10 @@ func mergingMapFieldsHaveConflicts(
 				if leftMarker != rightMarker {
 					return true, nil
 				}
+			}
+
+			if fieldPatchStrategy == replaceDirective {
+				return false, nil
 			}
 
 			// Check the individual keys.


### PR DESCRIPTION
This is one possible approach to https://bugzilla.redhat.com/show_bug.cgi?id=1403134

`ImageStreamTag` allows editing only annotations, but that works only with `oc annotate` or `oc patch` command which specifically say what's edited. When `oc edit` is being invoked it trips over the internal `Image` object of a IST, due to differences between internal and external representations of this object. 
This approach allows setting `patchStrategy` on struct objects, so they can be ignored, here deleted.

@deads2k || @liggitt does something like that makes sense?
@juanvallejo fyi