### PR TITLE
Changed the router to default to roundrobin when weights are used

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -153,7 +153,7 @@ backend be_sni
 
 frontend fe_sni
   # terminate ssl on edge
-  bind 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
+  bind 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} ssl no-sslv3 {{ if gt (len .DefaultCertificate) 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
   mode http
 
   # check re-encrypt backends first - from most specific to general path.
@@ -187,7 +187,7 @@ backend be_no_sni
 
 frontend fe_no_sni
   # terminate ssl on edge
-  bind 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} ssl no-sslv3 {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
+  bind 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} ssl no-sslv3 {{ if gt (len .DefaultCertificate) 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
   mode http
 
   # check re-encrypt backends first - path or host based.
@@ -255,7 +255,7 @@ backend be_edge_http_{{$cfgIdx}}
       {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_LOAD_BALANCE_ALGORITHM" "")) }}
   balance {{ env "ROUTER_LOAD_BALANCE_ALGORITHM" "leastconn"}}
       {{ else }}
-  balance leastconn
+  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
@@ -337,7 +337,11 @@ backend be_tcp_{{$cfgIdx}}
   balance {{ $balanceAlgo }}
       {{ end }}
     {{ else }}
-  balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source" }}
+      {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_TCP_BALANCE_SCHEME" "")) }}
+  balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source"}}
+      {{ else }}
+  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}source{{ end }}
+      {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
@@ -403,7 +407,7 @@ backend be_secure_{{$cfgIdx}}
       {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_LOAD_BALANCE_ALGORITHM" "")) }}
   balance {{ env "ROUTER_LOAD_BALANCE_ALGORITHM" "leastconn"}}
       {{ else }}
-  balance leastconn
+  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}

--- a/test/extended/testdata/weighted-router.yaml
+++ b/test/extended/testdata/weighted-router.yaml
@@ -46,8 +46,6 @@ items:
     labels:
       test: router
       select: weighted
-    annotations:
-      haproxy.router.openshift.io/balance: roundrobin
   spec:
     host: weighted.example.com
     to:
@@ -69,8 +67,6 @@ items:
     labels:
       test: router
       select: weighted
-    annotations:
-      haproxy.router.openshift.io/balance: roundrobin
   spec:
     host: zeroweight.example.com
     to:


### PR DESCRIPTION
If the route has weights set for the services it is associated with,
then we will set the default load balance policy to RoundRobin if no
policy is set with an annotation or as a global default with an
environment variable.  Without this change the user would need to both
set the weights, and then set an annotation to change the default
balancing algorithm... which people almost always forgot to do.

For bug 1416869 (https://bugzilla.redhat.com/show_bug.cgi?id=1416869)