### PR TITLE
Use a very high patch number on RPM release builds

### DIFF
--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -26,7 +26,7 @@ if [[ "${OS_GIT_VERSION}" =~ ^v([0-9](\.[0-9]+)*)(.*) ]]; then
 	# provided by the Origin build scripts to the
 	# version that RPM will expect.
 	rpm_version="${BASH_REMATCH[1]}"
-	rpm_release="0${BASH_REMATCH[3]//-/.}"
+	rpm_release="999${BASH_REMATCH[3]//-/.}"
 fi
 tito tag --use-version="${rpm_version}" \
          --use-release="${rpm_release}" \


### PR DESCRIPTION
Until we solidify logic for programmatically bumping the version that we
are building in an RPM release flow, we can just use a very high patch
amount in order to ensure that the release artifacts we build are not in
competition with others that may be available to the host.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]
[merge]