### PR TITLE
containerName shouldn't be hardcoded as it depends on the NAME parameter

### DIFF
--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -165,7 +165,7 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "rails-pgsql-persistent"
+                "${NAME}"
               ],
               "from": {
                 "kind": "ImageStreamTag",
@@ -191,7 +191,7 @@
           "spec": {
             "containers": [
               {
-                "name": "rails-pgsql-persistent",
+                "name": "${NAME}",
                 "image": " ",
                 "ports": [
                   {

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -10604,7 +10604,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "rails-pgsql-persistent"
+                "${NAME}"
               ],
               "from": {
                 "kind": "ImageStreamTag",
@@ -10630,7 +10630,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
           "spec": {
             "containers": [
               {
-                "name": "rails-pgsql-persistent",
+                "name": "${NAME}",
                 "image": " ",
                 "ports": [
                   {


### PR DESCRIPTION
Currently, the container name is hardcoded as "rails-pgsql-persistent" which
is the default value. However, if user changes the default value in NAME, then
the container name is not matched which causes the failure due to the container
can't be found.

The container name should n't be hardcoded as it should be based on the NAME
parameter that is provided and modified by user.

Signed-off-by: Vu Dinh <vdinh@redhat.com>