### PR TITLE
Deprecate User.groups field

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_user_api_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_user_api_v1.proto
@@ -87,7 +87,9 @@ message User {
   // Identities are the identities associated with this user
   repeated string identities = 3;
 
-  // Groups are the groups that this user is a member of
+  // Groups specifies group names this user is a member of.
+  // This field is deprecated and will be removed in a future release.
+  // Instead, create a Group object containing the name of this User.
   repeated string groups = 4;
 }
 

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -29566,7 +29566,7 @@
       "items": {
        "type": "string"
       },
-      "description": "Groups are the groups that this user is a member of"
+      "description": "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User."
      }
     }
    },

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -56446,7 +56446,7 @@
       "type": "string"
      },
      "groups": {
-      "description": "Groups are the groups that this user is a member of",
+      "description": "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
       "type": "array",
       "items": {
        "type": "string"

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -23889,7 +23889,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 					"groups": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Groups are the groups that this user is a member of",
+							Description: "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/user/api/v1/generated.proto
+++ b/pkg/user/api/v1/generated.proto
@@ -87,7 +87,9 @@ message User {
   // Identities are the identities associated with this user
   repeated string identities = 3;
 
-  // Groups are the groups that this user is a member of
+  // Groups specifies group names this user is a member of.
+  // This field is deprecated and will be removed in a future release.
+  // Instead, create a Group object containing the name of this User.
   repeated string groups = 4;
 }
 

--- a/pkg/user/api/v1/swagger_doc.go
+++ b/pkg/user/api/v1/swagger_doc.go
@@ -53,7 +53,7 @@ var map_User = map[string]string{
 	"metadata":   "Standard object's metadata.",
 	"fullName":   "FullName is the full name of user",
 	"identities": "Identities are the identities associated with this user",
-	"groups":     "Groups are the groups that this user is a member of",
+	"groups":     "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
 }
 
 func (User) SwaggerDoc() map[string]string {

--- a/pkg/user/api/v1/types.go
+++ b/pkg/user/api/v1/types.go
@@ -25,7 +25,9 @@ type User struct {
 	// Identities are the identities associated with this user
 	Identities []string `json:"identities" protobuf:"bytes,3,rep,name=identities"`
 
-	// Groups are the groups that this user is a member of
+	// Groups specifies group names this user is a member of.
+	// This field is deprecated and will be removed in a future release.
+	// Instead, create a Group object containing the name of this User.
 	Groups []string `json:"groups" protobuf:"bytes,4,rep,name=groups"`
 }
 


### PR DESCRIPTION
We meant to deprecate this in 1.1 when we introduced the Group object, and forgot.

It causes confusion, and is not where we would want per-session group membership to live (that would likely go on an identity or token object instead).

Mark as deprecated now so we can migrate/remove it in a few releases.