### PR TITLE
Add parent BuildConfig to Build OwnerReferences

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -410,6 +410,14 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   buildName,
 			Labels: bcCopy.Labels,
+			OwnerReferences: []kapi.OwnerReference{
+				{
+					APIVersion: "v1",          // BuildConfig.APIVersion is not populated
+					Kind:       "BuildConfig", // BuildConfig.Kind is not populated
+					Name:       bcCopy.Name,
+					UID:        bcCopy.UID,
+				},
+			},
 		},
 		Status: buildapi.BuildStatus{
 			Phase: buildapi.BuildPhaseNew,
@@ -748,9 +756,10 @@ func generateBuildFromBuild(build *buildapi.Build, buildConfig *buildapi.BuildCo
 	newBuild := &buildapi.Build{
 		Spec: buildCopy.Spec,
 		ObjectMeta: kapi.ObjectMeta{
-			Name:        getNextBuildNameFromBuild(buildCopy, buildConfig),
-			Labels:      buildCopy.ObjectMeta.Labels,
-			Annotations: buildCopy.ObjectMeta.Annotations,
+			Name:            getNextBuildNameFromBuild(buildCopy, buildConfig),
+			Labels:          buildCopy.ObjectMeta.Labels,
+			Annotations:     buildCopy.ObjectMeta.Annotations,
+			OwnerReferences: buildCopy.ObjectMeta.OwnerReferences,
 		},
 		Status: buildapi.BuildStatus{
 			Phase:  buildapi.BuildPhaseNew,

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -772,6 +772,7 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 	resources := mockResources()
 	bc := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
+			UID:       "test-uid",
 			Name:      "test-build-config",
 			Namespace: kapi.NamespaceDefault,
 			Labels:    map[string]string{"testlabel": "testvalue"},
@@ -840,6 +841,9 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 	}
 	if build.Annotations[buildapi.BuildNumberAnnotation] != "13" {
 		t.Errorf("Build number annotation value %s does not match expected value 13", build.Annotations[buildapi.BuildNumberAnnotation])
+	}
+	if len(build.OwnerReferences) == 0 || build.OwnerReferences[0].Kind != "BuildConfig" || build.OwnerReferences[0].Name != bc.Name {
+		t.Errorf("generated build does not have OwnerReference to parent BuildConfig")
 	}
 
 	// Test long name
@@ -1103,6 +1107,14 @@ func TestGenerateBuildFromBuild(t *testing.T) {
 				buildapi.BuildJenkinsBuildURIAnnotation:   "baz",
 				buildapi.BuildPodNameAnnotation:           "ruby-sample-build-1-build",
 			},
+			OwnerReferences: []kapi.OwnerReference{
+				{
+					Name:       "test-owner",
+					Kind:       "BuildConfig",
+					APIVersion: "v1",
+					UID:        "foo",
+				},
+			},
 		},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{
@@ -1137,6 +1149,10 @@ func TestGenerateBuildFromBuild(t *testing.T) {
 	if _, ok := newBuild.ObjectMeta.Annotations[buildapi.BuildPodNameAnnotation]; ok {
 		t.Errorf("%s annotation exists, expected it not to", buildapi.BuildPodNameAnnotation)
 	}
+	if !reflect.DeepEqual(build.ObjectMeta.OwnerReferences, newBuild.ObjectMeta.OwnerReferences) {
+		t.Errorf("Build OwnerReferences does not match the original Build OwnerReferences")
+	}
+
 }
 
 func TestGenerateBuildFromBuildWithBuildConfig(t *testing.T) {


### PR DESCRIPTION
This is a prelim step to enabling garbage collection instead of reaper code.

@openshift/devex ptal?