### PR TITLE
Increase journald rate limiter when running test-end-to-end-docker.sh

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -119,10 +119,11 @@ readonly -f os::util::format_seconds
 # Return:
 #  None
 function os::util::sed() {
+	local sudo="${USE_SUDO:+sudo}"
 	if LANG=C sed --help 2>&1 | grep -q "GNU sed"; then
-		sed -i'' "$@"
+		${sudo} sed -i'' "$@"
 	else
-		sed -i '' "$@"
+		${sudo} sed -i '' "$@"
 	fi
 }
 readonly -f os::util::sed

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -21,11 +21,35 @@ fi
 function cleanup() {
 	return_code=$?
 	os::cleanup::all "${return_code}"
+
+	# restore journald to previous form
+	if os::util::ensure::system_binary_exists 'systemctl'; then
+		os::log::info "Restoring journald limits"
+		${USE_SUDO:+sudo} mv /etc/systemd/{journald.conf.bak,journald.conf}
+		${USE_SUDO:+sudo} systemctl restart systemd-journald.service
+		# Docker has "some" problems when journald is restarted, so we need to
+		# restart docker, as well.
+		${USE_SUDO:+sudo} systemctl restart docker.service
+	fi
+
 	exit "${return_code}"
 }
 trap "cleanup" EXIT
 
 os::log::system::start
+
+# This turns-off rate limiting in journald to bypass the problem from
+# https://github.com/openshift/origin/issues/12558.
+if os::util::ensure::system_binary_exists 'systemctl'; then
+	os::log::info "Turning off journald limits"
+	${USE_SUDO:+sudo} cp /etc/systemd/{journald.conf,journald.conf.bak}
+	os::util::sed "s/^.*RateLimitInterval.*$/RateLimitInterval=0/g" /etc/systemd/journald.conf
+	os::util::sed "s/^.*RateLimitBurst.*$/RateLimitBurst=0/g" /etc/systemd/journald.conf
+	${USE_SUDO:+sudo} systemctl restart systemd-journald.service
+	# Docker has "some" problems when journald is restarted, so we need to
+	# restart docker, as well.
+	${USE_SUDO:+sudo} systemctl restart docker.service
+fi
 
 # Setup
 os::log::info "openshift version: `openshift version`"

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -378,30 +378,19 @@ os::cmd::expect_success 'oc login -u e2e-user'
 os::cmd::expect_success 'oc project test'
 os::cmd::expect_success 'oc whoami'
 
-if [[ -n "${SOLTYSH_DEBUG:-}" ]]; then
-    os::log::info "Running a CLI command in a container using the service account"
-    os::cmd::expect_success 'oc policy add-role-to-user view -z default'
-    os::cmd::try_until_success "oc sa get-token default"
-    oc run cli-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
-    set -o errexit
-    os::cmd::expect_success 'oc delete pod cli-with-token'
-    oc run cli-with-token-2 --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
-    set -o errexit
-    os::cmd::expect_success 'oc delete pod cli-with-token-2'
-    oc run kubectl-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
-    # TODO remove set +o errexit, once https://github.com/openshift/origin/issues/12558 gets proper fix
-    set +o errexit
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
-    os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
-    set -o errexit
-fi
+os::log::info "Running a CLI command in a container using the service account"
+os::cmd::expect_success 'oc policy add-role-to-user view -z default'
+os::cmd::try_until_success "oc sa get-token default"
+oc run cli-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli status --loglevel=4 > "${LOG_DIR}/cli-with-token.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token.log'" 'In project test'
+os::cmd::expect_success 'oc delete pod cli-with-token'
+oc run cli-with-token-2 --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never -- cli whoami --loglevel=4 > "${LOG_DIR}/cli-with-token2.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/cli-with-token2.log'" 'system:serviceaccount:test:default'
+os::cmd::expect_success 'oc delete pod cli-with-token-2'
+oc run kubectl-with-token --attach --image="${IMAGE_PREFIX}:${TAG}" --restart=Never --command -- kubectl get pods --loglevel=4 > "${LOG_DIR}/kubectl-with-token.log" 2>&1
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'Using in-cluster configuration'
+os::cmd::expect_success_and_text "cat '${LOG_DIR}/kubectl-with-token.log'" 'kubectl-with-token'
 
 os::log::info "Testing deployment logs and failing pre and mid hooks ..."
 # test hook selectors

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -460,7 +460,7 @@ os::log::info "Validating exec"
 frontend_pod=$(oc get pod -l deploymentconfig=frontend --template='{{(index .items 0).metadata.name}}')
 # when running as a restricted pod the registry will run with a pre-allocated
 # user in the neighborhood of 1000000+.  Look for a substring of the pre-allocated uid range
-os::cmd::expect_success_and_text "oc exec -p ${frontend_pod} id" '1000'
+os::cmd::expect_success_and_text "oc exec ${frontend_pod} id" '1000'
 os::cmd::expect_success_and_text "oc rsh pod/${frontend_pod} id -u" '1000'
 os::cmd::expect_success_and_text "oc rsh -T ${frontend_pod} id -u" '1000'
 


### PR DESCRIPTION
Fixes #12558 by increasing rate limiter values while running test-end-to-end-docker.sh. Additionally, this re-enables the tests that were disabled due to that error.

@stevekuznetsov another try... 
@mfojtik fyi