### PR TITLE
Fix oc get rolebindingrestrictions formatting

### DIFF
--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -1106,6 +1106,11 @@ func printRoleBindingRestriction(rbr *authorizationapi.RoleBindingRestriction, w
 		}
 	}
 
+	if options.WithNamespace {
+		if _, err := fmt.Fprintf(w, "%s\t", rbr.Namespace); err != nil {
+			return err
+		}
+	}
 	if _, err := fmt.Fprintf(w, "%s", name); err != nil {
 		return err
 	}


### PR DESCRIPTION
Print the "NAMESPACE" column in the output of `oc get rolebindingrestrictions --all-namespaces`.

Before:

```console
$ oc get rolebindingrestrictions --all-namespaces
NAMESPACE                    NAME             SUBJECT TYPE   SUBJECTS
match-own-admin-user         User             carol
match-own-service-accounts   ServiceAccount   carolproject/*
```

After:

```console
$ oc get rolebindingrestrictions --all-namespaces
NAMESPACE      NAME                         SUBJECT TYPE     SUBJECTS
carolproject   match-own-admin-user         User             carol
carolproject   match-own-service-accounts   ServiceAccount   carolproject/*
```

---

Please [test]!