### PR TITLE
openvswitch -- don't overwrite /usr/local/bin with a file

### DIFF
--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -20,7 +20,7 @@ VOLUME /etc/openswitch
 ENV HOME /root
 
 # files required to run as a system container
-COPY system-container/system-container-wrapper.sh /usr/local/bin
+COPY system-container/system-container-wrapper.sh /usr/local/bin/
 COPY system-container/config.json.template system-container/service.template /exports/
 
 ENTRYPOINT ["/usr/local/bin/ovs-run.sh"]


### PR DESCRIPTION
Fixes #13069 

Though, I don't understand how this isn't an issue in openshift/openvswitch:latest as there's no diff between the two. So I'm slightly concerned I don't understand the problem.