### PR TITLE
Provide configmap for extensions api server authentication

### DIFF
--- a/test/integration/extension_apiserver_test.go
+++ b/test/integration/extension_apiserver_test.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	utilwait "k8s.io/kubernetes/pkg/util/wait"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestExtensionAPIServerConfigMap(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var configmap *kapi.ConfigMap
+	err = utilwait.PollImmediate(50*time.Millisecond, 10*time.Second, func() (bool, error) {
+		configmap, err = clusterAdminKubeClient.Core().ConfigMaps(kapi.NamespaceSystem).Get("extension-apiserver-authentication")
+		if err == nil {
+			return true, nil
+		}
+		if kapierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := configmap.Data["client-ca-file"]; !ok {
+		t.Fatal("missing client-ca-file")
+	}
+}

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -46,6 +46,7 @@ var expectedIndex = []string{
 	"/healthz",
 	"/healthz/ping",
 	"/healthz/poststarthook/bootstrap-controller",
+	"/healthz/poststarthook/ca-registration",
 	"/healthz/poststarthook/extensions/third-party-resources",
 	"/healthz/ready",
 	"/metrics",

--- a/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"encoding/json"
+
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+)
+
+type ClientCARegistrationHook struct {
+	ClientCA []byte
+
+	RequestHeaderUsernameHeaders     []string
+	RequestHeaderGroupHeaders        []string
+	RequestHeaderExtraHeaderPrefixes []string
+	RequestHeaderCA                  []byte
+	RequestHeaderAllowedNames        []string
+}
+
+func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
+	if len(h.ClientCA) == 0 && len(h.RequestHeaderCA) == 0 {
+		return nil
+	}
+
+	client, err := coreclient.NewForConfig(hookContext.LoopbackClientConfig)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return nil
+	}
+
+	h.writeClientCAs(client)
+	return nil
+}
+
+// writeClientCAs is here for unit testing with a fake client
+func (h ClientCARegistrationHook) writeClientCAs(client coreclient.CoreInterface) {
+	if _, err := client.Namespaces().Create(&api.Namespace{ObjectMeta: api.ObjectMeta{Name: api.NamespaceSystem}}); err != nil && !apierrors.IsAlreadyExists(err) {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	data := map[string]string{}
+	if len(h.ClientCA) > 0 {
+		data["client-ca-file"] = string(h.ClientCA)
+	}
+
+	if len(h.RequestHeaderCA) > 0 {
+		var err error
+
+		data["requestheader-username-headers"], err = jsonSerializeStringSlice(h.RequestHeaderUsernameHeaders)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		data["requestheader-group-headers"], err = jsonSerializeStringSlice(h.RequestHeaderGroupHeaders)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		data["requestheader-extra-headers-prefix"], err = jsonSerializeStringSlice(h.RequestHeaderExtraHeaderPrefixes)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		data["requestheader-client-ca-file"] = string(h.RequestHeaderCA)
+		data["requestheader-allowed-names"], err = jsonSerializeStringSlice(h.RequestHeaderAllowedNames)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+	}
+
+	if err := writeConfigMap(client, "extension-apiserver-authentication", data); err != nil {
+		utilruntime.HandleError(err)
+	}
+
+	return
+}
+
+func jsonSerializeStringSlice(in []string) (string, error) {
+	out, err := json.Marshal(in)
+	if err != nil {
+		return "", err
+	}
+	return string(out), err
+}
+
+func writeConfigMap(client coreclient.ConfigMapsGetter, name string, data map[string]string) error {
+	existing, err := client.ConfigMaps(api.NamespaceSystem).Get(name)
+	if apierrors.IsNotFound(err) {
+		_, err := client.ConfigMaps(api.NamespaceSystem).Create(&api.ConfigMap{
+			ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: name},
+			Data:       data,
+		})
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	existing.Data = data
+	_, err = client.ConfigMaps(api.NamespaceSystem).Update(existing)
+	return err
+}

--- a/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	clienttesting "k8s.io/kubernetes/pkg/client/testing/core"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/diff"
+)
+
+func TestWriteClientCAs(t *testing.T) {
+	tests := []struct {
+		name               string
+		hook               ClientCARegistrationHook
+		preexistingObjs    []runtime.Object
+		expectedConfigMaps map[string]*api.ConfigMap
+		expectUpdate       bool
+	}{
+		{
+			name: "basic",
+			hook: ClientCARegistrationHook{
+				ClientCA:                         []byte("foo"),
+				RequestHeaderUsernameHeaders:     []string{"alfa", "bravo", "charlie"},
+				RequestHeaderGroupHeaders:        []string{"delta"},
+				RequestHeaderExtraHeaderPrefixes: []string{"echo", "foxtrot"},
+				RequestHeaderCA:                  []byte("bar"),
+				RequestHeaderAllowedNames:        []string{"first", "second"},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"client-ca-file":                     "foo",
+						"requestheader-username-headers":     `["alfa","bravo","charlie"]`,
+						"requestheader-group-headers":        `["delta"]`,
+						"requestheader-extra-headers-prefix": `["echo","foxtrot"]`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `["first","second"]`,
+					},
+				},
+			},
+		},
+		{
+			name: "skip extension-apiserver-authentication",
+			hook: ClientCARegistrationHook{
+				RequestHeaderCA:           []byte("bar"),
+				RequestHeaderAllowedNames: []string{"first", "second"},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `null`,
+						"requestheader-group-headers":        `null`,
+						"requestheader-extra-headers-prefix": `null`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `["first","second"]`,
+					},
+				},
+			},
+		},
+		{
+			name: "skip extension-apiserver-authentication",
+			hook: ClientCARegistrationHook{
+				ClientCA: []byte("foo"),
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"client-ca-file": "foo",
+					},
+				},
+			},
+		},
+		{
+			name: "empty allowed names",
+			hook: ClientCARegistrationHook{
+				RequestHeaderCA: []byte("bar"),
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `null`,
+						"requestheader-group-headers":        `null`,
+						"requestheader-extra-headers-prefix": `null`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `null`,
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite extension-apiserver-authentication",
+			hook: ClientCARegistrationHook{
+				ClientCA: []byte("foo"),
+			},
+			preexistingObjs: []runtime.Object{
+				&api.ConfigMap{
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"client-ca-file": "other",
+					},
+				},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"client-ca-file": "foo",
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "overwrite extension-apiserver-authentication requestheader",
+			hook: ClientCARegistrationHook{
+				RequestHeaderUsernameHeaders:     []string{},
+				RequestHeaderGroupHeaders:        []string{},
+				RequestHeaderExtraHeaderPrefixes: []string{},
+				RequestHeaderCA:                  []byte("bar"),
+				RequestHeaderAllowedNames:        []string{},
+			},
+			preexistingObjs: []runtime.Object{
+				&api.ConfigMap{
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `null`,
+						"requestheader-group-headers":        `null`,
+						"requestheader-extra-headers-prefix": `null`,
+						"requestheader-client-ca-file":       "something",
+						"requestheader-allowed-names":        `null`,
+					},
+				},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `[]`,
+						"requestheader-group-headers":        `[]`,
+						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `[]`,
+					},
+				},
+			},
+			expectUpdate: true,
+		},
+		{
+			name: "namespace exists",
+			hook: ClientCARegistrationHook{
+				ClientCA: []byte("foo"),
+			},
+			preexistingObjs: []runtime.Object{
+				&api.Namespace{ObjectMeta: api.ObjectMeta{Name: api.NamespaceSystem}},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{
+				"extension-apiserver-authentication": {
+					ObjectMeta: api.ObjectMeta{Namespace: api.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"client-ca-file": "foo",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		client := fake.NewSimpleClientset(test.preexistingObjs...)
+		test.hook.writeClientCAs(client.Core())
+
+		actualConfigMaps, updated := getFinalConfiMaps(client)
+		if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {
+			t.Errorf("%s: %v", test.name, diff.ObjectReflectDiff(test.expectedConfigMaps, actualConfigMaps))
+			continue
+		}
+		if test.expectUpdate != updated {
+			t.Errorf("%s: expected %v, got %v", test.name, test.expectUpdate, updated)
+			continue
+		}
+	}
+}
+
+func getFinalConfiMaps(client *fake.Clientset) (map[string]*api.ConfigMap, bool) {
+	ret := map[string]*api.ConfigMap{}
+	updated := false
+
+	for _, action := range client.Actions() {
+		if action.Matches("create", "configmaps") {
+			obj := action.(clienttesting.CreateAction).GetObject().(*api.ConfigMap)
+			ret[obj.Name] = obj
+		}
+		if action.Matches("update", "configmaps") {
+			updated = true
+			obj := action.(clienttesting.UpdateAction).GetObject().(*api.ConfigMap)
+			ret[obj.Name] = obj
+		}
+	}
+	return ret, updated
+}


### PR DESCRIPTION
This picks a 1.6 change that provides authentication configuration to extension API servers inside of a configmap in kube-system.  I had to add a drop commit to the kube post starthook implementation to wait until the loopback client config had permissions to call the post start hooks since its it can take a while on the current level of openshift.

@enj ptal.