### PR TITLE
Segregate iptables rules

### DIFF
--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -101,13 +101,13 @@ const VXLAN_PORT = "4789"
 // Get openshift iptables rules
 func (n *NodeIPTables) getStaticNodeIPTablesRules() []FirewallRule {
 	return []FirewallRule{
-		{"nat", "POSTROUTING", []string{"-s", n.clusterNetworkCIDR, "-j", "MASQUERADE"}},
-		{"filter", "INPUT", []string{"-p", "udp", "-m", "multiport", "--dports", VXLAN_PORT, "-m", "comment", "--comment", "001 vxlan incoming", "-j", "ACCEPT"}},
-		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "traffic from SDN", "-j", "ACCEPT"}},
-		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "traffic from docker", "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP"}},
-		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
+		{"nat", "POSTROUTING", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "masquerade pod-to-service and pod-to-external traffic", "-j", "MASQUERADE"}},
+		{"filter", "INPUT", []string{"-p", "udp", "--dport", VXLAN_PORT, "-m", "comment", "--comment", "VXLAN incoming", "-j", "ACCEPT"}},
+		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "from SDN to localhost", "-j", "ACCEPT"}},
+		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "from docker to localhost", "-j", "ACCEPT"}},
+		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "attempted resend after connection close", "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP"}},
+		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic from SDN", "-j", "ACCEPT"}},
+		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic to SDN", "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-i", TUN, "!", "-o", TUN, "-m", "comment", "--comment", "administrator overrides", "-j", string(OutputFilteringChain)}},
 	}
 }

--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -13,12 +13,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/iptables"
 )
 
-type FirewallRule struct {
-	table string
-	chain string
-	args  []string
-}
-
 type NodeIPTables struct {
 	ipt                iptables.Interface
 	clusterNetworkCIDR string
@@ -26,10 +20,6 @@ type NodeIPTables struct {
 
 	mu sync.Mutex // Protects concurrent access to syncIPTableRules()
 }
-
-const (
-	OutputFilteringChain iptables.Chain = "OPENSHIFT-ADMIN-OUTPUT-RULES"
-)
 
 func newNodeIPTables(clusterNetworkCIDR string, syncPeriod time.Duration) *NodeIPTables {
 	return &NodeIPTables{
@@ -70,8 +60,31 @@ func (n *NodeIPTables) syncLoop() {
 	}
 }
 
+type Chain struct {
+	table    string
+	name     string
+	srcChain string
+	srcRule  []string
+	rules    [][]string
+}
+
+// Adds all the rules in chain, returning true if they were all already present
+func (n *NodeIPTables) addChainRules(chain Chain) (bool, error) {
+	allExisted := true
+	for _, rule := range chain.rules {
+		existed, err := n.ipt.EnsureRule(iptables.Append, iptables.Table(chain.table), iptables.Chain(chain.name), rule...)
+		if err != nil {
+			return false, fmt.Errorf("failed to ensure rule %v exists: %v", rule, err)
+		}
+		if !existed {
+			allExisted = false
+		}
+	}
+	return allExisted, nil
+}
+
 // syncIPTableRules syncs the cluster network cidr iptables rules.
-// Called from SyncLoop() or firwalld reload()
+// Called from SyncLoop() or firewalld reload()
 func (n *NodeIPTables) syncIPTableRules() error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -82,32 +95,84 @@ func (n *NodeIPTables) syncIPTableRules() error {
 	}()
 	glog.V(3).Infof("Syncing openshift iptables rules")
 
-	if _, err := n.ipt.EnsureChain(iptables.TableFilter, OutputFilteringChain); err != nil {
-		return fmt.Errorf("failed to ensure chain %q exists: %v", OutputFilteringChain, err)
-	}
-
-	rules := n.getStaticNodeIPTablesRules()
-	for _, rule := range rules {
-		_, err := n.ipt.EnsureRule(iptables.Prepend, iptables.Table(rule.table), iptables.Chain(rule.chain), rule.args...)
+	for _, chain := range n.getNodeIPTablesChains() {
+		// Create chain if it does not already exist
+		chainExisted, err := n.ipt.EnsureChain(iptables.Table(chain.table), iptables.Chain(chain.name))
 		if err != nil {
-			return fmt.Errorf("failed to ensure rule %v exists: %v", rule, err)
+			return fmt.Errorf("failed to ensure chain %s exists: %v", chain.name, err)
+		}
+
+		// Create the rule pointing to it from its parent chain. Note that since we
+		// use iptables.Prepend each time, chains with the same table and srcChain
+		// (ie, OPENSHIFT-FIREWALL-FORWARD and OPENSHIFT-ADMIN-OUTPUT-RULES) will
+		// run in *reverse* order of how they are listed in getNodeIPTablesChains().
+		_, err = n.ipt.EnsureRule(iptables.Prepend, iptables.Table(chain.table), iptables.Chain(chain.srcChain), append(chain.srcRule, "-j", chain.name)...)
+		if err != nil {
+			return fmt.Errorf("failed to ensure rule from %s to %s exists: %v", chain.srcChain, chain.name, err)
+		}
+
+		// Add/sync the rules
+		rulesExisted, err := n.addChainRules(chain)
+		if err != nil {
+			return err
+		}
+		if chainExisted && !rulesExisted {
+			// Chain existed but not with the expected rules; this probably means
+			// it contained rules referring to a *different* subnet; flush them
+			// and try again.
+			if err = n.ipt.FlushChain(iptables.Table(chain.table), iptables.Chain(chain.name)); err != nil {
+				return fmt.Errorf("failed to flush chain %s: %v", chain.name, err)
+			}
+			if _, err = n.addChainRules(chain); err != nil {
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 
 const VXLAN_PORT = "4789"
 
-// Get openshift iptables rules
-func (n *NodeIPTables) getStaticNodeIPTablesRules() []FirewallRule {
-	return []FirewallRule{
-		{"nat", "POSTROUTING", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "masquerade pod-to-service and pod-to-external traffic", "-j", "MASQUERADE"}},
-		{"filter", "INPUT", []string{"-p", "udp", "--dport", VXLAN_PORT, "-m", "comment", "--comment", "VXLAN incoming", "-j", "ACCEPT"}},
-		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "from SDN to localhost", "-j", "ACCEPT"}},
-		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "from docker to localhost", "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "attempted resend after connection close", "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP"}},
-		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic from SDN", "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic to SDN", "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-i", TUN, "!", "-o", TUN, "-m", "comment", "--comment", "administrator overrides", "-j", string(OutputFilteringChain)}},
+func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
+	return []Chain{
+		{
+			table:    "nat",
+			name:     "OPENSHIFT-MASQUERADE",
+			srcChain: "POSTROUTING",
+			srcRule:  []string{"-m", "comment", "--comment", "rules for masquerading OpenShift traffic"},
+			rules: [][]string{
+				{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "masquerade pod-to-service and pod-to-external traffic", "-j", "MASQUERADE"},
+			},
+		},
+		{
+			table:    "filter",
+			name:     "OPENSHIFT-FIREWALL-ALLOW",
+			srcChain: "INPUT",
+			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
+			rules: [][]string{
+				{"-p", "udp", "--dport", VXLAN_PORT, "-m", "comment", "--comment", "VXLAN incoming", "-j", "ACCEPT"},
+				{"-i", TUN, "-m", "comment", "--comment", "from SDN to localhost", "-j", "ACCEPT"},
+				{"-i", "docker0", "-m", "comment", "--comment", "from docker to localhost", "-j", "ACCEPT"},
+			},
+		},
+		{
+			table:    "filter",
+			name:     "OPENSHIFT-FIREWALL-FORWARD",
+			srcChain: "FORWARD",
+			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
+			rules: [][]string{
+				{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "attempted resend after connection close", "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP"},
+				{"-d", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic from SDN", "-j", "ACCEPT"},
+				{"-s", n.clusterNetworkCIDR, "-m", "comment", "--comment", "forward traffic to SDN", "-j", "ACCEPT"},
+			},
+		},
+		{
+			table:    "filter",
+			name:     "OPENSHIFT-ADMIN-OUTPUT-RULES",
+			srcChain: "FORWARD",
+			srcRule:  []string{"-i", TUN, "!", "-o", TUN, "-m", "comment", "--comment", "administrator overrides"},
+			rules:    nil,
+		},
 	}
 }


### PR DESCRIPTION
While helping to debug a cluster-renumbering issue the other day, we noticed that the nodes in question had *two* sets of outdated iptables rules: one rule left over from an earlier 3.3→3.4 upgrade, and another set of rules still referring to the old clusterNetworkCIDR.

While it turned out that neither of these rules actually broke anything, it made me realize that we could easily do a better job here. This patch moves our rules out into their own chains, and flushes those chains on startup to clean out any cruft.

(I guess flushing on startup means we may drop some packets if you gratuitously restart OpenShift... is it worth doing extra work to try to only flush the tables if they're wrong?)

I considered adding some code to try to clean up the old non-segregated rules when upgrading, but: (a) this is annoying because you have to match them exactly, and we've made minor tweaks to them in the past, so we'd need multiple checks for some of the rules; and (b) the old rules will only cause problems in fairly weird circumstances, like if you change both clusterNetworkCIDR and serviceNetworkCIDR at the same time and one of their new values overlaps the other's old value. Still though, we could do this.

@openshift/networking PTAL