### PR TITLE
Build integration tests (in addition to extended tests) as part of release process

### DIFF
--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -37,6 +37,7 @@ readonly OS_CROSS_COMPILE_TARGETS=(
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 
 readonly OS_TEST_TARGETS=(
+  test/integration/integration.test
   test/extended/extended.test
 )
 


### PR DESCRIPTION
Following on from e-mail thread about integration tests not being able to use Go 1.7 features.  This PR should ensure that integration tests are compiled within the release container as part of `make release`, just like extended tests are.