### PR TITLE
[WIP] Add a configuration file for the `origin-ci-tool`

### DIFF
--- a/.oct-config.yml
+++ b/.oct-config.yml
@@ -1,0 +1,7 @@
+---
+build:
+  - target: release-rpms
+download:
+  - /tmp/openshift
+environment:
+  OS_BUILD_ENV_LOCAL_DOCKER=y hack/env


### PR DESCRIPTION
The Origin CI Tool tries not to store repository-specific information in
it's source, so each repository that wants to interact with the tool
needs to expose a `.oct-config.yml` file to instruct the tool which
`make` targets support a build, and install, a test run; which files on
a remote host should be fetched when a user executes `oct download`, and
what type of wrapper should be used on the shell for user interactions.

Origin builds a full set of artifacts and images using:

    $ make release-rpms

Origin does not contain any scripts to install itself, and no simple set
of steps to run tests exist, so the `.oct-config` does not contain these
entries. Artifacts from Origin actions are stored at:

    /tmp/openshift

Origin actions should be wrapped with the release container:

    OS_BUILD_ENV_LOCAL_DOCKER=y hack/env

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>