### PR TITLE
rely on the upstream namespace cleanup controller

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -1066,11 +1066,10 @@ func (c *MasterConfig) WebConsoleEnabled() bool {
 	return c.Options.AssetConfig != nil && !c.Options.DisabledFeatures.Has(configapi.FeatureWebConsole)
 }
 
-// OriginNamespaceControllerClients returns a client for openshift and kubernetes.
-// The openshift client object must have authority to delete openshift content in any namespace
+// OriginNamespaceControllerClient returns a client for openshift and kubernetes.
 // The kubernetes client object must have authority to execute a finalize request on a namespace
-func (c *MasterConfig) OriginNamespaceControllerClients() (*osclient.Client, kclientsetinternal.Interface) {
-	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClientsetInternal
+func (c *MasterConfig) OriginNamespaceControllerClient() kclientsetinternal.Interface {
+	return c.PrivilegedLoopbackKubernetesClientsetInternal
 }
 
 // UnidlingControllerClients returns the unidling controller clients

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -84,9 +84,8 @@ func (c *MasterConfig) RunProjectAuthorizationCache() {
 
 // RunOriginNamespaceController starts the controller that takes part in namespace termination of openshift content
 func (c *MasterConfig) RunOriginNamespaceController() {
-	osclient, kclient := c.OriginNamespaceControllerClients()
+	kclient := c.OriginNamespaceControllerClient()
 	factory := projectcontroller.NamespaceControllerFactory{
-		Client:     osclient,
 		KubeClient: kclient,
 	}
 	controller := factory.Create()

--- a/pkg/project/controller/factory.go
+++ b/pkg/project/controller/factory.go
@@ -12,13 +12,10 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	controller "github.com/openshift/origin/pkg/controller"
 )
 
 type NamespaceControllerFactory struct {
-	// Client is an OpenShift client.
-	Client osclient.Interface
 	// KubeClient is a Kubernetes client.
 	KubeClient kclientset.Interface
 }
@@ -37,7 +34,6 @@ func (factory *NamespaceControllerFactory) Create() controller.RunnableControlle
 	cache.NewReflector(namespaceLW, &kapi.Namespace{}, queue, 1*time.Minute).Run()
 
 	namespaceController := &NamespaceController{
-		Client:     factory.Client,
 		KubeClient: factory.KubeClient,
 	}
 
@@ -48,9 +44,6 @@ func (factory *NamespaceControllerFactory) Create() controller.RunnableControlle
 			cache.MetaNamespaceKeyFunc,
 			func(obj interface{}, err error, retries controller.Retry) bool {
 				utilruntime.HandleError(err)
-				if _, isFatal := err.(fatalError); isFatal {
-					return false
-				}
 				if retries.Count > 0 {
 					return false
 				}

--- a/pkg/project/controller/project_controller.go
+++ b/pkg/project/controller/project_controller.go
@@ -1,11 +1,8 @@
 package controller
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	projectutil "github.com/openshift/origin/pkg/project/util"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
@@ -13,17 +10,9 @@ import (
 // NamespaceController is responsible for participating in Kubernetes Namespace termination
 // Use the NamespaceControllerFactory to create this controller.
 type NamespaceController struct {
-	// Client is an OpenShift client.
-	Client osclient.Interface
 	// KubeClient is a Kubernetes client.
 	KubeClient internalclientset.Interface
 }
-
-// fatalError is an error which can't be retried.
-type fatalError string
-
-// Error implements the interface for errors
-func (e fatalError) Error() string { return "fatal error handling namespace: " + string(e) }
 
 // Handle processes a namespace and deletes content in origin if its terminating
 func (c *NamespaceController) Handle(namespace *kapi.Namespace) (err error) {
@@ -37,244 +26,11 @@ func (c *NamespaceController) Handle(namespace *kapi.Namespace) (err error) {
 		return nil
 	}
 
-	// there may still be content for us to remove
-	err = deleteAllContent(c.Client, namespace.Name)
-	if err != nil {
-		return err
-	}
-
 	// we have removed content, so mark it finalized by us
 	_, err = projectutil.Finalize(c.KubeClient, namespace)
 	if err != nil {
 		return err
 	}
 
-	return nil
-}
-
-// deleteAllContent will purge all content in openshift in the specified namespace
-func deleteAllContent(client osclient.Interface, namespace string) (err error) {
-	err = deleteBuildConfigs(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteBuilds(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteDeploymentConfigs(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteEgressNetworkPolicies(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteImageStreams(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deletePolicies(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deletePolicyBindings(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteRoleBindings(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteRoles(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteRoutes(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteTemplates(client, namespace)
-	if err != nil {
-		return err
-	}
-	err = deleteRoleBindingRestrictions(client, namespace)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func deleteRoleBindingRestrictions(client osclient.Interface, ns string) error {
-	items, err := client.RoleBindingRestrictions(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.RoleBindingRestrictions(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteTemplates(client osclient.Interface, ns string) error {
-	items, err := client.Templates(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.Templates(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteRoutes(client osclient.Interface, ns string) error {
-	items, err := client.Routes(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.Routes(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteRoles(client osclient.Interface, ns string) error {
-	items, err := client.Roles(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.Roles(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteRoleBindings(client osclient.Interface, ns string) error {
-	items, err := client.RoleBindings(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.RoleBindings(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deletePolicyBindings(client osclient.Interface, ns string) error {
-	items, err := client.PolicyBindings(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.PolicyBindings(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deletePolicies(client osclient.Interface, ns string) error {
-	items, err := client.Policies(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.Policies(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteImageStreams(client osclient.Interface, ns string) error {
-	items, err := client.ImageStreams(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.ImageStreams(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteEgressNetworkPolicies(client osclient.Interface, ns string) error {
-	items, err := client.EgressNetworkPolicies(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.EgressNetworkPolicies(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteDeploymentConfigs(client osclient.Interface, ns string) error {
-	items, err := client.DeploymentConfigs(ns).List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range items.Items {
-		err := client.DeploymentConfigs(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteBuilds(client osclient.Interface, ns string) error {
-	items, err := client.Builds(ns).List(metav1.ListOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	for i := range items.Items {
-		err := client.Builds(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func deleteBuildConfigs(client osclient.Interface, ns string) error {
-	items, err := client.BuildConfigs(ns).List(metav1.ListOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	for i := range items.Items {
-		err := client.BuildConfigs(ns).Delete(items.Items[i].Name)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	}
 	return nil
 }

--- a/pkg/project/controller/project_controller_test.go
+++ b/pkg/project/controller/project_controller_test.go
@@ -8,17 +8,14 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	"github.com/openshift/origin/pkg/project/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
 func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 	mockKubeClient := &fake.Clientset{}
-	mockOriginClient := &testclient.Fake{}
 	nm := NamespaceController{
 		KubeClient: mockKubeClient,
-		Client:     mockOriginClient,
 	}
 	now := metav1.Now()
 	testNamespace := &kapi.Namespace{
@@ -41,40 +38,22 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 
 	// TODO: we will expect a finalize namespace call after rebase
 	expectedActionSet := []clientgotesting.Action{
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "buildconfigs"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "policies"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "imagestreams"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "policybindings"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "rolebindings"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "roles"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "routes"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "templates"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "builds"}, "", metav1.ListOptions{}),
 		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespace"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "deploymentconfig"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "egressnetworkpolicy"}, "", metav1.ListOptions{}),
-		clientgotesting.NewListAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "rolebindingrestrictions"}, "", metav1.ListOptions{}),
 	}
 	kubeActionSet := []clientgotesting.Action{}
-	originActionSet := []clientgotesting.Action{}
 	for i := range mockKubeClient.Actions() {
 		kubeActionSet = append(kubeActionSet, mockKubeClient.Actions()[i])
 	}
-	for i := range mockOriginClient.Actions() {
-		originActionSet = append(originActionSet, mockOriginClient.Actions()[i])
-	}
 
-	if (len(kubeActionSet) + len(originActionSet)) != len(expectedActionSet) {
-		t.Errorf("Expected actions: %v, but got: %v and %v", expectedActionSet, originActionSet, kubeActionSet)
+	if (len(kubeActionSet)) != len(expectedActionSet) {
+		t.Errorf("Expected actions: %v, but got: %v", expectedActionSet, kubeActionSet)
 	}
 }
 
 func TestSyncNamespaceThatIsActive(t *testing.T) {
 	mockKubeClient := &fake.Clientset{}
-	mockOriginClient := &testclient.Fake{}
 	nm := NamespaceController{
 		KubeClient: mockKubeClient,
-		Client:     mockOriginClient,
 	}
 	testNamespace := &kapi.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -93,15 +72,11 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 		t.Errorf("Unexpected error when handling namespace %v", err)
 	}
 	kubeActionSet := []clientgotesting.Action{}
-	originActionSet := []clientgotesting.Action{}
 	for i := range mockKubeClient.Actions() {
 		kubeActionSet = append(kubeActionSet, mockKubeClient.Actions()[i])
 	}
-	for i := range mockOriginClient.Actions() {
-		originActionSet = append(originActionSet, mockOriginClient.Actions()[i])
-	}
 
-	if (len(kubeActionSet) + len(originActionSet)) != 0 {
-		t.Errorf("Expected no actions from contoller, but got: %#v and %#v", originActionSet, kubeActionSet)
+	if (len(kubeActionSet)) != 0 {
+		t.Errorf("Expected no actions from contoller, but got: %#v", kubeActionSet)
 	}
 }

--- a/test/cmd/status.sh
+++ b/test/cmd/status.sh
@@ -61,7 +61,8 @@ os::cmd::expect_success_and_text "oc project" 'Using project "project-bar-2"'
 # delete the current project `project-bar-2` and make sure `oc status` does not return the "no projects"
 # message since `project-bar` still exists
 os::cmd::expect_success_and_text "oc delete project project-bar-2" 'project "project-bar-2" deleted'
-os::cmd::expect_failure_and_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar-2"'
+# the deletion is asynchronous and can take a while, so wait until we see the error
+os::cmd::try_until_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar-2"'
 
 # delete "project-bar" and test that `oc status` still does not return the "no projects" message.
 # Although we are deleting the last remaining project, the current context's namespace is still set
@@ -69,7 +70,8 @@ os::cmd::expect_failure_and_text "oc status" 'Error from server \(Forbidden\): U
 # until the next time the user logs in.
 os::cmd::expect_success "oc project project-bar"
 os::cmd::expect_success "oc delete project project-bar"
-os::cmd::expect_failure_and_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar"'
+# the deletion is asynchronous and can take a while, so wait until we see the error
+os::cmd::try_until_text "oc status" 'Error from server \(Forbidden\): User "test-user" cannot get project "project-bar"'
 os::cmd::try_until_not_text "oc get projects" "project-bar"
 os::cmd::try_until_not_text "oc get projects" "project-bar-2"
 os::cmd::expect_success "oc logout"


### PR DESCRIPTION
This proves that the upstream namespace controller cleans up the groupified origin resources.

@smarterclayton @liggitt if we want to support new controllers against old api-servers, we'll need to restore this controller and simply have a way to disable it for the test (certainly a thing we can do).  We've been upgrading apiserver first for a while now though.  Do we care?

@enj ptal