### PR TITLE
Replace our Validator interface with upstream one

### DIFF
--- a/pkg/authorization/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/admission/restrictusers/restrictusers.go
@@ -39,7 +39,6 @@ type restrictUsersAdmission struct {
 
 var _ = oadmission.WantsOpenshiftClient(&restrictUsersAdmission{})
 var _ = oadmission.WantsGroupCache(&restrictUsersAdmission{})
-var _ = oadmission.Validator(&restrictUsersAdmission{})
 
 // NewRestrictUsersAdmission configures an admission plugin that enforces
 // restrictions on adding role bindings in a project.

--- a/pkg/build/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission.go
@@ -182,3 +182,10 @@ func (a *jenkinsBootstrapper) SetRESTClientConfig(restClientConfig restclient.Co
 func (a *jenkinsBootstrapper) SetOpenshiftClient(oclient client.Interface) {
 	a.openshiftClient = oclient
 }
+
+func (a *jenkinsBootstrapper) Validate() error {
+	if a.openshiftClient == nil {
+		return fmt.Errorf("missing openshiftClient")
+	}
+	return nil
+}

--- a/pkg/build/admission/secretinjector/admission.go
+++ b/pkg/build/admission/secretinjector/admission.go
@@ -7,15 +7,17 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	authclient "github.com/openshift/origin/pkg/auth/client"
-	buildapi "github.com/openshift/origin/pkg/build/api"
-	"github.com/openshift/origin/pkg/util/urlpattern"
 
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/client/restclient"
+
+	authclient "github.com/openshift/origin/pkg/auth/client"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
+	"github.com/openshift/origin/pkg/util/urlpattern"
 )
 
 func init() {
@@ -30,6 +32,8 @@ type secretInjector struct {
 	*admission.Handler
 	restClientConfig restclient.Config
 }
+
+var _ = oadmission.WantsRESTClientConfig(&secretInjector{})
 
 func (si *secretInjector) Admit(attr admission.Attributes) (err error) {
 	bc, ok := attr.GetObject().(*buildapi.BuildConfig)
@@ -103,4 +107,8 @@ func (si *secretInjector) Admit(attr admission.Attributes) (err error) {
 
 func (si *secretInjector) SetRESTClientConfig(restClientConfig restclient.Config) {
 	si.restClientConfig = restClientConfig
+}
+
+func (si *secretInjector) Validate() error {
+	return nil
 }

--- a/pkg/build/admission/strategyrestrictions/admission.go
+++ b/pkg/build/admission/strategyrestrictions/admission.go
@@ -27,7 +27,6 @@ type buildByStrategy struct {
 }
 
 var _ = oadmission.WantsOpenshiftClient(&buildByStrategy{})
-var _ = oadmission.Validator(&buildByStrategy{})
 
 // NewBuildByStrategy returns an admission control for builds that checks
 // on policy based on the build strategy type

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -81,7 +81,7 @@ func (i *PluginInitializer) Initialize(plugins []admission.Interface) {
 // the Validator interface.
 func Validate(plugins []admission.Interface) error {
 	for _, plugin := range plugins {
-		if validater, ok := plugin.(Validator); ok {
+		if validater, ok := plugin.(admission.Validator); ok {
 			err := validater.Validate()
 			if err != nil {
 				return err

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -1,6 +1,7 @@
 package admission
 
 import (
+	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/quota"
 
@@ -18,61 +19,65 @@ import (
 // an Openshift client
 type WantsOpenshiftClient interface {
 	SetOpenshiftClient(client.Interface)
+	admission.Validator
 }
 
 // WantsProjectCache should be implemented by admission plugins that need a
 // project cache
 type WantsProjectCache interface {
 	SetProjectCache(*cache.ProjectCache)
+	admission.Validator
 }
 
 // WantsQuotaRegistry should be implemented by admission plugins that need a quota registry
 type WantsOriginQuotaRegistry interface {
 	SetOriginQuotaRegistry(quota.Registry)
-}
-
-// Validator should be implemented by admission plugins that can validate themselves
-// after initialization has happened.
-type Validator interface {
-	Validate() error
+	admission.Validator
 }
 
 // WantsAuthorizer should be implemented by admission plugins that
 // need access to the Authorizer interface
 type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
+	admission.Validator
 }
 
 // WantsJenkinsPipelineConfig gives access to the JenkinsPipelineConfig.  This is a historical oddity.
 // It's likely that what we really wanted was this as an admission plugin config
 type WantsJenkinsPipelineConfig interface {
 	SetJenkinsPipelineConfig(jenkinsConfig configapi.JenkinsPipelineConfig)
+	admission.Validator
 }
 
 // WantsRESTClientConfig gives access to a RESTClientConfig.  It's useful for doing unusual things with transports.
 type WantsRESTClientConfig interface {
 	SetRESTClientConfig(restclient.Config)
+	admission.Validator
 }
 
 // WantsInformers should be implemented by admission plugins that will select its own informer
 type WantsInformers interface {
 	SetInformers(shared.InformerFactory)
+	admission.Validator
 }
 
 // WantsClusterQuotaMapper should be implemented by admission plugins that need to know how to map between
 // cluster quota and namespaces
 type WantsClusterQuotaMapper interface {
 	SetClusterQuotaMapper(clusterquotamapping.ClusterQuotaMapper)
+	admission.Validator
 }
 
 // WantsDefaultRegistryFunc should be implemented by admission plugins that need to know the default registry
 // address.
 type WantsDefaultRegistryFunc interface {
 	SetDefaultRegistryFunc(imageapi.DefaultRegistryFunc)
+	admission.Validator
 }
 
 // WantsGroupCache should be implemented by admission plugins that need a
 // group cache.
 type WantsGroupCache interface {
 	SetGroupCache(*usercache.GroupCache)
+	admission.Validator
 }

--- a/pkg/image/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/admission/imagepolicy/imagepolicy.go
@@ -64,7 +64,6 @@ type imagePolicyPlugin struct {
 }
 
 var _ = oadmission.WantsOpenshiftClient(&imagePolicyPlugin{})
-var _ = oadmission.Validator(&imagePolicyPlugin{})
 var _ = oadmission.WantsDefaultRegistryFunc(&imagePolicyPlugin{})
 
 type integratedRegistryMatcher struct {

--- a/pkg/project/admission/lifecycle/admission.go
+++ b/pkg/project/admission/lifecycle/admission.go
@@ -46,7 +46,6 @@ var recommendedCreatableResources = map[unversioned.GroupResource]bool{
 	authorizationapi.Resource("subjectrulesreviews"):        true,
 }
 var _ = oadmission.WantsProjectCache(&lifecycle{})
-var _ = oadmission.Validator(&lifecycle{})
 
 // Admit enforces that a namespace must have the openshift finalizer associated with it in order to create origin API objects within it
 func (e *lifecycle) Admit(a admission.Attributes) (err error) {

--- a/pkg/project/admission/nodeenv/admission.go
+++ b/pkg/project/admission/nodeenv/admission.go
@@ -28,7 +28,6 @@ type podNodeEnvironment struct {
 }
 
 var _ = oadmission.WantsProjectCache(&podNodeEnvironment{})
-var _ = oadmission.Validator(&podNodeEnvironment{})
 
 // Admit enforces that pod and its project node label selectors matches at least a node in the cluster.
 func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {

--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -69,7 +69,6 @@ type projectRequestLimit struct {
 // ensure that the required Openshift admission interfaces are implemented
 var _ = oadmission.WantsProjectCache(&projectRequestLimit{})
 var _ = oadmission.WantsOpenshiftClient(&projectRequestLimit{})
-var _ = oadmission.Validator(&projectRequestLimit{})
 
 // Admit ensures that only a configured number of projects can be requested by a particular user.
 func (o *projectRequestLimit) Admit(a admission.Attributes) (err error) {

--- a/pkg/project/admission/requestlimit/admission_test.go
+++ b/pkg/project/admission/requestlimit/admission_test.go
@@ -277,7 +277,7 @@ func TestAdmit(t *testing.T) {
 		}
 		reqLimit.(oadmission.WantsOpenshiftClient).SetOpenshiftClient(client)
 		reqLimit.(oadmission.WantsProjectCache).SetProjectCache(pCache)
-		if err = reqLimit.(oadmission.Validator).Validate(); err != nil {
+		if err = reqLimit.(admission.Validator).Validate(); err != nil {
 			t.Fatalf("validation error: %v", err)
 		}
 		err = reqLimit.Admit(admission.NewAttributesRecord(

--- a/pkg/quota/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission.go
@@ -59,7 +59,6 @@ type clusterResourceOverridePlugin struct {
 type limitRangerActions struct{}
 
 var _ = oadmission.WantsProjectCache(&clusterResourceOverridePlugin{})
-var _ = oadmission.Validator(&clusterResourceOverridePlugin{})
 var _ = limitranger.LimitRangerActions(&limitRangerActions{})
 var _ = admission.WantsInformerFactory(&clusterResourceOverridePlugin{})
 

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -54,7 +54,6 @@ type clusterQuotaAdmission struct {
 var _ oadmission.WantsInformers = &clusterQuotaAdmission{}
 var _ oadmission.WantsOpenshiftClient = &clusterQuotaAdmission{}
 var _ oadmission.WantsClusterQuotaMapper = &clusterQuotaAdmission{}
-var _ oadmission.Validator = &clusterQuotaAdmission{}
 
 const (
 	timeToWaitForCacheSync = 10 * time.Second

--- a/pkg/quota/admission/resourcequota/admission.go
+++ b/pkg/quota/admission/resourcequota/admission.go
@@ -37,7 +37,6 @@ type originQuotaAdmission struct {
 }
 
 var _ = oadmission.WantsOriginQuotaRegistry(&originQuotaAdmission{})
-var _ = oadmission.Validator(&originQuotaAdmission{})
 
 // NewOriginResourceQuota creates a new OriginResourceQuota admission plugin that takes care of admission of
 // origin resources abusing resource quota.

--- a/pkg/quota/admission/runonceduration/admission.go
+++ b/pkg/quota/admission/runonceduration/admission.go
@@ -68,7 +68,6 @@ type runOnceDuration struct {
 }
 
 var _ = oadmission.WantsProjectCache(&runOnceDuration{})
-var _ = oadmission.Validator(&runOnceDuration{})
 
 func (a *runOnceDuration) Admit(attributes admission.Attributes) error {
 	switch {

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -79,7 +79,6 @@ func shouldCheckResource(resource unversioned.GroupResource, kind unversioned.Gr
 	return true, nil
 }
 
-var _ = oadmission.Validator(&podNodeConstraints{})
 var _ = oadmission.WantsAuthorizer(&podNodeConstraints{})
 
 func readConfig(reader io.Reader) (*api.PodNodeConstraintsConfig, error) {

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	admission "k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -105,7 +105,7 @@ func TestPodNodeConstraints(t *testing.T) {
 		errPrefix := fmt.Sprintf("%d", i)
 		prc := NewPodNodeConstraints(tc.config)
 		prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
-		err := prc.(oadmission.Validator).Validate()
+		err := prc.(admission.Validator).Validate()
 		if err != nil {
 			checkAdmitError(t, err, expectedError, errPrefix)
 			continue
@@ -125,7 +125,7 @@ func TestPodNodeConstraintsPodUpdate(t *testing.T) {
 	errPrefix := "PodUpdate"
 	prc := NewPodNodeConstraints(testConfig())
 	prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
-	err := prc.(oadmission.Validator).Validate()
+	err := prc.(admission.Validator).Validate()
 	if err != nil {
 		checkAdmitError(t, err, expectedError, errPrefix)
 		return
@@ -141,7 +141,7 @@ func TestPodNodeConstraintsNonHandledResources(t *testing.T) {
 	var expectedError error
 	prc := NewPodNodeConstraints(testConfig())
 	prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
-	err := prc.(oadmission.Validator).Validate()
+	err := prc.(admission.Validator).Validate()
 	if err != nil {
 		checkAdmitError(t, err, expectedError, errPrefix)
 		return
@@ -265,7 +265,7 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 					errPrefix := fmt.Sprintf("%s; %s; %s", tr.prefix, tp.prefix, top.operation)
 					prc := NewPodNodeConstraints(tc.config)
 					prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
-					err := prc.(oadmission.Validator).Validate()
+					err := prc.(admission.Validator).Validate()
 					if err != nil {
 						checkAdmitError(t, err, expectedError, errPrefix)
 						continue

--- a/pkg/service/admission/endpoint_admission.go
+++ b/pkg/service/admission/endpoint_admission.go
@@ -58,6 +58,13 @@ func (r *restrictedEndpointsAdmission) SetAuthorizer(a authorizer.Authorizer) {
 	r.authorizer = a
 }
 
+func (r *restrictedEndpointsAdmission) Validate() error {
+	if r.authorizer == nil {
+		return fmt.Errorf("missing authorizer")
+	}
+	return nil
+}
+
 func (r *restrictedEndpointsAdmission) findRestrictedIP(ep *kapi.Endpoints) string {
 	for _, subset := range ep.Subsets {
 		for _, addr := range subset.Addresses {


### PR DESCRIPTION
One of the post-rebase tasks. Both our and upstream `Validator` interface are identical so I've removed ours and updated all other interfaces to include the `Validator` to follow the same pattern upstream has.

@deads2k || @ncdc ptal