### PR TITLE
print master config error if it exists

### DIFF
--- a/pkg/diagnostics/host/util.go
+++ b/pkg/diagnostics/host/util.go
@@ -18,15 +18,22 @@ var (
 
 func GetMasterConfig(r types.DiagnosticResult, masterConfigFile string) (*configapi.MasterConfig, error) {
 	if masterConfigLoaded { // no need to do this more than once
+		if masterConfigLoadError != nil {
+			printMasterConfigLoadError(r, masterConfigFile)
+		}
 		return masterConfig, masterConfigLoadError
 	}
 	r.Debug("DH0001", fmt.Sprintf("Looking for master config file at '%s'", masterConfigFile))
 	masterConfigLoaded = true
 	masterConfig, masterConfigLoadError = configapilatest.ReadAndResolveMasterConfig(masterConfigFile)
 	if masterConfigLoadError != nil {
-		r.Error("DH0002", masterConfigLoadError, fmt.Sprintf("Could not read master config file '%s':\n(%T) %[2]v", masterConfigFile, masterConfigLoadError))
+		printMasterConfigLoadError(r, masterConfigFile)
 	} else {
 		r.Debug("DH0003", fmt.Sprintf("Found a master config file: %[1]s", masterConfigFile))
 	}
 	return masterConfig, masterConfigLoadError
+}
+
+func printMasterConfigLoadError(r types.DiagnosticResult, masterConfigFile string) {
+	r.Error("DH0002", masterConfigLoadError, fmt.Sprintf("Could not read master config file '%s':\n(%T) %[2]v", masterConfigFile, masterConfigLoadError))
 }


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1419472

Although a MasterConfig load error is [stored globally](https://github.com/openshift/origin/blob/master/pkg/diagnostics/host/util.go#L16), it is only printed the [first time that it is encountered](https://github.com/openshift/origin/blob/master/pkg/diagnostics/host/util.go#L27) during a diagnostics check.

This patch ensures that, even if the error has already been encountered once, its message gets printed in subsequent diagnostic checks.

@openshift/cli-review @sosiouxme 