### PR TITLE
Bug 1425706 - protect from nil tlsConfig.

### DIFF
--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -488,7 +488,7 @@ func getClients(f *clientcmd.Factory, caBundle string) (*client.Client, kclients
 
 	// if the user specified a CA on the command line, add it to the
 	// client config's CA roots
-	if len(caBundle) > 0 {
+	if tlsConfig != nil && len(caBundle) > 0 {
 		data, err := ioutil.ReadFile(caBundle)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
In very special case (client config does not contain ca cert nor auth cert nor
set tls-insecure), tlsConfig can be nil and no error is returned from TLSConfigFor
either, thus we need to check for nil on tlsConfig before proceeding in
image pruning.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1425706.

@miminar || @legionus ptal