### PR TITLE
UPSTREAM: 38925: Fix nil pointer issue when making mounts for container

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_pods.go
@@ -109,7 +109,7 @@ func makeMounts(pod *api.Pod, podDir string, container *api.Container, hostName,
 	for _, mount := range container.VolumeMounts {
 		mountEtcHostsFile = mountEtcHostsFile && (mount.MountPath != etcHostsPath)
 		vol, ok := podVolumes[mount.Name]
-		if !ok {
+		if !ok || vol.Mounter == nil {
 			glog.Warningf("Mount cannot be satisfied for container %q, because the volume is missing: %q", container.Name, mount)
 			continue
 		}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/13263

Upstream (not yet merged):
https://github.com/kubernetes/kubernetes/pull/38925

Related:
https://github.com/kubernetes/kubernetes/pull/34251

Currently, there exists a gap in the kubelet state where the `vol.Mounter` can be `nil`.  This was somewhat addressed by https://github.com/kubernetes/kubernetes/pull/33616 but even upstream is still seeing the gap.

Simple check to protect against it is the previously excepted solution.

@smarterclayton @derekwaynecarr 