### PR TITLE
patch kubeconfig if token cannot be deleted via api

### DIFF
--- a/pkg/cmd/cli/cmd/login/logout.go
+++ b/pkg/cmd/cli/cmd/login/logout.go
@@ -125,12 +125,12 @@ func (o LogoutOptions) RunLogout() error {
 	}
 
 	if err := client.OAuthAccessTokens().Delete(token); err != nil {
-		glog.V(1).Infof("%v\n", err)
+		glog.V(1).Infof("%v", err)
 	}
 
 	configErr := deleteTokenFromConfig(*o.StartingKubeConfig, o.PathOptions, token)
 	if configErr == nil {
-		glog.V(1).Infof("Removed token from your local configuration.\n\n")
+		glog.V(1).Infof("Removed token from your local configuration.")
 
 		// only return error instead of successful message if removing token from client
 		// config fails. Any error that occurs deleting token using api is logged above.

--- a/pkg/cmd/cli/cmd/login/logout.go
+++ b/pkg/cmd/cli/cmd/login/logout.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -124,24 +125,29 @@ func (o LogoutOptions) RunLogout() error {
 	}
 
 	if err := client.OAuthAccessTokens().Delete(token); err != nil {
-		return err
+		glog.V(1).Infof("%v\n", err)
 	}
 
-	newConfig := *o.StartingKubeConfig
+	configErr := deleteTokenFromConfig(*o.StartingKubeConfig, o.PathOptions, token)
+	if configErr == nil {
+		glog.V(1).Infof("Removed token from your local configuration.\n\n")
 
-	for key, value := range newConfig.AuthInfos {
-		if value.Token == token {
+		// only return error instead of successful message if removing token from client
+		// config fails. Any error that occurs deleting token using api is logged above.
+		fmt.Fprintf(o.Out, "Logged %q out on %q\n", userInfo.Name, o.Config.Host)
+	}
+
+	return configErr
+}
+
+func deleteTokenFromConfig(config kclientcmdapi.Config, pathOptions *kclientcmd.PathOptions, bearerToken string) error {
+	for key, value := range config.AuthInfos {
+		if value.Token == bearerToken {
 			value.Token = ""
-			newConfig.AuthInfos[key] = value
+			config.AuthInfos[key] = value
 			// don't break, its possible that more than one user stanza has the same token.
 		}
 	}
 
-	if err := kclientcmd.ModifyConfig(o.PathOptions, newConfig, true); err != nil {
-		return err
-	}
-
-	fmt.Fprintf(o.Out, "Logged %q out on %q\n", userInfo.Name, o.Config.Host)
-
-	return nil
+	return kclientcmd.ModifyConfig(pathOptions, config, true)
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/7011
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1422252

Deletes a token in a kubeconfig user stanza even if the token could not be deleted via the API.

cc @openshift/cli-review @stevekuznetsov @deads2k 