### PR TITLE
Make `oc observe --type-env-var` pass current env vars

### DIFF
--- a/pkg/cmd/cli/cmd/observe/observe.go
+++ b/pkg/cmd/cli/cmd/observe/observe.go
@@ -660,6 +660,7 @@ func (o *ObserveOptions) next(deltaType cache.DeltaType, obj runtime.Object, out
 		cmd := exec.Command(command, args...)
 		cmd.Stdout = out
 		cmd.Stderr = errOut
+		cmd.Env = os.Environ()
 		if len(o.objectEnvVar) > 0 {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", o.objectEnvVar, string(output)))
 		}

--- a/test/cmd/observe.sh
+++ b/test/cmd/observe.sh
@@ -36,5 +36,8 @@ os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{{ or (.unknown) \"\" }}key" --output=gotemplate' 'badkey'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{{ .unknown }}key" --output=gotemplate --strict-templates' '\<no value\>'
 
+# --type-env-var
+os::cmd::expect_success_and_text 'MYENV=should_be_passed oc observe services --once --all-namespaces --type-env-var=EVENT -- /bin/sh -c "echo \$EVENT \$MYENV"' 'Sync should_be_passed'
+
 echo "observe: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/13190