### PR TITLE
Used `os::log` functions better in protobuf script

### DIFF
--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-if ! os::util::find::system_binary 'protoc' || [[ "$(protoc --version)" != "libprotoc 3.0."* ]]; then
-  echo "Generating protobuf requires protoc 3.0.x. Please download and"
-  echo "install the platform appropriate Protobuf package for your OS: "
-  echo
-  echo "  https://github.com/google/protobuf/releases"
-  echo
-  if [[ "${PROTO_OPTIONAL:-}" == "1" ]]; then
-    exit 0
-  fi
-  exit 1
+if [[ "${PROTO_OPTIONAL:-}" == "1" ]]; then
+  os::log::warn "Skipping protobuf generation as \$PROTO_OPTIONAL is set."
+  exit 0
+fi
+
+os::util::ensure::system_binary_exists 'protoc'
+if [[ "$(protoc --version)" != "libprotoc 3.0."* ]]; then
+  os::log::fatal "Generating protobuf requires protoc 3.0.x. Please download and
+install the platform appropriate Protobuf package for your OS:
+
+  https://github.com/google/protobuf/releases
+
+To skip protobuf generation, set \$PROTO_OPTIONAL."
 fi
 
 os::util::ensure::system_binary_exists 'goimports'


### PR DESCRIPTION
Previously it was pretty difficult to determine if the script was
exiting with a failure or not as the same error message was printed in
either case and the error message was not given a log level. These
changes should make it a lot easier to determine if the script failed
and why and also let a user know about `$PROTO_OPTIONAL` when it fails
if they wish to skip the script.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>