### PR TITLE
Revert "e2e test: remove PodCheckDns flake"

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -410,10 +410,7 @@ os::cmd::expect_success_and_text 'oc logs --previous dc/failing-dc-mid'  'test m
 
 os::log::info "Run pod diagnostics"
 # Requires a node to run the origin-deployer pod; expects registry deployed, deployer image pulled
-# TODO: Find out why this would flake expecting PodCheckDns to run
-# https://github.com/openshift/origin/issues/9888
-#os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
-os::cmd::expect_success_and_not_text "oadm diagnostics DiagnosticPod --images='${USE_IMAGES}'" ERROR
+os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
 
 os::log::info "Applying STI application config"
 os::cmd::expect_success "oc create -f ${STI_CONFIG_FILE}"


### PR DESCRIPTION
This reverts commit 2e901a59b3d9133a60db3c58ebd77b64173d09e7.

@sosiouxme ptal since you originally authored that and I see this bug has been closed long ago.