### PR TITLE
name/field fix in etcd key

### DIFF
--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -23,7 +23,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:     func() runtime.Object { return &api.HostSubnet{} },
 		NewListFunc: func() runtime.Object { return &api.HostSubnetList{} },
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.HostSubnet).Host, nil
+			return obj.(*api.HostSubnet).Name, nil
 		},
 		PredicateFunc: func(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
 			return hostsubnet.Matcher(label, field)

--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -23,7 +23,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:     func() runtime.Object { return &api.NetNamespace{} },
 		NewListFunc: func() runtime.Object { return &api.NetNamespaceList{} },
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.NetNamespace).NetName, nil
+			return obj.(*api.NetNamespace).Name, nil
 		},
 		PredicateFunc: func(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
 			return netnamespace.Matcher(label, field)


### PR DESCRIPTION
For issue #12697 
A separate search script needs to be run to find out and fix any anomalies where Host/NetName != Name for the objects Hostsubnet/NetNamespace respectively. 

cc @knobunc 