### PR TITLE
Improvements to secret injector

### DIFF
--- a/pkg/util/urlpattern/urlpattern.go
+++ b/pkg/util/urlpattern/urlpattern.go
@@ -12,7 +12,7 @@ var InvalidPatternError = errors.New("invalid pattern")
 
 var urlPatternRegex = regexp.MustCompile(`^` +
 	`(?:(\*|git|http|https|ssh)://)` +
-	`(\*|(?:\*\.)?[^/*]+)` +
+	`(\*|(?:\*\.)?[^@/*]+)` +
 	`(/.*)` +
 	`$`)
 

--- a/pkg/util/urlpattern/urlpattern_test.go
+++ b/pkg/util/urlpattern/urlpattern_test.go
@@ -44,7 +44,7 @@ func TestMatchPattern(t *testing.T) {
 			expectedScheme:   `^(git|http|https|ssh)$`,
 			expectedHost:     `^.*$`,
 			expectedPath:     `^/.*$`,
-			expectedMatch:    []string{`https://github.com/`},
+			expectedMatch:    []string{`https://github.com/`, `https://user:password@github.com/`, `ssh://git@github.com/`},
 			expectedNotMatch: []string{`ftp://github.com/`},
 		},
 		{
@@ -80,7 +80,7 @@ func TestMatchPattern(t *testing.T) {
 			expectedScheme:   `^https$`,
 			expectedHost:     `^github\.com$`,
 			expectedPath:     `^/.*$`,
-			expectedMatch:    []string{`https://github.com/`},
+			expectedMatch:    []string{`https://github.com/`, `https://user:password@github.com/`},
 			expectedNotMatch: []string{`https://test.github.com/`},
 		},
 		{
@@ -88,7 +88,7 @@ func TestMatchPattern(t *testing.T) {
 			expectedScheme: `^https$`,
 			expectedHost:   `^(?:.*\.)?github\.com$`,
 			expectedPath:   `^/.*$`,
-			expectedMatch:  []string{`https://github.com/`, `https://test.github.com/`},
+			expectedMatch:  []string{`https://github.com/`, `https://user:password@github.com/`, `https://test.github.com/`},
 		},
 		{
 			pattern:        `https://\.+?()|[]{}^$/*`,
@@ -106,6 +106,10 @@ func TestMatchPattern(t *testing.T) {
 		},
 		{
 			pattern:     `https://git*hub.com/*`,
+			expectedErr: true,
+		},
+		{
+			pattern:     `*://git@github.com/*`,
 			expectedErr: true,
 		},
 		{


### PR DESCRIPTION
Disallow @ character in host component of URL patterns, so that people don't mistakenly try to add URL patterns of the form user@host.

Extend admission controller to reject invalid URL patterns on secrets to provide early feedback to end users when their patterns are wrong.