### PR TITLE
Handle the edge cases where an eventqueue method panics 

### DIFF
--- a/pkg/router/controller/factory/event_queue_trapper.go
+++ b/pkg/router/controller/factory/event_queue_trapper.go
@@ -1,0 +1,122 @@
+package factory
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	oscache "github.com/openshift/origin/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// TrapperFunc defines the signature for a EventQueueTrapperFunc.
+type TrapperFunc func()
+
+// EventQueueTrapper is a Store implementation that catches failures in
+// the underlying EventQueue and calls the trapper function.
+type EventQueueTrapper struct {
+	queue   *oscache.EventQueue
+	trapper TrapperFunc
+}
+
+// NewEventQueueTrapper returns a new EventQueueTrapper.
+func NewEventQueueTrapper(queue *oscache.EventQueue, trapper TrapperFunc) *EventQueueTrapper {
+	return &EventQueueTrapper{queue, trapper}
+}
+
+// trapHandler checks if the event queue code executed in a goroutine traps
+// and if so, exits the program.
+func (t *EventQueueTrapper) trapHandler() {
+	if r := recover(); r != nil {
+		glog.Errorf("EventQueueTrapper handler caught a panic")
+
+		if t.trapper == nil {
+			os.Exit(70) // Internal software error.
+		}
+
+		t.trapper()
+	}
+}
+
+// Add enqueues a watch.Added event for the given state.
+func (t *EventQueueTrapper) Add(obj interface{}) error {
+	defer t.trapHandler()
+	return t.queue.Add(obj)
+}
+
+// Update enqueues a watch.Modified event for the given state.
+func (t *EventQueueTrapper) Update(obj interface{}) error {
+	defer t.trapHandler()
+	return t.queue.Update(obj)
+}
+
+// Delete enqueues a watch.Delete event for the given object.
+func (t *EventQueueTrapper) Delete(obj interface{}) error {
+	defer t.trapHandler()
+	return t.queue.Delete(obj)
+}
+
+// List returns a list of all enqueued items.
+func (t *EventQueueTrapper) List() []interface{} {
+	defer t.trapHandler()
+	return t.queue.List()
+}
+
+// ListKeys returns all enqueued keys.
+func (t *EventQueueTrapper) ListKeys() []string {
+	defer t.trapHandler()
+	return t.queue.ListKeys()
+}
+
+// Get returns the requested item, or sets exists=false.
+func (t *EventQueueTrapper) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	defer t.trapHandler()
+	return t.queue.Get(obj)
+}
+
+// GetByKey returns the requested item, or sets exists=false.
+func (t *EventQueueTrapper) GetByKey(key string) (item interface{}, exists bool, err error) {
+	defer t.trapHandler()
+	return t.queue.GetByKey(key)
+}
+
+// Replace initializes 'eq' with the state contained in the given map and
+// populates the queue with a watch.Modified event for each of the replaced
+// objects.  The backing store takes ownership of keyToObjs; you should not
+// reference the map again after calling this function.
+func (t *EventQueueTrapper) Replace(objects []interface{}, resourceVersion string) error {
+	defer t.trapHandler()
+	return t.queue.Replace(objects, resourceVersion)
+}
+
+// Resync will touch all objects to put them into the processing queue
+func (t *EventQueueTrapper) Resync() error {
+	defer t.trapHandler()
+	return t.queue.Resync()
+}
+
+// Pop gets the event and object at the head of the queue.  If the event
+// is a delete event, Pop deletes the key from the underlying cache.
+func (t *EventQueueTrapper) Pop() (watch.EventType, interface{}, error) {
+	defer t.trapHandler()
+	return t.queue.Pop()
+}
+
+// ListSuccessfulAtLeastOnce indicates whether a List operation was
+// successfully completed regardless of whether any items were queued.
+func (t *EventQueueTrapper) ListSuccessfulAtLeastOnce() bool {
+	defer t.trapHandler()
+	return t.queue.ListSuccessfulAtLeastOnce()
+}
+
+// ListCount returns how many objects were queued by the most recent List operation.
+func (t *EventQueueTrapper) ListCount() int {
+	defer t.trapHandler()
+	return t.queue.ListCount()
+}
+
+// ListConsumed indicates whether the items queued by a List/Relist
+// operation have been consumed.
+func (t *EventQueueTrapper) ListConsumed() bool {
+	defer t.trapHandler()
+	return t.queue.ListConsumed()
+}

--- a/pkg/router/controller/factory/event_queue_trapper_test.go
+++ b/pkg/router/controller/factory/event_queue_trapper_test.go
@@ -1,0 +1,256 @@
+package factory
+
+import (
+	"testing"
+
+	oscache "github.com/openshift/origin/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type cacheable struct {
+	key   string
+	value interface{}
+}
+
+func keyFunc(obj interface{}) (string, error) {
+	return obj.(cacheable).key, nil
+}
+
+func createNewInstance() *EventQueueTrapper {
+	q := oscache.NewEventQueue(keyFunc)
+	return NewEventQueueTrapper(q, nil)
+}
+
+func EventQueueTrapper_basic(t *testing.T) {
+	q := createNewInstance()
+
+	const amount = 500
+	go func() {
+		for i := 0; i < amount; i++ {
+			q.Add(cacheable{string([]rune{'a', rune(i)}), i + 1})
+		}
+	}()
+	go func() {
+		for u := uint(0); u < amount; u++ {
+			q.Add(cacheable{string([]rune{'b', rune(u)}), u + 1})
+		}
+	}()
+
+	lastInt := int(0)
+	lastUint := uint(0)
+	for i := 0; i < amount*2; i++ {
+		_, obj, _ := q.Pop()
+		value := obj.(cacheable).value
+		switch v := value.(type) {
+		case int:
+			if v <= lastInt {
+				t.Errorf("got %v (int) out of order, last was %v", v, lastInt)
+			}
+			lastInt = v
+		case uint:
+			if v <= lastUint {
+				t.Errorf("got %v (uint) out of order, last was %v", v, lastUint)
+			} else {
+				lastUint = v
+			}
+		default:
+			t.Fatalf("unexpected type %#v", obj)
+		}
+	}
+}
+
+func EventQueueTrapper_initialEventIsDelete(t *testing.T) {
+	q := createNewInstance()
+
+	q.Replace([]interface{}{
+		cacheable{"foo", 2},
+	}, "1")
+
+	q.Delete(cacheable{key: "foo"})
+
+	event, thing, _ := q.Pop()
+
+	value := thing.(cacheable).value
+	if value != 2 {
+		t.Fatalf("expected %v, got %v", 2, thing)
+	}
+
+	if event != watch.Deleted {
+		t.Fatalf("expected %s, got %s", watch.Added, event)
+	}
+}
+
+func EventQueueTrapper_compressAddDelete(t *testing.T) {
+	q := createNewInstance()
+
+	q.Add(cacheable{"foo", 10})
+	q.Delete(cacheable{key: "foo"})
+	q.Add(cacheable{"zab", 30})
+
+	event, thing, _ := q.Pop()
+
+	value := thing.(cacheable).value
+	if value != 30 {
+		t.Fatalf("expected %v, got %v", 30, value)
+	}
+
+	if event != watch.Added {
+		t.Fatalf("expected %s, got %s", watch.Added, event)
+	}
+}
+
+func EventQueueTrapper_compressAddUpdate(t *testing.T) {
+	q := createNewInstance()
+
+	q.Add(cacheable{"foo", 10})
+	q.Update(cacheable{"foo", 11})
+
+	event, thing, _ := q.Pop()
+	value := thing.(cacheable).value
+	if value != 11 {
+		t.Fatalf("expected %v, got %v", 11, value)
+	}
+
+	if event != watch.Added {
+		t.Fatalf("expected %s, got %s", watch.Added, event)
+	}
+}
+
+func EventQueueTrapper_compressTwoUpdates(t *testing.T) {
+	q := createNewInstance()
+
+	q.Replace([]interface{}{
+		cacheable{"foo", 2},
+	}, "1")
+
+	q.Update(cacheable{"foo", 3})
+	q.Update(cacheable{"foo", 4})
+
+	event, thing, _ := q.Pop()
+	value := thing.(cacheable).value
+	if value != 4 {
+		t.Fatalf("expected %v, got %v", 4, value)
+	}
+
+	if event != watch.Modified {
+		t.Fatalf("expected %s, got %s", watch.Modified, event)
+	}
+}
+
+func EventQueueTrapper_compressUpdateDelete(t *testing.T) {
+	q := createNewInstance()
+
+	q.Replace([]interface{}{
+		cacheable{"foo", 2},
+	}, "1")
+
+	q.Update(cacheable{"foo", 3})
+	q.Delete(cacheable{key: "foo"})
+
+	event, thing, _ := q.Pop()
+	value := thing.(cacheable).value
+	if value != 3 {
+		t.Fatalf("expected %v, got %v", 3, value)
+	}
+
+	if event != watch.Deleted {
+		t.Fatalf("expected %s, got %s", watch.Deleted, event)
+	}
+}
+
+func EventQueueTrapper_modifyEventsFromReplace(t *testing.T) {
+	q := createNewInstance()
+
+	q.Replace([]interface{}{
+		cacheable{"foo", 2},
+	}, "1")
+
+	q.Update(cacheable{"foo", 2})
+
+	event, thing, _ := q.Pop()
+	value := thing.(cacheable).value
+	if value != 2 {
+		t.Fatalf("expected %v, got %v", 2, value)
+	}
+
+	if event != watch.Modified {
+		t.Fatalf("expected %s, got %s", watch.Modified, event)
+	}
+}
+
+func EventQueueTrapper_ListConsumed(t *testing.T) {
+	q := createNewInstance()
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queue creation")
+	}
+
+	q.Replace([]interface{}{}, "1")
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after Replace() without items")
+	}
+
+	items := []interface{}{
+		cacheable{"foo", 2},
+	}
+	q.Replace(items, "1")
+	if q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be false after Replace() with items")
+	}
+
+	// Delete() only results in the removal of a queued item if it is
+	// of event type watch.Add.  Since items added by Replace() are of
+	// type watch.Modified, calling Delete() on those items will
+	// change the event type but not remove them from the queue.
+	q.Delete(items[0])
+	if q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be false after Delete()")
+	}
+
+	q.Pop()
+	if !q.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queued items read")
+	}
+}
+
+func EventQueueTrapper_trapErrors(t *testing.T) {
+	occurred := false
+	trapper := func() {
+		occurred = true
+	}
+
+	unsafeQueue := oscache.NewEventQueue(keyFunc)
+	q := NewEventQueueTrapper(unsafeQueue, trapper)
+
+	var err error
+
+	if err = q.Add(cacheable{"trap1", 1.0}); err != nil {
+		t.Fatalf("initial queue add failed: %s", err)
+	}
+
+	if err = q.Delete(cacheable{key: "trap1"}); err != nil {
+		t.Fatalf("queue delete failed: %s", err)
+	}
+
+	if err = q.Update(cacheable{"trap1", 1.1}); err != nil {
+		t.Fatalf("queue update failed: %s", err)
+	}
+	if err = q.Update(cacheable{"trap1", 1.2}); err != nil {
+		t.Fatalf("queue update #2 failed: %s", err)
+	}
+
+	if err = q.Delete(cacheable{key: "trap1"}); err != nil {
+		t.Fatalf("queue delete #2 failed: %s", err)
+	}
+
+	if err = q.Add(cacheable{"trap1", 2.0}); err != nil {
+		t.Fatalf("queue add #2 failed: %s", err)
+	}
+
+	if err = q.Delete(cacheable{key: "trap1"}); err != nil {
+		t.Fatalf("queue delete #3 failed: %s", err)
+	}
+
+	if !occurred {
+		t.Fatalf("expected the store trapper to catch an error")
+	}
+}

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"time"
 
@@ -59,7 +60,14 @@ func NewDefaultRouterControllerFactory(oc osclient.RoutesNamespacer, kc kclients
 // Create begins listing and watching against the API server for the desired route and endpoint
 // resources. It spawns child goroutines that cannot be terminated.
 func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes, enableIngress bool) *controller.RouterController {
-	routeEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	// EventQueue dies on certain event transitions - add a temporary
+	// hack/wrapper to catch those and kill the router otherwise the
+	// router will never get any updates after the goroutine crashes.
+	unsafeRouteEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	routeEventQueue := NewEventQueueTrapper(unsafeRouteEventQueue, func() {
+		os.Exit(70)
+	})
+
 	cache.NewReflector(&routeLW{
 		client:    factory.OSClient,
 		namespace: factory.Namespace,


### PR DESCRIPTION
Temporary band aid fix for bugz: https://bugzilla.redhat.com/show_bug.cgi?id=1419771

Since it was a bit too late to get the event queue code switched to use a work queue - this is a defensive fix if we want to put it in. 

When the event queue panic[k]s (ala see test case[s] below), don't leave the router process running because that router instance will never get any events. Instead kill the router and let it get restarted.

@knobunc @smarterclayton  PTAL   Thx

Couldn't reproduce the bug but I could simulate it via this test: https://gist.github.com/ramr/38423bad348846b743fcd8afba7533dd

And this test case/script also causes the same issue to manifest itself. You may have to run it a few times but normally within 2-3 attempts I can simulate it.
Test case:  https://gist.github.com/ramr/58dbdc3c5982db7b3c3154eb4bca60c8
`$  ./reproduce-eq-panic.sh [<route-json-yaml-file>]`