### PR TITLE
Change router event queue to use a work queue based implementation.

### DIFF
--- a/pkg/util/eventqueue/eventqueue.go
+++ b/pkg/util/eventqueue/eventqueue.go
@@ -1,0 +1,297 @@
+package eventqueue
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+
+	kcache "k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/util/uuid"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Event is an item added to the EventQueue.
+type Event struct {
+	id        string
+	eventType watch.EventType
+	obj       interface{}
+}
+
+// EventQueue is a Store implementation that provides an ordered sequence of
+// watched events (type and the affected object) to the consumer.
+type EventQueue struct {
+	lock sync.RWMutex
+	cond sync.Cond
+
+	store kcache.Store
+	keyFn kcache.KeyFunc
+
+	// List of generated events.
+	events map[string]*Event
+
+	// Queue containing the events ids to be processed.
+	queue *workqueue.Type
+
+	// Tracks whether Replace() has been called at least once.
+	replaced bool
+
+	// Tracks the last event added to the queue by the most recent
+	// Replace() call. A reflector replaces the queue contents on a
+	// re-list by calling Replace(), so a non-empty key indicates that
+	// the event has been consumed (read via Pop()).
+	lastReplaceEventId string
+
+	// Tracks the number of items queued by the last Replace() call.
+	lastReplaceCount int
+}
+
+// EventQueueStopped conveys that the EventQueue has been shutdown.
+type EventQueueStopped struct{}
+
+// EventQueue implements kcache.Store
+var _ kcache.Store = &EventQueue{}
+
+// Error returns a messsage indicating that the event queue was shutdown.
+func (es EventQueueStopped) Error() string {
+	return fmt.Sprintf("Event queue was stopped.")
+}
+
+// clearEvents resets the event queue - clearing all the events.
+func (eq *EventQueue) clearEvents() {
+	eq.lock.Lock()
+	defer eq.lock.Unlock()
+
+	eq.events = map[string]*Event{}
+}
+
+// getEvents returns a list of events currently in the event queue.
+func (eq *EventQueue) eventList() []*Event {
+	eq.lock.RLock()
+	defer eq.lock.RUnlock()
+
+	list := make([]*Event, 0, len(eq.events))
+	for _, ev := range eq.events {
+		list = append(list, ev)
+	}
+
+	return list
+}
+
+// updateStore updates the local object store based on the event type.
+func (eq *EventQueue) updateStore(obj interface{}, eventType watch.EventType) error {
+	switch eventType {
+	case watch.Deleted:
+		return eq.store.Delete(obj)
+	case watch.Added:
+		return eq.store.Add(obj)
+	case watch.Modified:
+		return eq.store.Update(obj)
+	}
+
+	return nil
+}
+
+// handleEvent is called by Add, Update, Delete, Reload and Resync to create
+// an entry in the underlying queue and optionally update the object store.
+func (eq *EventQueue) handleEvent(obj interface{}, eventType watch.EventType, update bool) (string, error) {
+	eq.lock.Lock()
+	defer eq.lock.Unlock()
+
+	eventId := fmt.Sprintf("%s", uuid.NewUUID())
+	eq.events[eventId] = &Event{eventId, eventType, obj}
+	eq.queue.Add(eventId)
+
+	if update {
+		if err := eq.updateStore(obj, eventType); err != nil {
+			return "", err
+		}
+	}
+
+	return eventId, nil
+}
+
+// Add enqueues a watch.Added event for the given state.
+func (eq *EventQueue) Add(obj interface{}) error {
+	_, err := eq.handleEvent(obj, watch.Added, true)
+	return err
+}
+
+// Update enqueues a watch.Modified event for the given state.
+func (eq *EventQueue) Update(obj interface{}) error {
+	_, err := eq.handleEvent(obj, watch.Modified, true)
+	return err
+}
+
+// Delete enqueues a watch.Delete event for the given object.
+func (eq *EventQueue) Delete(obj interface{}) error {
+	_, err := eq.handleEvent(obj, watch.Deleted, true)
+	return err
+}
+
+// List returns a list of objects associated with the enqueued events.
+func (eq *EventQueue) List() []interface{} {
+	events := eq.eventList()
+
+	list := make([]interface{}, 0, len(events))
+	for _, ev := range events {
+		list = append(list, ev.obj)
+	}
+
+	return list
+}
+
+// List returns a list of keys of the objects associated with the enqueued events.
+func (eq *EventQueue) ListKeys() []string {
+	events := eq.eventList()
+
+	list := make([]string, 0, len(events))
+	for _, ev := range events {
+		key, err := eq.keyFn(ev.obj)
+		if err != nil {
+			glog.V(4).Infof("invalid object %v, skipped for listing", ev.obj)
+		} else {
+			list = append(list, key)
+		}
+	}
+
+	return list
+}
+
+// Get returns the requested item, or sets exists=false.
+func (eq *EventQueue) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	key, err := eq.keyFn(obj)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return eq.store.GetByKey(key)
+}
+
+// GetByKey returns the requested item, or sets exists=false.
+func (eq *EventQueue) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return eq.store.GetByKey(key)
+}
+
+// Pop gets the event and object at the head of the queue.  If the event
+// is a delete event, Pop deletes the key from the underlying cache.
+func (eq *EventQueue) Pop() (watch.EventType, interface{}, error) {
+	for {
+		id, shutdown := eq.queue.Get()
+		if shutdown {
+			return watch.Error, nil, EventQueueStopped{}
+		}
+
+		eventId := id.(string)
+
+		eq.lock.Lock()
+		defer eq.lock.Unlock()
+
+		qevent, ok := eq.events[eventId]
+		if !ok {
+			// Note: The work queue may have "dirty" entries or
+			//       we have replaced the events.
+			// If we don't have the event, then skip the work
+			// queue entry but mark it as processed.
+			eq.queue.Done(id)
+			continue
+		}
+
+		// If this is the last replace event we are processing,
+		// reset it indicating that we have now processed all the
+		// replaced cache entries.
+		if eq.lastReplaceEventId == eventId {
+			eq.lastReplaceEventId = ""
+		}
+
+		// We have the event - remove it from the event queue and
+		// mark the work queue entry as processed.
+		delete(eq.events, eventId)
+		eq.queue.Done(id)
+
+		return qevent.eventType, qevent.obj, nil
+	}
+}
+
+// Replace initializes 'eq' with the state contained in the given map and
+// populates the events with a watch.Modified event for each of the replaced
+// objects.
+func (eq *EventQueue) Replace(objects []interface{}, resourceVersion string) error {
+	eq.clearEvents()
+	lastEventId := ""
+	for i := range objects {
+		lastEventId, _ = eq.handleEvent(objects[i], watch.Modified, false)
+	}
+
+	eq.lock.Lock()
+	defer eq.lock.Unlock()
+
+	eq.lastReplaceCount = len(objects)
+	eq.lastReplaceEventId = lastEventId
+	eq.replaced = true
+
+	return nil
+}
+
+// ListSuccessfulAtLeastOnce indicates whether a List operation was
+// successfully completed regardless of whether any items were queued.
+func (eq *EventQueue) ListSuccessfulAtLeastOnce() bool {
+	eq.lock.RLock()
+	defer eq.lock.RUnlock()
+
+	return eq.replaced
+}
+
+// ListCount returns how many objects were queued by the most recent List operation.
+func (eq *EventQueue) ListCount() int {
+	eq.lock.RLock()
+	defer eq.lock.RUnlock()
+
+	return eq.lastReplaceCount
+}
+
+// ListConsumed indicates whether the items queued by a List/Relist
+// operation have been consumed.
+func (eq *EventQueue) ListConsumed() bool {
+	eq.lock.RLock()
+	defer eq.lock.RUnlock()
+
+	return eq.lastReplaceEventId == ""
+}
+
+// Resync will add all currently stored objects to the processing queue.
+func (eq *EventQueue) Resync() error {
+	lastEventId := ""
+	storeKeys := eq.store.ListKeys()
+	for i := range storeKeys {
+		obj, exists, err := eq.store.GetByKey(storeKeys[i])
+		if err == nil && exists {
+			lastEventId, _ = eq.handleEvent(obj, watch.Modified, false)
+		}
+	}
+
+	eq.lock.Lock()
+	defer eq.lock.Unlock()
+
+	eq.lastReplaceEventId = lastEventId
+
+	return nil
+}
+
+// NewEventQueueForStore returns a new EventQueue that uses the provided store.
+func NewEventQueueForStore(keyFn kcache.KeyFunc, store kcache.Store) *EventQueue {
+	eq := &EventQueue{
+		store:  store,
+		keyFn:  keyFn,
+		events: make(map[string]*Event, 0),
+		queue:  workqueue.New(),
+	}
+	eq.cond.L = &eq.lock
+	return eq
+}
+
+// NewEventQueue returns a new EventQueue.
+func NewEventQueue(keyFn kcache.KeyFunc) *EventQueue {
+	return NewEventQueueForStore(keyFn, kcache.NewStore(keyFn))
+}

--- a/pkg/util/eventqueue/eventqueue_test.go
+++ b/pkg/util/eventqueue/eventqueue_test.go
@@ -1,0 +1,342 @@
+package eventqueue
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type cacheable struct {
+	key   string
+	value interface{}
+}
+
+func keyFunc(obj interface{}) (string, error) {
+	return obj.(cacheable).key, nil
+}
+
+func TestEventQueue_basic(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+
+	const amount = 500
+	go func() {
+		for i := 0; i < amount; i++ {
+			q.Add(cacheable{string([]rune{'a', rune(i)}), i + 1})
+		}
+	}()
+	go func() {
+		for u := uint(0); u < amount; u++ {
+			q.Add(cacheable{string([]rune{'b', rune(u)}), u + 1})
+		}
+	}()
+
+	lastInt := int(0)
+	lastUint := uint(0)
+	for i := 0; i < amount*2; i++ {
+		_, obj, _ := q.Pop()
+		value := obj.(cacheable).value
+		switch v := value.(type) {
+		case int:
+			if v <= lastInt {
+				t.Errorf("got %v (int) out of order, last was %v", v, lastInt)
+			}
+			lastInt = v
+		case uint:
+			if v <= lastUint {
+				t.Errorf("got %v (uint) out of order, last was %v", v, lastUint)
+			} else {
+				lastUint = v
+			}
+		default:
+			t.Fatalf("unexpected type %#v", obj)
+		}
+	}
+}
+
+func TestEventQueue_multipleEvents(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+
+	testCases := []struct {
+		Op  watch.EventType
+		Obj cacheable
+	}{
+		{watch.Added, cacheable{"foo", 10}},
+		{watch.Deleted, cacheable{key: "foo"}},
+		{watch.Added, cacheable{"foo", 20}},
+		{watch.Modified, cacheable{"foo", 21}},
+		{watch.Modified, cacheable{"foo", 22}},
+		{watch.Deleted, cacheable{key: "foo"}},
+		{watch.Modified, cacheable{"foo", 23}},
+		{watch.Added, cacheable{"foo", 30}},
+		{watch.Modified, cacheable{"foo", 31}},
+		{watch.Modified, cacheable{"foo", 32}},
+		{watch.Modified, cacheable{"foo", 33}},
+		{watch.Modified, cacheable{"foo", 34}},
+	}
+
+	for _, tc := range testCases {
+		switch tc.Op {
+		case watch.Added:
+			q.Add(tc.Obj)
+		case watch.Modified:
+			q.Update(tc.Obj)
+		case watch.Deleted:
+			q.Delete(tc.Obj)
+		default:
+			t.Errorf("Invalid operation %v", tc.Op)
+		}
+	}
+
+	for _, tc := range testCases {
+		event, thing, _ := q.Pop()
+		if event != tc.Op {
+			t.Errorf("expected event %v, got %v", tc.Op, event)
+		}
+
+		if event != watch.Deleted {
+			value := thing.(cacheable).value
+			if value != tc.Obj.value {
+				t.Fatalf("expected value %v, got %v", tc.Obj.value, value)
+			}
+		}
+	}
+}
+
+func TestEventQueue_List(t *testing.T) {
+	iq := NewEventQueue(keyFunc)
+	if len(iq.List()) != 0 {
+		t.Fatalf("expected List size to be 0 at queue creation")
+	}
+
+	single := []interface{}{cacheable{"single", 1}}
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	testCases := []struct {
+		Name     string
+		Objects  []interface{}
+		Version  string
+		Expected int
+	}{
+		{"without items", []interface{}{}, "1", 0},
+		{"with single item", single, "2", 1},
+		{"with multiple items", items, "3", len(items)},
+	}
+
+	for _, tc := range testCases {
+		q := NewEventQueue(keyFunc)
+		q.Replace(tc.Objects, tc.Version)
+		list := q.List()
+		if len(list) != tc.Expected {
+			t.Fatalf("expected List size to be %v after Replace() %s, got %v", tc.Expected, tc.Name, len(list))
+		}
+	}
+}
+
+func TestEventQueue_ListKeys(t *testing.T) {
+	iq := NewEventQueue(keyFunc)
+	if len(iq.ListKeys()) != 0 {
+		t.Fatalf("expected ListKeys to be 0 at queue creation")
+	}
+
+	single := []interface{}{cacheable{"single", 1}}
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	testCases := []struct {
+		Name     string
+		Objects  []interface{}
+		Version  string
+		Expected int
+	}{
+		{"without items", []interface{}{}, "1", 0},
+		{"with single item", single, "2", 1},
+		{"with multiple items", items, "3", len(items)},
+	}
+
+	for _, tc := range testCases {
+		q := NewEventQueue(keyFunc)
+		q.Replace(tc.Objects, tc.Version)
+		keys := q.ListKeys()
+		if len(keys) != tc.Expected {
+			t.Fatalf("expected ListKeys to be %v after Replace() %s, got %v", tc.Expected, tc.Name, len(keys))
+		}
+	}
+}
+
+func TestEventQueue_ListCount(t *testing.T) {
+	iq := NewEventQueue(keyFunc)
+	if iq.ListCount() != 0 {
+		t.Fatalf("expected ListCount to be 0 at queue creation")
+	}
+
+	single := []interface{}{cacheable{"single", 1}}
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	testCases := []struct {
+		Name     string
+		Objects  []interface{}
+		Version  string
+		Expected int
+	}{
+		{"without items", []interface{}{}, "1", 0},
+		{"with single item", single, "2", 1},
+		{"with multiple items", items, "3", len(items)},
+	}
+
+	for _, tc := range testCases {
+		q := NewEventQueue(keyFunc)
+		q.Replace(tc.Objects, tc.Version)
+		itemCount := q.ListCount()
+		if itemCount != tc.Expected {
+			t.Fatalf("expected ListCount to be %v after Replace() %s, got %v", tc.Expected, tc.Name, itemCount)
+		}
+	}
+}
+
+func TestEventQueue_ListSuccessfulAtLeastOnce(t *testing.T) {
+	iq := NewEventQueue(keyFunc)
+	if iq.ListSuccessfulAtLeastOnce() {
+		t.Fatalf("expected ListSuccessfulAtLeastOnce to be false at queue creation")
+	}
+
+	single := []interface{}{cacheable{"single", 1}}
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	testCases := []struct {
+		Name     string
+		Objects  []interface{}
+		Version  string
+		Expected bool
+	}{
+		{"without items", []interface{}{}, "1", true},
+		{"with single item", single, "2", true},
+		{"with multiple items", items, "3", true},
+	}
+
+	for _, tc := range testCases {
+		q := NewEventQueue(keyFunc)
+		q.Replace(tc.Objects, tc.Version)
+		flag := q.ListSuccessfulAtLeastOnce()
+		if flag != tc.Expected {
+			t.Fatalf("expected ListCount to be %v after Replace() %s, got %v", tc.Expected, tc.Name, flag)
+		}
+	}
+}
+
+func TestEventQueue_ListConsumed(t *testing.T) {
+	iq := NewEventQueue(keyFunc)
+	if !iq.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queue creation")
+	}
+
+	single := []interface{}{cacheable{"single", 1}}
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	testCases := []struct {
+		Name     string
+		Objects  []interface{}
+		Version  string
+		Expected bool
+	}{
+		{"without items", []interface{}{}, "1", true},
+		{"with single item", single, "2", false},
+		{"with multiple items", items, "3", false},
+	}
+
+	for _, tc := range testCases {
+		q := NewEventQueue(keyFunc)
+		q.Replace(tc.Objects, tc.Version)
+		flag := q.ListConsumed()
+		if flag != tc.Expected {
+			t.Fatalf("expected ListConsumed to be %v after Replace() %s, got %v", tc.Expected, tc.Name, flag)
+		}
+	}
+
+	pq := NewEventQueue(keyFunc)
+	pq.Replace(single, "5")
+	pq.Pop()
+	if !pq.ListConsumed() {
+		t.Fatalf("expected ListConsumed to be true after queued items read")
+	}
+}
+
+func TestEventQueue_Resync(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+	if len(q.ListKeys()) != 0 {
+		t.Fatalf("expected count to be 0 at queue creation")
+	}
+
+	items := []interface{}{
+		cacheable{"c1", 1},
+		cacheable{"c2", 2},
+		cacheable{"c3", 3},
+		cacheable{"c4", 4},
+		cacheable{"c5", 5},
+	}
+
+	expectation := 0
+	for i := range items {
+		q.Add(items[i])
+		expectation++
+	}
+
+	qcount := len(q.ListKeys())
+	if qcount != expectation {
+		t.Fatalf("expected count to be %d after adding items, got %d", expectation, qcount)
+	}
+
+	q.Resync()
+	expectation += len(items)
+	qcount = len(q.ListKeys())
+	if qcount != expectation {
+		t.Fatalf("expected count to be %d after Resync(), got %d", expectation, qcount)
+	}
+
+	q.Add(items[0])
+	expectation++
+	q.Add(items[0])
+	expectation++
+	qcount = len(q.ListKeys())
+	if qcount != expectation {
+		t.Fatalf("expected count to be %d after adding same event twice, got %d", expectation, qcount)
+	}
+
+	q.Replace([]interface{}{}, "2")
+	expectation = 0
+
+	q.Resync()
+	expectation += len(items)
+	qcount = len(q.ListKeys())
+	if qcount != expectation {
+		t.Fatalf("expected count to be %d after second Resync(), got %d", expectation, qcount)
+	}
+}


### PR DESCRIPTION
Associated trello card: https://trello.com/c/y6SFvOA7/442-8-replace-eventqueue-in-router-ingress
replaces event queue with a new work queue based event queue (too many queues!).

@rajatchopra  @knobunc  @smarterclayton  PTAL thx

I stress tested this with scripts from this repo:
     https://github.com/ramr/router-stress-scripts

And also checked that the original panic reproduction script from:      
     https://gist.github.com/ramr/58dbdc3c5982db7b3c3154eb4bca60c8
works fine as well. New code and no panics.