### PR TITLE
allow front proxy in front of API

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -241,6 +241,10 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.KeyFile)
 	}
 
+	if config.AuthConfig.RequestHeader != nil {
+		refs = append(refs, &config.AuthConfig.RequestHeader.ClientCA)
+	}
+
 	refs = append(refs, &config.ServiceAccountConfig.MasterCA)
 	refs = append(refs, &config.ServiceAccountConfig.PrivateKeyFile)
 	for i := range config.ServiceAccountConfig.PublicKeyFiles {
@@ -455,6 +459,21 @@ func GetOAuthClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
 	}
 
 	return allCerts, nil
+}
+
+func GetRequestHeaderClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
+	if !UseTLS(options.ServingInfo.ServingInfo) {
+		return nil, nil
+	}
+	if options.AuthConfig.RequestHeader == nil {
+		return nil, nil
+	}
+
+	certs, err := cmdutil.CertificatesFromFile(options.AuthConfig.RequestHeader.ClientCA)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s: %s", options.AuthConfig.RequestHeader.ClientCA, err)
+	}
+	return certs, nil
 }
 
 func getAPIClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -252,6 +252,10 @@ type MasterConfig struct {
 	// ServingInfo describes how to start serving
 	ServingInfo HTTPServingInfo
 
+	// AuthConfig configures authentication options in addition to the standard
+	// oauth token and client certificate authenticators
+	AuthConfig MasterAuthConfig
+
 	// CORSAllowedOrigins
 	CORSAllowedOrigins []string
 
@@ -340,6 +344,29 @@ type MasterConfig struct {
 
 	// AuditConfig holds information related to auditing capabilities.
 	AuditConfig AuditConfig
+}
+
+// MasterAuthConfig configures authentication options in addition to the standard
+// oauth token and client certificate authenticators
+type MasterAuthConfig struct {
+	// RequestHeader holds options for setting up a front proxy against the the API.  It is optional.
+	RequestHeader *RequestHeaderAuthenticationOptions
+}
+
+// RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire
+// API instead of against the /oauth endpoint.
+type RequestHeaderAuthenticationOptions struct {
+	// ClientCA is a file with the trusted signer certs.  It is required.
+	ClientCA string
+	// ClientCommonNames is a required list of common names to require a match from.
+	ClientCommonNames []string
+
+	// UsernameHeaders is the list of headers to check for user information.  First hit wins.
+	UsernameHeaders []string
+	// GroupNameHeader is the set of headers to check for group information.  All are unioned.
+	GroupHeaders []string
+	// ExtraHeaderPrefixes is the set of request header prefixes to inspect for user extra. X-Remote-Extra- is suggested.
+	ExtraHeaderPrefixes []string
 }
 
 // AuditConfig holds configuration for the audit capabilities

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -431,6 +431,15 @@ func (LocalQuota) SwaggerDoc() map[string]string {
 	return map_LocalQuota
 }
 
+var map_MasterAuthConfig = map[string]string{
+	"":              "MasterAuthConfig configures authentication options in addition to the standard oauth token and client certificate authenticators",
+	"requestHeader": "RequestHeader holds options for setting up a front proxy against the the API.  It is optional.",
+}
+
+func (MasterAuthConfig) SwaggerDoc() map[string]string {
+	return map_MasterAuthConfig
+}
+
 var map_MasterClients = map[string]string{
 	"": "MasterClients holds references to `.kubeconfig` files that qualify master clients for OpenShift and Kubernetes",
 	"openshiftLoopbackKubeConfig":                 "OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master",
@@ -446,6 +455,7 @@ func (MasterClients) SwaggerDoc() map[string]string {
 var map_MasterConfig = map[string]string{
 	"":                       "MasterConfig holds the necessary configuration options for the OpenShift master",
 	"servingInfo":            "ServingInfo describes how to start serving",
+	"authConfig":             "AuthConfig configures authentication options in addition to the standard oauth token and client certificate authenticators",
 	"corsAllowedOrigins":     "CORSAllowedOrigins",
 	"apiLevels":              "APILevels is a list of API levels that should be enabled on startup: v1 as examples",
 	"masterPublicURL":        "MasterPublicURL is how clients can access the OpenShift API server",
@@ -699,6 +709,19 @@ var map_RemoteConnectionInfo = map[string]string{
 
 func (RemoteConnectionInfo) SwaggerDoc() map[string]string {
 	return map_RemoteConnectionInfo
+}
+
+var map_RequestHeaderAuthenticationOptions = map[string]string{
+	"":                    "RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire API instead of against the /oauth endpoint.",
+	"clientCA":            "ClientCA is a file with the trusted signer certs.  It is required.",
+	"clientCommonNames":   "ClientCommonNames is a required list of common names to require a match from.",
+	"usernameHeaders":     "UsernameHeaders is the list of headers to check for user information.  First hit wins.",
+	"groupHeaders":        "GroupNameHeader is the set of headers to check for group information.  All are unioned.",
+	"extraHeaderPrefixes": "ExtraHeaderPrefixes is the set of request header prefixes to inspect for user extra. X-Remote-Extra- is suggested.",
+}
+
+func (RequestHeaderAuthenticationOptions) SwaggerDoc() map[string]string {
+	return map_RequestHeaderAuthenticationOptions
 }
 
 var map_RequestHeaderIdentityProvider = map[string]string{

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -174,6 +174,10 @@ type MasterConfig struct {
 	// ServingInfo describes how to start serving
 	ServingInfo HTTPServingInfo `json:"servingInfo"`
 
+	// AuthConfig configures authentication options in addition to the standard
+	// oauth token and client certificate authenticators
+	AuthConfig MasterAuthConfig `json:"authConfig"`
+
 	// CORSAllowedOrigins
 	CORSAllowedOrigins []string `json:"corsAllowedOrigins"`
 
@@ -262,6 +266,29 @@ type MasterConfig struct {
 
 	// AuditConfig holds information related to auditing capabilities.
 	AuditConfig AuditConfig `json:"auditConfig"`
+}
+
+// MasterAuthConfig configures authentication options in addition to the standard
+// oauth token and client certificate authenticators
+type MasterAuthConfig struct {
+	// RequestHeader holds options for setting up a front proxy against the the API.  It is optional.
+	RequestHeader *RequestHeaderAuthenticationOptions `json:"requestHeader"`
+}
+
+// RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire
+// API instead of against the /oauth endpoint.
+type RequestHeaderAuthenticationOptions struct {
+	// ClientCA is a file with the trusted signer certs.  It is required.
+	ClientCA string `json:"clientCA"`
+	// ClientCommonNames is a required list of common names to require a match from.
+	ClientCommonNames []string `json:"clientCommonNames"`
+
+	// UsernameHeaders is the list of headers to check for user information.  First hit wins.
+	UsernameHeaders []string `json:"usernameHeaders"`
+	// GroupNameHeader is the set of headers to check for group information.  All are unioned.
+	GroupHeaders []string `json:"groupHeaders"`
+	// ExtraHeaderPrefixes is the set of request header prefixes to inspect for user extra. X-Remote-Extra- is suggested.
+	ExtraHeaderPrefixes []string `json:"extraHeaderPrefixes"`
 }
 
 // AuditConfig holds configuration for the audit capabilities

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -112,6 +112,8 @@ auditConfig:
   maximumFileRetentionDays: 0
   maximumFileSizeMegabytes: 0
   maximumRetainedFiles: 0
+authConfig:
+  requestHeader: null
 controllerConfig:
   serviceServingCert:
     signer: null

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -193,6 +193,34 @@ func ValidateMasterConfig(config *api.MasterConfig, fldPath *field.Path) Validat
 
 	validationResults.Append(ValidateAuditConfig(config.AuditConfig, fldPath.Child("auditConfig")))
 
+	validationResults.Append(ValidateMasterAuthConfig(config.AuthConfig, fldPath.Child("authConfig")))
+
+	return validationResults
+}
+
+func ValidateMasterAuthConfig(config api.MasterAuthConfig, fldPath *field.Path) ValidationResults {
+	validationResults := ValidationResults{}
+
+	if config.RequestHeader == nil {
+		return validationResults
+	}
+
+	if len(config.RequestHeader.ClientCA) == 0 {
+		validationResults.AddErrors(field.Required(fldPath.Child("requestHeader.clientCA"), "must be specified for a secure connection"))
+	}
+	if len(config.RequestHeader.ClientCommonNames) == 0 {
+		validationResults.AddErrors(field.Required(fldPath.Child("requestHeader.clientCommonNames"), "must be specified for a secure connection"))
+	}
+	if len(config.RequestHeader.UsernameHeaders) == 0 {
+		validationResults.AddErrors(field.Required(fldPath.Child("requestHeader.usernameHeaders"), "must be specified for a secure connection"))
+	}
+	if len(config.RequestHeader.GroupHeaders) == 0 {
+		validationResults.AddErrors(field.Required(fldPath.Child("requestHeader.groupHeaders"), "must be specified for a secure connection"))
+	}
+	if len(config.RequestHeader.ExtraHeaderPrefixes) == 0 {
+		validationResults.AddErrors(field.Required(fldPath.Child("requestHeader.extraHeaderPrefixes"), "must be specified for a secure connection"))
+	}
+
 	return validationResults
 }
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -676,7 +676,7 @@ func newAuthenticator(config configapi.MasterConfig, restOptionsGetter restoptio
 			config.AuthConfig.RequestHeader.ExtraHeaderPrefixes,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error building front proxy auth config: %v", err)
 		}
 		topLevelAuthenticators = append(topLevelAuthenticators, requestHeaderAuthenticator)
 	}

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -13,7 +13,6 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	oauthapi "github.com/openshift/origin/pkg/oauth/api"
-	clientregistry "github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -90,6 +89,9 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 
 	// make our authorize request again, but this time our transport has properly set the auth info for the front proxy
 	req, err := http.NewRequest("GET", rawAuthorizeRequest, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	_, err = httpClient.Do(req)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -105,12 +107,6 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 		t.Errorf("Did not find code in any redirect: %v", redirectedUrls)
 	} else {
 		t.Logf("Found code %v\n", foundCode)
-	}
-}
-
-func createClient(t *testing.T, clientRegistry clientregistry.Registry, client *oauthapi.OAuthClient) {
-	if _, err := clientRegistry.CreateClient(kapi.NewContext(), client); err != nil {
-		t.Errorf("Error creating client: %v due to %v\n", client, err)
 	}
 }
 

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -1,0 +1,316 @@
+package integration
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/cmd/server/admin"
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectapiv1 "github.com/openshift/origin/pkg/project/api/v1"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestFrontProxy(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	frontProxyCAPrefix := "frontproxycatest"
+	proxyCertCommonName := "frontproxycerttest"
+	proxyUserHeader := "X-Remote-User"
+	proxyGroupHeader := "X-Remote-Group"
+
+	certDir, err := ioutil.TempDir("", "frontproxycatestdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(certDir)
+	t.Logf("cert dir is %s\n", certDir)
+
+	frontProxyClientCA, err := createCA(certDir, frontProxyCAPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyCert, err := createCert(proxyCertCommonName, certDir, frontProxyCAPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	masterConfig.AuthConfig.RequestHeader = &api.RequestHeaderAuthenticationOptions{
+		ClientCA:          frontProxyClientCA,
+		ClientCommonNames: []string{proxyCertCommonName},
+
+		// These don't get defaulted because we don't round trip config // TODO fix?
+		UsernameHeaders: []string{proxyUserHeader},
+		GroupHeaders:    []string{proxyGroupHeader},
+	}
+
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyHTTPHandler, err := newFrontProxyHandler(clusterAdminClientConfig.Host, masterConfig.ServingInfo.ClientCA, proxyUserHeader, proxyGroupHeader, proxyCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyServer := httptest.NewServer(proxyHTTPHandler)
+	defer proxyServer.Close()
+	t.Logf("front proxy server is on %v\n", proxyServer.URL)
+
+	w, err := clusterAdminClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	listProjectsRoleName := "list-projects-role"
+	if _, err := clusterAdminClient.ClusterRoles().Create(
+		&authorizationapi.ClusterRole{
+			ObjectMeta: kapi.ObjectMeta{Name: listProjectsRoleName},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule("list").Groups(projectapi.GroupName).Resources("projects").RuleOrDie(),
+			},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, username := range []string{"david", "jordan"} {
+		projectName := username + "-project"
+		if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, username); err != nil {
+			t.Fatal(err)
+		}
+		waitForAdd(projectName, w, t)
+
+		// make it so that the user can list projects without any groups
+		if _, err := clusterAdminClient.ClusterRoleBindings().Create(
+			&authorizationapi.ClusterRoleBinding{
+				ObjectMeta: kapi.ObjectMeta{Name: username + "-clusterrolebinding"},
+				Subjects: []kapi.ObjectReference{
+					{Kind: authorizationapi.UserKind, Name: username},
+				},
+				RoleRef: kapi.ObjectReference{Name: listProjectsRoleName},
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, test := range []struct {
+		name             string
+		user             user.Info
+		isUnauthorized   bool
+		expectedProjects sets.String
+	}{
+		{
+			name:           "empty user",
+			isUnauthorized: true,
+		},
+		{
+			name: "david can only see his project",
+			user: &user.DefaultInfo{
+				Name: "david",
+			},
+			expectedProjects: sets.NewString("david-project"),
+		},
+		{
+			name: "david can see all projects when given cluster admin group",
+			user: &user.DefaultInfo{
+				Name:   "david",
+				Groups: []string{bootstrappolicy.ClusterAdminGroup},
+			},
+			expectedProjects: sets.NewString(
+				"david-project",
+				"jordan-project",
+				"default",
+				"kube-system",
+				"openshift",
+				"openshift-infra",
+			),
+		},
+	} {
+		proxyHTTPHandler.setUser(test.user)
+
+		response, err := http.Get(proxyServer.URL + "/oapi/v1/projects")
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		dataString := string(data)
+
+		if test.isUnauthorized {
+			if dataString != "Unauthorized\n" || response.StatusCode != http.StatusUnauthorized {
+				t.Errorf("%s does not have unauthorized error: %d %s", test.name, response.StatusCode, dataString)
+			}
+			continue
+		}
+
+		projectList := &projectapiv1.ProjectList{}
+		if err := json.Unmarshal(data, projectList); err != nil {
+			t.Errorf("%s failed to unmarshal project list: %v %s", test.name, err, dataString)
+			continue
+		}
+
+		actualProjects := sets.NewString()
+		for _, project := range projectList.Items {
+			actualProjects.Insert(project.Name)
+		}
+
+		if !test.expectedProjects.Equal(actualProjects) {
+			t.Errorf("%s failed to list correct projects expected %v got %v %s", test.name, test.expectedProjects.List(), actualProjects.List(), dataString)
+		}
+	}
+}
+
+type frontProxyHandler struct {
+	proxier     *httputil.ReverseProxy
+	lock        sync.Mutex
+	user        user.Info
+	userHeader  string
+	groupHeader string
+}
+
+func (handler *frontProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Header.Del(handler.userHeader)
+	r.Header.Del(handler.groupHeader)
+
+	if handler.user != nil {
+		handler.lock.Lock()
+		defer handler.lock.Unlock()
+
+		r.Header.Set(handler.userHeader, handler.user.GetName())
+		for _, group := range handler.user.GetGroups() {
+			r.Header.Add(handler.groupHeader, group)
+		}
+	}
+
+	handler.proxier.ServeHTTP(w, r)
+}
+
+func (handler *frontProxyHandler) setUser(user user.Info) {
+	handler.lock.Lock()
+	defer handler.lock.Unlock()
+
+	handler.user = user
+}
+
+func newFrontProxyHandler(rawURL, clientCA, userHeader, groupHeader string, proxyCert *tls.Certificate) (*frontProxyHandler, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	rt, err := mutualAuthRoundTripper(clientCA, proxyCert)
+	if err != nil {
+		return nil, err
+	}
+	proxier := httputil.NewSingleHostReverseProxy(parsedURL)
+	proxier.Transport = rt
+	return &frontProxyHandler{
+		proxier:     proxier,
+		userHeader:  userHeader,
+		groupHeader: groupHeader,
+	}, nil
+}
+
+func mutualAuthRoundTripper(ca string, cert *tls.Certificate) (http.RoundTripper, error) {
+	caBundleBytes, err := ioutil.ReadFile(ca)
+	if err != nil {
+		return nil, err
+	}
+	bundle := x509.NewCertPool()
+	bundle.AppendCertsFromPEM(caBundleBytes)
+	tlsConfig := &tls.Config{
+		RootCAs:      bundle,
+		ClientCAs:    bundle,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		Certificates: []tls.Certificate{*cert},
+	}
+	tlsConfig.BuildNameToCertificate()
+	return &http.Transport{TLSClientConfig: tlsConfig}, nil
+}
+
+func createCert(commonName, certDir, caPrefix string) (*tls.Certificate, error) {
+	signerCertOptions := &admin.SignerCertOptions{
+		CertFile:   admin.DefaultCertFilename(certDir, caPrefix),
+		KeyFile:    admin.DefaultKeyFilename(certDir, caPrefix),
+		SerialFile: admin.DefaultSerialFilename(certDir, caPrefix),
+	}
+	clientCertOptions := &admin.CreateClientCertOptions{
+		SignerCertOptions: signerCertOptions,
+		CertFile:          admin.DefaultCertFilename(certDir, commonName),
+		KeyFile:           admin.DefaultKeyFilename(certDir, commonName),
+		ExpireDays:        crypto.DefaultCertificateLifetimeInDays,
+		User:              commonName,
+		Overwrite:         true,
+	}
+	if err := clientCertOptions.Validate(nil); err != nil {
+		return nil, err
+	}
+	certConfig, err := clientCertOptions.CreateClientCert()
+	if err != nil {
+		return nil, err
+	}
+	certBytes, keyBytes, err := certConfig.GetPEMBytes()
+	if err != nil {
+		return nil, err
+	}
+	cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
+}
+
+func createCA(certDir, caPrefix string) (string, error) {
+	createSignerCertOptions := admin.CreateSignerCertOptions{
+		CertFile:   admin.DefaultCertFilename(certDir, caPrefix),
+		KeyFile:    admin.DefaultKeyFilename(certDir, caPrefix),
+		SerialFile: admin.DefaultSerialFilename(certDir, caPrefix),
+		ExpireDays: crypto.DefaultCACertificateLifetimeInDays,
+		Name:       caPrefix,
+		Overwrite:  true,
+	}
+	if err := createSignerCertOptions.Validate(nil); err != nil {
+		return "", err
+	}
+	if _, err := createSignerCertOptions.CreateSignerCert(); err != nil {
+		return "", err
+	}
+	return createSignerCertOptions.CertFile, nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/apiserver/authenticator/authn.go
+++ b/vendor/k8s.io/kubernetes/pkg/apiserver/authenticator/authn.go
@@ -86,6 +86,8 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 			config.RequestHeaderConfig.ClientCA,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
+			[]string{},
+			[]string{},
 		)
 		if err != nil {
 			return nil, nil, err

--- a/vendor/k8s.io/kubernetes/pkg/apiserver/authenticator/authn.go
+++ b/vendor/k8s.io/kubernetes/pkg/apiserver/authenticator/authn.go
@@ -43,6 +43,11 @@ import (
 type RequestHeaderConfig struct {
 	// UsernameHeaders are the headers to check (in order, case-insensitively) for an identity. The first header with a value wins.
 	UsernameHeaders []string
+	// GroupHeaders are the headers to check (case-insensitively) for a group names.  All values will be used.
+	GroupHeaders []string
+	// ExtraHeaderPrefixes are the head prefixes to check (case-insentively) for filling in
+	// the user.Info.Extra.  All values of all matching headers will be added.
+	ExtraHeaderPrefixes []string
 	// ClientCA points to CA bundle file which is used verify the identity of the front proxy
 	ClientCA string
 	// AllowedClientNames is a list of common names that may be presented by the authenticating front proxy.  Empty means: accept any.
@@ -71,6 +76,20 @@ type AuthenticatorConfig struct {
 	RequestHeaderConfig *RequestHeaderConfig
 }
 
+func (c *RequestHeaderConfig) ToAuthenticator() (authenticator.Request, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	return headerrequest.NewSecure(
+		c.ClientCA,
+		c.AllowedClientNames,
+		c.UsernameHeaders,
+		c.GroupHeaders,
+		c.ExtraHeaderPrefixes,
+	)
+}
+
 // New returns an authenticator.Request or an error that supports the standard
 // Kubernetes authentication mechanisms.
 func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefinitions, error) {
@@ -79,22 +98,12 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 	hasBasicAuth := false
 	hasTokenAuth := false
 
-	// front-proxy, BasicAuth methods, local first, then remote
-	// Add the front proxy authenticator if requested
-	if config.RequestHeaderConfig != nil {
-		requestHeaderAuthenticator, err := headerrequest.NewSecure(
-			config.RequestHeaderConfig.ClientCA,
-			config.RequestHeaderConfig.AllowedClientNames,
-			config.RequestHeaderConfig.UsernameHeaders,
-			[]string{},
-			[]string{},
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		authenticators = append(authenticators, requestHeaderAuthenticator)
+	requestHeaderAuthenticator, err := config.RequestHeaderConfig.ToAuthenticator()
+	if err != nil {
+		return nil, nil, err
 	}
 
+	// BasicAuth methods, local first, then remote
 	if len(config.BasicAuthFile) > 0 {
 		basicAuth, err := newAuthenticatorFromBasicAuthFile(config.BasicAuthFile)
 		if err != nil {
@@ -187,27 +196,22 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 		}
 	}
 
-	if len(authenticators) == 0 {
-		if config.Anonymous {
-			return anonymous.NewAuthenticator(), &securityDefinitions, nil
-		}
+	topLevelAuthenticators := []authenticator.Request{}
+	if requestHeaderAuthenticator != nil {
+		topLevelAuthenticators = append(topLevelAuthenticators, requestHeaderAuthenticator)
+	}
+	if len(authenticators) > 0 {
+		topLevelAuthenticators = append(topLevelAuthenticators, group.NewGroupAdder(union.New(authenticators...), []string{user.AllAuthenticated}))
+	}
+	if config.Anonymous {
+		topLevelAuthenticators = append(topLevelAuthenticators, anonymous.NewAuthenticator())
 	}
 
-	switch len(authenticators) {
-	case 0:
+	if len(topLevelAuthenticators) == 0 {
 		return nil, &securityDefinitions, nil
 	}
 
-	authenticator := union.New(authenticators...)
-
-	authenticator = group.NewGroupAdder(authenticator, []string{user.AllAuthenticated})
-
-	if config.Anonymous {
-		// If the authenticator chain returns an error, return an error (don't consider a bad bearer token anonymous).
-		authenticator = union.NewFailOnError(authenticator, anonymous.NewAuthenticator())
-	}
-
-	return authenticator, &securityDefinitions, nil
+	return union.NewFailOnError(topLevelAuthenticators...), &securityDefinitions, nil
 }
 
 // IsValidServiceAccountKeyFile returns true if a valid public RSA key can be read from the given file

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
@@ -18,6 +18,7 @@ package headerrequest
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -107,7 +108,7 @@ func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string,
 func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
 	name := headerValue(req.Header, a.nameHeaders)
 	if len(name) == 0 {
-		return nil, false, nil
+		return nil, false, errors.New("proxy did not provide user information")
 	}
 	groups := allHeaderValues(req.Header, a.groupHeaders)
 	extra := newExtra(req.Header, a.extraHeaderPrefixes)

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -106,7 +106,8 @@ func NewVerifier(opts x509.VerifyOptions, auth authenticator.Request, allowedCom
 	return &Verifier{opts, auth, allowedCommonNames}
 }
 
-// AuthenticateRequest verifies the presented client certificate, then delegates to the wrapped auth
+// AuthenticateRequest verifies the presented client certificate.  If the cert and subject matches, then delegates to the wrapped auth.
+// If the cert or subject don't match, then it returns without a user as unauthenticated.
 func (a *Verifier) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
 	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
 		return nil, false, nil
@@ -122,10 +123,15 @@ func (a *Verifier) AuthenticateRequest(req *http.Request) (user.Info, bool, erro
 	}
 
 	if _, err := req.TLS.PeerCertificates[0].Verify(optsCopy); err != nil {
+		// if its an unknown cert authority, skip the error and simply don't match.
+		// otherwise, fail
+		if _, ok := err.(x509.UnknownAuthorityError); ok {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 	if err := a.verifySubject(req.TLS.PeerCertificates[0].Subject); err != nil {
-		return nil, false, err
+		return nil, false, nil
 	}
 	return a.auth.AuthenticateRequest(req)
 }

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509_test.go
@@ -757,13 +757,15 @@ func TestX509Verifier(t *testing.T) {
 			Opts:  getDefaultVerifyOptions(t),
 			Certs: getCerts(t, selfSignedCert),
 
-			ExpectErr: true,
+			ExpectOK:  false,
+			ExpectErr: false,
 		},
 
 		"server cert disallowed": {
 			Opts:  getDefaultVerifyOptions(t),
 			Certs: getCerts(t, serverCert),
 
+			ExpectOK:  false,
 			ExpectErr: true,
 		},
 		"server cert allowing non-client cert usages": {
@@ -787,7 +789,7 @@ func TestX509Verifier(t *testing.T) {
 			Certs:      getCerts(t, clientCNCert),
 
 			ExpectOK:  false,
-			ExpectErr: true,
+			ExpectErr: false,
 		},
 		"valid client cert with right CN": {
 			Opts:       getDefaultVerifyOptions(t),


### PR DESCRIPTION
This allows a front proxy to provide complete user information to our API server.  This is needed to integrate smoothly with the `kube-aggregator`.

WIP because I haven't written an integration test yet to handle the wiring.  Let's make sure we all agree this roughly right first.

@liggitt @mfojtik 
@openshift/api-review  for the config api types
@mfojtik this is probably card worthy to get it tested.
@jwforres because you hit it.