### PR TITLE
node: system container mounts /rootfs rslave

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -270,7 +270,7 @@
 	    "destination": "/rootfs",
 	    "options": [
 		"rbind",
-                "rprivate",
+                "rslave",
 		"ro"
 	    ]
         },


### PR DESCRIPTION
Already done for the Docker container:
https://github.com/openshift/openshift-ansible/pull/3727

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>