### PR TITLE
Allow retry action of pulling image in build process

### DIFF
--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -17,6 +17,7 @@ import (
 
 type FakeDocker struct {
 	pushImageFunc   func(opts docker.PushImageOptions, auth docker.AuthConfiguration) error
+	pullImageFunc   func(opts docker.PullImageOptions, auth docker.AuthConfiguration) error
 	buildImageFunc  func(opts docker.BuildImageOptions) error
 	removeImageFunc func(name string) error
 
@@ -51,6 +52,20 @@ func fakePushImageFunc(opts docker.PushImageOptions, auth docker.AuthConfigurati
 	}
 	return nil
 }
+
+func fakePullImageFunc(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
+	switch opts.Repository {
+	case "repo_test_succ_foo_bar":
+		return nil
+	case "repo_test_err_exist_foo_bar":
+		fooBarRunTimes++
+		return errors.New(RetriableErrors[0])
+	case "repo_test_err_no_exist_foo_bar":
+		return errors.New("no_exist_err_foo_bar")
+	}
+	return nil
+}
+
 func (d *FakeDocker) BuildImage(opts docker.BuildImageOptions) error {
 	if d.buildImageFunc != nil {
 		return d.buildImageFunc(opts)
@@ -77,6 +92,9 @@ func (d *FakeDocker) DownloadFromContainer(id string, opts docker.DownloadFromCo
 	return nil
 }
 func (d *FakeDocker) PullImage(opts docker.PullImageOptions, auth docker.AuthConfiguration) error {
+	if d.pullImageFunc != nil {
+		return d.pullImageFunc(opts, auth)
+	}
 	return nil
 }
 func (d *FakeDocker) RemoveContainer(opts docker.RemoveContainerOptions) error {
@@ -141,23 +159,23 @@ func TestTagImage(t *testing.T) {
 func TestPushImage(t *testing.T) {
 	var testImageName string
 
-	bakRetryCount := DefaultPushRetryCount
-	bakRetryDelay := DefaultPushRetryDelay
+	bakRetryCount := DefaultPushOrPullRetryCount
+	bakRetryDelay := DefaultPushOrPullRetryDelay
 
 	fakeDocker := NewFakeDockerClient()
 	fakeDocker.pushImageFunc = fakePushImageFunc
 	testAuth := docker.AuthConfiguration{
-		Username:      "usernname_foo_bar",
+		Username:      "username_foo_bar",
 		Password:      "password_foo_bar",
 		Email:         "email_foo_bar",
 		ServerAddress: "serveraddress_foo_bar",
 	}
 
 	//make test quickly, and recover the value after testing
-	DefaultPushRetryCount = 2
-	defer func() { DefaultPushRetryCount = bakRetryCount }()
-	DefaultPushRetryDelay = 1
-	defer func() { DefaultPushRetryDelay = bakRetryDelay }()
+	DefaultPushOrPullRetryCount = 2
+	defer func() { DefaultPushOrPullRetryCount = bakRetryCount }()
+	DefaultPushOrPullRetryDelay = 1
+	defer func() { DefaultPushOrPullRetryDelay = bakRetryDelay }()
 
 	//expect succ
 	testImageName = "repo_foo_bar:tag_test_succ_foo_bar"
@@ -172,7 +190,7 @@ func TestPushImage(t *testing.T) {
 		t.Errorf("Unexpect push image : %v, want error", err)
 	}
 	//expect run 3 times
-	if fooBarRunTimes != (DefaultPushRetryCount + 1) {
+	if fooBarRunTimes != (DefaultPushOrPullRetryCount + 1) {
 		t.Errorf("Unexpect run times : %d, we expect run three times", fooBarRunTimes)
 	}
 
@@ -180,6 +198,52 @@ func TestPushImage(t *testing.T) {
 	testImageName = "repo_foo_bar:tag_test_err_no_exist_foo_bar"
 	if _, err := pushImage(fakeDocker, testImageName, testAuth); err == nil {
 		t.Errorf("Unexpect push image : %v, want error", err)
+	}
+	defer func() { fooBarRunTimes = 0 }()
+}
+
+func TestPullImage(t *testing.T) {
+	var testImageName string
+
+	bakRetryCount := DefaultPushOrPullRetryCount
+	bakRetryDelay := DefaultPushOrPullRetryDelay
+
+	fakeDocker := NewFakeDockerClient()
+	fakeDocker.pullImageFunc = fakePullImageFunc
+	testAuth := docker.AuthConfiguration{
+		Username:      "username_foo_bar",
+		Password:      "password_foo_bar",
+		Email:         "email_foo_bar",
+		ServerAddress: "serveraddress_foo_bar",
+	}
+
+	//make test quickly, and recover the value after testing
+	DefaultPushOrPullRetryCount = 2
+	defer func() { DefaultPushOrPullRetryCount = bakRetryCount }()
+	DefaultPushOrPullRetryDelay = 1
+	defer func() { DefaultPushOrPullRetryDelay = bakRetryDelay }()
+
+	//expect succ
+	testImageName = "repo_test_succ_foo_bar"
+	if err := pullImage(fakeDocker, testImageName, testAuth); err != nil {
+		t.Errorf("Unexpect pull image : %v, want succ", err)
+	}
+
+	//expect fail
+	testImageName = "repo_test_err_exist_foo_bar"
+	err := pullImage(fakeDocker, testImageName, testAuth)
+	if err == nil {
+		t.Errorf("Unexpect pull image : %v, want error", err)
+	}
+	//expect run 3 times
+	if fooBarRunTimes != (DefaultPushOrPullRetryCount + 1) {
+		t.Errorf("Unexpect run times : %d, we expect run three times", fooBarRunTimes)
+	}
+
+	//expect fail
+	testImageName = "repo_test_err_no_exist_foo_bar"
+	if err := pullImage(fakeDocker, testImageName, testAuth); err == nil {
+		t.Errorf("Unexpect pull image : %v, want error", err)
 	}
 	defer func() { fooBarRunTimes = 0 }()
 }


### PR DESCRIPTION
**command :**
[cloud@centos ~]$ oc new-build https://github.com/openshift/ruby-hello-world --source-image=openshift/jenkins-1-centos7 --source-image-path=/var/lib/jenkins:tmp --allow-missing-images=false

**result:**

--> Found Docker image bce81d0 (2 weeks old) from Docker Hub for "centos/ruby-22-centos7"

    Ruby 2.2 
    -------- 
    Platform for building and running Ruby 2.2 applications

    Tags: builder, ruby, ruby22

    * An image stream will be created as "ruby-22-centos7:latest" that will track the source image
    * A Docker build using source code from https://github.com/openshift/ruby-hello-world will be created
      * The resulting image will be pushed to image stream "ruby-hello-world:latest"
      * Every time "ruby-22-centos7:latest" changes a new build will be triggered
```

--> Creating resources with label build=ruby-hello-world ...
    imagestream "ruby-22-centos7" created
    imagestream "ruby-hello-world" created
    buildconfig "ruby-hello-world" created
    imagestream "jenkins-1-centos7" created
--> Success
    Build configuration "ruby-hello-world" created and build triggered.
    Run 'oc logs -f bc/ruby-hello-world' to stream the build progress.

```
**Log:**
```
[cloud@centos ~]$ oc logs -f bc/ruby-hello-world
Cloning "https://github.com/openshift/ruby-hello-world" ...
	Commit:	022d87e4160c00274b63cdad7c238b5c6a299265 (Merge pull request #58 from junaruga/feature/fix-for-ruby24)
	Author:	Ben Parees <bparees@users.noreply.github.com>
	Date:	Fri Mar 3 15:29:12 2017 -0500
Pulling image "openshift/jenkins-1-centos7@sha256:1fc2d985e743c43ac32344d4987778647621c68810d2d25551736f40de34b2ce" ...
error: build error: error pulling image openshift/jenkins-1-centos7@sha256:1fc2d985e743c43ac32344d4987778647621c68810d2d25551736f40de34b2ce: Get https://registry-1.docker.io/v2/: read tcp 192.168.122.251:60528->50.17.62.194:443: read: **connection reset by peer**
```

Since the error **connection reset by peer**  had been handled in build pushing process,
I think we should add retry action of pulling image like what pushing image does. Test result  seems acceptable which always successful after retrying pull image 2~3 time in my workaround. 

/cc @bparees 
