### PR TITLE
Add `$GOPATH/bin` to `$PATH` only when `$GOPATH` is set

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -106,7 +106,13 @@ readonly -f os::util::environment::setup_all_server_vars
 # Returns:
 #  - export PATH
 function os::util::environment::update_path_var() {
-    PATH="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):${GOPATH}/bin:${PATH}"
+    local prefix
+    prefix="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+    if [[ -n "${GOPATH:-}" ]]; then
+        prefix+="${GOPATH}/bin:"
+    fi
+
+    PATH="${prefix}:${PATH}"
     export PATH
 }
 readonly -f os::util::environment::update_path_var


### PR DESCRIPTION
In some build environments, the `$GOPATH` is not set and the build
scripts set one themselves. We should only add `$GOPATH/bin` to the
`$PATH` as a best-effort process.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>