### PR TITLE
update route generater parameter name to match oc expose flag for wildcardpolicy

### DIFF
--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -101,7 +101,7 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 
 	wildcardpolicy := kcmdutil.GetFlagString(cmd, "wildcard-policy")
 	if len(wildcardpolicy) > 0 && (wildcardpolicy != "Subdomain" && wildcardpolicy != "None") {
-		return fmt.Errorf("only \"Subdomain\" or \"None\" are supported for wildcardpolicy")
+		return fmt.Errorf("only \"Subdomain\" or \"None\" are supported for wildcard-policy")
 	}
 
 	if len(infos) > 1 {

--- a/pkg/route/generator/generate.go
+++ b/pkg/route/generator/generate.go
@@ -27,7 +27,7 @@ func (RouteGenerator) ParamNames() []kubectl.GeneratorParam {
 		{Name: "name", Required: false},
 		{Name: "hostname", Required: false},
 		{Name: "path", Required: false},
-		{Name: "wildcardpolicy", Required: false},
+		{Name: "wildcard-policy", Required: false},
 	}
 }
 
@@ -70,7 +70,7 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 		},
 		Spec: api.RouteSpec{
 			Host:           params["hostname"],
-			WildcardPolicy: api.WildcardPolicyType(params["wildcardpolicy"]),
+			WildcardPolicy: api.WildcardPolicyType(params["wildcard-policy"]),
 			Path:           params["path"],
 			To: api.RouteTargetReference{
 				Name: params["default-name"],


### PR DESCRIPTION


When the wildcardpolicy flag was changed to wildcard-policy in oc expose the GeneraterParam was left unchanged this mismatch caused the wildcard-policy to be ignored and always appear as none when using oc expose

Bug 1421990 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1421990)
