### PR TITLE
oc describe scc: show seccomp profiles 

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/describe.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/describe.go
@@ -465,6 +465,7 @@ func describeSecurityContextConstraints(scc *api.SecurityContextConstraints) (st
 		fmt.Fprintf(out, "  Default Add Capabilities:\t%s\n", capsToString(scc.DefaultAddCapabilities))
 		fmt.Fprintf(out, "  Required Drop Capabilities:\t%s\n", capsToString(scc.RequiredDropCapabilities))
 		fmt.Fprintf(out, "  Allowed Capabilities:\t%s\n", capsToString(scc.AllowedCapabilities))
+		fmt.Fprintf(out, "  Allowed Seccomp Profiles:\t%s\n", stringOrNone(strings.Join(scc.SeccompProfiles, ",")))
 		fmt.Fprintf(out, "  Allowed Volume Types:\t%s\n", fsTypeToString(scc.Volumes))
 		fmt.Fprintf(out, "  Allow Host Network:\t%t\n", scc.AllowHostNetwork)
 		fmt.Fprintf(out, "  Allow Host Ports:\t%t\n", scc.AllowHostPorts)


### PR DESCRIPTION
Examples:
```console
$ oc describe scc privileged | grep seccomp
  Allowed Seccomp Profiles:			*
$ oc describe scc anyuid | grep seccomp
  Allowed Seccomp Profiles:			<none>
$ oc describe scc custom | grep seccomp
  Allowed Seccomp Profiles:			default/docker,default/something
```

Fix #13459

PTAL @pweil- 