### PR TITLE
Add list events permission to pv-provisioner clusterrole

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -828,7 +828,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule("get", "list", "watch", "update").Groups(kapiGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				// Needed for watching provisioning success and failure events
-				authorizationapi.NewRule("create", "update", "patch", "watch").Groups(kapiGroup).Resources("events").RuleOrDie(),
+				authorizationapi.NewRule("create", "update", "patch", "list", "watch").Groups(kapiGroup).Resources("events").RuleOrDie(),
 			},
 		},
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2389,6 +2389,7 @@ items:
     - events
     verbs:
     - create
+    - list
     - patch
     - update
     - watch


### PR DESCRIPTION
follow up to https://github.com/openshift/origin/pull/13333: I missed that unlike kube, openshift doesn't let me watch unless I can also list (I guess they should be paired together all the time anyway, but yeah) @liggitt PTAL, thank you!