### PR TITLE
Avoid printing cert message for already loaded route

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -808,7 +808,7 @@ func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
 			cfg.TLSTermination, cfg.Host)
 		// if a default cert is configured we'll assume it is meant to be a wildcard and only log info
 		// otherwise we'll consider this a warning
-		if len(r.defaultCertificate) > 0 {
+		if len(r.defaultCertificatePath) > 0 {
 			glog.V(4).Info(msg)
 		} else {
 			glog.Warning(msg)

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -459,7 +459,6 @@ func (r *templateRouter) writeConfig() error {
 // for details
 func (r *templateRouter) writeCertificates(cfg *ServiceAliasConfig) error {
 	if r.shouldWriteCerts(cfg) {
-		//TODO: better way so this doesn't need to create lots of files every time state is written, probably too expensive
 		return r.certManager.WriteCertificatesForConfig(cfg)
 	}
 	return nil
@@ -785,6 +784,12 @@ func cmpStrSlices(first []string, second []string) bool {
 // it will log a warning.  The route will still be written but users may receive browser errors
 // for a host/cert mismatch
 func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
+
+	// The cert is already written
+	if cfg.Status == ServiceAliasConfigStatusSaved {
+		return false
+	}
+
 	if cfg.Certificates == nil {
 		return false
 	}


### PR DESCRIPTION
Theres a certificate message that is being written to the log every
time the router reloads it's configuration, this message is only
useful when the route is being created or modified.

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1401503