### PR TITLE
Enhance new-app circular test to handle ImageStreamImage refs

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -823,6 +823,15 @@ func (c *AppConfig) followRefToDockerImage(ref *kapi.ObjectReference, isContext 
 		return &copy, nil
 	}
 
+	if ref.Kind == "ImageStreamImage" {
+		// even if the associated tag for this ImageStreamImage matches a output ImageStreamTag, when the image
+		// is built it will have a new sha ... you are essentially using a single/unique older version of a image as the base
+		// to build future images;  all this means we can leave the ref name as is and return with no error
+		// also do shallow copy like above
+		copy := *ref
+		return &copy, nil
+	}
+
 	if ref.Kind != "ImageStreamTag" {
 		return nil, fmt.Errorf("Unable to follow reference type: %q", ref.Kind)
 	}

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -377,6 +377,8 @@ os::cmd::expect_failure_and_text 'oc new-build mysql --source-image-path foo' 'e
 # ensure circular ref flagged but allowed for template
 os::cmd::expect_success 'oc create -f test/testdata/circular-is.yaml'
 os::cmd::expect_success_and_text 'oc new-app -f test/testdata/circular.yaml' 'should be different than input'
+# ensure circular does not choke on image stream image
+os::cmd::expect_success_and_not_text 'oc new-app -f test/testdata/bc-from-imagestreamimage.json --dry-run' 'Unable to follow reference type'
 
 # do not allow use of non-existent image (should fail)
 os::cmd::expect_failure_and_text 'oc new-app  openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml' "no match for"

--- a/test/testdata/bc-from-imagestreamimage.json
+++ b/test/testdata/bc-from-imagestreamimage.json
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: bc-from-imagestreamimage
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      name: bc-from-imagestreamimage
+      template: application-template-stibuild
+    name: bc-from-imagestreamimage
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: origin-ruby-sample:latest
+    postCommit:
+      args:
+      - bundle
+      - exec
+      - rake
+      - test
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      type: Git
+    strategy:
+      sourceStrategy:
+        env:
+        - name: EXAMPLE
+          value: sample-app
+        from:
+          kind: ImageStreamImage
+          name: ruby@sha256:5dc0856fea9551e102815863cceeabd3aee862ec4ad5f2625eb51564924f0360
+      type: Source
+    triggers:
+    - github:
+        secret: secret101
+      type: GitHub
+    - generic:
+        allowEnv: true
+        secret: secret101
+      type: Generic
+    - type: ConfigChange
+  status:
+    lastVersion: 0


### PR DESCRIPTION
bug 1422378
https://bugzilla.redhat.com/show_bug.cgi?id=1422378

@csrwng ptal

(quick background - I went back and forth on translating the ImageStreamImage name to docker refs or ImageStreamTags, but then convinced myself that was unnecessary)

@openshift/devex fyi