### PR TITLE
[3.3] Verify manifest with remote layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,22 @@ ifeq ($(TEST_ASSETS),true)
 endif
 .PHONY: test-assets
 
+# Run extended tests.
+#
+# Args:
+#   SUITE: Which Bash entrypoint under test/extended/ to use. Don't include the
+#          ending `.sh`. Ex: `core`.
+#   FOCUS: Literal string to pass to `--ginkgo.focus=`
+#
+# Example:
+#   make test-extended SUITE=core
+#   make test-extended SUITE=conformance FOCUS=pods
+SUITE ?= conformance
+FOCUS ?= .
+test-extended:
+	test/extended/$(SUITE).sh --ginkgo.focus="$(FOCUS)"
+.PHONY: test-extended
+
 # Build and run the complete test-suite.
 #
 # Example:

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,13 @@ endif
 #   make test-extended SUITE=core
 #   make test-extended SUITE=conformance FOCUS=pods
 SUITE ?= conformance
-FOCUS ?= .
+ifneq ($(strip $(FOCUS)),)
+	FOCUS_ARG=--ginkgo.focus="$(FOCUS)"
+else
+	FOCUS_ARG=
+endif
 test-extended:
-	test/extended/$(SUITE).sh --ginkgo.focus="$(FOCUS)"
+	test/extended/$(SUITE).sh $(FOCUS_ARG)
 .PHONY: test-extended
 
 # Build and run the complete test-suite.

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -16,6 +16,14 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
+const (
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	digestSha256EmptyTar = digest.Digest("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+	// digestSHA256GzippedEmptyTar is the canonical sha256 digest of gzippedEmptyTar
+	digestSHA256GzippedEmptyTar = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+)
+
 // ByGeneration allows for sorting tag events from latest to oldest.
 type ByGeneration []*imageapi.TagEvent
 
@@ -64,18 +72,29 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 
 	context.GetLogger(ctx).Debugf("could not stat layer link %q in repository %q: %v", dgst.String(), repo.Named().Name(), err)
 
-	// verify the blob is stored locally
+	// First attempt: looking for the blob locally
 	desc, err = dockerRegistry.BlobStatter().Stat(ctx, dgst)
-	if err != nil {
-		return desc, err
-	}
-
-	// ensure it's referenced inside of corresponding image stream
-	if imageStreamHasBlob(repo, dgst) {
+	if err == nil {
+		// only non-empty layers is wise to check for existence in the image stream.
+		// schema v2 has no empty layers.
+		if !isEmptyDigest(dgst) {
+			// ensure it's referenced inside of corresponding image stream
+			if !imageStreamHasBlob(repo, dgst) {
+				return distribution.Descriptor{}, distribution.ErrBlobUnknown
+			}
+		}
 		return desc, nil
 	}
 
-	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	if err == distribution.ErrBlobUnknown {
+		// Second attempt: looking for the blob on a remote server
+		remoteGetter, found := RemoteBlobGetterFrom(repo.ctx)
+		if found {
+			desc, err = remoteGetter.Stat(ctx, dgst)
+		}
+	}
+
+	return desc, err
 }
 
 func (bs *blobDescriptorService) Clear(ctx context.Context, dgst digest.Digest) error {
@@ -211,4 +230,8 @@ func imageHasBlob(
 	}
 
 	return false
+}
+
+func isEmptyDigest(dgst digest.Digest) bool {
+	return dgst == digestSha256EmptyTar || dgst == digestSHA256GzippedEmptyTar
 }

--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -8,11 +8,6 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-
-	"k8s.io/kubernetes/pkg/api/errors"
-
-	imageapi "github.com/openshift/origin/pkg/image/api"
-	"github.com/openshift/origin/pkg/image/importer"
 )
 
 // pullthroughBlobStore wraps a distribution.BlobStore and allows remote repositories to serve blobs from remote
@@ -20,9 +15,7 @@ import (
 type pullthroughBlobStore struct {
 	distribution.BlobStore
 
-	repo                       *repository
-	digestToStore              map[string]distribution.BlobStore
-	pullFromInsecureRegistries bool
+	repo *repository
 }
 
 var _ distribution.BlobStore = &pullthroughBlobStore{}
@@ -43,86 +36,43 @@ func (r *pullthroughBlobStore) Stat(ctx context.Context, dgst digest.Digest) (di
 		return desc, err
 	}
 
-	return r.remoteStat(ctx, dgst)
-}
-
-// remoteStat attempts to find requested blob in candidate remote repositories and if found, it updates
-// digestToRepository store. ErrBlobUnknown will be returned if not found.
-func (r *pullthroughBlobStore) remoteStat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	// look up the potential remote repositories that this blob could be part of (at this time,
-	// we don't know which image in the image stream surfaced the content).
-	is, err := r.repo.getImageStream()
-	if err != nil {
-		if errors.IsNotFound(err) || errors.IsForbidden(err) {
-			return distribution.Descriptor{}, distribution.ErrBlobUnknown
-		}
-		context.GetLogger(ctx).Errorf("Error retrieving image stream for blob: %v", err)
-		return distribution.Descriptor{}, err
+	remoteGetter, found := RemoteBlobGetterFrom(r.repo.ctx)
+	if !found {
+		context.GetLogger(ctx).Errorf("pullthroughBlobStore.Stat: failed to retrieve remote getter from context")
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
 	}
 
-	var localRegistry string
-	if local, err := imageapi.ParseDockerImageReference(is.Status.DockerImageRepository); err == nil {
-		// TODO: normalize further?
-		localRegistry = local.Registry
-	}
-
-	retriever := r.repo.importContext()
-	cached := r.repo.cachedLayers.RepositoriesForDigest(dgst)
-
-	// look at the first level of tagged repositories first
-	search := identifyCandidateRepositories(is, localRegistry, true)
-	if desc, err := r.findCandidateRepository(ctx, search, cached, dgst, retriever); err == nil {
-		return desc, nil
-	}
-
-	// look at all other repositories tagged by the server
-	secondary := identifyCandidateRepositories(is, localRegistry, false)
-	for k := range search {
-		delete(secondary, k)
-	}
-	if desc, err := r.findCandidateRepository(ctx, secondary, cached, dgst, retriever); err == nil {
-		return desc, nil
-	}
-
-	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-// proxyStat attempts to locate the digest in the provided remote repository or returns an error. If the digest is found,
-// r.digestToStore saves the store.
-func (r *pullthroughBlobStore) proxyStat(ctx context.Context, retriever importer.RepositoryRetriever, ref imageapi.DockerImageReference, dgst digest.Digest) (distribution.Descriptor, error) {
-	context.GetLogger(ctx).Infof("Trying to stat %q from %q", dgst, ref.Exact())
-	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), r.pullFromInsecureRegistries)
-	if err != nil {
-		context.GetLogger(ctx).Errorf("Error getting remote repository for image %q: %v", ref.Exact(), err)
-		return distribution.Descriptor{}, err
-	}
-	pullthroughBlobStore := repo.Blobs(ctx)
-	desc, err := pullthroughBlobStore.Stat(ctx, dgst)
-	if err != nil {
-		if err != distribution.ErrBlobUnknown {
-			context.GetLogger(ctx).Errorf("Error getting pullthroughBlobStore for image %q: %v", ref.Exact(), err)
-		}
-		return distribution.Descriptor{}, err
-	}
-
-	r.digestToStore[dgst.String()] = pullthroughBlobStore
-	return desc, nil
+	return remoteGetter.Stat(ctx, dgst)
 }
 
 // ServeBlob attempts to serve the requested digest onto w, using a remote proxy store if necessary.
 func (r *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
-	store, ok := r.digestToStore[dgst.String()]
-	if !ok {
-		return r.BlobStore.ServeBlob(ctx, w, req, dgst)
+	// This call should be done without BlobGetterService in the context.
+	err := r.BlobStore.ServeBlob(ctx, w, req, dgst)
+	switch {
+	case err == distribution.ErrBlobUnknown:
+		// continue on to the code below and look up the blob in a remote store since it is not in
+		// the local store
+	case err != nil:
+		context.GetLogger(ctx).Errorf("Failed to find blob %q: %#v", dgst.String(), err)
+		fallthrough
+	default:
+		return err
 	}
 
-	desc, err := store.Stat(ctx, dgst)
+	remoteGetter, found := RemoteBlobGetterFrom(r.repo.ctx)
+	if !found {
+		context.GetLogger(ctx).Errorf("pullthroughBlobStore.ServeBlob: failed to retrieve remote getter from context")
+		return distribution.ErrBlobUnknown
+	}
+
+	desc, err := remoteGetter.Stat(ctx, dgst)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("failed to stat digest %q: %v", dgst.String(), err)
 		return err
 	}
 
-	remoteReader, err := store.Open(ctx, dgst)
+	remoteReader, err := remoteGetter.Open(ctx, dgst)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("failure to open remote store for digest %q: %v", dgst.String(), err)
 		return err
@@ -138,97 +88,18 @@ func (r *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseWri
 
 // Get attempts to fetch the requested blob by digest using a remote proxy store if necessary.
 func (r *pullthroughBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	store, ok := r.digestToStore[dgst.String()]
-	if ok {
-		return store.Get(ctx, dgst)
-	}
-
 	data, originalErr := r.BlobStore.Get(ctx, dgst)
 	if originalErr == nil {
 		return data, nil
 	}
 
-	desc, err := r.remoteStat(ctx, dgst)
-	if err != nil {
-		context.GetLogger(ctx).Errorf("failed to stat blob %q in remote repositories: %v", dgst.String(), err)
+	remoteGetter, found := RemoteBlobGetterFrom(r.repo.ctx)
+	if !found {
+		context.GetLogger(ctx).Errorf("pullthroughBlobStore.Get: failed to retrieve remote getter from context")
 		return nil, originalErr
 	}
-	store, ok = r.digestToStore[desc.Digest.String()]
-	if !ok {
-		return nil, originalErr
-	}
-	return store.Get(ctx, desc.Digest)
-}
 
-// findCandidateRepository looks in search for a particular blob, referring to previously cached items
-func (r *pullthroughBlobStore) findCandidateRepository(ctx context.Context, search map[string]*imageapi.DockerImageReference, cachedLayers []string, dgst digest.Digest, retriever importer.RepositoryRetriever) (distribution.Descriptor, error) {
-	// no possible remote locations to search, exit early
-	if len(search) == 0 {
-		return distribution.Descriptor{}, distribution.ErrBlobUnknown
-	}
-
-	// see if any of the previously located repositories containing this digest are in this
-	// image stream
-	for _, repo := range cachedLayers {
-		ref, ok := search[repo]
-		if !ok {
-			continue
-		}
-		desc, err := r.proxyStat(ctx, retriever, *ref, dgst)
-		if err != nil {
-			delete(search, repo)
-			continue
-		}
-		context.GetLogger(ctx).Infof("Found digest location from cache %q in %q", dgst, repo)
-		return desc, nil
-	}
-
-	// search the remaining registries for this digest
-	for repo, ref := range search {
-		desc, err := r.proxyStat(ctx, retriever, *ref, dgst)
-		if err != nil {
-			continue
-		}
-		r.repo.cachedLayers.RememberDigest(dgst, r.repo.blobrepositorycachettl, repo)
-		context.GetLogger(ctx).Infof("Found digest location by search %q in %q", dgst, repo)
-		return desc, nil
-	}
-
-	return distribution.Descriptor{}, distribution.ErrBlobUnknown
-}
-
-// identifyCandidateRepositories returns a map of remote repositories referenced by this image stream.
-func identifyCandidateRepositories(is *imageapi.ImageStream, localRegistry string, primary bool) map[string]*imageapi.DockerImageReference {
-	// identify the canonical location of referenced registries to search
-	search := make(map[string]*imageapi.DockerImageReference)
-	for _, tagEvent := range is.Status.Tags {
-		var candidates []imageapi.TagEvent
-		if primary {
-			if len(tagEvent.Items) == 0 {
-				continue
-			}
-			candidates = tagEvent.Items[:1]
-		} else {
-			if len(tagEvent.Items) <= 1 {
-				continue
-			}
-			candidates = tagEvent.Items[1:]
-		}
-		for _, event := range candidates {
-			ref, err := imageapi.ParseDockerImageReference(event.DockerImageReference)
-			if err != nil {
-				continue
-			}
-			// skip anything that matches the innate registry
-			// TODO: there may be a better way to make this determination
-			if len(localRegistry) != 0 && localRegistry == ref.Registry {
-				continue
-			}
-			ref = ref.DockerClientDefaults()
-			search[ref.AsRepository().Exact()] = &ref
-		}
-	}
-	return search
+	return remoteGetter.Get(ctx, dgst)
 }
 
 // setResponseHeaders sets the appropriate content serving headers

--- a/pkg/dockerregistry/server/remoteblobgetter.go
+++ b/pkg/dockerregistry/server/remoteblobgetter.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/importer"
+)
+
+// BlobGetterService combines the operations to access and read blobs.
+type BlobGetterService interface {
+	distribution.BlobStatter
+	distribution.BlobProvider
+	distribution.BlobServer
+}
+
+// remoteBlobGetterService implements BlobGetterService and allows to serve blobs from remote
+// repositories.
+type remoteBlobGetterService struct {
+	repo                       *repository
+	digestToStore              map[string]distribution.BlobStore
+	pullFromInsecureRegistries bool
+}
+
+var _ BlobGetterService = &remoteBlobGetterService{}
+
+// Stat provides metadata about a blob identified by the digest. If the
+// blob is unknown to the describer, ErrBlobUnknown will be returned.
+func (rbs *remoteBlobGetterService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	// look up the potential remote repositories that this blob could be part of (at this time,
+	// we don't know which image in the image stream surfaced the content).
+	is, err := rbs.repo.getImageStream()
+	if err != nil {
+		if errors.IsNotFound(err) || errors.IsForbidden(err) {
+			return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		}
+		context.GetLogger(ctx).Errorf("Error retrieving image stream for blob: %v", err)
+		return distribution.Descriptor{}, err
+	}
+
+	rbs.pullFromInsecureRegistries = false
+
+	if insecure, ok := is.Annotations[imageapi.InsecureRepositoryAnnotation]; ok {
+		rbs.pullFromInsecureRegistries = insecure == "true"
+	}
+
+	var localRegistry string
+	if local, err := imageapi.ParseDockerImageReference(is.Status.DockerImageRepository); err == nil {
+		// TODO: normalize further?
+		localRegistry = local.Registry
+	}
+
+	retriever := rbs.repo.importContext()
+	cached := rbs.repo.cachedLayers.RepositoriesForDigest(dgst)
+
+	// look at the first level of tagged repositories first
+	search := rbs.identifyCandidateRepositories(is, localRegistry, true)
+	if desc, err := rbs.findCandidateRepository(ctx, search, cached, dgst, retriever); err == nil {
+		return desc, nil
+	}
+
+	// look at all other repositories tagged by the server
+	secondary := rbs.identifyCandidateRepositories(is, localRegistry, false)
+	for k := range search {
+		delete(secondary, k)
+	}
+	if desc, err := rbs.findCandidateRepository(ctx, secondary, cached, dgst, retriever); err == nil {
+		return desc, nil
+	}
+
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+func (rbs *remoteBlobGetterService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	store, ok := rbs.digestToStore[dgst.String()]
+	if ok {
+		return store.Open(ctx, dgst)
+	}
+
+	desc, err := rbs.Stat(ctx, dgst)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("Open: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
+		return nil, err
+	}
+
+	store, ok = rbs.digestToStore[desc.Digest.String()]
+	if !ok {
+		return nil, distribution.ErrBlobUnknown
+	}
+
+	return store.Open(ctx, desc.Digest)
+}
+
+func (rbs *remoteBlobGetterService) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	store, ok := rbs.digestToStore[dgst.String()]
+	if ok {
+		return store.ServeBlob(ctx, w, req, dgst)
+	}
+
+	desc, err := rbs.Stat(ctx, dgst)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("ServeBlob: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
+		return err
+	}
+
+	store, ok = rbs.digestToStore[desc.Digest.String()]
+	if !ok {
+		return distribution.ErrBlobUnknown
+	}
+
+	return store.ServeBlob(ctx, w, req, desc.Digest)
+}
+
+// proxyStat attempts to locate the digest in the provided remote repository or returns an error. If the digest is found,
+// rbs.digestToStore saves the store.
+func (rbs *remoteBlobGetterService) proxyStat(ctx context.Context, retriever importer.RepositoryRetriever, ref imageapi.DockerImageReference, dgst digest.Digest) (distribution.Descriptor, error) {
+	context.GetLogger(ctx).Infof("Trying to stat %q from %q", dgst, ref.Exact())
+
+	ctx = WithRemoteBlobGetter(ctx, rbs)
+
+	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), rbs.pullFromInsecureRegistries)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("error getting remote repository for image %q: %v", ref.Exact(), err)
+		return distribution.Descriptor{}, err
+	}
+
+	bs := repo.Blobs(ctx)
+
+	desc, err := bs.Stat(ctx, dgst)
+	if err != nil {
+		if err != distribution.ErrBlobUnknown {
+			context.GetLogger(ctx).Errorf("error getting remoteBlobGetterService for image %q: %v", ref.Exact(), err)
+		}
+		return distribution.Descriptor{}, err
+	}
+
+	rbs.digestToStore[dgst.String()] = bs
+
+	return desc, nil
+}
+
+// Get attempts to fetch the requested blob by digest using a remote proxy store if necessary.
+func (rbs *remoteBlobGetterService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	store, ok := rbs.digestToStore[dgst.String()]
+	if ok {
+		return store.Get(ctx, dgst)
+	}
+
+	desc, err := rbs.Stat(ctx, dgst)
+	if err != nil {
+		context.GetLogger(ctx).Errorf("Get: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
+		return nil, err
+	}
+
+	store, ok = rbs.digestToStore[desc.Digest.String()]
+	if !ok {
+		return nil, distribution.ErrBlobUnknown
+	}
+
+	return store.Get(ctx, desc.Digest)
+}
+
+// findCandidateRepository looks in search for a particular blob, referring to previously cached items
+func (rbs *remoteBlobGetterService) findCandidateRepository(ctx context.Context, search map[string]*imageapi.DockerImageReference, cachedLayers []string, dgst digest.Digest, retriever importer.RepositoryRetriever) (distribution.Descriptor, error) {
+	// no possible remote locations to search, exit early
+	if len(search) == 0 {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
+	// see if any of the previously located repositories containing this digest are in this
+	// image stream
+	for _, repo := range cachedLayers {
+		ref, ok := search[repo]
+		if !ok {
+			continue
+		}
+		desc, err := rbs.proxyStat(ctx, retriever, *ref, dgst)
+		if err != nil {
+			delete(search, repo)
+			continue
+		}
+		context.GetLogger(ctx).Infof("Found digest location from cache %q in %q", dgst, repo)
+		return desc, nil
+	}
+
+	// search the remaining registries for this digest
+	for repo, ref := range search {
+		desc, err := rbs.proxyStat(ctx, retriever, *ref, dgst)
+		if err != nil {
+			continue
+		}
+		rbs.repo.cachedLayers.RememberDigest(dgst, rbs.repo.blobrepositorycachettl, repo)
+		context.GetLogger(ctx).Infof("Found digest location by search %q in %q", dgst, repo)
+		return desc, nil
+	}
+
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+// identifyCandidateRepositories returns a map of remote repositories referenced by this image stream.
+func (rbs *remoteBlobGetterService) identifyCandidateRepositories(is *imageapi.ImageStream, localRegistry string, primary bool) map[string]*imageapi.DockerImageReference {
+	// identify the canonical location of referenced registries to search
+	search := make(map[string]*imageapi.DockerImageReference)
+	for _, tagEvent := range is.Status.Tags {
+		var candidates []imageapi.TagEvent
+		if primary {
+			if len(tagEvent.Items) == 0 {
+				continue
+			}
+			candidates = tagEvent.Items[:1]
+		} else {
+			if len(tagEvent.Items) <= 1 {
+				continue
+			}
+			candidates = tagEvent.Items[1:]
+		}
+		for _, event := range candidates {
+			ref, err := imageapi.ParseDockerImageReference(event.DockerImageReference)
+			if err != nil {
+				continue
+			}
+			// skip anything that matches the innate registry
+			// TODO: there may be a better way to make this determination
+			if len(localRegistry) != 0 && localRegistry == ref.Registry {
+				continue
+			}
+			ref = ref.DockerClientDefaults()
+			search[ref.AsRepository().Exact()] = &ref
+		}
+	}
+	return search
+}

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -18,6 +18,8 @@ import (
 const (
 	// repositoryKey serves to store/retrieve repository object to/from context.
 	repositoryKey = "openshift.repository"
+
+	remoteGetterServiceKey = "openshift.remote.getter.service"
 )
 
 func WithRepository(parent context.Context, repo *repository) context.Context {
@@ -25,6 +27,14 @@ func WithRepository(parent context.Context, repo *repository) context.Context {
 }
 func RepositoryFrom(ctx context.Context) (repo *repository, found bool) {
 	repo, found = ctx.Value(repositoryKey).(*repository)
+	return
+}
+
+func WithRemoteBlobGetter(parent context.Context, svc BlobGetterService) context.Context {
+	return context.WithValue(parent, remoteGetterServiceKey, svc)
+}
+func RemoteBlobGetterFrom(ctx context.Context) (svc BlobGetterService, found bool) {
+	svc, found = ctx.Value(remoteGetterServiceKey).(BlobGetterService)
 	return
 }
 


### PR DESCRIPTION
Problem
We pass all requests (including HEAD) to the remote service if the pullthrough is enabled. On the other hand when docker client pushes the manifest we check the presence of all these layers locally. The client checks a blob existance by HEAD request before sending it to the server.

If client image is based on the imported image (but not present in local registry) dockerregistry will say that it has all the layers from the base image. In this case docker client never send them to server, but manifest verification requires them locally. It means that the verification will always fail for remote layers.

Solution
Manifest verification must to take into account the possibility that the layers may not be local and check them on remote registry server before before give up.

We can't use pullthroughBlobStore because verification happens in ManifestService. So we need to move common code that gets the blobs from the remote server to BlobGetterService and use it for pullthrough and for verification.

Backport #13001
