### PR TITLE
cluster up: fix port checking, Mac startup

### DIFF
--- a/pkg/bootstrap/docker/host/host.go
+++ b/pkg/bootstrap/docker/host/host.go
@@ -145,7 +145,7 @@ func (h *HostHelper) Hostname() (string, error) {
 	return strings.ToLower(strings.TrimSpace(hostname)), nil
 }
 
-func (h *HostHelper) EnsureHostDirectories() error {
+func (h *HostHelper) EnsureHostDirectories(createVolumeShare bool) error {
 	// Attempt to create host directories only if they are
 	// the default directories. If the user specifies them, then the
 	// user is responsible for ensuring they exist, are mountable, etc.
@@ -171,6 +171,9 @@ func (h *HostHelper) EnsureHostDirectories() error {
 		if err != nil || rc != 0 {
 			return errors.NewError("cannot create host volumes directory").WithCause(err)
 		}
+	}
+	if createVolumeShare {
+		return h.EnsureVolumeShare()
 	}
 	return nil
 }

--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -44,7 +44,7 @@ var (
 	openShiftContainerBinds = []string{
 		"/var/log:/var/log:rw",
 		"/var/run:/var/run:rw",
-		"/sys:/sys:ro",
+		"/sys:/sys:rw",
 		"/sys/fs/cgroup:/sys/fs/cgroup:rw",
 		"/var/lib/docker:/var/lib/docker",
 		"/dev:/dev",

--- a/pkg/bootstrap/docker/openshift/login.go
+++ b/pkg/bootstrap/docker/openshift/login.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -31,6 +32,32 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 	}
 	for k := range adminConfig.AuthInfos {
 		adminConfig.AuthInfos[k].LocationOfOrigin = ""
+	}
+	serverFound := false
+	for k := range adminConfig.Clusters {
+		adminConfig.Clusters[k].LocationOfOrigin = ""
+		if adminConfig.Clusters[k].Server == server {
+			serverFound = true
+		}
+	}
+	if !serverFound {
+		// Create a server entry and admin context for
+		// local cluster
+		for k := range adminConfig.Clusters {
+			localCluster := *adminConfig.Clusters[k]
+			localCluster.Server = server
+			adminConfig.Clusters["local-cluster"] = &localCluster
+			for u := range adminConfig.AuthInfos {
+				if strings.HasPrefix(u, "system:admin") {
+					context := kclientcmdapi.NewContext()
+					context.Cluster = "local-cluster"
+					context.AuthInfo = u
+					context.Namespace = "default"
+					adminConfig.Contexts["default/local-cluster/system:admin"] = context
+				}
+			}
+			break
+		}
 	}
 	newConfig, err := config.MergeConfig(existingConfig, *adminConfig)
 	if err != nil {


### PR DESCRIPTION
Fixes the following issues:
- won't start in a machine that has dnsmasq running
- on a clean Mac install, cluster up won't create directory shares
- login fails for Docker for Mac when non-numeric public hostname is
used.