### PR TITLE
Expose product-specific string literals as ldflags

### DIFF
--- a/pkg/bootstrap/docker/openshift/logging.go
+++ b/pkg/bootstrap/docker/openshift/logging.go
@@ -51,6 +51,13 @@ func instantiateTemplate(client client.Interface, mapper configcmd.Mapper, templ
 
 // InstallLogging checks whether logging is installed and installs it if not already installed
 func (h *Helper) InstallLogging(f *clientcmd.Factory, publicHostname, loggerHost, imagePrefix, imageVersion string) error {
+	if !strings.EndsWith(imagePrefix, "/") {
+		// image prefixes like "openshift/origin" require a "-"
+		// separator between the prefix and the component name
+		// whereas prefixes like "openshift3/" do not
+		imagePrefix = imagePrefix + "-"
+	}
+
 	osClient, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -119,7 +126,7 @@ func (h *Helper) InstallLogging(f *clientcmd.Factory, publicHostname, loggerHost
 	// Instantiate logging deployer
 	deployerParams := map[string]string{
 		"IMAGE_VERSION": imageVersion,
-		"IMAGE_PREFIX":  fmt.Sprintf("%s-", imagePrefix),
+		"IMAGE_PREFIX":  imagePrefix,
 		"MODE":          "install",
 	}
 	err = instantiateTemplate(osClient, clientcmd.ResourceMapper(f), "openshift", loggingDeployerTemplate, loggingNamespace, deployerParams)

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -97,6 +97,10 @@ var (
 		"rhel7":   "examples/image-streams/image-streams-rhel7.json",
 	}
 
+	// defaultImageStreams is the default key for the above imageStreams
+	// mapping. It should be set during build via -ldflags.
+	defaultImageStreams string
+
 	templateLocations = map[string]string{
 		"mongodb":                     "examples/db-templates/mongodb-persistent-template.json",
 		"mariadb":                     "examples/db-templates/mariadb-persistent-template.json",
@@ -114,6 +118,14 @@ var (
 	}
 	dockerVersion19  = semver.MustParse("1.9.0")
 	dockerVersion110 = semver.MustParse("1.10.0")
+
+	// defaultMetricsImagePrefix is the default prefix for any metrics container
+	// image names. This value should be set duing build via -ldflags.
+	defaultMetricsImagePrefix string
+
+	// defaultLoggingImagePrefix is the default prefix for any logging container
+	// image names. This value should be set duing build via -ldflags.
+	defaultLoggingImagePrefix string
 )
 
 // NewCmdUp creates a command that starts openshift on Docker with reasonable defaults
@@ -223,8 +235,8 @@ func (config *CommonStartConfig) Bind(flags *pflag.FlagSet) {
 	flags.BoolVar(&config.ShouldCreateDockerMachine, "create-machine", false, "Create a Docker machine if one doesn't exist")
 	flags.StringVar(&config.DockerMachine, "docker-machine", "", "Specify the Docker machine to use")
 	flags.StringVar(&config.ImageVersion, "version", "", "Specify the tag for OpenShift images")
-	flags.StringVar(&config.Image, "image", "openshift/origin", "Specify the images to use for OpenShift")
-	flags.StringVar(&config.ImageStreams, "image-streams", "centos7", "Specify which image streams to use, centos7|rhel7")
+	flags.StringVar(&config.Image, "image", variable.defaultImagePrefix, "Specify the images to use for OpenShift")
+	flags.StringVar(&config.ImageStreams, "image-streams", defaultImageStreams, "Specify which image streams to use, centos7|rhel7")
 	flags.BoolVar(&config.SkipRegistryCheck, "skip-registry-check", false, "Skip Docker daemon registry check")
 	flags.StringVar(&config.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
 	flags.StringVar(&config.RoutingSuffix, "routing-suffix", "", "Default suffix for server routes")
@@ -857,7 +869,7 @@ func (c *ClientStartConfig) InstallLogging(out io.Writer) error {
 	if len(publicMaster) == 0 {
 		publicMaster = c.ServerIP
 	}
-	return c.OpenShiftHelper().InstallLogging(f, publicMaster, openshift.LoggingHost(c.RoutingSuffix, c.ServerIP), c.Image, c.ImageVersion)
+	return c.OpenShiftHelper().InstallLogging(f, publicMaster, openshift.LoggingHost(c.RoutingSuffix, c.ServerIP), defaultLoggingImagePrefix, c.ImageVersion)
 }
 
 // InstallMetrics will start the installation of Metrics components
@@ -866,7 +878,7 @@ func (c *ClientStartConfig) InstallMetrics(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return c.OpenShiftHelper().InstallMetrics(f, openshift.MetricsHost(c.RoutingSuffix, c.ServerIP), c.Image, c.ImageVersion)
+	return c.OpenShiftHelper().InstallMetrics(f, openshift.MetricsHost(c.RoutingSuffix, c.ServerIP), defaultMetricsImagePrefix, c.ImageVersion)
 }
 
 // Login logs into the new server and sets up a default user and project

--- a/pkg/cmd/util/variable/imagetemplate.go
+++ b/pkg/cmd/util/variable/imagetemplate.go
@@ -20,7 +20,14 @@ type ImageTemplate struct {
 	EnvFormat string
 }
 
-const defaultImageFormat = "openshift/origin-${component}:${version}"
+var (
+	// defaultImagePrefix is the default prefix for any container image names.
+	// This value should be set duing build via -ldflags.
+	defaultImagePrefix string
+
+	defaultImageFormat = defaultImagePrefix + "-${component}:${version}"
+)
+
 const defaultImageEnvFormat = "OPENSHIFT_%s_IMAGE"
 
 // NewDefaultImageTemplate returns the default image template


### PR DESCRIPTION
Many off the diffs between the Origin and OSE distributions of the
OpenShift codebase today come from differences in constants whose
values depend on the name of the product for which the build occurs.
Exposing these diffs as ldflags keeps them out of the source code
and sequesters them into the build environment.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>