### PR TITLE
UPSTREAM: 40342: Eliminate "Unknown service type: ExternalName"

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/rest.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/rest.go
@@ -554,6 +554,8 @@ func shouldAssignNodePorts(service *api.Service) bool {
 		return true
 	case api.ServiceTypeClusterIP:
 		return false
+	case api.ServiceTypeExternalName:
+		return false
 	default:
 		glog.Errorf("Unknown service type: %v", service.Spec.Type)
 		return false


### PR DESCRIPTION
As the ExternalName service is supported, the warning message: "Unknown service type: ExternalName" should be eliminated from rest.go.