### PR TITLE
Wrong comment for check target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Targets (see each target for more information):
 #   all: Build code.
 #   build: Build code.
-#   check: Run unit tests.
+#   check: Run verify, build, unit tests and cmd tests.
 #   test: Run all tests.
 #   run: Run all-in-one server
 #   clean: Clean up.


### PR DESCRIPTION
When i was working on https://github.com/openshift/source-to-image/pull/713，i found the comment of our check target in Makefile is not inaccurate. A small change.  : - )