### PR TITLE
Remove DeleteOptions, ListOptions and ExportOptions from Origin API groups

### DIFF
--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -93,9 +92,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/authorization/api/v1/register.go
+++ b/pkg/authorization/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -60,9 +59,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/build/api/register.go
+++ b/pkg/build/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -70,9 +69,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/build/api/v1/register.go
+++ b/pkg/build/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -36,9 +35,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/deploy/api/register.go
+++ b/pkg/deploy/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -80,14 +79,11 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&DeploymentRequest{},
 		&DeploymentLog{},
 		&DeploymentLogOptions{},
-		&extensions.Scale{},
 	}
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
+			&extensions.Scale{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/deploy/api/v1/register.go
+++ b/pkg/deploy/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -48,14 +47,11 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&DeploymentRequest{},
 		&DeploymentLog{},
 		&DeploymentLogOptions{},
-		&extensionsv1beta1.Scale{},
 	}
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
+			&extensionsv1beta1.Scale{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/image/api/register.go
+++ b/pkg/image/api/register.go
@@ -90,10 +90,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
 			&kapi.SecretList{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/image/api/v1/register.go
+++ b/pkg/image/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -62,10 +61,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
 			&kapiv1.SecretList{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/oauth/api/register.go
+++ b/pkg/oauth/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -72,9 +71,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/oauth/api/v1/register.go
+++ b/pkg/oauth/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -40,9 +39,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/project/api/register.go
+++ b/pkg/project/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -65,9 +64,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/project/api/v1/register.go
+++ b/pkg/project/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -34,9 +33,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/quota/api/register.go
+++ b/pkg/quota/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -67,9 +66,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/quota/api/v1/register.go
+++ b/pkg/quota/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -45,9 +44,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/route/api/register.go
+++ b/pkg/route/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -66,9 +65,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/route/api/v1/register.go
+++ b/pkg/route/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -34,9 +33,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/sdn/api/register.go
+++ b/pkg/sdn/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -71,9 +70,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/sdn/api/v1/register.go
+++ b/pkg/sdn/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -39,9 +38,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/security/api/register.go
+++ b/pkg/security/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -64,9 +63,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/security/api/v1/register.go
+++ b/pkg/security/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -34,9 +33,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/template/api/register.go
+++ b/pkg/template/api/register.go
@@ -68,9 +68,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 			&kapi.List{},
 		)...,
 	)

--- a/pkg/template/api/v1/register.go
+++ b/pkg/template/api/v1/register.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
 )
@@ -37,10 +37,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
-			&kapi.List{},
+			&kapiv1.List{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/user/api/register.go
+++ b/pkg/user/api/register.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -69,9 +68,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/user/api/v1/register.go
+++ b/pkg/user/api/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch/versioned"
@@ -38,9 +37,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		append(types,
 			&unversioned.Status{}, // TODO: revisit in 1.6 when Status is actually registered as unversioned
-			&kapi.ListOptions{},
-			&kapi.DeleteOptions{},
-			&kapi.ExportOptions{},
 		)...,
 	)
 	versioned.AddToGroupVersion(scheme, SchemeGroupVersion)


### PR DESCRIPTION
These extra types we register to each API group scheme seems to be not necessary and might cause
problems when serialized (DeleteOptions might get `template.openshift.io/v1` apiVersion) which might confuse the REST handlers.

* Also fixes `kapi.List` -> `kapiv1.List` in template.openshift.io/v1

@smarterclayton @deads2k @sttts FYI