### PR TITLE
UPSTREAM: <carry>: Change docker security opt separator to be compatible with 1.11+

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/securitycontext/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/securitycontext/types.go
@@ -41,9 +41,9 @@ type SecurityContextProvider interface {
 }
 
 const (
-	DockerLabelUser    string = "label:user"
-	DockerLabelRole    string = "label:role"
-	DockerLabelType    string = "label:type"
-	DockerLabelLevel   string = "label:level"
-	DockerLabelDisable string = "label:disable"
+	DockerLabelUser    string = "label=user"
+	DockerLabelRole    string = "label=role"
+	DockerLabelType    string = "label=type"
+	DockerLabelLevel   string = "label=level"
+	DockerLabelDisable string = "label=disable"
 )


### PR DESCRIPTION
Closes bug 1413100