### PR TITLE
Change MEMORY LIMIT parameter to be required one

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -196,7 +196,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -213,7 +213,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -196,7 +196,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -186,7 +186,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -203,7 +203,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/redis-ephemeral-template.json
+++ b/examples/db-templates/redis-ephemeral-template.json
@@ -157,7 +157,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/examples/db-templates/redis-persistent-template.json
+++ b/examples/db-templates/redis-persistent-template.json
@@ -174,7 +174,8 @@
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -2378,7 +2378,8 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -2665,7 +2666,8 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -2942,7 +2944,8 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -3475,7 +3478,8 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -3744,7 +3748,8 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -3974,7 +3979,8 @@ var _examplesDbTemplatesRedisEphemeralTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",
@@ -4199,7 +4205,8 @@ var _examplesDbTemplatesRedisPersistentTemplateJson = []byte(`{
       "name": "MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the container can use.",
-      "value": "512Mi"
+      "value": "512Mi",
+      "required": true
     },
     {
       "name": "NAMESPACE",


### PR DESCRIPTION
The memory limit parameter is a required one as if it is missing, the deployment
will fail.

Signed-off-by: Vu Dinh <vdinh@redhat.com>