### PR TITLE
Fix pkg/generate/git for Go 1.8

### DIFF
--- a/pkg/generate/git/git.go
+++ b/pkg/generate/git/git.go
@@ -21,13 +21,14 @@ import (
 // - ssh
 func ParseRepository(s string) (*url.URL, error) {
 	uri, err := url.Parse(s)
-	if err != nil {
-		return nil, err
+	if err == nil && uri.Scheme != "" && uri.Host != "" {
+		return uri, nil
 	}
 
 	// There are some shortcomings with url.Parse when it comes to GIT, namely wrt
 	// the GIT local/file and ssh protocols - it does not handle implied schema (i.e. no <proto>:// prefix)well;
 	// We handle those caveats here
+	uri = new(url.URL)
 	err = s2igit.New(s2iutil.NewFileSystem()).MungeNoProtocolURL(s, uri)
 	if err != nil {
 		return nil, err

--- a/pkg/generate/git/git_test.go
+++ b/pkg/generate/git/git_test.go
@@ -93,12 +93,18 @@ func TestParseRepository(t *testing.T) {
 			User:   url.User("git"),
 			Path:   "/repository.git",
 		},
+		"example.com:3000": {
+			Scheme: "ssh",
+			Host:   "example.com",
+			Path:   "3000",
+		},
 	}
 
 	for scenario, want := range tests {
 		got, err := ParseRepository(scenario)
 		if err != nil {
 			t.Errorf("ParseRepository returned err: %v", err)
+			continue
 		}
 
 		// go1.5 added the RawPath field to url.URL; it is not a field we need to manipulate with the
@@ -112,6 +118,19 @@ func TestParseRepository(t *testing.T) {
 			(got.User == nil && want.User != nil) ||
 			(got.User != nil && want.User == nil) {
 			t.Errorf("%s: got %#v, want %#v", scenario, *got, want)
+		}
+	}
+}
+
+func TestParseRepositoryError(t *testing.T) {
+	invalidRepos := []string{
+		"invalid-repo",
+		"git@example.com/foo",
+	}
+	for _, s := range invalidRepos {
+		uri, err := ParseRepository(s)
+		if err == nil {
+			t.Errorf("%s: got %v, want error", s, uri)
 		}
 	}
 }


### PR DESCRIPTION
Go 1.8 has stricter [URL parser][1] which no longer accepts `git@example.com:my-repo.git`.

[1]: https://golang.org/doc/go1.8#net_url