### PR TITLE
Disable local fsgroup quota test when not using XFS

### DIFF
--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -133,7 +133,9 @@ var _ = g.Describe("[Conformance][volumes] Test local storage quota", func() {
 			o.Expect(volDir).NotTo(o.Equal(""))
 			args := []string{"-f", "-c", "'%T'", volDir}
 			outBytes, _ := exec.Command("stat", args...).Output()
-			o.Expect(strings.Contains(string(outBytes), "xfs")).To(o.BeTrue())
+			if !strings.Contains(string(outBytes), "xfs") {
+				g.Skip("Volume directory is not on an XFS filesystem, skipping...")
+			}
 
 			g.By("lookup test projects fsGroup ID")
 			fsGroup, err := lookupFSGroup(oc, project)


### PR DESCRIPTION
Full installations of an OpenShift cluster using the OpenShift-
Ansible installer will not necessarily use an XFS filesystem for
volumes. If this test is to remain part of the [Conformance] suite,
it cannot fail when it's pre-requisite setup has not been done.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @dgoodwin
[test]