### PR TITLE
UPSTREAM: 41864: Allow 'kubectl drain --force' to remove orphaned pods

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
@@ -150,7 +150,8 @@ var (
 		DaemonSet controller, which ignores unschedulable markings.  If there are any
 		pods that are neither mirror pods nor managed by ReplicationController,
 		ReplicaSet, DaemonSet, StatefulSet or Job, then drain will not delete any pods unless you
-		use --force.
+		use --force.  --force will also allow deletion to proceed if the managing resource of one
+		or more pods is missing.
 
 		'drain' waits for graceful termination. You should not operate on the machine until
 		the command completes.
@@ -308,6 +309,10 @@ func (o *DrainOptions) unreplicatedFilter(pod api.Pod) (bool, *warning, *fatal) 
 
 	sr, err := o.getPodCreator(pod)
 	if err != nil {
+		// if we're forcing, remove orphaned pods with a warning
+		if apierrors.IsNotFound(err) && o.Force {
+			return true, &warning{err.Error()}, nil
+		}
 		return false, nil, &fatal{err.Error()}
 	}
 	if sr != nil {
@@ -320,11 +325,19 @@ func (o *DrainOptions) unreplicatedFilter(pod api.Pod) (bool, *warning, *fatal) 
 }
 
 func (o *DrainOptions) daemonsetFilter(pod api.Pod) (bool, *warning, *fatal) {
-	// Note that we return false in all cases where the pod is DaemonSet managed,
+	// Note that we return false in cases where the pod is DaemonSet managed,
 	// regardless of flags.  We never delete them, the only question is whether
 	// their presence constitutes an error.
+	//
+	// The exception is for pods that are orphaned (the referencing
+	// management resource - including DaemonSet - is not found).
+	// Such pods will be deleted if --force is used.
 	sr, err := o.getPodCreator(pod)
 	if err != nil {
+		// if we're forcing, remove orphaned pods with a warning
+		if apierrors.IsNotFound(err) && o.Force {
+			return true, &warning{err.Error()}, nil
+		}
 		return false, nil, &fatal{err.Error()}
 	}
 	if sr == nil || sr.Reference.Kind != "DaemonSet" {


### PR DESCRIPTION
If the managing resource of a given pod (e.g. DaemonSet/ReplicaSet/etc) is deleted (effectively orphaning the pod), and kubectl drain --force is invoked on the node hosting the pod, the command would fail with an error indicating that the managing resource was not found. This PR reduces the error to a warning if --force is specified, allowing nodes with orphaned pods to be drained.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1424678