### PR TITLE
add --cluster and --context flag support to login

### DIFF
--- a/pkg/bootstrap/docker/openshift/login.go
+++ b/pkg/bootstrap/docker/openshift/login.go
@@ -75,5 +75,5 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 		StartingKubeConfig: newConfig,
 		PathOptions:        config.NewPathOptions(c),
 	}
-	return login.RunLogin(nil, opts)
+	return login.RunLogin(c, opts)
 }


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1419857

This patch checks the values of these two flags and updates the
current context in kubeconfig based on that value.

cc @openshift/cli-review @deads2k 