### PR TITLE
in clear-route-status.sh alert users if 'jq' tool is not installed

### DIFF
--- a/images/router/clear-route-status.sh
+++ b/images/router/clear-route-status.sh
@@ -84,6 +84,11 @@ if [[ ${#} -ne 2 || "${@}" == *" help "* ]]; then
     exit
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+    printf "%s\n%s\n" "Command line JSON processor 'jq' not found." "please install 'jq' to use this script."
+    exit 1
+fi
+
 oc proxy > /dev/null &
 PROXY_PID="${!}"
 


### PR DESCRIPTION
currently clear-route-status.sh doesn't check whether 'jq' is installed on the system,
added a check for install and a clean exit with error message

"
Command line JSON processor 'jq' not found.
please install 'jq' to use this script.
"

Bug 1391585 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1391585)