### PR TITLE
Back-port: Fix namespace sync

### DIFF
--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -290,8 +290,16 @@ func (eq *EventQueue) Pop() (watch.EventType, interface{}, error) {
 		key := eq.queue[0]
 		eq.queue = eq.queue[1:]
 
-		eventType := eq.events[key]
-		delete(eq.events, key)
+		eventType, ok := eq.events[key]
+		if ok {
+			delete(eq.events, key)
+		} else {
+			// The event type has been removed by a previous call to
+			// Pop().  Since the object has already been seen and has
+			// not been deleted, and callers will need to be
+			// idempotent, watch.Modified can be safely assumed.
+			eventType = watch.Modified
+		}
 
 		// Track the last replace key immediately after the store
 		// state has been changed to prevent subsequent errors from

--- a/pkg/client/cache/eventqueue_test.go
+++ b/pkg/client/cache/eventqueue_test.go
@@ -205,3 +205,14 @@ func TestEventQueue_ListConsumed(t *testing.T) {
 		t.Fatalf("expected ListConsumed to be true after queued items read")
 	}
 }
+
+func TestEventQueue_PopAfterResyncShouldBeTypeModified(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+	q.Add(cacheable{"foo", 10})
+	q.Pop()
+	q.Resync()
+	eventType, _, _ := q.Pop()
+	if eventType != watch.Modified {
+		t.Fatalf("Expected resynced event to be of type watch.Modified, got %q", eventType)
+	}
+}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -61,6 +61,9 @@ type routerInterface interface {
 	// frontend key is used; all call sites make certain the frontend
 	// is created.
 
+	// SyncedAtLeastOnce indicates an initial sync has been performed
+	SyncedAtLeastOnce() bool
+
 	// CreateServiceUnit creates a new service named with the given id.
 	CreateServiceUnit(id string)
 	// FindServiceUnit finds the service with the given id.

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -204,6 +204,11 @@ func (r *TestRouter) HasRoute(route *routeapi.Route) bool {
 	return false
 }
 
+func (r *TestRouter) SyncedAtLeastOnce() bool {
+	// Not used
+	return false
+}
+
 func (r *TestRouter) FilterNamespaces(namespaces sets.String) {
 	if len(namespaces) == 0 {
 		r.State = make(map[string]ServiceAliasConfig)

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -822,6 +822,13 @@ func (r *templateRouter) HasRoute(route *routeapi.Route) bool {
 	return ok
 }
 
+// SyncedAtLeastOnce indicates whether the router has completed an initial sync.
+func (r *templateRouter) SyncedAtLeastOnce() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.synced
+}
+
 // hasRequiredEdgeCerts ensures that at least a host certificate and key are provided.
 // a ca cert is not required because it may be something that is in the root cert chain
 func hasRequiredEdgeCerts(cfg *ServiceAliasConfig) bool {


### PR DESCRIPTION
Back-port of @marun's fix: As per the referenced bz, a router filtering namespaces by label is not exposing routes from a newly-labeled namespace after the resync interval.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1415112

Cherry-pick of https://github.com/openshift/origin/pull/13436