### PR TITLE
[RPMs] Move /opt/cni/bin into node subpackage from sdn-ovs

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -506,6 +506,8 @@ fi
 %files node
 %{_unitdir}/%{name}-node.service
 %{_sysconfdir}/systemd/system.conf.d/origin-accounting.conf
+%dir /opt/cni/bin
+/opt/cni/bin/*
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-node
 %defattr(-,root,root,0700)
 %config(noreplace) %{_sysconfdir}/origin/node
@@ -528,10 +530,8 @@ fi
 %files sdn-ovs
 %dir %{_unitdir}/%{name}-node.service.d/
 %dir %{_sysconfdir}/cni/net.d
-%dir /opt/cni/bin
 %{_bindir}/openshift-sdn-ovs
 %{_unitdir}/%{name}-node.service.d/openshift-sdn-ovs.conf
-/opt/cni/bin/*
 
 %posttrans sdn-ovs
 # This path was installed by older packages but the directory wasn't owned by


### PR DESCRIPTION
So that standard cni plugins are available even if sdn-ovs isn't in use.