### PR TITLE
Set Git configuration for all users in release containers

### DIFF
--- a/images/release/golang-1.4/Dockerfile
+++ b/images/release/golang-1.4/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir $TMPDIR && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
-    git config --global user.name origin-release-container && \
-    git config --global user.email none@nowhere.com
+    git config --system user.name origin-release-container && \
+    git config --system user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.6/Dockerfile
+++ b/images/release/golang-1.6/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir $TMPDIR && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
-    git config --global user.name origin-release-container && \
-    git config --global user.email none@nowhere.com
+    git config --system user.name origin-release-container && \
+    git config --system user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.7/Dockerfile
+++ b/images/release/golang-1.7/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir $TMPDIR && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
-    git config --global user.name origin-release-container && \
-    git config --global user.email none@nowhere.com
+    git config --system user.name origin-release-container && \
+    git config --system user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \

--- a/images/release/golang-1.8/Dockerfile
+++ b/images/release/golang-1.8/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir $TMPDIR && \
     curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     go get golang.org/x/tools/cmd/cover golang.org/x/tools/cmd/goimports github.com/tools/godep github.com/golang/lint/golint github.com/openshift/imagebuilder/cmd/imagebuilder && \
     touch /os-build-image && \
-    git config --global user.name origin-release-container && \
-    git config --global user.email none@nowhere.com
+    git config --system user.name origin-release-container && \
+    git config --system user.email none@nowhere.com
 
 WORKDIR /go/src/github.com/openshift/origin
 LABEL io.k8s.display-name="OpenShift Origin Release Environment (golang-$VERSION)" \


### PR DESCRIPTION
When using `tito` inside of the `hack/env` release containers, `git`
configuration is necessary. In order to allow for the "local" use-case
for `hack/env` where the UID inside of the container is the same as the
user running the container, we need to set the `git` configuration for
all users instead of just `root`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @smarterclayton