### PR TITLE
Add imagebuilder to origin-release Dockerfiles

### DIFF
--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
+    go get github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com

--- a/images/release/golang-1.8/Dockerfile
+++ b/images/release/golang-1.8/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir $TMPDIR && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.zip | bsdtar -C /usr/local -xf - && \
     chmod uga+x /usr/local/bin/protoc && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
-    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint && \
+    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
     git config --global user.name origin-release-container && \
     git config --global user.email none@nowhere.com


### PR DESCRIPTION
Add imagebuilder to origin-release versioned Dockerfiles, as a dependency for `hack/build-images.sh`

@smarterclayton || @stevekuznetsov PTAL

Closes https://github.com/openshift/origin/issues/12934