### PR TITLE
503 page does not show guide detail as expected.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -42,6 +42,12 @@ defaults
   log global
 {{ end }}
 
+  # To configure custom default errors, you can either uncomment the
+  # line below (server ... 127.0.0.1:8080) and point it to your custom
+  # backend service or alternatively, you can send a custom 503 error.
+  #server openshift_backend 127.0.0.1:8080
+  errorfile 503 /var/lib/haproxy/conf/error-page-503.http
+
 {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_CONNECT_TIMEOUT" "")) }}
   timeout connect {{env "ROUTER_DEFAULT_CONNECT_TIMEOUT" "5s"}}
 {{ else }}
@@ -215,11 +221,6 @@ backend openshift_default
   option forwardfor
   #option http-keep-alive
   option http-pretend-keepalive
-  # To configure custom default errors, you can either uncomment the
-  # line below (server ... 127.0.0.1:8080) and point it to your custom
-  # backend service or alternatively, you can send a custom 503 error.
-  #server openshift_backend 127.0.0.1:8080
-  errorfile 503 /var/lib/haproxy/conf/error-page-503.http
 
 ##-------------- app level backends ----------------
 {{/*


### PR DESCRIPTION
503 page does not show guide detail when endpoint is down or unready

bug: 1414657
https://bugzilla.redhat.com/show_bug.cgi?id=1414657