### PR TITLE
a split on string can give empty elements - fix bz1421572

### DIFF
--- a/pkg/router/f5/f5.go
+++ b/pkg/router/f5/f5.go
@@ -1315,6 +1315,9 @@ func (f5 *f5LTM) addRoute(policyname, routename, poolname, hostname,
 		conditionPayload.HttpUri = true
 		conditionPayload.PathSegment = true
 		for i, segment := range segments[1:] {
+			if segment == "" {
+				continue
+			}
 			idx := fmt.Sprintf("%d", i+1)
 			conditionPayload.Name = idx
 			conditionPayload.Index = i + 1


### PR DESCRIPTION
Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1421572
A strings.split("/") gives two elements, both empty. And we would barf without this fix. Also for any path that ends with a "/" will give an empty last element.


cc @knobunc @openshift/networking 