### PR TITLE
syscontainers: add mount for /var/log to origin

### DIFF
--- a/images/origin/system-container/config.json.template
+++ b/images/origin/system-container/config.json.template
@@ -180,6 +180,16 @@
         },
 	{
 	    "type": "bind",
+	    "source": "/var/log",
+	    "destination": "/var/log",
+	    "options": [
+		"rbind",
+		"rw",
+		"mode=755"
+	    ]
+	},
+	{
+	    "type": "bind",
 	    "source": "/var/run",
 	    "destination": "/var/run",
 	    "options": [


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>