### PR TITLE
Allow users to parameterize the image prefix

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -5,7 +5,10 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+# determine the correct tag prefix
+tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+
 # Build the base image without the default image args
-OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" openshift/origin-base
+OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" "${tag_prefix}-base"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -119,24 +119,27 @@ os::provision::install-sdn "${OS_ROOT}" "${imagedir}" "${OS_ROOT}/images/node"
 mkdir -p images/node/conf/
 cp -pf "${OS_ROOT}/contrib/systemd/openshift-sdn-ovs.conf" images/node/conf/
 
-# images that depend on scratch / centos
-image openshift/origin-pod                   images/pod
-image openshift/openvswitch                  images/openvswitch
-# images that depend on openshift/origin-base
-image openshift/origin                       images/origin
-image openshift/origin-haproxy-router        images/router/haproxy
-image openshift/origin-keepalived-ipfailover images/ipfailover/keepalived
-image openshift/origin-docker-registry       images/dockerregistry
-image openshift/origin-egress-router         images/router/egress
+# determine the correct tag prefix
+tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 
-# images that depend on openshift/origin
-image openshift/origin-gitserver             examples/gitserver
-image openshift/origin-deployer              images/deployer
-image openshift/origin-recycler              images/recycler
-image openshift/origin-docker-builder        images/builder/docker/docker-builder
-image openshift/origin-sti-builder           images/builder/docker/sti-builder
-image openshift/origin-f5-router             images/router/f5
-image openshift/node                         images/node
+# images that depend on scratch / centos
+image "${tag_prefix}-pod"                   images/pod
+image openshift/openvswitch                 images/openvswitch
+# images that depend on "${tag_prefix}-base"
+image "${tag_prefix}"                       images/origin
+image "${tag_prefix}-haproxy-router"        images/router/haproxy
+image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived
+image "${tag_prefix}-docker-registry"       images/dockerregistry
+image "${tag_prefix}-egress-router"         images/router/egress
+
+# images that depend on "${tag_prefix}
+image "${tag_prefix}-gitserver"             examples/gitserver
+image "${tag_prefix}-deployer"              images/deployer
+image "${tag_prefix}-recycler"              images/recycler
+image "${tag_prefix}-docker-builder"        images/builder/docker/docker-builder
+image "${tag_prefix}-sti-builder"           images/builder/docker/sti-builder
+image "${tag_prefix}-f5-router"             images/router/f5
+image openshift/node                        images/node
 
 # extra images (not part of infrastructure)
 image openshift/hello-openshift       examples/hello-openshift


### PR DESCRIPTION
Building a set of release images for a distribution of Origin requires
that the user initating the build using our `hack/` scripts be able to
parameterize the image prefix from `openshift/origin` to something else.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>