### PR TITLE
Increase journald rate limiter when running test-end-to-end-docker.sh

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -120,10 +120,11 @@ readonly -f os::util::format_seconds
 # Return:
 #  None
 function os::util::sed() {
+	local sudo="${USE_SUDO:+sudo}"
 	if LANG=C sed --help 2>&1 | grep -q "GNU sed"; then
-		sed -i'' "$@"
+		${sudo} sed -i'' "$@"
 	else
-		sed -i '' "$@"
+		${sudo} sed -i '' "$@"
 	fi
 }
 readonly -f os::util::sed

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -378,30 +378,19 @@ os::cmd::expect_success 'oc login -u e2e-user'
 os::cmd::expect_success 'oc project test'
 os::cmd::expect_success 'oc whoami'
 
-if [[ -n "${SOLTYSH_DEBUG:-}" ]]; then
-    os::log::info "Running a CLI command in a container using the service account"
-    os::cmd::expect_success 'oc policy add-role-to-user view -z default'
-    os::cmd::try_until_success "oc sa get-token default"
-    oc run cli-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-    set -o errexit
-    os::cmd::expect_success 'oc delete pod cli-with-token'
-    oc run cli-with-token-2 --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
-    set -o errexit
-    os::cmd::expect_success 'oc delete pod cli-with-token-2'
-    oc run kubectl-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
-    set -o errexit
-fi
+os::log::info "Running a CLI command in a container using the service account"
+os::cmd::expect_success 'oc policy add-role-to-user view -z default'
+os::cmd::try_until_success "oc sa get-token default"
+oc run cli-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+os::cmd::expect_success 'oc delete pod cli-with-token'
+oc run cli-with-token-2 --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+os::cmd::expect_success 'oc delete pod cli-with-token-2'
+oc run kubectl-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
 
 os::log::info "Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors


### PR DESCRIPTION
Fixes #12558 by increasing rate limiter values while `running test-end-to-end-docker.sh`. Additionally, this re-enables the tests that were disabled due to that error. 

@stevekuznetsov ptal
@smarterclayton fyi