### PR TITLE
fix extra lines in new-app output

### DIFF
--- a/pkg/generate/app/cmd/template.go
+++ b/pkg/generate/app/cmd/template.go
@@ -50,7 +50,7 @@ func TransformTemplate(tpl *templateapi.Template, client client.TemplateConfigsN
 }
 
 func formatString(out io.Writer, tab, s string) {
-	labelVals := strings.Split(s, "\n")
+	labelVals := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
 
 	for _, lval := range labelVals {
 		fmt.Fprintf(out, fmt.Sprintf("%s%s\n", tab, lval))
@@ -83,7 +83,6 @@ func DescribeGeneratedTemplate(out io.Writer, input string, result *templateapi.
 			formatString(out, "     ", message)
 			fmt.Fprintln(out)
 		}
-		fmt.Fprintln(out)
 	}
 
 	if warnings := result.Annotations[app.GenerationWarningAnnotation]; len(warnings) > 0 {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/13492

Output now:
```
gmontero ~/go/src/github.com/openshift/origin  (13492)$ oc new-app --template=kube-system/heapster-standalone --dry-run
--> Deploying template "kube-system/heapster-standalone" for "kube-system/heapster-standalone" to project myproject

     Heapster Metrics (Standalone)
     ---------
     A simple metrics solution for an OpenShift cluster. Expects to be installed in the 'kube-system' namespace.

     * With parameters:
        * MASTER_URL=https://kubernetes.default.svc
        * IMAGE_PREFIX=openshift/origin-
        * IMAGE_VERSION=latest
        * METRIC_RESOLUTION=15s
        * STARTUP_TIMEOUT=500
        * NAMESPACE=kube-system

--> Creating resources ...
    serviceaccount "heapster" created (dry run)
    clusterrolebinding "heapster-cluster-reader" created (dry run)
    service "heapster" created (dry run)
    replicationcontroller "heapster" created (dry run)
--> Success (dry run)
```