### PR TITLE
Build rpms on aarch64, ppc64le and s390x

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -28,6 +28,16 @@ if [[ "${host_platform}" == "linux/ppc64le" ]]; then
   platforms+=( "linux/ppc64le" )
 fi
 
+# Special case aarch64
+if [[ "${host_platform}" == "linux/arm64" ]]; then
+  platforms+=( "linux/arm64" )
+fi
+
+# Special case s390x
+if [[ "${host_platform}" == "linux/s390x" ]]; then
+  platforms+=( "linux/s390x" )
+fi
+
 # On linux platforms, build images
 if [[ "${host_platform}" == linux/* ]]; then
   image_platforms+=( "${host_platform}" )

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -36,6 +36,10 @@ function os::build::host_platform_friendly() {
     echo "linux-64bit"
   elif [[ $platform == "linux/ppc64le" ]]; then
     echo "linux-powerpc64"
+  elif [[ $platform == "linux/arm64" ]]; then
+    echo "linux-arm64"
+  elif [[ $platform == "linux/s390x" ]]; then
+    echo "linux-s390"
   else
     echo "$(go env GOHOSTOS)-$(go env GOHOSTARCH)"
   fi
@@ -358,11 +362,17 @@ function os::build::place_bins() {
         elif [[ $platform == "linux-powerpc64" ]]; then
           OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
           OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
+        elif [[ $platform == "linux-aarch64" ]]; then
+          OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
+          OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
+        elif [[ $platform == "linux-s390" ]]; then
+          OS_RELEASE_ARCHIVE="openshift-origin-client-tools" os::build::archive_tar "${OS_BINARY_RELEASE_CLIENT_LINUX[@]}"
+          OS_RELEASE_ARCHIVE="openshift-origin-server" os::build::archive_tar "${OS_BINARY_RELEASE_SERVER_LINUX[@]}"
         else
           echo "++ ERROR: No release type defined for $platform"
         fi
       else
-        if [[ $platform == "linux-64bit" || $platform == "linux-powerpc64" ]]; then
+        if [[ $platform == "linux-64bit" || $platform == "linux-powerpc64" || $platform == "linux-aarch64" || $platform == "linux-s390" ]]; then
           os::build::archive_tar "./*"
         else
           echo "++ ERROR: No release type defined for $platform"


### PR DESCRIPTION
Redistributable rpms will only build on x86_64 due to libraries required.
aarch64 and s390 also needs the same hack script changes that ppc64le has.