### PR TITLE
Disable CLI tests in the e2e suite

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -378,28 +378,30 @@ os::cmd::expect_success 'oc login -u e2e-user'
 os::cmd::expect_success 'oc project test'
 os::cmd::expect_success 'oc whoami'
 
-os::log::info "Running a CLI command in a container using the service account"
-os::cmd::expect_success 'oc policy add-role-to-user view -z default'
-os::cmd::try_until_success "oc sa get-token default"
-oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-set -o errexit
-os::cmd::expect_success 'oc delete pod cli-with-token'
-oc run cli-with-token-2 --attach --image="openshift/origin:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
-set -o errexit
-os::cmd::expect_success 'oc delete pod cli-with-token-2'
-oc run kubectl-with-token --attach --image="openshift/origin:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-# TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-set +o errexit
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
-os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
-set -o errexit
+if [[ -n "${SOLTYSH_DEBUG:-}" ]]; then
+    os::log::info "Running a CLI command in a container using the service account"
+    os::cmd::expect_success 'oc policy add-role-to-user view -z default'
+    os::cmd::try_until_success "oc sa get-token default"
+    oc run cli-with-token --attach --image="openshift/origin:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
+    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+    set +o errexit
+    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+    set -o errexit
+    os::cmd::expect_success 'oc delete pod cli-with-token'
+    oc run cli-with-token-2 --attach --image="openshift/origin:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
+    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+    set +o errexit
+    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+    set -o errexit
+    os::cmd::expect_success 'oc delete pod cli-with-token-2'
+    oc run kubectl-with-token --attach --image="openshift/origin:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
+    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
+    set +o errexit
+    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
+    set -o errexit
+fi
 
 os::log::info "Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors


### PR DESCRIPTION
When these test run today, they generate jUnit. Even if they do not
cause the script to exit with a failed state, the failed tests in the
jUnit report cause Jenkins to mark the build as unstable. We have been
able to gather enough data from failed runs of these tests and we do not
continue to gather new data from the runs today, so it does not make
sense to continue running them any longer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @soltysh 

@smarterclayton this is making Jenkins jobs break... thoughts?

[test]