### PR TITLE
Remove unnecessary "!=" comparison

### DIFF
--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -304,7 +304,7 @@ func (eq *EventQueue) Pop() (watch.EventType, interface{}, error) {
 		// Track the last replace key immediately after the store
 		// state has been changed to prevent subsequent errors from
 		// leaving a stale key.
-		if eq.lastReplaceKey != "" && eq.lastReplaceKey == key {
+		if eq.lastReplaceKey == key {
 			eq.lastReplaceKey = ""
 		}
 


### PR DESCRIPTION
In the following lines from `eventqueu.go`,
```go
		if eq.lastReplaceKey != "" && eq.lastReplaceKey == key {
			eq.lastReplaceKey = ""
		}
```
The condition `eq.lastReplaceKey != ""` here is unnecessary here because if it is an empty string, the other condition `eq.lastReplaceKey == key` should never be `true`. Even in case the other condition is true, the result is also correct. So it is safe to remove the first conditon here and just compare whether it is equals to the `key`.