### PR TITLE
Add necessary files for running as system containers

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -31,4 +31,7 @@ LABEL io.k8s.display-name="OpenShift Origin Node" \
       io.k8s.description="This is a component of OpenShift Origin and contains the software for individual nodes when using SDN."
 VOLUME /etc/origin/node
 ENV KUBECONFIG=/etc/origin/node/node.kubeconfig
+
+COPY system-container/config.json.template system-container/service.template system-containers/tmpfiles.template /exports/
+
 ENTRYPOINT [ "/usr/local/bin/origin-node-run.sh" ]

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -26,4 +26,7 @@ LABEL io.k8s.display-name="OpenShift Origin Node" \
       io.k8s.description="This is a component of OpenShift Origin and contains the software for individual nodes when using SDN."
 VOLUME /etc/origin/node
 ENV KUBECONFIG=/etc/origin/node/node.kubeconfig
+
+COPY system-container/config.json.template system-container/service.template system-containers/tmpfiles.template /exports/
+
 ENTRYPOINT [ "/usr/local/bin/origin-node-run.sh" ]

--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -1,0 +1,347 @@
+{
+    "ociVersion": "1.0.0",
+    "platform": {
+	"os": "linux",
+	"arch": "amd64"
+    },
+    "process": {
+	"terminal": false,
+	"user": {},
+	"args": [
+	    "/usr/local/bin/system-container-wrapper.sh"
+	],
+	"env": [
+            "HOST=/rootfs",
+            "HOST_ETC=/host-etc",
+            "container=docker",
+            "PKGM=yum",
+            "NAME=$NAME",
+            "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin",
+            "HOME=/root",
+            "OPENSHIFT_CONTAINERIZED=true",
+            "KUBECONFIG=/etc/origin/node/node.kubeconfig",
+	    "TERM=xterm"
+	],
+	"cwd": "/var/lib/origin",
+	"capabilities": [
+            "CAP_CHOWN",
+            "CAP_DAC_OVERRIDE",
+            "CAP_DAC_READ_SEARCH",
+            "CAP_FOWNER",
+            "CAP_FSETID",
+            "CAP_KILL",
+            "CAP_SETGID",
+            "CAP_SETUID",
+            "CAP_SETPCAP",
+            "CAP_LINUX_IMMUTABLE",
+            "CAP_NET_BIND_SERVICE",
+            "CAP_NET_BROADCAST",
+            "CAP_NET_ADMIN",
+            "CAP_NET_RAW",
+            "CAP_IPC_LOCK",
+            "CAP_IPC_OWNER",
+            "CAP_SYS_MODULE",
+            "CAP_SYS_RAWIO",
+            "CAP_SYS_CHROOT",
+            "CAP_SYS_PTRACE",
+            "CAP_SYS_PACCT",
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_BOOT",
+            "CAP_SYS_NICE",
+            "CAP_SYS_RESOURCE",
+            "CAP_SYS_TIME",
+            "CAP_SYS_TTY_CONFIG",
+            "CAP_MKNOD",
+            "CAP_LEASE",
+            "CAP_AUDIT_WRITE",
+            "CAP_AUDIT_CONTROL",
+            "CAP_SETFCAP",
+            "CAP_MAC_OVERRIDE",
+            "CAP_MAC_ADMIN",
+            "CAP_SYSLOG",
+            "CAP_WAKE_ALARM",
+            "CAP_BLOCK_SUSPEND"
+	],
+	"rlimits": [
+	    {
+		"type": "RLIMIT_NOFILE",
+		"hard": 1024,
+		"soft": 1024
+	    }
+	],
+	"noNewPrivileges": true
+    },
+    "root": {
+	"path": "rootfs",
+	"readonly": true
+    },
+    "mounts": [
+	{
+	    "destination": "/dev",
+	    "type": "tmpfs",
+	    "source": "tmpfs",
+	    "options": [
+		"nosuid",
+		"strictatime",
+		"mode=755",
+		"size=65536k"
+	    ]
+	},
+	{
+	    "destination": "/dev/pts",
+	    "type": "devpts",
+	    "source": "devpts",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"newinstance",
+		"ptmxmode=0666",
+		"mode=0620",
+		"gid=5"
+	    ]
+	},
+	{
+	    "destination": "/dev/shm",
+	    "type": "tmpfs",
+	    "source": "shm",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev",
+		"mode=1777",
+		"size=65536k"
+	    ]
+	},
+	{
+	    "destination": "/dev/mqueue",
+	    "type": "mqueue",
+	    "source": "mqueue",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev"
+	    ]
+	},
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+	    "type": "rbind",
+	    "source": "/sys",
+	    "destination": "/sys",
+	    "options": [
+		"rbind",
+		"rw"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/usr/bin/docker-current",
+	    "destination": "/usr/bin/docker-current",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/localtime",
+	    "destination": "/etc/localtime",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/usr/bin/docker",
+	    "destination": "/usr/bin/docker",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/origin/sdn",
+	    "destination": "/etc/openshift-sdn",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/run",
+	    "destination": "/run",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/systemd/system",
+	    "destination": "/host-etc/systemd/system",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+            "type": "bind",
+            "source": "/var/run/secrets",
+            "destination": "/var/run/secrets",
+            "options": [
+                "rbind",
+                "rw",
+                "mode=755"
+            ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/lib/modules",
+	    "destination": "/lib/modules",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/origin/openvswitch",
+	    "destination": "/etc/openvswitch",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/var/lib/origin",
+	    "destination": "/var/lib/origin",
+	    "options": [
+		"rbind",
+		"rslave",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+            "type": "bind",
+            "source": "/var/lib/cni",
+            "destination": "/var/lib/cni",
+            "options": [
+                "bind",
+                "slave",
+                "rw",
+                "mode=777"
+            ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/machine-id",
+	    "destination": "/etc/machine-id",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/resolv.conf",
+	    "destination": "/etc/resolv.conf",
+	    "options": [
+		"bind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/var/lib/docker",
+	    "destination": "/var/lib/docker",
+	    "options": [
+		"bind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/var/log",
+	    "destination": "/var/log",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/",
+	    "destination": "/rootfs",
+	    "options": [
+		"rbind",
+                "rprivate",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/origin/node",
+	    "destination": "/etc/origin/node",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+	{
+	    "destination": "/tmp",
+	    "type": "tmpfs",
+	    "source": "tmpfs",
+	    "options": [
+		"mode=755",
+		"size=65536k"
+	    ]
+	}
+    ],
+    "hooks": {},
+    "linux": {
+	"rootfsPropagation" : "rslave",
+	"resources": {
+	    "devices": [
+		{
+		    "allow": false,
+		    "access": "rwm"
+		}
+	    ]
+	},
+	"namespaces": [
+	    {
+		"type": "mount"
+	    }
+	],
+	"maskedPaths": [
+	    "/proc/kcore",
+	    "/proc/latency_stats",
+	    "/proc/timer_stats",
+	    "/proc/sched_debug"
+	],
+	"readonlyPaths": [
+	    "/proc/asound",
+	    "/proc/bus",
+	    "/proc/fs",
+	    "/proc/irq",
+	    "/proc/sysrq-trigger"
+	]
+    }
+}
+

--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -1,0 +1,24 @@
+[Unit]
+After=atomic-openshift-master.service
+After=docker.service
+After=openvswitch.service
+PartOf=docker.service
+Requires=docker.service
+Requires=openvswitch.service
+Requires=$NAME-dep.service
+After=$NAME-dep.service
+
+[Service]
+EnvironmentFile=/etc/sysconfig/$NAME
+EnvironmentFile=/etc/sysconfig/$NAME-dep
+ExecStartPre=/bin/bash -c 'export -p > /run/$NAME-env'
+ExecStart=$EXEC_START
+ExecStop=$EXEC_STOP
+SyslogIdentifier=$NAME
+Restart=always
+RestartSec=5s
+WorkingDirectory=$DESTDIR
+RuntimeDirectory=${NAME}
+
+[Install]
+WantedBy=docker.service

--- a/images/node/system-container/system-container-wrapper.sh
+++ b/images/node/system-container/system-container-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+source /run/$NAME-env
+
+exec /usr/local/bin/origin-node-run.sh

--- a/images/node/system-container/tmpfiles.template
+++ b/images/node/system-container/tmpfiles.template
@@ -1,0 +1,4 @@
+d   /var/lib/origin - - - - -
+d   /var/lib/cni - - - - -
+d   /var/run/secrets - - - - -
+d   /etc/origin/sdn - - - - -

--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -18,4 +18,7 @@ LABEL io.k8s.display-name="OpenShift Origin OpenVSwitch Daemon" \
       io.k8s.description="This is a component of OpenShift Origin and runs an OpenVSwitch daemon process."
 VOLUME /etc/openswitch
 ENV HOME /root
+
+COPY system-container/config.json.template system-container/service.template /exports/
+
 ENTRYPOINT ["/usr/local/bin/ovs-run.sh"]

--- a/images/openvswitch/system-container/config.json.template
+++ b/images/openvswitch/system-container/config.json.template
@@ -1,0 +1,186 @@
+{
+    "ociVersion": "1.0.0",
+    "platform": {
+	"os": "linux",
+	"arch": "amd64"
+    },
+    "process": {
+	"terminal": false,
+	"user": {},
+	"args": [
+	    "/usr/local/bin/system-container-wrapper.sh"
+	],
+	"env": [
+            "container=docker",
+            "PKGM=yum",
+            "NAME=$NAME",
+            "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin",
+	    "TERM=xterm"
+	],
+	"cwd": "/",
+	"capabilities": [
+            "CAP_FOWNER",
+            "CAP_FSETID",
+            "CAP_KILL",
+            "CAP_SETGID",
+            "CAP_SETUID",
+            "CAP_SETPCAP",
+            "CAP_LINUX_IMMUTABLE",
+            "CAP_NET_BIND_SERVICE",
+            "CAP_NET_BROADCAST",
+            "CAP_NET_ADMIN",
+            "CAP_NET_RAW",
+            "CAP_IPC_LOCK",
+            "CAP_IPC_OWNER",
+            "CAP_SYS_MODULE",
+            "CAP_SYS_RAWIO",
+            "CAP_SYS_CHROOT",
+            "CAP_SYS_PTRACE",
+            "CAP_SYS_PACCT",
+            "CAP_SYS_ADMIN",
+            "CAP_SYS_BOOT",
+            "CAP_SYS_NICE",
+            "CAP_SYS_RESOURCE",
+            "CAP_SYS_TIME",
+            "CAP_SYS_TTY_CONFIG",
+            "CAP_MKNOD",
+            "CAP_LEASE",
+            "CAP_AUDIT_WRITE",
+            "CAP_AUDIT_CONTROL",
+            "CAP_SETFCAP",
+            "CAP_MAC_OVERRIDE",
+            "CAP_MAC_ADMIN",
+            "CAP_SYSLOG",
+            "CAP_WAKE_ALARM",
+            "CAP_BLOCK_SUSPEND"
+	],
+	"rlimits": [
+	    {
+		"type": "RLIMIT_NOFILE",
+		"hard": 1024,
+		"soft": 1024
+	    }
+	],
+	"noNewPrivileges": true
+    },
+    "root": {
+	"path": "rootfs",
+	"readonly": true
+    },
+    "mounts": [
+        {
+            "destination": "/tmp",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc"
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/run",
+	    "destination": "/run",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/lib/modules",
+	    "destination": "/lib/modules",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/origin/openvswitch",
+	    "destination": "/etc/openvswitch",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/etc/resolv.conf",
+	    "destination": "/etc/resolv.conf",
+	    "options": [
+		"bind",
+		"ro"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/dev",
+	    "destination": "/dev",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "/sys",
+	    "destination": "/sys",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        }
+    ],
+    "hooks": {},
+    "linux": {
+	"resources": {
+	    "devices": [
+		{
+		    "allow": false,
+		    "access": "rwm"
+		}
+	    ]
+	},
+	"namespaces": [
+	    {
+		"type": "mount"
+	    }
+	],
+	"maskedPaths": [
+	    "/proc/kcore",
+	    "/proc/latency_stats",
+	    "/proc/timer_stats",
+	    "/proc/sched_debug"
+	],
+	"readonlyPaths": [
+	    "/proc/asound",
+	    "/proc/bus",
+	    "/proc/fs",
+	    "/proc/irq",
+	    "/proc/sysrq-trigger"
+	]
+    }
+}

--- a/images/openvswitch/system-container/service.template
+++ b/images/openvswitch/system-container/service.template
@@ -1,0 +1,19 @@
+[Unit]
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+EnvironmentFile=/etc/sysconfig/$NAME
+ExecStartPre=/bin/bash -c 'export -p > /run/$NAME-env'
+ExecStart=$EXEC_START
+ExecStartPost=/usr/bin/sleep 5
+ExecStop=$EXEC_STOP
+SyslogIdentifier=$NAME
+Restart=always
+RestartSec=5s
+WorkingDirectory=$DESTDIR
+RuntimeDirectory=${NAME}
+
+[Install]
+WantedBy=docker.service

--- a/images/openvswitch/system-container/system-container-wrapper.sh
+++ b/images/openvswitch/system-container/system-container-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+source /run/$NAME-env
+
+exec /usr/local/bin/ovs-run.sh

--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -30,4 +30,7 @@ ENV HOME=/root \
     KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig
 WORKDIR /var/lib/origin
 EXPOSE 8443 53
+
+COPY system-container/config.json.template system-container/service.template /exports/
+
 ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/origin/Dockerfile.centos7
+++ b/images/origin/Dockerfile.centos7
@@ -24,4 +24,7 @@ ENV HOME=/root \
 VOLUME /var/lib/origin
 WORKDIR /var/lib/origin
 EXPOSE 8443 53
+
+COPY system-container/config.json.template system-container/service.template /exports/
+
 ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/origin/system-container/config.json.template
+++ b/images/origin/system-container/config.json.template
@@ -1,0 +1,199 @@
+{
+    "ociVersion": "1.0.0",
+    "platform": {
+	"os": "linux",
+	"arch": "amd64"
+    },
+    "process": {
+	"terminal": false,
+	"user": {},
+	"args": [
+            "/usr/local/bin/system-container-wrapper.sh"
+	],
+	"env": [
+            "container=docker",
+            "PKGM=yum",
+            "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin",
+            "HOME=/root",
+            "NAME=$NAME",
+            "OPENSHIFT_CONTAINERIZED=true",
+            "KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig",
+	    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	    "TERM=xterm"
+	],
+	"cwd": "/var/lib/origin",
+	"capabilities": [
+	    "CAP_AUDIT_WRITE",
+	    "CAP_KILL",
+	    "CAP_NET_BIND_SERVICE"
+	],
+	"rlimits": [
+	    {
+		"type": "RLIMIT_NOFILE",
+		"hard": 1024,
+		"soft": 1024
+	    }
+	],
+	"noNewPrivileges": true
+    },
+    "root": {
+	"path": "rootfs",
+	"readonly": true
+    },
+    "mounts": [
+	{
+	    "destination": "/proc",
+	    "type": "proc",
+	    "source": "proc"
+	},
+	{
+	    "destination": "/dev",
+	    "type": "tmpfs",
+	    "source": "tmpfs",
+	    "options": [
+		"nosuid",
+		"strictatime",
+		"mode=755",
+		"size=65536k"
+	    ]
+	},
+	{
+	    "destination": "/dev/pts",
+	    "type": "devpts",
+	    "source": "devpts",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"newinstance",
+		"ptmxmode=0666",
+		"mode=0620",
+		"gid=5"
+	    ]
+	},
+	{
+	    "destination": "/dev/shm",
+	    "type": "tmpfs",
+	    "source": "shm",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev",
+		"mode=1777",
+		"size=65536k"
+	    ]
+	},
+	{
+	    "destination": "/dev/mqueue",
+	    "type": "mqueue",
+	    "source": "mqueue",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev"
+	    ]
+	},
+	{
+	    "destination": "/sys",
+	    "type": "sysfs",
+	    "source": "sysfs",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev",
+		"ro"
+	    ]
+	},
+	{
+	    "destination": "/sys/fs/cgroup",
+	    "type": "cgroup",
+	    "source": "cgroup",
+	    "options": [
+		"nosuid",
+		"noexec",
+		"nodev",
+		"relatime",
+		"ro"
+	    ]
+	},
+        {
+	    "type": "bind",
+	    "source": "/etc/resolv.conf",
+	    "destination": "/etc/resolv.conf",
+	    "options": [
+		"rbind",
+		"ro"
+	    ]
+        },
+	{
+	    "type": "bind",
+	    "source": "/etc/origin",
+	    "destination": "/etc/origin",
+	    "options": [
+		"bind",
+		"rw",
+		"mode=755"
+	    ]
+	},
+	{
+	    "type": "bind",
+	    "source": "/var/lib/origin",
+	    "destination": "/var/lib/origin",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+	},
+        {
+            "destination": "/tmp",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+	{
+	    "type": "bind",
+	    "source": "/var/run",
+	    "destination": "/var/run",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+	}
+    ],
+    "hooks": {},
+    "linux": {
+	"resources": {
+	    "devices": [
+		{
+		    "allow": false,
+		    "access": "rwm"
+		}
+	    ]
+	},
+	"namespaces": [
+	    {
+		"type": "mount"
+	    }
+	],
+	"maskedPaths": [
+	    "/proc/kcore",
+	    "/proc/latency_stats",
+	    "/proc/timer_stats",
+	    "/proc/sched_debug"
+	],
+	"readonlyPaths": [
+	    "/proc/asound",
+	    "/proc/bus",
+	    "/proc/fs",
+	    "/proc/irq",
+	    "/proc/sys",
+	    "/proc/sysrq-trigger"
+	]
+    }
+}

--- a/images/origin/system-container/service.template
+++ b/images/origin/system-container/service.template
@@ -1,0 +1,18 @@
+[Unit]
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/$NAME
+ExecStartPre=/bin/bash -c 'export -p > /run/$NAME-env'
+ExecStart=$EXEC_START
+ExecStop=$EXEC_STOP
+SyslogIdentifier=$NAME
+Restart=always
+RestartSec=5s
+WorkingDirectory=$DESTDIR
+RuntimeDirectory=${NAME}
+
+[Install]
+WantedBy=docker.service

--- a/images/origin/system-container/system-container-wrapper.sh
+++ b/images/origin/system-container/system-container-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+source /run/$NAME-env
+
+exec /usr/bin/openshift start master --config=${CONFIG_FILE} $OPTIONS


### PR DESCRIPTION
Add the necessary files for running origin, node and openvswitch containers as [system containers](http://www.projectatomic.io/blog/2016/09/intro-to-system-containers/)

The openshift-ansible work is tracked here: https://github.com/openshift/openshift-ansible/pull/3109

These files do not change how the Docker containers work, but will enable us to start testing system containers in an easier way as it is not required to build customized images.
