### PR TITLE
Dump Jenkins build log for pipeline builds

### DIFF
--- a/examples/jenkins/pipeline/bluegreen-pipeline.yaml
+++ b/examples/jenkins/pipeline/bluegreen-pipeline.yaml
@@ -30,6 +30,7 @@ objects:
           def project=""
           def tag="blue"
           def altTag="green"
+          def verbose="${VERBOSE}"
 
           node {
             project = env.PROJECT_NAME
@@ -46,12 +47,12 @@ objects:
 
             stage("Build") {
               echo "building tag ${tag}"
-              openshiftBuild buildConfig: appName, showBuildLogs: "true"
+              openshiftBuild buildConfig: appName, showBuildLogs: "true", verbose: verbose
             }
 
             stage("Deploy Test") {
-              openshiftTag srcStream: appName, srcTag: 'latest', destinationStream: appName, destinationTag: tag
-              openshiftVerifyDeployment deploymentConfig: "${appName}-${tag}"
+              openshiftTag srcStream: appName, srcTag: 'latest', destinationStream: appName, destinationTag: tag, verbose: verbose
+              openshiftVerifyDeployment deploymentConfig: "${appName}-${tag}", verbose: verbose
             }
 
             stage("Test") {
@@ -440,3 +441,8 @@ parameters:
   name: NAMESPACE
   required: true
   value: openshift
+- description: Whether to enable verbose logging of Jenkinsfile steps in pipeline
+  displayName: Verbose
+  name: VERBOSE
+  required: true
+  value: "false"

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -4973,6 +4973,7 @@ objects:
           def project=""
           def tag="blue"
           def altTag="green"
+          def verbose="${VERBOSE}"
 
           node {
             project = env.PROJECT_NAME
@@ -4989,12 +4990,12 @@ objects:
 
             stage("Build") {
               echo "building tag ${tag}"
-              openshiftBuild buildConfig: appName, showBuildLogs: "true"
+              openshiftBuild buildConfig: appName, showBuildLogs: "true", verbose: verbose
             }
 
             stage("Deploy Test") {
-              openshiftTag srcStream: appName, srcTag: 'latest', destinationStream: appName, destinationTag: tag
-              openshiftVerifyDeployment deploymentConfig: "${appName}-${tag}"
+              openshiftTag srcStream: appName, srcTag: 'latest', destinationStream: appName, destinationTag: tag, verbose: verbose
+              openshiftVerifyDeployment deploymentConfig: "${appName}-${tag}", verbose: verbose
             }
 
             stage("Test") {
@@ -5383,6 +5384,11 @@ parameters:
   name: NAMESPACE
   required: true
   value: openshift
+- description: Whether to enable verbose logging of Jenkinsfile steps in pipeline
+  displayName: Verbose
+  name: VERBOSE
+  required: true
+  value: "false"
 `)
 
 func examplesJenkinsPipelineBluegreenPipelineYamlBytes() ([]byte, error) {

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -32,6 +32,7 @@ const (
 
 func debugAnyJenkinsFailure(br *exutil.BuildResult, name string, oc *exutil.CLI, dumpMaster bool) {
 	if !br.BuildSuccess {
+		br.LogDumper = jenkins.DumpLogs
 		fmt.Fprintf(g.GinkgoWriter, "\n\n START debugAnyJenkinsFailure\n\n")
 		j := jenkins.NewRef(oc)
 		jobLog, err := j.GetLastJobConsoleLogs(name)
@@ -218,7 +219,7 @@ var _ = g.Describe("[builds][Slow] openshift pipeline build", func() {
 		g.It("Blue-green pipeline should build and complete successfully", func() {
 			// instantiate the template
 			g.By(fmt.Sprintf("calling oc new-app -f %q", blueGreenPipelinePath))
-			err := oc.Run("new-app").Args("-f", blueGreenPipelinePath).Execute()
+			err := oc.Run("new-app").Args("-f", blueGreenPipelinePath, "-p", "VERBOSE=true").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			buildAndSwitch := func(newColour string) {

--- a/test/extended/util/jenkins/monitor.go
+++ b/test/extended/util/jenkins/monitor.go
@@ -61,6 +61,13 @@ func (jmon *JobMon) Await(timeout time.Duration) error {
 		}
 
 		ginkgolog("Jenkins job %q build complete:\n%s\n\n", jmon.jobName, body)
+		// If Jenkins job has completed, output its log
+		body, status, err = jmon.j.GetResource("job/%s/%s/consoleText", jmon.jobName, jmon.buildNumber)
+		if err != nil || status != 200 {
+			ginkgolog("Unable to retrieve job log from Jenkins.\nStatus code: %d\nError: %v\nResponse Text: %s\n", status, err, body)
+			return true, nil
+		}
+		ginkgolog("Jenkins job %q log:\n%s\n\n", jmon.jobName, body)
 		return true, nil
 	})
 	return err


### PR DESCRIPTION
Changes to help debug Jenkins-related extended test failures:
- Added optional verbose parameter to blue-green pipeline template
- Dump logs of related jenkins job when dumping build
- On Jenkins monitor, dump the logs of the Jenkins job if that job has completed