### PR TITLE
Add validation to SDN objects with invalid name funcs

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_sdn_api_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_sdn_api_v1.proto
@@ -91,8 +91,7 @@ message HostSubnet {
   // Standard object's metadata.
   optional k8s.io.kubernetes.pkg.api.v1.ObjectMeta metadata = 1;
 
-  // Host is the name of the node. (This is redundant with the object's name, and this
-  // field is not actually used any more.)
+  // Host is the name of the node. (This is the same as the object's name, but both fields must be set.)
   optional string host = 2;
 
   // HostIP is the IP address to be used as a VTEP by other nodes in the overlay network

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -26657,7 +26657,7 @@
      },
      "host": {
       "type": "string",
-      "description": "Host is the name of the node. (This is redundant with the object's name, and this field is not actually used any more.)"
+      "description": "Host is the name of the node. (This is the same as the object's name, but both fields must be set.)"
      },
      "hostIP": {
       "type": "string",

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -50864,7 +50864,7 @@
       "type": "string"
      },
      "host": {
-      "description": "Host is the name of the node. (This is redundant with the object's name, and this field is not actually used any more.)",
+      "description": "Host is the name of the node. (This is the same as the object's name, but both fields must be set.)",
       "type": "string"
      },
      "hostIP": {

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -13228,7 +13228,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 					"host": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Host is the name of the node. (This is redundant with the object's name, and this field is not actually used any more.)",
+							Description: "Host is the name of the node. (This is the same as the object's name, but both fields must be set.)",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/sdn/api/v1/generated.proto
+++ b/pkg/sdn/api/v1/generated.proto
@@ -91,8 +91,7 @@ message HostSubnet {
   // Standard object's metadata.
   optional k8s.io.kubernetes.pkg.api.v1.ObjectMeta metadata = 1;
 
-  // Host is the name of the node. (This is redundant with the object's name, and this
-  // field is not actually used any more.)
+  // Host is the name of the node. (This is the same as the object's name, but both fields must be set.)
   optional string host = 2;
 
   // HostIP is the IP address to be used as a VTEP by other nodes in the overlay network

--- a/pkg/sdn/api/v1/swagger_doc.go
+++ b/pkg/sdn/api/v1/swagger_doc.go
@@ -79,7 +79,7 @@ func (EgressNetworkPolicySpec) SwaggerDoc() map[string]string {
 var map_HostSubnet = map[string]string{
 	"":         "HostSubnet describes the container subnet network on a node. The HostSubnet object must have the same name as the Node object it corresponds to.",
 	"metadata": "Standard object's metadata.",
-	"host":     "Host is the name of the node. (This is redundant with the object's name, and this field is not actually used any more.)",
+	"host":     "Host is the name of the node. (This is the same as the object's name, but both fields must be set.)",
 	"hostIP":   "HostIP is the IP address to be used as a VTEP by other nodes in the overlay network",
 	"subnet":   "Subnet is the CIDR range of the overlay network assigned to the node for its pods",
 }

--- a/pkg/sdn/api/v1/types.go
+++ b/pkg/sdn/api/v1/types.go
@@ -45,8 +45,7 @@ type HostSubnet struct {
 	// Standard object's metadata.
 	kapi.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Host is the name of the node. (This is redundant with the object's name, and this
-	// field is not actually used any more.)
+	// Host is the name of the node. (This is the same as the object's name, but both fields must be set.)
 	Host string `json:"host" protobuf:"bytes,2,opt,name=host"`
 	// HostIP is the IP address to be used as a VTEP by other nodes in the overlay network
 	HostIP string `json:"hostIP" protobuf:"bytes,3,opt,name=hostIP"`

--- a/pkg/sdn/api/validation/validation.go
+++ b/pkg/sdn/api/validation/validation.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"net"
 
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -85,6 +86,10 @@ func ValidateClusterNetworkUpdate(obj *sdnapi.ClusterNetwork, old *sdnapi.Cluste
 func ValidateHostSubnet(hs *sdnapi.HostSubnet) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&hs.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
 
+	if hs.Host != hs.Name {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("host"), hs.Host, fmt.Sprintf("must be the same as metadata.name: %q", hs.Name)))
+	}
+
 	if hs.Subnet == "" {
 		// check if annotation exists, then let the Subnet field be empty
 		if _, ok := hs.Annotations[sdnapi.AssignHostSubnetAnnotation]; !ok {
@@ -117,8 +122,12 @@ func ValidateHostSubnetUpdate(obj *sdnapi.HostSubnet, old *sdnapi.HostSubnet) fi
 func ValidateNetNamespace(netnamespace *sdnapi.NetNamespace) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&netnamespace.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
 
+	if netnamespace.NetName != netnamespace.Name {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("netname"), netnamespace.NetName, fmt.Sprintf("must be the same as metadata.name: %q", netnamespace.Name)))
+	}
+
 	if err := sdnapi.ValidVNID(netnamespace.NetID); err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("netID"), netnamespace.NetID, err.Error()))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("netid"), netnamespace.NetID, err.Error()))
 	}
 	return allErrs
 }


### PR DESCRIPTION
Fixes #12697 with https://github.com/openshift/openshift-ansible/pull/3387 as a prerequisite.

Supersedes #12959

I left the two invalid `ObjectNameFunc`s alone as this prevents them from being a problem (and @soltysh has already removed them in #12541).

cc @openshift/api-review @mfojtik @sdodson @openshift/networking 

Signed-off-by: Monis Khan <mkhan@redhat.com>