### PR TITLE
correct the ways that routes are iterated over to be cleared

### DIFF
--- a/images/router/clear-route-status.sh
+++ b/images/router/clear-route-status.sh
@@ -22,9 +22,9 @@ function clear_status_set_by() {
     local router_name="${1}"
 
     for namespace in $( oc get namespaces -o 'jsonpath={.items[*].metadata.name}' ); do
-        local routes; routes=$(oc get routes -o jsonpath='{.items[*].metadata.name}' --namespace="${namespace}" 2>/dev/null)
-        if [[ -n "${routes}" ]]; then
-            for route in "${routes}"; do
+        local routes; routes=($(oc get routes -o jsonpath='{.items[*].metadata.name}' --namespace="${namespace}" 2>/dev/null))
+        if [[ "${#routes[@]}" -ne 0  ]]; then
+            for route in "${routes[@]}"; do
                 clear_routers_status "${namespace}" "${route}" "${router_name}"
             done
         else
@@ -106,9 +106,9 @@ namespace="${1}"
 route_name="${2}"
 
 if [[ "${route_name}" == "ALL" ]]; then
-    routes=$(oc get routes -o jsonpath='{.items[*].metadata.name}' --namespace="${namespace}" 2>/dev/null)
-    if [[ -n "${routes}" ]]; then
-        for route in "${routes}"; do
+    routes=($(oc get routes -o jsonpath='{.items[*].metadata.name}' --namespace="${namespace}" 2>/dev/null))
+    if [[ "${#routes[@]}" -ne 0 ]]; then
+        for route in "${routes[@]}"; do
             clear_status "${namespace}" "${route}"
         done
     else


### PR DESCRIPTION
there was an oversight in the way that the clear route status iterated
over the routes returned by

oc get routes -o jsonpath='{.items[*].metadata.name}' --namespace="${namespace}" 2>/dev/null

currently all routes are presented as one string that the server cannot find.
change that so that the routes are returned  into an array and correctly iterated over to present
to the server each route.

Bug 1429364 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1429364)
Bug 1429398 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1429398)