### PR TITLE
Make openshift authorizer.GetResoruce match upstream

### DIFF
--- a/pkg/authorization/api/synthetic.go
+++ b/pkg/authorization/api/synthetic.go
@@ -7,10 +7,10 @@ const (
 	CustomBuildResource          = "builds/custom"
 	JenkinsPipelineBuildResource = "builds/jenkinspipeline"
 
-	NodeMetricsResource = "nodes/metrics"
-	NodeStatsResource   = "nodes/stats"
-	NodeSpecResource    = "nodes/spec"
-	NodeLogResource     = "nodes/log"
+	NodeMetricsSubresource = "metrics"
+	NodeStatsSubresource   = "stats"
+	NodeSpecSubresource    = "spec"
+	NodeLogSubresource     = "log"
 
 	RestrictedEndpointsResource = "endpoints/restricted"
 )

--- a/pkg/authorization/authorizer/adapter/attributes.go
+++ b/pkg/authorization/authorizer/adapter/attributes.go
@@ -1,8 +1,6 @@
 package adapter
 
 import (
-	"strings"
-
 	kapi "k8s.io/kubernetes/pkg/api"
 	kauthorizer "k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/auth/user"
@@ -38,16 +36,11 @@ func OriginAuthorizerAttributes(kattrs kauthorizer.Attributes) (kapi.Context, oa
 		APIGroup:     kattrs.GetAPIGroup(),
 		APIVersion:   kattrs.GetAPIVersion(),
 		Resource:     kattrs.GetResource(),
+		Subresource:  kattrs.GetSubresource(),
 		ResourceName: kattrs.GetName(),
 
 		NonResourceURL: kattrs.IsResourceRequest() == false,
 		URL:            kattrs.GetPath(),
-
-		// TODO: add to kube authorizer attributes
-		// RequestAttributes interface{}
-	}
-	if len(kattrs.GetSubresource()) > 0 {
-		oattrs.Resource = kattrs.GetResource() + "/" + kattrs.GetSubresource()
 	}
 
 	return ctx, oattrs
@@ -86,19 +79,11 @@ func (a AdapterAttributes) GetName() string {
 }
 
 func (a AdapterAttributes) GetSubresource() string {
-	tokens := strings.SplitN(a.authorizationAttributes.GetResource(), "/", 2)
-	if len(tokens) != 2 {
-		return ""
-	}
-	return tokens[1]
+	return a.authorizationAttributes.GetSubresource()
 }
 
 func (a AdapterAttributes) GetResource() string {
-	tokens := strings.SplitN(a.authorizationAttributes.GetResource(), "/", 2)
-	if len(tokens) < 1 {
-		return ""
-	}
-	return tokens[0]
+	return a.authorizationAttributes.GetResource()
 }
 
 // GetUserName satisfies the kubernetes authorizer.Attributes interface

--- a/pkg/authorization/authorizer/adapter/attributes_test.go
+++ b/pkg/authorization/authorizer/adapter/attributes_test.go
@@ -18,14 +18,13 @@ var _ = kauthorizer.Attributes(AdapterAttributes{})
 func TestRoundTrip(t *testing.T) {
 	// Start with origin attributes
 	oattrs := oauthorizer.DefaultAuthorizationAttributes{
-		Verb:              "get",
-		APIVersion:        "av",
-		APIGroup:          "ag",
-		Resource:          "r",
-		ResourceName:      "rn",
-		RequestAttributes: "ra",
-		NonResourceURL:    true,
-		URL:               "/123",
+		Verb:           "get",
+		APIVersion:     "av",
+		APIGroup:       "ag",
+		Resource:       "r",
+		ResourceName:   "rn",
+		NonResourceURL: true,
+		URL:            "/123",
 	}
 
 	// Convert to kube attributes
@@ -84,9 +83,6 @@ func TestRoundTrip(t *testing.T) {
 	}
 	if oattrs.GetResourceName() != oattrs2.GetResourceName() {
 		t.Errorf("Expected %v, got %v", oattrs.GetResourceName(), oattrs2.GetResourceName())
-	}
-	if oattrs.GetRequestAttributes() != oattrs2.GetRequestAttributes() {
-		t.Errorf("Expected %v, got %v", oattrs.GetRequestAttributes(), oattrs2.GetRequestAttributes())
 	}
 	if oattrs.IsNonResourceURL() != oattrs2.IsNonResourceURL() {
 		t.Errorf("Expected %v, got %v", oattrs.IsNonResourceURL(), oattrs2.IsNonResourceURL())

--- a/pkg/authorization/authorizer/adapter/attributes_test.go
+++ b/pkg/authorization/authorizer/adapter/attributes_test.go
@@ -22,6 +22,7 @@ func TestRoundTrip(t *testing.T) {
 		APIVersion:     "av",
 		APIGroup:       "ag",
 		Resource:       "r",
+		Subresource:    "sub",
 		ResourceName:   "rn",
 		NonResourceURL: true,
 		URL:            "/123",
@@ -73,6 +74,9 @@ func TestRoundTrip(t *testing.T) {
 	if oattrs.GetResource() != oattrs2.GetResource() {
 		t.Errorf("Expected %v, got %v", oattrs.GetResource(), oattrs2.GetResource())
 	}
+	if oattrs.GetSubresource() != oattrs2.GetSubresource() {
+		t.Errorf("Expected %v, got %v", oattrs.GetSubresource(), oattrs2.GetSubresource())
+	}
 
 	// Ensure origin-specific info is preserved
 	if oattrs.GetAPIVersion() != oattrs2.GetAPIVersion() {
@@ -95,7 +99,7 @@ func TestRoundTrip(t *testing.T) {
 func TestAttributeIntersection(t *testing.T) {
 	// These are the things we expect to be shared
 	// Everything in this list should be used by OriginAuthorizerAttributes
-	expectedIntersection := sets.NewString("GetVerb", "GetResource", "GetAPIGroup", "GetAPIVersion")
+	expectedIntersection := sets.NewString("GetVerb", "GetResource", "GetSubresource", "GetAPIGroup", "GetAPIVersion")
 
 	// These are the things we expect to only be in the Kubernetes interface
 	// Everything in this list should be used by OriginAuthorizerAttributes or derivative (like IsReadOnly)

--- a/pkg/authorization/authorizer/attributes.go
+++ b/pkg/authorization/authorizer/attributes.go
@@ -21,7 +21,7 @@ type DefaultAuthorizationAttributes struct {
 
 // ToDefaultAuthorizationAttributes coerces Action to DefaultAuthorizationAttributes.  Namespace is not included
 // because the authorizer takes that information on the context
-func ToDefaultAuthorizationAttributes(in authorizationapi.Action) DefaultAuthorizationAttributes {
+func ToDefaultAuthorizationAttributes(in authorizationapi.Action) Action {
 	return DefaultAuthorizationAttributes{
 		Verb:           in.Verb,
 		APIGroup:       in.Group,
@@ -33,10 +33,10 @@ func ToDefaultAuthorizationAttributes(in authorizationapi.Action) DefaultAuthori
 	}
 }
 
-func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.PolicyRule) (bool, error) {
+func RuleMatches(a Action, rule authorizationapi.PolicyRule) (bool, error) {
 	if a.IsNonResourceURL() {
-		if a.nonResourceMatches(rule) {
-			if a.verbMatches(rule.Verbs) {
+		if nonResourceMatches(a, rule) {
+			if verbMatches(a, rule.Verbs) {
 				return true, nil
 			}
 		}
@@ -50,12 +50,12 @@ func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.Policy
 		return false, nil
 	}
 
-	if a.verbMatches(rule.Verbs) {
-		if a.apiGroupMatches(rule.APIGroups) {
+	if verbMatches(a, rule.Verbs) {
+		if apiGroupMatches(a, rule.APIGroups) {
 
 			allowedResourceTypes := authorizationapi.NormalizeResources(rule.Resources)
-			if a.resourceMatches(allowedResourceTypes) {
-				if a.nameMatches(rule.ResourceNames) {
+			if resourceMatches(a, allowedResourceTypes) {
+				if nameMatches(a, rule.ResourceNames) {
 					return true, nil
 				}
 			}
@@ -65,7 +65,7 @@ func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.Policy
 	return false, nil
 }
 
-func (a DefaultAuthorizationAttributes) apiGroupMatches(allowedGroups []string) bool {
+func apiGroupMatches(a Action, allowedGroups []string) bool {
 	// allowedGroups is expected to be small, so I don't feel bad about this.
 	for _, allowedGroup := range allowedGroups {
 		if allowedGroup == authorizationapi.APIGroupAll {
@@ -80,11 +80,11 @@ func (a DefaultAuthorizationAttributes) apiGroupMatches(allowedGroups []string) 
 	return false
 }
 
-func (a DefaultAuthorizationAttributes) verbMatches(verbs sets.String) bool {
+func verbMatches(a Action, verbs sets.String) bool {
 	return verbs.Has(authorizationapi.VerbAll) || verbs.Has(strings.ToLower(a.GetVerb()))
 }
 
-func (a DefaultAuthorizationAttributes) resourceMatches(allowedResourceTypes sets.String) bool {
+func resourceMatches(a Action, allowedResourceTypes sets.String) bool {
 	return allowedResourceTypes.Has(authorizationapi.ResourceAll) || allowedResourceTypes.Has(strings.ToLower(a.GetResource()))
 }
 
@@ -92,7 +92,7 @@ func (a DefaultAuthorizationAttributes) resourceMatches(allowedResourceTypes set
 // An empty string in the whitelist should only match the action's resourceName if the resourceName itself is empty string.  This behavior allows for the
 // combination of a whitelist for gets in the same rule as a list that won't have a resourceName.  I don't recommend writing such a rule, but we do
 // handle it like you'd expect: white list is respected for gets while not preventing the list you explicitly asked for.
-func (a DefaultAuthorizationAttributes) nameMatches(allowedResourceNames sets.String) bool {
+func nameMatches(a Action, allowedResourceNames sets.String) bool {
 	if len(allowedResourceNames) == 0 {
 		return true
 	}
@@ -100,12 +100,8 @@ func (a DefaultAuthorizationAttributes) nameMatches(allowedResourceNames sets.St
 	return allowedResourceNames.Has(a.GetResourceName())
 }
 
-func (a DefaultAuthorizationAttributes) GetVerb() string {
-	return a.Verb
-}
-
 // nonResourceMatches take the remainer of a URL and attempts to match it against a series of explicitly allowed steps that can end in a wildcard
-func (a DefaultAuthorizationAttributes) nonResourceMatches(rule authorizationapi.PolicyRule) bool {
+func nonResourceMatches(a Action, rule authorizationapi.PolicyRule) bool {
 	for allowedNonResourcePath := range rule.NonResourceURLs {
 		// if the allowed resource path ends in a wildcard, check to see if the URL starts with it
 		if strings.HasSuffix(allowedNonResourcePath, "*") {
@@ -134,6 +130,10 @@ func splitPath(thePath string) []string {
 
 // DefaultAuthorizationAttributes satisfies the Action interface
 var _ Action = DefaultAuthorizationAttributes{}
+
+func (a DefaultAuthorizationAttributes) GetVerb() string {
+	return a.Verb
+}
 
 func (a DefaultAuthorizationAttributes) GetAPIVersion() string {
 	return a.APIVersion

--- a/pkg/authorization/authorizer/attributes_builder.go
+++ b/pkg/authorization/authorizer/attributes_builder.go
@@ -30,16 +30,12 @@ func (a *openshiftAuthorizationAttributeBuilder) GetAttributes(req *http.Request
 		}, nil
 	}
 
-	resource := requestInfo.Resource
-	if len(requestInfo.Subresource) > 0 {
-		resource = requestInfo.Resource + "/" + requestInfo.Subresource
-	}
-
 	return DefaultAuthorizationAttributes{
 		Verb:           requestInfo.Verb,
 		APIGroup:       requestInfo.APIGroup,
 		APIVersion:     requestInfo.APIVersion,
-		Resource:       resource,
+		Resource:       requestInfo.Resource,
+		Subresource:    requestInfo.Subresource,
 		ResourceName:   requestInfo.Name,
 		NonResourceURL: false,
 		URL:            requestInfo.Path,

--- a/pkg/authorization/authorizer/attributes_builder.go
+++ b/pkg/authorization/authorizer/attributes_builder.go
@@ -36,13 +36,12 @@ func (a *openshiftAuthorizationAttributeBuilder) GetAttributes(req *http.Request
 	}
 
 	return DefaultAuthorizationAttributes{
-		Verb:              requestInfo.Verb,
-		APIGroup:          requestInfo.APIGroup,
-		APIVersion:        requestInfo.APIVersion,
-		Resource:          resource,
-		ResourceName:      requestInfo.Name,
-		RequestAttributes: req,
-		NonResourceURL:    false,
-		URL:               requestInfo.Path,
+		Verb:           requestInfo.Verb,
+		APIGroup:       requestInfo.APIGroup,
+		APIVersion:     requestInfo.APIVersion,
+		Resource:       resource,
+		ResourceName:   requestInfo.Name,
+		NonResourceURL: false,
+		URL:            requestInfo.Path,
 	}, nil
 }

--- a/pkg/authorization/authorizer/attributes_test.go
+++ b/pkg/authorization/authorizer/attributes_test.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"strings"
 	"testing"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -29,7 +30,21 @@ func (a authorizationAttributesAdapter) GetAPIGroup() string {
 }
 
 func (a authorizationAttributesAdapter) GetResource() string {
-	return a.attrs.Resource
+	// to match the RequestInfoFactory assuming an in.resource of one/two/three, one==resource, two==subresource, three=nothing
+	tokens := strings.SplitN(a.attrs.Resource, "/", 2)
+	if len(tokens) >= 1 {
+		return tokens[0]
+	}
+	return ""
+}
+
+func (a authorizationAttributesAdapter) GetSubresource() string {
+	// to match the RequestInfoFactory assuming an in.resource of one/two/three, one==resource, two==subresource, three=nothing
+	tokens := strings.SplitN(a.attrs.Resource, "/", 2)
+	if len(tokens) >= 2 {
+		return tokens[1]
+	}
+	return ""
 }
 
 func (a authorizationAttributesAdapter) GetResourceName() string {

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -132,13 +132,12 @@ func CoerceToDefaultAuthorizationAttributes(passedAttributes Action) *DefaultAut
 	attributes, ok := passedAttributes.(*DefaultAuthorizationAttributes)
 	if !ok {
 		attributes = &DefaultAuthorizationAttributes{
-			APIGroup:          passedAttributes.GetAPIGroup(),
-			Verb:              passedAttributes.GetVerb(),
-			RequestAttributes: passedAttributes.GetRequestAttributes(),
-			Resource:          passedAttributes.GetResource(),
-			ResourceName:      passedAttributes.GetResourceName(),
-			NonResourceURL:    passedAttributes.IsNonResourceURL(),
-			URL:               passedAttributes.GetURL(),
+			APIGroup:       passedAttributes.GetAPIGroup(),
+			Verb:           passedAttributes.GetVerb(),
+			Resource:       passedAttributes.GetResource(),
+			ResourceName:   passedAttributes.GetResourceName(),
+			NonResourceURL: passedAttributes.IsNonResourceURL(),
+			URL:            passedAttributes.GetURL(),
 		}
 	}
 

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -378,8 +378,9 @@ func TestAdminGetStatusInMallet(t *testing.T) {
 	test := &authorizeTest{
 		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			Verb:     "get",
-			Resource: "pods/status",
+			Verb:        "get",
+			Resource:    "pods",
+			Subresource: "status",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -56,7 +56,7 @@ func TestInvalidRole(t *testing.T) {
 			Resource: "buildConfigs",
 		},
 		expectedAllowed: false,
-		expectedError:   "unable to interpret:",
+		expectedReason:  `User "Brad" cannot get buildConfigs in project "mallet"`,
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = newInvalidExtensionPolicies()

--- a/pkg/authorization/authorizer/cache/authorizer.go
+++ b/pkg/authorization/authorizer/cache/authorizer.go
@@ -128,6 +128,7 @@ func cacheKey(ctx kapi.Context, a authorizer.Action) (string, error) {
 		"apiVersion":     a.GetAPIVersion(),
 		"apiGroup":       a.GetAPIGroup(),
 		"resource":       a.GetResource(),
+		"subresource":    a.GetSubresource(),
 		"resourceName":   a.GetResourceName(),
 		"nonResourceURL": a.IsNonResourceURL(),
 		"url":            a.GetURL(),

--- a/pkg/authorization/authorizer/cache/authorizer.go
+++ b/pkg/authorization/authorizer/cache/authorizer.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -124,11 +123,6 @@ func (c *CacheAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes author
 }
 
 func cacheKey(ctx kapi.Context, a authorizer.Action) (string, error) {
-	if a.GetRequestAttributes() != nil {
-		// TODO: see if we can serialize this?
-		return "", errors.New("cannot cache request attributes")
-	}
-
 	keyData := map[string]interface{}{
 		"verb":           a.GetVerb(),
 		"apiVersion":     a.GetAPIVersion(),

--- a/pkg/authorization/authorizer/cache/authorizer_test.go
+++ b/pkg/authorization/authorizer/cache/authorizer_test.go
@@ -29,7 +29,7 @@ func TestCacheKey(t *testing.T) {
 		"empty": {
 			Context:     kapi.NewContext(),
 			Attrs:       &authorizer.DefaultAuthorizationAttributes{},
-			ExpectedKey: `{"apiGroup":"","apiVersion":"","nonResourceURL":false,"resource":"","resourceName":"","url":"","verb":""}`,
+			ExpectedKey: `{"apiGroup":"","apiVersion":"","nonResourceURL":false,"resource":"","resourceName":"","subresource":"","url":"","verb":""}`,
 		},
 		"full": {
 			Context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "myns"), &user.DefaultInfo{Name: "me", Groups: []string{"group1", "group2"}}),
@@ -38,11 +38,12 @@ func TestCacheKey(t *testing.T) {
 				APIVersion:     "av",
 				APIGroup:       "ag",
 				Resource:       "r",
+				Subresource:    "sub",
 				ResourceName:   "rn",
 				NonResourceURL: true,
 				URL:            "/abc",
 			},
-			ExpectedKey: `{"apiGroup":"ag","apiVersion":"av","groups":["group1","group2"],"namespace":"myns","nonResourceURL":true,"resource":"r","resourceName":"rn","scopes":null,"url":"/abc","user":"me","verb":"v"}`,
+			ExpectedKey: `{"apiGroup":"ag","apiVersion":"av","groups":["group1","group2"],"namespace":"myns","nonResourceURL":true,"resource":"r","resourceName":"rn","scopes":null,"subresource":"sub","url":"/abc","user":"me","verb":"v"}`,
 		},
 	}
 

--- a/pkg/authorization/authorizer/cache/authorizer_test.go
+++ b/pkg/authorization/authorizer/cache/authorizer_test.go
@@ -26,11 +26,6 @@ func TestCacheKey(t *testing.T) {
 		ExpectedKey string
 		ExpectedErr bool
 	}{
-		"uncacheable request attributes": {
-			Context:     kapi.NewContext(),
-			Attrs:       &authorizer.DefaultAuthorizationAttributes{RequestAttributes: true},
-			ExpectedErr: true,
-		},
 		"empty": {
 			Context:     kapi.NewContext(),
 			Attrs:       &authorizer.DefaultAuthorizationAttributes{},
@@ -39,14 +34,13 @@ func TestCacheKey(t *testing.T) {
 		"full": {
 			Context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "myns"), &user.DefaultInfo{Name: "me", Groups: []string{"group1", "group2"}}),
 			Attrs: &authorizer.DefaultAuthorizationAttributes{
-				Verb:              "v",
-				APIVersion:        "av",
-				APIGroup:          "ag",
-				Resource:          "r",
-				ResourceName:      "rn",
-				RequestAttributes: nil,
-				NonResourceURL:    true,
-				URL:               "/abc",
+				Verb:           "v",
+				APIVersion:     "av",
+				APIGroup:       "ag",
+				Resource:       "r",
+				ResourceName:   "rn",
+				NonResourceURL: true,
+				URL:            "/abc",
 			},
 			ExpectedKey: `{"apiGroup":"ag","apiVersion":"av","groups":["group1","group2"],"namespace":"myns","nonResourceURL":true,"resource":"r","resourceName":"rn","scopes":null,"url":"/abc","user":"me","verb":"v"}`,
 		},

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -29,8 +29,6 @@ type Action interface {
 	// GetResource returns the resource type.  If IsNonResourceURL() is true, then GetResource() is "".
 	GetResource() string
 	GetResourceName() string
-	// GetRequestAttributes is of type interface{} because different verbs and different Authorizer/AuthorizationAttributeBuilder pairs may have different contract requirements.
-	GetRequestAttributes() interface{}
 	// IsNonResourceURL returns true if this is not an action performed against the resource API
 	IsNonResourceURL() bool
 	// GetURL returns the URL path being requested, including the leading '/'

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -28,6 +28,7 @@ type Action interface {
 	GetAPIGroup() string
 	// GetResource returns the resource type.  If IsNonResourceURL() is true, then GetResource() is "".
 	GetResource() string
+	GetSubresource() string
 	GetResourceName() string
 	// IsNonResourceURL returns true if this is not an action performed against the resource API
 	IsNonResourceURL() bool

--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -21,27 +21,28 @@ type ForbiddenMessageResolver struct {
 
 func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *ForbiddenMessageResolver {
 	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}{{.Attributes.GetAPIGroup}}.{{end}}"
+	resourceWithSubresourceIfNotEmpty := "{{if len .Attributes.GetSubresource }}{{.Attributes.GetResource}}/{{.Attributes.GetSubresource}}{{else}}{{.Attributes.GetResource}}{{end}}"
 
 	messageResolver := &ForbiddenMessageResolver{
 		namespacedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
 		rootScopedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
 		nonResourceURLForbiddenMessageMaker:               newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot "{{.Attributes.GetVerb}}" on "{{.Attributes.GetURL}}"`),
-		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot "{{.Attributes.GetVerb}}" "` + apiGroupIfNotEmpty + `{{.Attributes.GetResource}}" with name "{{.Attributes.GetResourceName}}" in project "{{.Namespace}}"`),
+		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot "{{.Attributes.GetVerb}}" "` + apiGroupIfNotEmpty + resourceWithSubresourceIfNotEmpty + `" with name "{{.Attributes.GetResourceName}}" in project "{{.Namespace}}"`),
 	}
 
 	// general messages
-	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list all `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot watch `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot watch all `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list all `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot watch `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot watch all `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
 
 	// project request rejection
 	projectRequestDeny := projectRequestForbiddenTemplate

--- a/pkg/authorization/authorizer/non_resource_match_test.go
+++ b/pkg/authorization/authorizer/non_resource_match_test.go
@@ -67,7 +67,7 @@ func (test *nonResourceMatchTest) run(t *testing.T) {
 
 	rule := authorizationapi.PolicyRule{NonResourceURLs: sets.NewString(test.matcher)}
 
-	result := attributes.nonResourceMatches(rule)
+	result := nonResourceMatches(attributes, rule)
 
 	if result != test.expectedResult {
 		t.Errorf("Expected %v, got %v", test.expectedResult, result)

--- a/pkg/authorization/authorizer/remote/authorizer.go
+++ b/pkg/authorization/authorizer/remote/authorizer.go
@@ -93,21 +93,19 @@ func (r *RemoteAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes autho
 }
 
 func getAction(namespace string, attributes authorizer.Action) authzapi.Action {
+	resource := attributes.GetResource()
+	if len(attributes.GetSubresource()) > 0 {
+		resource = resource + "/" + attributes.GetSubresource()
+	}
 	return authzapi.Action{
 		Namespace:    namespace,
 		Verb:         attributes.GetVerb(),
 		Group:        attributes.GetAPIGroup(),
 		Version:      attributes.GetAPIVersion(),
-		Resource:     attributes.GetResource(),
+		Resource:     resource,
 		ResourceName: attributes.GetResourceName(),
 
 		Path:             attributes.GetURL(),
 		IsNonResourceURL: attributes.IsNonResourceURL(),
-
-		// TODO: missing from authorizer.Action:
-		// Content
-
-		// TODO: missing from authzapi.Action
-		// RequestAttributes (unserializable?)
 	}
 }

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -357,7 +357,7 @@ func (e clusterRoleEvaluator) ResolveGettableNamespaces(scope string, clusterPol
 
 	errors := []error{}
 	for _, rule := range rules {
-		matches, err := attributes.RuleMatches(rule)
+		matches, err := authorizer.RuleMatches(attributes, rule)
 		if err != nil {
 			errors = append(errors, err)
 			continue

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -194,10 +194,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				// permissions to check PSP, these creates are non-mutating
 				authorizationapi.NewRule("create").Groups(securityGroup).Resources("podsecuritypolicysubjectreviews", "podsecuritypolicyselfsubjectreviews", "podsecuritypolicyreviews").RuleOrDie(),
 				// Allow read access to node metrics
-				authorizationapi.NewRule("get").Groups(kapiGroup).Resources(authorizationapi.NodeMetricsResource, authorizationapi.NodeSpecResource).RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("nodes/"+authorizationapi.NodeMetricsSubresource, "nodes/"+authorizationapi.NodeSpecSubresource).RuleOrDie(),
 				// Allow read access to stats
 				// Node stats requests are submitted as POSTs.  These creates are non-mutating
-				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources(authorizationapi.NodeStatsResource).RuleOrDie(),
+				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources("nodes/" + authorizationapi.NodeStatsSubresource).RuleOrDie(),
 
 				{
 					Verbs:           sets.NewString("get"),
@@ -693,7 +693,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes").RuleOrDie(),
 				// Allow all API calls to the nodes
 				authorizationapi.NewRule("proxy").Groups(kapiGroup).Resources("nodes").RuleOrDie(),
-				authorizationapi.NewRule("*").Groups(kapiGroup).Resources("nodes/proxy", authorizationapi.NodeMetricsResource, authorizationapi.NodeSpecResource, authorizationapi.NodeStatsResource, authorizationapi.NodeLogResource).RuleOrDie(),
+				authorizationapi.NewRule("*").Groups(kapiGroup).Resources("nodes/proxy", "nodes/"+authorizationapi.NodeMetricsSubresource, "nodes/"+authorizationapi.NodeSpecSubresource, "nodes/"+authorizationapi.NodeStatsSubresource, "nodes/"+authorizationapi.NodeLogSubresource).RuleOrDie(),
 			},
 		},
 		{
@@ -707,10 +707,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				// Allow read-only access to the API objects
 				authorizationapi.NewRule(read...).Groups(kapiGroup).Resources("nodes").RuleOrDie(),
 				// Allow read access to node metrics
-				authorizationapi.NewRule("get").Groups(kapiGroup).Resources(authorizationapi.NodeMetricsResource, authorizationapi.NodeSpecResource).RuleOrDie(),
+				authorizationapi.NewRule("get").Groups(kapiGroup).Resources("nodes/"+authorizationapi.NodeMetricsSubresource, "nodes/"+authorizationapi.NodeSpecSubresource).RuleOrDie(),
 				// Allow read access to stats
 				// Node stats requests are submitted as POSTs.  These creates are non-mutating
-				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources(authorizationapi.NodeStatsResource).RuleOrDie(),
+				authorizationapi.NewRule("get", "create").Groups(kapiGroup).Resources("nodes/" + authorizationapi.NodeStatsSubresource).RuleOrDie(),
 				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
 			},
 		},

--- a/pkg/cmd/server/kubernetes/node_auth.go
+++ b/pkg/cmd/server/kubernetes/node_auth.go
@@ -60,7 +60,8 @@ func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 		APIVersion:   "v1",
 		APIGroup:     "",
 		Verb:         apiVerb,
-		Resource:     "nodes/proxy",
+		Resource:     "nodes",
+		Subresource:  "proxy",
 		ResourceName: n.nodeName,
 		URL:          r.URL.Path,
 	}
@@ -70,16 +71,16 @@ func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 	switch {
 	case isSubpath(r, "/spec"):
 		attrs.Verb = apiVerb
-		attrs.Resource = authorizationapi.NodeSpecResource
+		attrs.Subresource = authorizationapi.NodeSpecSubresource
 	case isSubpath(r, "/stats"):
 		attrs.Verb = apiVerb
-		attrs.Resource = authorizationapi.NodeStatsResource
+		attrs.Subresource = authorizationapi.NodeStatsSubresource
 	case isSubpath(r, "/metrics"):
 		attrs.Verb = apiVerb
-		attrs.Resource = authorizationapi.NodeMetricsResource
+		attrs.Subresource = authorizationapi.NodeMetricsSubresource
 	case isSubpath(r, "/logs"):
 		attrs.Verb = apiVerb
-		attrs.Resource = authorizationapi.NodeLogResource
+		attrs.Subresource = authorizationapi.NodeLogSubresource
 	}
 	// TODO: handle other things like /healthz/*? not sure if "non-resource" urls on the kubelet make sense to authorize against master non-resource URL policy
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -826,9 +826,9 @@ func newAuthorizationAttributeBuilder(requestContextMapper kapi.RequestContextMa
 		sets.NewString(bootstrappolicy.AuthenticatedGroup),
 		requestInfoFactory,
 	)
-	personalSARRequestInfoResolveer := authorizer.NewPersonalSARRequestInfoResolver(browserSafeRequestInfoResolver)
+	personalSARRequestInfoResolver := authorizer.NewPersonalSARRequestInfoResolver(browserSafeRequestInfoResolver)
 
-	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, personalSARRequestInfoResolveer)
+	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, personalSARRequestInfoResolver)
 	return authorizationAttributeBuilder
 }
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -826,8 +826,9 @@ func newAuthorizationAttributeBuilder(requestContextMapper kapi.RequestContextMa
 		sets.NewString(bootstrappolicy.AuthenticatedGroup),
 		requestInfoFactory,
 	)
+	personalSARRequestInfoResolveer := authorizer.NewPersonalSARRequestInfoResolver(browserSafeRequestInfoResolver)
 
-	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, browserSafeRequestInfoResolver)
+	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestContextMapper, personalSARRequestInfoResolveer)
 	return authorizationAttributeBuilder
 }
 

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -177,9 +177,10 @@ func (o *podNodeConstraints) Validate() error {
 func (o *podNodeConstraints) checkPodsBindAccess(attr admission.Attributes) (bool, error) {
 	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), attr.GetNamespace()), attr.GetUserInfo())
 	authzAttr := authorizer.DefaultAuthorizationAttributes{
-		Verb:     "create",
-		Resource: "pods/binding",
-		APIGroup: kapi.GroupName,
+		Verb:        "create",
+		Resource:    "pods",
+		Subresource: "binding",
+		APIGroup:    kapi.GroupName,
 	}
 	if attr.GetResource().GroupResource() == kapi.Resource("pods") {
 		authzAttr.ResourceName = attr.GetName()

--- a/pkg/service/admission/endpoint_admission.go
+++ b/pkg/service/admission/endpoint_admission.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"reflect"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
@@ -86,7 +85,8 @@ func (r *restrictedEndpointsAdmission) checkAccess(attr kadmission.Attributes) (
 	ctx := kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), attr.GetNamespace()), attr.GetUserInfo())
 	authzAttr := authorizer.DefaultAuthorizationAttributes{
 		Verb:         "create",
-		Resource:     authorizationapi.RestrictedEndpointsResource,
+		Resource:     "endpoints",
+		Subresource:  "restricted",
 		APIGroup:     kapi.GroupName,
 		ResourceName: attr.GetName(),
 	}


### PR DESCRIPTION
Builds on https://github.com/openshift/origin/pull/13256 .

This switches us to use our own interface for authorization evaluation and updates our GetResource to match upstreams and adds the GetSubresource to have complete information.

@liggitt fyi
@enj ptal.