### PR TITLE
Increased the time the proxy will hold connections when unidling

### DIFF
--- a/pkg/proxy/unidler/unidlersocket.go
+++ b/pkg/proxy/unidler/unidlersocket.go
@@ -112,7 +112,7 @@ var (
 	// to be dropped after the limit is reached)
 	MaxHeldConnections = 16
 
-	needPodsWaitTimeout = 30 * time.Second
+	needPodsWaitTimeout = 120 * time.Second
 	needPodsTickLen     = 5 * time.Second
 )
 


### PR DESCRIPTION
Before we would wait 30 seconds for a pod to come live before dropping
the connections.  That time is too short, so we have increased it to
120 seconds.

Fixes bug 1416037 (https://bugzilla.redhat.com/show_bug.cgi?id=1416037)