### PR TITLE
Fix typos in router code

### DIFF
--- a/pkg/router/controller/extended_validator.go
+++ b/pkg/router/controller/extended_validator.go
@@ -27,7 +27,7 @@ type ExtendedValidator struct {
 	invalidRoutes map[string]routeapi.Route
 }
 
-// ExtendedValidator creates a plugin wrapper that ensures only routes that
+// NewExtendedValidator creates a plugin wrapper that ensures only routes that
 // pass extended validation are relayed to the next plugin in the chain.
 // Recorder is an interface for indicating why a route was rejected.
 func NewExtendedValidator(plugin router.Plugin, recorder RejectionRecorder) *ExtendedValidator {
@@ -73,7 +73,7 @@ func (p *ExtendedValidator) HandleRoute(eventType watch.EventType, route *routea
 	return p.plugin.HandleRoute(eventType, route)
 }
 
-// HandleAllowedNamespaces limits the scope of valid routes to only those that match
+// HandleNamespaces limits the scope of valid routes to only those that match
 // the provided namespace list.
 func (p *ExtendedValidator) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)

--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -147,7 +147,7 @@ func (p *HostAdmitter) HandleRoute(eventType watch.EventType, route *routeapi.Ro
 	return p.plugin.HandleRoute(eventType, route)
 }
 
-// HandleAllowedNamespaces limits the scope of valid routes to only those that match
+// HandleNamespaces limits the scope of valid routes to only those that match
 // the provided namespace list.
 func (p *HostAdmitter) HandleNamespaces(namespaces sets.String) error {
 	return p.plugin.HandleNamespaces(namespaces)

--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -29,7 +29,7 @@ var LogRejections = logRecorder{}
 
 type logRecorder struct{}
 
-func (_ logRecorder) RecordRouteRejection(route *routeapi.Route, reason, message string) {
+func (logRecorder) RecordRouteRejection(route *routeapi.Route, reason, message string) {
 	glog.V(4).Infof("Rejected route %s: %s: %s", route.Name, reason, message)
 }
 
@@ -234,7 +234,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 	return nil
 }
 
-// HandleAllowedNamespaces limits the scope of valid routes to only those that match
+// HandleNamespaces limits the scope of valid routes to only those that match
 // the provided namespace list.
 func (p *UniqueHost) HandleNamespaces(namespaces sets.String) error {
 	p.allowedNamespaces = namespaces

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -194,7 +194,7 @@ func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.
 	return nil
 }
 
-// HandleAllowedNamespaces limits the scope of valid routes to only those that match
+// HandleNamespaces limits the scope of valid routes to only those that match
 // the provided namespace list.
 func (p *TemplatePlugin) HandleNamespaces(namespaces sets.String) error {
 	p.Router.FilterNamespaces(namespaces)


### PR DESCRIPTION
Various typos, most in comments, are fixed.
And the unnecessary "_" receiver is also removed. 