### PR TITLE
Embed expiry in session, fix clock-skew issues in IE

### DIFF
--- a/pkg/auth/server/session/authenticator.go
+++ b/pkg/auth/server/session/authenticator.go
@@ -2,23 +2,30 @@ package session
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"time"
+
+	"strconv"
 
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
 const UserNameKey = "user.name"
 const UserUIDKey = "user.uid"
+const ExpiresKey = "expires"
 
 type Authenticator struct {
-	store Store
-	name  string
+	store  Store
+	name   string
+	maxAge int
 }
 
-func NewAuthenticator(store Store, name string) *Authenticator {
+func NewAuthenticator(store Store, name string, maxAge int) *Authenticator {
 	return &Authenticator{
-		store: store,
-		name:  name,
+		store:  store,
+		name:   name,
+		maxAge: maxAge,
 	}
 }
 
@@ -26,6 +33,25 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 	session, err := a.store.Get(req, a.name)
 	if err != nil {
 		return nil, false, err
+	}
+
+	expiresObj, ok := session.Values()[ExpiresKey]
+	if !ok {
+		return nil, false, nil
+	}
+	expiresString, ok := expiresObj.(string)
+	if !ok {
+		return nil, false, errors.New("expires on session is not a string")
+	}
+	if expiresString == "" {
+		return nil, false, nil
+	}
+	expires, err := strconv.ParseInt(expiresString, 10, 64)
+	if err != nil {
+		return nil, false, fmt.Errorf("error parsing expires timestamp: %v", err)
+	}
+	if expires < time.Now().Unix() {
+		return nil, false, nil
 	}
 
 	nameObj, ok := session.Values()[UserNameKey]
@@ -64,6 +90,7 @@ func (a *Authenticator) AuthenticationSucceeded(user user.Info, state string, w 
 	values := session.Values()
 	values[UserNameKey] = user.GetName()
 	values[UserUIDKey] = user.GetUID()
+	values[ExpiresKey] = strconv.FormatInt(time.Now().Add(time.Duration(a.maxAge)*time.Second).Unix(), 10)
 	// TODO: should we save groups, scope, and extra in the session as well?
 	return false, a.store.Save(w, req)
 }
@@ -75,5 +102,6 @@ func (a *Authenticator) InvalidateAuthentication(w http.ResponseWriter, req *htt
 	}
 	session.Values()[UserNameKey] = ""
 	session.Values()[UserUIDKey] = ""
+	session.Values()[ExpiresKey] = ""
 	return a.store.Save(w, req)
 }

--- a/pkg/auth/server/session/session.go
+++ b/pkg/auth/server/session/session.go
@@ -12,13 +12,13 @@ type store struct {
 	store sessions.Store
 }
 
-func NewStore(secure bool, maxAgeSeconds int, secrets ...string) Store {
+func NewStore(secure bool, secrets ...string) Store {
 	values := [][]byte{}
 	for _, secret := range secrets {
 		values = append(values, []byte(secret))
 	}
 	cookie := sessions.NewCookieStore(values...)
-	cookie.Options.MaxAge = maxAgeSeconds
+	cookie.Options.MaxAge = 0
 	cookie.Options.HttpOnly = true
 	cookie.Options.Secure = secure
 	return store{cookie}

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -109,8 +109,8 @@ func buildSessionAuth(secure bool, config *configapi.SessionConfig) (*session.Au
 	if err != nil {
 		return nil, nil, err
 	}
-	sessionStore := session.NewStore(secure, int(config.SessionMaxAgeSeconds), secrets...)
-	return session.NewAuthenticator(sessionStore, config.SessionName), sessionStore, nil
+	sessionStore := session.NewStore(secure, secrets...)
+	return session.NewAuthenticator(sessionStore, config.SessionName, int(config.SessionMaxAgeSeconds)), sessionStore, nil
 }
 
 func getSessionSecrets(filename string) ([]string, error) {


### PR DESCRIPTION
Embeds session timeout in the session content and makes the cookie a session cookie. Fixes clock skew issues in IE cookie handling.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1270436