### PR TITLE
auth: move apiGroup to be a suffix in error messages

### DIFF
--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -33,7 +33,7 @@ func (a *openshiftAuthorizer) Authorize(attributes authorizer.Attributes) (bool,
 		return false, "", err
 	}
 
-	denyReason, err := a.forbiddenMessageMaker.MakeMessage(MessageContext{attributes})
+	denyReason, err := a.forbiddenMessageMaker.MakeMessage(attributes)
 	if err != nil {
 		denyReason = err.Error()
 	}

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -47,7 +47,7 @@ func TestAPIGroupDeny(t *testing.T) {
 			Resource:        "pods",
 		},
 		expectedAllowed: false,
-		expectedReason:  `User "Anna" cannot list group.pods in project "adze"`,
+		expectedReason:  `User "Anna" cannot list pods.group in project "adze"`,
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = append(test.policies, newAdzePolicies()...)

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -20,12 +20,7 @@ type RequestInfoFactory interface {
 	NewRequestInfo(req *http.Request) (*request.RequestInfo, error)
 }
 
-// ForbiddenMessageMaker creates a forbidden message from a MessageContext
+// ForbiddenMessageMaker creates a forbidden message from Attributes
 type ForbiddenMessageMaker interface {
-	MakeMessage(ctx MessageContext) (string, error)
-}
-
-// MessageContext contains sufficient information to create a forbidden message.  It is bundled in this one object to make it easy and obvious how to build a golang template
-type MessageContext struct {
-	Attributes authorizer.Attributes
+	MakeMessage(attrs authorizer.Attributes) (string, error)
 }

--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"text/template"
 
+	"k8s.io/kubernetes/pkg/auth/authorizer"
+
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
@@ -20,29 +22,29 @@ type ForbiddenMessageResolver struct {
 }
 
 func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *ForbiddenMessageResolver {
-	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}.{{.Attributes.GetAPIGroup}}{{end}}"
-	resourceWithSubresourceIfNotEmpty := "{{if len .Attributes.GetSubresource }}{{.Attributes.GetResource}}/{{.Attributes.GetSubresource}}{{else}}{{.Attributes.GetResource}}{{end}}"
+	apiGroupIfNotEmpty := "{{if len .GetAPIGroup }}.{{.GetAPIGroup}}{{end}}"
+	resourceWithSubresourceIfNotEmpty := "{{if len .GetSubresource }}{{.GetResource}}/{{.GetSubresource}}{{else}}{{.GetResource}}{{end}}"
 
 	messageResolver := &ForbiddenMessageResolver{
 		namespacedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
 		rootScopedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
-		nonResourceURLForbiddenMessageMaker:               newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot "{{.Attributes.GetVerb}}" on "{{.Attributes.GetPath}}"`),
-		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot "{{.Attributes.GetVerb}}" "` + resourceWithSubresourceIfNotEmpty + apiGroupIfNotEmpty + `" with name "{{.Attributes.GetName}}" in project "{{.Attributes.GetNamespace}}"`),
+		nonResourceURLForbiddenMessageMaker:               newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot "{{.GetVerb}}" on "{{.GetPath}}"`),
+		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot "{{.GetVerb}}" "` + resourceWithSubresourceIfNotEmpty + apiGroupIfNotEmpty + `" with name "{{.GetName}}" in project "{{.GetNamespace}}"`),
 	}
 
 	// general messages
-	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot list `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot list all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot watch `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot watch all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
 
 	// project request rejection
 	projectRequestDeny := projectRequestForbiddenTemplate
@@ -52,7 +54,7 @@ func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *Forbid
 	messageResolver.addRootScopedForbiddenMessageMaker("create", "projectrequests", newTemplateForbiddenMessageMaker(projectRequestDeny))
 
 	// projects "get" request rejection
-	messageResolver.addNamespacedForbiddenMessageMaker("get", "projects", newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addNamespacedForbiddenMessageMaker("get", "projects", newTemplateForbiddenMessageMaker(`User "{{.GetUser.GetName}}" cannot get project "{{.GetNamespace}}"`))
 
 	return messageResolver
 }
@@ -75,35 +77,35 @@ func (m *ForbiddenMessageResolver) addForbiddenMessageMaker(target map[string]ma
 	resourcesToForbiddenMessageMaker[resource] = messageMaker
 }
 
-func (m *ForbiddenMessageResolver) MakeMessage(ctx MessageContext) (string, error) {
-	if !ctx.Attributes.IsResourceRequest() {
-		return m.nonResourceURLForbiddenMessageMaker.MakeMessage(ctx)
+func (m *ForbiddenMessageResolver) MakeMessage(attrs authorizer.Attributes) (string, error) {
+	if !attrs.IsResourceRequest() {
+		return m.nonResourceURLForbiddenMessageMaker.MakeMessage(attrs)
 	}
 
 	messageMakerMap := m.namespacedVerbsToResourcesToForbiddenMessageMaker
-	if len(ctx.Attributes.GetNamespace()) == 0 {
+	if len(attrs.GetNamespace()) == 0 {
 		messageMakerMap = m.rootScopedVerbsToResourcesToForbiddenMessageMaker
 	}
 
-	resourcesToForbiddenMessageMaker, exists := messageMakerMap[ctx.Attributes.GetVerb()]
+	resourcesToForbiddenMessageMaker, exists := messageMakerMap[attrs.GetVerb()]
 	if !exists {
 		resourcesToForbiddenMessageMaker, exists = messageMakerMap[authorizationapi.VerbAll]
 		if !exists {
-			return m.defaultForbiddenMessageMaker.MakeMessage(ctx)
+			return m.defaultForbiddenMessageMaker.MakeMessage(attrs)
 		}
 	}
 
-	messageMaker, exists := resourcesToForbiddenMessageMaker[ctx.Attributes.GetResource()]
+	messageMaker, exists := resourcesToForbiddenMessageMaker[attrs.GetResource()]
 	if !exists {
 		messageMaker, exists = resourcesToForbiddenMessageMaker[authorizationapi.ResourceAll]
 		if !exists {
-			return m.defaultForbiddenMessageMaker.MakeMessage(ctx)
+			return m.defaultForbiddenMessageMaker.MakeMessage(attrs)
 		}
 	}
 
-	specificMessage, err := messageMaker.MakeMessage(ctx)
+	specificMessage, err := messageMaker.MakeMessage(attrs)
 	if err != nil {
-		return m.defaultForbiddenMessageMaker.MakeMessage(ctx)
+		return m.defaultForbiddenMessageMaker.MakeMessage(attrs)
 	}
 
 	return specificMessage, nil
@@ -119,8 +121,8 @@ func newTemplateForbiddenMessageMaker(text string) templateForbiddenMessageMaker
 	return templateForbiddenMessageMaker{parsedTemplate}
 }
 
-func (m templateForbiddenMessageMaker) MakeMessage(ctx MessageContext) (string, error) {
+func (m templateForbiddenMessageMaker) MakeMessage(attrs authorizer.Attributes) (string, error) {
 	buffer := &bytes.Buffer{}
-	err := m.parsedTemplate.Execute(buffer, ctx)
+	err := m.parsedTemplate.Execute(buffer, attrs)
 	return string(buffer.Bytes()), err
 }

--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -20,29 +20,29 @@ type ForbiddenMessageResolver struct {
 }
 
 func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *ForbiddenMessageResolver {
-	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}{{.Attributes.GetAPIGroup}}.{{end}}"
+	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}.{{.Attributes.GetAPIGroup}}{{end}}"
 	resourceWithSubresourceIfNotEmpty := "{{if len .Attributes.GetSubresource }}{{.Attributes.GetResource}}/{{.Attributes.GetSubresource}}{{else}}{{.Attributes.GetResource}}{{end}}"
 
 	messageResolver := &ForbiddenMessageResolver{
 		namespacedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
 		rootScopedVerbsToResourcesToForbiddenMessageMaker: map[string]map[string]ForbiddenMessageMaker{},
 		nonResourceURLForbiddenMessageMaker:               newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot "{{.Attributes.GetVerb}}" on "{{.Attributes.GetPath}}"`),
-		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot "{{.Attributes.GetVerb}}" "` + apiGroupIfNotEmpty + resourceWithSubresourceIfNotEmpty + `" with name "{{.Attributes.GetName}}" in project "{{.Attributes.GetNamespace}}"`),
+		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot "{{.Attributes.GetVerb}}" "` + resourceWithSubresourceIfNotEmpty + apiGroupIfNotEmpty + `" with name "{{.Attributes.GetName}}" in project "{{.Attributes.GetNamespace}}"`),
 	}
 
 	// general messages
-	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list all `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch all `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+apiGroupIfNotEmpty+resourceWithSubresourceIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot create `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot get `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot list all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("watch", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot watch all `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot update `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` in project "{{.Attributes.GetNamespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.Attributes.GetUser.GetName}}" cannot delete `+resourceWithSubresourceIfNotEmpty+apiGroupIfNotEmpty+` at the cluster scope`))
 
 	// project request rejection
 	projectRequestDeny := projectRequestForbiddenTemplate

--- a/pkg/authorization/authorizer/messages_test.go
+++ b/pkg/authorization/authorizer/messages_test.go
@@ -10,8 +10,8 @@ import (
 func TestDefaultForbiddenMessages(t *testing.T) {
 	messageResolver := NewForbiddenMessageResolver("")
 
-	apiForbidden, err := messageResolver.defaultForbiddenMessageMaker.MakeMessage(MessageContext{
-		Attributes: kauthorizer.AttributesRecord{
+	apiForbidden, err := messageResolver.defaultForbiddenMessageMaker.MakeMessage(
+		kauthorizer.AttributesRecord{
 			ResourceRequest: true,
 			User:            &user.DefaultInfo{Name: "chris"},
 			Namespace:       "foo",
@@ -19,7 +19,7 @@ func TestDefaultForbiddenMessages(t *testing.T) {
 			Resource:        "pods",
 			Name:            "hammer",
 		},
-	})
+	)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -30,173 +30,178 @@ func TestDefaultForbiddenMessages(t *testing.T) {
 	}
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: false,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "post",
-				Path:            "/anything",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: false,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "post",
+			Path:            "/anything",
 		},
-		`User "chris" cannot "post" on "/anything"`,
+		expected: `User "chris" cannot "post" on "/anything"`,
+	}.run(t)
+}
+
+func TestAttributeRecord(t *testing.T) {
+	messageTest{
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "get",
+			Resource:        "users",
+			APIGroup:        "user.openshift.io",
+			APIVersion:      "v1",
+			Name:            "hammer",
+		},
+		expected: `User "chris" cannot get users.user.openshift.io in project "foo"`,
+	}.run(t)
+	messageTest{
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: false,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "get",
+			Resource:        "users",
+			APIGroup:        "user.openshift.io",
+			APIVersion:      "v1",
+			Path:            "/",
+		},
+		expected: `User "chris" cannot "get" on "/"`,
 	}.run(t)
 }
 
 func TestProjectRequestForbiddenMessage(t *testing.T) {
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "create",
-				Resource:        "projectrequests",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "create",
+			Resource:        "projectrequests",
 		},
-		DefaultProjectRequestForbidden,
+		expected: DefaultProjectRequestForbidden,
 	}.run(t)
 }
 
 func TestNamespacedForbiddenMessage(t *testing.T) {
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "create",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "create",
+			Resource:        "builds",
 		},
-		`User "chris" cannot create builds in project "foo"`,
+		expected: `User "chris" cannot create builds in project "foo"`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "get",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "get",
+			Resource:        "builds",
 		},
-		`User "chris" cannot get builds in project "foo"`,
+		expected: `User "chris" cannot get builds in project "foo"`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "list",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "list",
+			Resource:        "builds",
 		},
-		`User "chris" cannot list builds in project "foo"`,
+		expected: `User "chris" cannot list builds in project "foo"`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "update",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "update",
+			Resource:        "builds",
 		},
-		`User "chris" cannot update builds in project "foo"`,
+		expected: `User "chris" cannot update builds in project "foo"`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Namespace:       "foo",
-				Verb:            "delete",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Namespace:       "foo",
+			Verb:            "delete",
+			Resource:        "builds",
 		},
-		`User "chris" cannot delete builds in project "foo"`,
+		expected: `User "chris" cannot delete builds in project "foo"`,
 	}.run(t)
 
 }
 
 func TestRootScopedForbiddenMessage(t *testing.T) {
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "create",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "create",
+			Resource:        "builds",
 		},
-		`User "chris" cannot create builds at the cluster scope`,
+		expected: `User "chris" cannot create builds at the cluster scope`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "get",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "get",
+			Resource:        "builds",
 		},
-		`User "chris" cannot get builds at the cluster scope`,
+		expected: `User "chris" cannot get builds at the cluster scope`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "list",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "list",
+			Resource:        "builds",
 		},
-		`User "chris" cannot list all builds in the cluster`,
+		expected: `User "chris" cannot list all builds in the cluster`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "update",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "update",
+			Resource:        "builds",
 		},
-		`User "chris" cannot update builds at the cluster scope`,
+		expected: `User "chris" cannot update builds at the cluster scope`,
 	}.run(t)
 
 	messageTest{
-		MessageContext{
-			Attributes: kauthorizer.AttributesRecord{
-				ResourceRequest: true,
-				User:            &user.DefaultInfo{Name: "chris"},
-				Verb:            "delete",
-				Resource:        "builds",
-			},
+		attributes: kauthorizer.AttributesRecord{
+			ResourceRequest: true,
+			User:            &user.DefaultInfo{Name: "chris"},
+			Verb:            "delete",
+			Resource:        "builds",
 		},
-		`User "chris" cannot delete builds at the cluster scope`,
+		expected: `User "chris" cannot delete builds at the cluster scope`,
 	}.run(t)
 
 }
 
 type messageTest struct {
-	messageContext MessageContext
-	expected       string
+	attributes kauthorizer.Attributes
+	expected   string
 }
 
 func (test messageTest) run(t *testing.T) {
 	messageResolver := NewForbiddenMessageResolver("")
 
-	forbidden, err := messageResolver.MakeMessage(test.messageContext)
+	forbidden, err := messageResolver.MakeMessage(test.attributes)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/authorization/authorizer/scope/authorizer.go
+++ b/pkg/authorization/authorizer/scope/authorizer.go
@@ -54,7 +54,7 @@ func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (bool, str
 		}
 	}
 
-	denyReason, err := a.forbiddenMessageMaker.MakeMessage(defaultauthorizer.MessageContext{Attributes: attributes})
+	denyReason, err := a.forbiddenMessageMaker.MakeMessage(attributes)
 	if err != nil {
 		denyReason = err.Error()
 	}

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -1094,7 +1094,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		clusterReview:     askCanDannyGetProject,
 		kubeAuthInterface: dannySARGetter,
 		err:               `User "danny" cannot create subjectaccessreviews at the cluster scope`,
-		kubeErr:           `User "danny" cannot create authorization.k8s.io.subjectaccessreviews at the cluster scope`,
+		kubeErr:           `User "danny" cannot create subjectaccessreviews.authorization.k8s.io at the cluster scope`,
 	}.run(t)
 	subjectAccessReviewTest{
 		description:       "as anonymous, can I make cluster subject access reviews",
@@ -1102,7 +1102,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		clusterReview:     askCanDannyGetProject,
 		kubeAuthInterface: anonymousSARGetter,
 		err:               `User "system:anonymous" cannot create subjectaccessreviews at the cluster scope`,
-		kubeErr:           `User "system:anonymous" cannot create authorization.k8s.io.subjectaccessreviews at the cluster scope`,
+		kubeErr:           `User "system:anonymous" cannot create subjectaccessreviews.authorization.k8s.io at the cluster scope`,
 	}.run(t)
 
 	addValerie := &policy.RoleModificationOptions{
@@ -1175,7 +1175,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		kubeAuthInterface: haroldSARGetter,
 		kubeNamespace:     "mallet-project",
 		err:               `User "harold" cannot create localsubjectaccessreviews in project "mallet-project"`,
-		kubeErr:           `User "harold" cannot create authorization.k8s.io.localsubjectaccessreviews in project "mallet-project"`,
+		kubeErr:           `User "harold" cannot create localsubjectaccessreviews.authorization.k8s.io in project "mallet-project"`,
 	}.run(t)
 	subjectAccessReviewTest{
 		description:       "system:anonymous denied ability to run subject access review in project mallet-project",
@@ -1184,7 +1184,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		kubeAuthInterface: anonymousSARGetter,
 		kubeNamespace:     "mallet-project",
 		err:               `User "system:anonymous" cannot create localsubjectaccessreviews in project "mallet-project"`,
-		kubeErr:           `User "system:anonymous" cannot create authorization.k8s.io.localsubjectaccessreviews in project "mallet-project"`,
+		kubeErr:           `User "system:anonymous" cannot create localsubjectaccessreviews.authorization.k8s.io in project "mallet-project"`,
 	}.run(t)
 	// ensure message does not leak whether the namespace exists or not
 	subjectAccessReviewTest{
@@ -1194,7 +1194,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		kubeAuthInterface: haroldSARGetter,
 		kubeNamespace:     "nonexistent-project",
 		err:               `User "harold" cannot create localsubjectaccessreviews in project "nonexistent-project"`,
-		kubeErr:           `User "harold" cannot create authorization.k8s.io.localsubjectaccessreviews in project "nonexistent-project"`,
+		kubeErr:           `User "harold" cannot create localsubjectaccessreviews.authorization.k8s.io in project "nonexistent-project"`,
 	}.run(t)
 	subjectAccessReviewTest{
 		description:       "system:anonymous denied ability to run subject access review in project nonexistent-project",
@@ -1203,7 +1203,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		kubeAuthInterface: anonymousSARGetter,
 		kubeNamespace:     "nonexistent-project",
 		err:               `User "system:anonymous" cannot create localsubjectaccessreviews in project "nonexistent-project"`,
-		kubeErr:           `User "system:anonymous" cannot create authorization.k8s.io.localsubjectaccessreviews in project "nonexistent-project"`,
+		kubeErr:           `User "system:anonymous" cannot create localsubjectaccessreviews.authorization.k8s.io in project "nonexistent-project"`,
 	}.run(t)
 
 	askCanHaroldUpdateProject := &authorizationapi.LocalSubjectAccessReview{
@@ -1243,7 +1243,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		clusterReview:     askCanClusterAdminsCreateProject,
 		kubeAuthInterface: haroldSARGetter,
 		err:               `User "harold" cannot create subjectaccessreviews at the cluster scope`,
-		kubeErr:           `User "harold" cannot create authorization.k8s.io.subjectaccessreviews at the cluster scope`,
+		kubeErr:           `User "harold" cannot create subjectaccessreviews.authorization.k8s.io at the cluster scope`,
 	}.run(t)
 
 	askCanICreatePods := &authorizationapi.LocalSubjectAccessReview{

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -903,7 +903,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		kubeAuthInterface: clusterAdminKubeClient.Authorization(),
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   false,
-			Reason:    `User "harold" cannot get foo.horizontalpodautoscalers in project "hammer-project"`,
+			Reason:    `User "harold" cannot get horizontalpodautoscalers.foo in project "hammer-project"`,
 			Namespace: "hammer-project",
 		},
 	}.run(t)
@@ -917,7 +917,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		kubeAuthInterface: clusterAdminSARGetter,
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   false,
-			Reason:    `User "harold" cannot get *.horizontalpodautoscalers in project "hammer-project"`,
+			Reason:    `User "harold" cannot get horizontalpodautoscalers.* in project "hammer-project"`,
 			Namespace: "hammer-project",
 		},
 	}.run(t)

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -166,7 +166,7 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 		kubeAuthInterface: valerieKubeClient.Authorization(),
 		kubeNamespace:     "openshift",
 		err:               `User "valerie" cannot create localsubjectaccessreviews in project "openshift"`,
-		kubeErr:           `User "valerie" cannot create authorization.k8s.io.localsubjectaccessreviews in project "openshift"`,
+		kubeErr:           `User "valerie" cannot create localsubjectaccessreviews.authorization.k8s.io in project "openshift"`,
 	}.run(t)
 
 }


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/13445

@smarterclayton @enj PTAL

This will make the error messages in sync with rest of the upstream errors.