### PR TITLE
Bug 1433244 - allow imageimports to be long runing requests

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -61,7 +61,7 @@ import (
 
 // request paths that match this regular expression will be treated as long running
 // and not subjected to the default server timeout.
-const originLongRunningEndpointsRE = "(/|^)buildconfigs/.*/instantiatebinary$"
+const originLongRunningEndpointsRE = "(/|^)(buildconfigs/.*/instantiatebinary|imagestreamimports)$"
 
 var LegacyAPIGroupPrefixes = sets.NewString(genericapiserver.DefaultLegacyAPIPrefix, api.Prefix, api.LegacyPrefix)
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1433244.
