### PR TITLE
Attach the output of subtests to the parent test

### DIFF
--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -9,14 +9,15 @@ import (
 func newTestDataParser() testDataParser {
 	return testDataParser{
 		// testStartPattern matches the line in verbose `go test` output that marks the declaration of a test.
+		// Subtests are considered as a part of the parent test, therefore their declarations are not matched.
 		// The first submatch of this regex is the name of the test
-		testStartPattern: regexp.MustCompile(`=== RUN\s+(.+)$`),
+		testStartPattern: regexp.MustCompile(`=== RUN\s+([^/]+)$`),
 
 		// testResultPattern matches the line in verbose `go test` output that marks the result of a test.
 		// The first submatch of this regex is the result of the test (PASS, FAIL, or SKIP)
 		// The second submatch of this regex is the name of the test
 		// The third submatch of this regex is the time taken in seconds for the test to finish
-		testResultPattern: regexp.MustCompile(`--- (PASS|FAIL|SKIP):\s+(.+)\s+\((\d+\.\d+)(s| seconds)\)`),
+		testResultPattern: regexp.MustCompile(`--- (PASS|FAIL|SKIP):\s+([^/]+)\s+\((\d+\.\d+)(s| seconds)\)`),
 	}
 }
 

--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -76,8 +76,8 @@ func newTestSuiteDataParser() testSuiteDataParser {
 		// The first submatch of this regex matches the result of the test (ok or FAIL)
 		// The second submatch of this regex matches the name of the package
 		// The third submatch of this regex matches the time taken in seconds for tests in the package to finish
-		// The sixth (optional) submatch of this regex is the percent coverage
-		packageResultPattern: regexp.MustCompile(`(ok|FAIL)\s+(.+)[\s\t]+(\d+\.\d+(s| seconds))([\s\t]+coverage:\s+(\d+\.\d+)\% of statements)?`),
+		// The fourth (optional) submatch of this regex is the percent coverage
+		packageResultPattern: regexp.MustCompile(`(ok  |FAIL)\t(.+)\t(\d+\.\d+s)(?:\tcoverage: (\d+\.\d+)\% of statements)?`),
 	}
 }
 
@@ -118,7 +118,7 @@ func (p *testSuiteDataParser) ExtractProperties(line string) (map[string]string,
 
 	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 6 && len(resultMatches[6]) > 0 {
 		return map[string]string{
-			coveragePropertyName: resultMatches[6],
+			coveragePropertyName: resultMatches[4],
 		}, true
 	}
 	return map[string]string{}, false

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -21,12 +21,8 @@ func TestMarksTestBeginning(t *testing.T) {
 			testLine: "=== RUN 1234",
 		},
 		{
-			name:     "url",
-			testLine: "=== RUN github.com/maintainer/repository/package/file",
-		},
-		{
 			name:     "failed print",
-			testLine: "some other text=== RUN github.com/maintainer/repository/package/file",
+			testLine: "some other text=== RUN TestName",
 		},
 	}
 
@@ -53,11 +49,6 @@ func TestExtractTestName(t *testing.T) {
 			name:         "numeric",
 			testLine:     "=== RUN 1234",
 			expectedName: "1234",
-		},
-		{
-			name:         "url",
-			testLine:     "=== RUN github.com/maintainer/repository/package/file",
-			expectedName: "github.com/maintainer/repository/package/file",
 		},
 		{
 			name:         "basic end",
@@ -150,12 +141,12 @@ func TestExtractDuration(t *testing.T) {
 		expectedDuration string
 	}{
 		{
-			name:             "basic",
+			name:             "go1.3 timing",
 			testLine:         "--- PASS: Test (0.10 seconds)",
 			expectedDuration: "0.10s", // we make the conversion to time.Duration-parseable units internally
 		},
 		{
-			name:             "go1.5.1 timing",
+			name:             "go1.4+ timing",
 			testLine:         "--- PASS: TestTwo (0.03s)",
 			expectedDuration: "0.03s",
 		},

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -186,7 +186,7 @@ func TestExtractSuiteName(t *testing.T) {
 	}{
 		{
 			name: "basic",
-			testLine: "ok  	package/name 0.160s",
+			testLine: "ok  	package/name	0.160s",
 			expectedName: "package/name",
 		},
 		{
@@ -196,22 +196,22 @@ func TestExtractSuiteName(t *testing.T) {
 		},
 		{
 			name: "numeric",
-			testLine: "ok  	1234 0.160s",
+			testLine: "ok  	1234	0.160s",
 			expectedName: "1234",
 		},
 		{
 			name: "url",
-			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
+			testLine: "ok  	github.com/maintainer/repository/package/file	0.160s",
 			expectedName: "github.com/maintainer/repository/package/file",
 		},
 		{
 			name: "with coverage",
-			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			testLine: `ok  	package/name	0.400s	coverage: 10.0% of statements`,
 			expectedName: "package/name",
 		},
 		{
 			name: "failed print",
-			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+			testLine: `some other textok  	package/name	0.400s	coverage: 10.0% of statements`,
 			expectedName: "package/name",
 		},
 	}
@@ -241,7 +241,7 @@ func TestSuiteProperties(t *testing.T) {
 		},
 		{
 			name: "with package declaration",
-			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			testLine: `ok  	package/name 0.400s	coverage: 10.0% of statements`,
 			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
 		},
 		{
@@ -270,23 +270,23 @@ func TestMarksCompletion(t *testing.T) {
 	}{
 		{
 			name: "basic",
-			testLine: "ok  	package/name 0.160s",
+			testLine: "ok  	package/name	0.160s",
 		},
 		{
 			name: "numeric",
-			testLine: "ok  	1234 0.160s",
+			testLine: "ok  	1234	0.160s",
 		},
 		{
 			name: "url",
-			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
+			testLine: "ok  	github.com/maintainer/repository/package/file	0.160s",
 		},
 		{
 			name: "with coverage",
-			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			testLine: `ok  	package/name	0.400s	coverage: 10.0% of statements`,
 		},
 		{
 			name: "failed print",
-			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+			testLine: `some other textok  	package/name	0.400s	coverage: 10.0% of statements`,
 		},
 	}
 

--- a/tools/junitreport/pkg/parser/gotest/parser.go
+++ b/tools/junitreport/pkg/parser/gotest/parser.go
@@ -52,9 +52,9 @@ func (p *testOutputParser) Parse(input *bufio.Scanner) (*api.TestSuites, error) 
 				case api.TestResultFail:
 					currentTest.MarkFailed("", output)
 				}
-
 				currentSuite.AddTestCase(currentTest)
 			}
+
 			currentTest = &api.TestCase{}
 			currentTestResult = api.TestResultFail
 			currentTestOutput = []string{}
@@ -75,8 +75,8 @@ func (p *testOutputParser) Parse(input *bufio.Scanner) (*api.TestSuites, error) 
 		}
 
 		if properties, matched := p.suiteParser.ExtractProperties(line); matched {
-			for name := range properties {
-				currentSuite.AddProperty(name, properties[name])
+			for name, value := range properties {
+				currentSuite.AddProperty(name, value)
 			}
 			isTestOutput = false
 		}

--- a/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
@@ -253,7 +253,7 @@ func TestFlatParse(t *testing.T) {
 			},
 		},
 		{
-			name:     "nested ",
+			name:     "nested",
 			testFile: "9.txt",
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
@@ -367,6 +367,64 @@ PASS`,
 							{
 								Name:     "TestTwo",
 								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test case with subtests",
+			testFile: "12.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package/name",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  0.352,
+						Properties: []*api.TestSuiteProperty{
+							{
+								Name:  "coverage.statements.pct",
+								Value: "50.0",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.34,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== RUN   TestOne
+2017/03/27 14:33:13 top level log message
+=== RUN   TestOne/sub1
+2017/03/27 14:33:13 sub1 log message
+=== RUN   TestOne/sub1/subsub1
+2017/03/27 14:33:13 sub1 subsub1 failed
+=== RUN   TestOne/sub1/subsub2
+2017/03/27 14:33:14 sub1 subsub2 succeeded
+=== RUN   TestOne/sub2
+2017/03/27 14:33:14 sub2 succeeded
+2017/03/27 14:33:14 another
+multiline top level
+log message
+--- FAIL: TestOne (0.34s)
+	foo_test.go:11: top level log message
+    --- FAIL: TestOne/sub1 (0.31s)
+    	foo_test.go:14: sub1 log message
+        --- FAIL: TestOne/sub1/subsub1 (0.12s)
+        	foo_test.go:18: sub1 subsub1 failed
+        --- PASS: TestOne/sub1/subsub2 (0.15s)
+        	foo_test.go:23: sub1 subsub2 succeeded
+    --- PASS: TestOne/sub2 (0.01s)
+    	foo_test.go:30: sub2 succeeded
+	foo_test.go:34: another
+		multiline top level
+		log message`,
+								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0,
 							},
 						},
 					},

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -337,7 +337,7 @@ func TestNestedParse(t *testing.T) {
 			},
 		},
 		{
-			name:     "nested ",
+			name:     "nested",
 			testFile: "9.txt",
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
@@ -485,6 +485,72 @@ PASS`, // we include this line greedily even though it does not belong to the te
 									{
 										Name:     "TestTwo",
 										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test case with subtests",
+			testFile: "12.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  0.352,
+						Children: []*api.TestSuite{
+							{
+								Name:      "package/name",
+								NumTests:  2,
+								NumFailed: 1,
+								Duration:  0.352,
+								Properties: []*api.TestSuiteProperty{
+									{
+										Name:  "coverage.statements.pct",
+										Value: "50.0",
+									},
+								},
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.34,
+										FailureOutput: &api.FailureOutput{
+											Output: `=== RUN   TestOne
+2017/03/27 14:33:13 top level log message
+=== RUN   TestOne/sub1
+2017/03/27 14:33:13 sub1 log message
+=== RUN   TestOne/sub1/subsub1
+2017/03/27 14:33:13 sub1 subsub1 failed
+=== RUN   TestOne/sub1/subsub2
+2017/03/27 14:33:14 sub1 subsub2 succeeded
+=== RUN   TestOne/sub2
+2017/03/27 14:33:14 sub2 succeeded
+2017/03/27 14:33:14 another
+multiline top level
+log message
+--- FAIL: TestOne (0.34s)
+	foo_test.go:11: top level log message
+    --- FAIL: TestOne/sub1 (0.31s)
+    	foo_test.go:14: sub1 log message
+        --- FAIL: TestOne/sub1/subsub1 (0.12s)
+        	foo_test.go:18: sub1 subsub1 failed
+        --- PASS: TestOne/sub1/subsub2 (0.15s)
+        	foo_test.go:23: sub1 subsub2 succeeded
+    --- PASS: TestOne/sub2 (0.01s)
+    	foo_test.go:30: sub2 succeeded
+	foo_test.go:34: another
+		multiline top level
+		log message`,
+										},
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0,
 									},
 								},
 							},

--- a/tools/junitreport/test/gotest/testdata/1.txt
+++ b/tools/junitreport/test/gotest/testdata/1.txt
@@ -3,4 +3,4 @@
 === RUN TestTwo
 --- PASS: TestTwo (0.10 seconds)
 PASS
-ok  	package/name 0.160s
+ok  	package/name	0.160s

--- a/tools/junitreport/test/gotest/testdata/10.txt
+++ b/tools/junitreport/test/gotest/testdata/10.txt
@@ -3,4 +3,4 @@
 === RUN TestTwo
 --- PASS: TestTwo (0.10 seconds)
 PASS
-ok  	package/name 2.160s
+ok  	package/name	2.160s

--- a/tools/junitreport/test/gotest/testdata/11.txt
+++ b/tools/junitreport/test/gotest/testdata/11.txt
@@ -4,4 +4,4 @@
 --- PASS: TestTwo (0.10 seconds)
 PASS
 coverage: 10.0% of statements
-ok  	package/name 0.160s  coverage: 10.0% of statements
+ok  	package/name	0.160s	coverage: 10.0% of statements

--- a/tools/junitreport/test/gotest/testdata/12.txt
+++ b/tools/junitreport/test/gotest/testdata/12.txt
@@ -1,0 +1,40 @@
+=== RUN   TestOne
+2017/03/27 14:33:13 top level log message
+=== RUN   TestOne/sub1
+2017/03/27 14:33:13 sub1 log message
+=== RUN   TestOne/sub1/subsub1
+2017/03/27 14:33:13 sub1 subsub1 failed
+=== RUN   TestOne/sub1/subsub2
+2017/03/27 14:33:14 sub1 subsub2 succeeded
+=== RUN   TestOne/sub2
+2017/03/27 14:33:14 sub2 succeeded
+2017/03/27 14:33:14 another
+multiline top level
+log message
+--- FAIL: TestOne (0.34s)
+	foo_test.go:11: top level log message
+    --- FAIL: TestOne/sub1 (0.31s)
+    	foo_test.go:14: sub1 log message
+        --- FAIL: TestOne/sub1/subsub1 (0.12s)
+        	foo_test.go:18: sub1 subsub1 failed
+        --- PASS: TestOne/sub1/subsub2 (0.15s)
+        	foo_test.go:23: sub1 subsub2 succeeded
+    --- PASS: TestOne/sub2 (0.01s)
+    	foo_test.go:30: sub2 succeeded
+	foo_test.go:34: another
+		multiline top level
+		log message
+=== RUN   TestTwo
+=== RUN   TestTwo/sub1
+=== RUN   TestTwo/sub1/subsub1
+=== RUN   TestTwo/sub1/subsub2
+=== RUN   TestTwo/sub2
+--- PASS: TestTwo (0.00s)
+    --- PASS: TestTwo/sub1 (0.00s)
+        --- PASS: TestTwo/sub1/subsub1 (0.00s)
+        --- PASS: TestTwo/sub1/subsub2 (0.00s)
+    --- PASS: TestTwo/sub2 (0.00s)
+FAIL
+coverage: 50.0% of statements
+exit status 1
+FAIL	package/name	0.352s

--- a/tools/junitreport/test/gotest/testdata/2.txt
+++ b/tools/junitreport/test/gotest/testdata/2.txt
@@ -8,4 +8,4 @@
 --- PASS: TestTwo (0.13 seconds)
 FAIL
 exit status 1
-FAIL	package/name 0.150s
+FAIL	package/name	0.150s

--- a/tools/junitreport/test/gotest/testdata/3.txt
+++ b/tools/junitreport/test/gotest/testdata/3.txt
@@ -4,4 +4,4 @@
 === RUN TestTwo
 --- PASS: TestTwo (0.13 seconds)
 PASS
-ok	package/name 0.150s
+ok  	package/name	0.150s

--- a/tools/junitreport/test/gotest/testdata/5.txt
+++ b/tools/junitreport/test/gotest/testdata/5.txt
@@ -3,7 +3,7 @@
 === RUN TestTwo
 --- PASS: TestTwo (0.10 seconds)
 PASS
-ok  	package/name1 0.160s
+ok  	package/name1	0.160s
 === RUN TestOne
 --- FAIL: TestOne (0.02 seconds)
 	file_test.go:11: Error message
@@ -14,4 +14,4 @@ ok  	package/name1 0.160s
 --- PASS: TestTwo (0.13 seconds)
 FAIL
 exit status 1
-FAIL	package/name2 0.150s
+FAIL	package/name2	0.150s

--- a/tools/junitreport/test/gotest/testdata/6.txt
+++ b/tools/junitreport/test/gotest/testdata/6.txt
@@ -4,4 +4,4 @@
 --- PASS: TestTwo (0.10 seconds)
 PASS
 coverage: 13.37% of statements
-ok  	package/name 0.160s
+ok  	package/name	0.160s

--- a/tools/junitreport/test/gotest/testdata/7.txt
+++ b/tools/junitreport/test/gotest/testdata/7.txt
@@ -3,4 +3,4 @@
 === RUN TestTwo
 --- PASS: TestTwo (0.10 seconds)
 PASS
-ok  	package/name 0.160s  coverage: 10.0% of statements
+ok  	package/name	0.160s	coverage: 10.0% of statements


### PR DESCRIPTION
Adds support of t.Run output from Go 1.7.

see also #13537