### PR TITLE
[1.2] Fix image pruning with both strong & weak refs

### DIFF
--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -559,19 +559,15 @@ func edgeKind(g graph.Graph, from, to gonum.Node, desiredKind string) bool {
 // for a tag and the image stream is at least as old as the minimum pruning
 // age.
 func imageIsPrunable(g graph.Graph, imageNode *imagegraph.ImageNode) bool {
-	onlyWeakReferences := true
-
 	for _, n := range g.To(imageNode) {
 		glog.V(4).Infof("Examining predecessor %#v", n)
-		if !edgeKind(g, n, imageNode, WeakReferencedImageEdgeKind) {
+		if edgeKind(g, n, imageNode, ReferencedImageEdgeKind) {
 			glog.V(4).Infof("Strong reference detected")
-			onlyWeakReferences = false
-			break
+			return false
 		}
 	}
 
-	return onlyWeakReferences
-
+	return true
 }
 
 // calculatePrunableImages returns the list of prunable images and a

--- a/pkg/image/prune/imagepruner_test.go
+++ b/pkg/image/prune/imagepruner_test.go
@@ -19,10 +19,12 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 
+	"github.com/openshift/origin/pkg/api/graph"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
 )
 
 type fakeRegistryPinger struct {
@@ -909,5 +911,86 @@ func TestRegistryPruning(t *testing.T) {
 		if !reflect.DeepEqual(test.expectedManifestDeletions, manifestPruner.invocations) {
 			t.Errorf("%s: expected manifest deletions %#v, got %#v", name, test.expectedManifestDeletions, manifestPruner.invocations)
 		}
+	}
+}
+
+func TestImageWithStrongAndWeakRefsIsNotPruned(t *testing.T) {
+	flag.Lookup("v").Value.Set(fmt.Sprint(*logLevel))
+
+	images := imageList(
+		agedImage("id1", "registry1/foo/bar@id1", 1540),
+		agedImage("id2", "registry1/foo/bar@id2", 1540),
+		agedImage("id3", "registry1/foo/bar@id3", 1540),
+	)
+	streams := streamList(
+		stream("registry1", "foo", "bar", tags(
+			tag("latest",
+				tagEvent("id3", "registry1/foo/bar@id3"),
+				tagEvent("id2", "registry1/foo/bar@id2"),
+				tagEvent("id1", "registry1/foo/bar@id1"),
+			),
+			tag("strong",
+				tagEvent("id1", "registry1/foo/bar@id1"),
+			),
+		)),
+	)
+	pods := podList()
+	rcs := rcList()
+	bcs := bcList()
+	builds := buildList()
+	dcs := dcList()
+
+	options := ImageRegistryPrunerOptions{
+		Images:  &images,
+		Streams: &streams,
+		Pods:    &pods,
+		RCs:     &rcs,
+		BCs:     &bcs,
+		Builds:  &builds,
+		DCs:     &dcs,
+	}
+	keepYoungerThan := 24 * time.Hour
+	keepTagRevisions := 2
+	options.KeepYoungerThan = keepYoungerThan
+	options.KeepTagRevisions = keepTagRevisions
+	p := NewImageRegistryPruner(options)
+	p.(*imageRegistryPruner).registryPinger = &fakeRegistryPinger{}
+
+	imageDeleter := &fakeImagePruner{invocations: sets.NewString()}
+	streamDeleter := &fakeImageStreamPruner{invocations: sets.NewString()}
+	layerDeleter := &fakeLayerPruner{invocations: sets.NewString()}
+	blobDeleter := &fakeBlobPruner{invocations: sets.NewString()}
+	manifestDeleter := &fakeManifestPruner{invocations: sets.NewString()}
+
+	if err := p.Prune(imageDeleter, streamDeleter, layerDeleter, blobDeleter, manifestDeleter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if imageDeleter.invocations.Len() > 0 {
+		t.Fatalf("unexpected imageDeleter invocations: %v", imageDeleter.invocations)
+	}
+	if streamDeleter.invocations.Len() > 0 {
+		t.Fatalf("unexpected streamDeleter invocations: %v", streamDeleter.invocations)
+	}
+	if layerDeleter.invocations.Len() > 0 {
+		t.Fatalf("unexpected layerDeleter invocations: %v", layerDeleter.invocations)
+	}
+	if blobDeleter.invocations.Len() > 0 {
+		t.Fatalf("unexpected blobDeleter invocations: %v", blobDeleter.invocations)
+	}
+	if manifestDeleter.invocations.Len() > 0 {
+		t.Fatalf("unexpected manifestDeleter invocations: %v", manifestDeleter.invocations)
+	}
+}
+
+func TestImageIsPrunable(t *testing.T) {
+	g := graph.New()
+	imageNode := imagegraph.EnsureImageNode(g, &imageapi.Image{ObjectMeta: kapi.ObjectMeta{Name: "myImage"}})
+	streamNode := imagegraph.EnsureImageStreamNode(g, &imageapi.ImageStream{ObjectMeta: kapi.ObjectMeta{Name: "myStream"}})
+	g.AddEdge(streamNode, imageNode, ReferencedImageEdgeKind)
+	g.AddEdge(streamNode, imageNode, WeakReferencedImageEdgeKind)
+
+	if imageIsPrunable(g, imageNode.(*imagegraph.ImageNode)) {
+		t.Fatalf("Image is prunable although it should not")
 	}
 }


### PR DESCRIPTION
Fix a logic error where an image could incorrectly be considered
prunable if there were both strong and weak references from an image
stream to the image.

1.2 cherrypick of #13671