### PR TITLE
migrate.sh can flake if a namespace is still being deleted

### DIFF
--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -13,6 +13,8 @@ os::test::junit::declare_suite_start "cmd/migrate"
 # This test validates storage migration
 
 os::cmd::expect_success 'oc login -u system:admin'
+# ensure all namespaces have been deleted before attempting to perform global action
+os::cmd::try_until_not_text 'oc get ns --template "{{ range .items }}{{ if not (eq .status.phase \"Active\") }}1{{ end }}{{ end }}"' '1'
 
 os::test::junit::declare_suite_start "cmd/migrate/storage"
 os::cmd::expect_success_and_text     'oadm migrate storage' 'summary \(dry run\)'


### PR DESCRIPTION
Ensure all namespaces are terminated prior to starting test

Fixes an error:

```
=== BEGIN TEST CASE ===
test/cmd/migrate.sh:23: executing 'oadm migrate storage --loglevel=2 --confirm' expecting success and text 'unchanged:'
FAILURE after 9.373s: test/cmd/migrate.sh:23: executing 'oadm migrate storage --loglevel=2 --confirm' expecting success and text 'unchanged:': the command returned the wrong error code
Standard output from the command:
...
unchanged: securitycontextconstraints/privileged 
unchanged: securitycontextconstraints/restricted 
error:     serviceaccounts/builder -n cmd-convert: namespaces "cmd-convert" not found
error:     serviceaccounts/default -n cmd-convert: namespaces "cmd-convert" not found
error:     serviceaccounts/deployer -n cmd-convert: namespaces "cmd-convert" not found
unchanged: serviceaccounts/builder -n cmd-migrate
unchanged: serviceaccounts/default -n cmd-migrate
unchanged: serviceaccounts/deployer -n cmd-migrate
...
```