### PR TITLE
Extended test updates

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -97,6 +97,6 @@ function os::cleanup::internal::list_k8s_containers() {
 		fi
 	done
 
-	echo "${ids[*]}"
+	echo "${ids[*]:+"${ids[*]}"}"
 }
 readonly -f os::cleanup::internal::list_k8s_containers

--- a/test/extended/compatibility.sh
+++ b/test/extended/compatibility.sh
@@ -19,4 +19,4 @@ os::test::extended::focus "$@"
 
 
 os::log::info "Running compatibility tests"
-FOCUS="\[Compatibility\]" SKIP="${SKIP_TESTS:-}" TEST_REPORT_FILE_NAME=compatibility os::test::extended::run -- -ginkgo.v -test.timeout 2h
+FOCUS="\[Compatibility\]" SKIP="${SKIP_TESTS:-}" TEST_REPORT_FILE_NAME=compatibility os::test::extended::run -- -test.timeout 2h

--- a/test/extended/conformance.sh
+++ b/test/extended/conformance.sh
@@ -23,11 +23,11 @@ exitstatus=0
 
 # run parallel tests
 os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>}"
-TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=conformance_parallel os::test::extended::run -- -ginkgo.noColor -ginkgo.v -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=conformance_parallel os::test::extended::run -- -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 # run tests in serial
 os::log::info "Running serial tests"
-FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=conformance_serial os::test::extended::run -- -ginkgo.noColor -ginkgo.v -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=conformance_serial os::test::extended::run -- -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 os::test::extended::merge_junit
 

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -24,12 +24,12 @@ exitstatus=0
 
 # run parallel tests
 os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>}"
-TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=core_parallel os::test::extended::run -- -ginkgo.noColor -ginkgo.v -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=core_parallel os::test::extended::run -- -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 # run tests in serial
 os::log::info ""
 os::log::info "Running serial tests"
-FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=core_serial os::test::extended::run -- -ginkgo.noColor -ginkgo.v -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=core_serial os::test::extended::run -- -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 os::test::extended::merge_junit
 

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -250,6 +250,9 @@ readonly -f os::test::extended::test_list
 # This works around a gap in Jenkins JUnit reporter output that double counts skipped
 # files until https://github.com/jenkinsci/junit-plugin/pull/54 is merged.
 function os::test::extended::merge_junit () {
+	if [[ -z "${JUNIT_REPORT:-}" ]]; then
+		return
+	fi
 	local output
 	output="$( mktemp )"
 	"$( os::util::find::built_binary junitmerge )" "${TEST_REPORT_DIR}"/*.xml > "${output}"

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -205,7 +205,7 @@ function os::test::extended::run () {
 		return
 	fi
 
-	ginkgo -v "${runArgs[@]}" "$( os::util::find::built_binary extended.test )" "$@"
+	ginkgo -v -noColor "${runArgs[@]}" "$( os::util::find::built_binary extended.test )" "$@"
 }
 
 # Create a list of extended tests to be run with the given arguments


### PR DESCRIPTION
Always run extended tests with `-v -noColor`

We always want extended tests to be run in verbose mode and without
color escape codes being printed, as the `ginkgo` binary is not smart
enough to detect when it is not outputting to a TTY. There is no need
for each caller of `os::test::extended:run` to remember to pass these
arguments.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

When no jUnit suites are requested, don't merge them

The behavior today is to try to merge suites and fail to dereference
the `$TEST_REPORT_DIR`. We should just skip this when no suites are
expected.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Handle the case where no k8s containers exist for cleanup

When no k8s containers exist for the cleanup functions to iterate over,
the `$ids` array is empty and must be carefully dealt with so excessive
error messages are not printed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

