### PR TITLE
add authorization.k8s.io to the list of enabled APIs

### DIFF
--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -14894,6 +14894,236 @@
      }
     ]
    },
+   "/apis/authorization.k8s.io/": {
+    "get": {
+     "description": "get information of a group",
+     "consumes": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization"
+     ],
+     "operationId": "getAuthorizationAPIGroup",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.APIGroup"
+       }
+      }
+     }
+    }
+   },
+   "/apis/authorization.k8s.io/v1beta1/": {
+    "get": {
+     "description": "get available resources",
+     "consumes": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization_v1beta1"
+     ],
+     "operationId": "getAuthorizationV1beta1APIResources",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/unversioned.APIResourceList"
+       }
+      }
+     }
+    }
+   },
+   "/apis/authorization.k8s.io/v1beta1/localsubjectaccessreviews": {
+    "post": {
+     "description": "create a LocalSubjectAccessReview",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization_v1beta1"
+     ],
+     "operationId": "createAuthorizationV1beta1LocalSubjectAccessReviewForAllNamespaces",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+      }
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews": {
+    "post": {
+     "description": "create a LocalSubjectAccessReview",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization_v1beta1"
+     ],
+     "operationId": "createAuthorizationV1beta1NamespacedLocalSubjectAccessReview",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+      }
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews": {
+    "post": {
+     "description": "create a SelfSubjectAccessReview",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization_v1beta1"
+     ],
+     "operationId": "createAuthorizationV1beta1SelfSubjectAccessReview",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1beta1.SelfSubjectAccessReview"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1beta1.SelfSubjectAccessReview"
+      }
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
+   "/apis/authorization.k8s.io/v1beta1/subjectaccessreviews": {
+    "post": {
+     "description": "create a SubjectAccessReview",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "tags": [
+      "authorization_v1beta1"
+     ],
+     "operationId": "createAuthorizationV1beta1SubjectAccessReview",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1beta1.SubjectAccessReview"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "name": "body",
+      "in": "body",
+      "required": true,
+      "schema": {
+       "$ref": "#/definitions/v1beta1.SubjectAccessReview"
+      }
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
    "/apis/autoscaling/": {
     "get": {
      "description": "get information of a group",
@@ -57704,6 +57934,33 @@
      }
     }
    },
+   "v1beta1.LocalSubjectAccessReview": {
+    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
+      "$ref": "#/definitions/v1beta1.SubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
    "v1beta1.NetworkPolicy": {
     "properties": {
      "apiVersion": {
@@ -57809,6 +58066,19 @@
      "podSelector": {
       "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.",
       "$ref": "#/definitions/unversioned.LabelSelector"
+     }
+    }
+   },
+   "v1beta1.NonResourceAttributes": {
+    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "properties": {
+     "path": {
+      "description": "Path is the URL path of the request",
+      "type": "string"
+     },
+     "verb": {
+      "description": "Verb is the standard HTTP verb",
+      "type": "string"
      }
     }
    },
@@ -58192,6 +58462,39 @@
      }
     }
    },
+   "v1beta1.ResourceAttributes": {
+    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "properties": {
+     "group": {
+      "description": "Group is the API Group of the Resource.  \"*\" means all.",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+      "type": "string"
+     },
+     "namespace": {
+      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+      "type": "string"
+     },
+     "resource": {
+      "description": "Resource is one of the existing resource types.  \"*\" means all.",
+      "type": "string"
+     },
+     "subresource": {
+      "description": "Subresource is one of the existing resource types.  \"\" means none.",
+      "type": "string"
+     },
+     "verb": {
+      "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+      "type": "string"
+     },
+     "version": {
+      "description": "Version is the API Version of the Resource.  \"*\" means all.",
+      "type": "string"
+     }
+    }
+   },
    "v1beta1.RollbackConfig": {
     "properties": {
      "revision": {
@@ -58305,6 +58608,46 @@
      "targetSelector": {
       "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
       "type": "string"
+     }
+    }
+   },
+   "v1beta1.SelfSubjectAccessReview": {
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
+      "$ref": "#/definitions/v1beta1.SelfSubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
+   "v1beta1.SelfSubjectAccessReviewSpec": {
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "nonResourceAttributes": {
+      "description": "NonResourceAttributes describes information for a non-resource access request",
+      "$ref": "#/definitions/v1beta1.NonResourceAttributes"
+     },
+     "resourceAttributes": {
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
+      "$ref": "#/definitions/v1beta1.ResourceAttributes"
      }
     }
    },
@@ -58463,6 +58806,87 @@
      "metadata": {
       "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
       "$ref": "#/definitions/unversioned.ListMeta"
+     }
+    }
+   },
+   "v1beta1.SubjectAccessReview": {
+    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated",
+      "$ref": "#/definitions/v1beta1.SubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
+   "v1beta1.SubjectAccessReviewSpec": {
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "extra": {
+      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      }
+     },
+     "group": {
+      "description": "Groups is the groups you're testing for.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "nonResourceAttributes": {
+      "description": "NonResourceAttributes describes information for a non-resource access request",
+      "$ref": "#/definitions/v1beta1.NonResourceAttributes"
+     },
+     "resourceAttributes": {
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
+      "$ref": "#/definitions/v1beta1.ResourceAttributes"
+     },
+     "user": {
+      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
+      "type": "string"
+     }
+    }
+   },
+   "v1beta1.SubjectAccessReviewStatus": {
+    "description": "SubjectAccessReviewStatus",
+    "required": [
+     "allowed"
+    ],
+    "properties": {
+     "allowed": {
+      "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
+      "type": "boolean"
+     },
+     "evaluationError": {
+      "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "Reason is optional.  It indicates why a request was allowed or denied.",
+      "type": "string"
      }
     }
    },

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -47,6 +47,7 @@ var (
 	APIGroupExtensions     = "extensions"
 	APIGroupApps           = "apps"
 	APIGroupAuthentication = "authentication.k8s.io"
+	APIGroupAuthorization  = "authorization.k8s.io"
 	APIGroupAutoscaling    = "autoscaling"
 	APIGroupBatch          = "batch"
 	APIGroupCertificates   = "certificates.k8s.io"
@@ -60,6 +61,7 @@ var (
 		APIGroupExtensions:     {"v1beta1"},
 		APIGroupApps:           {"v1beta1"},
 		APIGroupAuthentication: {"v1beta1"},
+		APIGroupAuthorization:  {"v1beta1"},
 		APIGroupAutoscaling:    {"v1"},
 		APIGroupBatch:          {"v1", "v2alpha1"},
 		APIGroupCertificates:   {"v1alpha1"},


### PR DESCRIPTION
Adds authorization.k8s.io to the list of enabled APIs.

@enj we'll want a test to make sure it doesn't just return true for everything or something crazy like that.

@liggitt  Want to try to push into the 3.5 service stream?  If we only need to have openshift-node skew of version this lets us rewrite the remote authorizer one release from now.