### PR TITLE
Fix matchPattern log level

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -208,10 +208,10 @@ func matchValues(s string, allowedValues ...string) bool {
 }
 
 func matchPattern(pattern, s string) bool {
-	glog.V(4).Infof("matchPattern called with %s and %s", pattern, s)
+	glog.V(5).Infof("matchPattern called with %s and %s", pattern, s)
 	status, err := regexp.MatchString("^("+pattern+")$", s)
 	if err == nil {
-		glog.V(4).Infof("matchPattern returning status: %v", status)
+		glog.V(5).Infof("matchPattern returning status: %v", status)
 		return status
 	}
 	glog.Errorf("Error with regex pattern in call to matchPattern: %v", err)


### PR DESCRIPTION
 Fix matchPattern log level to be like debug messages - otherwise all the other messages logged at loglevel 4 get overwhelmed.

@knobunc  PTAL Thx