### PR TITLE
Error when user gives build args with non-Docker strat

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -532,6 +532,10 @@ func CompleteAppConfig(config *newcmd.AppConfig, f *clientcmd.Factory, c *cobra.
 	if config.BinaryBuild && config.Strategy == generate.StrategyPipeline {
 		return kcmdutil.UsageError(c, "specifying binary builds and the pipeline strategy at the same time is not allowed.")
 	}
+
+	if len(config.BuildArgs) > 0 && config.Strategy != generate.StrategyUnspecified && config.Strategy != generate.StrategyDocker {
+		return kcmdutil.UsageError(c, "Cannot use '--build-arg' without a Docker build")
+	}
 	return nil
 }
 

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -190,8 +190,12 @@ os::cmd::expect_success "oc new-build --binary php --build-env-file /dev/null --
 os::cmd::expect_failure_and_text "echo 'fo%(o=bar' | oc new-build --binary php --build-env-file -" 'invalid parameter assignment'
 os::cmd::expect_failure_and_text "echo 'S P A C E S=test' | oc new-build --binary php --build-env-file -" 'invalid parameter assignment'
 
-# new-build - check that we can set build-args in DockerStrategy 
+# new-build - check that we can set build args in DockerStrategy 
 os::cmd::expect_success_and_text "oc new-build ${OS_ROOT}/test/testdata/build-arg-dockerfile --build-arg 'foo=bar' --to 'test' -o jsonpath='{.items[?(@.kind==\"BuildConfig\")].spec.strategy.dockerStrategy.buildArgs[?(@.name==\"foo\")].value}'" 'bar'
+
+# check that we cannot set build args in a non-DockerStrategy build
+os::cmd::expect_failure_and_text "oc new-build https://github.com/openshift/ruby-hello-world --strategy=source --build-arg 'foo=bar'" "error: Cannot use '--build-arg' without a Docker build"
+os::cmd::expect_failure_and_text "oc new-build https://github.com/openshift/ruby-ex --build-arg 'foo=bar'" "error: Cannot use '--build-arg' without a Docker build"
 
 #
 # verify we can create from a template when some objects in the template declare an app label


### PR DESCRIPTION
Adds a new error message when a user specifies Docker build-args on a non-Docker build.

Fixes [bz1429326](https://bugzilla.redhat.com/show_bug.cgi?id=1429326)
Related Trello card [here](https://trello.com/c/Yh9BPAGi/1051-5-support-dockerfile-args-in-docker-build-techdebt-builds)

@openshift/devex @bparees @dongboyan77 ptal?

[test]