### PR TITLE
Make HAProxy's log format configurable

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -38,7 +38,11 @@ defaults
 
   # Add x-forwarded-for header.
 {{- if ne (env "ROUTER_SYSLOG_ADDRESS" "") "" }}
+  {{- if ne (env "ROUTER_SYSLOG_FORMAT" "") "" }}
+  log-format {{env "ROUTER_SYSLOG_FORMAT" ""}}
+  {{- else }}
   option httplog
+  {{- end }}
   log global
 {{- end }}
 


### PR DESCRIPTION
Users can use the environment varible `ROUTER_SYSLOG_FORMAT` to define HAProxy's log format now.