### PR TITLE
router: provide better indication of failure in ingress test

### DIFF
--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1876,7 +1876,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	// Verify that the routes are accessible
 	url := fmt.Sprintf("%s%s", routeAddress, path)
 	if err := waitForRoute(url, host, "http", nil, tr.HelloPodPath); err != nil {
-		t.Fatalf("Error accessing ingress configured route: %v", err)
+		t.Fatalf("Error accessing unsecured ingress configured route: %v", err)
 	}
 
 	// Once the unsecured route is exposed, the controller will have a cache entry for the referenced


### PR DESCRIPTION
Prompted by #12661

cc: @openshift/networking 