### PR TITLE
Remove global DefaultRegistryClient

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -54,7 +54,7 @@ type blobDescriptorService struct {
 // a proper repository object to be set on given context by upper openshift middleware wrappers.
 func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: starting with digest=%s", dgst.String())
-	repo, found := RepositoryFrom(ctx)
+	repo, found := repositoryFrom(ctx)
 	if !found || repo == nil {
 		err := fmt.Errorf("failed to retrieve repository from context")
 		context.GetLogger(ctx).Error(err)
@@ -90,7 +90,7 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 		return desc, nil
 	}
 
-	if err == distribution.ErrBlobUnknown && RemoteBlobAccessCheckEnabledFrom(ctx) {
+	if err == distribution.ErrBlobUnknown && remoteBlobAccessCheckEnabledFrom(ctx) {
 		// Second attempt: looking for the blob on a remote server
 		desc, err = repo.remoteBlobGetter.Stat(ctx, dgst)
 	}
@@ -99,7 +99,7 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 }
 
 func (bs *blobDescriptorService) Clear(ctx context.Context, dgst digest.Digest) error {
-	repo, found := RepositoryFrom(ctx)
+	repo, found := repositoryFrom(ctx)
 	if !found || repo == nil {
 		err := fmt.Errorf("failed to retrieve repository from context")
 		context.GetLogger(ctx).Error(err)

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -47,8 +47,6 @@ func GetTestPassThroughToUpstream(ctx context.Context) bool {
 // It relies on the fact that blobDescriptorService requires higher levels to set repository object on given
 // context. If the object isn't given, its method will err out.
 func TestBlobDescriptorServiceIsApplied(t *testing.T) {
-	ctx := context.Background()
-
 	// don't do any authorization check
 	installFakeAccessController(t)
 	m := fakeBlobDescriptorService(t)
@@ -64,14 +62,8 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	client.AddReactor("get", "imagestreams", imagetest.GetFakeImageStreamGetHandler(t, *testImageStream))
 	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *testImage))
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
+	ctx := context.Background()
+	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, fake.NewSimpleClientset()))
 	app := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{
@@ -463,7 +455,7 @@ func (bs *testBlobDescriptorService) Stat(ctx context.Context, dgst digest.Diges
 	bs.m.methodInvoked("Stat")
 	if bs.m.getUnsetRepository() {
 		bs.t.Logf("unsetting repository from the context")
-		ctx = WithRepository(ctx, nil)
+		ctx = withRepository(ctx, nil)
 	}
 
 	return bs.BlobDescriptorService.Stat(ctx, dgst)
@@ -472,7 +464,7 @@ func (bs *testBlobDescriptorService) Clear(ctx context.Context, dgst digest.Dige
 	bs.m.methodInvoked("Clear")
 	if bs.m.getUnsetRepository() {
 		bs.t.Logf("unsetting repository from the context")
-		ctx = WithRepository(ctx, nil)
+		ctx = withRepository(ctx, nil)
 	}
 	return bs.BlobDescriptorService.Clear(ctx, dgst)
 }
@@ -499,7 +491,7 @@ func (f *fakeAccessController) Authorized(ctx context.Context, access ...registr
 		f.t.Logf("fake authorizer: authorizing access to %s:%s:%s", access.Resource.Type, access.Resource.Name, access.Action)
 	}
 
-	ctx = WithAuthPerformed(ctx)
+	ctx = withAuthPerformed(ctx)
 	return ctx, nil
 }
 

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"github.com/docker/distribution/context"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+type contextKey string
+
+const (
+	// repositoryKey serves to store/retrieve repository object to/from context.
+	repositoryKey contextKey = "repository"
+
+	// remoteBlobAccessCheckEnabledKey is the key for the flag in Contexts
+	// to allow blobDescriptorService to stat remote blobs.
+	remoteBlobAccessCheckEnabledKey contextKey = "remoteBlobAccessCheckEnabled"
+
+	// registryClientKey is the key for RegistryClient values in Contexts.
+	registryClientKey contextKey = "registryClient"
+
+	// userClientKey is the key for a origin's client with the current user's
+	// credentials in Contexts.
+	userClientKey contextKey = "userClient"
+
+	// authPerformedKey is the key to indicate that authentication was
+	// performed in Contexts.
+	authPerformedKey contextKey = "authPerformed"
+
+	// deferredErrorsKey is the key for deferred errors in Contexts.
+	deferredErrorsKey contextKey = "deferredErrors"
+)
+
+// withRepository returns a new Context that carries value repo.
+func withRepository(parent context.Context, repo *repository) context.Context {
+	return context.WithValue(parent, repositoryKey, repo)
+}
+
+// repositoryFrom returns the repository value stored in ctx, if any.
+func repositoryFrom(ctx context.Context) (repo *repository, found bool) {
+	repo, found = ctx.Value(repositoryKey).(*repository)
+	return
+}
+
+// withRemoteBlobAccessCheckEnabled returns a new Context that allows
+// blobDescriptorService to stat remote blobs. It is useful only in case
+// of manifest verification.
+func withRemoteBlobAccessCheckEnabled(parent context.Context, enable bool) context.Context {
+	return context.WithValue(parent, remoteBlobAccessCheckEnabledKey, enable)
+}
+
+// remoteBlobAccessCheckEnabledFrom reports whether ctx allows
+// blobDescriptorService to stat remote blobs.
+func remoteBlobAccessCheckEnabledFrom(ctx context.Context) bool {
+	enabled, _ := ctx.Value(remoteBlobAccessCheckEnabledKey).(bool)
+	return enabled
+}
+
+// WithRegistryClient returns a new Context with provided registry client.
+func WithRegistryClient(ctx context.Context, client RegistryClient) context.Context {
+	return context.WithValue(ctx, registryClientKey, client)
+}
+
+// RegistryClientFrom returns the registry client stored in ctx if present.
+// It will panic otherwise.
+func RegistryClientFrom(ctx context.Context) RegistryClient {
+	return ctx.Value(registryClientKey).(RegistryClient)
+}
+
+// withUserClient returns a new Context with the origin's client.
+// This client should have the current user's credentials
+func withUserClient(parent context.Context, userClient client.Interface) context.Context {
+	return context.WithValue(parent, userClientKey, userClient)
+}
+
+// userClientFrom returns the origin's client stored in ctx, if any.
+func userClientFrom(ctx context.Context) (client.Interface, bool) {
+	userClient, ok := ctx.Value(userClientKey).(client.Interface)
+	return userClient, ok
+}
+
+// withAuthPerformed returns a new Context with indication that authentication
+// was performed.
+func withAuthPerformed(parent context.Context) context.Context {
+	return context.WithValue(parent, authPerformedKey, true)
+}
+
+// authPerformed reports whether ctx has indication that authentication was
+// performed.
+func authPerformed(ctx context.Context) bool {
+	authPerformed, ok := ctx.Value(authPerformedKey).(bool)
+	return ok && authPerformed
+}
+
+// withDeferredErrors returns a new Context that carries deferred errors.
+func withDeferredErrors(parent context.Context, errs deferredErrors) context.Context {
+	return context.WithValue(parent, deferredErrorsKey, errs)
+}
+
+// deferredErrorsFrom returns the deferred errors stored in ctx, if any.
+func deferredErrorsFrom(ctx context.Context) (deferredErrors, bool) {
+	errs, ok := ctx.Value(deferredErrorsKey).(deferredErrors)
+	return errs, ok
+}

--- a/pkg/dockerregistry/server/errorblobstore.go
+++ b/pkg/dockerregistry/server/errorblobstore.go
@@ -23,28 +23,28 @@ func (r *errorBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribu
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return distribution.Descriptor{}, err
 	}
-	return r.store.Stat(WithRepository(ctx, r.repo), dgst)
+	return r.store.Stat(withRepository(ctx, r.repo), dgst)
 }
 
 func (r *errorBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return nil, err
 	}
-	return r.store.Get(WithRepository(ctx, r.repo), dgst)
+	return r.store.Get(withRepository(ctx, r.repo), dgst)
 }
 
 func (r *errorBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return nil, err
 	}
-	return r.store.Open(WithRepository(ctx, r.repo), dgst)
+	return r.store.Open(withRepository(ctx, r.repo), dgst)
 }
 
 func (r *errorBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return distribution.Descriptor{}, err
 	}
-	return r.store.Put(WithRepository(ctx, r.repo), mediaType, p)
+	return r.store.Put(withRepository(ctx, r.repo), mediaType, p)
 }
 
 func (r *errorBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
@@ -52,7 +52,7 @@ func (r *errorBlobStore) Create(ctx context.Context, options ...distribution.Blo
 		return nil, err
 	}
 
-	ctx = WithRepository(ctx, r.repo)
+	ctx = withRepository(ctx, r.repo)
 
 	opts, err := effectiveCreateOptions(options)
 	if err != nil {
@@ -80,21 +80,21 @@ func (r *errorBlobStore) Resume(ctx context.Context, id string) (distribution.Bl
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return nil, err
 	}
-	return r.store.Resume(WithRepository(ctx, r.repo), id)
+	return r.store.Resume(withRepository(ctx, r.repo), id)
 }
 
 func (r *errorBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return err
 	}
-	return r.store.ServeBlob(WithRepository(ctx, r.repo), w, req, dgst)
+	return r.store.ServeBlob(withRepository(ctx, r.repo), w, req, dgst)
 }
 
 func (r *errorBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	if err := r.repo.checkPendingErrors(ctx); err != nil {
 		return err
 	}
-	return r.store.Delete(WithRepository(ctx, r.repo), dgst)
+	return r.store.Delete(withRepository(ctx, r.repo), dgst)
 }
 
 // checkPendingCrossMountErrors returns true if a cross-repo mount has been requested with given create

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -65,13 +65,13 @@ func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options .
 		ref = ref.DockerClientDefaults().AsRepository()
 	}
 
-	manifest, err := m.manifests.Get(WithRepository(ctx, m.repo), dgst, options...)
+	manifest, err := m.manifests.Get(withRepository(ctx, m.repo), dgst, options...)
 	switch err.(type) {
 	case distribution.ErrManifestUnknownRevision:
 		break
 	case nil:
 		m.repo.rememberLayersOfManifest(dgst, manifest, ref.Exact())
-		m.migrateManifest(WithRepository(ctx, m.repo), image, dgst, manifest, true)
+		m.migrateManifest(withRepository(ctx, m.repo), image, dgst, manifest, true)
 		return manifest, nil
 	default:
 		context.GetLogger(m.ctx).Errorf("unable to get manifest from storage: %v", err)
@@ -89,7 +89,7 @@ func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options .
 
 	manifest, err = m.repo.manifestFromImageWithCachedLayers(image, ref.Exact())
 	if err == nil {
-		m.migrateManifest(WithRepository(ctx, m.repo), image, dgst, manifest, false)
+		m.migrateManifest(withRepository(ctx, m.repo), image, dgst, manifest, false)
 	}
 
 	return manifest, err
@@ -114,11 +114,11 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 	}
 
 	// in order to stat the referenced blobs, repository need to be set on the context
-	if err := mh.Verify(WithRepository(ctx, m.repo), false); err != nil {
+	if err := mh.Verify(withRepository(ctx, m.repo), false); err != nil {
 		return "", err
 	}
 
-	_, err = m.manifests.Put(WithRepository(ctx, m.repo), manifest, options...)
+	_, err = m.manifests.Put(withRepository(ctx, m.repo), manifest, options...)
 	if err != nil {
 		return "", err
 	}
@@ -208,7 +208,7 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 // the content related to the manifest in the registry's storage (signatures).
 func (m *manifestService) Delete(ctx context.Context, dgst digest.Digest) error {
 	context.GetLogger(ctx).Debugf("(*manifestService).Delete")
-	return m.manifests.Delete(WithRepository(ctx, m.repo), dgst)
+	return m.manifests.Delete(withRepository(ctx, m.repo), dgst)
 }
 
 // manifestInflight tracks currently downloading manifests

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
-
 	"github.com/openshift/origin/pkg/client/testclient"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
@@ -43,14 +41,6 @@ func TestPullthroughServeBlob(t *testing.T) {
 	}
 	client := &testclient.Fake{}
 	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *testImage))
-
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
 
 	remoteRegistryServer := createTestRegistryServer(t, context.Background())
 	defer remoteRegistryServer.Close()
@@ -229,14 +219,6 @@ func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 	}
 	client := &testclient.Fake{}
 	client.AddReactor("get", "images", registrytest.GetFakeImageGetHandler(t, *testImage))
-
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
 
 	reader, dgst, err := registrytest.CreateRandomTarFile()
 	if err != nil {
@@ -687,14 +669,6 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 		},
 	} {
 		client := &testclient.Fake{}
-
-		// TODO: get rid of those nasty global vars
-		backupRegistryClient := DefaultRegistryClient
-		DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-		defer func() {
-			// set it back once this test finishes to make other unit tests working again
-			DefaultRegistryClient = backupRegistryClient
-		}()
 
 		tc.imageStreamInit(client)
 

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -102,6 +102,6 @@ func (m *pullthroughManifestService) getRemoteRepositoryClient(ctx context.Conte
 func (m *pullthroughManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
 	context.GetLogger(ctx).Debugf("(*pullthroughManifestService).Put: enabling remote blob access check")
 	// manifest dependencies (layers and config) may not be stored locally, we need to be able to stat them in remote repositories
-	ctx = WithRemoteBlobAccessCheckEnabled(ctx, true)
+	ctx = withRemoteBlobAccessCheckEnabled(ctx, true)
 	return m.ManifestService.Put(ctx, manifest, options...)
 }

--- a/pkg/dockerregistry/server/remoteblobgetter.go
+++ b/pkg/dockerregistry/server/remoteblobgetter.go
@@ -236,7 +236,10 @@ func (rbgs *remoteBlobGetterService) findCandidateRepository(
 
 	// search the remaining registries for this digest
 	for _, repo := range repositoryCandidates {
-		spec := search[repo]
+		spec, ok := search[repo]
+		if !ok {
+			continue
+		}
 		desc, err := rbgs.proxyStat(ctx, retriever, &spec, dgst)
 		if err != nil {
 			continue

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -282,10 +282,10 @@ func TestRepositoryBlobStat(t *testing.T) {
 
 		ctx := context.Background()
 		if !tc.skipAuth {
-			ctx = WithAuthPerformed(ctx)
+			ctx = withAuthPerformed(ctx)
 		}
 		if tc.deferredErrors != nil {
-			ctx = WithDeferredErrors(ctx, tc.deferredErrors)
+			ctx = withDeferredErrors(ctx, tc.deferredErrors)
 		}
 
 		client := &testclient.Fake{}
@@ -330,7 +330,7 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 	const blobRepoCacheTTL = time.Millisecond * 500
 
 	quotaEnforcing = &quotaEnforcingConfig{}
-	ctx := WithAuthPerformed(context.Background())
+	ctx := withAuthPerformed(context.Background())
 
 	// this driver holds all the testing blobs in memory during the whole test run
 	driver := inmemory.New()

--- a/pkg/dockerregistry/server/signaturedispatcher.go
+++ b/pkg/dockerregistry/server/signaturedispatcher.go
@@ -80,7 +80,7 @@ func (s *signatureHandler) Put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, ok := UserClientFrom(s.ctx)
+	client, ok := userClientFrom(s.ctx)
 	if !ok {
 		s.handleError(s.ctx, errcode.ErrorCodeUnknown.WithDetail("unable to get origin client"), w)
 		return
@@ -140,7 +140,7 @@ func (s *signatureHandler) Get(w http.ResponseWriter, req *http.Request) {
 		s.handleError(s.ctx, v2.ErrorCodeNameInvalid.WithDetail("missing image name or image ID"), w)
 		return
 	}
-	client, ok := UserClientFrom(s.ctx)
+	client, ok := userClientFrom(s.ctx)
 	if !ok {
 		s.handleError(s.ctx, errcode.ErrorCodeUnknown.WithDetail("unable to get origin client"), w)
 		return

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -30,15 +30,6 @@ import (
 
 func TestSignatureGet(t *testing.T) {
 	client := &testclient.Fake{}
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
-	ctx := WithUserClient(context.Background(), client)
 
 	installFakeAccessController(t)
 
@@ -68,6 +59,9 @@ func TestSignatureGet(t *testing.T) {
 
 	client.AddReactor("get", "imagestreamimages", registrytest.GetFakeImageStreamImageGetHandler(t, testImageStream, *testImage))
 
+	ctx := context.Background()
+	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, fake.NewSimpleClientset()))
+	ctx = withUserClient(ctx, client)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{
@@ -143,15 +137,6 @@ func TestSignatureGet(t *testing.T) {
 
 func TestSignaturePut(t *testing.T) {
 	client := &testclient.Fake{}
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
-	ctx := WithUserClient(context.Background(), client)
 
 	installFakeAccessController(t)
 
@@ -172,6 +157,9 @@ func TestSignaturePut(t *testing.T) {
 		return true, sign, nil
 	})
 
+	ctx := context.Background()
+	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, fake.NewSimpleClientset()))
+	ctx = withUserClient(ctx, client)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
 
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
-
 	"github.com/openshift/origin/pkg/client/testclient"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
@@ -63,15 +61,8 @@ func TestTagGet(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
+
 	serverURL, _ := url.Parse("docker.io/centos")
 
 	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
@@ -162,14 +153,6 @@ func TestTagGetWithoutImageStream(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
 
 	serverURL, _ := url.Parse("docker.io/centos")
@@ -209,15 +192,8 @@ func TestTagCreation(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
+
 	serverURL, _ := url.Parse("docker.io/centos")
 
 	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
@@ -292,14 +268,6 @@ func TestTagCreationWithoutImageStream(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
 
 	serverURL, _ := url.Parse("docker.io/centos")
@@ -336,15 +304,8 @@ func TestTagDeletion(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
+
 	serverURL, _ := url.Parse("docker.io/centos")
 
 	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
@@ -433,14 +394,6 @@ func TestTagDeletionWithoutImageStream(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
 
 	serverURL, _ := url.Parse("docker.io/centos")
@@ -477,15 +430,8 @@ func TestTagGetAll(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
+
 	serverURL, _ := url.Parse("docker.io/centos")
 
 	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
@@ -552,14 +498,6 @@ func TestTagGetAllWithoutImageStream(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
 
 	serverURL, _ := url.Parse("docker.io/centos")
@@ -596,15 +534,8 @@ func TestTagLookup(t *testing.T) {
 	tag := "latest"
 	client := &testclient.Fake{}
 
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
-
 	ctx := context.Background()
+
 	serverURL, _ := url.Parse("docker.io/centos")
 
 	testImage := createTestImageReactor(t, client, serverURL, namespace, repo)
@@ -688,14 +619,6 @@ func TestTagLookupWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 	client := &testclient.Fake{}
-
-	// TODO: get rid of those nasty global vars
-	backupRegistryClient := DefaultRegistryClient
-	DefaultRegistryClient = makeFakeRegistryClient(client, fake.NewSimpleClientset())
-	defer func() {
-		// set it back once this test finishes to make other unit tests working again
-		DefaultRegistryClient = backupRegistryClient
-	}()
 
 	ctx := context.Background()
 

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -21,34 +21,6 @@ import (
 	"github.com/openshift/origin/pkg/image/importer"
 )
 
-// Context keys
-const (
-	// repositoryKey serves to store/retrieve repository object to/from context.
-	repositoryKey = "openshift.repository"
-
-	remoteGetterServiceKey = "openshift.remote.getter.service"
-
-	// remoteBlobAccessCheckEnabledKey allows blobDescriptorService to stat remote blobs which is useful only
-	// in case of manifest verification.
-	remoteBlobAccessCheckEnabledKey = "openshift.remote.blobaccesscheck.enabled"
-)
-
-func WithRepository(parent context.Context, repo *repository) context.Context {
-	return context.WithValue(parent, repositoryKey, repo)
-}
-func RepositoryFrom(ctx context.Context) (repo *repository, found bool) {
-	repo, found = ctx.Value(repositoryKey).(*repository)
-	return
-}
-
-func WithRemoteBlobAccessCheckEnabled(parent context.Context, enable bool) context.Context {
-	return context.WithValue(parent, remoteBlobAccessCheckEnabledKey, enable)
-}
-func RemoteBlobAccessCheckEnabledFrom(ctx context.Context) bool {
-	enabled, _ := ctx.Value(remoteBlobAccessCheckEnabledKey).(bool)
-	return enabled
-}
-
 func getOptionValue(
 	envVar string,
 	optionName string,


### PR DESCRIPTION
Global variables really complicate tests and make them impossible to run concurrently. So I've tried to remove one of a such variable.