### PR TITLE
Make /usr/local/bin/ovs-run.sh executable

### DIFF
--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -18,5 +18,6 @@ ENV HOME /root
 # files required to run as a system container
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
 COPY system-container/config.json.template system-container/service.template system-container/tmpfiles.template system-container/manifest.json /exports/
+RUN chmod +x /usr/local/bin/*.sh
 
 ENTRYPOINT ["/usr/local/bin/ovs-run.sh"]


### PR DESCRIPTION
While COPY says that new files are created with mode 0755, for some reason images built via OSBS don't seem to be so explicitly make the script executable.