### PR TITLE
inform port is required as part of set-probe error when port missing

### DIFF
--- a/pkg/cmd/cli/cmd/set/probe.go
+++ b/pkg/cmd/cli/cmd/set/probe.go
@@ -339,6 +339,11 @@ func (o *ProbeOptions) Run() error {
 		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, kapi.StrategicMergePatchType, patch.Patch)
 		if err != nil {
 			handlePodUpdateError(o.Err, err, "probes")
+
+			// if no port was specified, inform that one must be provided
+			if len(o.HTTPGet) > 0 && len(o.HTTPGetAction.Port.String()) == 0 {
+				fmt.Fprintf(o.Err, "\nA port must be specified as part of a url (http://127.0.0.1:3306).\nSee 'oc set probe -h' for help and examples.\n")
+			}
 			failed = true
 			continue
 		}


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1332871

```
oc set probe dc/database --liveness --get-url="http://google.com"
error: DeploymentConfig "database" is invalid

* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain at least one letter or number (a-z, 0-9)

A port must be specified as part of a url (http://127.0.0.1:3306).
See 'oc set probe -h' for help and examples.
```

cc @openshift/cli-review @mfojtik 