### PR TITLE
Update `$PATH` to include `$GOPATH/bin` by default

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -106,7 +106,7 @@ readonly -f os::util::environment::setup_all_server_vars
 # Returns:
 #  - export PATH
 function os::util::environment::update_path_var() {
-    PATH="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):${PATH}"
+    PATH="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):${GOPATH}/bin:${PATH}"
     export PATH
 }
 readonly -f os::util::environment::update_path_var

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -13,7 +13,7 @@ if ! os::util::ensure::system_binary_exists 'protoc' || [[ "$(protoc --version)"
   exit 1
 fi
 
-os::util::ensure::system_binary_exists 'goimports'
+os::util::ensure::gopath_binary_exists 'goimports'
 os::build::setup_env
 
 os::util::ensure::built_binary_exists 'genprotobuf'


### PR DESCRIPTION
Search for `goimports` in `$GOPATH`, not `$PATH`

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Update `$PATH` to include `$GOPATH/bin` by default

Test scripts should not need to assume anything other than `$GOPATH`
is set. As we use binaries installed with `go get` we need to add the
`$GOPATH/bin` to our `$PATH`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
