### PR TITLE
change the router eventqueue key function

### DIFF
--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -22,6 +22,7 @@ import (
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	"github.com/openshift/origin/pkg/router"
 	"github.com/openshift/origin/pkg/router/controller"
+	"k8s.io/kubernetes/pkg/api/meta"
 )
 
 // RouterControllerFactory initializes and manages the watches that drive a router
@@ -56,10 +57,27 @@ func NewDefaultRouterControllerFactory(oc osclient.RoutesNamespacer, kc kclients
 	}
 }
 
+// routerKeyFn comes from MetaNamespaceKeyFunc in vendor/k8s.io/kubernetes/pkg/client/cache/store.go.
+// It was modified and added here because there is no way to know if an ExplicitKey was passed before
+// adding the UID to prevent an invalid state transistion if deletions and adds happen quickly.
+func routerKeyFn(obj interface{}) (string, error) {
+	if key, ok := obj.(cache.ExplicitKey); ok {
+		return string(key), nil
+	}
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("object has no meta: %v", err)
+	}
+	if len(meta.GetNamespace()) > 0 {
+		return meta.GetNamespace() + "/" + meta.GetName() + "/" + string(meta.GetUID()), nil
+	}
+	return meta.GetName() + "/" + string(meta.GetUID()), nil
+}
+
 // Create begins listing and watching against the API server for the desired route and endpoint
 // resources. It spawns child goroutines that cannot be terminated.
 func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes, enableIngress bool) *controller.RouterController {
-	routeEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	routeEventQueue := oscache.NewEventQueue(routerKeyFn)
 	cache.NewReflector(&routeLW{
 		client:    factory.OSClient,
 		namespace: factory.Namespace,
@@ -67,14 +85,14 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 		label:     factory.Labels,
 	}, &routeapi.Route{}, routeEventQueue, factory.ResyncInterval).Run()
 
-	endpointsEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	endpointsEventQueue := oscache.NewEventQueue(routerKeyFn)
 	cache.NewReflector(&endpointsLW{
 		client:    factory.KClient,
 		namespace: factory.Namespace,
 		// we do not scope endpoints by labels or fields because the route labels != endpoints labels
 	}, &kapi.Endpoints{}, endpointsEventQueue, factory.ResyncInterval).Run()
 
-	nodeEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	nodeEventQueue := oscache.NewEventQueue(routerKeyFn)
 	if watchNodes {
 		cache.NewReflector(&nodeLW{
 			client: factory.NodeClient,
@@ -83,8 +101,8 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 		}, &kapi.Node{}, nodeEventQueue, factory.ResyncInterval).Run()
 	}
 
-	ingressEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
-	secretEventQueue := oscache.NewEventQueue(cache.MetaNamespaceKeyFunc)
+	ingressEventQueue := oscache.NewEventQueue(routerKeyFn)
+	secretEventQueue := oscache.NewEventQueue(routerKeyFn)
 	var ingressTranslator *controller.IngressTranslator
 	if enableIngress {
 		ingressTranslator = controller.NewIngressTranslator(factory.SecretClient)
@@ -195,7 +213,7 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 // resources. It spawns child goroutines that cannot be terminated. It is a more efficient store of a
 // route system.
 func (factory *RouterControllerFactory) CreateNotifier(changed func()) RoutesByHost {
-	keyFn := cache.MetaNamespaceKeyFunc
+	keyFn := routerKeyFn
 	routeStore := cache.NewIndexer(keyFn, cache.Indexers{"host": hostIndexFunc})
 	routeEventQueue := oscache.NewEventQueueForStore(keyFn, routeStore)
 	cache.NewReflector(&routeLW{


### PR DESCRIPTION
changing the router eventqueue key function so that there is a higher chance that
each item will have a unique key so the router does not panic.

originally the thought was to add the creation timestamp because it was not user
editable but the accessor function meta.CreationTimestamp() only gives the timestamp
to the second and since these actions need to occur quickly a second is too long. Only
adding creation timestamp I was able to observe the panic with the test script. I
decided to use UID because it is much more likely that the UID is unique.

Bug: 1429823 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1429823)