### PR TITLE
make new-app error reports clearer

### DIFF
--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -195,7 +195,7 @@ func TestBuildTemplates(t *testing.T) {
 			continue
 		}
 
-		resolved, err := Resolve(&appCfg.Resolvers, &appCfg.ComponentInputs, &appCfg.GenerationInputs)
+		resolved, err := Resolve(&appCfg)
 		if err != nil {
 			t.Errorf("%s: Unexpected error: %v", n, err)
 			continue

--- a/pkg/generate/app/cmd/resolve.go
+++ b/pkg/generate/app/cmd/resolve.go
@@ -95,7 +95,10 @@ type ResolvedComponents struct {
 
 // Resolve transforms unstructured inputs (component names, templates, images) into
 // a set of resolved components, or returns an error.
-func Resolve(r *Resolvers, c *ComponentInputs, g *GenerationInputs) (*ResolvedComponents, error) {
+func Resolve(appConfig *AppConfig) (*ResolvedComponents, error) {
+	r := &appConfig.Resolvers
+	c := &appConfig.ComponentInputs
+	g := &appConfig.GenerationInputs
 	b := &app.ReferenceBuilder{}
 
 	if err := AddComponentInputsToRefBuilder(b, r, c, g); err != nil {
@@ -116,7 +119,7 @@ func Resolve(r *Resolvers, c *ComponentInputs, g *GenerationInputs) (*ResolvedCo
 	}
 
 	if g.Strategy != generate.StrategyUnspecified && len(repositories) == 0 && !g.BinaryBuild {
-		return nil, errors.New("when --strategy is specified you must provide at least one source code location")
+		return nil, errors.New("--strategy is specified and none of the arguments provided could be classified as a source code location")
 	}
 
 	if g.BinaryBuild && (len(repositories) > 0 || components.HasSource()) {

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -10,16 +10,16 @@ import (
 	"k8s.io/kubernetes/pkg/util/errors"
 )
 
-// IsComponentReference returns true if the provided string appears to be a reference to a source repository
+// IsComponentReference returns an error if the provided string does not appear to be a reference to a source repository
 // on disk, at a URL, a docker image name (which might be on a Docker registry or an OpenShift image stream),
 // or a template.
-func IsComponentReference(s string) bool {
+func IsComponentReference(s string) error {
 	if len(s) == 0 {
-		return false
+		return fmt.Errorf("empty string provided to component reference check")
 	}
 	all := strings.Split(s, "+")
 	_, _, _, err := componentWithSource(all[0])
-	return err == nil
+	return err
 }
 
 // componentWithSource parses the provided string and returns an image component

--- a/pkg/generate/app/file.go
+++ b/pkg/generate/app/file.go
@@ -5,13 +5,13 @@ import (
 )
 
 // isFile returns true if the passed-in argument is a file in the filesystem
-func isFile(name string) bool {
+func isFile(name string) (bool, error) {
 	info, err := os.Stat(name)
-	return err == nil && !info.IsDir()
+	return err == nil && !info.IsDir(), err
 }
 
-// isDirectory returns true if the passed-in argument is a directory in the filesystem
-func isDirectory(name string) bool {
+// IsDirectory returns true if the passed-in argument is a directory in the filesystem
+func IsDirectory(name string) (bool, error) {
 	info, err := os.Stat(name)
-	return err == nil && info.IsDir()
+	return err == nil && info.IsDir(), err
 }

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -66,30 +66,25 @@ func (d dockerfileContents) Contents() string {
 	return d.contents
 }
 
-// IsPossibleSourceRepository checks whether the provided string is a source repository or not
-func IsPossibleSourceRepository(s string) bool {
-	return IsRemoteRepository(s) || isDirectory(s)
-}
-
 // IsRemoteRepository checks whether the provided string is a remote repository or not
-func IsRemoteRepository(s string) bool {
+func IsRemoteRepository(s string) (bool, error) {
 	if !s2igit.New(s2iutil.NewFileSystem()).ValidCloneSpecRemoteOnly(s) {
 		glog.V(5).Infof("%s is not a valid remote git clone spec", s)
-		return false
+		return false, nil
 	}
 	url, err := url.Parse(s)
 	if err != nil {
 		glog.V(5).Infof("%s is not a valid url: %v", s, err)
-		return false
+		return false, err
 	}
 	url.Fragment = ""
 	gitRepo := git.NewRepository()
 	if _, _, err := gitRepo.ListRemote(url.String()); err != nil {
 		glog.V(5).Infof("could not list git remotes for %s: %v", s, err)
-		return false
+		return false, err
 	}
 	glog.V(5).Infof("%s is a valid remote git repository", s)
-	return true
+	return true, nil
 }
 
 // SourceRepository represents a code repository that may be the target of a build.

--- a/pkg/generate/app/templatelookup.go
+++ b/pkg/generate/app/templatelookup.go
@@ -95,7 +95,7 @@ func (r TemplateSearcher) Search(precise bool, terms ...string) (ComponentMatche
 }
 
 // IsPossibleTemplateFile returns true if the argument can be a template file
-func IsPossibleTemplateFile(value string) bool {
+func IsPossibleTemplateFile(value string) (bool, error) {
 	return isFile(value)
 }
 

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -40,6 +40,16 @@ os::cmd::expect_success_and_text 'oc new-app mysql -o yaml --as-test' 'test: tru
 # docker strategy with repo that has no dockerfile
 os::cmd::expect_failure_and_text 'oc new-app https://github.com/openshift/nodejs-ex --strategy=docker' 'No Dockerfile was found'
 
+# repo related error message validation
+os::cmd::expect_failure_and_text 'oc new-app mysql-persisten mysql' 'mysql-persisten as a local directory'
+os::cmd::expect_failure_and_text 'oc new-app mysql-persisten mysql' 'mysql as a local directory'
+os::cmd::expect_failure_and_text 'oc new-app --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'as a Git repository URL:  '
+os::cmd::expect_failure_and_text 'oc new-app https://www.google.com/openshift/nodejs-e' 'as a Git repository URL:  '
+os::cmd::expect_failure_and_text 'oc new-app https://githb.com/openshift/nodejs-e' 'as a Git repository URL:  '
+os::cmd::expect_failure_and_text 'oc new-build --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'as a Git repository URL:  '
+os::cmd::expect_failure_and_text 'oc new-build https://www.google.com/openshift/nodejs-e' 'as a Git repository URL:  '
+os::cmd::expect_failure_and_text 'oc new-build https://githb.com/openshift/nodejs-e' 'as a Git repository URL:  '
+
 # check label creation
 os::cmd::try_until_success 'oc get imagestreamtags php:latest'
 os::cmd::try_until_success 'oc get imagestreamtags php:5.5'

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -47,6 +47,6 @@ var _ = g.Describe("[builds][Conformance] oc new-app", func() {
 		g.By("calling oc new-app")
 		out, err := oc.Run("new-app").Args("https://github.com/openshift/nodejs-ex", "--name", a59).Output()
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(out).To(o.HavePrefix("error: invalid name: "))
+		o.Expect(out).To(o.ContainSubstring("error: invalid name: "))
 	})
 })


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/12892

@openshift/devex ptal

Some sample output:

1)

```
gmontero ~/go/src/github.com/openshift/origin  (issue12892)$ oc new-app --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git --dry-run
error: Errors occurred while determining argument types:

https://192.30.253.113/openshift/ruby-hello-world.git as a Git repository URL:  fatal: unable to access 'https://192.30.253.113/openshift/ruby-hello-world.git/': Unable to communicate securely with peer: requested domain name does not match the server's certificate.

https://192.30.253.113/openshift/ruby-hello-world.git as a local directory pointing to a Git repository:  stat https://192.30.253.113/openshift/ruby-hello-world.git: no such file or directory

Errors occurred during resource creation:
error: --strategy is specified and none of the arguments provided could be classified as a source code location
```

2)

```
gmontero ~/go/src/github.com/openshift/origin  (issue12892)$ oc new-app https://www.google.com/openshift/nodejs-e --dry-run
error: Errors occurred while determining argument types:

https://www.google.com/openshift/nodejs-e as a Git repository URL:  fatal: repository 'https://www.google.com/openshift/nodejs-e/' not found

https://www.google.com/openshift/nodejs-e as a local directory pointing to a Git repository:  stat https://www.google.com/openshift/nodejs-e: no such file or directory

Errors occurred during resource creation:
error: unable to load template file "https://www.google.com/openshift/nodejs-e": unable to read URL "https://www.google.com/openshift/nodejs-e", server reported 404 Not Found, status code=404
error: no match for "https://www.google.com/openshift/nodejs-e"

The 'oc new-app' command will match arguments to the following types:

  1. Images tagged into image streams in the current project or the 'openshift' project
     - if you don't specify a tag, we'll add ':latest'
  2. Images in the Docker Hub, on remote registries, or on the local Docker engine
  3. Templates in the current project or the 'openshift' project
  4. Git repository URLs or local paths that point to Git repositories

--allow-missing-images can be used to point to an image that does not exist yet.

See 'oc new-app -h' for examples.
```

3)

```
gmontero ~/go/src/github.com/openshift/origin  (issue12892)$ oc new-app https://githb.com/openshift/nodejs-e --dry-run
error: Errors occurred while determining argument types:

https://githb.com/openshift/nodejs-e as a Git repository URL:  fatal: unable to access 'https://githb.com/openshift/nodejs-e/': Network file descriptor is not connected

https://githb.com/openshift/nodejs-e as a local directory pointing to a Git repository:  stat https://githb.com/openshift/nodejs-e: no such file or directory

Errors occurred during resource creation:
error: unable to load template file "https://githb.com/openshift/nodejs-e": Get https://githb.com/openshift/nodejs-e: dial tcp 158.69.145.48:443: i/o timeout
error: no match for "https://githb.com/openshift/nodejs-e"

The 'oc new-app' command will match arguments to the following types:

  1. Images tagged into image streams in the current project or the 'openshift' project
     - if you don't specify a tag, we'll add ':latest'
  2. Images in the Docker Hub, on remote registries, or on the local Docker engine
  3. Templates in the current project or the 'openshift' project
  4. Git repository URLs or local paths that point to Git repositories

--allow-missing-images can be used to point to an image that does not exist yet.

See 'oc new-app -h' for examples.

```