### PR TITLE
Ensure RPMs are only build from clean git trees

### DIFF
--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -18,6 +18,9 @@ fi
 
 os::log::info 'Building Origin release RPMs with tito...'
 os::build::get_version_vars
+if [[ "${OS_GIT_TREE_STATE}" == "dirty" ]]; then
+	os::log::fatal "Cannot build RPMs with a dirty git tree. Commit your changes and try again."
+fi
 if [[ "${OS_GIT_VERSION}" =~ ^v([0-9](\.[0-9]+)*)(.*) ]]; then
 	# we need to translate from the semantic version
 	# provided by the Origin build scripts to the


### PR DESCRIPTION
The `tito` process for building RPMs will not incorporate any changes
that are not committed in the git tree, so if we notice that the git
three state is dirty during the RPM build, we should fail early and
ask the user to commit their changes first before re-trying the build.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 
[test]