### PR TITLE
Fix cookies for reencrypt routes with InsecureEdgeTerminationPolicy " Allow

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -448,7 +448,11 @@ backend be_secure_{{$cfgIdx}}
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
   {{ if not (matchPattern "true|TRUE" (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}
+    {{ if ne $cfg.InsecureEdgeTerminationPolicy "Allow" }}
   cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly secure
+    {{ else }}
+  cookie {{$cfg.RoutingKeyName}} insert indirect nocache httponly
+    {{ end }}
   {{ end }}
     {{ range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
       {{ if ne $weight 0 }}


### PR DESCRIPTION
This is a backport of origin PR [13221](https://github.com/openshift/origin/pull/13221)

currently secure cookies are always generated for reencrypt routes this changes
that to correctly create unsecured cookies when InsecureEdgeTermination policy is
"Allow"

Bug 1428720