### PR TITLE
Bump OVS version requirement to 2.6.1

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -13,7 +13,7 @@
 # tuned_version is the version of tuned requires by packages
 %global tuned_version  2.3
 # openvswitch_version is the version of openvswitch requires by packages
-%global openvswitch_version 2.3.1
+%global openvswitch_version 2.6.1
 # this is the version we obsolete up to. The packaging changed for Origin
 # 1.0.6 and OSE 3.1 such that 'openshift' package names were no longer used.
 %global package_refector_version 3.0.2.900


### PR DESCRIPTION
Origin 3.6 and 1.5 will require OVS 2.6.1