### PR TITLE
revert SCMAuth: use local proxy when password length exceeds 255 chars

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -123,7 +123,6 @@ func (c *builderConfig) setupGitEnvironment() (string, []string, error) {
 			return sourceSecretDir, nil, fmt.Errorf("cannot setup source secret: %v", err)
 		}
 		if overrideURL != nil {
-			c.build.Annotations[bld.OriginalSourceURLAnnotationKey] = gitSource.URI
 			gitSource.URI = overrideURL.String()
 		}
 		gitEnv = append(gitEnv, secretsEnv...)

--- a/pkg/build/builder/cmd/scmauth/password_test.go
+++ b/pkg/build/builder/cmd/scmauth/password_test.go
@@ -102,7 +102,7 @@ func TestPassword(t *testing.T) {
 
 	for k, tc := range testcases {
 		u, _ := url.Parse(tc.URL)
-		sourceURL, configURL, err := doSetup(*u, tc.Username, tc.Password, tc.Token, removeCredentials)
+		sourceURL, configURL, err := doSetup(*u, tc.Username, tc.Password, tc.Token)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -23,8 +23,6 @@ import (
 var glog = utilglog.ToFile(os.Stderr, 2)
 
 const (
-	OriginalSourceURLAnnotationKey = "openshift.io/original-source-url"
-
 	// containerNamePrefix prefixes the name of containers launched by a build.
 	// We cannot reuse the prefix "k8s" because we don't want the containers to
 	// be managed by a kubelet.
@@ -54,11 +52,7 @@ func buildInfo(build *api.Build, sourceInfo *git.SourceInfo) []KeyValue {
 		{"OPENSHIFT_BUILD_NAMESPACE", build.Namespace},
 	}
 	if build.Spec.Source.Git != nil {
-		sourceURL := build.Spec.Source.Git.URI
-		if originalURL, ok := build.Annotations[OriginalSourceURLAnnotationKey]; ok {
-			sourceURL = originalURL
-		}
-		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_SOURCE", sourceURL})
+		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_SOURCE", build.Spec.Source.Git.URI})
 		if build.Spec.Source.Git.Ref != "" {
 			kv = append(kv, KeyValue{"OPENSHIFT_BUILD_REFERENCE", build.Spec.Source.Git.Ref})
 		}

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -1,11 +1,8 @@
 package builds
 
-// these tests are disabled because the xip.io dns hook was proving way too unreliable;
-// we will reenable once an agreeable alternative is derived to get name resolution for the routes
-
-/*import (
-	"net"
+import (
 	"fmt"
+	"net"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -15,7 +12,6 @@ package builds
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	testutil "github.com/openshift/origin/test/util"
-
 )
 
 // hostname returns the hostname from a hostport specification
@@ -69,28 +65,20 @@ var _ = g.Describe("[builds][Slow] can use private repositories as build input",
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("expecting the deployment of the gitserver to be in the Complete phase")
-		err = exutil.WaitForADeploymentToComplete(oc.KubeClient().Core().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName)
+		err = exutil.WaitForADeploymentToComplete(oc.KubeClient().Core().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		sourceSecretName := secretFunc()
 
 		sourceURL := fmt.Sprintf(urlTemplate, routeSuffix)
-		g.By(fmt.Sprintf("creating a new BuildConfig by calling oc new-app -f %q -p SOURCE_SECRET=%s,SOURCE_URL=%s",
+		g.By(fmt.Sprintf("creating a new BuildConfig by calling oc new-app -f %q -p SOURCE_SECRET=%s -p SOURCE_URL=%s",
 			testBuildFixture, sourceSecretName, sourceURL))
-		err = oc.Run("new-app").Args("-f", testBuildFixture, "-p", fmt.Sprintf("SOURCE_SECRET=%s,SOURCE_URL=%s",
-			sourceSecretName, sourceURL)).Execute()
+		err = oc.Run("new-app").Args("-f", testBuildFixture, "-p", fmt.Sprintf("SOURCE_SECRET=%s", sourceSecretName), "-p", fmt.Sprintf("SOURCE_URL=%s", sourceURL)).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("starting a test build")
-		buildName, err := oc.Run("start-build").Args(buildConfigName).Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By(fmt.Sprintf("expecting build %s to complete successfully", buildName))
-		err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), buildName, nil, nil, nil)
-		if err != nil {
-			exutil.DumpBuildLogs(buildConfigName, oc)
-		}
-		o.Expect(err).NotTo(o.HaveOccurred())
+		br, _ := exutil.StartBuildAndWait(oc, buildConfigName)
+		br.AssertSuccess()
 	}
 
 	g.Describe("Build using a username, password, and CA certificate", func() {
@@ -129,4 +117,4 @@ var _ = g.Describe("[builds][Slow] can use private repositories as build input",
 			})
 		})
 	})
-})*/
+})


### PR DESCRIPTION
I believe that #5908 can now be reverted since future versions of OCP will require a version of RHEL which has https://bugzilla.redhat.com/show_bug.cgi?id=1260178 included.

@csrwng do you have any thoughts about what should be done about test/extended/builds/gitauth.go (which is currently entirely commented out)?

@openshift/devex 