### PR TITLE
networking tests for a pre configured cluster using cni plugin

### DIFF
--- a/test/extended/cni_vendor_test.sh
+++ b/test/extended/cni_vendor_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+# Set this to false if namespaces are not isolated
+export OPENSHIFT_NETWORK_ISOLATION="${OPENSHIFT_NETWORK_ISOLATION:-true}"
+export NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-\[networking\]}"
+export NETWORKING_E2E_MINIMAL=1
+
+# Checking for a given kubeconfig
+os::log::info "Starting 'networking' extended tests for cni plugin"
+if [[ -n "${OPENSHIFT_TEST_KUBECONFIG:-}" ]]; then
+  # Run tests against an existing cluster
+  "${OS_ROOT}/test/extended/networking.sh" $@
+else
+  os::log::error "Please set env OPENSHIFT_TEST_KUBECONFIG to run the tests against an existing cluster"
+  exit 1
+fi

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -23,8 +23,6 @@ NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 NETWORKING_E2E_MINIMAL="${NETWORKING_E2E_MINIMAL:-}"
 
 DEFAULT_SKIP_LIST=(
-  # TODO(marun) This should work with docker >= 1.10
-  "openshift router"
   "\[Feature:Federation\]"
 
   # Skipped until https://github.com/openshift/origin/issues/11042 is resolved


### PR DESCRIPTION
A new script that runs networking tests meant for a cluster configured with a vendor's cni plugin.

Also, this PR removes the 'openshift router' testcases from the SKIP LIST.

@marun PTAL