### PR TITLE
UPSTREAM: 38527: Fail kubelet if runtime is unresponsive for 30 seconds

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -96,7 +96,7 @@ import (
 
 const (
 	// Max amount of time to wait for the container runtime to come up.
-	maxWaitForContainerRuntime = 5 * time.Minute
+	maxWaitForContainerRuntime = 30 * time.Second
 
 	// nodeStatusUpdateRetry specifies how many times kubelet retries when posting node status failed.
 	nodeStatusUpdateRetry = 5


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1418461

Related: https://github.com/kubernetes/kubernetes/pull/38527