### PR TITLE
Fix the use of the variable schedulerLong correctly

### DIFF
--- a/pkg/cmd/server/start/kubernetes/scheduler.go
+++ b/pkg/cmd/server/start/kubernetes/scheduler.go
@@ -16,7 +16,7 @@ import (
 const schedulerLong = `
 Start Kubernetes scheduler
 
-This command launches an instance of the Kubernetes controller-manager (kube-controller-manager).`
+This command launches an instance of the Kubernetes scheduler (kube-scheduler).`
 
 // NewSchedulerCommand provides a CLI handler for the 'scheduler' command
 func NewSchedulerCommand(name, fullName string, out io.Writer) *cobra.Command {
@@ -25,7 +25,7 @@ func NewSchedulerCommand(name, fullName string, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Launch Kubernetes scheduler (kube-scheduler)",
-		Long:  controllersLong,
+		Long:  schedulerLong,
 		Run: func(c *cobra.Command, args []string) {
 			startProfiler()
 


### PR DESCRIPTION
When launching an instance of kubernetes scheduler, it should user schedulerLong constant, not controllersLong.