### PR TITLE
Use DefaultImagePrefix instead of hardcoded 'openshift/origin' for network diagnostic image.

### DIFF
--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -12,6 +12,7 @@ import (
 
 	osclient "github.com/openshift/origin/pkg/client"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/sdn/api"
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/util/netutils"
@@ -31,8 +32,10 @@ const (
 	NetworkDiagNodeLogDirPrefix      = "/nodes"
 	NetworkDiagMasterLogDirPrefix    = "/master"
 	NetworkDiagPodLogDirPrefix       = "/pods"
+)
 
-	NetworkDiagDefaultPodImage = "openshift/origin"
+var (
+	NetworkDiagDefaultPodImage = variable.DefaultImagePrefix
 )
 
 func GetOpenShiftNetworkPlugin(osClient *osclient.Client) (string, bool, error) {


### PR DESCRIPTION
DefaultImagePrefix will have proper default value based on origin or OCP environment.