### PR TITLE
don't use base cmd name when printing client version

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -292,7 +292,7 @@ func CommandFor(basename string) *cobra.Command {
 	case "kubectl":
 		cmd = NewCmdKubectl(basename, out)
 	default:
-		cmd = NewCommandCLI(basename, basename, in, out, errout)
+		cmd = NewCommandCLI("oc", "oc", in, out, errout)
 	}
 
 	if cmd.UsageFunc() == nil {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/12768

This patch addresses an issue where the client name will be printed as
what the "base / root" command was when invoking the "version" cmd.

**Before**
```
$ sudo ln -S $(which oc) ./newoc
$ ./newoc version
newoc v1.5.0-alpha.1+f3cb48a-659-dirty
kubernetes v1.5.2+43a9be4
features: Basic-Auth

Server https://10.13.137.149:8443
openshift v1.5.0-alpha.1+d776328-602-dirty
kubernetes v1.5.2+43a9be4
```

**After**
```
$ sudo ln -S $(which oc) ./newoc
$ ./newoc version
oc v1.5.0-alpha.1+f3cb48a-659-dirty
kubernetes v1.5.2+43a9be4
features: Basic-Auth

Server https://10.13.137.149:8443
openshift v1.5.0-alpha.1+d776328-602-dirty
kubernetes v1.5.2+43a9be4
```

cc @soltysh @openshift/cli-review 