### PR TITLE
Add synthetic Ginkgo foci for parallel and serial conformance suites

### DIFF
--- a/test/extended/conformance.sh
+++ b/test/extended/conformance.sh
@@ -7,27 +7,15 @@ source "${OS_ROOT}/test/extended/setup.sh"
 os::test::extended::setup
 os::test::extended::focus "$@"
 
-function join { local IFS="$1"; shift; echo "$*"; }
-
-parallel_only=( "${CONFORMANCE_TESTS[@]}" )
-parallel_exclude=( "${EXCLUDED_TESTS[@]}" "${SERIAL_TESTS[@]}" )
-serial_only=( "${SERIAL_TESTS[@]}" )
-serial_exclude=( "${EXCLUDED_TESTS[@]}" )
-
-pf=$(join '|' "${parallel_only[@]}")
-ps=$(join '|' "${parallel_exclude[@]}")
-sf=$(join '|' "${serial_only[@]}")
-ss=$(join '|' "${serial_exclude[@]}")
-
 exitstatus=0
 
 # run parallel tests
 os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>}"
-TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=conformance_parallel os::test::extended::run -- -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_PARALLEL="${PARALLEL_NODES:-5}" TEST_REPORT_FILE_NAME=conformance_parallel os::test::extended::run -- -suite "parallel.conformance.openshift.io" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 # run tests in serial
 os::log::info "Running serial tests"
-FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=conformance_serial os::test::extended::run -- -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_REPORT_FILE_NAME=conformance_serial os::test::extended::run -- -suite "serial.conformance.openshift.io" -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 os::test::extended::merge_junit
 

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -8,28 +8,16 @@ source "${OS_ROOT}/test/extended/setup.sh"
 os::test::extended::setup
 os::test::extended::focus "$@"
 
-function join { local IFS="$1"; shift; echo "$*"; }
-
-parallel_only=()
-parallel_exclude=( "${EXCLUDED_TESTS[@]}" "${SERIAL_TESTS[@]}" )
-serial_only=( "${SERIAL_TESTS[@]}" )
-serial_exclude=( "${EXCLUDED_TESTS[@]}" )
-
-pf=$(join '|' "${parallel_only[@]:-}")
-ps=$(join '|' "${parallel_exclude[@]}")
-sf=$(join '|' "${serial_only[@]}")
-ss=$(join '|' "${serial_exclude[@]}")
-
 exitstatus=0
 
 # run parallel tests
 os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>}"
-TEST_PARALLEL="${PARALLEL_NODES:-5}" FOCUS="${pf}" SKIP="${ps}" TEST_REPORT_FILE_NAME=core_parallel os::test::extended::run -- -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_PARALLEL="${PARALLEL_NODES:-5}" TEST_REPORT_FILE_NAME=core_parallel os::test::extended::run -- -suite "parallel.conformance.openshift.io" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 # run tests in serial
 os::log::info ""
 os::log::info "Running serial tests"
-FOCUS="${sf}" SKIP="${ss}" TEST_REPORT_FILE_NAME=core_serial os::test::extended::run -- -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+TEST_REPORT_FILE_NAME=core_serial os::test::extended::run -- -suite "parallel.conformance.openshift.io" -test.timeout 2h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 os::test::extended::merge_junit
 

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -193,18 +193,18 @@ function os::test::extended::run () {
 
 	if [[ -n "${SHOW_ALL-}" ]]; then
 		PRINT_TESTS=1
-		os::test::extended::test_list "${listArgs[@]}"
+		os::test::extended::test_list "${listArgs[@]:+"${listArgs[@]}"}"
 		return
 	fi
 
-	os::test::extended::test_list "${listArgs[@]}"
+	os::test::extended::test_list "${listArgs[@]:+"${listArgs[@]}"}"
 
 	if [[ "${TEST_COUNT}" -eq 0 ]]; then
 		os::log::warning "No tests were selected"
 		return
 	fi
 
-	ginkgo -v -noColor "${runArgs[@]}" "$( os::util::find::built_binary extended.test )" "$@"
+	ginkgo -v -noColor "${runArgs[@]:+"${runArgs[@]}"}" "$( os::util::find::built_binary extended.test )" "$@"
 }
 
 # Create a list of extended tests to be run with the given arguments
@@ -221,7 +221,7 @@ function os::test::extended::test_list () {
 	while IFS= read -r; do
 		full_test_list+=( "${REPLY}" )
 	done < <(TEST_OUTPUT_QUIET=true extended.test "$@" --ginkgo.dryRun --ginkgo.noColor )
-	if [[ "{$REPLY}" ]]; then lines+=( "$REPLY" ); fi
+	if [[ "${REPLY}" ]]; then lines+=( "$REPLY" ); fi
 
 	for test in "${full_test_list[@]}"; do
 		if [[ -n "${SKIP_ONLY:-}" ]]; then
@@ -259,126 +259,3 @@ function os::test::extended::merge_junit () {
 	mv "${output}" "${TEST_REPORT_DIR}/junit.xml"
 }
 readonly -f os::test::extended::merge_junit
-
-# Not run by any suite
-readonly EXCLUDED_TESTS=(
-	"\[Skipped\]"
-	"\[Disruptive\]"
-	"\[Slow\]"
-	"\[Flaky\]"
-	"\[Compatibility\]"
-
-	"\[Feature:Performance\]"
-
-	# not enabled in Origin yet
-	"\[Feature:GarbageCollector\]"
-
-	# Depends on external components, may not need yet
-	Monitoring              # Not installed, should be
-	"Cluster level logging" # Not installed yet
-	Kibana                  # Not installed
-	Ubernetes               # Can't set zone labels today
-	kube-ui                 # Not installed by default
-	"^Kubernetes Dashboard"  # Not installed by default (also probably slow image pull)
-
-	"\[Feature:Federation\]"   # Not enabled yet
-	"\[Feature:Federation12\]"   # Not enabled yet
-	Ingress                    # Not enabled yet
-	"Cinder"                   # requires an OpenStack cluster
-	"should support r/w"       # hostPath: This test expects that host's tmp dir is WRITABLE by a container.  That isn't something we need to guarantee for openshift.
-	"should check that the kubernetes-dashboard instance is alive" # we don't create this
-	"\[Feature:ManualPerformance\]" # requires /resetMetrics which we don't expose
-
-	# See the CanSupport implementation in upstream to determine wether these work.
-	"Ceph RBD"      # Works if ceph-common Binary installed (but we can't guarantee this on all clusters).
-	"GlusterFS" # May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)
-	"should support r/w" # hostPath: This test expects that host's tmp dir is WRITABLE by a container.  That isn't something we need to guarantee for openshift.
-
-	# Failing because of https://github.com/openshift/origin/issues/12365 against a real cluster
-	"should allow starting 95 pods per node"
-
-	# Need fixing
-	"Horizontal pod autoscaling" # needs heapster
-	PersistentVolume           # https://github.com/openshift/origin/pull/6884 for recycler
-	"mount an API token into pods" # We add 6 secrets, not 1
-	"ServiceAccounts should ensure a single API token exists" # We create lots of secrets
-	"Networking should function for intra-pod" # Needs two nodes, add equiv test for 1 node, then use networking suite
-	"should test kube-proxy"     # needs 2 nodes
-	"authentication: OpenLDAP"   # needs separate setup and bucketing for openldap bootstrapping
-	"NFS"                      # no permissions https://github.com/openshift/origin/pull/6884
-	"\[Feature:Example\]"      # may need to pre-pull images
-	"NodeProblemDetector"        # requires a non-master node to run on
-	"unchanging, static URL paths for kubernetes api services" # the test needs to exclude URLs that are not part of conformance (/logs)
-
-	# Needs triage to determine why it is failing
-	"Addon update"          # TRIAGE
-	SSH                     # TRIAGE
-	"\[Feature:Upgrade\]"   # TRIAGE
-	"SELinux relabeling"    # started failing
-	"openshift mongodb replication creating from a template" # flaking on deployment
-	"Update Demo should do a rolling update of a replication controller" # this is flaky and needs triaging
-
-	# Test will never work
-	"should proxy to cadvisor" # we don't expose cAdvisor port directly for security reasons
-
-	# Need to relax security restrictions
-	"validates that InterPod Affinity and AntiAffinity is respected if matching" # this *may* now be safe
-
-	# Requires too many pods per node for the per core defaults
-	"should ensure that critical pod is scheduled in case there is no resources available"
-
-	# Need multiple nodes
-	"validates that InterPodAntiAffinity is respected if matching 2"
-
-	# Inordinately slow tests
-	"should create and stop a working application"
-	"should always delete fast" # will be uncommented in etcd3
-
-	# tested by networking.sh and requires the environment that script sets up
-	"\[networking\] OVS"
-
-	# We don't install KubeDNS
-	"should check if Kubernetes master services is included in cluster-info"
-
-	# this tests dns federation configuration via configmap, which we don't support yet
-	"DNS configMap"
-
-	# this tests the _kube_ downgrade. we don't support that.
-	"\[Feature:Downgrade\]"
-
-	# upstream flakes:
-	"Basic StatefulSet functionality \[StatefulSetBasic\] should provide basic identity"
-	"SchedulerPredicates \[Serial\] validates resource limits of pods that are allowed to run"
-)
-
-readonly SERIAL_TESTS=(
-	"\[Serial\]"
-	"\[Feature:ManualPerformance\]" # requires isolation
-	"Service endpoints latency" # requires low latency
-	"\[Feature:HighDensityPerformance\]" # requires no other namespaces
-	"Clean up pods on node" # schedules max pods per node
-)
-
-readonly CONFORMANCE_TESTS=(
-	"\[Conformance\]"
-	"Services.*NodePort"
-	"ResourceQuota should"
-	"EmptyDir"
-	"StatefulSet"
-	"Downward API"
-	"DNS for ExternalName services"
-	"DNS for pods for Hostname and Subdomain annotation"
-	"PrivilegedPod should test privileged pod"
-	"Pods should support remote command execution"
-	"Pods should support retrieving logs from the container"
-	"Kubectl client Simple pod should support"
-	"Job should run a job to completion when tasks succeed"
-	"Variable Expansion"
-	"init containers"
-	"Clean up pods on node kubelet"
-	"\[Feature\:SecurityContext\]"
-	"should create a LimitRange with defaults"
-	"Generated release_1_2 clientset"
-	"should create a pod that reads a secret"
-	"should create a pod that prints his name and namespace"
-)

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,7 +15,6 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
-	flag "github.com/spf13/pflag"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 var (
 	reportDir      string
 	reportFileName string
+	syntheticSuite string
 	quiet          bool
 )
 
@@ -45,11 +47,12 @@ var TestContext *e2e.TestContextType = &e2e.TestContext
 // TEST_REPORT_DIR - If set, JUnit output will be written to this directory for each test
 // TEST_REPORT_FILE_NAME - If set, will determine the name of the file that JUnit output is written to
 func InitTest() {
-	// Add hooks to skip all kubernetes or origin tests
-	ginkgo.BeforeEach(checkSuiteSkips)
+	// interpret synthetic input in `--ginkgo.focus` and/or `--ginkgo.skip`
+	ginkgo.BeforeEach(checkSyntheticInput)
 
 	e2e.RegisterCommonFlags()
 	e2e.RegisterClusterFlags()
+	flag.StringVar(&syntheticSuite, "suite", "", "Optional suite selector to filter which tests are run.")
 
 	extendedOutputDir := filepath.Join(os.TempDir(), "openshift-extended-tests")
 	os.MkdirAll(extendedOutputDir, 0777)
@@ -201,6 +204,160 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 	}
 
 	return ns, err
+}
+
+var (
+	excludedTests = []string{
+		`\[Skipped\]`,
+		`\[Disruptive\]`,
+		`\[Slow\]`,
+		`\[Flaky\]`,
+		`\[Compatibility\]`,
+
+		`\[Feature:Performance\]`,
+
+		// not enabled in Origin yet
+		`\[Feature:GarbageCollector\]`,
+
+		// Depends on external components, may not need yet
+		`Monitoring`,            // Not installed, should be
+		`Cluster level logging`, // Not installed yet
+		`Kibana`,                // Not installed
+		`Ubernetes`,             // Can't set zone labels today
+		`kube-ui`,               // Not installed by default
+		`^Kubernetes Dashboard`, // Not installed by default (also probably slow image pull)
+
+		`\[Feature:Federation\]`,                                       // Not enabled yet
+		`\[Feature:Federation12\]`,                                     // Not enabled yet
+		`Ingress`,                                                      // Not enabled yet
+		`Cinder`,                                                       // requires an OpenStack cluster
+		`should support r/w`,                                           // hostPath: This test expects that host's tmp dir is WRITABLE by a container.  That isn't something we need to guarantee for openshift.
+		`should check that the kubernetes-dashboard instance is alive`, // we don't create this
+		`\[Feature:ManualPerformance\]`,                                // requires /resetMetrics which we don't expose
+
+		// See the CanSupport implementation in upstream to determine wether these work.
+		`Ceph RBD`,           // Works if ceph-common Binary installed (but we can't guarantee this on all clusters).
+		`GlusterFS`,          // May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)
+		`should support r/w`, // hostPath: This test expects that host's tmp dir is WRITABLE by a container.  That isn't something we need to guarantee for openshift.
+
+		// Failing because of https://github.com/openshift/origin/issues/12365 against a real cluster
+		`should allow starting 95 pods per node`,
+
+		// Need fixing
+		`Horizontal pod autoscaling`,                              // needs heapster
+		`PersistentVolume`,                                        // https://github.com/openshift/origin/pull/6884 for recycler
+		`mount an API token into pods`,                            // We add 6 secrets, not 1
+		`ServiceAccounts should ensure a single API token exists`, // We create lots of secrets
+		`Networking should function for intra-pod`,                // Needs two nodes, add equiv test for 1 node, then use networking suite
+		`should test kube-proxy`,                                  // needs 2 nodes
+		`authentication: OpenLDAP`,                                // needs separate setup and bucketing for openldap bootstrapping
+		`NFS`, // no permissions https://github.com/openshift/origin/pull/6884
+		`\[Feature:Example\]`,                                      // may need to pre-pull images
+		`NodeProblemDetector`,                                      // requires a non-master node to run on
+		`unchanging, static URL paths for kubernetes api services`, // the test needs to exclude URLs that are not part of conformance (/logs)
+
+		// Needs triage to determine why it is failing
+		`Addon update`, // TRIAGE
+		`SSH`,          // TRIAGE
+		`\[Feature:Upgrade\]`,                                                // TRIAGE
+		`SELinux relabeling`,                                                 // started failing
+		`openshift mongodb replication creating from a template`,             // flaking on deployment
+		`Update Demo should do a rolling update of a replication controller`, // this is flaky and needs triaging
+
+		// Test will never work
+		`should proxy to cadvisor`, // we don't expose cAdvisor port directly for security reasons
+
+		// Need to relax security restrictions
+		`validates that InterPod Affinity and AntiAffinity is respected if matching`, // this *may* now be safe
+
+		// Requires too many pods per node for the per core defaults
+		`should ensure that critical pod is scheduled in case there is no resources available`,
+
+		// Need multiple nodes
+		`validates that InterPodAntiAffinity is respected if matching 2`,
+
+		// Inordinately slow tests
+		`should create and stop a working application`,
+		`should always delete fast`, // will be uncommented in etcd3
+
+		// tested by networking.sh and requires the environment that script sets up
+		`\[networking\] OVS`,
+
+		// We don't install KubeDNS
+		`should check if Kubernetes master services is included in cluster-info`,
+
+		// this tests dns federation configuration via configmap, which we don't support yet
+		`DNS configMap`,
+
+		// this tests the _kube_ downgrade. we don't support that.
+		`\[Feature:Downgrade\]`,
+
+		// upstream flakes
+		`Basic StatefulSet functionality \[StatefulSetBasic\] should provide basic identity`,
+		`SchedulerPredicates \[Serial\] validates resource limits of pods that are allowed to run`,
+	}
+	excludedTestsFilter = regexp.MustCompile(strings.Join(excludedTests, `|`))
+
+	parallelConformanceTests = []string{
+		`\[Conformance\]`,
+		`Services.*NodePort`,
+		`ResourceQuota should`,
+		`EmptyDir`,
+		`StatefulSet`,
+		`Downward API`,
+		`DNS for ExternalName services`,
+		`DNS for pods for Hostname and Subdomain annotation`,
+		`PrivilegedPod should test privileged pod`,
+		`Pods should support remote command execution`,
+		`Pods should support retrieving logs from the container`,
+		`Kubectl client Simple pod should support`,
+		`Job should run a job to completion when tasks succeed`,
+		`Variable Expansion`,
+		`init containers`,
+		`Clean up pods on node kubelet`,
+		`\[Feature\:SecurityContext\]`,
+		`should create a LimitRange with defaults`,
+		`Generated release_1_2 clientset`,
+		`should create a pod that reads a secret`,
+		`should create a pod that prints his name and namespace`,
+	}
+	parallelConformanceTestsFilter = regexp.MustCompile(strings.Join(parallelConformanceTests, `|`))
+
+	serialConformanceTests = []string{
+		`\[Serial\]`,
+		`\[Feature:ManualPerformance\]`,      // requires isolation
+		`Service endpoints latency`,          // requires low latency
+		`\[Feature:HighDensityPerformance\]`, // requires no other namespaces
+		`Clean up pods on node`,              // schedules max pods per node
+	}
+	serialConformanceTestsFilter = regexp.MustCompile(strings.Join(serialConformanceTests, `|`))
+)
+
+// checkSyntheticInput selects tests based on synthetic skips or focuses
+func checkSyntheticInput() {
+	checkSuiteFocuses()
+	checkSuiteSkips()
+}
+
+// checkSuiteFocuses ensures Origin conformance suite synthetic labels are applied
+func checkSuiteFocuses() {
+	if !strings.Contains(syntheticSuite, "conformance.openshift.io") {
+		return
+	}
+
+	testName := []byte(ginkgo.CurrentGinkgoTestDescription().FullTestText)
+	testFocused := false
+	textExcluded := excludedTestsFilter.Match(testName)
+	if syntheticSuite == "parallel.conformance.openshift.io" {
+		testFocused = parallelConformanceTestsFilter.Match(testName)
+		textExcluded = textExcluded || serialConformanceTestsFilter.Match(testName)
+	} else if syntheticSuite == "serial.conformance.openshift.io" {
+		testFocused = serialConformanceTestsFilter.Match(testName)
+	}
+
+	if !testFocused || textExcluded {
+		ginkgo.Skip("skipping tests not in the Origin conformance suite")
+	}
 }
 
 // checkSuiteSkips ensures Origin/Kubernetes synthetic skip labels are applied


### PR DESCRIPTION
In order to allow consumers of the `extended.test` and the test RPM to
run the conformance tests in a simple manner without internalizing the
logic in `test/extended/setup.sh`, synthetic Ginkgo foci are set up to
mirror that logic.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]