### PR TITLE
Reorder extended startup to yield jUnit with TEST_ONLY

### DIFF
--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -143,3 +143,39 @@ function os::test::junit::reconcile_output() {
     done
 }
 readonly -f os::test::junit::reconcile_output
+
+# os::test::junit::generate_oscmd_report generats an XML jUnit report
+# for the `os::cmd` suite from the raw test output. This function should
+# be trapped on EXIT.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - ARTIFACT_DIR
+# Arguments:
+#  None
+# Returns:
+#  None
+function os::test::junit::generate_oscmd_report() {
+    if [[ -z "${JUNIT_REPORT_OUTPUT:-}" ||
+          -n "${JUNIT_REPORT_OUTPUT:-}" && ! -s "${JUNIT_REPORT_OUTPUT:-}" ]]; then
+          # we can't generate a report
+          return
+    fi
+
+    # get the jUnit output file into a workable state in case we
+    # crashed in the middle of testing something
+    os::test::junit::reconcile_output
+
+    # check that we didn't mangle jUnit output
+    os::test::junit::check_test_counters
+
+    # use the junitreport tool to generate us a report
+    os::util::ensure::built_binary_exists 'junitreport'
+
+    junitreport --type oscmd                          \
+                --suites nested                       \
+                --roots github.com/openshift/origin   \
+                --output "${ARTIFACT_DIR}/report.xml" \
+                <"${JUNIT_REPORT_OUTPUT}"
+    junitreport summarize <"${ARTIFACT_DIR}/report.xml"
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -29,24 +29,7 @@ function cleanup()
         go tool pprof -text "./_output/local/bin/$(os::util::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
     fi
 
-    # TODO(skuznets): un-hack this nonsense once traps are in a better state
-    if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-      # get the jUnit output file into a workable state in case we crashed in the middle of testing something
-      os::test::junit::reconcile_output
-
-      # check that we didn't mangle jUnit output
-      os::test::junit::check_test_counters
-
-      # use the junitreport tool to generate us a report
-      os::util::ensure::built_binary_exists 'junitreport'
-
-      cat "${JUNIT_REPORT_OUTPUT}"                        \
-        | junitreport --type oscmd                        \
-                      --suites nested                     \
-                      --roots github.com/openshift/origin \
-                      --output "${ARTIFACT_DIR}/report.xml"
-      cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-    fi
+    os::test::junit::generate_oscmd_report
 
     ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
     os::log::info "Exiting with ${out}"

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -12,25 +12,7 @@ function cleanup()
 	out=$?
 	kill $OS_PID
 
-	# TODO(skuznets): un-hack this nonsense once traps are in a better state
-	if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-		# get the jUnit output file into a workable state in case we crashed in
-		# the middle of testing something
-		os::test::junit::reconcile_output
-
-		# check that we didn't mangle jUnit output
-		os::test::junit::check_test_counters
-
-		# use the junitreport tool to generate us a report
-		os::util::ensure::built_binary_exists 'junitreport'
-
-		cat "${JUNIT_REPORT_OUTPUT}" \
-			| junitreport --type oscmd \
-			--suites nested \
-			--roots github.com/openshift/origin \
-			--output "${ARTIFACT_DIR}/report.xml"
-		cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-	fi
+	os::test::junit::generate_oscmd_report
 
 	os::log::info "Exiting"
 	exit $out

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -15,25 +15,7 @@ function cleanup()
 	out=$?
 	cleanup_openshift
 
-	# TODO(skuznets): un-hack this nonsense once traps are in a better state
-	if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-		# get the jUnit output file into a workable state in case we crashed in
-		# the middle of testing something
-		os::test::junit::reconcile_output
-
-		# check that we didn't mangle jUnit output
-		os::test::junit::check_test_counters
-
-		# use the junitreport tool to generate us a report
-		os::util::ensure::built_binary_exists 'junitreport'
-
-		cat "${JUNIT_REPORT_OUTPUT}" \
-			| junitreport --type oscmd \
-			--suites nested \
-			--roots github.com/openshift/origin \
-			--output "${ARTIFACT_DIR}/report.xml"
-		cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-	fi
+	os::test::junit::generate_oscmd_report
 
 	os::log::info "Exiting"
 	exit $out

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -15,25 +15,7 @@ function cleanup()
 	docker rmi test/scratchimage
 	cleanup_openshift
 
-	# TODO(skuznets): un-hack this nonsense once traps are in a better state
-	if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-		# get the jUnit output file into a workable state in case we crashed in
-		# the middle of testing something
-		os::test::junit::reconcile_output
-
-		# check that we didn't mangle jUnit output
-		os::test::junit::check_test_counters
-
-		# use the junitreport tool to generate us a report
-		os::util::ensure::built_binary_exists 'junitreport'
-
-		cat "${JUNIT_REPORT_OUTPUT}" \
-			| junitreport --type oscmd \
-			--suites nested \
-			--roots github.com/openshift/origin \
-			--output "${ARTIFACT_DIR}/report.xml"
-		cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-	fi
+	os::test::junit::generate_oscmd_report
 
 	os::log::info "Exiting"
 	return "${out}"

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -35,24 +35,7 @@ function cleanup() {
     set +e
     cleanup_openshift
 
-    # TODO(skuznets): un-hack this nonsense once traps are in a better state
-    if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-      # get the jUnit output file into a workable state in case we crashed in the middle of testing something
-      os::test::junit::reconcile_output
-
-      # check that we didn't mangle jUnit output
-      os::test::junit::check_test_counters
-
-      # use the junitreport tool to generate us a report
-      os::util::ensure::built_binary_exists 'junitreport'
-
-      cat "${JUNIT_REPORT_OUTPUT}" "${junit_gssapi_output}" \
-        | junitreport --type oscmd                          \
-                      --suites nested                       \
-                      --roots github.com/openshift/origin   \
-                      --output "${ARTIFACT_DIR}/report.xml"
-      cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-    fi
+    os::test::junit::generate_oscmd_report
 
     endtime=$(date +%s); echo "$0 took $((endtime - starttime)) seconds"
     exit $out

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -13,25 +13,7 @@ function cleanup()
 	out=$?
 	cleanup_openshift
 
-	# TODO(skuznets): un-hack this nonsense once traps are in a better state
-	if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-		# get the jUnit output file into a workable state in case we crashed in
-		# the middle of testing something
-		os::test::junit::reconcile_output
-
-		# check that we didn't mangle jUnit output
-		os::test::junit::check_test_counters
-
-		# use the junitreport tool to generate us a report
-		os::util::ensure::built_binary_exists 'junitreport'
-
-		cat "${JUNIT_REPORT_OUTPUT}" \
-			| junitreport --type oscmd \
-			--suites nested \
-			--roots github.com/openshift/origin \
-			--output "${ARTIFACT_DIR}/report.xml"
-		cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-	fi
+	os::test::junit::generate_oscmd_report
 
 	os::log::info "Exiting"
 	return $out

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -50,26 +50,7 @@ function os::test::extended::setup () {
 		out=$?
 		cleanup_openshift
 
-		# TODO(skuznets): un-hack this nonsense once traps are in a better
-		# state
-		if [[ -n "${JUNIT_REPORT_OUTPUT:-}" ]]; then
-			# get the jUnit output file into a workable state in case we
-			# crashed in the middle of testing something
-			os::test::junit::reconcile_output
-
-			# check that we didn't mangle jUnit output
-			os::test::junit::check_test_counters
-
-			# use the junitreport tool to generate us a report
-			os::util::ensure::built_binary_exists 'junitreport'
-
-			cat "${JUNIT_REPORT_OUTPUT}" \
-				| junitreport --type oscmd \
-				--suites nested \
-				--roots github.com/openshift/origin \
-				--output "${ARTIFACT_DIR}/report.xml"
-			cat "${ARTIFACT_DIR}/report.xml" | junitreport summarize
-		fi
+		os::test::junit::generate_oscmd_report
 
 		os::log::info "Exiting"
 		return $out


### PR DESCRIPTION
The current ordering of the parsing of `$JUNIT_REPORT` and `$TEST_ONLY`
means that no jUnit is generated or placed when running with both
options. This patch re-orders the parsing so that jobs running extended
tests against pre-existing clusters get jUnit output as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]
@smarterclayton PTAL