### PR TITLE
cluster up: add the STARTUP_TIMEOUT environment variable to the metrics deployer

### DIFF
--- a/pkg/bootstrap/docker/openshift/metrics.go
+++ b/pkg/bootstrap/docker/openshift/metrics.go
@@ -146,6 +146,10 @@ func metricsDeployerJob(hostName, imagePrefix, imageVersion string) *kbatch.Job 
 			Name:  "METRIC_RESOLUTION",
 			Value: "10s",
 		},
+		{
+			Name:  "STARTUP_TIMEOUT",
+			Value: "500",
+		},
 	}
 	podSpec := kapi.PodSpec{
 		DNSPolicy:          kapi.DNSClusterFirst,


### PR DESCRIPTION
The latest metrics deployer requires this environment variable
(See https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_hosted_templates/files/v1.5/origin/metrics-deployer.yaml#L166-L168)