### PR TITLE
better error on invalid types

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -294,7 +294,6 @@ func (o *NewAppOptions) RunNewApp() error {
 			}
 		}
 	}
-
 	if err := setAnnotations(map[string]string{newcmd.GeneratedByNamespace: newcmd.GeneratedByNewApp}, result); err != nil {
 		return err
 	}
@@ -543,7 +542,7 @@ func setAnnotations(annotations map[string]string, result *newcmd.AppResult) err
 	for _, object := range result.List.Items {
 		err := util.AddObjectAnnotations(object, annotations)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to add annotation to object of type %q, this resource type is probably unsupported by your client version.", object.GetObjectKind().GroupVersionKind())
 		}
 	}
 	return nil
@@ -553,7 +552,7 @@ func setLabels(labels map[string]string, result *newcmd.AppResult) error {
 	for _, object := range result.List.Items {
 		err := util.AddObjectLabels(object, labels)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to add annotation to object of type %q, this resource type is probably unsupported by your client version.", object.GetObjectKind().GroupVersionKind())
 		}
 	}
 	return nil


### PR DESCRIPTION
new output:
```
$ oc new-app -f https://raw.githubusercontent.com/sclorg/mongodb-container/cf99d38bfcff2657fd1effba7c2bf69e6bc96dfd/examples/petset/mongodb-petset-persistent.yaml 
--> Deploying template "p1/mongodb-petset-replication" for "https://raw.githubusercontent.com/sclorg/mongodb-container/cf99d38bfcff2657fd1effba7c2bf69e6bc96dfd/examples/petset/mongodb-petset-persistent.yaml" to project p1

     mongodb-petset-replication
     ---------
     MongoDB Replication Example (based on PetSet). You must have persistent volumes available in your cluster to use this template.

     * With parameters:
        * MongoDB Connection Username=JC3 # generated
        * MongoDB Connection Password=rXQ8IYV1xkfKVj7J # generated
        * MongoDB Database Name=sampledb
        * MongoDB Admin Password=txWXnHk4JlRDmALd # generated
        * Replica Set Name=rs0
        * Keyfile Content=GnXnRTowqwHTP0qK10MkK3UyBUHDnKoD27rAHOaQJEOW2regO1JbBBvm4WkGrI5S8eGVUKrbewhJ64HEycw6YvFoOCdctVhCGDAxYNrKHG5T47dJLI37sFeVO5P6mA10egWAHFm17QsWnwHPiECtPndRDPqx2YkJ0dSCRg3jY5O5uvFXWyaHHqxdnnmhmwf80UXY5xFQcnhY0jM6MxSD4JSfyABfi7oVAhNUJLbMcvX3VkgcnNbMs5rdvWwMQyA # generated
        * MongoDB Docker Image=centos/mongodb-32-centos7
        * OpenShift Service Name=mongodb
        * Volume Capacity=1Gi
        * Memory Limit=512Mi

error: failed to add annotation to object of type "apps/v1alpha1, Kind=PetSet", this type is probably unknown.

```

(fix for https://github.com/openshift/origin/issues/13615)
