### PR TITLE
Add conversions from RBAC resources to origin resources

### DIFF
--- a/pkg/authorization/api/conversion.go
+++ b/pkg/authorization/api/conversion.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/user/api/validation"
+)
+
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddConversionFuncs(
+		Convert_api_ClusterRole_To_rbac_ClusterRole,
+		Convert_api_Role_To_rbac_Role,
+		Convert_api_ClusterRoleBinding_To_rbac_ClusterRoleBinding,
+		Convert_api_RoleBinding_To_rbac_RoleBinding,
+		Convert_rbac_ClusterRole_To_api_ClusterRole,
+		Convert_rbac_Role_To_api_Role,
+		Convert_rbac_ClusterRoleBinding_To_api_ClusterRoleBinding,
+		Convert_rbac_RoleBinding_To_api_RoleBinding,
+	); err != nil { // If one of the conversion functions is malformed, detect it immediately.
+		return err
+	}
+	return nil
+}
+
+func Convert_api_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac.ClusterRole, _ conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	out.Rules = convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
+	return nil
+}
+
+func Convert_api_Role_To_rbac_Role(in *Role, out *rbac.Role, _ conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	out.Rules = convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
+	return nil
+}
+
+func Convert_api_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *ClusterRoleBinding, out *rbac.ClusterRoleBinding, _ conversion.Scope) error {
+	var err error
+	if out.Subjects, err = convert_api_Subjects_To_rbac_Subjects(in.Subjects); err != nil {
+		return err
+	}
+	out.RoleRef = convert_api_RoleRef_To_rbac_RoleRef(&in.RoleRef)
+	out.ObjectMeta = in.ObjectMeta
+	return nil
+}
+
+func Convert_api_RoleBinding_To_rbac_RoleBinding(in *RoleBinding, out *rbac.RoleBinding, _ conversion.Scope) error {
+	if len(in.RoleRef.Namespace) != 0 && in.RoleRef.Namespace != in.Namespace {
+		return fmt.Errorf("invalid origin role binding %s: attempts to reference role in namespace %q instead of current namespace %q", in.Name, in.RoleRef.Namespace, in.Namespace)
+	}
+	var err error
+	if out.Subjects, err = convert_api_Subjects_To_rbac_Subjects(in.Subjects); err != nil {
+		return err
+	}
+	out.RoleRef = convert_api_RoleRef_To_rbac_RoleRef(&in.RoleRef)
+	out.ObjectMeta = in.ObjectMeta
+	return nil
+}
+
+func convert_api_PolicyRules_To_rbac_PolicyRules(in []PolicyRule) []rbac.PolicyRule {
+	rules := make([]rbac.PolicyRule, 0, len(in))
+	for _, rule := range in {
+		// Origin's authorizer's RuleMatches func ignores rules that have AttributeRestrictions.
+		// Since we know this rule will never be respected in Origin, we do not preserve it during conversion.
+		if rule.AttributeRestrictions != nil {
+			continue
+		}
+		r := rbac.PolicyRule{
+			APIGroups:       rule.APIGroups,
+			Verbs:           rule.Verbs.List(),
+			Resources:       rule.Resources.List(),
+			ResourceNames:   rule.ResourceNames.List(),
+			NonResourceURLs: rule.NonResourceURLs.List(),
+		}
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+func convert_api_Subjects_To_rbac_Subjects(in []api.ObjectReference) ([]rbac.Subject, error) {
+	subjects := make([]rbac.Subject, 0, len(in))
+	for _, subject := range in {
+		s := rbac.Subject{
+			Name:       subject.Name,
+			APIVersion: rbac.GroupName,
+		}
+
+		switch subject.Kind {
+		case ServiceAccountKind:
+			s.Kind = rbac.ServiceAccountKind
+			s.Namespace = subject.Namespace
+		case UserKind, SystemUserKind:
+			s.Kind = rbac.UserKind
+		case GroupKind, SystemGroupKind:
+			s.Kind = rbac.GroupKind
+		default:
+			return nil, fmt.Errorf("invalid kind for origin subject: %q", subject.Kind)
+		}
+
+		subjects = append(subjects, s)
+	}
+	return subjects, nil
+}
+
+func convert_api_RoleRef_To_rbac_RoleRef(in *api.ObjectReference) rbac.RoleRef {
+	return rbac.RoleRef{
+		APIGroup: rbac.GroupName,
+		Kind:     getRBACRoleRefKind(in.Namespace),
+		Name:     in.Name,
+	}
+}
+
+// Infers the scope of the kind based on the presence of the namespace
+func getRBACRoleRefKind(namespace string) string {
+	kind := "ClusterRole"
+	if len(namespace) != 0 {
+		kind = "Role"
+	}
+	return kind
+}
+
+func Convert_rbac_ClusterRole_To_api_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, _ conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	out.Rules = convert_rbac_PolicyRules_To_api_PolicyRules(in.Rules)
+	return nil
+}
+
+func Convert_rbac_Role_To_api_Role(in *rbac.Role, out *Role, _ conversion.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+	out.Rules = convert_rbac_PolicyRules_To_api_PolicyRules(in.Rules)
+	return nil
+}
+
+func Convert_rbac_ClusterRoleBinding_To_api_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *ClusterRoleBinding, _ conversion.Scope) error {
+	var err error
+	if out.Subjects, err = convert_rbac_Subjects_To_api_Subjects(in.Subjects); err != nil {
+		return err
+	}
+	out.RoleRef = convert_rbac_RoleRef_To_api_RoleRef(&in.RoleRef, "")
+	out.ObjectMeta = in.ObjectMeta
+	return nil
+}
+
+func Convert_rbac_RoleBinding_To_api_RoleBinding(in *rbac.RoleBinding, out *RoleBinding, _ conversion.Scope) error {
+	var err error
+	if out.Subjects, err = convert_rbac_Subjects_To_api_Subjects(in.Subjects); err != nil {
+		return err
+	}
+	out.RoleRef = convert_rbac_RoleRef_To_api_RoleRef(&in.RoleRef, in.Namespace)
+	out.ObjectMeta = in.ObjectMeta
+	return nil
+}
+
+func convert_rbac_Subjects_To_api_Subjects(in []rbac.Subject) ([]api.ObjectReference, error) {
+	subjects := make([]api.ObjectReference, 0, len(in))
+	for _, subject := range in {
+		s := api.ObjectReference{
+			Name: subject.Name,
+		}
+
+		switch subject.Kind {
+		case rbac.ServiceAccountKind:
+			s.Kind = ServiceAccountKind
+			s.Namespace = subject.Namespace
+		case rbac.UserKind:
+			s.Kind = determineUserKind(subject.Name, validation.ValidateUserName)
+		case rbac.GroupKind:
+			s.Kind = determineGroupKind(subject.Name, validation.ValidateGroupName)
+		default:
+			return nil, fmt.Errorf("invalid kind for rbac subject: %q", subject.Kind)
+		}
+
+		subjects = append(subjects, s)
+	}
+	return subjects, nil
+}
+
+// rbac.RoleRef has no namespace field since that can be inferred.
+// The Origin role ref (api.ObjectReference) requires its namespace value to match the binding's namespace.
+// Thus we have to explicitly provide that value as a parameter.
+func convert_rbac_RoleRef_To_api_RoleRef(in *rbac.RoleRef, namespace string) api.ObjectReference {
+	return api.ObjectReference{
+		Name:      in.Name,
+		Namespace: namespace,
+	}
+}
+
+func convert_rbac_PolicyRules_To_api_PolicyRules(in []rbac.PolicyRule) []PolicyRule {
+	rules := make([]PolicyRule, 0, len(in))
+	for _, rule := range in {
+		r := PolicyRule{
+			APIGroups:       rule.APIGroups,
+			Verbs:           sets.NewString(rule.Verbs...),
+			Resources:       sets.NewString(rule.Resources...),
+			ResourceNames:   sets.NewString(rule.ResourceNames...),
+			NonResourceURLs: sets.NewString(rule.NonResourceURLs...),
+		}
+		rules = append(rules, r)
+	}
+	return rules
+}

--- a/pkg/authorization/api/conversion_test.go
+++ b/pkg/authorization/api/conversion_test.go
@@ -1,0 +1,362 @@
+package api_test // prevent import cycle between authorizationapi and rulevalidation
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/diff"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
+
+	"github.com/google/gofuzz"
+)
+
+// make sure rbac <-> origin round trip does not lose any data
+
+func TestOriginClusterRoleFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ocr := &authorizationapi.ClusterRole{}
+		ocr2 := &authorizationapi.ClusterRole{}
+		rcr := &rbac.ClusterRole{}
+		fuzzer.Fuzz(ocr)
+		if err := authorizationapi.Convert_api_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_rbac_ClusterRole_To_api_ClusterRole(rcr, ocr2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ocr, ocr2) {
+			t.Errorf("origin cluster data not preserved; the diff is %s", diff.ObjectDiff(ocr, ocr2))
+		}
+	}
+}
+
+func TestOriginRoleFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		or := &authorizationapi.Role{}
+		or2 := &authorizationapi.Role{}
+		rr := &rbac.Role{}
+		fuzzer.Fuzz(or)
+		if err := authorizationapi.Convert_api_Role_To_rbac_Role(or, rr, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_rbac_Role_To_api_Role(rr, or2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(or, or2) {
+			t.Errorf("origin local data not preserved; the diff is %s", diff.ObjectDiff(or, or2))
+		}
+	}
+}
+
+func TestOriginClusterRoleBindingFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ocrb := &authorizationapi.ClusterRoleBinding{}
+		ocrb2 := &authorizationapi.ClusterRoleBinding{}
+		rcrb := &rbac.ClusterRoleBinding{}
+		fuzzer.Fuzz(ocrb)
+		if err := authorizationapi.Convert_api_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_rbac_ClusterRoleBinding_To_api_ClusterRoleBinding(rcrb, ocrb2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ocrb, ocrb2) {
+			t.Errorf("origin cluster binding data not preserved; the diff is %s", diff.ObjectDiff(ocrb, ocrb2))
+		}
+	}
+}
+
+func TestOriginRoleBindingFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		orb := &authorizationapi.RoleBinding{}
+		orb2 := &authorizationapi.RoleBinding{}
+		rrb := &rbac.RoleBinding{}
+		fuzzer.Fuzz(orb)
+		if err := authorizationapi.Convert_api_RoleBinding_To_rbac_RoleBinding(orb, rrb, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_rbac_RoleBinding_To_api_RoleBinding(rrb, orb2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(orb, orb2) {
+			t.Errorf("origin local binding data not preserved; the diff is %s", diff.ObjectDiff(orb, orb2))
+		}
+	}
+}
+
+func TestRBACClusterRoleFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rcr := &rbac.ClusterRole{}
+		rcr2 := &rbac.ClusterRole{}
+		ocr := &authorizationapi.ClusterRole{}
+		fuzzer.Fuzz(rcr)
+		if err := authorizationapi.Convert_rbac_ClusterRole_To_api_ClusterRole(rcr, ocr, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_api_ClusterRole_To_rbac_ClusterRole(ocr, rcr2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(rcr, rcr2) {
+			t.Errorf("rbac cluster data not preserved; the diff is %s", diff.ObjectDiff(rcr, rcr2))
+		}
+	}
+}
+
+func TestRBACRoleFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rr := &rbac.Role{}
+		rr2 := &rbac.Role{}
+		or := &authorizationapi.Role{}
+		fuzzer.Fuzz(rr)
+		if err := authorizationapi.Convert_rbac_Role_To_api_Role(rr, or, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_api_Role_To_rbac_Role(or, rr2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(rr, rr2) {
+			t.Errorf("rbac local data not preserved; the diff is %s", diff.ObjectDiff(rr, rr2))
+		}
+	}
+}
+
+func TestRBACClusterRoleBindingFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rcrb := &rbac.ClusterRoleBinding{}
+		rcrb2 := &rbac.ClusterRoleBinding{}
+		ocrb := &authorizationapi.ClusterRoleBinding{}
+		fuzzer.Fuzz(rcrb)
+		if err := authorizationapi.Convert_rbac_ClusterRoleBinding_To_api_ClusterRoleBinding(rcrb, ocrb, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_api_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(rcrb, rcrb2) {
+			t.Errorf("rbac cluster binding data not preserved; the diff is %s", diff.ObjectDiff(rcrb, rcrb2))
+		}
+	}
+}
+
+func TestRBACRoleBindingFidelity(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		rrb := &rbac.RoleBinding{}
+		rrb2 := &rbac.RoleBinding{}
+		orb := &authorizationapi.RoleBinding{}
+		fuzzer.Fuzz(rrb)
+		if err := authorizationapi.Convert_rbac_RoleBinding_To_api_RoleBinding(rrb, orb, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := authorizationapi.Convert_api_RoleBinding_To_rbac_RoleBinding(orb, rrb2, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(rrb, rrb2) {
+			t.Errorf("rbac local binding data not preserved; the diff is %s", diff.ObjectDiff(rrb, rrb2))
+		}
+	}
+}
+
+func TestConversionErrors(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		expected string
+		f        func() error
+	}{
+		{
+			name:     "invalid origin role ref",
+			expected: `invalid origin role binding rolebindingname: attempts to reference role in namespace "ns1" instead of current namespace "ns0"`,
+			f: func() error {
+				return authorizationapi.Convert_api_RoleBinding_To_rbac_RoleBinding(&authorizationapi.RoleBinding{
+					ObjectMeta: api.ObjectMeta{Name: "rolebindingname", Namespace: "ns0"},
+					RoleRef:    api.ObjectReference{Namespace: "ns1"},
+				}, &rbac.RoleBinding{}, nil)
+			},
+		},
+		{
+			name:     "invalid origin subject kind",
+			expected: `invalid kind for origin subject: "fancyuser"`,
+			f: func() error {
+				return authorizationapi.Convert_api_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&authorizationapi.ClusterRoleBinding{
+					Subjects: []api.ObjectReference{
+						{Kind: "fancyuser"},
+					},
+				}, &rbac.ClusterRoleBinding{}, nil)
+			},
+		},
+		{
+			name:     "invalid RBAC subject kind",
+			expected: `invalid kind for rbac subject: "evenfancieruser"`,
+			f: func() error {
+				return authorizationapi.Convert_rbac_ClusterRoleBinding_To_api_ClusterRoleBinding(&rbac.ClusterRoleBinding{
+					Subjects: []rbac.Subject{
+						{Kind: "evenfancieruser"},
+					},
+				}, &authorizationapi.ClusterRoleBinding{}, nil)
+			},
+		},
+	} {
+		if err := test.f(); err == nil || test.expected != err.Error() {
+			t.Errorf("%s failed: expected %q got %v", test.name, test.expected, err)
+		}
+	}
+}
+
+// rules with AttributeRestrictions should not be preserved during conversion
+func TestAttributeRestrictionsRuleLoss(t *testing.T) {
+	ocr := &authorizationapi.ClusterRole{
+		Rules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("get"), Resources: sets.NewString("a")},
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("b"), AttributeRestrictions: &authorizationapi.Role{}},
+			{Verbs: sets.NewString("update"), Resources: sets.NewString("c")},
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("d"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		},
+	}
+	ocr2 := &authorizationapi.ClusterRole{}
+	rcr := &rbac.ClusterRole{}
+	if err := authorizationapi.Convert_api_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorizationapi.Convert_rbac_ClusterRole_To_api_ClusterRole(rcr, ocr2, nil); err != nil {
+		t.Fatal(err)
+	}
+	if covered, uncoveredRules := rulevalidation.Covers(ocr.Rules, ocr2.Rules); !covered {
+		t.Errorf("input rules expected AttributeRestrictions loss not seen; the uncovered rules are %#v", uncoveredRules)
+	}
+	if covered, uncoveredRules := rulevalidation.Covers(ocr2.Rules, ocr.Rules); !covered {
+		t.Errorf("output rules expected AttributeRestrictions loss not seen; the uncovered rules are %#v", uncoveredRules)
+	}
+}
+
+var fuzzer = fuzz.New().NilChance(0).Funcs(
+	func(*unversioned.TypeMeta, fuzz.Continue) {}, // Ignore TypeMeta
+	func(*runtime.Object, fuzz.Continue) {},       // Ignore AttributeRestrictions since they are deprecated
+	func(ocrb *authorizationapi.ClusterRoleBinding, c fuzz.Continue) {
+		c.FuzzNoCustom(ocrb)
+		setRandomOriginRoleBindingData(ocrb.Subjects, &ocrb.RoleRef, "", c)
+	},
+	func(orb *authorizationapi.RoleBinding, c fuzz.Continue) {
+		c.FuzzNoCustom(orb)
+		setRandomOriginRoleBindingData(orb.Subjects, &orb.RoleRef, orb.Namespace, c)
+	},
+	func(rcrb *rbac.ClusterRoleBinding, c fuzz.Continue) {
+		c.FuzzNoCustom(rcrb)
+		setRandomRBACRoleBindingData(rcrb.Subjects, &rcrb.RoleRef, "", c)
+	},
+	func(rrb *rbac.RoleBinding, c fuzz.Continue) {
+		c.FuzzNoCustom(rrb)
+		setRandomRBACRoleBindingData(rrb.Subjects, &rrb.RoleRef, rrb.Namespace, c)
+	},
+	func(rr *rbac.Role, c fuzz.Continue) {
+		c.FuzzNoCustom(rr)
+		sortAndDeduplicateRBACRulesFields(rr.Rules) // []string <-> sets.String
+	},
+	func(rcr *rbac.ClusterRole, c fuzz.Continue) {
+		c.FuzzNoCustom(rcr)
+		sortAndDeduplicateRBACRulesFields(rcr.Rules) // []string <-> sets.String
+	},
+)
+
+func setRandomRBACRoleBindingData(subjects []rbac.Subject, roleRef *rbac.RoleRef, namespace string, c fuzz.Continue) {
+	for i := range subjects {
+		subject := &subjects[i]
+		subject.APIVersion = rbac.GroupName
+		setValidRBACKindAndNamespace(subject, i, c)
+	}
+	roleRef.APIGroup = rbac.GroupName
+	roleRef.Kind = getRBACRoleRefKind(namespace)
+}
+
+func setValidRBACKindAndNamespace(subject *rbac.Subject, i int, c fuzz.Continue) {
+	kinds := []string{rbac.UserKind, rbac.GroupKind, rbac.ServiceAccountKind}
+	kind := kinds[c.Intn(len(kinds))]
+	subject.Kind = kind
+
+	if subject.Kind != rbac.ServiceAccountKind {
+		subject.Namespace = ""
+	} else {
+		if len(validation.ValidateServiceAccountName(subject.Name, false)) != 0 {
+			subject.Name = fmt.Sprintf("sanamehere%d", i)
+		}
+	}
+}
+
+func setRandomOriginRoleBindingData(subjects []api.ObjectReference, roleRef *api.ObjectReference, namespace string, c fuzz.Continue) {
+	for i := range subjects {
+		subject := &subjects[i]
+		unsetUnusedOriginFields(subject)
+		setValidOriginKindAndNamespace(subject, i, c)
+	}
+	unsetUnusedOriginFields(roleRef)
+	roleRef.Kind = ""
+	roleRef.Namespace = namespace
+}
+
+func setValidOriginKindAndNamespace(subject *api.ObjectReference, i int, c fuzz.Continue) {
+	kinds := []string{authorizationapi.UserKind, authorizationapi.SystemUserKind, authorizationapi.GroupKind, authorizationapi.SystemGroupKind, authorizationapi.ServiceAccountKind}
+	kind := kinds[c.Intn(len(kinds))]
+	subject.Kind = kind
+
+	if subject.Kind != authorizationapi.ServiceAccountKind {
+		subject.Namespace = ""
+	}
+
+	switch subject.Kind {
+
+	case authorizationapi.UserKind:
+		if len(uservalidation.ValidateUserName(subject.Name, false)) != 0 {
+			subject.Name = fmt.Sprintf("validusername%d", i)
+		}
+
+	case authorizationapi.GroupKind:
+		if len(uservalidation.ValidateGroupName(subject.Name, false)) != 0 {
+			subject.Name = fmt.Sprintf("validgroupname%d", i)
+		}
+
+	case authorizationapi.SystemUserKind, authorizationapi.SystemGroupKind:
+		subject.Name = ":" + subject.Name
+
+	case authorizationapi.ServiceAccountKind:
+		if len(validation.ValidateServiceAccountName(subject.Name, false)) != 0 {
+			subject.Name = fmt.Sprintf("sanamehere%d", i)
+		}
+
+	default:
+		panic("invalid kind")
+	}
+}
+
+func unsetUnusedOriginFields(ref *api.ObjectReference) {
+	ref.UID = ""
+	ref.ResourceVersion = ""
+	ref.FieldPath = ""
+	ref.APIVersion = ""
+}
+
+func sortAndDeduplicateRBACRulesFields(in []rbac.PolicyRule) {
+	for i := range in {
+		rule := &in[i]
+		rule.Verbs = sets.NewString(rule.Verbs...).List()
+		rule.Resources = sets.NewString(rule.Resources...).List()
+		rule.ResourceNames = sets.NewString(rule.ResourceNames...).List()
+		rule.NonResourceURLs = sets.NewString(rule.NonResourceURLs...).List()
+	}
+}
+
+// copied from authorizationapi since it is a private helper and we need to test in a different package to prevent an import cycle
+func getRBACRoleRefKind(namespace string) string {
+	kind := "ClusterRole"
+	if len(namespace) != 0 {
+		kind = "Role"
+	}
+	return kind
+}

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -164,24 +164,32 @@ func BuildSubjects(users, groups []string, userNameValidator, groupNameValidator
 			continue
 		}
 
-		kind := UserKind
-		if len(userNameValidator(user, false)) != 0 {
-			kind = SystemUserKind
-		}
-
+		kind := determineUserKind(user, userNameValidator)
 		subjects = append(subjects, kapi.ObjectReference{Kind: kind, Name: user})
 	}
 
 	for _, group := range groups {
-		kind := GroupKind
-		if len(groupNameValidator(group, false)) != 0 {
-			kind = SystemGroupKind
-		}
-
+		kind := determineGroupKind(group, groupNameValidator)
 		subjects = append(subjects, kapi.ObjectReference{Kind: kind, Name: group})
 	}
 
 	return subjects
+}
+
+func determineUserKind(user string, userNameValidator validation.ValidateNameFunc) string {
+	kind := UserKind
+	if len(userNameValidator(user, false)) != 0 {
+		kind = SystemUserKind
+	}
+	return kind
+}
+
+func determineGroupKind(group string, groupNameValidator validation.ValidateNameFunc) string {
+	kind := GroupKind
+	if len(groupNameValidator(group, false)) != 0 {
+		kind = SystemGroupKind
+	}
+	return kind
 }
 
 // StringSubjectsFor returns users and groups for comparison against user.Info.  currentNamespace is used to

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -19,7 +19,7 @@ var (
 	LegacySchemeBuilder    = runtime.NewSchemeBuilder(addLegacyKnownTypes)
 	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
 
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addConversionFuncs)
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -177,7 +177,6 @@ func (userEvaluator) ResolveRules(scope, namespace string, clusterPolicyGetter c
 	case UserAccessCheck:
 		return []authorizationapi.PolicyRule{
 			authorizationapi.NewRule("create").Groups(kauthorizationapi.GroupName).Resources("selfsubjectaccessreviews").RuleOrDie(),
-			{Verbs: sets.NewString("create"), APIGroups: []string{authorizationapi.GroupName, authorizationapi.LegacyGroupName}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			authorizationapi.NewRule("create").Groups(authorizationapi.GroupName, authorizationapi.LegacyGroupName).Resources("selfsubjectrulesreviews").RuleOrDie(),
 		}, nil
 	case UserListScopedProjects:

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -45,12 +45,12 @@ func TestUserEvaluator(t *testing.T) {
 		{
 			name:     "access",
 			scopes:   []string{UserAccessCheck},
-			numRules: 4,
+			numRules: 3,
 		},
 		{
 			name:     "both",
 			scopes:   []string{UserInfo, UserAccessCheck},
-			numRules: 5,
+			numRules: 4,
 		},
 		{
 			name:     "list--scoped-projects",

--- a/pkg/authorization/rulevalidation/policy_comparator_test.go
+++ b/pkg/authorization/rulevalidation/policy_comparator_test.go
@@ -411,6 +411,118 @@ func TestMixedResourceNonResourceUncovered(t *testing.T) {
 	}.test(t)
 }
 
+func TestAttributeRestrictionsCovering(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+			{Verbs: sets.NewString("update"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+			{Verbs: sets.NewString("update"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("pods")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+			{Verbs: sets.NewString("update"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.ClusterRole{}},
+			{Verbs: sets.NewString("impersonate"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.ClusterPolicyBinding{}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString(authorizationapi.VerbAll), Resources: sets.NewString(authorizationapi.ResourceAll), AttributeRestrictions: &authorizationapi.Role{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+			{Verbs: sets.NewString("update"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.ClusterRole{}},
+			{Verbs: sets.NewString("impersonate"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.ClusterPolicyBinding{}},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("create"), Resources: sets.NewString("builds")},
+		},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.Role{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds")},
+		},
+	}.test(t)
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString(authorizationapi.VerbAll), Resources: sets.NewString(authorizationapi.ResourceAll), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: sets.NewString("delete"), Resources: sets.NewString("builds")},
+		},
+	}.test(t)
+}
+
 func (test escalationTest) test(t *testing.T) {
 	actualCovered, actualUncoveredRules := Covers(test.ownerRules, test.servantRules)
 

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -476,7 +476,6 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("list").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				authorizationapi.NewRule("list", "watch").Groups(projectGroup, legacyProjectGroup).Resources("projects").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(authzGroup, legacyAuthzGroup).Resources("selfsubjectrulesreviews").RuleOrDie(),
-				{Verbs: sets.NewString("create"), APIGroups: []string{authzGroup, legacyAuthzGroup}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 				authorizationapi.NewRule("create").Groups(kAuthzGroup).Resources("selfsubjectaccessreviews").RuleOrDie(),
 			},
 		},
@@ -489,7 +488,6 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				authorizationapi.NewRule("create").Groups(authzGroup, legacyAuthzGroup).Resources("selfsubjectrulesreviews").RuleOrDie(),
-				{Verbs: sets.NewString("create"), APIGroups: []string{authzGroup, legacyAuthzGroup}, Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 				authorizationapi.NewRule("create").Groups(kAuthzGroup).Resources("selfsubjectaccessreviews").RuleOrDie(),
 			},
 		},

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1631,17 +1631,6 @@ items:
     verbs:
     - create
   - apiGroups:
-    - authorization.openshift.io
-    - ""
-    attributeRestrictions:
-      apiVersion: authorization.openshift.io/v1
-      kind: IsPersonalSubjectAccessReview
-    resources:
-    - localsubjectaccessreviews
-    - subjectaccessreviews
-    verbs:
-    - create
-  - apiGroups:
     - authorization.k8s.io
     attributeRestrictions: null
     resources:
@@ -1662,17 +1651,6 @@ items:
     attributeRestrictions: null
     resources:
     - selfsubjectrulesreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.openshift.io
-    - ""
-    attributeRestrictions:
-      apiVersion: authorization.openshift.io/v1
-      kind: IsPersonalSubjectAccessReview
-    resources:
-    - localsubjectaccessreviews
-    - subjectaccessreviews
     verbs:
     - create
   - apiGroups:


### PR DESCRIPTION
Trello ref: https://trello.com/c/viECLnNa

@deads2k It would probably take ~3 conversions to build a semantic compare function - assuming `unsetUnpreservedFields` and `sortAndDeduplicateRulesFields` do not invalidate the tests.

cc @liggitt 

Signed-off-by: Monis Khan <mkhan@redhat.com>