### PR TITLE
Plumb and allow customizing ciphers and tls version

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -559,6 +559,12 @@ type ServingInfo struct {
 	ClientCA string
 	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
 	NamedCertificates []NamedCertificate
+	// MinTLSVersion is the minimum TLS version supported.
+	// Values must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
+	MinTLSVersion string
+	// CipherSuites contains an overridden list of ciphers for the server to support.
+	// Values must match cipher suite IDs from https://golang.org/pkg/crypto/tls/#pkg-constants
+	CipherSuites []string
 }
 
 // NamedCertificate specifies a certificate/key, and the names it should be served for

--- a/pkg/cmd/server/api/v1/swagger_doc.go
+++ b/pkg/cmd/server/api/v1/swagger_doc.go
@@ -765,6 +765,8 @@ var map_ServingInfo = map[string]string{
 	"bindNetwork":       "BindNetwork is the type of network to bind to - defaults to \"tcp4\", accepts \"tcp\", \"tcp4\", and \"tcp6\"",
 	"clientCA":          "ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates",
 	"namedCertificates": "NamedCertificates is a list of certificates to use to secure requests to specific hostnames",
+	"minTLSVersion":     "MinTLSVersion is the minimum TLS version supported. Values must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants",
+	"cipherSuites":      "CipherSuites contains an overridden list of ciphers for the server to support. Values must match cipher suite IDs from https://golang.org/pkg/crypto/tls/#pkg-constants",
 }
 
 func (ServingInfo) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -511,6 +511,12 @@ type ServingInfo struct {
 	ClientCA string `json:"clientCA"`
 	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
 	NamedCertificates []NamedCertificate `json:"namedCertificates"`
+	// MinTLSVersion is the minimum TLS version supported.
+	// Values must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
+	MinTLSVersion string `json:"minTLSVersion,omitempty"`
+	// CipherSuites contains an overridden list of ciphers for the server to support.
+	// Values must match cipher suite IDs from https://golang.org/pkg/crypto/tls/#pkg-constants
+	CipherSuites []string `json:"cipherSuites,omitempty"`
 }
 
 // NamedCertificate specifies a certificate/key, and the names it should be served for

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/validation/field"
 
 	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 )
@@ -129,6 +130,15 @@ func ValidateServingInfo(info api.ServingInfo, fldPath *field.Path) ValidationRe
 	} else {
 		if len(info.ClientCA) > 0 {
 			validationResults.AddErrors(field.Invalid(fldPath.Child("clientCA"), info.ClientCA, "cannot specify a clientCA without a certFile"))
+		}
+	}
+
+	if _, err := crypto.TLSVersion(info.MinTLSVersion); err != nil {
+		validationResults.AddErrors(field.NotSupported(fldPath.Child("minTLSVersion"), info.MinTLSVersion, crypto.ValidTLSVersions()))
+	}
+	for i, cipher := range info.CipherSuites {
+		if _, err := crypto.CipherSuite(cipher); err != nil {
+			validationResults.AddErrors(field.NotSupported(fldPath.Child("cipherSuites").Index(i), cipher, crypto.ValidCipherSuites()))
 		}
 	}
 

--- a/pkg/cmd/server/crypto/crypto_test.go
+++ b/pkg/cmd/server/crypto/crypto_test.go
@@ -5,11 +5,53 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"go/importer"
+	"strings"
 	"testing"
 	"time"
 )
 
 const certificateLifetime = 365 * 2
+
+func TestConstantMaps(t *testing.T) {
+	pkg, err := importer.Default().Import("crypto/tls")
+	if err != nil {
+		fmt.Printf("error: %s\n", err.Error())
+		return
+	}
+	discoveredVersions := map[string]bool{}
+	discoveredCiphers := map[string]bool{}
+	for _, declName := range pkg.Scope().Names() {
+		if strings.HasPrefix(declName, "VersionTLS") {
+			discoveredVersions[declName] = true
+		}
+		if strings.HasPrefix(declName, "TLS_RSA_") || strings.HasPrefix(declName, "TLS_ECDHE_") {
+			discoveredCiphers[declName] = true
+		}
+	}
+
+	for k := range discoveredCiphers {
+		if _, ok := ciphers[k]; !ok {
+			t.Errorf("discovered cipher tls.%s not in ciphers map", k)
+		}
+	}
+	for k := range ciphers {
+		if _, ok := discoveredCiphers[k]; !ok {
+			t.Errorf("ciphers map has %s not in tls package", k)
+		}
+	}
+
+	for k := range discoveredVersions {
+		if _, ok := versions[k]; !ok {
+			t.Errorf("discovered version tls.%s not in version map", k)
+		}
+	}
+	for k := range versions {
+		if _, ok := discoveredVersions[k]; !ok {
+			t.Errorf("versions map has %s not in tls package", k)
+		}
+	}
+}
 
 func TestCrypto(t *testing.T) {
 	roots := x509.NewCertPool()

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openshift/origin/pkg/api"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/server/election"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/controller/shared"
@@ -298,6 +299,8 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	genericConfig.LegacyAPIGroupPrefixes = LegacyAPIGroupPrefixes
 	genericConfig.SecureServingInfo.BindAddress = options.ServingInfo.BindAddress
 	genericConfig.SecureServingInfo.BindNetwork = options.ServingInfo.BindNetwork
+	genericConfig.SecureServingInfo.MinTLSVersion = crypto.TLSVersionOrDie(options.ServingInfo.MinTLSVersion)
+	genericConfig.SecureServingInfo.CipherSuites = crypto.CipherSuitesOrDie(options.ServingInfo.CipherSuites)
 	oAuthClientCertCAs, err := configapi.GetOAuthClientCertCAs(options)
 	if err != nil {
 		glog.Fatalf("Error setting up OAuth2 client certificates: %v", err)

--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -273,6 +273,8 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 				// Do not use NameToCertificate, since that requires certificates be included in the server's tlsConfig.Certificates list,
 				// which we do not control when running with http.Server#ListenAndServeTLS
 				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
+				MinVersion:     crypto.TLSVersionOrDie(options.ServingInfo.MinTLSVersion),
+				CipherSuites:   crypto.CipherSuitesOrDie(options.ServingInfo.CipherSuites),
 			}),
 			CertFile: options.ServingInfo.ServerCert.CertFile,
 			KeyFile:  options.ServingInfo.ServerCert.KeyFile,

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -73,6 +73,8 @@ func (c *AssetConfig) Run() {
 			server.TLSConfig = crypto.SecureTLSConfig(&tls.Config{
 				// Set SNI certificate func
 				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
+				MinVersion:     crypto.TLSVersionOrDie(c.Options.ServingInfo.MinTLSVersion),
+				CipherSuites:   crypto.CipherSuitesOrDie(c.Options.ServingInfo.CipherSuites),
 			})
 			glog.Infof("Web console listening at https://%s", c.Options.ServingInfo.BindAddress)
 			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -396,6 +396,8 @@ func (c *MasterConfig) serve(handler http.Handler, messages []string) {
 				ClientCAs:  c.ClientCAs,
 				// Set SNI certificate func
 				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
+				MinVersion:     crypto.TLSVersionOrDie(c.Options.ServingInfo.MinTLSVersion),
+				CipherSuites:   crypto.CipherSuitesOrDie(c.Options.ServingInfo.CipherSuites),
 			})
 			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
 		} else {

--- a/test/integration/tls_test.go
+++ b/test/integration/tls_test.go
@@ -1,0 +1,170 @@
+package integration
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestTLSDefaults(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	master, node, components, err := testserver.DefaultAllInOneOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = testserver.StartConfiguredAllInOne(master, node, components)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify we fail with TLS versions less than the default, and work with TLS versions >= the default
+	for _, tlsVersionName := range crypto.ValidTLSVersions() {
+		tlsVersion := crypto.TLSVersionOrDie(tlsVersionName)
+		expectSuccess := tlsVersion >= crypto.DefaultTLSVersion()
+		config := &tls.Config{MinVersion: tlsVersion, MaxVersion: tlsVersion, InsecureSkipVerify: true}
+
+		{
+			conn, err := tls.Dial(master.ServingInfo.BindNetwork, master.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+			}
+			if success := err == nil; success != expectSuccess {
+				t.Errorf("Expected success %v, got %v with TLS version %s dialing master", expectSuccess, success, tlsVersionName)
+			}
+		}
+		{
+			conn, err := tls.Dial(node.ServingInfo.BindNetwork, node.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+			}
+			if success := err == nil; success != expectSuccess {
+				t.Errorf("Expected success %v, got %v with TLS version %s dialing node", expectSuccess, success, tlsVersionName)
+			}
+		}
+	}
+
+	// Verify the only ciphers we work with are in the default set.
+	// Not all default ciphers will succeed because they depend on the serving cert type.
+	defaultCiphers := map[uint16]bool{}
+	for _, defaultCipher := range crypto.DefaultCiphers() {
+		defaultCiphers[defaultCipher] = true
+	}
+	for _, cipherName := range crypto.ValidCipherSuites() {
+		cipher, err := crypto.CipherSuite(cipherName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectFailure := !defaultCiphers[cipher]
+		config := &tls.Config{CipherSuites: []uint16{cipher}, InsecureSkipVerify: true}
+
+		{
+			conn, err := tls.Dial(master.ServingInfo.BindNetwork, master.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+				if expectFailure {
+					t.Errorf("Expected failure on cipher %s, got success dialing master", cipherName)
+				}
+			}
+		}
+		{
+			conn, err := tls.Dial(node.ServingInfo.BindNetwork, node.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+				if expectFailure {
+					t.Errorf("Expected failure on cipher %s, got success dialing node", cipherName)
+				}
+			}
+		}
+	}
+}
+
+func TestTLSOverrides(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	master, node, components, err := testserver.DefaultAllInOneOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pick these ciphers because the first is http2 compatible, and the second works with TLS10
+	master.ServingInfo.MinTLSVersion = "VersionTLS10"
+	master.ServingInfo.CipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA"}
+	node.ServingInfo.MinTLSVersion = "VersionTLS10"
+	node.ServingInfo.CipherSuites = []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA"}
+
+	_, err = testserver.StartConfiguredAllInOne(master, node, components)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify we work with all TLS versions
+	for _, tlsVersionName := range crypto.ValidTLSVersions() {
+		tlsVersion := crypto.TLSVersionOrDie(tlsVersionName)
+		expectSuccess := true
+		config := &tls.Config{MinVersion: tlsVersion, MaxVersion: tlsVersion, InsecureSkipVerify: true}
+
+		{
+			conn, err := tls.Dial(master.ServingInfo.BindNetwork, master.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+			}
+			if success := err == nil; success != expectSuccess {
+				t.Errorf("Expected success %v, got %v with TLS version %s dialing master", expectSuccess, success, tlsVersionName)
+			}
+		}
+		{
+			conn, err := tls.Dial(node.ServingInfo.BindNetwork, node.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+			}
+			if success := err == nil; success != expectSuccess {
+				t.Errorf("Expected success %v, got %v with TLS version %s dialing node", expectSuccess, success, tlsVersionName)
+			}
+		}
+	}
+
+	// Verify the only ciphers we work with are the ones we chose
+	defaultCiphers := map[uint16]bool{}
+	for _, defaultCipher := range crypto.DefaultCiphers() {
+		defaultCiphers[defaultCipher] = true
+	}
+	for _, cipherName := range crypto.ValidCipherSuites() {
+		cipher, err := crypto.CipherSuite(cipherName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectFailure := true
+		switch cipher {
+		case tls.TLS_RSA_WITH_AES_128_CBC_SHA:
+			expectFailure = false
+		case tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
+			expectFailure = false
+		default:
+			expectFailure = true
+		}
+		config := &tls.Config{CipherSuites: []uint16{cipher}, InsecureSkipVerify: true}
+
+		{
+			conn, err := tls.Dial(master.ServingInfo.BindNetwork, master.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+				if expectFailure {
+					t.Errorf("Expected failure on cipher %s, got success dialing master", cipherName)
+				}
+			}
+		}
+		{
+			conn, err := tls.Dial(node.ServingInfo.BindNetwork, node.ServingInfo.BindAddress, config)
+			if err == nil {
+				conn.Close()
+				if expectFailure {
+					t.Errorf("Expected failure on cipher %s, got success dialing node", cipherName)
+				}
+			}
+		}
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/config.go
@@ -168,6 +168,12 @@ type SecureServingInfo struct {
 	SNICerts []NamedCertKey
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA *x509.CertPool
+	// MinTLSVersion optionally overrides the minimum TLS version supported.
+	// If 0, the default is used.
+	MinTLSVersion uint16
+	// CipherSuites optionally overrides the list of cipher suites for the server.
+	// If empty, the default is used.
+	CipherSuites []uint16
 }
 
 type CertKey struct {

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/serve.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/serve.go
@@ -61,6 +61,13 @@ func (s *GenericAPIServer) serveSecurely(stopCh <-chan struct{}) error {
 		},
 	}
 
+	if s.SecureServingInfo.MinTLSVersion > 0 {
+		secureServer.TLSConfig.MinVersion = s.SecureServingInfo.MinTLSVersion
+	}
+	if len(s.SecureServingInfo.CipherSuites) > 0 {
+		secureServer.TLSConfig.CipherSuites = s.SecureServingInfo.CipherSuites
+	}
+
 	if len(s.SecureServingInfo.ServerCert.CertFile) != 0 || len(s.SecureServingInfo.ServerCert.KeyFile) != 0 {
 		secureServer.TLSConfig.Certificates = make([]tls.Certificate, 1)
 		secureServer.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(s.SecureServingInfo.ServerCert.CertFile, s.SecureServingInfo.ServerCert.KeyFile)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1427919
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1387789

- [x] default to existing secure cipher list
- [x] switch config to human readable names, add validation
- [x] plumb to kubelet server init
- [x] integration test

Allows the following in all `servingInfo` stanzas:
```
bindAddress: ...
...
minTLSVersion: VersionTLS10
cipherSuites:
- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
...
```

Valid tls versions are "VersionTLS10", "VersionTLS11", "VersionTLS12"

Valid cipher suites are https://golang.org/pkg/crypto/tls/#pkg-constants for the golang version used to build origin, taken from descriptions of http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-4