### PR TITLE
add timeout http-keep-alive to the router template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -68,6 +68,11 @@ defaults
 {{ else }}
   timeout http-request 10s
 {{ end }}
+{{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE" "")) }}
+  timeout http-keep-alive {{env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE" "" }}
+{{ else }}
+  timeout http-keep-alive 300s
+{{ end }}
 
   # Long timeout for WebSocket connections.
 {{ if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "")) }}


### PR DESCRIPTION
a customer reported that when using "timeout http-request" for slowloris
protection it can impact connections with keep-alive. The HAProxy router
sets "timeout http-keep-alive" to "timeout http-request" when the former
is set and the latter is not and that can degrade the performance of browsers
that do not expect such a low timeout for HTTP keep-alive connections.

I added this timeout in commit: 527899eda and it was removed in
commit: a41ce2c. It looks like the removal was an oversight.

Bug 1391585