### PR TITLE
Handle RPM version calculations correctly when we're on a tag

### DIFF
--- a/hack/lib/build/rpm.sh
+++ b/hack/lib/build/rpm.sh
@@ -30,28 +30,34 @@ function os::build::rpm::get_nvra_vars() {
 
 	# we can generate the package release from the git version metadata
 	# OS_GIT_VERSION will always have metadata, but either contain
-	# pre-release information _and_ build metadata, or only the latter
+	# pre-release information _and_ build metadata, or only the latter.
+	# Build metadata may or may not contain the number of commits past
+	# the last tag. If no commit number exists, we are on a tag and use 0.
 	# ex.
 	#    -alpha.0+shasums-123-dirty
 	#    -alpha.0+shasums-123
+	#    -alpha.0+shasums-dirty
+	#    -alpha.0+shasums
 	#    +shasums-123-dirty
 	#    +shasums-123
+	#    +shasums-dirty
+	#    +shasums
 	if [[ "${metadata:0:1}" == "+" ]]; then
 		# we only have build metadata, but need to massage it so
 		# we can generate a valid RPM release from it
-		if [[ "${metadata}" =~ ^\+([a-z0-9]{7})-([0-9]+)(-dirty)?$ ]]; then
+		if [[ "${metadata}" =~ ^\+([a-z0-9]{7})(-([0-9]+))?(-dirty)?$ ]]; then
 			build_sha="${BASH_REMATCH[1]}"
-			build_num="${BASH_REMATCH[2]}"
+			build_num="${BASH_REMATCH[3]:-0}"
 		else
 			os::log::fatal "Malformed git version metadata: ${metadata}"
 		fi
 		OS_RPM_RELEASE="1.${build_num}.${build_sha}"
 	elif [[ "${metadata:0:1}" == "-" ]]; then
 		# we have both build metadata and pre-release info
-		if [[ "${metadata}" =~ ^-([^\+]+)\+([a-z0-9]{7})-([0-9]+)(-dirty)?$ ]]; then
+		if [[ "${metadata}" =~ ^-([^\+]+)\+([a-z0-9]{7})(-([0-9]+))?(-dirty)?$ ]]; then
 			pre_release="${BASH_REMATCH[1]}"
 			build_sha="${BASH_REMATCH[2]}"
-			build_num="${BASH_REMATCH[3]}"
+			build_num="${BASH_REMATCH[4]:-0}"
 		else
 			os::log::fatal "Malformed git version metadata: ${metadata}"
 		fi


### PR DESCRIPTION
When we are sitting on a tag, the version that `$OS_GIT_VERSION` reports
will not have any commit number. However, in order to ensure that we are
emitting RPM versions that are always sortable, we need to translate
this into 0 commits past the tag instead of omitting it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test][merge]