### PR TITLE
Generate jUnit XML reports from hack/test-end-to-end.sh

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -12,6 +12,11 @@ unset KUBECONFIG
 os::util::environment::use_sudo
 os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
 
+# Allow setting $JUNIT_REPORT to toggle output behavior
+if [[ -n "${JUNIT_REPORT:-}" ]]; then
+	export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
+fi
+
 function cleanup()
 {
 	out=$?
@@ -44,6 +49,7 @@ function cleanup()
 	journalctl --unit docker.service --since -15minutes > "${LOG_DIR}/docker.log"
 
 	truncate_large_logs
+	os::test::junit::generate_oscmd_report
 	set -e
 
 	os::log::info "Exiting"

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -32,6 +32,7 @@ function cleanup()
 	echo
 
 	cleanup_openshift
+	os::test::junit::generate_oscmd_report
 	os::log::info "Exiting"
 	ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
 	exit $out
@@ -44,6 +45,11 @@ trap "cleanup" EXIT
 # Start All-in-one server and wait for health
 os::util::environment::use_sudo
 os::util::environment::setup_all_server_vars "test-end-to-end/"
+
+# Allow setting $JUNIT_REPORT to toggle output behavior
+if [[ -n "${JUNIT_REPORT:-}" ]]; then
+	export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
+fi
 
 os::log::system::start
 


### PR DESCRIPTION
The convention of setting `${JUNIT_REPORT}` to enable the jUnit XML
report generation was never being followed in the end-to-end scripts in
the past. This led to no jUnit reports ever being generated for these
tests.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>