### PR TITLE
Default imagePullPolicy for the registry

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -338,6 +338,7 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 						Name:      "registry-storage",
 						MountPath: opts.Config.Volume,
 					}),
+					ImagePullPolicy: kapi.PullIfNotPresent,
 					SecurityContext: &kapi.SecurityContext{
 						Privileged: &mountHost,
 					},


### PR DESCRIPTION
Enterprise installations where the latest version is used (enterprise
and latest is hopefully not a thing) are broken because the registry
defaults to imagePullPolicy=Always and tries to pull the enterprise
image from DockerHub. This fix brings the registry deployment on par
with the router deployment too.

@mfojtik @legionus 