### PR TITLE
Changed the router default to roundrobin if non-zero weights are used

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -255,7 +255,7 @@ backend be_edge_http_{{$cfgIdx}}
       {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_LOAD_BALANCE_ALGORITHM" "")) }}
   balance {{ env "ROUTER_LOAD_BALANCE_ALGORITHM" "leastconn"}}
       {{ else }}
-  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}leastconn{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
@@ -340,7 +340,7 @@ backend be_tcp_{{$cfgIdx}}
       {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_TCP_BALANCE_SCHEME" "")) }}
   balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source"}}
       {{ else }}
-  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}source{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}
       {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
@@ -407,7 +407,7 @@ backend be_secure_{{$cfgIdx}}
       {{ if (matchPattern "roundrobin|leastconn|source" (env "ROUTER_LOAD_BALANCE_ALGORITHM" "")) }}
   balance {{ env "ROUTER_LOAD_BALANCE_ALGORITHM" "leastconn"}}
       {{ else }}
-  balance {{ if gt (len $cfg.ServiceUnitNames) 1 }}roundrobin{{ else }}leastconn{{ end }}
+  balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{ end }}
     {{ end }}
     {{ with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -598,14 +598,24 @@ func (r *templateRouter) createServiceAliasConfig(route *routeapi.Route, routeKe
 	// The router config trumps what the route asks for/wants.
 	wildcard := r.allowWildcardRoutes && wantsWildcardSupport
 
+	// Get the service units and count the active ones (with a non-zero weight)
+	serviceUnits := getServiceUnits(route)
+	activeServiceUnits := 0
+	for _, weight := range serviceUnits {
+		if weight > 0 {
+			activeServiceUnits++
+		}
+	}
+
 	config := ServiceAliasConfig{
-		Name:             route.Name,
-		Namespace:        route.Namespace,
-		Host:             route.Spec.Host,
-		Path:             route.Spec.Path,
-		IsWildcard:       wildcard,
-		Annotations:      route.Annotations,
-		ServiceUnitNames: getServiceUnits(route),
+		Name:               route.Name,
+		Namespace:          route.Namespace,
+		Host:               route.Spec.Host,
+		Path:               route.Spec.Path,
+		IsWildcard:         wildcard,
+		Annotations:        route.Annotations,
+		ServiceUnitNames:   serviceUnits,
+		ActiveServiceUnits: activeServiceUnits,
 	}
 
 	if route.Spec.Port != nil {

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -323,9 +323,11 @@ func TestCreateServiceAliasConfig(t *testing.T) {
 
 	// Basic sanity, validate more fields as necessary
 	if config.Host != route.Spec.Host || config.Path != route.Spec.Path || !compareTLS(route, config, t) ||
-		config.PreferPort != route.Spec.Port.TargetPort.String() || !reflect.DeepEqual(expectedSUs, config.ServiceUnitNames) {
+		config.PreferPort != route.Spec.Port.TargetPort.String() || !reflect.DeepEqual(expectedSUs, config.ServiceUnitNames) ||
+		config.ActiveServiceUnits != 1 {
 		t.Errorf("Route %v did not match service alias config %v", route, config)
 	}
+
 }
 
 // TestAddRoute validates that adding a route creates a service alias config and associated service units

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -52,6 +52,9 @@ type ServiceAliasConfig struct {
 	// ServiceUnitNames is a collection of services that support this route, keyed by service name
 	// and valued on the weight attached to it with respect to other entries in the map
 	ServiceUnitNames map[string]int32
+
+	// ActiveServiceUnits is a count of the service units with a non-zero weight
+	ActiveServiceUnits int
 }
 
 type ServiceAliasConfigStatus string


### PR DESCRIPTION
If the route has non-zero weights set for the services it is
associated with, then we will set the default load balance policy to
RoundRobin if no policy is set with an annotation or as a global
default with an environment variable. Without this change the user
would need to both set the weights, and then set an annotation to
change the default balancing algorithm... which people almost always
forgot to do.

For bug 1416869 (https://bugzilla.redhat.com/show_bug.cgi?id=1416869)