### PR TITLE
Fixes failing router integration test

### DIFF
--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -369,9 +369,7 @@ func TestRouter(t *testing.T) {
 
 		//clean up
 		routeEvent.Type = watch.Deleted
-		endpointEvent.Type = watch.Modified
-		endpoints := endpointEvent.Object.(*kapi.Endpoints)
-		endpoints.Subsets = []kapi.EndpointSubset{}
+		endpointEvent.Type = watch.Deleted
 
 		sendTimeout(t, fakeMasterAndPod.EndpointChannel, eventString(endpointEvent), 30*time.Second)
 		sendTimeout(t, fakeMasterAndPod.RouteChannel, eventString(routeEvent), 30*time.Second)


### PR DESCRIPTION
Fix failing router integration tests - use watch.Deleted event on the endpoints to ensure we do a valid transition Deleted -> Added instead of Modified -> Added   for the events we are simulating in
the test code.

Otherwise the event queue code panics and kills the cache reflector
goroutine which causes events to never be delivered to the test router process.
fixes #12736

Associated error in the logs was 
```
I0131 15:40:08.587336       1 reflector.go:392] github.com/openshift/origin/pkg/router/controller/factory/factory.go:75: Watch close - *api.Endpoints total 1 items received
E0131 15:40:08.588072       1 runtime.go:64] Observed a panic: "Invalid state transition: MODIFIED -> ADDED" (Invalid state transition: MODIFIED -> ADDED)
```

There is a the panic is logged in 
https://github.com/openshift/origin/blob/master/pkg/client/cache/eventqueue.go#L132
which causes the cache.NewReflector goroutine  (in `pkg/router/controller/factory/factory.go`) to die off and no events get delivered in the tests causing failures further down the road.

fixes #12736 

@knobunc  PTAL  Thx 