### PR TITLE
migration: fixes to manifest migration script

### DIFF
--- a/contrib/migration/migrate-image-manifests.sh
+++ b/contrib/migration/migrate-image-manifests.sh
@@ -4,6 +4,8 @@ set -iuo pipefail
 IFS=$'\n\t'
 
 readonly AUDITOR_ROLE='system:image-auditor'
+readonly CLUSTER_READER_ROLE='cluster-reader'
+readonly REGISTRY_VIEWER_ROLE='registry-viewer'
 
 readonly USAGE="Usage: $(basename ${BASH_SOURCE[0]}) [OPTIONS]
 
@@ -32,7 +34,8 @@ Options:
                      Run this command as cluster admin to give particular
                      user enough rights to query the images:
 
-                       \$ oadm policy add-cluster-role-to-user registry-viewer <user>
+                       \$ oadm policy add-cluster-role-to-user ${REGISTRY_VIEWER_ROLE} <user>
+                       \$ oadm policy add-cluster-role-to-user ${CLUSTER_READER_ROLE} <user>
 
   -f                 Force migration of externally managed images (those imported
                      from remote registries). A migration attempt is done by
@@ -47,6 +50,7 @@ Options:
                      For this to work, the user must be an image auditor:
 
                        \$ oadm policy add-cluster-role-to-user ${AUDITOR_ROLE} <user>
+                       \$ oadm policy add-cluster-role-to-user ${CLUSTER_READER_ROLE} <user>
 "
 
 registry_address=""
@@ -79,23 +83,32 @@ function get_docker_registry_url() {
 }
 
 function check_permissions() {
-    local authorized=1
-    local verb
-    for verb in get list update; do
-        if [[ "$(oc policy can-i "${verb}" images)" != yes ]]; then
-            echo "The user isn't authorized to ${verb} images!" >&2
-            authorized=0
+    declare -a verbs
+    local authorized=1 verb resource
+    for resource in images projects; do
+        if [[ "${resource}" == "images" ]]; then
+            verbs=( get list update )
+        else
+            verbs=( get list )
         fi
+        for verb in "${verbs[@]}"; do
+            if ! oc policy can-i -q --all-namespaces "${verb}" "${resource}"; then
+                echo "The user isn't authorized to ${verb} ${resource}!" >&2
+                authorized=0
+            fi
+        done
     done
     if [[ "${authorized}" == 0 ]]; then
         echo "Ask your admin to give you permissions to work with images, e.g.:" >&2
         echo "  oadm policy add-cluster-role-to-user ${AUDITOR_ROLE} $(oc whoami)" >&2
+        echo "  oadm policy add-cluster-role-to-user ${CLUSTER_READER_ROLE} $(oc whoami)" >&2
         return 1
     fi
 
-    if [[ "$(oc policy can-i get imagestreams/layers --token=${token})" != yes ]]; then
+    if ! oc policy can-i -q get --all-namespaces imagestreams/layers --token="${token}"; then
         echo "The registry user isn't authorized to get imagestreams/layers!" >&2
         echo "  oadm policy add-cluster-role-to-user registry-viewer <user>" >&2
+        echo "  oadm policy add-cluster-role-to-user ${CLUSTER_READER_ROLE} <user>" >&2
         return 1
     fi
 }


### PR DESCRIPTION
Thorough permission checks. Require cluster-reader role to be able to
get imagestreams/layers and list projects in all the namespaces.

Robust guessing of integrated docker registry url.

Signed-off-by: Michal Minář <miminar@redhat.com>