### PR TITLE
Wait for the registry SA to have privileges

### DIFF
--- a/test/extended/registry/registry.go
+++ b/test/extended/registry/registry.go
@@ -43,6 +43,15 @@ var _ = g.Describe("[Conformance][registry][migration] manifest migration from e
 		err := oc.Run("policy").Args("add-role-to-user", "registry-viewer", "system:anonymous").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		adminClientConfig, err := testutil.GetClusterAdminClientConfig(exutil.KubeConfigPath())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		registryClient, _, _, err := testutil.GetClientForUser(*adminClientConfig, "system:serviceaccount:default:registry")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = testutil.WaitForClusterPolicyUpdate(registryClient, "get", imageapi.Resource("imagestreams"), true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
 		dClient, err := testutil.NewDockerClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
Some extended test failures seemingly occur when the registry service
account does not have the requisite privilges from the `system:registry`
cluster role. This wait check should ensure that the failures do not
occur.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>