### PR TITLE
cluster up: remove hardcoded docker root mount

### DIFF
--- a/pkg/bootstrap/docker/dockerhelper/helper.go
+++ b/pkg/bootstrap/docker/dockerhelper/helper.go
@@ -96,6 +96,15 @@ var (
 	rhelPackage   = regexp.MustCompile("\\.el[0-9_]*\\.")
 )
 
+// DockerRoot returns the root directory for Docker
+func (h *Helper) DockerRoot() (string, error) {
+	info, err := h.dockerInfo()
+	if err != nil {
+		return "", nil
+	}
+	return info.DockerRootDir, nil
+}
+
 // Version returns the Docker version and whether it is a Red Hat distro version
 func (h *Helper) Version() (*semver.Version, bool, error) {
 	glog.V(5).Infof("Retrieving Docker version")

--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -46,7 +46,6 @@ var (
 		"/var/run:/var/run:rw",
 		"/sys:/sys:ro",
 		"/sys/fs/cgroup:/sys/fs/cgroup:rw",
-		"/var/lib/docker:/var/lib/docker",
 		"/dev:/dev",
 	}
 	BasePorts             = []int{4001, 7001, 8443, 10250}
@@ -94,6 +93,7 @@ type StartOptions struct {
 	HTTPSProxy               string
 	NoProxy                  []string
 	KubeconfigContents       string
+	DockerRoot               string
 }
 
 // NewHelper creates a new OpenShift helper
@@ -258,6 +258,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 		binds = append(binds, fmt.Sprintf("%[1]s:%[1]s%[2]s", opt.HostVolumesDir, propagationMode))
 	}
 	env = append(env, opt.Environment...)
+	binds = append(binds, fmt.Sprintf("%[1]s:%[1]s", opt.DockerRoot))
 	binds = append(binds, fmt.Sprintf("%s:/var/lib/origin/openshift.local.config:z", opt.HostConfigDir))
 
 	// Kubelet needs to be able to write to

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -740,6 +740,11 @@ func (c *ClientStartConfig) StartOpenShift(out io.Writer) error {
 		c.updateNoProxy()
 	}
 
+	dockerRoot, err := c.DockerHelper().DockerRoot()
+	if err != nil {
+		return err
+	}
+
 	opt := &openshift.StartOptions{
 		ServerIP:                 c.ServerIP,
 		RouterIP:                 c.RouterIP,
@@ -759,6 +764,7 @@ func (c *ClientStartConfig) StartOpenShift(out io.Writer) error {
 		HTTPProxy:                c.HTTPProxy,
 		HTTPSProxy:               c.HTTPSProxy,
 		NoProxy:                  c.NoProxy,
+		DockerRoot:               dockerRoot,
 	}
 	if c.ShouldInstallMetrics {
 		opt.MetricsHost = openshift.MetricsHost(c.RoutingSuffix, c.ServerIP)


### PR DESCRIPTION
Uses the docker root retrieved from docker info to mount that into
the origin container, instead of hardconding '/var/lib/docker'

Fixes https://github.com/openshift/origin/issues/12111