### PR TITLE
[3.5] Enable garbage collector for replicaset and rc controller

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -192,7 +192,11 @@ func (c *MasterConfig) RunReplicaSetController(client *kclientset.Clientset) {
 		client,
 		replicasetcontroller.BurstReplicas,
 		int(c.ControllerManager.LookupCacheSizeForRC),
-		c.ControllerManager.EnableGarbageCollector,
+		// The garbage collector flag has to be set true, otherwise the controller won't see
+		// the owners references of pods which might lead to removal of pods that are not
+		// owned by this controller.
+		// This flag will be removed in 1.6.
+		true,
 	)
 	go controller.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
 }
@@ -205,7 +209,11 @@ func (c *MasterConfig) RunReplicationController(client *kclientset.Clientset) {
 		kctrlmgr.ResyncPeriod(c.ControllerManager),
 		replicationcontroller.BurstReplicas,
 		int(c.ControllerManager.LookupCacheSizeForRC),
-		c.ControllerManager.EnableGarbageCollector,
+		// The garbage collector flag has to be set true, otherwise the controller won't see
+		// the owners references of pods which might lead to removal of pods that are not
+		// owned by this controller.
+		// This flag will be removed in 1.6.
+		true,
 	)
 	go controllerManager.Run(int(c.ControllerManager.ConcurrentRCSyncs), utilwait.NeverStop)
 }


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/12927 (for 3.5)
Master: https://github.com/openshift/origin/pull/13079