### PR TITLE
ensure next build is kicked off when a build completes

### DIFF
--- a/pkg/build/controller/buildpod/controller_test.go
+++ b/pkg/build/controller/buildpod/controller_test.go
@@ -158,7 +158,7 @@ func TestHandlePod(t *testing.T) {
 			outStatus:           buildapi.BuildPhaseComplete,
 			podStatus:           kapi.PodSucceeded,
 			exitCode:            0,
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 4
@@ -167,7 +167,7 @@ func TestHandlePod(t *testing.T) {
 			outStatus:           buildapi.BuildPhaseFailed,
 			podStatus:           kapi.PodFailed,
 			exitCode:            -1,
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 5
@@ -177,7 +177,7 @@ func TestHandlePod(t *testing.T) {
 			podStatus:           kapi.PodSucceeded,
 			exitCode:            0,
 			buildUpdater:        &errBuildUpdater{},
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 6

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -447,7 +447,7 @@ func TestCancelBuild(t *testing.T) {
 			inStatus:            buildapi.BuildPhaseNew,
 			outStatus:           buildapi.BuildPhaseCancelled,
 			exitCode:            0,
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 1
@@ -455,7 +455,7 @@ func TestCancelBuild(t *testing.T) {
 			outStatus:           buildapi.BuildPhaseCancelled,
 			podStatus:           kapi.PodRunning,
 			exitCode:            0,
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 2
@@ -463,7 +463,7 @@ func TestCancelBuild(t *testing.T) {
 			outStatus:           buildapi.BuildPhaseCancelled,
 			podStatus:           kapi.PodRunning,
 			exitCode:            0,
-			startTimestamp:      nil,
+			startTimestamp:      curtime,
 			completionTimestamp: curtime,
 		},
 		{ // 3

--- a/pkg/build/controller/policy/policy.go
+++ b/pkg/build/controller/policy/policy.go
@@ -142,17 +142,21 @@ func handleComplete(lister buildclient.BuildLister, updater buildclient.BuildUpd
 	}
 	for _, build := range nextBuilds {
 		// TODO: replace with informer notification requeueing in the future
-		build.Annotations[buildapi.BuildAcceptedAnnotation] = uuid.NewRandom().String()
-		err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
-			err := updater.Update(build.Namespace, build)
-			if err != nil && errors.IsConflict(err) {
-				glog.V(5).Infof("Error updating build %s/%s: %v (will retry)", build.Namespace, build.Name, err)
-				return false, nil
+
+		// only set the annotation once.
+		if _, ok := build.Annotations[buildapi.BuildAcceptedAnnotation]; !ok {
+			build.Annotations[buildapi.BuildAcceptedAnnotation] = uuid.NewRandom().String()
+			err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+				err := updater.Update(build.Namespace, build)
+				if err != nil && errors.IsConflict(err) {
+					glog.V(5).Infof("Error updating build %s/%s: %v (will retry)", build.Namespace, build.Name, err)
+					return false, nil
+				}
+				return true, err
+			})
+			if err != nil {
+				return err
 			}
-			return true, err
-		})
-		if err != nil {
-			return err
 		}
 	}
 	return nil

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -5626,10 +5626,27 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
             from: 
               kind: "DockerImage"
               name: "centos/ruby-22-centos7"
-        resources: {}
-      status: 
-        lastVersion: 0
-
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "sample-serial-build-fail"
+      spec: 
+        runPolicy: "Serial"
+        triggers: 
+          - 
+            type: "imageChange"
+            imageChange: {}
+        source: 
+          type: "Git"
+          git: 
+            uri: "git://github.com/openshift/invalidrepo.git"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "DockerImage"
+              name: "centos/ruby-22-centos7"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -24,7 +24,24 @@
             from: 
               kind: "DockerImage"
               name: "centos/ruby-22-centos7"
-        resources: {}
-      status: 
-        lastVersion: 0
-
+    - 
+      kind: "BuildConfig"
+      apiVersion: "v1"
+      metadata: 
+        name: "sample-serial-build-fail"
+      spec: 
+        runPolicy: "Serial"
+        triggers: 
+          - 
+            type: "imageChange"
+            imageChange: {}
+        source: 
+          type: "Git"
+          git: 
+            uri: "git://github.com/openshift/invalidrepo.git"
+        strategy: 
+          type: "Source"
+          sourceStrategy: 
+            from: 
+              kind: "DockerImage"
+              name: "centos/ruby-22-centos7"


### PR DESCRIPTION
fixes bugs:

https://bugzilla.redhat.com/show_bug.cgi?id=1440147 (we weren't immediately starting the next build when a build failed, nor setting the completion timestamp on the failed build)

https://bugzilla.redhat.com/show_bug.cgi?id=1436395 (we weren't setting the start time on a build if it went from new->complete extremely quickly, but we were setting the completion time)

