### PR TITLE
Wait for the `kubernetes` service on server start

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -295,6 +295,7 @@ function os::start::master() {
 	os::test::junit::declare_suite_start "setup/start-master"
 	os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
 	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
+	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 
 	os::log::info "OpenShift server health checks done at: "
@@ -351,6 +352,7 @@ function os::start::all_in_one() {
 	os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
 	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 2 * minute )) 0.5
 	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
+	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 160 * second )) 0.25
 	os::cmd::try_until_success "oc get --raw /api/v1/nodes/${KUBELET_HOST} --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 80 * second )) 0.25
 	os::test::junit::declare_suite_end
 


### PR DESCRIPTION
When starting the server for tests, we seem to race against the core
machinery to start services like the router and registry. If we manage
to start a pod before the core `kubernetes` service is up, environment
variables like `$KUBERNETES_SERVICE_HOST` and `$KUBERNETES_SERVICE_PORT`
are not present and the pod fails if it expected them. By waiting for
the `kubernetes` service, we should remove this race on server start.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>