### PR TITLE
System containers: use SD_NOTIFY for openvswitch

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -16,7 +16,7 @@ COPY etc/cni/net.d/* /etc/cni/net.d/
 COPY conf/openshift-sdn-ovs.conf /usr/lib/systemd/system/origin-node.service.d/
 COPY scripts/* /usr/local/bin/
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
-COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
+COPY system-container/manifest.json system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
 
 RUN curl -L -o /etc/yum.repos.d/origin-next-epel-7.repo https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo && \
     INSTALL_PKGS="libmnl libnetfilter_conntrack conntrack-tools openvswitch \

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -12,7 +12,7 @@ FROM openshift/origin
 
 COPY scripts/* /usr/local/bin/
 COPY system-container/system-container-wrapper.sh /usr/local/bin
-COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
+COPY system-container/manifest.json system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
 
 RUN INSTALL_PKGS="origin-sdn-ovs libmnl libnetfilter_conntrack conntrack-tools openvswitch \
       libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \

--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -138,15 +138,6 @@
         },
         {
 	    "type": "bind",
-	    "source": "/usr/bin/docker-current",
-	    "destination": "/usr/bin/docker-current",
-	    "options": [
-		"rbind",
-		"ro"
-	    ]
-        },
-        {
-	    "type": "bind",
 	    "source": "/etc/localtime",
 	    "destination": "/etc/localtime",
 	    "options": [
@@ -161,16 +152,6 @@
 	    "options": [
 		"rbind",
 		"ro"
-	    ]
-        },
-        {
-	    "type": "bind",
-	    "source": "/etc/origin/sdn",
-	    "destination": "/etc/openshift-sdn",
-	    "options": [
-		"rbind",
-		"rw",
-		"mode=755"
 	    ]
         },
         {
@@ -215,7 +196,7 @@
         },
         {
 	    "type": "bind",
-	    "source": "/etc/origin/openvswitch",
+	    "source": "$ORIGIN_CONFIG_DIR/openvswitch",
 	    "destination": "/etc/openvswitch",
 	    "options": [
 		"rbind",
@@ -225,7 +206,7 @@
         },
         {
 	    "type": "bind",
-	    "source": "/var/lib/origin",
+	    "source": "$ORIGIN_DATA_DIR",
 	    "destination": "/var/lib/origin",
 	    "options": [
 		"rbind",
@@ -295,8 +276,28 @@
         },
         {
 	    "type": "bind",
-	    "source": "/etc/origin/node",
+	    "source": "$ORIGIN_CONFIG_DIR/sdn",
+	    "destination": "/etc/openshift-sdn",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "$ORIGIN_CONFIG_DIR/node",
 	    "destination": "/etc/origin/node",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
+	    "type": "bind",
+	    "source": "$ORIGIN_CONFIG_DIR/cloudprovider",
+	    "destination": "/etc/origin/cloudprovider",
 	    "options": [
 		"rbind",
 		"rw",

--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+	"MASTER_SERVICE": "atomic-openshift-master"
+    }
+}
+

--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -1,7 +1,9 @@
 {
     "version": "1.0",
     "defaultValues": {
-	"MASTER_SERVICE": "atomic-openshift-master"
+        "MASTER_SERVICE": "atomic-openshift-master.service",
+        "DOCKER_SERVICE": "docker.service",
+        "OPENVSWITCH_SERVICE": "openvswitch.service"
     }
 }
 

--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -1,9 +1,10 @@
 {
     "version": "1.0",
     "defaultValues": {
+        "ORIGIN_CONFIG_DIR": "/etc/origin",
+        "ORIGIN_DATA_DIR": "/var/lib/origin",
         "MASTER_SERVICE": "atomic-openshift-master.service",
         "DOCKER_SERVICE": "docker.service",
         "OPENVSWITCH_SERVICE": "openvswitch.service"
     }
 }
-

--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -1,5 +1,5 @@
 [Unit]
-After=atomic-openshift-master.service
+After=${MASTER_SERVICE}.service
 After=docker.service
 After=openvswitch.service
 PartOf=docker.service

--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -1,12 +1,9 @@
 [Unit]
-After=${MASTER_SERVICE}.service
-After=docker.service
-After=openvswitch.service
-PartOf=docker.service
-Requires=docker.service
-Requires=openvswitch.service
-Requires=$NAME-dep.service
+After=${DOCKER_SERVICE}
+After=${OPENVSWITCH_SERVICE}
+Wants=${DOCKER_SERVICE}
 After=$NAME-dep.service
+After=${MASTER_SERVICE}
 
 [Service]
 EnvironmentFile=/etc/sysconfig/$NAME

--- a/images/node/system-container/tmpfiles.template
+++ b/images/node/system-container/tmpfiles.template
@@ -1,4 +1,5 @@
-d   /var/lib/origin - - - - -
+d   $ORIGIN_DATA_DIR - - - - -
 d   /var/lib/cni - - - - -
 d   /var/run/secrets - - - - -
-d   /etc/origin/sdn - - - - -
+d   $ORIGIN_CONFIG_DIR/sdn - - - - -
+d   $ORIGIN_CONFIG_DIR/cloudprovider  - - - - -

--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -17,6 +17,6 @@ ENV HOME /root
 
 # files required to run as a system container
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
-COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
+COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template system-container/manifest.json /exports/
 
 ENTRYPOINT ["/usr/local/bin/ovs-run.sh"]

--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -17,6 +17,6 @@ ENV HOME /root
 
 # files required to run as a system container
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
-COPY system-container/config.json.template system-container/service.template /exports/
+COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
 
 ENTRYPOINT ["/usr/local/bin/ovs-run.sh"]

--- a/images/openvswitch/system-container/config.json.template
+++ b/images/openvswitch/system-container/config.json.template
@@ -117,7 +117,7 @@
         },
         {
 	    "type": "bind",
-	    "source": "/etc/origin/openvswitch",
+	    "source": "$ORIGIN_CONFIG_DIR/openvswitch",
 	    "destination": "/etc/openvswitch",
 	    "options": [
 		"rbind",

--- a/images/openvswitch/system-container/manifest.json
+++ b/images/openvswitch/system-container/manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.0",
+    "defaultValues": {
+        "DOCKER_SERVICE": "docker.service"
+    }
+}

--- a/images/openvswitch/system-container/manifest.json
+++ b/images/openvswitch/system-container/manifest.json
@@ -1,6 +1,7 @@
 {
     "version": "1.0",
     "defaultValues": {
+        "ORIGIN_CONFIG_DIR": "/etc/origin",
         "DOCKER_SERVICE": "docker.service"
     }
 }

--- a/images/openvswitch/system-container/service.template
+++ b/images/openvswitch/system-container/service.template
@@ -7,11 +7,11 @@ PartOf=docker.service
 EnvironmentFile=/etc/sysconfig/$NAME
 ExecStartPre=/bin/bash -c 'export -p > /run/$NAME-env'
 ExecStart=$EXEC_START
-ExecStartPost=/usr/bin/sleep 5
 ExecStop=$EXEC_STOP
 SyslogIdentifier=$NAME
 Restart=always
-RestartSec=5s
+Type=notify
+NotifyAccess=all
 WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
 

--- a/images/openvswitch/system-container/service.template
+++ b/images/openvswitch/system-container/service.template
@@ -1,7 +1,7 @@
 [Unit]
-After=docker.service
-Requires=docker.service
-PartOf=docker.service
+After=${DOCKER_SERVICE}
+Requires=${DOCKER_SERVICE}
+PartOf=${DOCKER_SERVICE}
 
 [Service]
 EnvironmentFile=/etc/sysconfig/$NAME

--- a/images/openvswitch/system-container/system-container-wrapper.sh
+++ b/images/openvswitch/system-container/system-container-wrapper.sh
@@ -1,4 +1,29 @@
-#!/bin/sh
+#!/bin/bash
 source /run/$NAME-env
+
+MAINPID=`sed -n -e "/^PPid/ s|PPid:\t||p" /proc/$$/status`
+
+# openvswitch 2.4 has no systemd-notify support, so add it here.
+# Workaround for a bug in systemd-notify 219.  Whenever used with --pid, systemd-notify 219
+# sends an incorrect packet to $NOTIFY_SOCKET and the process hangs.
+# Newer versions of systemd-notify don't have this issue, and also this change in runc,
+# even if addressing another issue: https://github.com/opencontainers/runc/pull/1308
+# will ensure once it gets in a release that the notify events are properly propagated.
+if test -n ${NOTIFY_SOCKET-}; then
+    /usr/share/openvswitch/scripts/ovs-ctl status
+    while /usr/share/openvswitch/scripts/ovs-ctl status | grep -q "not running"; do
+        sleep 1
+    done
+    ps aux | grep $MAINPID
+    python - << EOF
+import socket
+import os
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+e = os.getenv('NOTIFY_SOCKET')
+s.connect(e)
+s.sendall('MAINPID=%i\nREADY=1\n' % $MAINPID)
+s.close()
+EOF
+fi &
 
 exec /usr/local/bin/ovs-run.sh

--- a/images/openvswitch/system-container/tmpfiles.template
+++ b/images/openvswitch/system-container/tmpfiles.template
@@ -1,0 +1,1 @@
+d   /etc/origin/openvswitch - - - - -

--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -11,7 +11,7 @@
 FROM openshift/origin-base
 
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
-COPY system-container/config.json.template system-container/manifest.json system-container/service.template /exports/
+COPY system-container/config.json.template system-container/manifest.json system-container/service.template system-container/tmpfiles.template /exports/
 COPY bin/openshift /usr/bin/openshift
 RUN ln -s /usr/bin/openshift /usr/bin/oc && \
     ln -s /usr/bin/openshift /usr/bin/oadm && \

--- a/images/origin/Dockerfile.centos7
+++ b/images/origin/Dockerfile.centos7
@@ -27,6 +27,6 @@ EXPOSE 8443 53
 
 # files required to run as a system container
 COPY system-container/system-container-wrapper.sh /usr/local/bin
-COPY system-container/config.json.template system-container/manifest.json system-container/service.template /exports/
+COPY system-container/config.json.template system-container/manifest.json system-container/service.template system-container/tmpfiles.template /exports/
 
 ENTRYPOINT ["/usr/bin/openshift"]

--- a/images/origin/system-container/config.json.template
+++ b/images/origin/system-container/config.json.template
@@ -127,7 +127,7 @@
         },
 	{
 	    "type": "bind",
-	    "source": "/etc/origin",
+	    "source": "$ORIGIN_CONFIG_DIR",
 	    "destination": "/etc/origin",
 	    "options": [
 		"bind",
@@ -137,7 +137,7 @@
 	},
 	{
 	    "type": "bind",
-	    "source": "/var/lib/origin",
+	    "source": "$ORIGIN_DATA_DIR",
 	    "destination": "/var/lib/origin",
 	    "options": [
 		"rbind",

--- a/images/origin/system-container/manifest.json
+++ b/images/origin/system-container/manifest.json
@@ -2,6 +2,8 @@
     "version": "1.0",
     "defaultValues": {
         "COMMAND": "",
+        "ORIGIN_CONFIG_DIR": "/etc/origin",
+        "ORIGIN_DATA_DIR": "/var/lib/origin",
         "ETCD_SERVICE": "etcd.service",
         "NODE_SERVICE": "atomic-openshift-node.service"
     }

--- a/images/origin/system-container/manifest.json
+++ b/images/origin/system-container/manifest.json
@@ -1,7 +1,9 @@
 {
     "version": "1.0",
     "defaultValues": {
-	"COMMAND": ""
+        "COMMAND": "",
+        "ETCD_SERVICE": "etcd.service",
+        "NODE_SERVICE": "atomic-openshift-node.service"
     }
 }
 

--- a/images/origin/system-container/service.template
+++ b/images/origin/system-container/service.template
@@ -1,7 +1,7 @@
 [Unit]
-After=docker.service
-Requires=docker.service
-PartOf=docker.service
+After=network-online.target
+After=${ETCD_SERVICE}
+Before=${NODE_SERVICE}
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/$NAME

--- a/images/origin/system-container/tmpfiles.template
+++ b/images/origin/system-container/tmpfiles.template
@@ -1,0 +1,2 @@
+d   $ORIGIN_CONFIG_DIR - - - - -
+d   $ORIGIN_DATA_DIR - - - - -


### PR DESCRIPTION
The most important change is that the openvswitch system container uses SD_NOTIFY to notify systemd when it is ready.  Plus some other minor fixes I've accumulated here.  Some of them are necessary for the cluster to come back online after a reboot.