### PR TITLE
image(router): Add logging facility to router tmpl

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -9,7 +9,7 @@ global
   # maxconn 4096
   daemon
 {{ with (env "ROUTER_SYSLOG_ADDRESS" "") }}
-  log {{.}} local1 {{env "ROUTER_LOG_LEVEL" "warning"}}
+  log {{.}} {{env "ROUTER_LOG_FACILITY" "local1"}} {{env "ROUTER_LOG_LEVEL" "warning"}}
 {{ end}}
   ca-base /etc/ssl
   crt-base /etc/ssl


### PR DESCRIPTION
* Allow to set logging facility other than local1, defaulting to local1
unless otherwise specified

Fixes #12794 