### PR TITLE
Egress Network policy fixes

### DIFF
--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -37,6 +37,9 @@ type OsdnProxy struct {
 	lock         sync.Mutex
 	firewall     map[string]*proxyFirewallItem
 	allEndpoints []kapi.Endpoints
+
+	idLock sync.Mutex
+	ids    map[string]uint32
 }
 
 // Called by higher layers to create the proxy plugin instance; only used by nodes
@@ -48,6 +51,7 @@ func NewProxyPlugin(pluginName string, osClient *osclient.Client, kClient *kclie
 	return &OsdnProxy{
 		kClient:  kClient,
 		osClient: osClient,
+		ids:      make(map[string]uint32),
 		firewall: make(map[string]*proxyFirewallItem),
 	}, nil
 }
@@ -71,6 +75,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsConfigHandler) error 
 	}
 
 	go utilwait.Forever(proxy.watchEgressNetworkPolicies, 0)
+	go utilwait.Forever(proxy.watchNetNamespaces, 0)
 	return nil
 }
 
@@ -93,8 +98,43 @@ func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
 	})
 }
 
+// TODO: Abstract common code shared between proxy and node
+func (proxy *OsdnProxy) watchNetNamespaces() {
+	RunEventQueue(proxy.osClient, NetNamespaces, func(delta cache.Delta) error {
+		netns := delta.Object.(*osapi.NetNamespace)
+		name := netns.ObjectMeta.Name
+
+		glog.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, name)
+		proxy.idLock.Lock()
+		defer proxy.idLock.Unlock()
+		switch delta.Type {
+		case cache.Sync, cache.Added, cache.Updated:
+			proxy.ids[name] = netns.NetID
+		case cache.Deleted:
+			delete(proxy.ids, name)
+		}
+		return nil
+	})
+}
+
+func (proxy *OsdnProxy) isNamespaceGlobal(ns string) bool {
+	proxy.idLock.Lock()
+	defer proxy.idLock.Unlock()
+
+	if proxy.ids[ns] == osapi.GlobalVNID {
+		return true
+	}
+	return false
+}
+
 func (proxy *OsdnProxy) updateEgressNetworkPolicy(policy osapi.EgressNetworkPolicy) {
 	ns := policy.Namespace
+	if proxy.isNamespaceGlobal(ns) {
+		// Firewall not allowed for global namespaces
+		glog.Errorf("EgressNetworkPolicy in global network namespace (%s) is not allowed (%s); ignoring firewall rules", ns, policy.Name)
+		return
+	}
+
 	firewall := make([]firewallItem, len(policy.Spec.Egress))
 	for i, rule := range policy.Spec.Egress {
 		_, cidr, err := net.ParseCIDR(rule.To.CIDRSelector)

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -14,12 +14,18 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	pconfig "k8s.io/kubernetes/pkg/proxy/config"
+	ktypes "k8s.io/kubernetes/pkg/types"
 	utilwait "k8s.io/kubernetes/pkg/util/wait"
 )
 
+type firewallItem struct {
+	ruleType osapi.EgressNetworkPolicyRuleType
+	net      *net.IPNet
+}
+
 type proxyFirewallItem struct {
-	policy osapi.EgressNetworkPolicyRuleType
-	net    *net.IPNet
+	namespaceFirewalls map[ktypes.UID][]firewallItem
+	activePolicy       *ktypes.UID
 }
 
 type OsdnProxy struct {
@@ -29,7 +35,7 @@ type OsdnProxy struct {
 	baseEndpointsHandler pconfig.EndpointsConfigHandler
 
 	lock         sync.Mutex
-	firewall     map[string][]proxyFirewallItem
+	firewall     map[string]*proxyFirewallItem
 	allEndpoints []kapi.Endpoints
 }
 
@@ -42,7 +48,7 @@ func NewProxyPlugin(pluginName string, osClient *osclient.Client, kClient *kclie
 	return &OsdnProxy{
 		kClient:  kClient,
 		osClient: osClient,
-		firewall: make(map[string][]proxyFirewallItem),
+		firewall: make(map[string]*proxyFirewallItem),
 	}, nil
 }
 
@@ -61,7 +67,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsConfigHandler) error 
 		return fmt.Errorf("could not get EgressNetworkPolicies: %s", err)
 	}
 	for _, policy := range policies.Items {
-		proxy.updateNetworkPolicy(policy)
+		proxy.updateEgressNetworkPolicy(policy)
 	}
 
 	go utilwait.Forever(proxy.watchEgressNetworkPolicies, 0)
@@ -78,7 +84,7 @@ func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
 		func() {
 			proxy.lock.Lock()
 			defer proxy.lock.Unlock()
-			proxy.updateNetworkPolicy(*policy)
+			proxy.updateEgressNetworkPolicy(*policy)
 			if proxy.allEndpoints != nil {
 				proxy.updateEndpoints()
 			}
@@ -87,29 +93,61 @@ func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
 	})
 }
 
-func (proxy *OsdnProxy) updateNetworkPolicy(policy osapi.EgressNetworkPolicy) {
-	firewall := make([]proxyFirewallItem, len(policy.Spec.Egress))
+func (proxy *OsdnProxy) updateEgressNetworkPolicy(policy osapi.EgressNetworkPolicy) {
+	ns := policy.Namespace
+	firewall := make([]firewallItem, len(policy.Spec.Egress))
 	for i, rule := range policy.Spec.Egress {
 		_, cidr, err := net.ParseCIDR(rule.To.CIDRSelector)
 		if err != nil {
 			// should have been caught by validation
-			glog.Errorf("Illegal CIDR value %q in EgressNetworkPolicy rule", rule.To.CIDRSelector)
+			glog.Errorf("Illegal CIDR value %q in EgressNetworkPolicy rule for policy: %v", rule.To.CIDRSelector, policy.UID)
 			return
 		}
-		firewall[i] = proxyFirewallItem{rule.Type, cidr}
+		firewall[i] = firewallItem{rule.Type, cidr}
 	}
 
+	// Add/Update/Delete firewall rules for the namespace
 	if len(firewall) > 0 {
-		proxy.firewall[policy.Namespace] = firewall
-	} else {
-		delete(proxy.firewall, policy.Namespace)
+		if _, ok := proxy.firewall[ns]; !ok {
+			item := &proxyFirewallItem{}
+			item.namespaceFirewalls = make(map[ktypes.UID][]firewallItem)
+			item.activePolicy = nil
+			proxy.firewall[ns] = item
+		}
+		proxy.firewall[ns].namespaceFirewalls[policy.UID] = firewall
+	} else if _, ok := proxy.firewall[ns]; ok {
+		delete(proxy.firewall[ns].namespaceFirewalls, policy.UID)
+		if len(proxy.firewall[ns].namespaceFirewalls) == 0 {
+			delete(proxy.firewall, ns)
+		}
+	}
+
+	// Set active policy for the namespace
+	if ref, ok := proxy.firewall[ns]; ok {
+		if len(ref.namespaceFirewalls) == 1 {
+			for uid := range ref.namespaceFirewalls {
+				ref.activePolicy = &uid
+				glog.Infof("Applied firewall egress network policy: %q to namespace: %q", uid, ns)
+			}
+		} else {
+			ref.activePolicy = nil
+			// We only allow one policy per namespace otherwise it's hard to determine which policy to apply first
+			glog.Errorf("Found multiple egress policies, dropping all firewall rules for namespace: %q", ns)
+		}
 	}
 }
 
 func (proxy *OsdnProxy) firewallBlocksIP(namespace string, ip net.IP) bool {
-	for _, item := range proxy.firewall[namespace] {
-		if item.net.Contains(ip) {
-			return item.policy == osapi.EgressNetworkPolicyRuleDeny
+	if ref, ok := proxy.firewall[namespace]; ok {
+		if ref.activePolicy == nil {
+			// Block all connections if active policy is not set
+			return true
+		}
+
+		for _, item := range ref.namespaceFirewalls[*ref.activePolicy] {
+			if item.net.Contains(ip) {
+				return item.ruleType == osapi.EgressNetworkPolicyRuleDeny
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
- We allow multiple policies to be created per namespace but we only recommend
  one policy per namespace as per our design.
  In case of multiple policies per namespace, we drop all corresponding ovs rules
  because its hard to determine which policy to apply first but currently we keep
  the latest policy firewall rules in this case. To be consistent with ovs rules
  behavior, this fix will drop all firewall rules as well.
- Renamed proxy.updateNetworkPolicy() to proxy.updateEgressNetworkPolicy()
  to make it more clear and not to get confused with np.updateNetworkPolicy()
  in networkpolicy.go