### PR TITLE
oc: rolling back to the same dc version should be a no-op

### DIFF
--- a/pkg/deploy/registry/rollback/rest.go
+++ b/pkg/deploy/registry/rollback/rest.go
@@ -64,6 +64,8 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 		return nil, newInvalidError(rollback, "cannot rollback an undeployed config")
 	case 1:
 		return nil, newInvalidError(rollback, fmt.Sprintf("no previous deployment exists for %q", deployutil.LabelForDeploymentConfig(from)))
+	case rollback.Spec.Revision:
+		return nil, newInvalidError(rollback, fmt.Sprintf("version %d is already the latest", rollback.Spec.Revision))
 	}
 
 	revision := from.Status.LatestVersion - 1

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -111,6 +111,8 @@ os::cmd::expect_failure 'oc rollback database -o yaml'
 os::cmd::expect_success 'oc set image dc/database ruby-helloworld-database=foo --source=docker'
 # wait for the new deployment
 os::cmd::try_until_success 'oc rollout history dc/database --revision=2'
+# rolling back to the same revision should fail
+os::cmd::expect_failure 'oc rollback dc/database --to-version=2'
 # undo --dry-run should report the original image
 os::cmd::expect_success_and_text 'oc rollout undo dc/database --dry-run' 'mysql-57-centos7'
 echo "rollback: ok"


### PR DESCRIPTION
Refrain from rolling back deploymentconfig if from.Status.LatestVersion equals rollback.Spec.Revision