### PR TITLE
Revert "Install tito from source in `openshift/origin-release`"

### DIFF
--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -23,8 +23,6 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    git clone https://github.com/dgoodwin/tito.git && \
-    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -24,8 +24,6 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    git clone https://github.com/dgoodwin/tito.git && \
-    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -24,8 +24,6 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    git clone https://github.com/dgoodwin/tito.git && \
-    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.8/Dockerfile
+++ b/images/release/golang-1.8/Dockerfile
@@ -24,8 +24,6 @@ RUN mkdir $TMPDIR && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
-    git clone https://github.com/dgoodwin/tito.git && \
-    pushd tito && yum-builddep -y tito.spec && tito build --test --rpm && rpm --upgrade --force /tmp/tito/noarch/tito*.rpm && rm -rf /tmp/tito /tito && popd && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com


### PR DESCRIPTION
This reverts commit 6fd65ca27a1777cfd2d94cd5c25a929ff4770d63. The
necessary version of `tito` is now available in EPEL, so we have no need
to install `tito` from source any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>