### PR TITLE
WIP: Add controller to update cross image stream tag aliases

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -71,6 +71,7 @@ import (
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 	imagepolicy "github.com/openshift/origin/pkg/image/admission/imagepolicy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	imageclient "github.com/openshift/origin/pkg/image/clientset/internalclientset"
 	ingressadmission "github.com/openshift/origin/pkg/ingress/admission"
 	accesstokenregistry "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
@@ -901,6 +902,11 @@ func (c *MasterConfig) BuildLogClient() *kclientset.Clientset {
 // BuildConfigWebHookClient returns the webhook client object
 func (c *MasterConfig) BuildConfigWebHookClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
+}
+
+func (c *MasterConfig) UpdateTrackingTagsControllerClient() imageclient.Interface {
+	clientConfig := c.PrivilegedLoopbackClientConfig
+	return imageclient.NewForConfigOrDie(&clientConfig)
 }
 
 // BuildControllerClients returns the build controller client objects

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -402,6 +402,12 @@ func (c *MasterConfig) RunServiceServingCertController(client *kclientset.Client
 	go servingCertUpdateController.Run(5, make(chan struct{}))
 }
 
+func (c *MasterConfig) RunUpdateTrackingTagController() {
+	options := imagecontroller.UpdateTrackingTagsControllerOptions{Resync: 10 * time.Minute}
+	ctrl := imagecontroller.NewUpdateTrackingTagsController(c.UpdateTrackingTagsControllerClient(), options)
+	go ctrl.Run(5, utilwait.NeverStop)
+}
+
 // RunImageImportController starts the image import trigger controller process.
 func (c *MasterConfig) RunImageImportController() {
 	osclient := c.ImageImportControllerClient()

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -734,6 +734,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunDeploymentConfigController()
 	oc.RunDeploymentTriggerController()
 	oc.RunImageImportController()
+	oc.RunUpdateTrackingTagController()
 	oc.RunOriginNamespaceController()
 	oc.RunSDNController()
 

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -192,6 +192,8 @@ type ImageStreamList struct {
 	Items []ImageStream
 }
 
+// +genclient=true
+
 // ImageStream stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a stream, and an optional reference to a Docker image
 // repository on a registry.
@@ -347,6 +349,8 @@ type ImageStreamMapping struct {
 	// A string value this image can be located with inside the repository.
 	Tag string
 }
+
+// +genclient=true
 
 // ImageStreamTag has a .Name in the format <stream name>:<tag>.
 type ImageStreamTag struct {

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_image_client.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_image_client.go
@@ -14,6 +14,14 @@ func (c *FakeImage) Images() internalversion.ImageResourceInterface {
 	return &FakeImages{c}
 }
 
+func (c *FakeImage) ImageStreams(namespace string) internalversion.ImageStreamInterface {
+	return &FakeImageStreams{c, namespace}
+}
+
+func (c *FakeImage) ImageStreamTags(namespace string) internalversion.ImageStreamTagInterface {
+	return &FakeImageStreamTags{c, namespace}
+}
+
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeImage) RESTClient() restclient.Interface {

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_imagestream.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_imagestream.go
@@ -1,0 +1,101 @@
+package fake
+
+import (
+	api "github.com/openshift/origin/pkg/image/api"
+	pkg_api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeImageStreams implements ImageStreamInterface
+type FakeImageStreams struct {
+	Fake *FakeImage
+	ns   string
+}
+
+var imagestreamsResource = unversioned.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagestreams"}
+
+func (c *FakeImageStreams) Create(imageStream *api.ImageStream) (result *api.ImageStream, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction(imagestreamsResource, c.ns, imageStream), &api.ImageStream{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStream), err
+}
+
+func (c *FakeImageStreams) Update(imageStream *api.ImageStream) (result *api.ImageStream, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction(imagestreamsResource, c.ns, imageStream), &api.ImageStream{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStream), err
+}
+
+func (c *FakeImageStreams) Delete(name string, options *pkg_api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction(imagestreamsResource, c.ns, name), &api.ImageStream{})
+
+	return err
+}
+
+func (c *FakeImageStreams) DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error {
+	action := core.NewDeleteCollectionAction(imagestreamsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ImageStreamList{})
+	return err
+}
+
+func (c *FakeImageStreams) Get(name string) (result *api.ImageStream, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction(imagestreamsResource, c.ns, name), &api.ImageStream{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStream), err
+}
+
+func (c *FakeImageStreams) List(opts pkg_api.ListOptions) (result *api.ImageStreamList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction(imagestreamsResource, c.ns, opts), &api.ImageStreamList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := core.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ImageStreamList{}
+	for _, item := range obj.(*api.ImageStreamList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested imageStreams.
+func (c *FakeImageStreams) Watch(opts pkg_api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction(imagestreamsResource, c.ns, opts))
+
+}
+
+// Patch applies the patch and returns the patched imageStream.
+func (c *FakeImageStreams) Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStream, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchSubresourceAction(imagestreamsResource, c.ns, name, data, subresources...), &api.ImageStream{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStream), err
+}

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_imagestreamtag.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/fake/fake_imagestreamtag.go
@@ -1,0 +1,101 @@
+package fake
+
+import (
+	api "github.com/openshift/origin/pkg/image/api"
+	pkg_api "k8s.io/kubernetes/pkg/api"
+	unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	core "k8s.io/kubernetes/pkg/client/testing/core"
+	labels "k8s.io/kubernetes/pkg/labels"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeImageStreamTags implements ImageStreamTagInterface
+type FakeImageStreamTags struct {
+	Fake *FakeImage
+	ns   string
+}
+
+var imagestreamtagsResource = unversioned.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagestreamtags"}
+
+func (c *FakeImageStreamTags) Create(imageStreamTag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewCreateAction(imagestreamtagsResource, c.ns, imageStreamTag), &api.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStreamTag), err
+}
+
+func (c *FakeImageStreamTags) Update(imageStreamTag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewUpdateAction(imagestreamtagsResource, c.ns, imageStreamTag), &api.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStreamTag), err
+}
+
+func (c *FakeImageStreamTags) Delete(name string, options *pkg_api.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(core.NewDeleteAction(imagestreamtagsResource, c.ns, name), &api.ImageStreamTag{})
+
+	return err
+}
+
+func (c *FakeImageStreamTags) DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error {
+	action := core.NewDeleteCollectionAction(imagestreamtagsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ImageStreamTagList{})
+	return err
+}
+
+func (c *FakeImageStreamTags) Get(name string) (result *api.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewGetAction(imagestreamtagsResource, c.ns, name), &api.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStreamTag), err
+}
+
+func (c *FakeImageStreamTags) List(opts pkg_api.ListOptions) (result *api.ImageStreamTagList, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewListAction(imagestreamtagsResource, c.ns, opts), &api.ImageStreamTagList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := core.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.ImageStreamTagList{}
+	for _, item := range obj.(*api.ImageStreamTagList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested imageStreamTags.
+func (c *FakeImageStreamTags) Watch(opts pkg_api.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(core.NewWatchAction(imagestreamtagsResource, c.ns, opts))
+
+}
+
+// Patch applies the patch and returns the patched imageStreamTag.
+func (c *FakeImageStreamTags) Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(core.NewPatchSubresourceAction(imagestreamtagsResource, c.ns, name, data, subresources...), &api.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ImageStreamTag), err
+}

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/generated_expansion.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/generated_expansion.go
@@ -1,3 +1,7 @@
 package internalversion
 
 type ImageResourceExpansion interface{}
+
+type ImageStreamExpansion interface{}
+
+type ImageStreamTagExpansion interface{}

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/image_client.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/image_client.go
@@ -9,6 +9,8 @@ import (
 type ImageInterface interface {
 	RESTClient() restclient.Interface
 	ImagesGetter
+	ImageStreamsGetter
+	ImageStreamTagsGetter
 }
 
 // ImageClient is used to interact with features provided by the k8s.io/kubernetes/pkg/apimachinery/registered.Group group.
@@ -18,6 +20,14 @@ type ImageClient struct {
 
 func (c *ImageClient) Images() ImageResourceInterface {
 	return newImages(c)
+}
+
+func (c *ImageClient) ImageStreams(namespace string) ImageStreamInterface {
+	return newImageStreams(c, namespace)
+}
+
+func (c *ImageClient) ImageStreamTags(namespace string) ImageStreamTagInterface {
+	return newImageStreamTags(c, namespace)
 }
 
 // NewForConfig creates a new ImageClient for the given config.

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/imagestream.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/imagestream.go
@@ -1,0 +1,136 @@
+package internalversion
+
+import (
+	api "github.com/openshift/origin/pkg/image/api"
+	pkg_api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ImageStreamsGetter has a method to return a ImageStreamInterface.
+// A group's client should implement this interface.
+type ImageStreamsGetter interface {
+	ImageStreams(namespace string) ImageStreamInterface
+}
+
+// ImageStreamInterface has methods to work with ImageStream resources.
+type ImageStreamInterface interface {
+	Create(*api.ImageStream) (*api.ImageStream, error)
+	Update(*api.ImageStream) (*api.ImageStream, error)
+	Delete(name string, options *pkg_api.DeleteOptions) error
+	DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error
+	Get(name string) (*api.ImageStream, error)
+	List(opts pkg_api.ListOptions) (*api.ImageStreamList, error)
+	Watch(opts pkg_api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStream, err error)
+	ImageStreamExpansion
+}
+
+// imageStreams implements ImageStreamInterface
+type imageStreams struct {
+	client restclient.Interface
+	ns     string
+}
+
+// newImageStreams returns a ImageStreams
+func newImageStreams(c *ImageClient, namespace string) *imageStreams {
+	return &imageStreams{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a imageStream and creates it.  Returns the server's representation of the imageStream, and an error, if there is any.
+func (c *imageStreams) Create(imageStream *api.ImageStream) (result *api.ImageStream, err error) {
+	result = &api.ImageStream{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		Body(imageStream).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a imageStream and updates it. Returns the server's representation of the imageStream, and an error, if there is any.
+func (c *imageStreams) Update(imageStream *api.ImageStream) (result *api.ImageStream, err error) {
+	result = &api.ImageStream{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		Name(imageStream.Name).
+		Body(imageStream).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageStream and deletes it. Returns an error if one occurs.
+func (c *imageStreams) Delete(name string, options *pkg_api.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *imageStreams) DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		VersionedParams(&listOptions, pkg_api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the imageStream, and returns the corresponding imageStream object, and an error if there is any.
+func (c *imageStreams) Get(name string) (result *api.ImageStream, err error) {
+	result = &api.ImageStream{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ImageStreams that match those selectors.
+func (c *imageStreams) List(opts pkg_api.ListOptions) (result *api.ImageStreamList, err error) {
+	result = &api.ImageStreamList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreams").
+		VersionedParams(&opts, pkg_api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested imageStreams.
+func (c *imageStreams) Watch(opts pkg_api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("imagestreams").
+		VersionedParams(&opts, pkg_api.ParameterCodec).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched imageStream.
+func (c *imageStreams) Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStream, err error) {
+	result = &api.ImageStream{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("imagestreams").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/clientset/internalclientset/typed/image/internalversion/imagestreamtag.go
+++ b/pkg/image/clientset/internalclientset/typed/image/internalversion/imagestreamtag.go
@@ -1,0 +1,136 @@
+package internalversion
+
+import (
+	api "github.com/openshift/origin/pkg/image/api"
+	pkg_api "k8s.io/kubernetes/pkg/api"
+	restclient "k8s.io/kubernetes/pkg/client/restclient"
+	watch "k8s.io/kubernetes/pkg/watch"
+)
+
+// ImageStreamTagsGetter has a method to return a ImageStreamTagInterface.
+// A group's client should implement this interface.
+type ImageStreamTagsGetter interface {
+	ImageStreamTags(namespace string) ImageStreamTagInterface
+}
+
+// ImageStreamTagInterface has methods to work with ImageStreamTag resources.
+type ImageStreamTagInterface interface {
+	Create(*api.ImageStreamTag) (*api.ImageStreamTag, error)
+	Update(*api.ImageStreamTag) (*api.ImageStreamTag, error)
+	Delete(name string, options *pkg_api.DeleteOptions) error
+	DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error
+	Get(name string) (*api.ImageStreamTag, error)
+	List(opts pkg_api.ListOptions) (*api.ImageStreamTagList, error)
+	Watch(opts pkg_api.ListOptions) (watch.Interface, error)
+	Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStreamTag, err error)
+	ImageStreamTagExpansion
+}
+
+// imageStreamTags implements ImageStreamTagInterface
+type imageStreamTags struct {
+	client restclient.Interface
+	ns     string
+}
+
+// newImageStreamTags returns a ImageStreamTags
+func newImageStreamTags(c *ImageClient, namespace string) *imageStreamTags {
+	return &imageStreamTags{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a imageStreamTag and creates it.  Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Create(imageStreamTag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a imageStreamTag and updates it. Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Update(imageStreamTag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(imageStreamTag.Name).
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageStreamTag and deletes it. Returns an error if one occurs.
+func (c *imageStreamTags) Delete(name string, options *pkg_api.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *imageStreamTags) DeleteCollection(options *pkg_api.DeleteOptions, listOptions pkg_api.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		VersionedParams(&listOptions, pkg_api.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the imageStreamTag, and returns the corresponding imageStreamTag object, and an error if there is any.
+func (c *imageStreamTags) Get(name string) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ImageStreamTags that match those selectors.
+func (c *imageStreamTags) List(opts pkg_api.ListOptions) (result *api.ImageStreamTagList, err error) {
+	result = &api.ImageStreamTagList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		VersionedParams(&opts, pkg_api.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested imageStreamTags.
+func (c *imageStreamTags) Watch(opts pkg_api.ListOptions) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		VersionedParams(&opts, pkg_api.ParameterCodec).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched imageStreamTag.
+func (c *imageStreamTags) Patch(name string, pt pkg_api.PatchType, data []byte, subresources ...string) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/controller/update_tracking_tags.go
+++ b/pkg/image/controller/update_tracking_tags.go
@@ -1,0 +1,253 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/runtime"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	imageclient "github.com/openshift/origin/pkg/image/clientset/internalclientset"
+)
+
+const (
+	MaxRetriesBeforeResync = 5
+
+	ImageStreamFromIndexName = "image.openshift.io/from"
+)
+
+type UpdateTrackingTagsControllerOptions struct {
+	// Resync is the time.Duration at which to fully re-list images.
+	// If zero, re-list will be delayed as long as possible
+	Resync time.Duration
+}
+
+type UpdateTrackingTagsController struct {
+	client imageclient.Interface
+
+	isCache      cache.Store
+	isController *cache.Controller
+	isIndex      cache.Indexer
+
+	queue workqueue.RateLimitingInterface
+
+	syncHandler func(isTagKey string) error
+}
+
+func NewUpdateTrackingTagsController(cl imageclient.Interface, options UpdateTrackingTagsControllerOptions) *UpdateTrackingTagsController {
+	c := &UpdateTrackingTagsController{
+		client: cl,
+		queue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+
+	c.isIndex, c.isController = cache.NewIndexerInformer(
+		&cache.ListWatch{
+			ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+				return c.client.Image().ImageStreams(kapi.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+				return c.client.Image().ImageStreams(kapi.NamespaceAll).Watch(options)
+			},
+		},
+		&imageapi.ImageStream{},
+		options.Resync,
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, cur interface{}) {
+				is := cur.(*imageapi.ImageStream)
+				glog.V(4).Infof("Updating ImageStream %s/%s", is.Namespace, is.Name)
+				c.enqueueImageStream(cur)
+			},
+			DeleteFunc: func(obj interface{}) {
+				// TODO: Handle delete
+				// c.enqueueImageStream(obj)
+			},
+		},
+		cache.Indexers{
+			ImageStreamFromIndexName: imageStreamFromIndex,
+			cache.NamespaceIndex:     cache.MetaNamespaceIndexFunc,
+		},
+	)
+
+	c.syncHandler = c.syncImageStream
+
+	return c
+}
+
+func (c *UpdateTrackingTagsController) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	glog.Infof("Starting update tracking tags controller")
+	go c.isController.Run(stopCh)
+	for !c.isController.HasSynced() {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	glog.Infof("Shutting down update tracking tags controller")
+	c.queue.ShutDown()
+}
+
+func (c *UpdateTrackingTagsController) worker() {
+	for {
+		if !c.work() {
+			return
+		}
+	}
+}
+
+func (c *UpdateTrackingTagsController) work() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	if err := c.syncHandler(key.(string)); err == nil {
+		// this means the request was successfully handled.  We should "forget" the item so that any retry
+		// later on is reset
+		c.queue.Forget(key)
+	} else {
+		// if we had an error it means that we didn't handle it, which means that we want to requeue the work
+		if c.queue.NumRequeues(key) > MaxRetriesBeforeResync {
+			utilruntime.HandleError(fmt.Errorf("error syncing image stream tag, it will be tried again on a resync %v: %v", key, err))
+			c.queue.Forget(key)
+		} else {
+			glog.V(4).Infof("error syncing image stream tag, it will be retried %v: %v", key, err)
+			c.queue.AddRateLimited(key)
+		}
+	}
+
+	return true
+}
+
+func (c *UpdateTrackingTagsController) enqueueImageStream(obj interface{}) {
+	if _, ok := obj.(*imageapi.ImageStream); !ok {
+		return
+	}
+	key, err := controller.KeyFunc(obj)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// syncImageStream does the work
+func (c *UpdateTrackingTagsController) syncImageStream(key string) error {
+	obj, exists, err := c.isIndex.GetByKey(key)
+	if err != nil {
+		glog.V(4).Infof("Unable to retrieve image stream tag %v from store: %v", key, err)
+		return err
+	}
+	if !exists {
+		glog.V(4).Infof("ImageStream %v has been deleted", key)
+		return nil
+	}
+	is, ok := obj.(*imageapi.ImageStream)
+	if !ok {
+		glog.V(4).Infof("Expected ImageStream, received %#v", obj)
+		return nil
+	}
+
+	for _, tag := range is.Spec.Tags {
+		// If the "source" image stream was updated, enqueue all image stream that reference
+		// the update stream for tags change.
+		if tag.From == nil || tag.From.Kind == "DockerImage" {
+			objects, err := c.isIndex.ByIndex(ImageStreamFromIndexName, imageStreamTagName(is, tag.Name))
+			if err != nil {
+				glog.V(4).Infof("Error fetching image streams referencing %s/%s:%s: %v (skipping)", is.Namespace, is.Name, tag.Name, err)
+				continue
+			}
+			// Enqueue all referenced image streams for update
+			for _, obj := range objects {
+				c.enqueueImageStream(obj)
+			}
+			continue
+		}
+
+		// Handle the image stream tags referencing another image stream.
+		if tag.From.Kind == "ImageStreamTag" {
+			namespace := tag.From.Namespace
+			if len(namespace) == 0 {
+				namespace = is.Namespace
+			}
+			if strings.Contains(tag.From.Name, ":") {
+			}
+			// FIXME: This is weird, for local tags the name of the image stream is not set,
+			// but for cross-image stream tags it is. We should probably unify this.
+			name, tagName, ok := imageapi.SplitImageStreamTag(tag.From.Name)
+			if !ok {
+				name = is.Name
+				tagName = tag.From.Name
+			}
+			sourceStreamObj, exists, err := c.isIndex.GetByKey(namespace + "/" + name)
+			if err != nil {
+				glog.V(4).Infof("Error fetching source image stream %s/%s: %v", namespace, name, err)
+				continue
+			}
+			if !exists {
+				// FIXME: Should enqueue for deletion
+				glog.V(4).Infof("Source image stream %s/%s was deleted", namespace, name)
+				continue
+			}
+			sourceStream, ok := sourceStreamObj.(*imageapi.ImageStream)
+			if !ok {
+				glog.V(4).Infof("Error getting source image stream from %#v", sourceStreamObj)
+				continue
+			}
+			latestSource := imageapi.LatestTaggedImage(sourceStream, tagName)
+			if imageapi.DifferentTagEvent(is, tag.Name, *latestSource) {
+				isCopyObj, err := kapi.Scheme.DeepCopy(is)
+				if err != nil {
+					glog.V(4).Infof("Unable to copy image stream %s/%s: %v", is.Namespace, is.Name, err)
+					continue
+				}
+				isCopy := isCopyObj.(*imageapi.ImageStream)
+				if imageapi.AddTagEventToImageStream(isCopy, tag.Name, *latestSource) {
+					glog.V(4).Infof("Synchronized image stream %s/%s:%s -> %s/%s:%s (new %q is %s)", isCopy.Namespace, isCopy.Name, tag.Name, sourceStream.Namespace, sourceStream.Name, tagName, tagName, latestSource.Image)
+					// FIXME: This is broken because the client set does not have UpdateStatus(), it
+					// will be added in 1.6 rebase...
+					if _, err := c.client.Image().ImageStreams(isCopy.Namespace).Update(isCopy); err != nil {
+						glog.V(4).Infof("Failed to update image stream %s/%s: %v (will retry)", isCopy.Namespac, isCopy.Name, err)
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func imageStreamTagName(is *imageapi.ImageStream, tagName string) string {
+	return fmt.Sprintf("%s/%s:%s", is.Namespace, is.Name, tagName)
+}
+
+// imageStreamFromIndex indexes all image streams tags that are aliases to another image
+// stream tags.
+func imageStreamFromIndex(obj interface{}) ([]string, error) {
+	is := obj.(*imageapi.ImageStream)
+	for _, tag := range is.Spec.Tags {
+		if from := tag.From; from != nil && from.Kind == "ImageStreamTag" {
+			namespace := from.Namespace
+			if len(namespace) == 0 {
+				namespace = is.Namespace
+			}
+			return []string{namespace + "/" + from.Name}, nil
+		}
+	}
+	return []string{}, nil
+}


### PR DESCRIPTION
Today, when you create imagestreamtag alias like:

```
$ oc import-image openshift/origin-pod:latest --confirm
$ oc tag --source=imagestreamtag origin-pod:latest foo:bar --alias=true
Tag second:foo set up to track origin-pod:latest
```

The message above is a lie, no tracking is setupped for the origin-pod:latest, the "second:foo" will never update. To prove this:

```
$ oc tag --source=docker openshift/origin-pod:v3.6.0-alpha.0 test/origin-pod:latest
```

Then check the `second:foo` and you will see it still points to previous version of `origin-pod:latest`.

To fix this we should have a controller that handles relations between aliased image stream and automatically update the status of the aliased image stream to reflect an update in the source image stream.