### PR TITLE
RestrictUsersAdmission: allow service account with implicit namespace

### DIFF
--- a/pkg/authorization/admission/restrictusers/subjectchecker_test.go
+++ b/pkg/authorization/admission/restrictusers/subjectchecker_test.go
@@ -192,7 +192,7 @@ func TestSubjectCheckers(t *testing.T) {
 			shouldAllow: true,
 		},
 		{
-			name: "allow service account by literal name match",
+			name: "allow service account with explicit namespace by match on literal name and explicit namespace",
 			checker: mustNewSubjectChecker(t,
 				&authorizationapi.RoleBindingRestrictionSpec{
 					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
@@ -208,7 +208,7 @@ func TestSubjectCheckers(t *testing.T) {
 			shouldAllow: true,
 		},
 		{
-			name: "allow service account by literal name match with implicit namespace",
+			name: "allow service account with explicit namespace by match on literal name and implicit namespace",
 			checker: mustNewSubjectChecker(t,
 				&authorizationapi.RoleBindingRestrictionSpec{
 					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
@@ -219,6 +219,113 @@ func TestSubjectCheckers(t *testing.T) {
 				}),
 			subject:     serviceaccountRef,
 			shouldAllow: true,
+		},
+		{
+			name: "prohibit service account with explicit namespace where literal name matches but explicit namespace does not",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{
+								Namespace: serviceaccountRef.Namespace,
+								Name:      serviceaccountRef.Name,
+							},
+						},
+					},
+				}),
+			subject: kapi.ObjectReference{
+				Kind:      authorizationapi.ServiceAccountKind,
+				Namespace: "othernamespace",
+				Name:      serviceaccountRef.Name,
+			},
+			shouldAllow: false,
+		},
+		{
+			name: "prohibit service account with explicit namespace where literal name matches but implicit namespace does not",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{Name: serviceaccountRef.Name},
+						},
+					},
+				}),
+			subject: kapi.ObjectReference{
+				Kind:      authorizationapi.ServiceAccountKind,
+				Namespace: "othernamespace",
+				Name:      serviceaccountRef.Name,
+			},
+			shouldAllow: false,
+		},
+		{
+			name: "allow service account with implicit namespace by match on literal name and explicit namespace",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{
+								Name:      serviceaccountRef.Name,
+								Namespace: serviceaccountRef.Namespace,
+							},
+						},
+					},
+				}),
+			subject: kapi.ObjectReference{
+				Kind: authorizationapi.ServiceAccountKind,
+				Name: serviceaccountRef.Name,
+			},
+			shouldAllow: true,
+		},
+		{
+			name: "allow service account with implicit namespace by match on literal name and implicit namespace",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{Name: serviceaccountRef.Name},
+						},
+					},
+				}),
+			subject: kapi.ObjectReference{
+				Kind: authorizationapi.ServiceAccountKind,
+				Name: serviceaccountRef.Name,
+			},
+			shouldAllow: true,
+		},
+		{
+			name: "prohibit service account with implicit namespace where literal name matches but explicit namespace does not",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{
+								Namespace: "othernamespace",
+								Name:      serviceaccountRef.Name,
+							},
+						},
+					},
+				}),
+			subject: kapi.ObjectReference{
+				Kind: authorizationapi.ServiceAccountKind,
+				Name: serviceaccountRef.Name,
+			},
+			shouldAllow: false,
+		},
+		{
+			name: "prohibit service account with explicit namespace where explicit namespace matches but literal name does not",
+			checker: mustNewSubjectChecker(t,
+				&authorizationapi.RoleBindingRestrictionSpec{
+					ServiceAccountRestriction: &authorizationapi.ServiceAccountRestriction{
+						ServiceAccounts: []authorizationapi.ServiceAccountReference{
+							{
+								Namespace: serviceaccountRef.Namespace,
+								Name:      "othername",
+							},
+						},
+					},
+				}),
+			subject:     serviceaccountRef,
+			shouldAllow: false,
 		},
 		{
 			name: "allow service account by match on namespace",


### PR DESCRIPTION
Allow role binding restrictions to match and allow a service account subject with an implicit namespace, which is inferred to be the namespace of the role binding.

The use-case for this change is that an application template should be able to specify a role binding with a service account as the subject, without hard-coding the namespace in the template or requiring the user to specify the namespace as a parameter.  In this scenario, the subject's namespace gets defaulted to the role binding's namespace, but only after the admission control plug-in executes; the subject that the plug-in sees is a service account with no namespace specified, so RestrictUsersAdmission should infer the namespace to be that the one which will be defaulted later.

---

Related to <https://bugzilla.redhat.com/show_bug.cgi?id=1439065>.

---

openshift-bot, please [test]!

@deads2k, please review!

@abhgupta, FYI.