### PR TITLE
Remove errexit around previously failing end-to-end test

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -358,24 +358,15 @@ os::log::info "Running a CLI command in a container using the service account"
 os::cmd::expect_success 'oc policy add-role-to-user view -z default'
 os::cmd::try_until_success "oc sa get-token default"
 oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-set -o errexit
 os::cmd::expect_success 'oc delete pod cli-with-token'
 oc run cli-with-token-2 --attach --image="openshift/origin:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
-set -o errexit
 os::cmd::expect_success 'oc delete pod cli-with-token-2'
 oc run kubectl-with-token --attach --image="openshift/origin:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
 os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
-set -o errexit
 
 os::log::info "Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors


### PR DESCRIPTION
@mfojtik @pweil- this is one of my blocker bugs and needs your approval. 

It looks like the problem does not exist anymore since the switch to the new infra, the docker upgrade apparently fixed it. I'm not 100% sure, b/c I don't see there @ncdc change that will land only in 1.12.6 (we're currently on 1.12.5). But I've checked all the logs since after the switch and none of them failed. Similarly my test PR (https://github.com/openshift/origin/pull/12749#issuecomment-276919653) did not fail since after that upgrade, whereas before if failed quite consistently every other time. 

@stevekuznetsov fyi

Closes #12558. 