### PR TITLE
hack/lib/cleanup.sh: fix find invocation

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -94,8 +94,8 @@ function os::cleanup::tmpdir() {
         done
     fi
 
-		# delete any sub directory underneath BASETMPDIR
-    for directory in $( find "${BASETMPDIR}" -d 2 ); do
+    # delete any sub directory underneath BASETMPDIR
+    for directory in $( find "${BASETMPDIR}" -mindepth 2 -maxdepth 2 ); do
         ${USE_SUDO:+sudo} rm -rf "${directory}"
     done
 }


### PR DESCRIPTION
Before it failed with error: "find: paths must precede expression: 2"

Fixes #13453

PTAL @smarterclayton @mfojtik @stevekuznetsov 