### PR TITLE
Use subtests in pkg/dockerregistry/server

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -112,7 +112,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		expectedMethodInvocations map[string]int
 	}
 
-	doTest := func(tc testCase) {
+	doTest := func(t *testing.T, tc testCase) {
 		m.clearStats()
 		m.changeUnsetRepository(tc.unsetRepository)
 
@@ -314,7 +314,9 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 			expectedMethodInvocations: map[string]int{"Stat": 1},
 		},
 	} {
-		doTest(tc)
+		t.Run(tc.name, func(t *testing.T) {
+			doTest(t, tc)
+		})
 	}
 }
 

--- a/pkg/dockerregistry/server/digestcache_test.go
+++ b/pkg/dockerregistry/server/digestcache_test.go
@@ -307,30 +307,31 @@ func TestRepositoryBucketAdd(t *testing.T) {
 				generated[4]),
 		},
 	} {
-		b := repositoryBucket{
-			clock: clock,
-			list:  tc.entries,
-		}
-		b.Add(tc.ttl, tc.repos...)
+		t.Run(tc.name, func(t *testing.T) {
+			b := repositoryBucket{
+				clock: clock,
+				list:  tc.entries,
+			}
+			b.Add(tc.ttl, tc.repos...)
 
-		if len(b.list) != len(tc.expectedEntries) {
-			t.Errorf("[%s] got unexpected number of entries in bucket: %d != %d", tc.name, len(b.list), len(tc.expectedEntries))
-		}
-		for i := 0; i < len(b.list); i++ {
-			if i >= len(tc.expectedEntries) {
-				t.Errorf("[%s] index=%d got unexpected entry: %#+v", tc.name, i, b.list[i])
-				continue
+			if len(b.list) != len(tc.expectedEntries) {
+				t.Errorf("got unexpected number of entries in bucket: %d != %d", len(b.list), len(tc.expectedEntries))
 			}
-			a, b := b.list[i], tc.expectedEntries[i]
-			if !bucketEntriesEqual(a, b) {
-				t.Errorf("[%s] index=%d got unexpected entry: %#+v != %#+v", tc.name, i, a, b)
+			for i := 0; i < len(b.list); i++ {
+				if i >= len(tc.expectedEntries) {
+					t.Fatalf("index=%d got unexpected entry: %#+v", i, b.list[i])
+				}
+				a, b := b.list[i], tc.expectedEntries[i]
+				if !bucketEntriesEqual(a, b) {
+					t.Errorf("index=%d got unexpected entry: %#+v != %#+v", i, a, b)
+				}
 			}
-		}
-		for i := len(b.list); i < len(tc.expectedEntries); i++ {
-			if i >= len(tc.expectedEntries) {
-				t.Errorf("[%s] index=%d missing expected entry %#+v", tc.name, i, tc.expectedEntries[i])
+			for i := len(b.list); i < len(tc.expectedEntries); i++ {
+				if i >= len(tc.expectedEntries) {
+					t.Errorf("index=%d missing expected entry %#+v", i, tc.expectedEntries[i])
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -532,30 +533,32 @@ func TestRepositoryBucketRemove(t *testing.T) {
 			},
 		},
 	} {
-		b := repositoryBucket{
-			clock: clock,
-			list:  tc.entries,
-		}
-		b.Remove(tc.repos...)
+		t.Run(tc.name, func(t *testing.T) {
+			b := repositoryBucket{
+				clock: clock,
+				list:  tc.entries,
+			}
+			b.Remove(tc.repos...)
 
-		if len(b.list) != len(tc.expectedEntries) {
-			t.Errorf("[%s] got unexpected number of entries in bucket: %d != %d", tc.name, len(b.list), len(tc.expectedEntries))
-		}
-		for i := 0; i < len(b.list); i++ {
-			if i >= len(tc.expectedEntries) {
-				t.Errorf("[%s] index=%d got unexpected entry: %#+v", tc.name, i, b.list[i])
-				continue
+			if len(b.list) != len(tc.expectedEntries) {
+				t.Errorf("[%s] got unexpected number of entries in bucket: %d != %d", tc.name, len(b.list), len(tc.expectedEntries))
 			}
-			a, b := b.list[i], tc.expectedEntries[i]
-			if !bucketEntriesEqual(a, b) {
-				t.Errorf("[%s] index=%d got unexpected entry: %#+v != %#+v", tc.name, i, a, b)
+			for i := 0; i < len(b.list); i++ {
+				if i >= len(tc.expectedEntries) {
+					t.Errorf("[%s] index=%d got unexpected entry: %#+v", tc.name, i, b.list[i])
+					continue
+				}
+				a, b := b.list[i], tc.expectedEntries[i]
+				if !bucketEntriesEqual(a, b) {
+					t.Errorf("[%s] index=%d got unexpected entry: %#+v != %#+v", tc.name, i, a, b)
+				}
 			}
-		}
-		for i := len(b.list); i < len(tc.expectedEntries); i++ {
-			if i >= len(tc.expectedEntries) {
-				t.Errorf("[%s] index=%d missing expected entry %#+v", tc.name, i, tc.expectedEntries[i])
+			for i := len(b.list); i < len(tc.expectedEntries); i++ {
+				if i >= len(tc.expectedEntries) {
+					t.Errorf("[%s] index=%d missing expected entry %#+v", tc.name, i, tc.expectedEntries[i])
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -599,15 +602,17 @@ func TestRepositoryBucketCopy(t *testing.T) {
 			expectedRepos: []string{"a", "b"},
 		},
 	} {
-		b := repositoryBucket{
-			clock: clock,
-			list:  tc.entries,
-		}
-		result := b.Copy()
+		t.Run(tc.name, func(t *testing.T) {
+			b := repositoryBucket{
+				clock: clock,
+				list:  tc.entries,
+			}
+			result := b.Copy()
 
-		if !reflect.DeepEqual(result, tc.expectedRepos) {
-			t.Errorf("[%s] got unexpected repo list: %s", tc.name, diff.ObjectGoPrintDiff(result, tc.expectedRepos))
-		}
+			if !reflect.DeepEqual(result, tc.expectedRepos) {
+				t.Errorf("[%s] got unexpected repo list: %s", tc.name, diff.ObjectGoPrintDiff(result, tc.expectedRepos))
+			}
+		})
 	}
 }
 

--- a/pkg/dockerregistry/server/remoteblobgetter_test.go
+++ b/pkg/dockerregistry/server/remoteblobgetter_test.go
@@ -191,26 +191,28 @@ func TestIdentifyCandidateRepositories(t *testing.T) {
 			},
 		},
 	} {
-		repositories, search := identifyCandidateRepositories(tc.is, tc.localRegistry, tc.primary)
+		t.Run(tc.name, func(t *testing.T) {
+			repositories, search := identifyCandidateRepositories(tc.is, tc.localRegistry, tc.primary)
 
-		if !reflect.DeepEqual(repositories, tc.expectedRepositories) {
-			if len(repositories) != 0 || len(tc.expectedRepositories) != 0 {
-				t.Errorf("[%s] got unexpected repositories: %s", tc.name, diff.ObjectGoPrintDiff(repositories, tc.expectedRepositories))
+			if !reflect.DeepEqual(repositories, tc.expectedRepositories) {
+				if len(repositories) != 0 || len(tc.expectedRepositories) != 0 {
+					t.Errorf("[%s] got unexpected repositories: %s", tc.name, diff.ObjectGoPrintDiff(repositories, tc.expectedRepositories))
+				}
 			}
-		}
 
-		for repo, spec := range search {
-			if expSpec, exists := tc.expectedSearch[repo]; !exists {
-				t.Errorf("[%s] got unexpected repository among results: %q: %#+v", tc.name, repo, spec)
-			} else if !reflect.DeepEqual(spec, expSpec) {
-				t.Errorf("[%s] got unexpected pull spec for repo %q: %s", tc.name, repo, diff.ObjectGoPrintDiff(spec, expSpec))
+			for repo, spec := range search {
+				if expSpec, exists := tc.expectedSearch[repo]; !exists {
+					t.Errorf("[%s] got unexpected repository among results: %q: %#+v", tc.name, repo, spec)
+				} else if !reflect.DeepEqual(spec, expSpec) {
+					t.Errorf("[%s] got unexpected pull spec for repo %q: %s", tc.name, repo, diff.ObjectGoPrintDiff(spec, expSpec))
+				}
 			}
-		}
-		for expRepo, expSpec := range tc.expectedSearch {
-			if _, exists := tc.expectedSearch[expRepo]; !exists {
-				t.Errorf("[%s] missing expected repository among results: %q: %#+v", tc.name, expRepo, expSpec)
+			for expRepo, expSpec := range tc.expectedSearch {
+				if _, exists := tc.expectedSearch[expRepo]; !exists {
+					t.Errorf("[%s] missing expected repository among results: %q: %#+v", tc.name, expRepo, expSpec)
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/pkg/dockerregistry/server/util_test.go
+++ b/pkg/dockerregistry/server/util_test.go
@@ -113,18 +113,20 @@ func TestGetBoolOption(t *testing.T) {
 			expectedError: true,
 		},
 	} {
-		for key, value := range tc.exportEnv {
-			os.Setenv(key, value)
-		}
-		d, err := getBoolOption(tc.envName, tc.option, tc.defaultValue, tc.options)
-		if err == nil && tc.expectedError {
-			t.Errorf("[%s] unexpected non-error", tc.name)
-		} else if err != nil && !tc.expectedError {
-			t.Errorf("[%s] unexpected error: %v", tc.name, err)
-		}
-		if d != tc.expected {
-			t.Errorf("[%s] got unexpected duration: %t != %t", tc.name, d, tc.expected)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			for key, value := range tc.exportEnv {
+				os.Setenv(key, value)
+			}
+			d, err := getBoolOption(tc.envName, tc.option, tc.defaultValue, tc.options)
+			if err == nil && tc.expectedError {
+				t.Errorf("[%s] unexpected non-error", tc.name)
+			} else if err != nil && !tc.expectedError {
+				t.Errorf("[%s] unexpected error: %v", tc.name, err)
+			}
+			if d != tc.expected {
+				t.Errorf("[%s] got unexpected duration: %t != %t", tc.name, d, tc.expected)
+			}
+		})
 	}
 }
 
@@ -217,17 +219,19 @@ func TestGetDurationOption(t *testing.T) {
 			expectedError:    true,
 		},
 	} {
-		for key, value := range tc.exportEnv {
-			os.Setenv(key, value)
-		}
-		d, err := getDurationOption(tc.envName, tc.option, tc.defaultValue, tc.options)
-		if err == nil && tc.expectedError {
-			t.Errorf("[%s] unexpected non-error", tc.name)
-		} else if err != nil && !tc.expectedError {
-			t.Errorf("[%s] unexpected error: %v", tc.name, err)
-		}
-		if d != tc.expectedDuration {
-			t.Errorf("[%s] got unexpected duration: %s != %s", tc.name, d.String(), tc.expectedDuration.String())
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			for key, value := range tc.exportEnv {
+				os.Setenv(key, value)
+			}
+			d, err := getDurationOption(tc.envName, tc.option, tc.defaultValue, tc.options)
+			if err == nil && tc.expectedError {
+				t.Errorf("[%s] unexpected non-error", tc.name)
+			} else if err != nil && !tc.expectedError {
+				t.Errorf("[%s] unexpected error: %v", tc.name, err)
+			}
+			if d != tc.expectedDuration {
+				t.Errorf("[%s] got unexpected duration: %s != %s", tc.name, d.String(), tc.expectedDuration.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
It separates t.Log's output from each subtest, and it allows to run a specific subtest.

Because of changed indentation it's better to use `git log -p -w` or `git diff -w` for review.