### PR TITLE
ipfailover - Permission denied for check and notify scripts

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -229,14 +229,6 @@ function generate_failover_config() {
   local ipaddr ; ipaddr=$(get_device_ip_address "${interface}")
   local port="${HA_MONITOR_PORT//[^0-9]/}"
 
-  # scripts may not have execute set
-  if [[ -n "${HA_CHECK_SCRIPT}" ]]; then
-    chmod +x "${HA_CHECK_SCRIPT}"
-  fi
-  if [[ -n "${HA_NOTIFY_SCRIPT}" ]]; then
-    chmod +x "${HA_NOTIFY_SCRIPT}"
-  fi
-
   echo "! Configuration File for keepalived
 
 $(generate_global_config "${HA_CONFIG_NAME}")


### PR DESCRIPTION
Reverted the last changes. chmod +x is not correct.
The fix is in adding volumes:configMap:defaultMode: 493 in the RC

bug 1408172
https://bugzilla.redhat.com/show_bug.cgi?id=1408172