### PR TITLE
Bash function deprecations

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -74,7 +74,7 @@ function image-build() {
 
 	# build the image
 	if ! os::build::image "${dir}" "${dest}"; then
-		os::log::warn "Retrying build once"
+		os::log::warning "Retrying build once"
 		os::build::image "${dir}" "${dest}"
 	fi
 

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -50,8 +50,8 @@ elif [[ "${#output_directories[@]}" -gt 1 ]]; then
 			output_directory="${directory}"
 		fi
 	done
-	os::log::warn 'After the tito build, more than one rpmbuild directory was found!'
-	os::log::warn 'This script will unpack the most recently modified directory: '"${output_directory}"
+	os::log::warning 'After the tito build, more than one rpmbuild directory was found!'
+	os::log::warning 'This script will unpack the most recently modified directory: '"${output_directory}"
 else
 	output_directory="${output_directories[0]}"
 fi
@@ -83,5 +83,5 @@ name = OpenShift Origin Release from Local Source
 	os::log::info "Repository file for \`yum\` or \`dnf\` placed at ${repo_path}/origin-local-release.repo"
 	os::log::info "Install it with: "$'\n\t'"$ mv '${repo_path}/origin-local-release.repo' '/etc/yum.repos.d"
 else
-	os::log::warn "Repository file for \`yum\` or \`dnf\` could not be generated, install \`createrepo\`."
+	os::log::warning "Repository file for \`yum\` or \`dnf\` could not be generated, install \`createrepo\`."
 fi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -555,10 +555,10 @@ function os::build::get_version_vars() {
       return
     fi
     if [[ ! -d "${OS_ROOT}/.git" ]]; then
-      os::log::warn "No version file at ${OS_VERSION_FILE}"
+      os::log::warning "No version file at ${OS_VERSION_FILE}"
       exit 1
     fi
-    os::log::warn "No version file at ${OS_VERSION_FILE}, falling back to git versions"
+    os::log::warning "No version file at ${OS_VERSION_FILE}, falling back to git versions"
   fi
   os::build::os_version_vars
   os::build::kube_version_vars
@@ -739,7 +739,7 @@ function os::build::image() {
       return $?
     fi
 
-    os::log::warn "Unable to locate 'imagebuilder' on PATH, falling back to Docker build"
+    os::log::warning "Unable to locate 'imagebuilder' on PATH, falling back to Docker build"
     # clear options since we were unable to select imagebuilder
     options=""
   fi

--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -128,8 +128,8 @@ function os::build::environment::start() {
       fi
       os::log::debug "Copying from ${container}:${workingdir}/${path} to ${parent}"
       if ! output="$( docker cp "${container}:${workingdir}/${path}" "${parent}" 2>&1 )"; then
-        os::log::warn "Copying ${path} from the container failed!"
-        os::log::warn "${output}"
+        os::log::warning "Copying ${path} from the container failed!"
+        os::log::warning "${output}"
       fi
     done
     IFS="${oldIFS}"

--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -27,7 +27,7 @@ function os::cleanup::dump_etcd() {
 #  None
 function os::cleanup::containers() {
 	if ! os::util::find::system_binary docker >/dev/null 2>&1; then
-		os::log::warning "No \`docker\` binary found, skipping container cleanup."
+		os::log::warninging "No \`docker\` binary found, skipping container cleanup."
 		return
 	fi
 
@@ -60,7 +60,7 @@ readonly -f os::cleanup::containers
 #  None
 function os::cleanup::dump_container_logs() {
 	if ! os::util::find::system_binary docker >/dev/null 2>&1; then
-		os::log::warning "No \`docker\` binary found, skipping container cleanup."
+		os::log::warninging "No \`docker\` binary found, skipping container cleanup."
 		return
 	fi
 

--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -14,16 +14,23 @@ function os::log::info() {
 }
 readonly -f os::log::info
 
-# os::log::warn writes the message to stderr.
+# os::log::warning writes the message to stderr.
 # A warning indicates something went wrong but
 # not so wrong that we cannot recover.
 #
 # Arguments:
 #  - all: message to write
-function os::log::warn() {
+function os::log::warning() {
 	local message; message="$( os::log::internal::prefix_lines "[WARNING]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	os::text::print_yellow "${message}" 1>&2
+}
+readonly -f os::log::warning
+
+# os::log::warn remains for backward compatibility
+function os::log::warn() {
+	os::log::warning "os::log::warn is deprecated and will be removed in the future. Use os::log::warning instead."
+	os::log::warning "$@"
 }
 readonly -f os::log::warn
 

--- a/hack/lib/log/system.sh
+++ b/hack/lib/log/system.sh
@@ -51,7 +51,7 @@ function os::log::system::clean_up() {
     fi
 
     if ! which sadf  >/dev/null 2>&1; then
-        os::log::warn "System logger data could not be unpacked and graphed, 'sadf' binary not found in this environment."
+        os::log::warning "System logger data could not be unpacked and graphed, 'sadf' binary not found in this environment."
         return 0
     fi
 

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -55,7 +55,7 @@ function os::util::ensure::built_binary_exists() {
 		fi
 
 		if [[ -n "${target}" ]]; then
-			os::log::warn "No compiled \`${binary}\` binary was found. Attempting to build one using:
+			os::log::warning "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
 			"${OS_ROOT}/hack/build-go.sh" "${target}"
 		else

--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -14,8 +14,8 @@ function os::golang::verify_go_version() {
 			os::log::error "Please install Go version 1.7 or use PERMISSIVE_GO=y to bypass this check."
 			return 1
 		else
-			os::log::warn "Detected golang version doesn't match preferred Go version for Origin."
-			os::log::warn "This version mismatch could lead to differences in execution between this run and the Origin CI systems."
+			os::log::warning "Detected golang version doesn't match preferred Go version for Origin."
+			os::log::warning "This version mismatch could lead to differences in execution between this run and the Origin CI systems."
 			return 0
 		fi
 	fi

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -80,7 +80,7 @@ if [[ "${tag}" != ":latest" ]]; then
       docker pull "${OS_PUSH_BASE_REGISTRY-}${image}:${source_tag}"
     done
   else
-    os::log::warn "Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}*${tag}"
+    os::log::warning "Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}*${tag}"
     if [[ -z "${OS_PUSH_ALWAYS:-}" ]]; then
       echo "  CTRL+C to cancel, or any other key to continue"
       read

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -11,7 +11,7 @@ if [[ -z "${tag}" ]]; then
   fi
   tag="$( git tag --points-at HEAD )"
 elif [[ "$( git rev-parse "${tag}" )" != "$( git rev-parse HEAD )" ]]; then
-  os::log::warn "You are running a version of hack/release.sh that does not match OS_TAG - images may not be build correctly"
+  os::log::warning "You are running a version of hack/release.sh that does not match OS_TAG - images may not be build correctly"
 fi
 commit="$( git rev-parse ${tag} )"
 

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -41,32 +41,6 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::build::setup_env
 os::util::environment::setup_tmpdir_vars "test-go"
 
-# TODO(skuznets): remove these once we've migrated all tools to the new vars
-if [[ -n "${KUBE_TIMEOUT+x}" ]]; then
-    TIMEOUT="${KUBE_TIMEOUT}"
-    os::log::warning "The flag \$KUBE_TIMEOUT for $0 is deprecated, use \$TIMEOUT instead."
-fi
-
-if [[ -n "${KUBE_COVER+x}" ]]; then
-    COVERAGE_SPEC="${KUBE_COVER}"
-    os::log::warning "The flag \$KUBE_COVER for $0 is deprecated, use \$COVERAGE_SPEC instead."
-fi
-
-if [[ -n "${OUTPUT_COVERAGE+x}" ]]; then
-    COVERAGE_OUTPUT_DIR="${OUTPUT_COVERAGE}"
-    os::log::warning "The flag \$OUTPUT_COVERAGE for $0 is deprecated, use \$COVERAGE_OUTPUT_DIR instead."
-fi
-
-if [[ -n "${KUBE_RACE+x}" ]]; then
-    DETECT_RACES="${KUBE_RACE}"
-    os::log::warning "The flag \$KUBE_RACE for $0 is deprecated, use \$DETECT_RACES instead."
-fi
-
-if [[ -n "${PRINT_PACKAGES+x}" ]]; then
-    DRY_RUN="${PRINT_PACKAGES}"
-    os::log::warning "The flag \$PRINT_PACKAGES for $0 is deprecated, use \$DRY_RUN instead."
-fi
-
 # Internalize environment variables we consume and default if they're not set
 dry_run="${DRY_RUN:-}"
 test_kube="${TEST_KUBE:-}"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -44,27 +44,27 @@ os::util::environment::setup_tmpdir_vars "test-go"
 # TODO(skuznets): remove these once we've migrated all tools to the new vars
 if [[ -n "${KUBE_TIMEOUT+x}" ]]; then
     TIMEOUT="${KUBE_TIMEOUT}"
-    os::log::warn "The flag \$KUBE_TIMEOUT for $0 is deprecated, use \$TIMEOUT instead."
+    os::log::warning "The flag \$KUBE_TIMEOUT for $0 is deprecated, use \$TIMEOUT instead."
 fi
 
 if [[ -n "${KUBE_COVER+x}" ]]; then
     COVERAGE_SPEC="${KUBE_COVER}"
-    os::log::warn "The flag \$KUBE_COVER for $0 is deprecated, use \$COVERAGE_SPEC instead."
+    os::log::warning "The flag \$KUBE_COVER for $0 is deprecated, use \$COVERAGE_SPEC instead."
 fi
 
 if [[ -n "${OUTPUT_COVERAGE+x}" ]]; then
     COVERAGE_OUTPUT_DIR="${OUTPUT_COVERAGE}"
-    os::log::warn "The flag \$OUTPUT_COVERAGE for $0 is deprecated, use \$COVERAGE_OUTPUT_DIR instead."
+    os::log::warning "The flag \$OUTPUT_COVERAGE for $0 is deprecated, use \$COVERAGE_OUTPUT_DIR instead."
 fi
 
 if [[ -n "${KUBE_RACE+x}" ]]; then
     DETECT_RACES="${KUBE_RACE}"
-    os::log::warn "The flag \$KUBE_RACE for $0 is deprecated, use \$DETECT_RACES instead."
+    os::log::warning "The flag \$KUBE_RACE for $0 is deprecated, use \$DETECT_RACES instead."
 fi
 
 if [[ -n "${PRINT_PACKAGES+x}" ]]; then
     DRY_RUN="${PRINT_PACKAGES}"
-    os::log::warn "The flag \$PRINT_PACKAGES for $0 is deprecated, use \$DRY_RUN instead."
+    os::log::warning "The flag \$PRINT_PACKAGES for $0 is deprecated, use \$DRY_RUN instead."
 fi
 
 # Internalize environment variables we consume and default if they're not set
@@ -229,24 +229,24 @@ if [[ -n "${junit_report}" ]]; then
 
     if echo "${summary}" | grep -q ', 0 failed,'; then
         if [[ "${test_return_code}" -ne "0" ]]; then
-            os::log::warn "While the jUnit report found no failed tests, the \`go test\` process failed."
-            os::log::warn "This usually means that the unit test suite failed to compile."
+            os::log::warning "While the jUnit report found no failed tests, the \`go test\` process failed."
+            os::log::warning "This usually means that the unit test suite failed to compile."
         fi
     fi
 
     if [[ -s "${test_error_file}" ]]; then
-        os::log::warn "\`go test\` had the following output to stderr:"
+        os::log::warning "\`go test\` had the following output to stderr:"
         cat "${test_error_file}"
     fi
 
     if grep -q 'WARNING: DATA RACE' "${test_output_file}"; then
         locations=( $( sed -n '/WARNING: DATA RACE/=' "${test_output_file}") )
         if [[ "${#locations[@]}" -gt 1 ]]; then
-            os::log::warn "\`go test\` detected data races."
-            os::log::warn "Details can be found in the full output file at lines ${locations[*]}."
+            os::log::warning "\`go test\` detected data races."
+            os::log::warning "Details can be found in the full output file at lines ${locations[*]}."
         else
-            os::log::warn "\`go test\` detected a data race."
-            os::log::warn "Details can be found in the full output file at line ${locations[*]}."
+            os::log::warning "\`go test\` detected a data race."
+            os::log::warning "Details can be found in the full output file at line ${locations[*]}."
         fi
     fi
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -28,7 +28,7 @@ verbose="${VERBOSE:-}"
 
 # build the test executable
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
-  os::log::warn "Skipping build due to OPENSHIFT_SKIP_BUILD"
+  os::log::warning "Skipping build due to OPENSHIFT_SKIP_BUILD"
 else
 	"${OS_ROOT}/hack/build-go.sh" "${package}/${name}.test"
 fi

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -9,7 +9,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 platform="$(os::build::host_platform)"
 if [[ "${platform}" != "linux/amd64" ]]; then
-  os::log::warn "Generating completions on ${platform} may not be identical to running on linux/amd64 due to conditional compilation."
+  os::log::warning "Generating completions on ${platform} may not be identical to running on linux/amd64 due to conditional compilation."
 fi
 
 OUTPUT_REL_DIR=${1:-""}

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -2,7 +2,7 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 if [[ "${PROTO_OPTIONAL:-}" == "1" ]]; then
-  os::log::warn "Skipping protobuf generation as \$PROTO_OPTIONAL is set."
+  os::log::warning "Skipping protobuf generation as \$PROTO_OPTIONAL is set."
   exit 0
 fi
 

--- a/hack/verify-generated-completions.sh
+++ b/hack/verify-generated-completions.sh
@@ -5,7 +5,7 @@ echo "===== Verifying Generated Completions ====="
 
 platform="$(os::build::host_platform)"
 if [[ "${platform}" != "linux/amd64" ]]; then
-  os::log::warn "Completions cannot be verified on non-Linux systems (${platform})"
+  os::log::warning "Completions cannot be verified on non-Linux systems (${platform})"
   exit 0
 fi
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -224,7 +224,7 @@ function run-extended-tests() {
 
   if [[ -n "${log_path}" ]]; then
     if [[ -n "${dlv_debug}" ]]; then
-      os::log::warn "Not logging to file since DLV_DEBUG is enabled"
+      os::log::warning "Not logging to file since DLV_DEBUG is enabled"
     else
       test_cmd="${test_cmd} | tee ${log_path}"
     fi
@@ -266,7 +266,7 @@ TEST_EXTRA_ARGS="$@"
 
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]] &&
      os::util::find::built_binary 'extended.test' >/dev/null 2>&1; then
-  os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=1"
+  os::log::warning "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=1"
 else
   hack/build-go.sh test/extended/extended.test
 fi

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -91,7 +91,7 @@ function os::test::extended::setup () {
 		LOCAL_STORAGE_QUOTA="1"
 		export VOLUME_DIR="/mnt/openshift-xfs-vol-dir"
 	else
-		os::log::warn "/mnt/openshift-xfs-vol-dir does not exist, local storage quota tests may fail."
+		os::log::warning "/mnt/openshift-xfs-vol-dir does not exist, local storage quota tests may fail."
 	fi
 
 	# Allow setting $JUNIT_REPORT to toggle output behavior
@@ -201,7 +201,7 @@ function os::test::extended::run () {
 	os::test::extended::test_list "${listArgs[@]}"
 
 	if [[ "${TEST_COUNT}" -eq 0 ]]; then
-		os::log::warn "No tests were selected"
+		os::log::warning "No tests were selected"
 		return
 	fi
 
@@ -237,7 +237,7 @@ function os::test::extended::test_list () {
 	done
 	if [[ -n "${PRINT_TESTS:-}" ]]; then
 		if [[ ${#selected_tests[@]} -eq 0 ]]; then
-			os::log::warn "No tests were selected"
+			os::log::warning "No tests were selected"
 		else
 			printf '%s\n' "${selected_tests[@]}" | sort
 		fi


### PR DESCRIPTION
Finish deprecation of old `hack/test-go.sh` envars

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Begin deprecation of `os::log::warn` in favor of `os::log::warning`

The pattern with all other `os::log` functions is that the logging
function in the `os::log` namespace is the same as the prefix that
is printed in the logfiles. This patch begins the migration of the
`os::log::warn` function, which did not conform to this API.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

[test]