### PR TITLE
router: fix ingress compatibility with f5

### DIFF
--- a/pkg/router/controller/ingress.go
+++ b/pkg/router/controller/ingress.go
@@ -556,7 +556,7 @@ func GetNameForHost(name string) string {
 func GetSafeRouteName(name string) string {
 	if IsGeneratedRouteName(name) {
 		// The name of a route generated from an ingress path will contain '/', which
-		// isn't compatible with HAproxy.
+		// isn't compatible with HAproxy or F5.
 		return strings.Replace(name, "/", "_", -1)
 	}
 	return name

--- a/pkg/router/f5/plugin.go
+++ b/pkg/router/f5/plugin.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 
 	routeapi "github.com/openshift/origin/pkg/route/api"
+	"github.com/openshift/origin/pkg/router/controller"
 	"github.com/openshift/origin/pkg/util/netutils"
 )
 
@@ -320,7 +321,8 @@ func (p *F5Plugin) HandleEndpoints(eventType watch.EventType,
 // routeName returns a string that can be used as a rule name in F5 BIG-IP and
 // is distinct for the given route.
 func routeName(route routeapi.Route) string {
-	return fmt.Sprintf("openshift_route_%s_%s", route.Namespace, route.Name)
+	name := controller.GetSafeRouteName(route.Name)
+	return fmt.Sprintf("openshift_route_%s_%s", route.Namespace, name)
 }
 
 // In order to map OpenShift routes to F5 objects, we must divide routes into


### PR DESCRIPTION
f5 needs the same name conversion already used for haproxy to ensure that the names of routes generated from ingresses can be used safely.

cc: @openshift/networking 