### PR TITLE
Remove List and ListOptions from non-round-trippable types in serialization test

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -604,7 +604,7 @@ func TestSpecificKind(t *testing.T) {
 
 // Keep this in sync with the respective upstream set
 // WatchEvent does not have TypeMeta and cannot be roundtripped.
-var nonInternalRoundTrippableTypes = sets.NewString("List", "ListOptions", "WatchEvent")
+var nonInternalRoundTrippableTypes = sets.NewString("WatchEvent")
 
 // TestTypes will try to roundtrip all OpenShift and Kubernetes stable api types
 func TestTypes(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/5529

@deads2k @kargakis FYI

@smarterclayton any reason why these should not be round-trippable?