### PR TITLE
dind: upgrade to fedora 25

### DIFF
--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -18,7 +18,7 @@
 #      $ docker run -d --privileged openshift/dind
 #
 
-FROM fedora:24
+FROM fedora:25
 
 # Fix 'WARNING: terminal is not fully functional' when TERM=dumb
 ENV TERM=xterm


### PR DESCRIPTION
Pending changes to origin require docker 1.12, which is available in fedora 25 but not 24.

Once the 1.12 dependencies land, anyone using dind will need to rebuild their images (``hack/dind-cluster.sh build-images`` or ``hack/dind-cluster.sh start -i``).

cc: @openshift/networking @pmorie @stevekuznetsov 