### PR TITLE
Fixed blobdescriptorservice unit test flake

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -256,6 +256,33 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		},
 
 		{
+			name:     "delete manifest with repository unset",
+			method:   http.MethodDelete,
+			endpoint: v2.RouteNameManifest,
+			vars: []string{
+				"name", "user/app",
+				"reference", testImage.Name,
+			},
+			unsetRepository: true,
+			expectedStatus:  http.StatusInternalServerError,
+			// we don't allow to delete manifests from etcd; in this case, we attempt to delete layer link
+			expectedMethodInvocations: map[string]int{"Stat": 1},
+		},
+
+		{
+			name:     "delete manifest",
+			method:   http.MethodDelete,
+			endpoint: v2.RouteNameManifest,
+			vars: []string{
+				"name", "user/app",
+				"reference", testImage.Name,
+			},
+			expectedStatus: http.StatusNotFound,
+			// we don't allow to delete manifests from etcd; in this case, we attempt to delete layer link
+			expectedMethodInvocations: map[string]int{"Stat": 1},
+		},
+
+		{
 			name:     "get manifest with repository unset",
 			method:   http.MethodGet,
 			endpoint: v2.RouteNameManifest,
@@ -281,36 +308,6 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			// manifest is retrieved from etcd
 			expectedMethodInvocations: map[string]int{"Stat": 1},
-		},
-
-		{
-			name:     "delete manifest with repository unset",
-			method:   http.MethodDelete,
-			endpoint: v2.RouteNameManifest,
-			vars: []string{
-				"name", "user/app",
-				"reference", testImage.Name,
-			},
-			unsetRepository: true,
-			expectedStatus:  http.StatusInternalServerError,
-			// we don't allow to delete manifests from etcd; in this case, we attempt to delete layer link
-			expectedMethodInvocations: map[string]int{"Stat": 1},
-		},
-
-		{
-			name:     "delete manifest",
-			method:   http.MethodDelete,
-			endpoint: v2.RouteNameManifest,
-			vars: []string{
-				"name", "user/app",
-				"reference", testImage.Name,
-			},
-			expectedStatus: http.StatusAccepted,
-			// we don't allow to delete manifests from etcd; in this case, we attempt to delete layer link
-			expectedMethodInvocations: map[string]int{
-				"Stat":  1,
-				"Clear": 1,
-			},
 		},
 	} {
 		doTest(tc)

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -77,6 +77,11 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			"delete": configuration.Parameters{
 				"enabled": true,
 			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
+			},
 		},
 		Middleware: map[string][]configuration.Middleware{
 			"registry":   {{Name: "openshift"}},

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
@@ -31,7 +29,6 @@ import (
 func TestPullthroughServeBlob(t *testing.T) {
 	namespace, name := "user", "app"
 	repoName := fmt.Sprintf("%s/%s", namespace, name)
-	log.SetLevel(log.DebugLevel)
 	installFakeAccessController(t)
 	setPassthroughBlobDescriptorServiceFactory()
 
@@ -209,7 +206,6 @@ func TestPullthroughServeBlob(t *testing.T) {
 func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 	namespace, name := "user", "app"
 	repoName := fmt.Sprintf("%s/%s", namespace, name)
-	log.SetLevel(log.DebugLevel)
 	installFakeAccessController(t)
 	setPassthroughBlobDescriptorServiceFactory()
 
@@ -367,7 +363,6 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 	repo1Name := fmt.Sprintf("%s/%s", namespace, repo1)
 	repo2Name := fmt.Sprintf("%s/%s", namespace, repo2)
 
-	log.SetLevel(log.DebugLevel)
 	installFakeAccessController(t)
 	setPassthroughBlobDescriptorServiceFactory()
 

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
@@ -39,6 +37,11 @@ func createTestRegistryServer(t *testing.T, ctx context.Context) *httptest.Serve
 			"delete": configuration.Parameters{
 				"enabled": true,
 			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
+			},
 		},
 	})
 
@@ -59,7 +62,6 @@ func TestPullthroughManifests(t *testing.T) {
 	repoName := fmt.Sprintf("%s/%s", namespace, repo)
 	tag := "latest"
 
-	log.SetLevel(log.DebugLevel)
 	client := &testclient.Fake{}
 
 	installFakeAccessController(t)
@@ -179,7 +181,6 @@ func TestPullthroughManifestInsecure(t *testing.T) {
 	repo := "zapp"
 	repoName := fmt.Sprintf("%s/%s", namespace, repo)
 
-	log.SetLevel(log.DebugLevel)
 	installFakeAccessController(t)
 	setPassthroughBlobDescriptorServiceFactory()
 

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -40,6 +40,10 @@ const (
 	testImageLayerCount = 2
 )
 
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
 func TestRepositoryBlobStat(t *testing.T) {
 	quotaEnforcing = &quotaEnforcingConfig{}
 
@@ -326,7 +330,6 @@ func TestRepositoryBlobStat(t *testing.T) {
 }
 
 func TestRepositoryBlobStatCacheEviction(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
 	const blobRepoCacheTTL = time.Millisecond * 500
 
 	quotaEnforcing = &quotaEnforcingConfig{}

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -75,6 +75,11 @@ func TestSignatureGet(t *testing.T) {
 			"delete": configuration.Parameters{
 				"enabled": true,
 			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
+			},
 		},
 		Middleware: map[string][]configuration.Middleware{
 			"registry":   {{Name: "openshift"}},
@@ -172,6 +177,11 @@ func TestSignaturePut(t *testing.T) {
 			},
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"maintenance": configuration.Parameters{
+				"uploadpurging": map[interface{}]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{


### PR DESCRIPTION
Avoid a race when trying to delete just uploaded manifest. The purpose of the
test is just to verify that our blobdescriptorservice is in use.

Resolves #13288