### PR TITLE
Build rpms on aarch64 and ppc64le

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -28,6 +28,11 @@ if [[ "${host_platform}" == "linux/ppc64le" ]]; then
   platforms+=( "linux/ppc64le" )
 fi
 
+# Special case aarch64
+if [[ "${host_platform}" == "linux/arm64" ]]; then
+  platforms+=( "linux/arm64" )
+fi
+
 # On linux platforms, build images
 if [[ "${host_platform}" == linux/* ]]; then
   image_platforms+=( "${host_platform}" )

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -358,6 +358,9 @@ function os::build::place_bins() {
         elif [[ $platform == "linux/ppc64le" ]]; then
           platform="linux/ppc64le" OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
           platform="linux/ppc64le" OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
+        elif [[ $platform == "linux/arm64" ]]; then
+          platform="linux/arm64" OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
+          platform="linux/arm64" OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
         else
           echo "++ ERROR: No release type defined for $platform"
         fi
@@ -366,6 +369,8 @@ function os::build::place_bins() {
           platform="linux/64bit" os::build::archive_tar "./*"
         elif [[ $platform == "linux/ppc64le" ]]; then
           platform="linux/ppc64le" os::build::archive_tar "./*"
+        elif [[ $platform == "linux/arm64" ]]; then
+          platform="linux/arm64" os::build::archive_tar "./*"
         else
           echo "++ ERROR: No release type defined for $platform"
         fi

--- a/origin.spec
+++ b/origin.spec
@@ -33,7 +33,12 @@
 %if 0%{?fedora} || 0%{?epel}
 %global make_redistributable 0
 %else
+# Due to library availability, redistributable builds only work on x86_64
+%ifarch x86_64
 %global make_redistributable 1
+%else
+%global make_redistributable 0
+%endif
 %endif
 }
 
@@ -203,8 +208,25 @@ of docker.  Exclude those versions of docker.
 %setup -q
 
 %build
-# Create Binaries
+%if 0%{make_redistributable}
+# Create Binaries for all supported arches
 %{os_git_vars} hack/build-cross.sh
+%else
+# Create Binaries only for building arch
+%ifarch x86_64
+  BUILD_PLATFORM="linux/amd64"
+%endif
+%ifarch %{ix86}
+  BUILD_PLATFORM="linux/386"
+%endif
+%ifarch ppc64le
+  BUILD_PLATFORM="linux/ppc64le"
+%endif
+%ifarch %{arm} aarch64
+  BUILD_PLATFORM="linux/arm64"
+%endif
+OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} hack/build-cross.sh
+%endif
 
 %install
 


### PR DESCRIPTION
Redistributable rpms will only build on x86_64 due to libraries required.
aarch64 also needs the same hack script changes that ppc64le has.