### PR TITLE
Disable IngressConfiguredRouter test

### DIFF
--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1891,6 +1891,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 
 // TestRouterIngress validates that an ingress resource can configure a router to expose a tls route.
 func TestIngressConfiguredRouter(t *testing.T) {
+	t.Skip()
 	enableIngress := true
 	// Enable namespace filtering to allow validation of compatibility with ingress.
 	namespaceNames := []string{defaultNamespace}


### PR DESCRIPTION
We need to be compiling the integration tests using `hack/env` in order
to do so under Go 1.7, as that is newer than the newest versions of Go
that are available on RHEL. This test has not been configured correctly
in order to work inside of a container, so it must be disables for the
time being until it can operate inside of the `hack/env` container.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @deads2k @smarterclayton @knobunc 