### PR TITLE
Add infra build support for ppc64le platform

### DIFF
--- a/examples/gitserver/Dockerfile.ppc64le
+++ b/examples/gitserver/Dockerfile.ppc64le
@@ -1,0 +1,18 @@
+#
+# This is an example Git server for OpenShift Origin.
+#
+# The standard name for this image is openshift/origin-gitserver
+#
+FROM openshift/origin-ppc64le
+
+COPY bin/gitserver /usr/bin/gitserver
+COPY hooks/ /var/lib/git-hooks/
+COPY gitconfig /var/lib/gitconfig/.gitconfig
+RUN mkdir -p /var/lib/git && \
+    mkdir -p /var/lib/gitconfig && \
+    chmod 777 /var/lib/gitconfig && \
+    ln -s /usr/bin/gitserver /usr/bin/gitrepo-buildconfigs
+VOLUME /var/lib/git
+ENV HOME=/var/lib/gitconfig
+
+ENTRYPOINT ["/usr/bin/gitserver"]

--- a/examples/hello-openshift/Dockerfile.ppc64le
+++ b/examples/hello-openshift/Dockerfile.ppc64le
@@ -1,0 +1,5 @@
+FROM scratch
+MAINTAINER Jessica Forrester <jforrest@redhat.com>
+COPY bin/hello-openshift /hello-openshift
+EXPOSE 8080 8888
+ENTRYPOINT ["/hello-openshift"]

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -5,10 +5,29 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+HOST_ARCH=$(os::build::host_arch)
+
+DOCKERFILE="Dockerfile"
+
+if [[ "${HOST_ARCH}" != "amd64" ]]; then
+  DOCKERFILE+=".${HOST_ARCH}"
+fi
+
 # determine the correct tag prefix
 tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 
+BASE_EXTRA_TAG=""
+if [[ "${HOST_ARCH}" == "amd64" ]]; then
+  BASE_EXTRA_TAG="${tag_prefix}-base"
+fi
+
 # Build the base image without the default image args
-OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" "${tag_prefix}-base"
+OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" "${tag_prefix}-base-${HOST_ARCH}" ${DOCKERFILE} ${BASE_EXTRA_TAG}
+
+# Build release image only on ppc64le platform because automatic dockerbuild is not supported for ppc64le platform in hub.docker.com
+if [[ "${HOST_ARCH}" == "ppc64le" ]]; then
+  GOLANG_VERSION="1.8"
+  OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/release/golang-${GOLANG_VERSION}" "${tag_prefix}-release-${HOST_ARCH}" ${DOCKERFILE} "${tag_prefix}-release-${HOST_ARCH}:golang-${GOLANG_VERSION}"
+fi
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -10,9 +10,11 @@ STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 source "${OS_ROOT}/contrib/node/install-sdn.sh"
 
+PLATFORM=$(os::build::host_platform)
+
 if [[ "${OS_RELEASE:-}" == "n" ]]; then
 	# Use local binaries
-	imagedir="${OS_OUTPUT_BINPATH}/linux/amd64"
+	imagedir="${OS_OUTPUT_BINPATH}/${PLATFORM}"
 	# identical to build-cross.sh
 	os::build::os_version_vars
 	OS_RELEASE_COMMIT="${OS_GIT_VERSION//+/-}"
@@ -34,7 +36,7 @@ else
 	fi
 
 	# Extract the release archives to a staging area.
-	os::build::detect_local_release_tars "linux-64bit"
+	os::build::detect_local_release_tars $(os::build::host_platform_friendly)
 
 	echo "Building images from release tars for commit ${OS_RELEASE_COMMIT}:"
 	echo " primary: $(basename ${OS_PRIMARY_RELEASE_TAR})"
@@ -63,6 +65,7 @@ function ln_or_cp {
 function image-build() {
 	local tag=$1
 	local dir=$2
+        local dockerfile=${3:-}
 	local dest="${tag}"
 	local extra=
 	if [[ ! "${tag}" == *":"* ]]; then
@@ -76,9 +79,9 @@ function image-build() {
 	STARTTIME="$(date +%s)"
 
 	# build the image
-	if ! os::build::image "${dir}" "${dest}" "" "${extra}"; then
+	if ! os::build::image "${dir}" "${dest}" "${dockerfile}" "${extra}"; then
 		os::log::warning "Retrying build once"
-		if ! os::build::image "${dir}" "${dest}" "" "${extra}"; then
+		if ! os::build::image "${dir}" "${dest}" "${dockerfile}" "${extra}"; then
 			return 1
 		fi
 	fi
@@ -95,9 +98,17 @@ function image() {
 	local tag=$1
 	local dir=$2
 	local out
+
+	local DOCKERFILE="Dockerfile"
+	HOST_ARCH=$(os::build::host_arch)
+	if [[ "${HOST_ARCH}" != "amd64" ]]; then
+		DOCKERFILE+=".${HOST_ARCH}"
+		tag+="-${HOST_ARCH}"
+	fi
+
 	mkdir -p "${BASETMPDIR}"
 	out="$( mktemp "${BASETMPDIR}/imagelogs.XXXXX" )"
-	if ! image-build "${tag}" "${dir}" > "${out}" 2>&1; then
+	if ! image-build "${tag}" "${dir}" "${DOCKERFILE}" > "${out}" 2>&1; then
 		sed -e "s|^|$1: |" "${out}" 1>&2
 		os::log::error "Failed to build $1"
 		return 1
@@ -138,9 +149,12 @@ image "${tag_prefix}-recycler"              images/recycler
 image "${tag_prefix}-docker-builder"        images/builder/docker/docker-builder
 image "${tag_prefix}-sti-builder"           images/builder/docker/sti-builder
 image "${tag_prefix}-f5-router"             images/router/f5
-image "openshift/node"                      images/node
+image openshift/node                        images/node
+
 # images that depend on "openshift/node"
-image "openshift/openvswitch"               images/openvswitch
+if [[ ${PLATFORM} != "linux/ppc64le" ]];then
+	image "openshift/openvswitch"               images/openvswitch
+fi
 
 # extra images (not part of infrastructure)
 image "openshift/hello-openshift"           examples/hello-openshift

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -20,6 +20,11 @@ function os::build::host_platform() {
 }
 readonly -f os::build::host_platform
 
+function os::build::host_arch() {
+  echo "$(go env GOHOSTARCH)"
+}
+readonly -f os::build::host_arch
+
 # Create a user friendly version of host_platform for end users
 function os::build::host_platform_friendly() {
   local platform=${1:-}
@@ -748,7 +753,7 @@ function os::build::image() {
         extra_tag="-t '${extra_tag}'"
       fi
       if [[ -n "${dockerfile}" ]]; then
-        eval "imagebuilder -f '${dockerfile}' -t '${tag}' ${extra_tag} ${options} '${directory}'"
+        eval "imagebuilder -f '${directory}/${dockerfile}' -t '${tag}' ${extra_tag} ${options} '${directory}'"
         return $?
       fi
       eval "imagebuilder -t '${tag}' ${extra_tag} ${options} '${directory}'"
@@ -761,7 +766,7 @@ function os::build::image() {
   fi
 
   if [[ -n "${dockerfile}" ]]; then
-    eval "docker build -f '${dockerfile}' -t '${tag}' ${options} '${directory}'"
+    eval "docker build -f '${directory}/${dockerfile}' -t '${tag}' ${options} '${directory}'"
     if [[ -n "${extra_tag}" ]]; then
       docker tag "${tag}" "${extra_tag}"
     fi

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -2,8 +2,16 @@
 
 # This script provides constants for the Golang binary build process
 
-readonly OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.7}"
-readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"
+OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.7}"
+OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"
+
+if [[ "$(go env GOARCH)" == "ppc64le" ]]; then
+  OS_BUILD_ENV_GOLANG="1.8"
+  OS_BUILD_ENV_IMAGE="openshift/origin-release-ppc64le:golang-${OS_BUILD_ENV_GOLANG}"
+fi
+
+readonly OS_BUILD_ENV_GOLANG
+readonly OS_BUILD_ENV_IMAGE
 
 readonly OS_OUTPUT_SUBPATH="${OS_OUTPUT_SUBPATH:-_output/local}"
 readonly OS_OUTPUT="${OS_ROOT}/${OS_OUTPUT_SUBPATH}"

--- a/images/base/Dockerfile.ppc64le
+++ b/images/base/Dockerfile.ppc64le
@@ -1,0 +1,18 @@
+#
+# This is the base image from which all OpenShift Origin images inherit. Only packages
+# common to all downstream images should be here. Depends on Centos 7.2+.
+#
+# The standard name for this image is openshift/origin-base
+#
+FROM ppc64le/centos:centos7
+
+RUN INSTALL_PKGS="which git tar wget hostname sysvinit-tools util-linux bsdtar epel-release \
+      socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof device-mapper-persistent-data ceph-common" && \
+    yum install -y epel-release && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/origin
+
+LABEL io.k8s.display-name="OpenShift Origin Centos 7 Base" \
+      io.k8s.description="This is the base image from which all OpenShift Origin images inherit."

--- a/images/builder/docker/custom-docker-builder/Dockerfile.ppc64le
+++ b/images/builder/docker/custom-docker-builder/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+# This image is intended for testing purposes, it has the same behavior as
+# the origin-docker-builder image, but does so as a custom image so it can
+# be used with Custom build strategies.  It expects a set of
+# environment variables to parameterize the build:
+#
+#   OUTPUT_REGISTRY - the Docker registry URL to push this image to
+#   OUTPUT_IMAGE - the name to tag the image with
+#   SOURCE_URI - a URI to fetch the build context from
+#   SOURCE_REF - a reference to pass to Git for which commit to use (optional)
+#
+# This image expects to have the Docker socket bind-mounted into the container.
+# If "/root/.dockercfg" is bind mounted in, it will use that as authorization
+# to a Docker registry.
+#
+# The standard name for this image is openshift/origin-custom-docker-builder
+#
+FROM openshift/origin-base-ppc64le
+
+RUN INSTALL_PKGS="gettext automake make docker" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+LABEL io.k8s.display-name="OpenShift Origin Custom Builder Example" \
+      io.k8s.description="This is an example of a custom builder for use with OpenShift Origin."
+ENV HOME=/root
+COPY build.sh /tmp/build.sh
+CMD ["/tmp/build.sh"]

--- a/images/builder/docker/docker-builder/Dockerfile.ppc64le
+++ b/images/builder/docker/docker-builder/Dockerfile.ppc64le
@@ -1,0 +1,17 @@
+#
+# This is the image that executes a Docker build inside Origin. It expects the
+# following environment variables:
+#
+#   BUILD - JSON string containing the openshift build object
+#
+# This image expects to have the Docker socket bind-mounted into the container.
+# If "/root/.dockercfg" is bind mounted in, it will use that as authorization to a
+# Docker registry. It depends on bsdtar for extraction of binaries over STDIN.
+#
+# The standard name for this image is openshift/origin-docker-builder
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Origin Docker Builder" \
+      io.k8s.description="This is a component of OpenShift Origin and is responsible for executing Docker image builds."
+ENTRYPOINT ["/usr/bin/openshift-docker-build"]

--- a/images/builder/docker/sti-builder/Dockerfile.ppc64le
+++ b/images/builder/docker/sti-builder/Dockerfile.ppc64le
@@ -1,0 +1,17 @@
+#
+# This is the image that executes a S2I build inside Origin. It expects the
+# following environment variables:
+#
+#   BUILD - JSON string containing the openshift build object
+#
+# This image expects to have the Docker socket bind-mounted into the container.
+# If "/root/.dockercfg" is bind mounted in, it will use that as authorization to a
+# Docker registry.
+#
+# The standard name for this image is openshift/origin-sti-builder
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Origin S2I Builder" \
+      io.k8s.description="This is a component of OpenShift Origin and is responsible for executing source-to-image (s2i) image builds."
+ENTRYPOINT ["/usr/bin/openshift-sti-build"]

--- a/images/deployer/Dockerfile.ppc64le
+++ b/images/deployer/Dockerfile.ppc64le
@@ -1,0 +1,19 @@
+#
+# This is the default deployment strategy image for OpenShift Origin. It expects a set of
+# environment variables to parameterize the deploy:
+#
+#   "OPENSHIFT_DEPLOYMENT_NAME" - the name of a replication controller that is being deployed
+#   "OPENSHIFT_DEPLOYMENT_NAMESPACE" - the namespace of the replication controller that is being deployed
+#
+# It also expects to receive the standard Kubernetes service account secret to connect back to
+# the OpenShift API to drive the deployment.
+#
+# The standard name for this image is openshift/origin-deployer
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Origin Deployer" \
+      io.k8s.description="This is a component of OpenShift Origin and executes the user deployment process to roll out new containers. It may be used as a base image for building your own custom deployer image."
+# The deployer doesn't require a root user.
+USER 1001
+ENTRYPOINT ["/usr/bin/openshift-deploy"]

--- a/images/dind/Dockerfile.ppc64le
+++ b/images/dind/Dockerfile.ppc64le
@@ -1,0 +1,84 @@
+#
+# Image configured with systemd and docker-in-docker.  Useful for
+# simulating multinode deployments.
+#
+# The standard name for this image is openshift/dind
+#
+# Notes:
+#
+#  - disable SELinux on the docker host (not compatible with dind)
+#
+#  - to use the overlay graphdriver, ensure the overlay module is
+#    installed on the docker host
+#
+#      $ modprobe overlay
+#
+#  - run with --privileged
+#
+#      $ docker run -d --privileged openshift/dind
+#
+
+FROM ppc64le/fedora:25
+
+# Fix 'WARNING: terminal is not fully functional' when TERM=dumb
+ENV TERM=xterm
+
+## Configure systemd to run in a container
+
+ENV container=docker
+
+VOLUME ["/run", "/tmp"]
+
+STOPSIGNAL SIGRTMIN+3
+
+RUN systemctl mask\
+ auditd.service\
+ console-getty.service\
+ dev-hugepages.mount\
+ dnf-makecache.service\
+ docker-storage-setup.service\
+ getty.target\
+ lvm2-lvmetad.service\
+ sys-fs-fuse-connections.mount\
+ systemd-logind.service\
+ systemd-remount-fs.service\
+ systemd-udev-hwdb-update.service\
+ systemd-udev-trigger.service\
+ systemd-udevd.service\
+ systemd-vconsole-setup.service
+RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/;\
+ sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+
+# Remove non-english translations for glibc to reduce image size by 100mb.
+# docker-v1.10-migrator is unnecessary for a new docker installation
+# selinux-policy-minimum is unnecessary since selinux won't be enabled
+RUN dnf -y update && dnf -y install\
+ docker\
+ glibc-langpack-en\
+ iptables\
+ openssh-clients\
+ openssh-server\
+ && dnf clean all
+
+## Configure docker
+
+RUN systemctl enable docker.service
+
+# Default storage to vfs.  overlay will be enabled at runtime if available.
+RUN echo "DOCKER_STORAGE_OPTIONS=--storage-driver vfs" >\
+ /etc/sysconfig/docker-storage
+
+RUN mkdir -p /usr/local/bin
+COPY dind-setup.sh /usr/local/bin/
+COPY dind-setup.service /etc/systemd/system/
+RUN systemctl enable dind-setup.service
+
+VOLUME ["/var/lib/docker"]
+
+# Hardlink init to another name to avoid having oci-systemd-hooks
+# detect containers using this image as requiring read-only cgroup
+# mounts.  containers running docker need to be run with --privileged
+# to ensure cgroups are mounted with read-write permissions.
+RUN ln /usr/sbin/init /usr/sbin/dind_init
+
+CMD ["/usr/sbin/dind_init"]

--- a/images/dind/master/Dockerfile.ppc64le
+++ b/images/dind/master/Dockerfile.ppc64le
@@ -1,0 +1,29 @@
+#
+# This image is for the master of an openshift dind dev cluster.
+#
+# The standard name for this image is openshift/dind-master
+#
+
+FROM openshift/dind-node-ppc64le
+
+# Disable iptables on the master since it will prevent access to the
+# openshift api from outside the master.
+RUN systemctl disable iptables.service
+
+COPY openshift-generate-master-config.sh /usr/local/bin/
+
+COPY openshift-disable-master-node.sh /usr/local/bin/
+COPY openshift-disable-master-node.service /etc/systemd/system/
+RUN systemctl enable openshift-disable-master-node.service
+
+COPY openshift-get-hosts.sh /usr/local/bin/
+COPY openshift-add-to-hosts.sh /usr/local/bin/
+COPY openshift-remove-from-hosts.sh /usr/local/bin/
+COPY openshift-sync-etc-hosts.service /etc/systemd/system/
+RUN systemctl enable openshift-sync-etc-hosts.service
+
+COPY openshift-master.service /etc/systemd/system/
+RUN systemctl enable openshift-master.service
+
+RUN mkdir -p /etc/systemd/system/openshift-node.service.d
+COPY master-node.conf /etc/systemd/system/openshift-node.service.d/

--- a/images/dind/node/Dockerfile.ppc64le
+++ b/images/dind/node/Dockerfile.ppc64le
@@ -1,0 +1,72 @@
+#
+# This is the base image for nodes of an openshift dind dev cluster.
+#
+# The standard name for this image is openshift/dind-node
+#
+
+FROM openshift/dind-ppc64le
+
+## Install packages
+RUN dnf -y update && dnf -y install\
+ bind-utils\
+ findutils\
+ hostname\
+ iproute\
+ iputils\
+ less\
+ procps-ng\
+ tar\
+ which\
+ # Node-specific packages
+ bridge-utils\
+ ethtool\
+ iptables-services\
+ openvswitch\
+ && dnf clean all
+
+# A default deny firewall (either iptables or firewalld) is
+# installed by default on non-cloud fedora and rhel, so all
+# network plugins need to be able to work with one enabled.
+RUN systemctl enable iptables.service
+
+# Ensure that master-to-kubelet communication will work with iptables
+COPY iptables /etc/sysconfig/
+
+COPY openshift-generate-node-config.sh /usr/local/bin/
+COPY openshift-dind-lib.sh /usr/local/bin/
+
+RUN systemctl enable openvswitch
+
+COPY openshift-node.service /etc/systemd/system/
+RUN systemctl enable openshift-node.service
+# Ensure the working directory for the unit file exists
+RUN mkdir -p /var/lib/origin
+
+COPY openshift-enable-ssh-access.sh /usr/local/bin/
+COPY openshift-enable-ssh-access.service /etc/systemd/system/
+RUN systemctl enable openshift-enable-ssh-access.service
+
+# SDN plugin setup
+RUN mkdir -p /etc/cni/net.d
+RUN mkdir -p /opt/cni/bin
+
+# Symlink from the data path intended to be mounted as a volume to
+# make reloading easy.  Revisit if/when dind becomes useful for more
+# than dev/test.
+RUN ln -sf /data/openshift-sdn-ovs /usr/local/bin/ && \
+    ln -sf /data/openshift /usr/local/bin/ && \
+    ln -sf /data/openshift /usr/local/bin/oc && \
+    ln -sf /data/openshift /usr/local/bin/oadm && \
+    ln -sf /data/openshift /usr/local/bin/osc && \
+    ln -sf /data/openshift /usr/local/bin/osadm && \
+    ln -sf /data/openshift /usr/local/bin/kubectl && \
+    ln -sf /data/openshift /usr/local/bin/openshift-deploy && \
+    ln -sf /data/openshift /usr/local/bin/openshift-docker-build && \
+    ln -sf /data/openshift /usr/local/bin/openshift-sti-build && \
+    ln -sf /data/openshift /usr/local/bin/openshift-f5-router && \
+    ln -sf /data/openshift-sdn /opt/cni/bin/ && \
+    ln -sf /data/host-local    /opt/cni/bin/ && \
+    ln -sf /data/loopback      /opt/cni/bin/ && \
+    ln -sf /data/80-openshift-sdn.conf /etc/cni/net.d/
+
+ENV KUBECONFIG /data/openshift.local.config/master/admin.kubeconfig

--- a/images/dockerregistry/Dockerfile.ppc64le
+++ b/images/dockerregistry/Dockerfile.ppc64le
@@ -1,0 +1,21 @@
+#
+# This is the integrated OpenShift Origin Docker registry. It is configured to
+# publish metadata to OpenShift to provide automatic management of images on push.
+#
+# The standard name for this image is openshift/origin-docker-registry
+#
+FROM openshift/origin-base-ppc64le
+
+COPY config.yml $REGISTRY_CONFIGURATION_PATH
+COPY bin/dockerregistry /dockerregistry
+
+LABEL io.k8s.display-name="OpenShift Origin Image Registry" \
+      io.k8s.description="This is a component of OpenShift Origin and exposes a Docker registry that is integrated with the cluster for authentication and management."
+
+# The registry doesn't require a root user.
+USER 1001
+EXPOSE 5000
+VOLUME /registry
+ENV REGISTRY_CONFIGURATION_PATH=/config.yml
+
+CMD DOCKER_REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} /dockerregistry ${REGISTRY_CONFIGURATION_PATH}

--- a/images/ipfailover/keepalived/Dockerfile.ppc64le
+++ b/images/ipfailover/keepalived/Dockerfile.ppc64le
@@ -1,0 +1,18 @@
+#
+# VIP failover monitoring container for OpenShift Origin.
+#
+# ImageName: openshift/origin-keepalived-ipfailover
+#
+FROM openshift/origin-ppc64le
+
+RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+COPY . /var/lib/ipfailover/keepalived/
+
+LABEL io.k8s.display-name="OpenShift Origin IP Failover" \
+      io.k8s.description="This is a component of OpenShift Origin and runs a clustered keepalived instance across multiple hosts to allow highly available IP addresses."
+EXPOSE 1985
+WORKDIR /var/lib/ipfailover
+ENTRYPOINT ["/var/lib/ipfailover/keepalived/monitor.sh"]

--- a/images/node/Dockerfile.ppc64le
+++ b/images/node/Dockerfile.ppc64le
@@ -1,0 +1,35 @@
+#
+# This is an OpenShift Origin node image with integrated OpenvSwitch SDN
+# If you do not require OVS SDN use the openshift/origin image instead.
+#
+# This image expects to have a volume mounted at /etc/origin/node that contains
+# a KUBECONFIG file giving the node permission to talk to the master and a
+# node configuration file.
+#
+# The standard name for this image is openshift/node
+#
+FROM openshift/origin-ppc64le
+
+COPY usr/bin/* /usr/bin/
+COPY opt/cni/bin/* /opt/cni/bin/
+COPY etc/cni/net.d/* /etc/cni/net.d/
+COPY conf/openshift-sdn-ovs.conf /usr/lib/systemd/system/origin-node.service.d/
+COPY scripts/* /usr/local/bin/
+COPY system-container/system-container-wrapper.sh /usr/local/bin/
+COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
+
+RUN INSTALL_PKGS="libmnl libnetfilter_conntrack conntrack-tools \
+      libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
+      binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
+      iscsi-initiator-utils" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /usr/lib/systemd/system/origin-node.service.d /usr/lib/systemd/system/docker.service.d
+
+LABEL io.k8s.display-name="OpenShift Origin Node" \
+      io.k8s.description="This is a component of OpenShift Origin and contains the software for individual nodes when using SDN."
+VOLUME /etc/origin/node
+ENV KUBECONFIG=/etc/origin/node/node.kubeconfig
+
+ENTRYPOINT [ "/usr/local/bin/origin-node-run.sh" ]

--- a/images/observe/Dockerfile.ppc64le
+++ b/images/observe/Dockerfile.ppc64le
@@ -1,0 +1,15 @@
+#
+# This is the observer image for OpenShift Origin that makes it easy to script a reaction
+# to changes on the cluster. It uses the `oc observe` command and expects to be run inside
+# of a Kubernetes pod or have security information set via KUBECONFIG and a bind mounted
+# kubeconfig file.
+#
+# The standard name for this image is openshift/observe
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Observer" \
+      io.k8s.description="This image runs the oc observe command to watch and react to changes on your cluster."
+# The observer doesn't require a root user.
+USER 1001
+ENTRYPOINT ["/usr/bin/oc", "observe"]

--- a/images/openldap/Dockerfile.ppc64le
+++ b/images/openldap/Dockerfile.ppc64le
@@ -1,0 +1,23 @@
+FROM openshift/openldap-2441-centos7-ppc64le:latest
+
+# OpenLDAP server image for OpenShift Origin testing based on OpenLDAP 2.4.41
+#
+# Volumes:
+# * /var/lib/openldap/data - Datastore for OpenLDAP
+# * /etc/openldap/slapd.d  - Config directory for slapd
+# Environment:
+# * $OPENLDAP_DEBUG_LEVEL (Optional) - OpenLDAP debugging level, defaults to 256
+
+MAINTAINER Steve Kuznetsov <skuznets@redhat.com>
+
+# Add LDAP test data and script
+COPY *init.sh /usr/local/bin/
+COPY contrib/init.ldif /usr/local/etc/openldap/
+
+# Set OpenLDAP data and config directories in a data volume
+VOLUME ["/var/lib/ldap", "/etc/openldap"]
+
+# Expose default ports for ldap and ldaps
+EXPOSE 389 636
+
+CMD ["/usr/local/bin/init.sh"]

--- a/images/origin/Dockerfile.ppc64le
+++ b/images/origin/Dockerfile.ppc64le
@@ -1,0 +1,36 @@
+#
+# This is the official OpenShift Origin image. It has as its entrypoint the OpenShift
+# all-in-one binary.
+#
+# While this image can be used for a simple node it does not support OVS based
+# SDN or storage plugins required for EBS, GCE, Gluster, Ceph, or iSCSI volume
+# management. For those features please use 'openshift/node'
+#
+# The standard name for this image is openshift/origin
+#
+FROM openshift/origin-base-ppc64le
+
+COPY system-container/system-container-wrapper.sh /usr/local/bin/
+COPY system-container/config.json.template system-container/manifest.json system-container/service.template /exports/
+COPY bin/openshift /usr/bin/openshift
+RUN ln -s /usr/bin/openshift /usr/bin/oc && \
+    ln -s /usr/bin/openshift /usr/bin/oadm && \
+    ln -s /usr/bin/openshift /usr/bin/origin && \
+    ln -s /usr/bin/openshift /usr/bin/kubectl && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-deploy && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-recycle && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-router && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-docker-build && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-sti-build && \
+    ln -s /usr/bin/openshift /usr/bin/openshift-f5-router && \
+    setcap 'cap_net_bind_service=ep' /usr/bin/openshift
+
+LABEL io.k8s.display-name="OpenShift Origin Application Platform" \
+      io.k8s.description="OpenShift Origin is a platform for developing, building, and deploying containerized applications. See https://docs.openshift.org/latest for more on running OpenShift Origin."
+ENV HOME=/root \
+    OPENSHIFT_CONTAINERIZED=true \
+    KUBECONFIG=/var/lib/origin/openshift.local.config/master/admin.kubeconfig
+WORKDIR /var/lib/origin
+EXPOSE 8443 53
+
+ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/pod/Dockerfile.ppc64le
+++ b/images/pod/Dockerfile.ppc64le
@@ -1,0 +1,16 @@
+#
+# This is the official OpenShift Origin pod infrastructure image. It will stay running
+# until terminated by a signal and is the heart of each running pod. It holds on to
+# the network and IPC namespaces as containers come and go during the lifetime of the
+# pod.
+#
+# The standard name for this image is openshift/origin-pod
+#
+FROM scratch
+
+COPY bin/pod /pod
+
+USER 1001
+LABEL io.k8s.display-name="OpenShift Origin Pod Infrastructure" \
+      io.k8s.description="This is a component of OpenShift Origin and holds on to the shared Linux namespaces within a Pod."
+ENTRYPOINT ["/pod"]

--- a/images/recycler/Dockerfile.ppc64le
+++ b/images/recycler/Dockerfile.ppc64le
@@ -1,0 +1,10 @@
+#
+# This is the default OpenShift Origin persistent volume recycler image.
+#
+# The standard name for this image is openshift/origin-recycler
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Origin Volume Recycler" \
+      io.k8s.description="This is a component of OpenShift Origin and is used to prepare persistent volumes for reuse after they are deleted."
+ENTRYPOINT ["/usr/bin/openshift-recycle"]

--- a/images/release/Dockerfile.ppc64le
+++ b/images/release/Dockerfile.ppc64le
@@ -1,0 +1,35 @@
+#
+# This is the image that controls the standard build environment for releasing OpenShift Origin.
+# It is responsible for performing a cross platform build of OpenShift.
+#
+# The standard name for this image is openshift/origin-release
+#
+FROM openshift/origin-base-ppc64le
+
+ENV VERSION=1.8 \
+    GOARCH=ppc64le \
+    GOARM=5 \
+    GOPATH=/go \
+    GOROOT=/usr/local/go \
+    OS_VERSION_FILE=/go/src/github.com/openshift/origin/os-version-defs \
+    TMPDIR=/openshifttmp
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+RUN mkdir $TMPDIR && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync bind-utils file jq openssl" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    curl https://storage.googleapis.com/golang/go$VERSION.linux-$GOARCH.tar.gz | tar -C /usr/local -xzf - && \
+    go get golang.org/x/tools/cmd/cover github.com/tools/godep github.com/golang/lint/golint && \
+    touch /os-build-image
+
+# Allows building Origin sources mounted using volume
+COPY openshift-origin-build.sh /usr/bin/openshift-origin-build.sh
+
+WORKDIR /go/src/github.com/openshift/origin
+LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION-$GOARCH)" \
+      io.k8s.description="This is the standard release image for OpenShift Origin and contains the necessary build tools to build the platform."
+
+# Expect a tar with the source of OpenShift Origin (and /os-version-defs in the root)
+CMD bsdtar mxzf - && hack/build-cross.sh

--- a/images/release/golang-1.8/Dockerfile.ppc64le
+++ b/images/release/golang-1.8/Dockerfile.ppc64le
@@ -1,0 +1,34 @@
+#
+# This is the image that controls the standard build environment for releasing OpenShift Origin.
+# It is responsible for performing a cross platform build of OpenShift.
+#
+# The standard name for this image is openshift/origin-release
+#
+FROM openshift/origin-base-ppc64le
+
+ENV VERSION=1.8 \
+    GOARCH=ppc64le \
+    GOARM=5 \
+    GOPATH=/go \
+    GOROOT=/usr/local/go \
+    OS_VERSION_FILE=/go/src/github.com/openshift/origin/os-version-defs \
+    TMPDIR=/openshifttmp
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+RUN mkdir $TMPDIR && \
+    INSTALL_PKGS="make gcc zip mercurial krb5-devel bsdtar bc rsync bind-utils file jq tito createrepo openssl" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    curl https://storage.googleapis.com/golang/go$VERSION.linux-$GOARCH.tar.gz | tar -C /usr/local -xzf - && \
+    go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
+    touch /os-build-image && \
+    git config --global user.name origin-release-container && \
+    git config --global user.email none@nowhere.com
+
+WORKDIR /go/src/github.com/openshift/origin
+LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \
+      io.k8s.description="This is the standard release image for OpenShift Origin and contains the necessary build tools to build the platform."
+
+# Expect the working directory to be populated with the repo source
+CMD hack/build-cross.sh

--- a/images/router/egress/Dockerfile.ppc64le
+++ b/images/router/egress/Dockerfile.ppc64le
@@ -1,0 +1,15 @@
+#
+# This is the egress router for OpenShift Origin
+#
+# The standard name for this image is openshift/origin-egress-router
+
+FROM openshift/origin-base-ppc64le
+
+RUN INSTALL_PKGS="iproute iputils" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+ADD egress-router.sh /bin/egress-router.sh
+
+ENTRYPOINT /bin/egress-router.sh

--- a/images/router/f5/Dockerfile.ppc64le
+++ b/images/router/f5/Dockerfile.ppc64le
@@ -1,0 +1,10 @@
+#
+# This is the F5 router for OpenShift Origin.
+#
+# The standard name for this image is openshift/origin-f5-router
+#
+FROM openshift/origin-ppc64le
+
+LABEL io.k8s.display-name="OpenShift Origin F5 Router" \
+      io.k8s.description="This is a component of OpenShift Origin and programs a BigIP F5 router to expose services within the cluster."
+ENTRYPOINT ["/usr/bin/openshift-f5-router"]

--- a/images/router/haproxy/Dockerfile.ppc64le
+++ b/images/router/haproxy/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+#
+# This is the HAProxy router for OpenShift Origin.
+#
+# The standard name for this image is openshift/origin-haproxy-router
+#
+FROM openshift/origin-ppc64le
+
+RUN INSTALL_PKGS="haproxy" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
+    mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_route_http_expose,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
+    chown -R :0 /var/lib/haproxy && \
+    chmod -R g+w /var/lib/haproxy
+
+COPY . /var/lib/haproxy/
+
+LABEL io.k8s.display-name="OpenShift Origin HAProxy Router" \
+      io.k8s.description="This is a component of OpenShift Origin and contains an HAProxy instance that automatically exposes services within the cluster through routes, and offers TLS termination, reencryption, or SNI-passthrough on ports 80 and 443."
+USER 1001
+EXPOSE 80 443
+WORKDIR /var/lib/haproxy/conf
+ENV TEMPLATE_FILE=/var/lib/haproxy/conf/haproxy-config.template \
+    RELOAD_SCRIPT=/var/lib/haproxy/reload-haproxy
+ENTRYPOINT ["/usr/bin/openshift-router"]


### PR DESCRIPTION
This PR Addresses:

- Enables build scripts to build multi arch docker images
- Infra Dockerfiles for ppc64le platform