### PR TITLE
Stop depending on `$BASETMPDIR` for `os::cmd` tempfiles

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -76,31 +76,6 @@ function os::cleanup::dump_container_logs() {
 }
 readonly -f os::cleanup::dump_container_logs
 
-# os::cleanup::tmpdir performs cleanup of temp directories as a precondition for running a test. It tries to
-# clean up mounts in the temp directories.
-#
-# Globals:
-#  - BASETMPDIR
-#  - USE_SUDO
-# Returns:
-#  None
-function os::cleanup::tmpdir() {
-    # ensure that the directories are clean
-    if os::util::find::system_binary "findmnt" &>/dev/null; then
-        for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
-            if [[ "${target}" == "${BASETMPDIR}"* ]]; then
-                ${USE_SUDO:+sudo} umount "${target}"
-            fi
-        done
-    fi
-
-		# delete any sub directory underneath BASETMPDIR
-    for directory in $( find "${BASETMPDIR}" -d 2 ); do
-        ${USE_SUDO:+sudo} rm -rf "${directory}"
-    done
-}
-readonly -f os::cleanup::tmpdir
-
 # os::cleanup::internal::list_k8s_containers returns a space-delimited list of
 # docker containers that belonged to k8s.
 #
@@ -123,3 +98,28 @@ function os::cleanup::internal::list_k8s_containers() {
 	echo "${ids[*]:+"${ids[*]}"}"
 }
 readonly -f os::cleanup::internal::list_k8s_containers
+
+# os::cleanup::tmpdir performs cleanup of temp directories as a precondition for running a test. It tries to
+# clean up mounts in the temp directories.
+#
+# Globals:
+#  - BASETMPDIR
+#  - USE_SUDO
+# Returns:
+#  None
+function os::cleanup::tmpdir() {
+	# ensure that the directories are clean
+	if os::util::find::system_binary "findmnt" &>/dev/null; then
+		for target in $( ${USE_SUDO:+sudo} findmnt --output TARGET --list ); do
+			if [[ "${target}" == "${BASETMPDIR}"* ]]; then
+				${USE_SUDO:+sudo} umount "${target}"
+			fi
+		done
+	fi
+
+	# delete any sub directory underneath BASETMPDIR
+	for directory in $( find "${BASETMPDIR}" -d 2 ); do
+		${USE_SUDO:+sudo} rm -rf "${directory}"
+	done
+}
+readonly -f os::cleanup::tmpdir

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -157,8 +157,7 @@ readonly -f os::cmd::try_until_text
 
 # In order to harvest stderr and stdout at the same time into different buckets, we need to stick them into files
 # in an intermediate step
-BASETMPDIR="${TMPDIR:-"/tmp"}/openshift"
-os_cmd_internal_tmpdir="${BASETMPDIR}/test-cmd"
+os_cmd_internal_tmpdir="${TMPDIR:-"/tmp"}/openshift"
 os_cmd_internal_tmpout="${os_cmd_internal_tmpdir}/tmp_stdout.log"
 os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
 


### PR DESCRIPTION
Stop depending on `$BASETMPDIR` for `os::cmd` tempfiles

The resolution of the temporary file assignment in the `os::cmd` code
now happens before `$BASETMPDIR` is set, so we should not rely on it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Update style of temp dir cleanup function

The function was in the middle of other internal functions, so it was
moved for readability. Indentation was changed to tabs and made to be
consistent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---