### PR TITLE
Allow multicast for VNID 0

### DIFF
--- a/pkg/sdn/plugin/multitenant.go
+++ b/pkg/sdn/plugin/multitenant.go
@@ -122,9 +122,6 @@ func (mp *multiTenantPlugin) GetNamespaces(vnid uint32) []string {
 }
 
 func (mp *multiTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
-	if vnid == osapi.GlobalVNID {
-		return false
-	}
 	return mp.vnids.GetMulticastEnabled(vnid)
 }
 


### PR DESCRIPTION
The spec for this feature says that VNID 0 should just behave like all other VNIDs with multicast: you can multicast within the VNID, but you don't get the "global" effect like with unicast VNID 0 traffic. @dcbw's original code did this right, but when I added the annotation I changed it because I misremembered what behavior we'd decided on.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1419652