### PR TITLE
Expose product-specific string literals as ldflags

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -658,6 +658,13 @@ EOF
 }
 readonly -f os::build::save_version_vars
 
+# os::build::get_product_vars exports variables that we expect to change
+# depending on the distribution of Origin
+function os::build::get_product_vars() {
+  export OS_BUILD_LDFLAGS_IMAGE_PREFIX="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+  export OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS="${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS:-"centos7"}"
+}
+
 # golang 1.5 wants `-X key=val`, but golang 1.4- REQUIRES `-X key val`
 function os::build::ldflag() {
   local key=${1}
@@ -682,11 +689,14 @@ function os::build::ldflags() {
   cd "${OS_ROOT}"
 
   os::build::get_version_vars
+  os::build::get_product_vars
 
   local buildDate="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
   declare -a ldflags=()
 
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/bootstrap/docker.defaultImageStreams" "${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/cmd/util/variable.DefaultImagePrefix" "${OS_BUILD_LDFLAGS_IMAGE_PREFIX}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.majorFromGit" "${OS_GIT_MAJOR}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.minorFromGit" "${OS_GIT_MINOR}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.versionFromGit" "${OS_GIT_VERSION}"))

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -97,6 +97,10 @@ var (
 		"rhel7":   "examples/image-streams/image-streams-rhel7.json",
 	}
 
+	// defaultImageStreams is the default key for the above imageStreams
+	// mapping. It should be set during build via -ldflags.
+	defaultImageStreams string
+
 	templateLocations = map[string]string{
 		"mongodb":                     "examples/db-templates/mongodb-persistent-template.json",
 		"mariadb":                     "examples/db-templates/mariadb-persistent-template.json",
@@ -223,8 +227,8 @@ func (config *CommonStartConfig) Bind(flags *pflag.FlagSet) {
 	flags.BoolVar(&config.ShouldCreateDockerMachine, "create-machine", false, "Create a Docker machine if one doesn't exist")
 	flags.StringVar(&config.DockerMachine, "docker-machine", "", "Specify the Docker machine to use")
 	flags.StringVar(&config.ImageVersion, "version", "", "Specify the tag for OpenShift images")
-	flags.StringVar(&config.Image, "image", "openshift/origin", "Specify the images to use for OpenShift")
-	flags.StringVar(&config.ImageStreams, "image-streams", "centos7", "Specify which image streams to use, centos7|rhel7")
+	flags.StringVar(&config.Image, "image", variable.DefaultImagePrefix, "Specify the images to use for OpenShift")
+	flags.StringVar(&config.ImageStreams, "image-streams", defaultImageStreams, "Specify which image streams to use, centos7|rhel7")
 	flags.BoolVar(&config.SkipRegistryCheck, "skip-registry-check", false, "Skip Docker daemon registry check")
 	flags.StringVar(&config.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
 	flags.StringVar(&config.RoutingSuffix, "routing-suffix", "", "Default suffix for server routes")

--- a/pkg/cmd/util/variable/imagetemplate.go
+++ b/pkg/cmd/util/variable/imagetemplate.go
@@ -20,7 +20,16 @@ type ImageTemplate struct {
 	EnvFormat string
 }
 
-const defaultImageFormat = "openshift/origin-${component}:${version}"
+var (
+	// defaultImagePrefix is the default prefix for any container image names.
+	// This value should be set duing build via -ldflags.
+	DefaultImagePrefix string
+
+	// defaultImageFormat is the default format for container image names used
+	// to run containerized components of the platform
+	defaultImageFormat = DefaultImagePrefix + "-${component}:${version}"
+)
+
 const defaultImageEnvFormat = "OPENSHIFT_%s_IMAGE"
 
 // NewDefaultImageTemplate returns the default image template


### PR DESCRIPTION
Many off the diffs between the Origin and OSE distributions of the
OpenShift codebase today come from differences in constants whose
values depend on the name of the product for which the build occurs.
Exposing these diffs as ldflags keeps them out of the source code
and sequesters them into the build environment.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>