### PR TITLE
Correct the way that haproxy uses the secure cookie attribute

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -292,7 +292,7 @@ backend be_edge_http_{{$cfgIdx}}
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   {{ if not (matchPattern "true|TRUE" (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
-    {{ if and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "None") }}
+    {{ if and (eq $cfg.TLSTermination "edge") (ne $cfg.InsecureEdgeTerminationPolicy "Allow") }}
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
     {{ else }}
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly


### PR DESCRIPTION
the only time that we dont want a cookie flagged as secure is when the
InsecureEdgePolicy is set to Allow, currently that is not the case

This patch changes the conditional and flags cookies as secure appropriately

Bug 1412591 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1412591)