### PR TITLE
Updated with correct Insecure registries location

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -95,7 +95,7 @@ $ oc cluster down
 1. Install [Docker for Mac](https://docs.docker.com/docker-for-mac/) making sure you meet the [prerequisites](https://docs.docker.com/docker-for-mac/#/what-to-know-before-you-install).
 2. Once Docker is running, add an insecure registry of `172.30.0.0/16`:
    - From the Docker menu in the toolbar, select `Preferences...`
-   - Click on `Advanced` in the preferences dialog
+   - Click on `Daemon` in the preferences dialog
    - Under `Insecure registries:`, click on the `+` icon to add a new entry
    - Enter `172.30.0.0/16` and press `return`
    - Click on `Apply and Restart`


### PR DESCRIPTION
On the current version of Docker for Mac (17.03.0-ce), the location of the *Insecure registries* list is under the "Daemon" section.

<img width="380" alt="screen shot 2017-03-05 at 15 45 07" src="https://cloud.githubusercontent.com/assets/429760/23588830/1a288c18-01bb-11e7-8efb-61c5a08a32af.png">
