### PR TITLE
UPSTREAM: 43460: Remove unused DockerManager daemon version [1.5]

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockertools/docker_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockertools/docker_manager.go
@@ -1795,8 +1795,7 @@ func (dm *DockerManager) calculateOomScoreAdj(pod *api.Pod, container *api.Conta
 
 // versionInfo wraps api version and daemon version.
 type versionInfo struct {
-	apiVersion    kubecontainer.Version
-	daemonVersion kubecontainer.Version
+	apiVersion kubecontainer.Version
 }
 
 // checkDockerAPIVersion checks current docker API version against expected version.
@@ -2634,19 +2633,14 @@ func (dm *DockerManager) GetPodStatus(uid kubetypes.UID, name, namespace string)
 	return podStatus, nil
 }
 
-// getVersionInfo returns apiVersion & daemonVersion of docker runtime
+// getVersionInfo returns apiVersion of docker runtime
 func (dm *DockerManager) getVersionInfo() (versionInfo, error) {
 	apiVersion, err := dm.APIVersion()
 	if err != nil {
 		return versionInfo{}, err
 	}
-	daemonVersion, err := dm.Version()
-	if err != nil {
-		return versionInfo{}, err
-	}
 	return versionInfo{
-		apiVersion:    apiVersion,
-		daemonVersion: daemonVersion,
+		apiVersion: apiVersion,
 	}, nil
 }
 


### PR DESCRIPTION
upstream carry of kubernetes/kubernetes#43460

Fixes broken kubelet on latest Docker version (Docker for Mac/Windows)