### PR TITLE
“oc expose svc” should use service targetPort number

### DIFF
--- a/pkg/cmd/cli/cmd/create/route.go
+++ b/pkg/cmd/cli/cmd/create/route.go
@@ -109,7 +109,7 @@ func CreateEdgeRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, ar
 	if err != nil {
 		return err
 	}
-	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"))
+	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"), false)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func CreatePassthroughRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comm
 	if err != nil {
 		return err
 	}
-	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"))
+	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"), false)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comman
 	if err != nil {
 		return err
 	}
-	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"))
+	route, err := cmdutil.UnsecuredRoute(kc, ns, routeName, serviceName, kcmdutil.GetFlagString(cmd, "port"), false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -132,7 +132,10 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 			cmd.Flags().Set("generator", generator)
 			fallthrough
 		case "route/v1":
-			route, err := cmdutil.UnsecuredRoute(kc, namespace, info.Name, info.Name, kcmdutil.GetFlagString(cmd, "port"))
+			// The upstream generator will incorrectly chose service.Port instead of service.TargetPort
+			// for the route TargetPort when no port is present.  Passing forcePort=true
+			// causes UnsecuredRoute to always set a Port so the upstream default is not used.
+			route, err := cmdutil.UnsecuredRoute(kc, namespace, info.Name, info.Name, kcmdutil.GetFlagString(cmd, "port"), true)
 			if err != nil {
 				return err
 			}

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -283,7 +283,7 @@ os::cmd::expect_success 'oc delete svc external'
 # Expose multiport service and verify we set a port in the route
 os::cmd::expect_success 'oc create -f test/testdata/multiport-service.yaml'
 os::cmd::expect_success 'oc expose svc/frontend --name route-with-set-port'
-os::cmd::expect_success_and_text "oc get route route-with-set-port --template='{{.spec.port.targetPort}}' --output-version=v1" "web"
+os::cmd::expect_success_and_text "oc get route route-with-set-port --template='{{.spec.port.targetPort}}'" "web"
 echo "expose: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
When the generator creates the route.TargetPort it selects the
service.Port. This change forces it to use the service.TargetPort
The router takes over loadbalancing the service endpoints and
to do that it needs to use the TargetPort.


bug 1431781
https://bugzilla.redhat.com/show_bug.cgi?id=1431781

Signed-off-by: Phil Cameron <pcameron@redhat.com>