### PR TITLE
Separate tmpdir_vars from server setup, reorganize extended (again)

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -76,7 +76,30 @@ function os::cleanup::dump_container_logs() {
 }
 readonly -f os::cleanup::dump_container_logs
 
+# os::cleanup::tmpdir performs cleanup of temp directories as a precondition for running a test. It tries to
+# clean up mounts in the temp directories.
+#
+# Globals:
+#  - BASETMPDIR
+#  - USE_SUDO
+# Returns:
+#  None
+function os::cleanup::tmpdir() {
+    # ensure that the directories are clean
+    if os::util::find::system_binary "findmnt" &>/dev/null; then
+        for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
+            if [[ "${target}" == "${BASETMPDIR}"* ]]; then
+                ${USE_SUDO:+sudo} umount "${target}"
+            fi
+        done
+    fi
 
+		# delete any sub directory underneath BASETMPDIR
+    for directory in $( find "${BASETMPDIR}" -d 2 ); do
+        ${USE_SUDO:+sudo} rm -rf "${directory}"
+    done
+}
+readonly -f os::cleanup::tmpdir
 
 # os::cleanup::internal::list_k8s_containers returns a space-delimited list of
 # docker containers that belonged to k8s.

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -52,3 +52,7 @@ os::log::stacktrace::install
 # binaries that we build so we don't have to find
 # them before every invocation.
 os::util::environment::update_path_var
+
+if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
+	os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
+fi

--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -86,7 +86,7 @@ readonly -f os::log::debug
 # Arguments:
 #  - all: message to write
 function os::log::internal::to_logfile() {
-	if [[ -n "${LOG_DIR:-}" ]]; then
+	if [[ -n "${LOG_DIR:-}" && -d "${LOG_DIR-}" ]]; then
 		echo "$*" >>"${LOG_DIR}/scripts.log"
 	fi
 }

--- a/hack/lib/util/docs.sh
+++ b/hack/lib/util/docs.sh
@@ -11,6 +11,7 @@ function generate_manual_pages() {
 	local skipprefix="${3:-}"
 
 	os::util::environment::setup_tmpdir_vars generate/manuals
+	os::cleanup::tmpdir
 
 	# We do this in a tmpdir in case the dest has other non-autogenned files
 	# We don't want to include them in the list of gen'd files
@@ -50,6 +51,7 @@ function generate_documentation() {
 	local skipprefix="${1:-}"
 
 	os::util::environment::setup_tmpdir_vars generate/docs
+	os::cleanup::tmpdir
 
 	# We do this in a tmpdir in case the dest has other non-autogenned files
 	# We don't want to include them in the list of gen'd files

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -120,9 +120,6 @@ readonly -f os::util::environment::update_path_var
 #
 # Globals:
 #  - TMPDIR
-#  - LOG_DIR
-#  - ARTIFACT_DIR
-#  - USE_SUDO
 # Arguments:
 #  - 1: the path under the root temporary directory for OpenShift where these subdirectories should be made
 # Returns:
@@ -132,6 +129,7 @@ readonly -f os::util::environment::update_path_var
 #  - export ARTIFACT_DIR
 #  - export FAKE_HOME_DIR
 #  - export HOME
+#  - export OS_TMP_ENV_SET
 function os::util::environment::setup_tmpdir_vars() {
     local sub_dir=$1
 
@@ -150,19 +148,9 @@ function os::util::environment::setup_tmpdir_vars() {
     HOME="${FAKE_HOME_DIR}"
     export HOME
 
-    # ensure that the directories are clean
-    if os::util::find::system_binary "findmnt" &>/dev/null; then
-        for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
-            if [[ "${target}" == "${BASETMPDIR}"* ]]; then
-                ${USE_SUDO:+sudo} umount "${target}"
-            fi
-        done
-    fi
+    mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}"
 
-    for directory in "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"; do
-        ${USE_SUDO:+sudo} rm -rf "${directory}"
-        mkdir -p "${directory}"
-    done
+    export OS_TMP_ENV_SET="${sub_dir}"
 }
 readonly -f os::util::environment::setup_tmpdir_vars
 

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -141,12 +141,8 @@ function os::util::environment::setup_tmpdir_vars() {
     export VOLUME_DIR
     ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
     export ARTIFACT_DIR
-
-    # change the location of $HOME so no one does anything naughty
     FAKE_HOME_DIR="${BASETMPDIR}/openshift.local.home"
     export FAKE_HOME_DIR
-    HOME="${FAKE_HOME_DIR}"
-    export HOME
 
     mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}"
 

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -86,9 +86,6 @@ readonly -f os::util::environment::setup_time_vars
 #  - export USE_IMAGES
 #  - export TAG
 function os::util::environment::setup_all_server_vars() {
-    local subtempdir=$1
-
-    os::util::environment::setup_tmpdir_vars "${subtempdir}"
     os::util::environment::setup_kubelet_vars
     os::util::environment::setup_etcd_vars
     os::util::environment::setup_server_vars

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -72,7 +72,8 @@ export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 
-os::util::environment::setup_all_server_vars "test-cmd/"
+os::util::environment::setup_tmpdir_vars "test-cmd/"
+os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -74,6 +74,7 @@ export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 
 os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
+export HOME="${FAKE_HOME_DIR}"
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -72,7 +72,7 @@ export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 
-os::util::environment::setup_tmpdir_vars "test-cmd/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -10,7 +10,8 @@ os::log::info "Starting containerized end-to-end test"
 unset KUBECONFIG
 
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
+os::util::environment::setup_tmpdir_vars "test-end-to-end-docker/"
+os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -12,6 +12,7 @@ unset KUBECONFIG
 os::util::environment::use_sudo
 os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
+export HOME="${FAKE_HOME_DIR}"
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -10,7 +10,7 @@ os::log::info "Starting containerized end-to-end test"
 unset KUBECONFIG
 
 os::util::environment::use_sudo
-os::util::environment::setup_tmpdir_vars "test-end-to-end-docker/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -44,7 +44,7 @@ trap "cleanup" EXIT
 
 # Start All-in-one server and wait for health
 os::util::environment::use_sudo
-os::util::environment::setup_tmpdir_vars "test-end-to-end/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -44,7 +44,8 @@ trap "cleanup" EXIT
 
 # Start All-in-one server and wait for health
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "test-end-to-end/"
+os::util::environment::setup_tmpdir_vars "test-end-to-end/"
+os::util::environment::setup_all_server_vars
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -39,7 +39,7 @@ trap exit_trap EXIT
 start_time=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::build::setup_env
-os::util::environment::setup_tmpdir_vars "test-go"
+os::cleanup::tmpdir
 
 # Internalize environment variables we consume and default if they're not set
 dry_run="${DRY_RUN:-}"

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -6,7 +6,7 @@ os::build::setup_env
 
 export API_SCHEME="http"
 export API_BIND_HOST="127.0.0.1"
-os::util::environment::setup_tmpdir_vars "test-integration/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 function cleanup() {

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -6,7 +6,8 @@ os::build::setup_env
 
 export API_SCHEME="http"
 export API_BIND_HOST="127.0.0.1"
-os::util::environment::setup_all_server_vars "test-integration/"
+os::util::environment::setup_tmpdir_vars "test-integration/"
+os::util::environment::setup_all_server_vars
 
 function cleanup() {
 	out=$?

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -20,7 +20,6 @@ trap exit_trap EXIT
 
 start_time=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
-os::util::environment::setup_tmpdir_vars "test-lib"
 
 cd "${OS_ROOT}"
 

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -3,7 +3,8 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
-os::util::environment::setup_all_server_vars "test-os-cmd/"
+os::util::environment::setup_tmpdir_vars "test-os-cmd/"
+os::util::environment::setup_all_server_vars
 export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 
 # set verbosity so we can see that command output renders correctly

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -3,7 +3,7 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
-os::util::environment::setup_tmpdir_vars "test-os-cmd/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -5,6 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 
 os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
+export HOME="${FAKE_HOME_DIR}"
 export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 
 # set verbosity so we can see that command output renders correctly

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -27,7 +27,7 @@ export API_BIND_HOST=127.0.0.1
 export API_PORT=38443
 export ETCD_PORT=34001
 export ETCD_PEER_PORT=37001
-os::util::environment::setup_tmpdir_vars "generate-swagger-spec/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 os::start::configure_server
 

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -27,7 +27,8 @@ export API_BIND_HOST=127.0.0.1
 export API_PORT=38443
 export ETCD_PORT=34001
 export ETCD_PEER_PORT=37001
-os::util::environment::setup_all_server_vars "generate-swagger-spec/"
+os::util::environment::setup_tmpdir_vars "generate-swagger-spec/"
+os::util::environment::setup_all_server_vars
 os::start::configure_server
 
 SWAGGER_SPEC_REL_DIR="${1:-}"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -46,10 +46,10 @@ function cleanup_openshift() {
 	# really have it smack people in their logs.  This is a severe correctness problem
 	grep -a5 "CACHE.*ALTERED" ${LOG_DIR}/openshift.log
 
-	os::cleanup::dump_etcd
 	os::cleanup::dump_container_logs
 
 	if [[ -z "${SKIP_TEARDOWN-}" ]]; then
+		os::cleanup::dump_etcd
 		os::log::info "Tearing down test"
 		kill_all_processes
 

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -3,7 +3,8 @@
 # This scripts starts the OpenShift server with custom TLS certs, and verifies generated kubeconfig files can be used to talk to it.
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-os::util::environment::setup_all_server_vars "test-extended-alternate-certs/"
+os::util::environment::setup_tmpdir_vars "test-extended-alternate-certs/"
+os::util::environment::setup_all_server_vars
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
 

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -3,7 +3,7 @@
 # This scripts starts the OpenShift server with custom TLS certs, and verifies generated kubeconfig files can be used to talk to it.
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-os::util::environment::setup_tmpdir_vars "test-extended-alternate-certs/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -6,7 +6,8 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "test-extended-alternate-launches/"
+os::util::environment::setup_tmpdir_vars "test-extended-alternate-launches/"
+os::util::environment::setup_all_server_vars
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
 

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -6,7 +6,7 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 os::util::environment::use_sudo
-os::util::environment::setup_tmpdir_vars "test-extended-alternate-launches/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -27,7 +27,7 @@ trap "cleanup" EXIT
 os::log::info "Starting server"
 
 os::util::environment::use_sudo
-os::util::environment::setup_tmpdir_vars "test-extended/cmd/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 os::log::system::start

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -27,7 +27,8 @@ trap "cleanup" EXIT
 os::log::info "Starting server"
 
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "test-extended/cmd/"
+os::util::environment::setup_tmpdir_vars "test-extended/cmd/"
+os::util::environment::setup_all_server_vars
 
 os::log::system::start
 

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -12,7 +12,7 @@ os::build::setup_env
 
 os::util::environment::use_sudo
 os::util::environment::setup_time_vars
-os::util::environment::setup_tmpdir_vars "${test_name}"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 os::log::system::start

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -12,7 +12,8 @@ os::build::setup_env
 
 os::util::environment::use_sudo
 os::util::environment::setup_time_vars
-os::util::environment::setup_all_server_vars "${test_name}"
+os::util::environment::setup_tmpdir_vars "${test_name}"
+os::util::environment::setup_all_server_vars
 
 os::log::system::start
 

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -26,7 +26,7 @@ os::log::info "Starting server"
 
 os::util::ensure::iptables_privileges_exist
 os::util::environment::use_sudo
-os::util::environment::setup_tmpdir_vars "test-extended/ldap_groups/"
+os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 
 os::log::system::start

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -26,7 +26,8 @@ os::log::info "Starting server"
 
 os::util::ensure::iptables_privileges_exist
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "test-extended/ldap_groups/"
+os::util::environment::setup_tmpdir_vars "test-extended/ldap_groups/"
+os::util::environment::setup_all_server_vars
 
 os::log::system::start
 

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -316,7 +316,7 @@ else
     "${OPENSHIFT_CLUSTER_ID}-node-2"
   )
 
-  os::util::environment::setup_tmpdir_vars "test-extended/networking"
+  os::cleanup::tmpdir
 
   # Allow setting $JUNIT_REPORT to toggle output behavior
   if [[ -n "${JUNIT_REPORT:-}" ]]; then

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -34,7 +34,6 @@ function os::test::extended::setup () {
 	export KUBE_REPO_ROOT="${OS_ROOT}/vendor/k8s.io/kubernetes"
 
 	os::util::environment::setup_time_vars
-	os::util::environment::setup_tmpdir_vars "test-extended/core"
 
 	# Allow setting $JUNIT_REPORT to toggle output behavior
 	if [[ -n "${JUNIT_REPORT:-}" ]]; then
@@ -73,6 +72,7 @@ function os::test::extended::setup () {
 	trap "cleanup" EXIT
 
 	os::util::environment::use_sudo
+	os::cleanup::tmpdir
 	os::util::environment::setup_all_server_vars
 	os::util::ensure::iptables_privileges_exist
 

--- a/test/extended/testdata/gssapi/scripts/test-wrapper.sh
+++ b/test/extended/testdata/gssapi/scripts/test-wrapper.sh
@@ -9,7 +9,7 @@ source hack/lib/init.sh
 
 export TEST_NAME="test-extended/gssapiproxy-tests/$(uname -n)-${CLIENT}-${SERVER}"
 os::util::environment::setup_time_vars
-os::util::environment::setup_tmpdir_vars "${TEST_NAME}"
+os::cleanup::tmpdir
 export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 
 # use a subshell and `if` statement to prevent `exit` calls from killing this script


### PR DESCRIPTION
TEST_ONLY is broken now - it assumes a) that it needs sudo, b) that it
needs iptables, and c) that it needs to start a server.

[test]