### PR TITLE
node/sdn: make /var/lib/cni persistent to ensure IPAM allocations stick around across node restart

### DIFF
--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -8,7 +8,7 @@ PartOf=docker.service
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node
 ExecStartPre=-/usr/bin/docker rm -f origin-node
-ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:rw -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/origin:/var/lib/origin:rslave -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
+ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:rw -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni -v /var/lib/origin:/var/lib/origin:rslave -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always


### PR DESCRIPTION
With the move to a CNI plugin, docker no longer handles IPAM, but CNI does through
openshift-sdn's usage of the 'host-local' CNI IPAM plugin.  That plugin stores
IPAM allocations under /var/lib/cni/.

If the node container gets restarted, without presreving /var/lib/cni, the IPs
currently allocated to running pods get lost and on restart, openshift-sdn
may allocate those IPs to new pods causing duplicate allocations.

This never happened with docker because it has its own persistent IPAM store that
does not get removed when docker restarts.  Also because (historically) when docker
restarted, all the containers died and the IP allocations were released by the
daemon.

Fix this by ensuring that IPAM allocations (which are tied to the life of the pod,
*not* the life of the openshift-node process) persist even if the openshift-node
process restarts.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1427789

@sdodson @openshift/networking @eparis 