### PR TITLE
[1.4] Change logging deployer image name from 'logging-deployment' to 'logging-deployer'

### DIFF
--- a/examples/logging/logging-deployer.yaml
+++ b/examples/logging/logging-deployer.yaml
@@ -107,7 +107,7 @@ items:
       generateName: logging-deployer-
     spec:
       containers:
-      - image: ${IMAGE_PREFIX}logging-deployment:${IMAGE_VERSION}
+      - image: ${IMAGE_PREFIX}logging-deployer:${IMAGE_VERSION}
         imagePullPolicy: Always
         name: deployer
         volumeMounts:

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -7126,7 +7126,7 @@ items:
       generateName: logging-deployer-
     spec:
       containers:
-      - image: ${IMAGE_PREFIX}logging-deployment:${IMAGE_VERSION}
+      - image: ${IMAGE_PREFIX}logging-deployer:${IMAGE_VERSION}
         imagePullPolicy: Always
         name: deployer
         volumeMounts:


### PR DESCRIPTION
Backport of https://github.com/openshift/origin/pull/13151