### PR TITLE
Validate that SDN API object CIDRs are in canonical form

### DIFF
--- a/pkg/sdn/api/validation/validation_test.go
+++ b/pkg/sdn/api/validation/validation_test.go
@@ -37,6 +37,16 @@ func TestValidateClusterNetwork(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
+			name: "Bad network CIDR",
+			cn: &api.ClusterNetwork{
+				ObjectMeta:       kapi.ObjectMeta{Name: "any"},
+				Network:          "10.20.0.1/16",
+				HostSubnetLength: 8,
+				ServiceNetwork:   "172.30.0.0/16",
+			},
+			expectedErrors: 1,
+		},
+		{
 			name: "Invalid subnet length",
 			cn: &api.ClusterNetwork{
 				ObjectMeta:       kapi.ObjectMeta{Name: "any"},
@@ -53,6 +63,16 @@ func TestValidateClusterNetwork(t *testing.T) {
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
 				ServiceNetwork:   "1172.30.0.0/16",
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Bad service network CIDR",
+			cn: &api.ClusterNetwork{
+				ObjectMeta:       kapi.ObjectMeta{Name: "any"},
+				Network:          "10.20.0.0/16",
+				HostSubnetLength: 8,
+				ServiceNetwork:   "172.30.1.0/16",
 			},
 			expectedErrors: 1,
 		},
@@ -126,6 +146,18 @@ func TestValidateHostSubnet(t *testing.T) {
 				Host:   "abc.def.com",
 				HostIP: "10.20.30.40",
 				Subnet: "8.8.0/24",
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Malformed subnet CIDR",
+			hs: &api.HostSubnet{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "abc.def.com",
+				},
+				Host:   "abc.def.com",
+				HostIP: "10.20.30.40",
+				Subnet: "8.8.0.1/24",
 			},
 			expectedErrors: 1,
 		},

--- a/pkg/util/netutils/common.go
+++ b/pkg/util/netutils/common.go
@@ -94,3 +94,22 @@ func GetNodeIP(nodeName string) (string, error) {
 	}
 	return ip.String(), nil
 }
+
+// ParseCIDRMask parses a CIDR string and ensures that it has no bits set beyond the
+// network mask length. Use this when the input is supposed to be either a description of
+// a subnet (eg, "192.168.1.0/24", meaning "192.168.1.0 to 192.168.1.255"), or a mask for
+// matching against (eg, "192.168.1.15/32", meaning "must match all 32 bits of the address
+// "192.168.1.15"). Use net.ParseCIDR() when the input is a host address that also
+// describes the subnet that it is on (eg, "192.168.1.15/24", meaning "the address
+// 192.168.1.15 on the network 192.168.1.0/24").
+func ParseCIDRMask(cidr string) (*net.IPNet, error) {
+	ip, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	if !ip.Equal(net.IP) {
+		maskLen, addrLen := net.Mask.Size()
+		return nil, fmt.Errorf("CIDR network specification %q is not in canonical form (should be %s/%d or %s/%d?)", cidr, ip.Mask(net.Mask).String(), maskLen, ip.String(), addrLen)
+	}
+	return net, nil
+}

--- a/pkg/util/netutils/common_test.go
+++ b/pkg/util/netutils/common_test.go
@@ -2,6 +2,7 @@ package netutils
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -38,5 +39,52 @@ func TestGenerateGateway(t *testing.T) {
 	gatewayIP := GenerateDefaultGateway(sn)
 	if gatewayIP.String() != "10.1.0.1" {
 		t.Fatalf("Did not get expected gateway IP Address (gatewayIP=%s)", gatewayIP.String())
+	}
+}
+
+func TestParseCIDRMask(t *testing.T) {
+	tests := []struct {
+		cidr       string
+		fixedShort string
+		fixedLong  string
+	}{
+		{
+			cidr: "192.168.0.0/16",
+		},
+		{
+			cidr: "192.168.1.0/24",
+		},
+		{
+			cidr: "192.168.1.1/32",
+		},
+		{
+			cidr:       "192.168.1.0/16",
+			fixedShort: "192.168.0.0/16",
+			fixedLong:  "192.168.1.0/32",
+		},
+		{
+			cidr:       "192.168.1.1/24",
+			fixedShort: "192.168.1.0/24",
+			fixedLong:  "192.168.1.1/32",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := ParseCIDRMask(test.cidr)
+		if test.fixedShort == "" && test.fixedLong == "" {
+			if err != nil {
+				t.Fatalf("unexpected error parsing CIDR mask %q: %v", test.cidr, err)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("unexpected lack of error parsing CIDR mask %q", test.cidr)
+			}
+			if !strings.Contains(err.Error(), test.fixedShort) {
+				t.Fatalf("error does not contain expected string %q: %v", test.fixedShort, err)
+			}
+			if !strings.Contains(err.Error(), test.fixedLong) {
+				t.Fatalf("error does not contain expected string %q: %v", test.fixedLong, err)
+			}
+		}
 	}
 }

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -268,29 +268,29 @@ var etcdStorageData = map[unversioned.GroupVersionResource]struct {
 		expectedGVK:      gvkP("", "v1", "NetNamespace"), // expect the legacy group to be persisted
 	},
 	gvr("", "v1", "hostsubnets"): {
-		stub:             `{"host": "hostname", "hostIP": "192.168.1.1", "metadata": {"name": "hostname"}, "subnet": "192.168.1.1/24"}`,
+		stub:             `{"host": "hostname", "hostIP": "192.168.1.1", "metadata": {"name": "hostname"}, "subnet": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnsubnets/hostname",
 	},
 	gvr("network.openshift.io", "v1", "hostsubnets"): {
-		stub:             `{"host": "hostnameg", "hostIP": "192.168.1.1", "metadata": {"name": "hostnameg"}, "subnet": "192.168.1.1/24"}`,
+		stub:             `{"host": "hostnameg", "hostIP": "192.168.1.1", "metadata": {"name": "hostnameg"}, "subnet": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnsubnets/hostnameg",
 		expectedGVK:      gvkP("", "v1", "HostSubnet"), // expect the legacy group to be persisted
 	},
 	gvr("", "v1", "clusternetworks"): {
-		stub:             `{"metadata": {"name": "cn1"}, "network": "192.168.0.1/24", "serviceNetwork": "192.168.1.1/24"}`,
+		stub:             `{"metadata": {"name": "cn1"}, "network": "192.168.0.0/24", "serviceNetwork": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1",
 	},
 	gvr("network.openshift.io", "v1", "clusternetworks"): {
-		stub:             `{"metadata": {"name": "cn1g"}, "network": "192.168.0.1/24", "serviceNetwork": "192.168.1.1/24"}`,
+		stub:             `{"metadata": {"name": "cn1g"}, "network": "192.168.0.0/24", "serviceNetwork": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1g",
 		expectedGVK:      gvkP("", "v1", "ClusterNetwork"), // expect the legacy group to be persisted
 	},
 	gvr("", "v1", "egressnetworkpolicies"): {
-		stub:             `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.1/24"}, "type": "Allow"}]}}`,
+		stub:             `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
 		expectedEtcdPath: "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1",
 	},
 	gvr("network.openshift.io", "v1", "egressnetworkpolicies"): {
-		stub:             `{"metadata": {"name": "enp1g"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.1/24"}, "type": "Allow"}]}}`,
+		stub:             `{"metadata": {"name": "enp1g"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
 		expectedEtcdPath: "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1g",
 		expectedGVK:      gvkP("", "v1", "EgressNetworkPolicy"), // expect the legacy group to be persisted
 	},


### PR DESCRIPTION
Eg, if you want ClusterNetwork to be "10.128.0.0/14", you have to say "10.128.0.0/14", not "10.128.0.1/14" or "10.128.32.99/14". (net.ParseCIDR() accepts the latter two, because they are valid ways of
referring to hosts within that network, but they aren't valid ways of referring to the network itself, which is what we want here).

Tagging needs-api-review because, in particular, this could cause previously-considered-valid EgressNetworkPolicy objects to start being rejected (existing objects when they're updated, or new objects if the admin is creating them automatically from a buggy script/template or something). I'm claiming that this is a bug fix rather than an API break though, on the grounds that we are currently probably doing the wrong thing with policies like "allow traffic to 192.168.1.15/24" right now; currently we pass it to OVS as-is, and OVS interprets it as meaning "allow traffic to 192.168.1.**0**/24", but the user probably actually meant "allow traffic to 192.168.1.15/**32**". (Meaning, they wanted to allow traffic to a single host, and we're allowing traffic to the entire subnet instead.) (It's not clear that anyone is *actually* making this mistake in production, but if they did, this is what would happen.)

(The same concern theoretically also applies to ClusterNetwork and HostSubnet objects, which are also affected by this patch, but ClusterNetwork would only be checked when restarting master, and it should be obvious what needs to be fixed then; and the HostSubnet.Subnet field is always populated by OpenShift itself, with a correct value, so the extra validation shouldn't hurt anything there.)