### PR TITLE
UPSTREAM: 42973: Fix selinux support in vsphere

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -179,6 +179,7 @@ type vsphereVolumeMounter struct {
 func (b *vsphereVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
 		SupportsSELinux: true,
+		Managed:         true,
 	}
 }
 


### PR DESCRIPTION
Managed flag must be true for SELinux relabelling to work
for vsphere.