### PR TITLE
deploy: retry scaling when the admission caches are not fully synced

### DIFF
--- a/pkg/deploy/cmd/test/support.go
+++ b/pkg/deploy/cmd/test/support.go
@@ -3,6 +3,8 @@ package test
 import (
 	"fmt"
 
+	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl"
 )
 
@@ -22,4 +24,24 @@ func (t *FakeScaler) Scale(namespace, name string, newSize uint, preconditions *
 
 func (t *FakeScaler) ScaleSimple(namespace, name string, preconditions *kubectl.ScalePrecondition, newSize uint) (string, error) {
 	return "", fmt.Errorf("unexpected call to ScaleSimple")
+}
+
+type FakeLaggedScaler struct {
+	Events     []ScaleEvent
+	RetryCount int
+}
+
+func (t *FakeLaggedScaler) Scale(namespace, name string, newSize uint, preconditions *kubectl.ScalePrecondition, retry, wait *kubectl.RetryParams) error {
+	if t.RetryCount != 2 {
+		t.RetryCount += 1
+		// This is faking a real error from the
+		// "k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle" package.
+		return errors.NewForbidden(unversioned.GroupResource{Resource: "ReplicationController"}, name, fmt.Errorf("%s: not yet ready to handle request", name))
+	}
+	t.Events = append(t.Events, ScaleEvent{name, newSize})
+	return nil
+}
+
+func (t *FakeLaggedScaler) ScaleSimple(namespace, name string, preconditions *kubectl.ScalePrecondition, newSize uint) (string, error) {
+	return "", nil
 }


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1427992

This happens when the https://github.com/mfojtik/origin/blob/b83842eff0f6989f9735f483d4348ecc0d710ac7/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go#L112 occurs. That leads to immediate deployment failure without retry.

This pull should keep retrying for 30 seconds (can be higher maybe? @kargakis) with the assumption the caches will get warmed up eventually and the scaling succeed.