### PR TITLE
DO NOT MERGE deleteoptions reproducer

### DIFF
--- a/pkg/template/registry/brokertemplateinstance/strategy.go
+++ b/pkg/template/registry/brokertemplateinstance/strategy.go
@@ -59,6 +59,17 @@ func (brokerTemplateInstanceStrategy) ValidateUpdate(ctx kapi.Context, obj, old 
 	return validation.ValidateBrokerTemplateInstanceUpdate(obj.(*api.BrokerTemplateInstance), old.(*api.BrokerTemplateInstance))
 }
 
+func (brokerTemplateInstanceStrategy) CheckGracefulDelete(ctx kapi.Context, obj runtime.Object, options *kapi.DeleteOptions) bool {
+	if options == nil {
+		return false
+	}
+	if options.GracePeriodSeconds == nil {
+		grace := int64(0)
+		options.GracePeriodSeconds = &grace
+	}
+	return true
+}
+
 // Matcher returns a generic matcher for a given label and field selector.
 func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
 	return storage.SelectionPredicate{

--- a/pkg/template/servicebroker/deprovision.go
+++ b/pkg/template/servicebroker/deprovision.go
@@ -27,7 +27,8 @@ func (b *Broker) Deprovision(instanceID string) *api.Response {
 		return api.InternalServerError(err)
 	}
 
-	opts := kapi.NewPreconditionDeleteOptions(string(brokerTemplateInstance.UID))
+	opts := kapi.NewDeleteOptions(1)
+	opts.Preconditions = &kapi.Preconditions{UID: &brokerTemplateInstance.UID}
 	err = b.templateclient.BrokerTemplateInstances().Delete(instanceID, opts)
 	if err != nil {
 		if kerrors.IsNotFound(err) {

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -192,9 +192,9 @@ var _ = g.Describe("[templates] templateservicebroker end-to-end test", func() {
 		err := brokercli.Deprovision(context.Background(), instanceID)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.AdminTemplateClient().BrokerTemplateInstances().Get(instanceID)
-		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(kerrors.IsNotFound(err)).To(o.BeTrue())
+		brokerTemplateInstance, err := cli.AdminTemplateClient().BrokerTemplateInstances().Get(instanceID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(brokerTemplateInstance.DeletionTimestamp).NotTo(o.BeNil())
 
 		_, err = cli.TemplateClient().TemplateInstances(cli.Namespace()).Get(instanceID)
 		o.Expect(err).To(o.HaveOccurred())


### PR DESCRIPTION
@deads2k @mfojtik with this patch, the "templateservicebroker end-to-end test" extended test fails at the end.
After graceful deletion, the test expects the BrokerTemplateInstance object to still exist and have its DeletionTimestamp set.  However it has already been deleted.