### PR TITLE
Make the default Docker volume size larger

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -367,7 +367,7 @@ runcmd:
           },
           {
              "DeviceName" => "/dev/sdb",
-             "Ebs.VolumeSize" => vagrant_openshift_config['docker_volume_size'] || 25,
+             "Ebs.VolumeSize" => vagrant_openshift_config['docker_volume_size'] || 35,
              "Ebs.VolumeType" => "gp2"
           }
         ]


### PR DESCRIPTION
The push-s2i-images and extended test jobs can require up to 30GB when
setting up docker storage with docker-storage-setup. Adding more room
to prevent future flakes.