### PR TITLE
deploy: add owner reference to rc from the deployer

### DIFF
--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -324,6 +324,17 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 			Labels: map[string]string{
 				deployapi.DeployerPodForDeploymentLabel: deployment.Name,
 			},
+			// Set the owner reference to current deployment, so in case the deployment fails
+			// and the deployer pod is preserved when a revisionHistory limit is reached and the
+			// deployment is removed, we also remove the deployer pod with it.
+			OwnerReferences: []kapi.OwnerReference{{
+				// FIXME: This will have to point to apps.openshift.io/v1 after we switch to
+				// clientsets.
+				APIVersion: "v1",
+				Kind:       deployapi.Kind("DeploymentConfig").Kind,
+				Name:       deployment.Name,
+				UID:        deployment.UID,
+			}},
 		},
 		Spec: kapi.PodSpec{
 			Containers: []kapi.Container{


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/13554

This will only take effect when the `revisionHistory` is set and there are "failed" deployments. In that case we are keeping the deployer pods (so users can get logs/etc.). 