### PR TITLE
build API: mark fields related to extended builds as deprecated

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_build_api_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_build_api_v1.proto
@@ -798,14 +798,16 @@ message SourceBuildStrategy {
   // without unneeded dependencies installed. The building of the application
   // is still done in the builder image but, post build, you can copy the
   // needed artifacts in the runtime image for use.
-  // This field and the feature it enables are in tech preview.
+  // Deprecated: This feature will be removed in a future release. Use ImageSource
+  // to copy binary artifacts created from one build into a separate runtime image.
   optional k8s.io.kubernetes.pkg.api.v1.ObjectReference runtimeImage = 7;
 
   // runtimeArtifacts specifies a list of source/destination pairs that will be
   // copied from the builder to the runtime image. sourcePath can be a file or
   // directory. destinationDir must be a directory. destinationDir can also be
   // empty or equal to ".", in this case it just refers to the root of WORKDIR.
-  // This field and the feature it enables are in tech preview.
+  // Deprecated: This feature will be removed in a future release. Use ImageSource
+  // to copy binary artifacts created from one build into a separate runtime image.
   repeated ImageSourcePath runtimeArtifacts = 8;
 }
 

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -23400,14 +23400,14 @@
      },
      "runtimeImage": {
       "$ref": "v1.ObjectReference",
-      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. This field and the feature it enables are in tech preview."
+      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image."
      },
      "runtimeArtifacts": {
       "type": "array",
       "items": {
        "$ref": "v1.ImageSourcePath"
       },
-      "description": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. This field and the feature it enables are in tech preview."
+      "description": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image."
      }
     }
    },

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -55995,14 +55995,14 @@
       "$ref": "#/definitions/v1.LocalObjectReference"
      },
      "runtimeArtifacts": {
-      "description": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. This field and the feature it enables are in tech preview.",
+      "description": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/v1.ImageSourcePath"
       }
      },
      "runtimeImage": {
-      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. This field and the feature it enables are in tech preview.",
+      "description": "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
       "$ref": "#/definitions/v1.ObjectReference"
      },
      "scripts": {

--- a/pkg/build/api/v1/generated.proto
+++ b/pkg/build/api/v1/generated.proto
@@ -798,14 +798,16 @@ message SourceBuildStrategy {
   // without unneeded dependencies installed. The building of the application
   // is still done in the builder image but, post build, you can copy the
   // needed artifacts in the runtime image for use.
-  // This field and the feature it enables are in tech preview.
+  // Deprecated: This feature will be removed in a future release. Use ImageSource
+  // to copy binary artifacts created from one build into a separate runtime image.
   optional k8s.io.kubernetes.pkg.api.v1.ObjectReference runtimeImage = 7;
 
   // runtimeArtifacts specifies a list of source/destination pairs that will be
   // copied from the builder to the runtime image. sourcePath can be a file or
   // directory. destinationDir must be a directory. destinationDir can also be
   // empty or equal to ".", in this case it just refers to the root of WORKDIR.
-  // This field and the feature it enables are in tech preview.
+  // Deprecated: This feature will be removed in a future release. Use ImageSource
+  // to copy binary artifacts created from one build into a separate runtime image.
   repeated ImageSourcePath runtimeArtifacts = 8;
 }
 

--- a/pkg/build/api/v1/swagger_doc.go
+++ b/pkg/build/api/v1/swagger_doc.go
@@ -460,8 +460,8 @@ var map_SourceBuildStrategy = map[string]string{
 	"scripts":          "scripts is the location of Source scripts",
 	"incremental":      "incremental flag forces the Source build to do incremental builds if true.",
 	"forcePull":        "forcePull describes if the builder should pull the images from registry prior to building.",
-	"runtimeImage":     "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. This field and the feature it enables are in tech preview.",
-	"runtimeArtifacts": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. This field and the feature it enables are in tech preview.",
+	"runtimeImage":     "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
+	"runtimeArtifacts": "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
 }
 
 func (SourceBuildStrategy) SwaggerDoc() map[string]string {

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -534,14 +534,16 @@ type SourceBuildStrategy struct {
 	// without unneeded dependencies installed. The building of the application
 	// is still done in the builder image but, post build, you can copy the
 	// needed artifacts in the runtime image for use.
-	// This field and the feature it enables are in tech preview.
+	// Deprecated: This feature will be removed in a future release. Use ImageSource
+	// to copy binary artifacts created from one build into a separate runtime image.
 	RuntimeImage *kapi.ObjectReference `json:"runtimeImage,omitempty" protobuf:"bytes,7,opt,name=runtimeImage"`
 
 	// runtimeArtifacts specifies a list of source/destination pairs that will be
 	// copied from the builder to the runtime image. sourcePath can be a file or
 	// directory. destinationDir must be a directory. destinationDir can also be
 	// empty or equal to ".", in this case it just refers to the root of WORKDIR.
-	// This field and the feature it enables are in tech preview.
+	// Deprecated: This feature will be removed in a future release. Use ImageSource
+	// to copy binary artifacts created from one build into a separate runtime image.
 	RuntimeArtifacts []ImageSourcePath `json:"runtimeArtifacts,omitempty" protobuf:"bytes,8,rep,name=runtimeArtifacts"`
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -22939,13 +22939,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 					"runtimeImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. This field and the feature it enables are in tech preview.",
+							Description: "runtimeImage is an optional image that is used to run an application without unneeded dependencies installed. The building of the application is still done in the builder image but, post build, you can copy the needed artifacts in the runtime image for use. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
 							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectReference"),
 						},
 					},
 					"runtimeArtifacts": {
 						SchemaProps: spec.SchemaProps{
-							Description: "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. This field and the feature it enables are in tech preview.",
+							Description: "runtimeArtifacts specifies a list of source/destination pairs that will be copied from the builder to the runtime image. sourcePath can be a file or directory. destinationDir must be a directory. destinationDir can also be empty or equal to \".\", in this case it just refers to the root of WORKDIR. Deprecated: This feature will be removed in a future release. Use ImageSource to copy binary artifacts created from one build into a separate runtime image.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
Mark extended build related fields as deprecated in the builds v1 API