### PR TITLE
[1.5] cluster up: warn on error parsing Docker version

### DIFF
--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -608,10 +608,12 @@ func (c *CommonStartConfig) CheckNsenterMounter(out io.Writer) error {
 
 // CheckDockerVersion checks that the appropriate Docker version is installed based on whether we are using the nsenter mounter
 // or shared volumes for OpenShift
-func (c *CommonStartConfig) CheckDockerVersion(io.Writer) error {
+func (c *CommonStartConfig) CheckDockerVersion(out io.Writer) error {
 	ver, rh, err := c.DockerHelper().Version()
 	if err != nil {
-		return err
+		glog.V(1).Infof("Failed to check Docker version: %v", err)
+		fmt.Fprintf(out, "WARNING: Cannot verify Docker version\n")
+		return nil
 	}
 	needVersion := dockerVersion19
 	if !rh {


### PR DESCRIPTION
The latest version of Docker for Mac/Windows uses the Community Edition
versioning scheme. This causes 'cluster up' to halt with an error because
the new version cannot be parsed by the 'semver' library. This commit
changes the behavior to display a warning instead of exiting with an
error.