### PR TITLE
Don't try to use `go env` if `go` is not installed

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -107,12 +107,14 @@ readonly -f os::util::environment::setup_all_server_vars
 #  - export PATH
 function os::util::environment::update_path_var() {
     local prefix
-    prefix="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+    if os::util::find::system_binary 'go' >/dev/null 2>&1; then
+        prefix+="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+    fi
     if [[ -n "${GOPATH:-}" ]]; then
         prefix+="${GOPATH}/bin:"
     fi
 
-    PATH="${prefix}:${PATH}"
+    PATH="${prefix}${PATH}"
     export PATH
 }
 readonly -f os::util::environment::update_path_var


### PR DESCRIPTION
When someone is running our scripts without `go` installed, they will
not be able to take advantage of the `$OS_OUTPUT_BINPATH` prefix for
the `$PATH` by default, as we will not be able to determine where the
built binaries would go.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @sdodson

[test]