### PR TITLE
Fix TestNewAppSourceAuthRequired integration test flake

### DIFF
--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -1929,7 +1929,12 @@ func setupLocalGitRepo(t *testing.T, passwordProtected bool, requireProxy bool) 
 	}
 
 	// Set initial repo contents
-	gitRepo := git.NewRepository()
+	gitRepo := git.NewRepositoryWithEnv([]string{
+		"GIT_AUTHOR_NAME=developer",
+		"GIT_AUTHOR_EMAIL=developer@example.com",
+		"GIT_COMMITTER_NAME=developer",
+		"GIT_COMMITTER_EMAIL=developer@example.com",
+	})
 	if err = gitRepo.Init(initialRepoDir, false); err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Adds git environment variables so test doesn't rely on a valid
user/e-mail being present in the machine running the test.

Fixes #13328