### PR TITLE
Fix NetworkPolicies allowing from all to *some* (not all)

### DIFF
--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -364,7 +364,6 @@ func (np *networkPolicyPlugin) selectPods(npns *npNamespace, lsel *unversioned.L
 
 func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *extensions.NetworkPolicy) (*npPolicy, error) {
 	npp := &npPolicy{policy: *policy}
-	allowAll := false
 
 	var destFlows []string
 	if len(policy.Spec.PodSelector.MatchLabels) > 0 || len(policy.Spec.PodSelector.MatchExpressions) > 0 {
@@ -377,11 +376,6 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *ext
 	}
 
 	for _, rule := range policy.Spec.Ingress {
-		if len(rule.Ports) == 0 && len(rule.From) == 0 {
-			allowAll = true
-			break
-		}
-
 		var portFlows, peerFlows []string
 		if len(rule.Ports) == 0 {
 			portFlows = []string{""}
@@ -446,11 +440,7 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *ext
 		}
 	}
 
-	if allowAll {
-		npp.flows = []string{""}
-	} else {
-		sort.Strings(npp.flows)
-	}
+	sort.Strings(npp.flows)
 	glog.V(5).Infof("Parsed NetworkPolicy: %#v", npp)
 	return npp, nil
 }


### PR DESCRIPTION
The NetworkPolicy flow-computing code had a short circuit where if you had a policy that allowed all traffic, it wouldn't bother outputting any other rules that might be present to only allow a subset of traffic, since those rules would be unnecessary. But (a) the short-circuit was buggy, in that it got triggered by any rule that accepted traffic *from* all sources, even if it wasn't supposed to allow traffic *to* all destinations, and (b) we weren't making any effort to filter out any other redundant rules (eg, if you had two identical copies of the same NetworkPolicy), and (c) there's no particular reason to think the kind of rule redundancy we were special-casing is going to be more likely than any other kind. So this just gets rid of the special case.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1421091

@openshift/networking PTAL