### PR TITLE
Streamline cluster up output

### DIFF
--- a/pkg/bootstrap/docker/join.go
+++ b/pkg/bootstrap/docker/join.go
@@ -101,7 +101,7 @@ func (c *ClientJoinConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) 
 	}
 
 	// Create an OpenShift configuration and start a container that uses it.
-	c.addTask("Joining OpenShift cluster", c.StartOpenShiftNode)
+	c.addTask(simpleTask("Joining OpenShift cluster", c.StartOpenShiftNode))
 
 	return nil
 }

--- a/pkg/bootstrap/docker/openshift/cnetwork.go
+++ b/pkg/bootstrap/docker/openshift/cnetwork.go
@@ -1,14 +1,22 @@
 package openshift
 
+import (
+	"fmt"
+)
+
 const podNetworkTestCmd = `#!/bin/bash
 set -e
 echo 'Testing connectivity to master API'
-for i in {1..40}; do 
-	if curl -s -S -k -m 1 https://172.30.0.1:8443; then 
-	  continue
+failed=0
+for i in {1..40}; do
+	if curl -s -S -k -m 1 https://${MASTER_IP}:8443; then
+	  failed=0
+	  break
+	else
+	  failed=1
 	fi
 done
-if [[ ! $? -eq 0 ]]; then
+if [[ failed -eq 1 ]]; then
     exit 1
 fi
 echo 'Testing connectivity to master DNS server'
@@ -16,16 +24,16 @@ for i in {1..40}; do
    if curl -s -S -k -m 1 https://kubernetes.default.svc.cluster.local; then
       exit 0
    fi
-   sleep 1
 done
 exit 1
 `
 
 // TestContainerNetworking launches a container that will check whether the container
 // can communicate with the master API and DNS endpoints.
-func (h *Helper) TestContainerNetworking() error {
+func (h *Helper) TestContainerNetworking(ip string) error {
 	_, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
+		Env(fmt.Sprintf("MASTER_IP=%s", ip)).
 		DNS("172.30.0.1").
 		Entrypoint("/bin/bash").
 		Command("-c", podNetworkTestCmd).

--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -617,6 +617,7 @@ func GetConfigFromContainer(client *docker.Client) (*configapi.MasterConfig, err
 func (h *Helper) serverVersion() (semver.Version, error) {
 	versionText, _, _, err := h.runHelper.New().Image(h.image).
 		Command("version").
+		DiscardContainer().
 		Output()
 	if err != nil {
 		return semver.Version{}, err


### PR DESCRIPTION
Outputs previous messages when either an error occurs during startup or
loglevel > 0.

Now only executes container network test if loglevel > 0 to speed up
startup time.

Fixes https://github.com/openshift/origin/issues/12715
https://github.com/openshift/origin/issues/12531