### PR TITLE
Fix OVS connection tracking in networkpolicy plugin

### DIFF
--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -75,8 +75,8 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 
 	otx := node.ovs.NewTransaction()
 	otx.AddFlow("table=21, priority=200, ip, nw_dst=%s, actions=goto_table:30", np.node.networkInfo.ServiceNetwork.String())
-	otx.AddFlow("table=21, priority=100, ip, actions=ct(commit),goto_table:30")
-	otx.AddFlow("table=80, priority=50, ip, actions=ct(commit),goto_table:81")
+	otx.AddFlow("table=21, priority=100, ip, actions=ct(commit,table=30)")
+	otx.AddFlow("table=80, priority=50, ip, actions=ct(commit,table=81)")
 	otx.AddFlow("table=81, priority=100, ip, ct_state=+trk+est, actions=output:NXM_NX_REG2[]")
 	otx.AddFlow("table=81, priority=0, actions=drop")
 	if err := otx.EndTransaction(); err != nil {


### PR DESCRIPTION
In a last-minute attempt to get Services mostly-working before submitting the original NetworkPolicy PR, I ended up breaking almost everything else. This fixes it again.

(The difference between `actions=ct(commit),goto_table:81` and the fixed `actions=ct(commit,table=81)` is that former ensures that the packet is tracked but then continues in table 81 with the original (unset) value of `ct_state`, while the latter ensures that the packet is tracked and then continues in table 81 with `ct_state` having been filled in from conntrack. In particular, this fixes it so that when a reply comes to a pod-to-pod connection, the `ct_state=+trk+est` rule will match and accept it regardless of other policies. So without the fix, any test where a pod has to send a reply to a pod it would otherwise be unable to talk to will fail.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1419393 and https://bugzilla.redhat.com/show_bug.cgi?id=1419469

@openshift/networking PTAL