### PR TITLE
Sort `List` for virtual resources

### DIFF
--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -3,6 +3,7 @@ package policybased
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
@@ -64,6 +65,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runt
 		}
 	}
 
+	sort.Sort(byName(roleList.Items))
 	return roleList, nil
 }
 
@@ -282,3 +284,9 @@ func NewEmptyPolicy(namespace string) *authorizationapi.Policy {
 
 	return policy
 }
+
+type byName []authorizationapi.Role
+
+func (r byName) Len() int           { return len(r) }
+func (r byName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r byName) Less(i, j int) bool { return r[i].Name < r[j].Name }

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -3,6 +3,7 @@ package policybased
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
@@ -71,6 +72,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, options *kapi.ListOptions) (runt
 		}
 	}
 
+	sort.Sort(byName(roleBindingList.Items))
 	return roleBindingList, nil
 }
 
@@ -338,3 +340,9 @@ func (m *VirtualStorage) getPolicyBindingOwningRoleBinding(ctx kapi.Context, bin
 
 	return nil, kapierrors.NewNotFound(m.Resource, bindingName)
 }
+
+type byName []authorizationapi.RoleBinding
+
+func (r byName) Len() int           { return len(r) }
+func (r byName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r byName) Less(i, j int) bool { return r[i].Name < r[j].Name }

--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -447,7 +447,7 @@ func (ac *AuthorizationCache) List(userInfo user.Info) (*kapi.NamespaceList, err
 	}
 
 	namespaceList := &kapi.NamespaceList{}
-	for key := range keys {
+	for _, key := range keys.List() {
 		namespaceObj, exists, err := ac.namespaceStore.GetByKey(key)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #12792

```
$ oc get clusterrole
NAME
admin
basic-user
cluster-admin
cluster-reader
cluster-status
edit
registry-admin
registry-editor
registry-viewer
self-access-reviewer
self-provisioner
storage-admin
sudoer
system:build-controller
system:build-strategy-custom
system:build-strategy-docker
system:build-strategy-jenkinspipeline
system:build-strategy-source
system:certificate-signing-controller
system:daemonset-controller
system:deployer
system:deployment-controller
system:deploymentconfig-controller
system:discovery
system:disruption-controller
system:endpoint-controller
system:gc-controller
system:hpa-controller
system:image-auditor
system:image-builder
system:image-pruner
system:image-puller
system:image-pusher
system:image-signer
system:job-controller
system:master
system:namespace-controller
system:node
system:node-admin
system:node-bootstrapper
system:node-proxier
system:node-reader
system:oauth-token-deleter
system:pv-attach-detach-controller
system:pv-binder-controller
system:pv-provisioner-controller
system:pv-recycler-controller
system:registry
system:replicaset-controller
system:replication-controller
system:router
system:sdn-manager
system:sdn-reader
system:service-ingress-ip-controller
system:service-load-balancer-controller
system:service-serving-cert-controller
system:statefulset-controller
system:unidling-controller
system:webhook
view
```

@smarterclayton PTAL

Signed-off-by: Monis Khan <mkhan@redhat.com>