### PR TITLE
deploy: bump number of retries in trigger integration test

### DIFF
--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -18,7 +18,7 @@ import (
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
-const maxUpdateRetries = 5
+const maxUpdateRetries = 10
 
 func TestTriggers_manual(t *testing.T) {
 	const namespace = "test-triggers-manual"


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/11772

Note that this is just a band-aid fix, the more reasonable fix is to switch to use Patch() when updating the env vars in deployment config (we do Patch() now in edit/set/etc.). However the legacy client used in integration suite does not have Patch() defined for DeploymentConfig.

Spawned https://github.com/openshift/origin/issues/12883 to track this tech debt.