### PR TITLE
Revert "CGO_ENABLED prevents build cache reuse"

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -237,7 +237,7 @@ os::build::internal::build_binaries() {
       for test in "${tests[@]:+${tests[@]}}"; do
         local outfile="${OS_OUTPUT_BINPATH}/${platform}/$(basename ${test})"
         # disabling cgo allows use of delve
-        CGO_ENABLED="${OS_TEST_CGO_ENABLED:-}" GOOS=${platform%/*} GOARCH=${platform##*/} go test \
+        CGO_ENABLED=0 GOOS=${platform%/*} GOARCH=${platform##*/} go test \
           -pkgdir "${OS_OUTPUT_PKGDIR}/${platform}" \
           -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_test_envvar:-}" \
           -ldflags "${version_ldflags}" \

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -26,11 +26,6 @@ name="$(basename ${package})"
 dlv_debug="${DLV_DEBUG:-}"
 verbose="${VERBOSE:-}"
 
-# CGO must be disabled in order to debug
-if [[ -n "${dlv_debug}" ]]; then
-	export OS_TEST_CGO_ENABLED=0
-fi
-
 # build the test executable
 if [[ -n "${OPENSHIFT_SKIP_BUILD:-}" ]]; then
   os::log::warning "Skipping build due to OPENSHIFT_SKIP_BUILD"


### PR DESCRIPTION
Reverts openshift/origin#13291

[test]
[test_install]
