### PR TITLE
hack/install-etcd.sh: don't create unused temporary directories

### DIFF
--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This prevents creation of temporary directories inside of the /tmp. This
+# script don't need them and creating them under root user could lead to other
+# scripts failing down the road.
+OS_TMP_ENV_SET=install-etcd
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 etcd_version=$(go run ${OS_ROOT}/tools/godepversion/godepversion.go ${OS_ROOT}/Godeps/Godeps.json github.com/coreos/etcd/etcdserver)


### PR DESCRIPTION
This PR improves install-etcd.sh to not create temporary directories which this script doesn't use.

Also it improves error reporting for the case when temp directory is missing or user doesn't have permissions to access it:

```console
$ vagrant build-origin-base-images
Building base images...
/data/src/github.com/openshift/origin ~
WARNING: Current user doesn't have permissions to create directories in the /tmp/openshift
WARNING: Directory info:
WARNING: dr-xr-xr-x. 2 1000 1000 unconfined_u:object_r:user_tmp_t:s0 40 Apr  4 13:28 /tmp/openshift
WARNING: Current user info:
WARNING: uid=1000(vagrant) gid=1000(vagrant) groups=1000(vagrant),1001(docker),10001(rkt),427680(_subgroup) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
WARNING: SELinux state: Permissive
WARNING: audit logs:
<no matches>
WARNING: end of audit logs
mkdir: cannot create directory ‘/tmp/openshift/build-base-images’: Permission denied
mkdir: cannot create directory ‘/tmp/openshift/build-base-images’: Permission denied
mkdir: cannot create directory ‘/tmp/openshift/build-base-images’: Permission denied
mkdir: cannot create directory ‘/tmp/openshift/build-base-images’: Permission denied
[ERROR] PID 25705: hack/lib/util/environment.sh:157: `mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}"` exited with status 1.
[INFO] 		Stack Trace: 
[INFO] 		  1: hack/lib/util/environment.sh:157: `mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}"`
[INFO] 		  2: hack/lib/init.sh:57: os::util::environment::setup_tmpdir_vars
[INFO] 		  3: hack/build-base-images.sh:8: source
[INFO]   Exiting with code 1.
```

PTAL @stevekuznetsov