### PR TITLE
only report no running pods once

### DIFF
--- a/pkg/diagnostics/cluster/registry.go
+++ b/pkg/diagnostics/cluster/registry.go
@@ -175,7 +175,8 @@ func (d *ClusterRegistry) Check() types.DiagnosticResult {
 	if service := d.getRegistryService(r); service != nil {
 		// Check that it actually has pod(s) selected and running
 		if runningPods := d.getRegistryPods(service, r); len(runningPods) == 0 {
-			r.Error("DClu1001", nil, fmt.Sprintf(clRegNoRunningPods, registryName))
+			// not reporting an error here, if there are no running pods an error
+			// is reported by getRegistryPods
 			return r
 		} else if d.checkRegistryEndpoints(runningPods, r) { // Check that matching endpoint exists on the service
 			// attempt to create an imagestream and see if it gets the same registry service IP from the service cache


### PR DESCRIPTION
Currently registry diagnostics reports DCLu1006 and DCLu1001 for the same condition.  This ensures that the condition is only reported once (with DCLu1006) to avoid confusion.  

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1301464

@sosiouxme @fabianofranz  