### PR TITLE
Add a new cluster-debugger role and enable debugging on masters

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -49,6 +49,7 @@ const (
 	SudoerRoleName             = "sudoer"
 	ClusterReaderRoleName      = "cluster-reader"
 	StorageAdminRoleName       = "storage-admin"
+	ClusterDebuggerRoleName    = "cluster-debugger"
 	AdminRoleName              = "admin"
 	EditRoleName               = "edit"
 	ViewRoleName               = "view"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -206,6 +206,20 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: ClusterDebuggerRoleName,
+				Annotations: map[string]string{
+					roleSystemOnly: roleIsSystemOnly,
+				},
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:           sets.NewString("get"),
+					NonResourceURLs: sets.NewString("/metrics", "/debug/pprof", "/debug/pprof/*"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: BuildStrategyDockerRoleName,
 				Annotations: map[string]string{
 					roleSystemOnly: roleIsSystemOnly,

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -104,7 +104,7 @@ func BuildDefaultAPIServer(options configapi.MasterConfig) (*apiserveroptions.Se
 	server.GenericServerRunOptions.AnonymousAuth = true
 	server.GenericServerRunOptions.ServiceClusterIPRange = net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 	server.GenericServerRunOptions.ServiceNodePortRange = *portRange
-	server.GenericServerRunOptions.EnableProfiling = false
+	server.GenericServerRunOptions.EnableProfiling = true
 	server.GenericServerRunOptions.MasterCount = options.KubernetesMasterConfig.MasterCount
 
 	server.GenericServerRunOptions.SecurePort = port

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -392,6 +392,23 @@ items:
     annotations:
       authorization.openshift.io/system-only: "true"
     creationTimestamp: null
+    name: cluster-debugger
+  rules:
+  - apiGroups: null
+    attributeRestrictions: null
+    nonResourceURLs:
+    - /debug/pprof
+    - /debug/pprof/*
+    - /metrics
+    resources: []
+    verbs:
+    - get
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
     name: system:build-strategy-docker
   rules:
   - apiGroups:


### PR DESCRIPTION
In order to better allow clusters to be instrumented, it should be
possible for the cluster admin to control access to the debugging
endpoint using our normal privilege roles (the kubelet already checks
this), vs having special local ports (OPENSHIFT_PROFILE=web) which are
dangerous to expose to all users.  Add a new role that has only
permission for the debug endpoints and for the metrics endpoint.

[test] @deads2k