### PR TITLE
docs: bump Go requirement from 1.6.x to 1.7.x in contributing

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -43,7 +43,7 @@ You can develop OpenShift 3 on Windows, Mac, or Linux, but you'll need Docker in
 Here's how to get set up:
 
 1. For Go, Git and optionally also Docker, follow the links below to get to installation information for these tools: +
-** http://golang.org/doc/install[Installing Go]. Currently, OpenShift supports building using Go 1.6.x. Do NOT use $HOME/go for Go installation, save that for the Go workspace below.
+** http://golang.org/doc/install[Installing Go]. Currently, OpenShift supports building using Go 1.7.x. Do NOT use $HOME/go for Go installation, save that for the Go workspace below.
 ** http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git]
 ** https://docs.docker.com/installation/[Installing Docker]
 +


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/13384

@smarterclayton @stevekuznetsov  i believe this is now correct (for the master).