### PR TITLE
Use WaitAndGetVNID() instead of GetVNID() when initializing network policy plugin on the node

### DIFF
--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -106,7 +106,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	for _, ns := range namespaces.Items {
 		np.kNamespaces[ns.Name] = ns
 
-		if vnid, err := np.vnids.GetVNID(ns.Name); err == nil {
+		if vnid, err := np.vnids.WaitAndGetVNID(ns.Name); err == nil {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
@@ -125,7 +125,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 		return err
 	}
 	for _, policy := range policies.Items {
-		vnid, err := np.vnids.GetVNID(policy.Namespace)
+		vnid, err := np.vnids.WaitAndGetVNID(policy.Namespace)
 		if err != nil {
 			continue
 		}

--- a/pkg/sdn/plugin/vnids_node_test.go
+++ b/pkg/sdn/plugin/vnids_node_test.go
@@ -144,14 +144,14 @@ func TestNodeVNIDMap(t *testing.T) {
 }
 
 func checkExists(t *testing.T, vmap *nodeVNIDMap, name string, expected uint32) {
-	id, err := vmap.GetVNID(name)
+	id, err := vmap.getVNID(name)
 	if id != expected || err != nil {
 		t.Fatalf("Unexpected failure: %d, %v", id, err)
 	}
 }
 
 func checkNotExists(t *testing.T, vmap *nodeVNIDMap, name string) {
-	id, err := vmap.GetVNID(name)
+	id, err := vmap.getVNID(name)
 	if err == nil {
 		t.Fatalf("Unexpected success: %d", id)
 	}


### PR DESCRIPTION
If a new namespace was created after vnid population and before listing namespaces in initNamespaces()[networkpolicy.go],GetVNID() could fail. Similar case after listing policies in initNamespaces().
Using WaitAndGetVNID() may not fix the issue but will alleviate the problem.