### PR TITLE
allow namespace specification via parameter in templates

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_template_api_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_template_api_v1.proto
@@ -71,6 +71,11 @@ message Template {
   optional string message = 2;
 
   // objects is an array of resources to include in this template.
+  // If a namespace value is hardcoded in the object, it will be removed
+  // during template instantiation, however if the namespace value
+  // is, or contains, a ${PARAMETER_REFERENCE}, the resolved
+  // value after parameter substitution will be respected and the object
+  // will be created in that namespace.
   repeated k8s.io.kubernetes.pkg.runtime.RawExtension objects = 3;
 
   // parameters is an optional array of Parameters used during the

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -28593,7 +28593,7 @@
       "items": {
        "$ref": "runtime.RawExtension"
       },
-      "description": "objects is an array of resources to include in this template."
+      "description": "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace."
      },
      "parameters": {
       "type": "array",

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -56428,7 +56428,7 @@
       "$ref": "#/definitions/v1.ObjectMeta"
      },
      "objects": {
-      "description": "objects is an array of resources to include in this template.",
+      "description": "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/runtime.RawExtension"

--- a/pkg/config/cmd/cmd.go
+++ b/pkg/config/cmd/cmd.go
@@ -131,6 +131,9 @@ func HaltOnError(fn AfterFunc) AfterFunc {
 
 // Create is the default create operation for a generic resource.
 func Create(info *resource.Info, namespace string, obj runtime.Object) (runtime.Object, error) {
+	if len(info.Namespace) > 0 {
+		namespace = info.Namespace
+	}
 	return resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, obj)
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -23696,7 +23696,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 					"objects": {
 						SchemaProps: spec.SchemaProps{
-							Description: "objects is an array of resources to include in this template.",
+							Description: "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/template/api/types.go
+++ b/pkg/template/api/types.go
@@ -26,6 +26,11 @@ type Template struct {
 	Parameters []Parameter
 
 	// objects is an array of resources to include in this template.
+	// If a namespace value is hardcoded in the object, it will be removed
+	// during template instantiation, however if the namespace value
+	// is, or contains, a ${PARAMETER_REFERENCE}, the resolved
+	// value after parameter substitution will be respected and the object
+	// will be created in that namespace.
 	Objects []runtime.Object
 
 	// objectLabels is an optional set of labels that are applied to every

--- a/pkg/template/api/v1/generated.proto
+++ b/pkg/template/api/v1/generated.proto
@@ -71,6 +71,11 @@ message Template {
   optional string message = 2;
 
   // objects is an array of resources to include in this template.
+  // If a namespace value is hardcoded in the object, it will be removed
+  // during template instantiation, however if the namespace value
+  // is, or contains, a ${PARAMETER_REFERENCE}, the resolved
+  // value after parameter substitution will be respected and the object
+  // will be created in that namespace.
   repeated k8s.io.kubernetes.pkg.runtime.RawExtension objects = 3;
 
   // parameters is an optional array of Parameters used during the

--- a/pkg/template/api/v1/swagger_doc.go
+++ b/pkg/template/api/v1/swagger_doc.go
@@ -24,7 +24,7 @@ var map_Template = map[string]string{
 	"":           "Template contains the inputs needed to produce a Config.",
 	"metadata":   "Standard object's metadata.",
 	"message":    "message is an optional instructional message that will be displayed when this template is instantiated. This field should inform the user how to utilize the newly created resources. Parameter substitution will be performed on the message before being displayed so that generated credentials and other parameters can be included in the output.",
-	"objects":    "objects is an array of resources to include in this template.",
+	"objects":    "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace.",
 	"parameters": "parameters is an optional array of Parameters used during the Template to Config transformation.",
 	"labels":     "labels is a optional set of labels that are applied to every object during the Template to Config transformation.",
 }

--- a/pkg/template/api/v1/types.go
+++ b/pkg/template/api/v1/types.go
@@ -23,6 +23,11 @@ type Template struct {
 	Message string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
 
 	// objects is an array of resources to include in this template.
+	// If a namespace value is hardcoded in the object, it will be removed
+	// during template instantiation, however if the namespace value
+	// is, or contains, a ${PARAMETER_REFERENCE}, the resolved
+	// value after parameter substitution will be respected and the object
+	// will be created in that namespace.
 	Objects []runtime.RawExtension `json:"objects" protobuf:"bytes,3,rep,name=objects"`
 
 	// parameters is an optional array of Parameters used during the

--- a/test/testdata/template-with-namespaces.json
+++ b/test/testdata/template-with-namespaces.json
@@ -1,0 +1,121 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "ruby-helloworld-sample",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "some objects in this template declare their own namespace via a parameter confirm new-app will tolerate it",
+      "iconClass": "icon-ruby",
+      "tags": "instant-app,ruby,mysql"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge-stripped",
+        "namespace": "STRIPPED"
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge-substituted",
+        "namespace": "${SUBSTITUTED}"
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge-prefix-substituted",
+        "namespace": "prefix-${SUBSTITUTED}"
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge-refstripped",
+        "namespace": "${{SUBSTITUTED}}"
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge-prefix-refstripped",
+        "namespace": "prefix-${{SUBSTITUTED}}"
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge"
+        }
+      },
+      "status": {}
+    }
+  ],
+  "parameters": [
+    {
+      "name": "SUBSTITUTED",
+      "description": "namespace value",
+      "value": "substituted",
+      "required": true
+    }
+  ],
+  "labels": {
+    "template": "application-template-stibuild"
+  }
+}


### PR DESCRIPTION
with this change it's now possible to set a namespace on objects in a template and have them created in that namespace. (prior to this change, any namespace value in the template object was cleared and the objects were created in the target namespace for the template instantiation).

notice that we're intentionally still clearing hardcoded namespace values to provide some level of backwards compatibility, but if the namespace value comes from parameter substitution, we respect the parameter value for the object creation.
