### PR TITLE
authorize personalSAR based on selfsubjectaccessreviews.authorization.k8s.io

### DIFF
--- a/pkg/authorization/authorizer/adapter/attributes_test.go
+++ b/pkg/authorization/authorizer/adapter/attributes_test.go
@@ -18,14 +18,13 @@ var _ = kauthorizer.Attributes(AdapterAttributes{})
 func TestRoundTrip(t *testing.T) {
 	// Start with origin attributes
 	oattrs := oauthorizer.DefaultAuthorizationAttributes{
-		Verb:              "get",
-		APIVersion:        "av",
-		APIGroup:          "ag",
-		Resource:          "r",
-		ResourceName:      "rn",
-		RequestAttributes: "ra",
-		NonResourceURL:    true,
-		URL:               "/123",
+		Verb:           "get",
+		APIVersion:     "av",
+		APIGroup:       "ag",
+		Resource:       "r",
+		ResourceName:   "rn",
+		NonResourceURL: true,
+		URL:            "/123",
 	}
 
 	// Convert to kube attributes
@@ -84,9 +83,6 @@ func TestRoundTrip(t *testing.T) {
 	}
 	if oattrs.GetResourceName() != oattrs2.GetResourceName() {
 		t.Errorf("Expected %v, got %v", oattrs.GetResourceName(), oattrs2.GetResourceName())
-	}
-	if oattrs.GetRequestAttributes() != oattrs2.GetRequestAttributes() {
-		t.Errorf("Expected %v, got %v", oattrs.GetRequestAttributes(), oattrs2.GetRequestAttributes())
 	}
 	if oattrs.IsNonResourceURL() != oattrs2.IsNonResourceURL() {
 		t.Errorf("Expected %v, got %v", oattrs.IsNonResourceURL(), oattrs2.IsNonResourceURL())

--- a/pkg/authorization/authorizer/attributes_builder.go
+++ b/pkg/authorization/authorizer/attributes_builder.go
@@ -36,13 +36,12 @@ func (a *openshiftAuthorizationAttributeBuilder) GetAttributes(req *http.Request
 	}
 
 	return DefaultAuthorizationAttributes{
-		Verb:              requestInfo.Verb,
-		APIGroup:          requestInfo.APIGroup,
-		APIVersion:        requestInfo.APIVersion,
-		Resource:          resource,
-		ResourceName:      requestInfo.Name,
-		RequestAttributes: req,
-		NonResourceURL:    false,
-		URL:               requestInfo.Path,
+		Verb:           requestInfo.Verb,
+		APIGroup:       requestInfo.APIGroup,
+		APIVersion:     requestInfo.APIVersion,
+		Resource:       resource,
+		ResourceName:   requestInfo.Name,
+		NonResourceURL: false,
+		URL:            requestInfo.Path,
 	}, nil
 }

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -132,13 +132,12 @@ func CoerceToDefaultAuthorizationAttributes(passedAttributes Action) *DefaultAut
 	attributes, ok := passedAttributes.(*DefaultAuthorizationAttributes)
 	if !ok {
 		attributes = &DefaultAuthorizationAttributes{
-			APIGroup:          passedAttributes.GetAPIGroup(),
-			Verb:              passedAttributes.GetVerb(),
-			RequestAttributes: passedAttributes.GetRequestAttributes(),
-			Resource:          passedAttributes.GetResource(),
-			ResourceName:      passedAttributes.GetResourceName(),
-			NonResourceURL:    passedAttributes.IsNonResourceURL(),
-			URL:               passedAttributes.GetURL(),
+			APIGroup:       passedAttributes.GetAPIGroup(),
+			Verb:           passedAttributes.GetVerb(),
+			Resource:       passedAttributes.GetResource(),
+			ResourceName:   passedAttributes.GetResourceName(),
+			NonResourceURL: passedAttributes.IsNonResourceURL(),
+			URL:            passedAttributes.GetURL(),
 		}
 	}
 

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -56,7 +56,7 @@ func TestInvalidRole(t *testing.T) {
 			Resource: "buildConfigs",
 		},
 		expectedAllowed: false,
-		expectedError:   "unable to interpret:",
+		expectedReason:  `User "Brad" cannot get buildConfigs in project "mallet"`,
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = newInvalidExtensionPolicies()

--- a/pkg/authorization/authorizer/cache/authorizer.go
+++ b/pkg/authorization/authorizer/cache/authorizer.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -124,11 +123,6 @@ func (c *CacheAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes author
 }
 
 func cacheKey(ctx kapi.Context, a authorizer.Action) (string, error) {
-	if a.GetRequestAttributes() != nil {
-		// TODO: see if we can serialize this?
-		return "", errors.New("cannot cache request attributes")
-	}
-
 	keyData := map[string]interface{}{
 		"verb":           a.GetVerb(),
 		"apiVersion":     a.GetAPIVersion(),

--- a/pkg/authorization/authorizer/cache/authorizer_test.go
+++ b/pkg/authorization/authorizer/cache/authorizer_test.go
@@ -26,11 +26,6 @@ func TestCacheKey(t *testing.T) {
 		ExpectedKey string
 		ExpectedErr bool
 	}{
-		"uncacheable request attributes": {
-			Context:     kapi.NewContext(),
-			Attrs:       &authorizer.DefaultAuthorizationAttributes{RequestAttributes: true},
-			ExpectedErr: true,
-		},
 		"empty": {
 			Context:     kapi.NewContext(),
 			Attrs:       &authorizer.DefaultAuthorizationAttributes{},
@@ -39,14 +34,13 @@ func TestCacheKey(t *testing.T) {
 		"full": {
 			Context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "myns"), &user.DefaultInfo{Name: "me", Groups: []string{"group1", "group2"}}),
 			Attrs: &authorizer.DefaultAuthorizationAttributes{
-				Verb:              "v",
-				APIVersion:        "av",
-				APIGroup:          "ag",
-				Resource:          "r",
-				ResourceName:      "rn",
-				RequestAttributes: nil,
-				NonResourceURL:    true,
-				URL:               "/abc",
+				Verb:           "v",
+				APIVersion:     "av",
+				APIGroup:       "ag",
+				Resource:       "r",
+				ResourceName:   "rn",
+				NonResourceURL: true,
+				URL:            "/abc",
 			},
 			ExpectedKey: `{"apiGroup":"ag","apiVersion":"av","groups":["group1","group2"],"namespace":"myns","nonResourceURL":true,"resource":"r","resourceName":"rn","scopes":null,"url":"/abc","user":"me","verb":"v"}`,
 		},

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -29,8 +29,6 @@ type Action interface {
 	// GetResource returns the resource type.  If IsNonResourceURL() is true, then GetResource() is "".
 	GetResource() string
 	GetResourceName() string
-	// GetRequestAttributes is of type interface{} because different verbs and different Authorizer/AuthorizationAttributeBuilder pairs may have different contract requirements.
-	GetRequestAttributes() interface{}
 	// IsNonResourceURL returns true if this is not an action performed against the resource API
 	IsNonResourceURL() bool
 	// GetURL returns the URL path being requested, including the leading '/'

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -826,8 +826,9 @@ func newAuthorizationAttributeBuilder(requestContextMapper kapi.RequestContextMa
 		sets.NewString(bootstrappolicy.AuthenticatedGroup),
 		requestInfoFactory,
 	)
+	personalSARRequestInfoResolveer := authorizer.NewPersonalSARRequestInfoResolver(browserSafeRequestInfoResolver)
 
-	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, browserSafeRequestInfoResolver)
+	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, personalSARRequestInfoResolveer)
 	return authorizationAttributeBuilder
 }
 


### PR DESCRIPTION
This eliminates our usage of the AttributeRestrictions for policy rules and the matching authorization attributes.  It helps us collapse onto the upstream authorizer interface.

Instead of authorizing using the AttributeRestrictions, the requestInfoResolver uses the information to lie about the resource being accessed.  When its a personalSAR or personalLSAR, the requestInfo is written to selfsubjectaccessreviews.authorization.k8s.io

@liggitt This is what we spoke about
@enj ptal
@mfojtik @soltysh fyi