### PR TITLE
UPSTREAM: 42275: discovery restmapping should always prefer /v1

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/client/typed/discovery/restmapper.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/typed/discovery/restmapper.go
@@ -42,8 +42,9 @@ func NewRESTMapper(groupResources []*APIGroupResources, versionInterfaces meta.V
 	unionMapper := meta.MultiRESTMapper{}
 
 	var groupPriority []string
-	var resourcePriority []unversioned.GroupVersionResource
-	var kindPriority []unversioned.GroupVersionKind
+	// /v1 is special.  It should always come first
+	resourcePriority := []unversioned.GroupVersionResource{{Group: "", Version: "v1", Resource: meta.AnyResource}}
+	kindPriority := []unversioned.GroupVersionKind{{Group: "", Version: "v1", Kind: meta.AnyKind}}
 
 	for _, group := range groupResources {
 		groupPriority = append(groupPriority, group.Group.Name)


### PR DESCRIPTION
@enj upstream pick of the restmapping fix for the authorization pull.

Try picking this into your branch and seeing if it works.  I'll merge on lgtm upstream.