### PR TITLE
Refactor custom `tito` components and build process

### DIFF
--- a/.tito/lib/origin/builder/__init__.py
+++ b/.tito/lib/origin/builder/__init__.py
@@ -1,21 +1,12 @@
 """
 Code for building Origin
 """
-
-import sys
 import json
 
-from tito.common import (
-    get_latest_commit,
-    get_latest_tagged_version,
-    check_tag_exists,
-    run_command,
-    find_spec_file,
-    get_spec_version_and_release,
-    munge_specfile
-)
-
+from tito.common import get_latest_commit, run_command
 from tito.builder import Builder
+
+from ..common import inject_os_git_vars
 
 class OriginBuilder(Builder):
     """
@@ -24,10 +15,12 @@ class OriginBuilder(Builder):
     Used For:
         - Packages that want to know the commit in all situations
     """
+    def _get_tag_for_version(self, version):
+        return "v{}".format(version)
 
     def _get_rpmbuild_dir_options(self):
         git_hash = get_latest_commit()
-        cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; echo $(os::build::ldflags)'
+        cmd = 'source ./hack/lib/init.sh; os::build::ldflags'
         ldflags = run_command("bash -c '{0}'".format(cmd))
 
         return ('--define "_topdir %s" --define "_sourcedir %s" --define "_builddir %s" '
@@ -40,46 +33,12 @@ class OriginBuilder(Builder):
 
     def _setup_test_specfile(self):
         if self.test and not self.ran_setup_test_specfile:
-            # If making a test rpm we need to get a little crazy with the spec
-            # file we're building off. (note that this is a temp copy of the
-            # spec) Swap out the actual release for one that includes the git
-            # SHA1 we're building for our test package:
-            sha = self.git_commit_id[:7]
-            fullname = "{0}-{1}".format(self.project_name, self.display_version)
-            munge_specfile(
-                self.spec_file,
-                sha,
-                self.commit_count,
-                fullname,
-                self.tgz_filename,
-            )
-            # Custom Openshift v3 stuff follows, everything above is the standard
-            # builder
+            super(OriginBuilder, self)._setup_test_specfile()
 
-            ## Fixup os_git_vars
-            cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_COMMIT}'
-            os_git_commit = run_command("bash -c '{0}'".format(cmd))
-            cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_VERSION}'
-            os_git_version = run_command("bash -c '{0}'".format(cmd))
-            os_git_version = os_git_version.replace('-dirty', '')
-            cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MAJOR}'
-            os_git_major = run_command("bash -c '{0}'".format(cmd))
-            cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MINOR}'
-            os_git_minor = run_command("bash -c '{0}'".format(cmd))
-            print("OS_GIT_COMMIT::{0}".format(os_git_commit))
-            print("OS_GIT_VERSION::{0}".format(os_git_version))
-            print("OS_GIT_MAJOR::{0}".format(os_git_major))
-            print("OS_GIT_MINOR::{0}".format(os_git_minor))
-            update_os_git_vars = \
-                    "sed -i 's|^%global os_git_vars .*$|%global os_git_vars OS_GIT_TREE_STATE='clean' OS_GIT_VERSION={0} OS_GIT_COMMIT={1} OS_GIT_MAJOR={2} OS_GIT_MINOR={3}|' {4}".format(
-                        os_git_version,
-                        os_git_commit,
-                        os_git_major,
-                        os_git_minor,
-                        self.spec_file
-                    )
-            output = run_command(update_os_git_vars)
+            inject_os_git_vars(self.spec_file)
+            self._inject_bundled_deps()
 
+    def _inject_bundled_deps(self):
             # Add bundled deps for Fedora Guidelines as per:
             # https://fedoraproject.org/wiki/Packaging:Guidelines#Bundling_and_Duplication_of_system_libraries
             provides_list = []
@@ -112,35 +71,5 @@ class OriginBuilder(Builder):
                             )
                     else:
                         spec_file_f.write(line)
-
-            self.build_version += ".git." + \
-                str(self.commit_count) + \
-                "." + \
-                str(self.git_commit_id[:7])
-            self.ran_setup_test_specfile = True
-
-    def _get_build_version(self):
-        """
-        Figure out the git tag and version-release we're building.
-        """
-        # Determine which package version we should build:
-        build_version = None
-        if self.build_tag:
-            build_version = self.build_tag[len(self.project_name + "-"):]
-        else:
-            build_version = get_latest_tagged_version(self.project_name)
-            if build_version is None:
-                if not self.test:
-                    error_out(["Unable to lookup latest package info.",
-                            "Perhaps you need to tag first?"])
-                sys.stderr.write("WARNING: unable to lookup latest package "
-                    "tag, building untagged test project\n")
-                build_version = get_spec_version_and_release(self.start_dir,
-                    find_spec_file(in_dir=self.start_dir))
-            self.build_tag = "v{0}".format(build_version)
-
-        if not self.test:
-            check_tag_exists(self.build_tag, offline=self.offline)
-        return build_version
 
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:

--- a/.tito/lib/origin/common.py
+++ b/.tito/lib/origin/common.py
@@ -1,0 +1,60 @@
+from tito.common import run_command, get_latest_commit
+
+def inject_os_git_vars(spec_file):
+    """
+    Determine the OpenShift version variables as dictated by the Origin
+    shell utilities and overwrite the specfile to reflect them. A line
+    with the following syntax is expected in the specfile:
+
+    %global os_git_vars
+
+    This line will be overwritten to add the git tree state, the full
+    "git version", the last source commit in the release, and the major
+    and minor versions of the current product release.
+    """
+    os_git_vars = get_os_git_vars()
+    for var_name in os_git_vars:
+        print("{}::{}".format(var_name, os_git_vars[var_name]))
+
+    update_os_git_vars = \
+        "sed -i 's|^%global os_git_vars .*$|%global os_git_vars {}|' {}".format(
+            " ".join(["{}={}".format(key, value) for key, value in os_git_vars.items()]),
+            spec_file
+        )
+    output = run_command(update_os_git_vars)
+
+def get_os_git_vars():
+    """
+    Determine the OpenShift version variables as dictated by the Origin
+    shell utilities. The git tree state is spoofed.
+    """
+    git_vars = {}
+    for var in ["COMMIT", "VERSION", "MAJOR", "MINOR"]:
+        var_name = "OS_GIT_{}".format(var)
+        git_vars[var_name] = run_command(
+            "bash -c 'source ./hack/lib/init.sh; os::build::os_version_vars; echo ${}'".format(var_name)
+        )
+
+    # we hard-code this to a clean state as tito will have dirtied up the tree
+    # but that will not have changed any of the source used for the product
+    # release and we therefore don't want that reflected in the release version
+    git_vars["OS_GIT_TREE_STATE"] = "clean"
+    git_vars["OS_GIT_VERSION"] = git_vars["OS_GIT_VERSION"].replace("-dirty", "")
+    return git_vars
+
+def update_global_hash(spec_file):
+    """
+    Update the specfile to reflect the latest commit. A line
+    with the following syntax is expected in the specfile:
+
+    %global commit
+
+    This line will be overwritten to add the git commit.
+    """
+    git_hash = get_latest_commit()
+    update_commit = \
+        "sed -i 's/^%global commit .*$/%global commit {0}/' {1}".format(
+            git_hash,
+            spec_file
+        )
+    output = run_command(update_commit)

--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -1,36 +1,14 @@
 """
 Code for tagging Origin packages
 """
-
-import os
-import re
-import shutil
-import subprocess
-import tempfile
-import textwrap
-
-from tito.common import (
-    debug,
-    find_git_root,
-    get_latest_commit,
-    run_command,
-    get_latest_tagged_version,
-    tag_exists_locally,
-    tag_exists_remotely,
-    head_points_to_tag,
-    undo_tag,
-    tito_config_dir,
-)
-
-from tito.compat import write
 from tito.tagger import VersionTagger
-from tito.exception import TitoException
 
+from ..common import inject_os_git_vars, update_global_hash
 
 class OriginTagger(VersionTagger):
     """
-    Origin custom tagger. This tagger has several deviations from normal
-    the normal tito tagger.
+    Origin custom tagger. This tagger has several deviations from the normal
+    tito tagger.
 
     ** Rather than versions being tagged %{name}-%{version}-%{release} they're
     tagged as v%{version} in order to preserve compatibility with origin build
@@ -52,200 +30,15 @@ class OriginTagger(VersionTagger):
     Requires that your ldflags global is written on one single line like this:
     %global ldflags -X foo -X bar
 
-    NOTE: Does not work with --use-version as tito does not provide a way to
-    override the forced version tagger, see
-    https://github.com/dgoodwin/tito/pull/163
-
-
     Used For:
     - Origin, probably not much else
     """
 
     def _tag_release(self):
-        """
-        Tag a new release of the package, add specfile global named commit.
-        (ie: x.y.z-r+1) and ldflags from hack/common.sh os::build::ldflags
-        """
-        self._make_changelog()
-        new_version = self._bump_version()
-        new_version = re.sub(r"-.*", "", new_version)
-        git_hash = get_latest_commit()
-        update_commit = \
-            "sed -i 's/^%global commit .*$/%global commit {0}/' {1}".format(
-                git_hash,
-                self.spec_file
-            )
-        output = run_command(update_commit)
+        update_global_hash(self.spec_file)
+        inject_os_git_vars(self.spec_file)
+        super(OriginTagger, self)._tag_release()
 
-        ## Fixup os_git_vars
-        cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_COMMIT}'
-        os_git_commit = run_command("bash -c '{0}'".format(cmd))
-        cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_VERSION}'
-        os_git_version = run_command("bash -c '{0}'".format(cmd))
-        os_git_version = os_git_version.replace('-dirty', '')
-        cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MAJOR}'
-        os_git_major = run_command("bash -c '{0}'".format(cmd))
-        cmd = '. ./hack/common.sh ; OS_ROOT=$(pwd) ; os::build::os_version_vars ; echo ${OS_GIT_MINOR}'
-        os_git_minor = run_command("bash -c '{0}'".format(cmd))
-        print("OS_GIT_COMMIT::{0}".format(os_git_commit))
-        print("OS_GIT_VERSION::{0}".format(os_git_version))
-        print("OS_GIT_MAJOR::{0}".format(os_git_major))
-        print("OS_GIT_MINOR::{0}".format(os_git_minor))
-        update_os_git_vars = \
-            "sed -i 's|^%global os_git_vars .*$|%global os_git_vars OS_GIT_TREE_STATE='clean' OS_GIT_VERSION={0} OS_GIT_COMMIT={1} OS_GIT_MAJOR={2} OS_GIT_MINOR={3}|' {4}".format(
-                os_git_version,
-                os_git_commit,
-                os_git_major,
-                os_git_minor,
-                self.spec_file
-            )
-        output = run_command(update_os_git_vars)
-
-        self._check_tag_does_not_exist(self._get_new_tag(new_version))
-        self._update_changelog(new_version)
-        self._update_package_metadata(new_version)
-
-    def _get_new_tag(self, new_version):
-        """ Returns the actual tag we'll be creating. """
-        return "v{0}".format(new_version)
-
-    def get_latest_tagged_version(package_name):
-        """
-        Return the latest git tag for this package in the current branch.
-        Uses the info in .tito/packages/package-name.
-
-        Returns None if file does not exist.
-        """
-        git_root = find_git_root()
-        rel_eng_dir = os.path.join(git_root, tito_config_dir())
-        file_path = "{0}/packages/{1}".format(rel_eng_dir, package_name)
-        debug("Getting latest package info from: {0}".format(file_path))
-        if not os.path.exists(file_path):
-            return None
-
-        output = run_command("awk '{ print $1 ; exit }' {0}".format(file_path))
-        if output is None or output.strip() == "":
-            error_out("Error looking up latest tagged version in: {0}".format(file_path))
-
-        return output
-
-    def _make_changelog(self):
-        """
-        Create a new changelog entry in the spec, with line items from git
-        """
-        if self._no_auto_changelog:
-            debug("Skipping changelog generation.")
-            return
-
-        in_f = open(self.spec_file, 'r')
-        out_f = open(self.spec_file + ".new", 'w')
-
-        found_changelog = False
-        for line in in_f.readlines():
-            out_f.write(line)
-
-            if not found_changelog and line.startswith("%changelog"):
-                found_changelog = True
-
-                old_version = get_latest_tagged_version(self.project_name)
-
-                # don't die if this is a new package with no history
-                if old_version is not None:
-                    last_tag = "v%s" % (old_version)
-                    output = self._generate_default_changelog(last_tag)
-                else:
-                    output = self._new_changelog_msg
-
-                fd, name = tempfile.mkstemp()
-                write(fd, "# Create your changelog entry below:\n")
-                if self.git_email is None or \
-                        (('HIDE_EMAIL' in self.user_config) and
-                        (self.user_config['HIDE_EMAIL'] not in ['0', ''])):
-                    header = "* {0} {1}\n".format(self.today, self.git_user)
-                else:
-                    header = "* {0} {1} <{2}>\n".format(
-                        self.today,
-                        self.git_user,
-                        self.git_email
-                    )
-
-                write(fd, header)
-
-                for cmd_out in output.split("\n"):
-                    write(fd, "- ")
-                    write(fd, "\n  ".join(textwrap.wrap(cmd_out, 77)))
-                    write(fd, "\n")
-
-                write(fd, "\n")
-
-                if not self._accept_auto_changelog:
-                    # Give the user a chance to edit the generated changelog:
-                    editor = 'vi'
-                    if "EDITOR" in os.environ:
-                        editor = os.environ["EDITOR"]
-                    subprocess.call(editor.split() + [name])
-
-                os.lseek(fd, 0, 0)
-                file = os.fdopen(fd)
-
-                for line in file.readlines():
-                    if not line.startswith("#"):
-                        out_f.write(line)
-
-                output = file.read()
-
-                file.close()
-                os.unlink(name)
-
-        if not found_changelog:
-            print("WARNING: no %%changelog section find in spec file. Changelog entry was not appended.")
-
-        in_f.close()
-        out_f.close()
-
-        shutil.move(self.spec_file + ".new", self.spec_file)
-
-    def _undo(self):
-        """
-        Undo the most recent tag.
-
-        Tag commit must be the most recent commit, and the tag must not
-        exist in the remote git repo, otherwise we report and error out.
-        """
-        tag = "v{0}".format(get_latest_tagged_version(self.project_name))
-        print("Undoing tag: {0}".format(tag))
-        if not tag_exists_locally(tag):
-            raise TitoException(
-                "Cannot undo tag that does not exist locally.")
-        if not self.offline and tag_exists_remotely(tag):
-            raise TitoException("Cannot undo tag that has been pushed.")
-
-        # Tag must be the most recent commit.
-        if not head_points_to_tag(tag):
-            raise TitoException("Cannot undo if tag is not the most recent commit.")
-
-        # Everything looks good:
-        print
-        undo_tag(tag)
-
-# This won't do anything until tito supports configuring the forcedversion tagger
-# See https://github.com/dgoodwin/tito/pull/163
-class OriginForceVersionTagger(OriginTagger):
-    """
-    Tagger which forcibly updates the spec file to a version provided on the
-    command line by the --use-version option.
-    TODO: could this be merged into main taggers?
-    """
-
-    def _tag_release(self):
-        """
-        Tag a new release of the package.
-        """
-        self._make_changelog()
-        new_version = self._bump_version(force=True)
-        self._check_tag_does_not_exist(self._get_new_tag(new_version))
-        self._update_changelog(new_version)
-        self._update_setup_py(new_version)
-        self._update_package_metadata(new_version)
-
+    def _get_tag_for_version(self, version):
+        return "v{}".format(version)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -7,4 +7,4 @@ changelog_format = %s (%ae)
 lib_dir = .tito/lib
 
 [requirements]
-tito = 0.6
+tito = 0.6.10

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -7,7 +7,6 @@
 #  - BUILD_TESTS: whether or not to build a test RPM, off by default
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::build::setup_env
-os::util::environment::setup_tmpdir_vars "build-rpm-release"
 
 if [[ "${OS_ONLY_BUILD_PLATFORMS:-}" == 'linux/amd64' ]]; then
 	# when the user is asking for only Linux binaries, we will
@@ -18,10 +17,22 @@ else
 fi
 
 os::log::info 'Building Origin release RPMs with tito...'
+os::build::get_version_vars
+if [[ "${OS_GIT_VERSION}" =~ ^v([0-9](\.[0-9]+)*)(.*) ]]; then
+	# we need to translate from the semantic version
+	# provided by the Origin build scripts to the
+	# version that RPM will expect.
+	rpm_version="${BASH_REMATCH[1]}"
+	rpm_release="0${BASH_REMATCH[3]//-/.}"
+fi
+tito tag --use-version="${rpm_version}" \
+         --use-release="${rpm_release}" \
+         --no-auto-changelog --offline
 tito_tmp_dir="${BASETMPDIR}/tito"
 mkdir -p "${tito_tmp_dir}"
-tito build --output="${tito_tmp_dir}" --rpm --test --no-cleanup \
-           --rpmbuild-options="--define 'make_redistributable ${make_redistributable}' --define 'build_tests ${BUILD_TESTS:-0}'"
+tito build --output="${tito_tmp_dir}" --rpm --no-cleanup --quiet --offline \
+           --rpmbuild-options="--define 'make_redistributable ${make_redistributable}'"
+tito tag --undo --offline
 
 os::log::info 'Unpacking tito artifacts for reuse...'
 output_directories=( $( find "${tito_tmp_dir}" -type d -name 'rpmbuild-origin*' ) )

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -53,9 +53,9 @@ else
 	output_directory="${output_directories[0]}"
 fi
 
-if ! tito_output_directory="$( find "${output_directory}" -type d -path '*/BUILD/origin-git-*/_output/local' )"; then
-	os::log::error 'No _output artifact directory found in tito rpmbuild artifacts!'
-	exit 1
+tito_output_directory="$( find "${output_directory}" -type d -path "*/BUILD/origin-${rpm_version}/_output/local" )"
+if [[ -z "${tito_output_directory}" ]]; then
+        os::log::fatal 'No _output artifact directory found in tito rpmbuild artifacts!'
 fi
 
 # clean up our local state so we can unpack the tito artifacts cleanly


### PR DESCRIPTION
Provide canonical version and release to `tito`

The Origin project does not keep the `origin.spec` manifest up to date
with releases, so it is necessary to instruct `tito build` to use a
hard-coded version and release for the RPMs that are created instead. We
can reverse-engineer the version and release from the `${OS_GIT_VERSION}`
that is used to create Origin release tars.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Bumped minimum acceptable tito version

Refactors to the custom tito builder and tagger require a newer version
of `tito` than before. Any version after 26219ab contain all of the
refactoring in `tito` that is necessary to support the new Origin custom
tagger and builder.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Refactored custom `tito` tagger and builder

The previous implementation of the custom `tito` tagger and builder for
Origin were based on a `tito` codebase from many iterations ago. At the
time, the upstream code was not factored in such a way as to make it
easy for a custom tagger and builder implementation to change the manner
in which a tag was generated from a version. The resulting custom
implementations necessarily copied lots of code from upstream, which led
to large drift as upstream methods changed but their overridden counter-
parts in Origin did not. This refactor takes advantage of recent changes
in `tito` to allow for a more concise version->tag mapping override.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

