### PR TITLE
sdn: handle offset>0 fragments when validating service traffic

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -225,6 +225,10 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	err = plugin.ovs.SetFrags("nx-match")
+	if err != nil {
+		return false, err
+	}
 	_ = plugin.ovs.DeletePort(VXLAN)
 	_, err = plugin.ovs.AddPort(VXLAN, 1, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`)
 	if err != nil {
@@ -457,11 +461,21 @@ func (plugin *OsdnNode) AddServiceRules(service *kapi.Service, netID uint32) {
 	glog.V(5).Infof("AddServiceRules for %v", service)
 
 	otx := plugin.ovs.NewTransaction()
+	action := fmt.Sprintf(", priority=100, actions=load:%d->NXM_NX_REG1[], load:2->NXM_NX_REG2[], goto_table:80", netID)
+
+	// Add blanket rule allowing subsequent IP fragments
+	otx.AddFlow(generateBaseServiceRule(service.Spec.ClusterIP) + ", ip_frag=later" + action)
+
 	for _, port := range service.Spec.Ports {
-		otx.AddFlow(generateAddServiceRule(netID, service.Spec.ClusterIP, port.Protocol, int(port.Port)))
-		if err := otx.EndTransaction(); err != nil {
-			glog.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err)
+		baseRule, err := generateBaseAddServiceRule(service.Spec.ClusterIP, port.Protocol, int(port.Port))
+		if err != nil {
+			glog.Errorf("Error creating OVS flow for service %v, netid %d: %v", service, netID, err)
 		}
+		otx.AddFlow(baseRule + action)
+	}
+
+	if err := otx.EndTransaction(); err != nil {
+		glog.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err)
 	}
 }
 
@@ -469,23 +483,22 @@ func (plugin *OsdnNode) DeleteServiceRules(service *kapi.Service) {
 	glog.V(5).Infof("DeleteServiceRules for %v", service)
 
 	otx := plugin.ovs.NewTransaction()
-	for _, port := range service.Spec.Ports {
-		otx.DeleteFlows(generateDeleteServiceRule(service.Spec.ClusterIP, port.Protocol, int(port.Port)))
-		if err := otx.EndTransaction(); err != nil {
-			glog.Errorf("Error deleting OVS flows for service %v: %v", service, err)
-		}
+	otx.DeleteFlows(generateBaseServiceRule(service.Spec.ClusterIP))
+	otx.EndTransaction()
+}
+
+func generateBaseServiceRule(IP string) string {
+	return fmt.Sprintf("table=60, ip, nw_dst=%s", IP)
+}
+
+func generateBaseAddServiceRule(IP string, protocol kapi.Protocol, port int) (string, error) {
+	var dst string
+	if protocol == kapi.ProtocolUDP {
+		dst = fmt.Sprintf(", udp, udp_dst=%d", port)
+	} else if protocol == kapi.ProtocolTCP {
+		dst = fmt.Sprintf(", tcp, tcp_dst=%d", port)
+	} else {
+		return "", fmt.Errorf("unhandled protocol %v", protocol)
 	}
-}
-
-func generateBaseServiceRule(IP string, protocol kapi.Protocol, port int) string {
-	return fmt.Sprintf("table=60, %s, nw_dst=%s, tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
-}
-
-func generateAddServiceRule(netID uint32, IP string, protocol kapi.Protocol, port int) string {
-	baseRule := generateBaseServiceRule(IP, protocol, port)
-	return fmt.Sprintf("%s, priority=100, actions=load:%d->NXM_NX_REG1[], load:2->NXM_NX_REG2[], goto_table:80", baseRule, netID)
-}
-
-func generateDeleteServiceRule(IP string, protocol kapi.Protocol, port int) string {
-	return generateBaseServiceRule(IP, protocol, port)
+	return generateBaseServiceRule(IP) + dst, nil
 }

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -144,6 +144,11 @@ func (ovsif *Interface) DeletePort(port string) error {
 	return err
 }
 
+func (ovsif *Interface) SetFrags(mode string) error {
+	_, err := ovsif.exec(OVS_OFCTL, "set-frags", ovsif.bridge, mode)
+	return err
+}
+
 type Transaction struct {
 	ovsif *Interface
 	err   error


### PR DESCRIPTION
By default (set-frag normal) all fragments of a fragmented packet
have a port number of 0.  This is quite unhelpful; to get the right
port number for all fragments requires un-fragmenting the packet
with OVS's contrack capability, but this interacts badly with
iptables' contrack capability.

Instead, use the 'nx-match' mode which keeps the port numbers in
the first fragment of a fragmented packet, and add rules to allow
subsequent fragments (with port=0) to pass through.  Assume that
the destination IP stack will reject offset>0 fragments that
arrive without a corresponding offset=0 first fragment.

We can't just drop the port checking because services can be
manually created with a static service IP address, and perhaps
users rely on creating two distinct services with the same service
IP address, but differentiated via port numbers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1419692

@openshift/networking @danwinship how awful is this workaround? Can we make the assumption that the destination IP stack will do the right thing?  In any case, I've verified with packet counters that offset>0 fragments are hitting the port=0 rules, and my UDP echo tools work.

I suppose I could try to add a large UDP packet testcase to the extended networking test suite too.