### PR TITLE
[1.5][BACKPORT] Pull-through using insecure transport based on tag import policy

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -87,7 +87,7 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 		return desc, nil
 	}
 
-	if err == distribution.ErrBlobUnknown && repo.pullthrough {
+	if err == distribution.ErrBlobUnknown && RemoteBlobAccessCheckEnabledFrom(ctx) {
 		// Second attempt: looking for the blob on a remote server
 		desc, err = repo.remoteBlobGetter.Stat(ctx, dgst)
 	}

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -53,6 +53,7 @@ type blobDescriptorService struct {
 // corresponding image stream. This method is invoked from inside of upstream's linkedBlobStore. It expects
 // a proper repository object to be set on given context by upper openshift middleware wrappers.
 func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: starting with digest=%s", dgst.String())
 	repo, found := RepositoryFrom(ctx)
 	if !found || repo == nil {
 		err := fmt.Errorf("failed to retrieve repository from context")
@@ -71,16 +72,18 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 		return desc, nil
 	}
 
-	context.GetLogger(ctx).Debugf("could not stat layer link %q in repository %q: %v", dgst.String(), repo.Named().Name(), err)
+	context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: could not stat layer link %s in repository %s: %v", dgst.String(), repo.Named().Name(), err)
 
 	// First attempt: looking for the blob locally
 	desc, err = dockerRegistry.BlobStatter().Stat(ctx, dgst)
 	if err == nil {
+		context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: blob %s exists in the global blob store", dgst.String())
 		// only non-empty layers is wise to check for existence in the image stream.
 		// schema v2 has no empty layers.
 		if !isEmptyDigest(dgst) {
 			// ensure it's referenced inside of corresponding image stream
 			if !imageStreamHasBlob(repo, dgst) {
+				context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: blob %s is neither empty nor referenced in image stream %s", dgst.String(), repo.Named().Name())
 				return distribution.Descriptor{}, distribution.ErrBlobUnknown
 			}
 		}

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -32,6 +32,17 @@ import (
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
 )
 
+const testPassthroughToUpstream = "openshift.test.passthrough-to-upstream"
+
+func WithTestPassthroughToUpstream(ctx context.Context, passthrough bool) context.Context {
+	return context.WithValue(ctx, testPassthroughToUpstream, passthrough)
+}
+
+func GetTestPassThroughToUpstream(ctx context.Context) bool {
+	passthrough, found := ctx.Value(testPassthroughToUpstream).(bool)
+	return found && passthrough
+}
+
 // TestBlobDescriptorServiceIsApplied ensures that blobDescriptorService middleware gets applied.
 // It relies on the fact that blobDescriptorService requires higher levels to set repository object on given
 // context. If the object isn't given, its method will err out.
@@ -42,7 +53,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	// to make other unit tests working
 	defer m.changeUnsetRepository(false)
 
-	testImage, err := registrytest.NewImageForManifest("user/app", registrytest.SampleImageManifestSchema1, true)
+	testImage, err := registrytest.NewImageForManifest("user/app", registrytest.SampleImageManifestSchema1, "", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +104,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	}
 	os.Setenv("DOCKER_REGISTRY_URL", serverURL.Host)
 
-	desc, _, err := registrytest.UploadTestBlob(serverURL, nil, "user/app")
+	desc, _, err := registrytest.UploadRandomTestBlob(serverURL, nil, "user/app")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,4 +520,43 @@ func (f *fakeRegistryClient) Clients() (osclient.Interface, kclientset.Interface
 }
 func (f *fakeRegistryClient) SafeClientConfig() restclient.Config {
 	return (&registryClient{}).SafeClientConfig()
+}
+
+// passthroughBlobDescriptorService passes all Stat and Clear requests to
+// custom blobDescriptorService by default. If
+// "openshift.test.passthrough-to-upstream" is set on context with value
+// "true", all the requests will be passed straight to the upstream blob
+// descriptor service.
+type passthroughBlobDescriptorService struct {
+	distribution.BlobDescriptorService
+}
+
+func (pbds *passthroughBlobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	passthrough := GetTestPassThroughToUpstream(ctx)
+	if passthrough {
+		context.GetLogger(ctx).Debugf("(*passthroughBlobDescriptorService).Stat: passing down to upstream blob descriptor service")
+		return pbds.BlobDescriptorService.Stat(ctx, dgst)
+	}
+	context.GetLogger(ctx).Debugf("(*passthroughBlobDescriptorService).Stat: passing to openshift wrapper")
+	return (&blobDescriptorServiceFactory{}).BlobAccessController(pbds.BlobDescriptorService).Stat(ctx, dgst)
+}
+
+func (pbds *passthroughBlobDescriptorService) Clear(ctx context.Context, dgst digest.Digest) error {
+	passthrough := GetTestPassThroughToUpstream(ctx)
+	if passthrough {
+		context.GetLogger(ctx).Debugf("(*passthroughBlobDescriptorService).Clear: passing down to upstream blob descriptor service")
+		return pbds.BlobDescriptorService.Clear(ctx, dgst)
+	}
+	context.GetLogger(ctx).Debugf("(*passthroughBlobDescriptorService).Clear: passing to openshift wrapper")
+	return (&blobDescriptorServiceFactory{}).BlobAccessController(pbds.BlobDescriptorService).Clear(ctx, dgst)
+}
+
+type passthroughBlobDescriptorServiceFactory struct{}
+
+func (pbf *passthroughBlobDescriptorServiceFactory) BlobAccessController(svc distribution.BlobDescriptorService) distribution.BlobDescriptorService {
+	return &passthroughBlobDescriptorService{svc}
+}
+
+func setPassthroughBlobDescriptorServiceFactory() {
+	middleware.RegisterOptions(storage.BlobDescriptorServiceFactory(&passthroughBlobDescriptorServiceFactory{}))
 }

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -36,8 +36,6 @@ import (
 // It relies on the fact that blobDescriptorService requires higher levels to set repository object on given
 // context. If the object isn't given, its method will err out.
 func TestBlobDescriptorServiceIsApplied(t *testing.T) {
-	ctx := context.Background()
-
 	// don't do any authorization check
 	installFakeAccessController(t)
 	m := fakeBlobDescriptorService(t)
@@ -61,7 +59,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		DefaultRegistryClient = backupRegistryClient
 	}()
 
-	app := handlers.NewApp(ctx, &configuration.Configuration{
+	app := handlers.NewApp(context.Background(), &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{
 			fakeAuthorizerName: {"realm": fakeAuthorizerName},
@@ -73,6 +71,11 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			},
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{
@@ -95,7 +98,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, tc := range []struct {
+	type testCase struct {
 		name                      string
 		method                    string
 		endpoint                  string
@@ -103,7 +106,70 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		unsetRepository           bool
 		expectedStatus            int
 		expectedMethodInvocations map[string]int
-	}{
+	}
+
+	doTest := func(tc testCase) {
+		m.clearStats()
+		m.changeUnsetRepository(tc.unsetRepository)
+
+		route := router.GetRoute(tc.endpoint).Host(serverURL.Host)
+		u, err := route.URL(tc.vars...)
+		if err != nil {
+			t.Errorf("[%s] failed to build route: %v", tc.name, err)
+			return
+		}
+
+		req, err := http.NewRequest(tc.method, u.String(), nil)
+		if err != nil {
+			t.Errorf("[%s] failed to make request: %v", tc.name, err)
+		}
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("[%s] failed to do the request: %v", tc.name, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != tc.expectedStatus {
+			t.Errorf("[%s] unexpected status code: %v != %v", tc.name, resp.StatusCode, tc.expectedStatus)
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+			content, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("[%s] failed to read body: %v", tc.name, err)
+			} else if len(content) > 0 {
+				errs := errcode.Errors{}
+				err := errs.UnmarshalJSON(content)
+				if err != nil {
+					t.Logf("[%s] failed to parse body as error: %v", tc.name, err)
+					t.Logf("[%s] received body: %v", tc.name, string(content))
+				} else {
+					t.Logf("[%s] received errors: %#+v", tc.name, errs)
+				}
+			}
+		}
+
+		stats, err := m.getStats(tc.expectedMethodInvocations, time.Second*5)
+		if err != nil {
+			t.Fatalf("[%s] failed to get stats: %v", tc.name, err)
+		}
+		for method, exp := range tc.expectedMethodInvocations {
+			invoked := stats[method]
+			if invoked != exp {
+				t.Errorf("[%s] unexpected number of invocations of method %q: %v != %v", tc.name, method, invoked, exp)
+			}
+		}
+		for method, invoked := range stats {
+			if _, ok := tc.expectedMethodInvocations[method]; !ok {
+				t.Errorf("[%s] unexpected method %q invoked %d times", tc.name, method, invoked)
+			}
+		}
+	}
+
+	for _, tc := range []testCase{
 		{
 			name:     "get blob with repository unset",
 			method:   http.MethodGet,
@@ -190,34 +256,6 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		},
 
 		{
-			name:     "get manifest with repository unset",
-			method:   http.MethodGet,
-			endpoint: v2.RouteNameManifest,
-			vars: []string{
-				"name", "user/app",
-				"reference", "latest",
-			},
-			unsetRepository: true,
-			// failed because we trying to get manifest from storage driver first.
-			expectedStatus: http.StatusNotFound,
-			// manifest can't be retrieved from etcd
-			expectedMethodInvocations: map[string]int{"Stat": 1},
-		},
-
-		{
-			name:     "get manifest",
-			method:   http.MethodGet,
-			endpoint: v2.RouteNameManifest,
-			vars: []string{
-				"name", "user/app",
-				"reference", "latest",
-			},
-			expectedStatus: http.StatusOK,
-			// manifest is retrieved from etcd
-			expectedMethodInvocations: map[string]int{"Stat": 3},
-		},
-
-		{
 			name:     "delete manifest with repository unset",
 			method:   http.MethodDelete,
 			endpoint: v2.RouteNameManifest,
@@ -243,67 +281,36 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			// we don't allow to delete manifests from etcd; in this case, we attempt to delete layer link
 			expectedMethodInvocations: map[string]int{"Stat": 1},
 		},
+
+		{
+			name:     "get manifest with repository unset",
+			method:   http.MethodGet,
+			endpoint: v2.RouteNameManifest,
+			vars: []string{
+				"name", "user/app",
+				"reference", "latest",
+			},
+			unsetRepository: true,
+			// failed because we trying to get manifest from storage driver first.
+			expectedStatus: http.StatusNotFound,
+			// manifest can't be retrieved from etcd
+			expectedMethodInvocations: map[string]int{"Stat": 1},
+		},
+
+		{
+			name:     "get manifest",
+			method:   http.MethodGet,
+			endpoint: v2.RouteNameManifest,
+			vars: []string{
+				"name", "user/app",
+				"reference", "latest",
+			},
+			expectedStatus: http.StatusOK,
+			// manifest is retrieved from etcd
+			expectedMethodInvocations: map[string]int{"Stat": 1},
+		},
 	} {
-		m.clearStats()
-		m.changeUnsetRepository(tc.unsetRepository)
-
-		route := router.GetRoute(tc.endpoint).Host(serverURL.Host)
-		u, err := route.URL(tc.vars...)
-		if err != nil {
-			t.Errorf("[%s] failed to build route: %v", tc.name, err)
-			continue
-		}
-
-		req, err := http.NewRequest(tc.method, u.String(), nil)
-		if err != nil {
-			t.Errorf("[%s] failed to make request: %v", tc.name, err)
-			continue
-		}
-
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Errorf("[%s] failed to do the request: %v", tc.name, err)
-			continue
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != tc.expectedStatus {
-			t.Errorf("[%s] unexpected status code: %v != %v", tc.name, resp.StatusCode, tc.expectedStatus)
-		}
-
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-			content, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Errorf("[%s] failed to read body: %v", tc.name, err)
-			} else if len(content) > 0 {
-				errs := errcode.Errors{}
-				err := errs.UnmarshalJSON(content)
-				if err != nil {
-					t.Logf("[%s] failed to parse body as error: %v", tc.name, err)
-					t.Logf("[%s] received body: %v", tc.name, string(content))
-				} else {
-					t.Logf("[%s] received errors: %#+v", tc.name, errs)
-				}
-			}
-		}
-
-		stats, err := m.getStats(tc.expectedMethodInvocations, time.Second*5)
-		if err != nil {
-			t.Errorf("[%s] failed to get stats: %v", tc.name, err)
-			continue
-		}
-		for method, exp := range tc.expectedMethodInvocations {
-			invoked := stats[method]
-			if invoked != exp {
-				t.Errorf("[%s] unexpected number of invocations of method %q: %v != %v", tc.name, method, invoked, exp)
-			}
-		}
-		for method, invoked := range stats {
-			if _, ok := tc.expectedMethodInvocations[method]; !ok {
-				t.Errorf("[%s] unexpected method %q invoked %d times", tc.name, method, invoked)
-			}
-		}
+		doTest(tc)
 	}
 }
 
@@ -366,30 +373,38 @@ func (m *testBlobDescriptorManager) changeUnsetRepository(unset bool) {
 // collected numbers of invocations per each method watched. An error will be returned if a given timeout is
 // reached without satisfying minimum limit.s
 func (m *testBlobDescriptorManager) getStats(minimumLimits map[string]int, timeout time.Duration) (map[string]int, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var err error
 	end := time.Now().Add(timeout)
+	stats := make(map[string]int)
 
-	if len(minimumLimits) > 0 {
-	Loop:
-		for !statsGreaterThanOrEqual(m.stats, minimumLimits) {
-			c := make(chan struct{})
-			go func() { m.cond.Wait(); c <- struct{}{} }()
-
-			now := time.Now()
-			select {
-			case <-time.After(end.Sub(now)):
-				err = fmt.Errorf("timeout while waiting on expected stats")
-				break Loop
-			case <-c:
-				continue Loop
-			}
+	if len(minimumLimits) == 0 {
+		m.mu.Lock()
+		for k, v := range m.stats {
+			stats[k] = v
 		}
+		m.mu.Unlock()
+		return stats, nil
 	}
 
-	stats := make(map[string]int)
+	c := make(chan struct{})
+	go func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		for !statsGreaterThanOrEqual(m.stats, minimumLimits) {
+			m.cond.Wait()
+		}
+		c <- struct{}{}
+	}()
+
+	var err error
+	select {
+	case <-time.After(end.Sub(time.Now())):
+		err = fmt.Errorf("timeout while waiting on expected stats")
+	case <-c:
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for k, v := range m.stats {
 		stats[k] = v
 	}

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/registry/api/errcode"
 	regapi "github.com/docker/distribution/registry/api/v2"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -34,7 +35,7 @@ type manifestService struct {
 func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Exists")
 
-	image, err := m.repo.getImage(dgst)
+	image, _, err := m.repo.getImageOfImageStream(dgst)
 	if err != nil {
 		return false, err
 	}
@@ -45,14 +46,8 @@ func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool,
 func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Get")
 
-	if _, err := m.repo.getImageStreamImage(dgst); err != nil {
-		context.GetLogger(ctx).Errorf("error retrieving ImageStreamImage %s/%s@%s: %v", m.repo.namespace, m.repo.name, dgst.String(), err)
-		return nil, err
-	}
-
-	image, err := m.repo.getImage(dgst)
+	image, _, err := m.repo.getImageOfImageStream(dgst)
 	if err != nil {
-		context.GetLogger(ctx).Errorf("error retrieving image %s: %v", dgst.String(), err)
 		return nil, err
 	}
 
@@ -186,22 +181,12 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 			return "", err
 		}
 
-		stream := imageapi.ImageStream{}
-		stream.Name = m.repo.name
-
-		uclient, ok := UserClientFrom(m.ctx)
-		if !ok {
-			context.GetLogger(ctx).Errorf("error creating user client to auto provision image stream: Origin user client unavailable")
-			return "", statusErr
-		}
-
-		if _, err := uclient.ImageStreams(m.repo.namespace).Create(&stream); err != nil {
-			if quotautil.IsErrorQuotaExceeded(err) {
-				context.GetLogger(ctx).Errorf("denied creating ImageStream: %v", err)
-				return "", distribution.ErrAccessDenied
+		if _, err := m.repo.createImageStream(ctx); err != nil {
+			if e, ok := err.(errcode.Error); ok && e.ErrorCode() == errcode.ErrorCodeUnknown {
+				// TODO: convert statusErr to distribution error
+				return "", statusErr
 			}
-			context.GetLogger(ctx).Errorf("error auto provisioning ImageStream: %s", err)
-			return "", statusErr
+			return "", err
 		}
 
 		// try to create the ISM again

--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -38,13 +38,7 @@ func (r *pullthroughBlobStore) Stat(ctx context.Context, dgst digest.Digest) (di
 		return desc, err
 	}
 
-	remoteGetter, found := RemoteBlobGetterFrom(r.repo.ctx)
-	if !found {
-		context.GetLogger(ctx).Errorf("pullthroughBlobStore.Stat: failed to retrieve remote getter from context")
-		return distribution.Descriptor{}, distribution.ErrBlobUnknown
-	}
-
-	return remoteGetter.Stat(ctx, dgst)
+	return r.repo.remoteBlobGetter.Stat(ctx, dgst)
 }
 
 // ServeBlob attempts to serve the requested digest onto w, using a remote proxy store if necessary.
@@ -66,11 +60,7 @@ func (pbs *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseW
 		return err
 	}
 
-	remoteGetter, found := RemoteBlobGetterFrom(pbs.repo.ctx)
-	if !found {
-		context.GetLogger(ctx).Errorf("pullthroughBlobStore.ServeBlob: failed to retrieve remote getter from context")
-		return distribution.ErrBlobUnknown
-	}
+	remoteGetter := pbs.repo.remoteBlobGetter
 
 	// store the content locally if requested, but ensure only one instance at a time
 	// is storing to avoid excessive local writes
@@ -105,13 +95,7 @@ func (r *pullthroughBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]b
 		return data, nil
 	}
 
-	remoteGetter, found := RemoteBlobGetterFrom(r.repo.ctx)
-	if !found {
-		context.GetLogger(ctx).Errorf("pullthroughBlobStore.Get: failed to retrieve remote getter from context")
-		return nil, originalErr
-	}
-
-	return remoteGetter.Get(ctx, dgst)
+	return r.repo.remoteBlobGetter.Get(ctx, dgst)
 }
 
 // setResponseHeaders sets the appropriate content serving headers

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -12,14 +12,11 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
-	//"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/handlers"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
@@ -34,7 +31,6 @@ import (
 func TestPullthroughServeBlob(t *testing.T) {
 	namespace, name := "user", "app"
 	repoName := fmt.Sprintf("%s/%s", namespace, name)
-	log.SetLevel(log.DebugLevel)
 	installFakeAccessController(t)
 
 	testImage, err := registrytest.NewImageForManifest(repoName, registrytest.SampleImageManifestSchema1, false)
@@ -65,6 +61,11 @@ func TestPullthroughServeBlob(t *testing.T) {
 			},
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -13,11 +13,9 @@ import (
 	"time"
 
 	"github.com/docker/distribution"
-	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/registry/handlers"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
@@ -32,8 +30,9 @@ func TestPullthroughServeBlob(t *testing.T) {
 	namespace, name := "user", "app"
 	repoName := fmt.Sprintf("%s/%s", namespace, name)
 	installFakeAccessController(t)
+	setPassthroughBlobDescriptorServiceFactory()
 
-	testImage, err := registrytest.NewImageForManifest(repoName, registrytest.SampleImageManifestSchema1, false)
+	testImage, err := registrytest.NewImageForManifest(repoName, registrytest.SampleImageManifestSchema1, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,33 +47,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 		DefaultRegistryClient = backupRegistryClient
 	}()
 
-	// pullthrough middleware will attempt to pull from this registry instance
-	remoteRegistryApp := handlers.NewApp(context.Background(), &configuration.Configuration{
-		Loglevel: "debug",
-		Auth: map[string]configuration.Parameters{
-			fakeAuthorizerName: {"realm": fakeAuthorizerName},
-		},
-		Storage: configuration.Storage{
-			"inmemory": configuration.Parameters{},
-			"cache": configuration.Parameters{
-				"blobdescriptor": "inmemory",
-			},
-			"delete": configuration.Parameters{
-				"enabled": true,
-			},
-			"maintenance": configuration.Parameters{
-				"uploadpurging": map[interface{}]interface{}{
-					"enabled": false,
-				},
-			},
-		},
-		Middleware: map[string][]configuration.Middleware{
-			"registry":   {{Name: "openshift"}},
-			"repository": {{Name: "openshift", Options: configuration.Parameters{"pullthrough": false}}},
-			"storage":    {{Name: "openshift"}},
-		},
-	})
-	remoteRegistryServer := httptest.NewServer(remoteRegistryApp)
+	remoteRegistryServer := createTestRegistryServer(t, context.Background())
 	defer remoteRegistryServer.Close()
 
 	serverURL, err := url.Parse(remoteRegistryServer.URL)
@@ -92,11 +65,11 @@ func TestPullthroughServeBlob(t *testing.T) {
 
 	client.AddReactor("get", "imagestreams", imagetest.GetFakeImageStreamGetHandler(t, *testImageStream))
 
-	blob1Desc, blob1Content, err := registrytest.UploadTestBlob(serverURL, nil, repoName)
+	blob1Desc, blob1Content, err := registrytest.UploadRandomTestBlob(serverURL, nil, repoName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	blob2Desc, blob2Content, err := registrytest.UploadTestBlob(serverURL, nil, repoName)
+	blob2Desc, blob2Content, err := registrytest.UploadRandomTestBlob(serverURL, nil, repoName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +148,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 	} {
 		localBlobStore := newTestBlobStore(tc.localBlobs)
 
-		ctx := context.Background()
+		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepositoryForPullthrough(t, ctx, nil, namespace, name, client, true)
 		ptbs := &pullthroughBlobStore{
 			BlobStore: localBlobStore,
@@ -193,6 +166,392 @@ func TestPullthroughServeBlob(t *testing.T) {
 		_, err = ptbs.Stat(ctx, dgst)
 		if err != tc.expectedStatError {
 			t.Errorf("[%s] Stat returned unexpected error: %#+v != %#+v", tc.name, err, tc.expectedStatError)
+		}
+		if err != nil || tc.expectedStatError != nil {
+			continue
+		}
+		err = ptbs.ServeBlob(ctx, w, req, dgst)
+		if err != nil {
+			t.Errorf("[%s] unexpected ServeBlob error: %v", tc.name, err)
+			continue
+		}
+
+		clstr := w.Header().Get("Content-Length")
+		if cl, err := strconv.ParseInt(clstr, 10, 64); err != nil {
+			t.Errorf(`[%s] unexpected Content-Length: %q != "%d"`, tc.name, clstr, tc.expectedContentLength)
+		} else {
+			if cl != tc.expectedContentLength {
+				t.Errorf("[%s] Content-Length does not match expected size: %d != %d", tc.name, cl, tc.expectedContentLength)
+			}
+		}
+		if w.Header().Get("Content-Type") != "application/octet-stream" {
+			t.Errorf("[%s] Content-Type does not match expected: %q != %q", tc.name, w.Header().Get("Content-Type"), "application/octet-stream")
+		}
+
+		body := w.Body.Bytes()
+		if int64(len(body)) != tc.expectedBytesServed {
+			t.Errorf("[%s] unexpected size of body: %d != %d", tc.name, len(body), tc.expectedBytesServed)
+		}
+
+		for name, expCount := range tc.expectedLocalCalls {
+			count := localBlobStore.calls[name]
+			if count != expCount {
+				t.Errorf("[%s] expected %d calls to method %s of local blob store, not %d", tc.name, expCount, name, count)
+			}
+		}
+		for name, count := range localBlobStore.calls {
+			if _, exists := tc.expectedLocalCalls[name]; !exists {
+				t.Errorf("[%s] expected no calls to method %s of local blob store, got %d", tc.name, name, count)
+			}
+		}
+
+		if localBlobStore.bytesServed != tc.expectedBytesServedLocally {
+			t.Errorf("[%s] unexpected number of bytes served locally: %d != %d", tc.name, localBlobStore.bytesServed, tc.expectedBytesServed)
+		}
+	}
+}
+
+func TestPullthroughServeBlobInsecure(t *testing.T) {
+	namespace := "user"
+	repo1 := "app1"
+	repo2 := "app2"
+	repo1Name := fmt.Sprintf("%s/%s", namespace, repo1)
+	repo2Name := fmt.Sprintf("%s/%s", namespace, repo2)
+
+	installFakeAccessController(t)
+	setPassthroughBlobDescriptorServiceFactory()
+
+	remoteRegistryServer := createTestRegistryServer(t, context.Background())
+	defer remoteRegistryServer.Close()
+
+	serverURL, err := url.Parse(remoteRegistryServer.URL)
+	if err != nil {
+		t.Fatalf("error parsing server url: %v", err)
+	}
+
+	m1dgst, m1canonical, m1cfg, m1manifest, err := registrytest.CreateAndUploadTestManifest(
+		registrytest.ManifestSchema2, 2, serverURL, nil, repo1Name, "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, m1payload, err := m1manifest.Payload()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("m1dgst=%s, m1manifest: %s", m1dgst, m1canonical)
+	m2dgst, m2canonical, m2cfg, m2manifest, err := registrytest.CreateAndUploadTestManifest(
+		registrytest.ManifestSchema2, 2, serverURL, nil, repo2Name, "bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, m2payload, err := m2manifest.Payload()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("m2dgst=%s, m2manifest: %s", m2dgst, m2canonical)
+
+	m1img, err := registrytest.NewImageForManifest(repo1Name, string(m1payload), m1cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1img.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo1, m1img.Name)
+	m1img.DockerImageManifest = ""
+	m2img, err := registrytest.NewImageForManifest(repo2Name, string(m2payload), m2cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m2img.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo2, m2img.Name)
+	m2img.DockerImageManifest = ""
+
+	for _, tc := range []struct {
+		name                       string
+		method                     string
+		blobDigest                 digest.Digest
+		localBlobs                 map[digest.Digest][]byte
+		imageStreamInit            func(client *testclient.Fake) *imageapi.ImageStream
+		expectedStatError          error
+		expectedContentLength      int64
+		expectedBytesServed        int64
+		expectedBytesServedLocally int64
+		expectedLocalCalls         map[string]int
+	}{
+		{
+			name:       "stat remote blob with insecure repository",
+			method:     "HEAD",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "true"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedContentLength: int64(m1img.DockerImageLayers[0].LayerSize),
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+		},
+
+		{
+			name:       "serve remote blob with insecure repository",
+			method:     "GET",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "true"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedContentLength: int64(m1img.DockerImageLayers[0].LayerSize),
+			expectedBytesServed:   int64(m1img.DockerImageLayers[0].LayerSize),
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+		},
+
+		{
+			name:       "stat remote blob with secure repository",
+			method:     "HEAD",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedStatError: distribution.ErrBlobUnknown,
+		},
+
+		{
+			name:       "serve remote blob with secure repository",
+			method:     "GET",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedStatError: distribution.ErrBlobUnknown,
+		},
+
+		{
+			name:       "stat remote blob with with insecure tag",
+			method:     "HEAD",
+			blobDigest: digest.Digest(m2img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img, *m2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				is.Status.Tags["tag2"] = imageapi.TagEventList{
+					Items: []imageapi.TagEvent{
+						{
+							Image:                m2img.Name,
+							DockerImageReference: m2img.DockerImageReference,
+						},
+					},
+				}
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"tag1": {
+						Name:         "tag1",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"tag2": {
+						Name:         "tag2",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedContentLength: int64(m2img.DockerImageLayers[0].LayerSize),
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+		},
+
+		{
+			name:       "serve remote blob with insecure tag",
+			method:     "GET",
+			blobDigest: digest.Digest(m2img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img, *m2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1img.Name, m1img.DockerImageReference)
+				is.Status.Tags["tag2"] = imageapi.TagEventList{
+					Items: []imageapi.TagEvent{
+						{
+							Image:                m2img.Name,
+							DockerImageReference: m2img.DockerImageReference,
+						},
+					},
+				}
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"tag1": {
+						Name:         "tag1",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"tag2": {
+						Name:         "tag2",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+			expectedContentLength: int64(m2img.DockerImageLayers[0].LayerSize),
+			expectedBytesServed:   int64(m2img.DockerImageLayers[0].LayerSize),
+		},
+
+		{
+			name:       "insecure flag propagates to all repositories of the registry",
+			method:     "GET",
+			blobDigest: digest.Digest(m2img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img, *m2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1img.Name, m1img.DockerImageReference)
+				is.Status.Tags["tag2"] = imageapi.TagEventList{
+					Items: []imageapi.TagEvent{
+						{
+							Image:                m2img.Name,
+							DockerImageReference: m2img.DockerImageReference,
+						},
+					},
+				}
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"tag1": {
+						Name: "tag1",
+						// This value will propagate to the other tag as well.
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+					"tag2": {
+						Name:         "tag2",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+			expectedContentLength: int64(m2img.DockerImageLayers[0].LayerSize),
+			expectedBytesServed:   int64(m2img.DockerImageLayers[0].LayerSize),
+		},
+
+		{
+			name:       "serve remote blob with secure tag",
+			method:     "GET",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img, *m2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1dgst.String(), m1img.DockerImageReference)
+				ref, err := imageapi.ParseDockerImageReference(m2img.DockerImageReference)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// The two references must differ because all repositories of particular registry are
+				// considered insecure if there's at least one insecure flag for the registry.
+				ref.Registry = "docker.io"
+				is.Status.Tags["tag2"] = imageapi.TagEventList{
+					Items: []imageapi.TagEvent{
+						{
+							Image:                m2img.Name,
+							DockerImageReference: ref.DockerClientDefaults().Exact(),
+						},
+					},
+				}
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"tag1": {
+						Name:         "tag1",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"tag2": {
+						Name:         "tag2",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedStatError: distribution.ErrBlobUnknown,
+		},
+
+		{
+			name:       "serve remote blob with 2 tags pointing to the same image",
+			method:     "GET",
+			blobDigest: digest.Digest(m1img.DockerImageLayers[0].Name),
+			imageStreamInit: func(client *testclient.Fake) *imageapi.ImageStream {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *m1img, *m2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo1, "tag1", m1img.Name, m1img.DockerImageReference)
+				is.Status.Tags["tag2"] = imageapi.TagEventList{
+					Items: []imageapi.TagEvent{
+						{
+							Image:                m1img.Name,
+							DockerImageReference: m1img.DockerImageReference,
+						},
+					},
+				}
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"tag1": {
+						Name:         "tag1",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"tag2": {
+						Name:         "tag2",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return is
+			},
+			expectedLocalCalls:    map[string]int{"Stat": 1, "ServeBlob": 1},
+			expectedContentLength: int64(m1img.DockerImageLayers[0].LayerSize),
+			expectedBytesServed:   int64(m1img.DockerImageLayers[0].LayerSize),
+		},
+	} {
+		client := &testclient.Fake{}
+
+		// TODO: get rid of those nasty global vars
+		backupRegistryClient := DefaultRegistryClient
+		DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
+		defer func() {
+			// set it back once this test finishes to make other unit tests working again
+			DefaultRegistryClient = backupRegistryClient
+		}()
+
+		tc.imageStreamInit(client)
+
+		localBlobStore := newTestBlobStore(tc.localBlobs)
+
+		ctx := WithTestPassthroughToUpstream(context.Background(), false)
+
+		repo := newTestRepositoryForPullthrough(t, ctx, nil, namespace, repo1, client, true)
+
+		ptbs := &pullthroughBlobStore{
+			BlobStore: localBlobStore,
+			repo:      repo,
+		}
+
+		req, err := http.NewRequest(tc.method, fmt.Sprintf("http://example.org/v2/user/app/blobs/%s", tc.blobDigest), nil)
+		if err != nil {
+			t.Fatalf("[%s] failed to create http request: %v", tc.name, err)
+		}
+		w := httptest.NewRecorder()
+
+		dgst := digest.Digest(tc.blobDigest)
+
+		_, err = ptbs.Stat(ctx, dgst)
+		if err != tc.expectedStatError {
+			t.Fatalf("[%s] Stat returned unexpected error: %#+v != %#+v", tc.name, err, tc.expectedStatError)
 		}
 		if err != nil || tc.expectedStatError != nil {
 			continue

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -15,13 +15,13 @@ import (
 type pullthroughManifestService struct {
 	distribution.ManifestService
 
-	repo                       *repository
-	pullFromInsecureRegistries bool
+	repo *repository
 }
 
 var _ distribution.ManifestService = &pullthroughManifestService{}
 
 func (m *pullthroughManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	context.GetLogger(ctx).Debugf("(*pullthroughManifestService).Get: starting with dgst=%s", dgst.String())
 	manifest, err := m.ManifestService.Get(ctx, dgst, options...)
 	switch err.(type) {
 	case distribution.ErrManifestUnknownRevision:
@@ -37,27 +37,19 @@ func (m *pullthroughManifestService) Get(ctx context.Context, dgst digest.Digest
 
 func (m *pullthroughManifestService) remoteGet(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	context.GetLogger(ctx).Debugf("(*pullthroughManifestService).remoteGet: starting with dgst=%s", dgst.String())
-	image, is, err := m.repo.getImageOfImageStream(dgst)
+	image, _, err := m.repo.getImageOfImageStream(dgst)
 	if err != nil {
 		return nil, err
-	}
-
-	m.pullFromInsecureRegistries = false
-
-	if insecure, ok := is.Annotations[imageapi.InsecureRepositoryAnnotation]; ok {
-		m.pullFromInsecureRegistries = insecure == "true"
 	}
 
 	ref, err := imageapi.ParseDockerImageReference(image.DockerImageReference)
 	if err != nil {
-		context.GetLogger(ctx).Errorf("bad DockerImageReference in Image %s/%s@%s: %v", m.repo.namespace, m.repo.name, dgst.String(), err)
+		context.GetLogger(ctx).Errorf("bad DockerImageReference (%q) in Image %s/%s@%s: %v", image.DockerImageReference, m.repo.namespace, m.repo.name, dgst.String(), err)
 		return nil, err
 	}
 	ref = ref.DockerClientDefaults()
 
-	retriever := getImportContext(ctx, m.repo.registryOSClient, is.Namespace, is.Name)
-
-	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), m.pullFromInsecureRegistries)
+	repo, err := m.getRemoteRepositoryClient(ctx, &ref, dgst, options...)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error getting remote repository for image %q: %v", ref.Exact(), err)
 		return nil, err
@@ -80,6 +72,31 @@ func (m *pullthroughManifestService) remoteGet(ctx context.Context, dgst digest.
 	}
 
 	return manifest, err
+}
+
+func (m *pullthroughManifestService) getRemoteRepositoryClient(ctx context.Context, ref *imageapi.DockerImageReference, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Repository, error) {
+	retriever := getImportContext(ctx, m.repo.registryOSClient, m.repo.namespace, m.repo.name)
+
+	// determine, whether to fall-back to insecure transport based on a specification of image's tag
+	// if the client pulls by tag, use that
+	tag := ""
+	for _, option := range options {
+		if opt, ok := option.(distribution.WithTagOption); ok {
+			tag = opt.Tag
+			break
+		}
+	}
+	if len(tag) == 0 {
+		is, err := m.repo.imageStreamGetter.get()
+		if err != nil {
+			return nil, err // this is impossible
+		}
+		// if the client pulled by digest, find the corresponding tag in the image stream
+		tag, _ = imageapi.LatestImageTagEvent(is, dgst.String())
+	}
+	insecure := pullInsecureByDefault(m.repo.imageStreamGetter.get, tag)
+
+	return retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), insecure)
 }
 
 func (m *pullthroughManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -81,3 +81,10 @@ func (m *pullthroughManifestService) remoteGet(ctx context.Context, dgst digest.
 
 	return manifest, err
 }
+
+func (m *pullthroughManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	context.GetLogger(ctx).Debugf("(*pullthroughManifestService).Put: enabling remote blob access check")
+	// manifest dependencies (layers and config) may not be stored locally, we need to be able to stat them in remote repositories
+	ctx = WithRemoteBlobAccessCheckEnabled(ctx, true)
+	return m.ManifestService.Put(ctx, manifest, options...)
+}

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -133,21 +133,12 @@ func TestPullthroughManifests(t *testing.T) {
 	} {
 		localManifestService := newTestManifestService(namespace+"/"+repo, tc.localData)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
+		ctx := context.Background()
 
+		repo := newTestRepositoryForPullthrough(t, ctx, nil, namespace, repo, client, true)
 		ptms := &pullthroughManifestService{
 			ManifestService: localManifestService,
-			repo: &repository{
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      true,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:            repo,
 		}
 
 		manifestResult, err := ptms.Get(ctx, tc.manifestDigest)

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -1,30 +1,30 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/handlers"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
-	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	"github.com/openshift/origin/pkg/client/testclient"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 func createTestRegistryServer(t *testing.T, ctx context.Context) *httptest.Server {
+	ctx = WithTestPassthroughToUpstream(ctx, true)
+
 	// pullthrough middleware will attempt to pull from this registry instance
 	remoteRegistryApp := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
@@ -39,11 +39,11 @@ func createTestRegistryServer(t *testing.T, ctx context.Context) *httptest.Serve
 			"delete": configuration.Parameters{
 				"enabled": true,
 			},
-		},
-		Middleware: map[string][]configuration.Middleware{
-			"registry":   {{Name: "openshift"}},
-			"repository": {{Name: "openshift"}},
-			"storage":    {{Name: "openshift"}},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
+			},
 		},
 	})
 
@@ -61,6 +61,7 @@ func createTestRegistryServer(t *testing.T, ctx context.Context) *httptest.Serve
 func TestPullthroughManifests(t *testing.T) {
 	namespace := "fuser"
 	repo := "zapp"
+	repoName := fmt.Sprintf("%s/%s", namespace, repo)
 	tag := "latest"
 
 	client := &testclient.Fake{}
@@ -74,10 +75,9 @@ func TestPullthroughManifests(t *testing.T) {
 	}()
 
 	installFakeAccessController(t)
+	setPassthroughBlobDescriptorServiceFactory()
 
-	ctx := context.Background()
-
-	remoteRegistryServer := createTestRegistryServer(t, ctx)
+	remoteRegistryServer := createTestRegistryServer(t, context.Background())
 	defer remoteRegistryServer.Close()
 
 	serverURL, err := url.Parse(remoteRegistryServer.URL)
@@ -85,17 +85,26 @@ func TestPullthroughManifests(t *testing.T) {
 		t.Fatalf("error parsing server url: %v", err)
 	}
 
-	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
-	testImage.DockerImageManifest = ""
-
-	testImageStream := createTestImageStreamReactor(t, client, testImage, namespace, repo, tag)
-
-	client.AddReactor("get", "imagestreamimages", registrytest.GetFakeImageStreamImageGetHandler(t, testImageStream, *testImage))
-
-	signedManifest := &schema1.SignedManifest{}
-	if err := json.Unmarshal([]byte(etcdManifest), signedManifest); err != nil {
-		t.Fatalf("error unmarshaling signed manifest: %v", err)
+	ms1dgst, ms1canonical, _, ms1manifest, err := registrytest.CreateAndUploadTestManifest(
+		registrytest.ManifestSchema1, 2, serverURL, nil, repoName, "schema1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+	_, ms1payload, err := ms1manifest.Payload()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("ms1dgst=%s, ms1manifest: %s", ms1dgst, ms1canonical)
+
+	image, err := registrytest.NewImageForManifest(repoName, string(ms1payload), "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	image.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, image.Name)
+	image.DockerImageManifest = ""
+	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *image))
+
+	createTestImageStreamReactor(t, client, image, namespace, repo, tag)
 
 	for _, tc := range []struct {
 		name                  string
@@ -106,18 +115,18 @@ func TestPullthroughManifests(t *testing.T) {
 		expectedNotFoundError bool
 	}{
 		{
-			name:           "manifest digest",
-			manifestDigest: etcdDigest,
+			name:           "manifest digest from local store",
+			manifestDigest: ms1dgst,
 			localData: map[digest.Digest]distribution.Manifest{
-				etcdDigest: signedManifest,
+				ms1dgst: ms1manifest,
 			},
 			expectedLocalCalls: map[string]int{
 				"Get": 1,
 			},
 		},
 		{
-			name:           "manifest digest XXX",
-			manifestDigest: digest.Digest(testImage.Name),
+			name:           "manifest served from remote repository",
+			manifestDigest: digest.Digest(image.Name),
 			expectedLocalCalls: map[string]int{
 				"Get": 1,
 			},
@@ -131,11 +140,12 @@ func TestPullthroughManifests(t *testing.T) {
 			},
 		},
 	} {
-		localManifestService := newTestManifestService(namespace+"/"+repo, tc.localData)
+		localManifestService := newTestManifestService(repoName, tc.localData)
 
-		ctx := context.Background()
+		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 
 		repo := newTestRepositoryForPullthrough(t, ctx, nil, namespace, repo, client, true)
+
 		ptms := &pullthroughManifestService{
 			ManifestService: localManifestService,
 			repo:            repo,
@@ -155,15 +165,6 @@ func TestPullthroughManifests(t *testing.T) {
 			if tc.expectedError {
 				break
 			}
-			if tc.expectedNotFoundError && err == distribution.ErrBlobUnknown {
-				break
-			}
-			// TODO: The middleware should return distribution errors, not kube ones.
-			if e, ok := err.(*kerrors.StatusError); ok {
-				if tc.expectedNotFoundError && e.ErrStatus.Code == http.StatusNotFound {
-					break
-				}
-			}
 			t.Fatalf("[%s] unexpected error: %#+v", tc.name, err)
 		}
 
@@ -172,6 +173,261 @@ func TestPullthroughManifests(t *testing.T) {
 				t.Fatalf("[%s] unexpected result returned", tc.name)
 			}
 		}
+
+		for name, count := range localManifestService.calls {
+			expectCount, exists := tc.expectedLocalCalls[name]
+			if !exists {
+				t.Errorf("[%s] expected no calls to method %s of local manifest service, got %d", tc.name, name, count)
+			}
+			if count != expectCount {
+				t.Errorf("[%s] unexpected number of calls to method %s of local manifest service, got %d", tc.name, name, count)
+			}
+		}
+	}
+}
+
+func TestPullthroughManifestInsecure(t *testing.T) {
+	namespace := "fuser"
+	repo := "zapp"
+	repoName := fmt.Sprintf("%s/%s", namespace, repo)
+
+	installFakeAccessController(t)
+	setPassthroughBlobDescriptorServiceFactory()
+
+	remoteRegistryServer := createTestRegistryServer(t, context.Background())
+	defer remoteRegistryServer.Close()
+
+	serverURL, err := url.Parse(remoteRegistryServer.URL)
+	if err != nil {
+		t.Fatalf("error parsing server url: %v", err)
+	}
+
+	ms1dgst, ms1canonical, _, ms1manifest, err := registrytest.CreateAndUploadTestManifest(
+		registrytest.ManifestSchema1, 2, serverURL, nil, repoName, "schema1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, ms1payload, err := ms1manifest.Payload()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("ms1dgst=%s, ms1manifest: %s", ms1dgst, ms1canonical)
+	ms2dgst, ms2canonical, ms2config, ms2manifest, err := registrytest.CreateAndUploadTestManifest(
+		registrytest.ManifestSchema2, 2, serverURL, nil, repoName, "schema2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, ms2payload, err := ms2manifest.Payload()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("ms2dgst=%s, ms2manifest: %s", ms2dgst, ms2canonical)
+
+	ms1img, err := registrytest.NewImageForManifest(repoName, string(ms1payload), "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms1img.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, ms1img.Name)
+	ms1img.DockerImageManifest = ""
+	ms2img, err := registrytest.NewImageForManifest(repoName, string(ms2payload), ms2config, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms2img.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, ms2img.Name)
+	ms2img.DockerImageManifest = ""
+
+	for _, tc := range []struct {
+		name                string
+		manifestDigest      digest.Digest
+		localData           map[digest.Digest]distribution.Manifest
+		imageStreamInit     func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream)
+		expectedManifest    distribution.Manifest
+		expectedLocalCalls  map[string]int
+		expectedErrorString string
+	}{
+
+		{
+			name:           "fetch schema 1 with allowed insecure",
+			manifestDigest: ms1dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *ms1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema1", string(ms1dgst), ms1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "true"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return ms1img, is
+			},
+			expectedManifest: ms1manifest,
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+
+		{
+			name:           "fetch schema 2 with allowed insecure",
+			manifestDigest: ms2dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *ms2img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema2", string(ms2dgst), ms2img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "true"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return ms2img, is
+			},
+			expectedManifest: ms2manifest,
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+
+		{
+			name:           "explicit forbid insecure",
+			manifestDigest: ms1dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *ms1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema1", string(ms1dgst), ms1img.DockerImageReference)
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "false"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return ms1img, is
+			},
+			expectedErrorString: "server gave HTTP response to HTTPS client",
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+
+		{
+			name:           "implicit forbid insecure",
+			manifestDigest: ms1dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *ms1img))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema1", string(ms1dgst), ms1img.DockerImageReference)
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return ms1img, is
+			},
+			expectedErrorString: "server gave HTTP response to HTTPS client",
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+
+		{
+			name:           "pullthrough from insecure tag",
+			manifestDigest: ms1dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				image, err := registrytest.NewImageForManifest(repoName, string(ms1payload), "", false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				image.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, ms1dgst)
+				image.DockerImageManifest = ""
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *image))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema1", string(ms1dgst), ms1img.DockerImageReference)
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"foo": {
+						Name:         "foo",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"schema1": {
+						Name:         "schema1",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
+					},
+				}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return image, is
+			},
+			expectedManifest: ms1manifest,
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+
+		{
+			name:           "pull insecure if either image stream is insecure or the tag",
+			manifestDigest: ms2dgst,
+			imageStreamInit: func(client *testclient.Fake) (*imageapi.Image, *imageapi.ImageStream) {
+				image, err := registrytest.NewImageForManifest(repoName, string(ms2payload), ms2config, false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				image.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, image.Name)
+				image.DockerImageManifest = ""
+				client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *image))
+
+				is := registrytest.TestNewImageStreamObject(namespace, repo, "schema2", image.Name, image.DockerImageReference)
+				is.Spec.Tags = map[string]imageapi.TagReference{
+					"foo": {
+						Name:         "foo",
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+					"schema2": {
+						Name: "schema2",
+						// the value doesn't override is annotation because we cannot determine whether the
+						// value is explicit or just the default
+						ImportPolicy: imageapi.TagImportPolicy{Insecure: false},
+					},
+				}
+				is.Annotations = map[string]string{imageapi.InsecureRepositoryAnnotation: "true"}
+				client.AddReactor("get", "imagestreams", registrytest.GetFakeImageStreamGetHandler(t, *is))
+				return image, is
+			},
+			expectedManifest: ms2manifest,
+			expectedLocalCalls: map[string]int{
+				"Get": 1,
+			},
+		},
+	} {
+		client := &testclient.Fake{}
+
+		// TODO: get rid of those nasty global vars
+		backupRegistryClient := DefaultRegistryClient
+		DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
+		defer func() {
+			// set it back once this test finishes to make other unit tests working again
+			DefaultRegistryClient = backupRegistryClient
+		}()
+
+		tc.imageStreamInit(client)
+
+		localManifestService := newTestManifestService(repoName, tc.localData)
+
+		ctx := WithTestPassthroughToUpstream(context.Background(), false)
+		repo := newTestRepositoryForPullthrough(t, ctx, nil, namespace, repo, client, true)
+		ctx = WithRepository(ctx, repo)
+
+		ptms := &pullthroughManifestService{
+			ManifestService: localManifestService,
+			repo:            repo,
+		}
+
+		manifestResult, err := ptms.Get(ctx, tc.manifestDigest)
+		switch err.(type) {
+		case nil:
+			if len(tc.expectedErrorString) > 0 {
+				t.Errorf("[%s] unexpected successful response", tc.name)
+				continue
+			}
+		default:
+			if len(tc.expectedErrorString) > 0 {
+				if !strings.Contains(err.Error(), tc.expectedErrorString) {
+					t.Fatalf("expected error string %q, got instead: %s (%#+v)", tc.expectedErrorString, err.Error(), err)
+				}
+				break
+			}
+			t.Fatalf("[%s] unexpected error: %#+v (%s)", tc.name, err, err.Error())
+		}
+
+		if tc.localData != nil {
+			if manifestResult != nil && manifestResult != tc.localData[tc.manifestDigest] {
+				t.Errorf("[%s] unexpected result returned", tc.name)
+				continue
+			}
+		}
+
+		registrytest.AssertManifestsEqual(t, tc.name, manifestResult, tc.expectedManifest)
 
 		for name, count := range localManifestService.calls {
 			expectCount, exists := tc.expectedLocalCalls[name]

--- a/pkg/dockerregistry/server/remoteblobgetter_test.go
+++ b/pkg/dockerregistry/server/remoteblobgetter_test.go
@@ -1,0 +1,223 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/diff"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+)
+
+func TestIdentifyCandidateRepositories(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		is                   *imageapi.ImageStream
+		localRegistry        string
+		primary              bool
+		expectedRepositories []string
+		expectedSearch       map[string]imagePullthroughSpec
+	}{
+		{
+			name:          "empty image stream",
+			is:            &imageapi.ImageStream{},
+			localRegistry: "localhost:5000",
+		},
+
+		{
+			name: "secure image stream with one image",
+			is: &imageapi.ImageStream{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"tag": {
+							Items: []imageapi.TagEvent{{DockerImageReference: "docker.io/busybox"}},
+						},
+					},
+				},
+			},
+			localRegistry:        "localhost:5000",
+			primary:              true,
+			expectedRepositories: []string{"docker.io/library/busybox"},
+			expectedSearch: map[string]imagePullthroughSpec{
+				"docker.io/library/busybox": makeTestImagePullthroughSpec(t, "docker.io/library/busybox:latest", false),
+			},
+		},
+
+		{
+			name: "secure image stream with one insecure image",
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"insecure": {ImportPolicy: imageapi.TagImportPolicy{Insecure: true}},
+					},
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"secure": {
+							Items: []imageapi.TagEvent{
+								{DockerImageReference: "example.org/user/app:tag"},
+								{DockerImageReference: "secure.example.org/user/app"},
+							},
+						},
+						"insecure": {
+							Items: []imageapi.TagEvent{
+								{DockerImageReference: "registry.example.org/user/app"},
+								{DockerImageReference: "other.org/user/app"},
+							},
+						},
+					},
+				},
+			},
+			localRegistry:        "localhost:5000",
+			primary:              true,
+			expectedRepositories: []string{"example.org/user/app", "registry.example.org/user/app"},
+			expectedSearch: map[string]imagePullthroughSpec{
+				"example.org/user/app":          makeTestImagePullthroughSpec(t, "example.org/user/app:tag", false),
+				"registry.example.org/user/app": makeTestImagePullthroughSpec(t, "registry.example.org/user/app:latest", true),
+			},
+		},
+
+		{
+			name: "search secondary results in insecure image stream",
+			is: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Annotations: map[string]string{imageapi.InsecureRepositoryAnnotation: "true"},
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"insecure": {ImportPolicy: imageapi.TagImportPolicy{Insecure: false}},
+					},
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"secure": {
+							Items: []imageapi.TagEvent{
+								{DockerImageReference: "example.org/user/app:tag"},
+								{DockerImageReference: "example.org/app:tag2"},
+							},
+						},
+						"insecure": {Items: []imageapi.TagEvent{{DockerImageReference: "registry.example.org/user/app"}}},
+					},
+				},
+			},
+			localRegistry:        "localhost:5000",
+			primary:              false,
+			expectedRepositories: []string{"example.org/app"},
+			expectedSearch: map[string]imagePullthroughSpec{
+				"example.org/app": makeTestImagePullthroughSpec(t, "example.org/app:tag2", true),
+			},
+		},
+
+		{
+			name: "empty secondary search",
+			is: &imageapi.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Annotations: map[string]string{imageapi.InsecureRepositoryAnnotation: "true"},
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"insecure": {ImportPolicy: imageapi.TagImportPolicy{Insecure: false}},
+					},
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"secure":   {Items: []imageapi.TagEvent{{DockerImageReference: "example.org/user/app:tag"}}},
+						"insecure": {Items: []imageapi.TagEvent{{DockerImageReference: "registry.example.org/user/app"}}},
+					},
+				},
+			},
+			localRegistry: "localhost:5000",
+			primary:       false,
+		},
+
+		{
+			name: "insecure flag propagates to the whole registry",
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"insecure": {ImportPolicy: imageapi.TagImportPolicy{Insecure: true}},
+					},
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"secure":   {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/c"}}},
+						"insecure": {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/app"}}},
+						"foo":      {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/c/foo"}}},
+						"bar":      {Items: []imageapi.TagEvent{{DockerImageReference: "other.b/bar"}}},
+						"gas":      {Items: []imageapi.TagEvent{{DockerImageReference: "a.a/app"}}},
+					},
+				},
+			},
+			localRegistry:        "localhost:5000",
+			primary:              true,
+			expectedRepositories: []string{"a.a/app", "other.b/bar", "a.b/app", "a.b/c", "a.b/c/foo"},
+			expectedSearch: map[string]imagePullthroughSpec{
+				"a.a/app":     makeTestImagePullthroughSpec(t, "a.a/app:latest", false),
+				"other.b/bar": makeTestImagePullthroughSpec(t, "other.b/bar:latest", false),
+				"a.b/app":     makeTestImagePullthroughSpec(t, "a.b/app:latest", true),
+				"a.b/c":       makeTestImagePullthroughSpec(t, "a.b/c:latest", true),
+				"a.b/c/foo":   makeTestImagePullthroughSpec(t, "a.b/c/foo:latest", true),
+			},
+		},
+
+		{
+			name: "duplicate entries",
+			is: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"insecure": {ImportPolicy: imageapi.TagImportPolicy{Insecure: true}},
+					},
+				},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"secure":   {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/foo"}}},
+						"insecure": {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/app:latest"}}},
+						"foo":      {Items: []imageapi.TagEvent{{DockerImageReference: "a.b/app"}}},
+						"bar":      {Items: []imageapi.TagEvent{{DockerImageReference: "a.b.c/app"}}},
+						"gas":      {Items: []imageapi.TagEvent{{DockerImageReference: "a.b.c/app"}}},
+					},
+				},
+			},
+			localRegistry:        "localhost:5000",
+			primary:              true,
+			expectedRepositories: []string{"a.b.c/app", "a.b/app", "a.b/foo"},
+			expectedSearch: map[string]imagePullthroughSpec{
+				"a.b.c/app": makeTestImagePullthroughSpec(t, "a.b.c/app:latest", false),
+				"a.b/app":   makeTestImagePullthroughSpec(t, "a.b/app:latest", true),
+				"a.b/foo":   makeTestImagePullthroughSpec(t, "a.b/foo:latest", true),
+			},
+		},
+	} {
+		repositories, search := identifyCandidateRepositories(tc.is, tc.localRegistry, tc.primary)
+
+		if !reflect.DeepEqual(repositories, tc.expectedRepositories) {
+			if len(repositories) != 0 || len(tc.expectedRepositories) != 0 {
+				t.Errorf("[%s] got unexpected repositories: %s", tc.name, diff.ObjectGoPrintDiff(repositories, tc.expectedRepositories))
+			}
+		}
+
+		for repo, spec := range search {
+			if expSpec, exists := tc.expectedSearch[repo]; !exists {
+				t.Errorf("[%s] got unexpected repository among results: %q: %#+v", tc.name, repo, spec)
+			} else if !reflect.DeepEqual(spec, expSpec) {
+				t.Errorf("[%s] got unexpected pull spec for repo %q: %s", tc.name, repo, diff.ObjectGoPrintDiff(spec, expSpec))
+			}
+		}
+		for expRepo, expSpec := range tc.expectedSearch {
+			if _, exists := tc.expectedSearch[expRepo]; !exists {
+				t.Errorf("[%s] missing expected repository among results: %q: %#+v", tc.name, expRepo, expSpec)
+			}
+		}
+	}
+}
+
+func makeTestImagePullthroughSpec(t *testing.T, ref string, insecure bool) imagePullthroughSpec {
+	r, err := imageapi.ParseDockerImageReference(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return imagePullthroughSpec{dockerImageReference: &r, insecure: insecure}
+}

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/api/errcode"
 	repomw "github.com/docker/distribution/registry/middleware/repository"
+	registrystorage "github.com/docker/distribution/registry/storage"
 
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
@@ -233,7 +234,10 @@ func newRepositoryWithClient(
 
 // Manifests returns r, which implements distribution.ManifestService.
 func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
-	ms, err := r.Repository.Manifests(WithRepository(ctx, r))
+	// we do a verification of our own
+	// TODO: let upstream do the verification once they pass correct context object to their manifest handler
+	opts := append(options, registrystorage.SkipLayerVerification())
+	ms, err := r.Repository.Manifests(WithRepository(ctx, r), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
@@ -324,6 +326,7 @@ func TestRepositoryBlobStat(t *testing.T) {
 }
 
 func TestRepositoryBlobStatCacheEviction(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
 	const blobRepoCacheTTL = time.Millisecond * 500
 
 	quotaEnforcing = &quotaEnforcingConfig{}
@@ -390,6 +393,10 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 	}
 
 	// query etcd
+	repo, err = reg.Repository(ctx, ref) // the repository needs to be recreated since it caches image streams and images
+	if err != nil {
+		t.Fatalf("failed to get repository: %v", err)
+	}
 	desc, err = repo.Blobs(ctx).Stat(ctx, blob1Dgst)
 	if err != nil {
 		t.Fatalf("got unexpected stat error: %v", err)
@@ -418,6 +425,10 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 	}
 
 	// cache hit - don't query etcd
+	repo, err = reg.Repository(ctx, ref) // the repository needs to be recreated since it caches image streams and images
+	if err != nil {
+		t.Fatalf("failed to get repository: %v", err)
+	}
 	desc, err = repo.Blobs(ctx).Stat(ctx, blob2Dgst)
 	if err != nil {
 		t.Fatalf("got unexpected stat error: %v", err)
@@ -431,6 +442,10 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 	lastStatTimestamp := time.Now()
 
 	// hit the cache
+	repo, err = reg.Repository(ctx, ref)
+	if err != nil {
+		t.Fatalf("failed to get repository: %v", err)
+	}
 	desc, err = repo.Blobs(ctx).Stat(ctx, blob2Dgst)
 	if err != nil {
 		t.Fatalf("got unexpected stat error: %v", err)
@@ -445,6 +460,10 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 	t.Logf("sleeping %s while waiting for eviction of blob %q from cache", blobRepoCacheTTL.String(), blob2Dgst.String())
 	time.Sleep(blobRepoCacheTTL - (time.Now().Sub(lastStatTimestamp)))
 
+	repo, err = reg.Repository(ctx, ref)
+	if err != nil {
+		t.Fatalf("failed to get repository: %v", err)
+	}
 	desc, err = repo.Blobs(ctx).Stat(ctx, blob2Dgst)
 	if err != nil {
 		t.Fatalf("got unexpected stat error: %v", err)
@@ -686,8 +705,8 @@ type testRegistry struct {
 
 var _ distribution.Namespace = &testRegistry{}
 
-func (r *testRegistry) Repository(ctx context.Context, ref reference.Named) (distribution.Repository, error) {
-	repo, err := r.Namespace.Repository(ctx, ref)
+func (reg *testRegistry) Repository(ctx context.Context, ref reference.Named) (distribution.Repository, error) {
+	repo, err := reg.Namespace.Repository(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -699,20 +718,43 @@ func (r *testRegistry) Repository(ctx context.Context, ref reference.Named) (dis
 		return nil, fmt.Errorf("failed to parse repository name %q", ref.Name())
 	}
 
-	return &repository{
+	nm, name := parts[0], parts[1]
+
+	isGetter := &cachedImageStreamGetter{
+		ctx:          ctx,
+		namespace:    nm,
+		name:         name,
+		isNamespacer: reg.osClient,
+	}
+
+	r := &repository{
 		Repository: repo,
 
 		ctx:              ctx,
 		quotaClient:      kFakeClient.Core(),
 		limitClient:      kFakeClient.Core(),
-		registryOSClient: r.osClient,
+		registryOSClient: reg.osClient,
 		registryAddr:     "localhost:5000",
-		namespace:        parts[0],
-		name:             parts[1],
-		blobrepositorycachettl: r.blobrepositorycachettl,
+		namespace:        nm,
+		name:             name,
+		blobrepositorycachettl: reg.blobrepositorycachettl,
+		imageStreamGetter:      isGetter,
+		cachedImages:           make(map[digest.Digest]*imageapi.Image),
 		cachedLayers:           cachedLayers,
-		pullthrough:            r.pullthrough,
-	}, nil
+		pullthrough:            reg.pullthrough,
+	}
+
+	if reg.pullthrough {
+		r.remoteBlobGetter = NewBlobGetterService(
+			nm,
+			name,
+			defaultBlobRepositoryCacheTTL,
+			isGetter.get,
+			reg.osClient,
+			cachedLayers)
+	}
+
+	return r, nil
 }
 
 func testNewDescriptorForLayer(layer imageapi.ImageLayer) distribution.Descriptor {

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -82,7 +82,7 @@ func TestRepositoryBlobStat(t *testing.T) {
 		name    string
 		managed bool
 	}{{"nm/is", true}, {"registry.org:5000/user/app", false}} {
-		img, err := registrytest.NewImageForManifest(d.name, registrytest.SampleImageManifestSchema1, d.managed)
+		img, err := registrytest.NewImageForManifest(d.name, registrytest.SampleImageManifestSchema1, "", d.managed)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -40,6 +40,10 @@ const (
 	testImageLayerCount = 2
 )
 
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
 func TestRepositoryBlobStat(t *testing.T) {
 	quotaEnforcing = &quotaEnforcingConfig{}
 
@@ -326,7 +330,6 @@ func TestRepositoryBlobStat(t *testing.T) {
 }
 
 func TestRepositoryBlobStatCacheEviction(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
 	const blobRepoCacheTTL = time.Millisecond * 500
 
 	quotaEnforcing = &quotaEnforcingConfig{}

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -50,7 +50,7 @@ func TestSignatureGet(t *testing.T) {
 		Content: []byte("owGbwMvMwMQorp341GLVgXeMpw9kJDFE1LxLq1ZKLsosyUxOzFGyqlbKTEnNK8ksqQSxU/KTs1OLdItS01KLUvOSU5WslHLygeoy8otLrEwNDAz0S1KLS8CEVU4iiFKq1VHKzE1MT0XSnpuYl5kGlNNNyUwHKbFSKs5INDI1szIxMLIwtzBKNrBITUw1SbRItkw0skhKMzMzTDZItEgxTDZKS7ZINbRMSUpMTDVKMjC0SDIyNDA0NLQ0TzU0sTABWVZSWQByVmJJfm5mskJyfl5JYmZeapFCcWZ6XmJJaVE"),
 	}
 
-	testImage, err := registrytest.NewImageForManifest("user/app", registrytest.SampleImageManifestSchema1, false)
+	testImage, err := registrytest.NewImageForManifest("user/app", registrytest.SampleImageManifestSchema1, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,6 +80,11 @@ func TestSignatureGet(t *testing.T) {
 			},
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{
@@ -184,6 +189,11 @@ func TestSignaturePut(t *testing.T) {
 			},
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{

--- a/pkg/dockerregistry/server/tagservice.go
+++ b/pkg/dockerregistry/server/tagservice.go
@@ -18,7 +18,7 @@ type tagService struct {
 }
 
 func (t tagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
-	imageStream, err := t.repo.getImageStream()
+	imageStream, err := t.repo.imageStreamGetter.get()
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error retrieving ImageStream %s/%s: %v", t.repo.namespace, t.repo.name, err)
 		return distribution.Descriptor{}, distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
@@ -50,7 +50,7 @@ func (t tagService) Get(ctx context.Context, tag string) (distribution.Descripto
 func (t tagService) All(ctx context.Context) ([]string, error) {
 	tags := []string{}
 
-	imageStream, err := t.repo.getImageStream()
+	imageStream, err := t.repo.imageStreamGetter.get()
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error retrieving ImageStream %s/%s: %v", t.repo.namespace, t.repo.name, err)
 		return tags, distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
@@ -97,7 +97,7 @@ func (t tagService) All(ctx context.Context) ([]string, error) {
 func (t tagService) Lookup(ctx context.Context, desc distribution.Descriptor) ([]string, error) {
 	tags := []string{}
 
-	imageStream, err := t.repo.getImageStream()
+	imageStream, err := t.repo.imageStreamGetter.get()
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error retrieving ImageStream %s/%s: %v", t.repo.namespace, t.repo.name, err)
 		return tags, distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
@@ -147,7 +147,7 @@ func (t tagService) Lookup(ctx context.Context, desc distribution.Descriptor) ([
 }
 
 func (t tagService) Tag(ctx context.Context, tag string, dgst distribution.Descriptor) error {
-	imageStream, err := t.repo.getImageStream()
+	imageStream, err := t.repo.imageStreamGetter.get()
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error retrieving ImageStream %s/%s: %v", t.repo.namespace, t.repo.name, err)
 		return distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
@@ -183,7 +183,7 @@ func (t tagService) Tag(ctx context.Context, tag string, dgst distribution.Descr
 }
 
 func (t tagService) Untag(ctx context.Context, tag string) error {
-	imageStream, err := t.repo.getImageStream()
+	imageStream, err := t.repo.imageStreamGetter.get()
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error retrieving ImageStream %s/%s: %v", t.repo.namespace, t.repo.name, err)
 		return distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -33,6 +33,7 @@ func createTestImageReactor(t *testing.T, client *testclient.Fake, serverURL *ur
 	testImage, err := registrytest.NewImageForManifest(
 		fmt.Sprintf("%s/%s", namespace, repo),
 		string(testManifestSchema1),
+		"",
 		false)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -125,21 +125,10 @@ func TestTagGet(t *testing.T) {
 
 		localTagService := newTestTagService(nil)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
-
+		r := newTestRepositoryForPullthrough(t, ctx, nil, namespace, repo, client, tc.pullthrough)
 		ts := &tagService{
 			TagService: localTagService,
-			repo: &repository{
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      tc.pullthrough,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:       r,
 		}
 
 		resultDesc, err := ts.Get(ctx, tc.tagName)
@@ -191,27 +180,15 @@ func TestTagGetWithoutImageStream(t *testing.T) {
 
 	localTagService := newTestTagService(nil)
 
-	cachedLayers, err := newDigestToRepositoryCache(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, true)
 	ts := &tagService{
 		TagService: localTagService,
-		repo: &repository{
-			Repository:       &testRepository{name: named},
-			ctx:              ctx,
-			namespace:        namespace,
-			name:             repo,
-			pullthrough:      true,
-			cachedLayers:     cachedLayers,
-			registryOSClient: client,
-		},
+		repo:       r,
 	}
 
 	_, err = ts.Get(ctx, tag)
@@ -283,27 +260,14 @@ func TestTagCreation(t *testing.T) {
 
 		localTagService := newTestTagService(nil)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, tc.pullthrough)
 		ts := &tagService{
 			TagService: localTagService,
-			repo: &repository{
-				Repository:       &testRepository{name: named},
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      tc.pullthrough,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:       r,
 		}
 
 		err = ts.Tag(ctx, tc.tagName, tc.tagValue)
@@ -344,27 +308,14 @@ func TestTagCreationWithoutImageStream(t *testing.T) {
 
 	localTagService := newTestTagService(nil)
 
-	cachedLayers, err := newDigestToRepositoryCache(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, true)
 	ts := &tagService{
 		TagService: localTagService,
-		repo: &repository{
-			Repository:       &testRepository{name: named},
-			ctx:              ctx,
-			namespace:        namespace,
-			name:             repo,
-			pullthrough:      true,
-			cachedLayers:     cachedLayers,
-			registryOSClient: client,
-		},
+		repo:       r,
 	}
 
 	err = ts.Tag(ctx, tag, distribution.Descriptor{Digest: digest.Digest(testImage.Name)})
@@ -444,27 +395,15 @@ func TestTagDeletion(t *testing.T) {
 
 		localTagService := newTestTagService(nil)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 		if err != nil {
 			t.Fatal(err)
 		}
 
+		r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, tc.pullthrough)
 		ts := &tagService{
 			TagService: localTagService,
-			repo: &repository{
-				Repository:       &testRepository{name: named},
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      tc.pullthrough,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:       r,
 		}
 
 		err = ts.Untag(ctx, tc.tagName)
@@ -510,27 +449,14 @@ func TestTagDeletionWithoutImageStream(t *testing.T) {
 
 	localTagService := newTestTagService(nil)
 
-	cachedLayers, err := newDigestToRepositoryCache(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, true)
 	ts := &tagService{
 		TagService: localTagService,
-		repo: &repository{
-			Repository:       &testRepository{name: named},
-			ctx:              ctx,
-			namespace:        namespace,
-			name:             repo,
-			pullthrough:      true,
-			cachedLayers:     cachedLayers,
-			registryOSClient: client,
-		},
+		repo:       r,
 	}
 
 	err = ts.Untag(ctx, tag)
@@ -597,27 +523,14 @@ func TestTagGetAll(t *testing.T) {
 
 		localTagService := newTestTagService(nil)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, tc.pullthrough)
 		ts := &tagService{
 			TagService: localTagService,
-			repo: &repository{
-				Repository:       &testRepository{name: named},
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      tc.pullthrough,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:       r,
 		}
 
 		result, err := ts.All(ctx)
@@ -655,27 +568,14 @@ func TestTagGetAllWithoutImageStream(t *testing.T) {
 
 	localTagService := newTestTagService(nil)
 
-	cachedLayers, err := newDigestToRepositoryCache(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, true)
 	ts := &tagService{
 		TagService: localTagService,
-		repo: &repository{
-			Repository:       &testRepository{name: named},
-			ctx:              ctx,
-			namespace:        namespace,
-			name:             repo,
-			pullthrough:      true,
-			cachedLayers:     cachedLayers,
-			registryOSClient: client,
-		},
+		repo:       r,
 	}
 
 	_, err = ts.All(ctx)
@@ -753,27 +653,14 @@ func TestTagLookup(t *testing.T) {
 
 		localTagService := newTestTagService(nil)
 
-		cachedLayers, err := newDigestToRepositoryCache(10)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, tc.pullthrough)
 		ts := &tagService{
 			TagService: localTagService,
-			repo: &repository{
-				Repository:       &testRepository{name: named},
-				ctx:              ctx,
-				namespace:        namespace,
-				name:             repo,
-				pullthrough:      tc.pullthrough,
-				cachedLayers:     cachedLayers,
-				registryOSClient: client,
-			},
+			repo:       r,
 		}
 
 		result, err := ts.Lookup(ctx, tc.tagValue)
@@ -818,27 +705,15 @@ func TestTagLookupWithoutImageStream(t *testing.T) {
 
 	localTagService := newTestTagService(nil)
 
-	cachedLayers, err := newDigestToRepositoryCache(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	named, err := reference.ParseNamed(fmt.Sprintf("%s/%s", namespace, repo))
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	r := newTestRepositoryForPullthrough(t, ctx, &testRepository{name: named}, namespace, repo, client, true)
 	ts := &tagService{
 		TagService: localTagService,
-		repo: &repository{
-			Repository:       &testRepository{name: named},
-			ctx:              ctx,
-			namespace:        namespace,
-			name:             repo,
-			pullthrough:      true,
-			cachedLayers:     cachedLayers,
-			registryOSClient: client,
-		},
+		repo:       r,
 	}
 
 	_, err = ts.Lookup(ctx, distribution.Descriptor{Digest: digest.Digest(testImage.Name)})

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -27,6 +27,10 @@ const (
 	repositoryKey = "openshift.repository"
 
 	remoteGetterServiceKey = "openshift.remote.getter.service"
+
+	// remoteBlobAccessCheckEnabledKey allows blobDescriptorService to stat remote blobs which is useful only
+	// in case of manifest verification.
+	remoteBlobAccessCheckEnabledKey = "openshift.remote.blobaccesscheck.enabled"
 )
 
 func WithRepository(parent context.Context, repo *repository) context.Context {
@@ -35,6 +39,14 @@ func WithRepository(parent context.Context, repo *repository) context.Context {
 func RepositoryFrom(ctx context.Context) (repo *repository, found bool) {
 	repo, found = ctx.Value(repositoryKey).(*repository)
 	return
+}
+
+func WithRemoteBlobAccessCheckEnabled(parent context.Context, enable bool) context.Context {
+	return context.WithValue(parent, remoteBlobAccessCheckEnabledKey, enable)
+}
+func RemoteBlobAccessCheckEnabledFrom(ctx context.Context) bool {
+	enabled, _ := ctx.Value(remoteBlobAccessCheckEnabledKey).(bool)
+	return enabled
 }
 
 func getOptionValue(

--- a/pkg/dockerregistry/testutil/manifests.go
+++ b/pkg/dockerregistry/testutil/manifests.go
@@ -4,18 +4,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	distclient "github.com/docker/distribution/registry/client"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/libtrust"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/diff"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-type ManifestSchemaVesion int
+type ManifestSchemaVersion int
 type LayerPayload []byte
 type ConfigPayload []byte
 
@@ -25,25 +37,27 @@ type Payload struct {
 }
 
 const (
-	ManifestSchema1 ManifestSchemaVesion = 1
-	ManifestSchema2 ManifestSchemaVesion = 2
+	ManifestSchema1 ManifestSchemaVersion = 1
+	ManifestSchema2 ManifestSchemaVersion = 2
 )
 
 // MakeSchema1Manifest constructs a schema 1 manifest from a given list of digests and returns
 // the digest of the manifest
 // github.com/docker/distribution/testutil
-func MakeSchema1Manifest(layers []distribution.Descriptor) (string, distribution.Manifest, error) {
-	manifest := schema1.Manifest{
+func MakeSchema1Manifest(name, tag string, layers []distribution.Descriptor) (string, distribution.Manifest, error) {
+	m := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
-		Name: "who",
-		Tag:  "cares",
+		FSLayers: make([]schema1.FSLayer, 0, len(layers)),
+		History:  make([]schema1.History, 0, len(layers)),
+		Name:     name,
+		Tag:      tag,
 	}
 
 	for _, layer := range layers {
-		manifest.FSLayers = append(manifest.FSLayers, schema1.FSLayer{BlobSum: layer.Digest})
-		manifest.History = append(manifest.History, schema1.History{V1Compatibility: "{}"})
+		m.FSLayers = append(m.FSLayers, schema1.FSLayer{BlobSum: layer.Digest})
+		m.History = append(m.History, schema1.History{V1Compatibility: "{}"})
 	}
 
 	pk, err := libtrust.GenerateECP256PrivateKey()
@@ -51,7 +65,7 @@ func MakeSchema1Manifest(layers []distribution.Descriptor) (string, distribution
 		return "", nil, fmt.Errorf("unexpected error generating private key: %v", err)
 	}
 
-	signedManifest, err := schema1.Sign(&manifest, pk)
+	signedManifest, err := schema1.Sign(&m, pk)
 	if err != nil {
 		return "", nil, fmt.Errorf("error signing manifest: %v", err)
 	}
@@ -65,7 +79,7 @@ func MakeSchema2Manifest(config distribution.Descriptor, layers []distribution.D
 	m := schema2.Manifest{
 		Versioned: schema2.SchemaVersion,
 		Config:    config,
-		Layers:    make([]distribution.Descriptor, len(layers)),
+		Layers:    make([]distribution.Descriptor, 0, len(layers)),
 	}
 	m.Config.MediaType = schema2.MediaTypeConfig
 
@@ -127,7 +141,7 @@ func MakeManifestConfig() (ConfigPayload, distribution.Descriptor, error) {
 	return jsonBytes, cfgDesc, nil
 }
 
-func CreateRandomManifest(schemaVersion ManifestSchemaVesion, layerCount int) (string, distribution.Manifest, *Payload, error) {
+func CreateRandomManifest(schemaVersion ManifestSchemaVersion, layerCount int) (string, distribution.Manifest, *Payload, error) {
 	var (
 		rawManifest string
 		manifest    distribution.Manifest
@@ -146,9 +160,9 @@ func CreateRandomManifest(schemaVersion ManifestSchemaVesion, layerCount int) (s
 
 	switch schemaVersion {
 	case ManifestSchema1:
-		rawManifest, manifest, err = MakeSchema1Manifest(layersDescs)
+		rawManifest, manifest, err = MakeSchema1Manifest("who", "cares", layersDescs)
 	case ManifestSchema2:
-		payload.Config, cfgDesc, err = MakeManifestConfig()
+		_, cfgDesc, err = MakeManifestConfig()
 		if err != nil {
 			return "", nil, nil, err
 		}
@@ -158,4 +172,183 @@ func CreateRandomManifest(schemaVersion ManifestSchemaVesion, layerCount int) (s
 	}
 
 	return rawManifest, manifest, payload, err
+}
+
+// CreateUploadTestManifest generates a random manifest blob and uploads it to the given repository. For this
+// purpose, a given number of layers will be created and uploaded.
+func CreateAndUploadTestManifest(
+	schemaVersion ManifestSchemaVersion,
+	layerCount int,
+	serverURL *url.URL,
+	creds auth.CredentialStore,
+	repoName, tag string,
+) (dgst digest.Digest, canonical, manifestConfig string, manifest distribution.Manifest, err error) {
+	var (
+		layerDescriptors = make([]distribution.Descriptor, 0, layerCount)
+	)
+
+	for i := 0; i < layerCount; i++ {
+		ds, _, err := UploadRandomTestBlob(serverURL, creds, repoName)
+		if err != nil {
+			return "", "", "", nil, fmt.Errorf("unexpected error generating test blob layer: %v", err)
+		}
+		layerDescriptors = append(layerDescriptors, ds)
+	}
+
+	switch schemaVersion {
+	case ManifestSchema1:
+		canonical, manifest, err = MakeSchema1Manifest(repoName, tag, layerDescriptors)
+		if err != nil {
+			return "", "", "", nil, fmt.Errorf("failed to make manifest of schema 1: %v", err)
+		}
+	case ManifestSchema2:
+		cfgPayload, cfgDesc, err := MakeManifestConfig()
+		if err != nil {
+			return "", "", "", nil, err
+		}
+		_, err = UploadPayloadAsBlob(cfgPayload, serverURL, creds, repoName)
+		if err != nil {
+			return "", "", "", nil, fmt.Errorf("failed to upload manifest config of schema 2: %v", err)
+		}
+		canonical, manifest, err = MakeSchema2Manifest(cfgDesc, layerDescriptors)
+		if err != nil {
+			return "", "", "", nil, fmt.Errorf("failed to make manifest schema 2: %v", err)
+		}
+		manifestConfig = string(cfgPayload)
+	default:
+		return "", "", "", nil, fmt.Errorf("unsupported manifest version %d", schemaVersion)
+	}
+
+	expectedDgst := digest.FromBytes([]byte(canonical))
+
+	ctx := context.Background()
+	ref, err := reference.ParseNamed(repoName)
+	if err != nil {
+		return "", "", "", nil, err
+	}
+
+	var rt http.RoundTripper
+	if creds != nil {
+		challengeManager := auth.NewSimpleChallengeManager()
+		_, err := ping(challengeManager, serverURL.String()+"/v2/", "")
+		if err != nil {
+			return "", "", "", nil, err
+		}
+		rt = transport.NewTransport(
+			nil,
+			auth.NewAuthorizer(
+				challengeManager,
+				auth.NewTokenHandler(nil, creds, repoName, "pull", "push"),
+				auth.NewBasicHandler(creds)))
+	}
+	repo, err := distclient.NewRepository(ctx, ref, serverURL.String(), rt)
+	if err != nil {
+		return "", "", "", nil, fmt.Errorf("failed to get repository %q: %v", repoName, err)
+	}
+
+	ms, err := repo.Manifests(ctx)
+	if err != nil {
+		return "", "", "", nil, err
+	}
+	dgst, err = ms.Put(ctx, manifest)
+	if err != nil {
+		return "", "", "", nil, err
+	}
+
+	if expectedDgst != dgst {
+		return "", "", "", nil, fmt.Errorf("registry server computed different digest for uploaded manifest than expected: %q != %q", dgst, expectedDgst)
+	}
+
+	return dgst, canonical, manifestConfig, manifest, nil
+}
+
+// AssertManifestsEqual compares two manifests and returns if they are equal. Signatures of manifest schema 1
+// are not taken into account.
+func AssertManifestsEqual(t *testing.T, description string, ma distribution.Manifest, mb distribution.Manifest) {
+	if ma == mb {
+		return
+	}
+
+	if (ma == nil) != (mb == nil) {
+		t.Fatalf("[%s] only one of the manifests is nil", description)
+	}
+
+	_, pa, err := ma.Payload()
+	if err != nil {
+		t.Fatalf("[%s] failed to get payload for first manifest: %v", description, err)
+	}
+	_, pb, err := mb.Payload()
+	if err != nil {
+		t.Fatalf("[%s] failed to get payload for second manifest: %v", description, err)
+	}
+
+	var va, vb manifest.Versioned
+	if err := json.Unmarshal([]byte(pa), &va); err != nil {
+		t.Fatalf("[%s] failed to unmarshal payload of the first manifest: %v", description, err)
+	}
+	if err := json.Unmarshal([]byte(pb), &vb); err != nil {
+		t.Fatalf("[%s] failed to unmarshal payload of the second manifest: %v", description, err)
+	}
+
+	if !reflect.DeepEqual(va, vb) {
+		t.Fatalf("[%s] manifests are of different version: %s", description, diff.ObjectGoPrintDiff(va, vb))
+	}
+
+	switch va.SchemaVersion {
+	case 1:
+		ms1a, ok := ma.(*schema1.SignedManifest)
+		if !ok {
+			t.Fatalf("[%s] failed to convert first manifest (%T) to schema1.SignedManifest", description, ma)
+		}
+		ms1b, ok := mb.(*schema1.SignedManifest)
+		if !ok {
+			t.Fatalf("[%s] failed to convert first manifest (%T) to schema1.SignedManifest", description, mb)
+		}
+		if !reflect.DeepEqual(ms1a.Manifest, ms1b.Manifest) {
+			t.Fatalf("[%s] manifests don't match: %s", description, diff.ObjectGoPrintDiff(ms1a.Manifest, ms1b.Manifest))
+		}
+
+	case 2:
+		if !reflect.DeepEqual(ma, mb) {
+			t.Fatalf("[%s] manifests don't match: %s", description, diff.ObjectGoPrintDiff(ma, mb))
+		}
+
+	default:
+		t.Fatalf("[%s] unrecognized manifest schema version: %d", description, va.SchemaVersion)
+	}
+}
+
+// NewImageManifest creates a new Image object for the given manifest string. Note that the manifest must
+// contain signatures if it is of schema 1.
+func NewImageForManifest(repoName string, rawManifest string, manifestConfig string, managedByOpenShift bool) (*imageapi.Image, error) {
+	var versioned manifest.Versioned
+	if err := json.Unmarshal([]byte(rawManifest), &versioned); err != nil {
+		return nil, err
+	}
+
+	_, desc, err := distribution.UnmarshalManifest(versioned.MediaType, []byte(rawManifest))
+	if err != nil {
+		return nil, err
+	}
+
+	annotations := make(map[string]string)
+	if managedByOpenShift {
+		annotations[imageapi.ManagedByOpenShiftAnnotation] = "true"
+	}
+
+	img := &imageapi.Image{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:        desc.Digest.String(),
+			Annotations: annotations,
+		},
+		DockerImageReference: fmt.Sprintf("localhost:5000/%s@%s", repoName, desc.Digest.String()),
+		DockerImageManifest:  rawManifest,
+		DockerImageConfig:    manifestConfig,
+	}
+
+	if err := imageapi.ImageWithMetadata(img); err != nil {
+		return nil, fmt.Errorf("failed to fill image with metadata: %v", err)
+	}
+
+	return img, nil
 }

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -455,9 +455,12 @@ func ImageWithMetadata(image *Image) error {
 	case 2:
 		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
 
+		if len(image.DockerImageConfig) == 0 {
+			return fmt.Errorf("dockerImageConfig must not be empty for manifest schema 2")
+		}
 		config := DockerImageConfig{}
 		if err := json.Unmarshal([]byte(image.DockerImageConfig), &config); err != nil {
-			return err
+			return fmt.Errorf("failed to parse dockerImageConfig: %v", err)
 		}
 
 		image.DockerImageLayers = make([]ImageLayer, len(manifest.Layers))

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -281,7 +281,7 @@ middleware:
 
 func putManifest(name, user, token string) (digest.Digest, error) {
 	creds := registryutil.NewBasicCredentialStore(user, token)
-	desc, _, err := registryutil.UploadTestBlob(&url.URL{Host: "127.0.0.1:5000", Scheme: "http"}, creds, testutil.Namespace()+"/"+name)
+	desc, _, err := registryutil.UploadRandomTestBlob(&url.URL{Host: "127.0.0.1:5000", Scheme: "http"}, creds, testutil.Namespace()+"/"+name)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Insecure istag now allows for insecure transport.

Resolves: [bz#1421954](https://bugzilla.redhat.com/show_bug.cgi?id=1421954)

This is a backport of #13114