### PR TITLE
sdn traffic leaking out of the cluster

### DIFF
--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -95,6 +95,7 @@ func (n *NodeIPTables) getStaticNodeIPTablesRules() []FirewallRule {
 		{"filter", "INPUT", []string{"-p", "udp", "-m", "multiport", "--dports", VXLAN_PORT, "-m", "comment", "--comment", "001 vxlan incoming", "-j", "ACCEPT"}},
 		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "traffic from SDN", "-j", "ACCEPT"}},
 		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "traffic from docker", "-j", "ACCEPT"}},
+		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP"}},
 		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
 	}


### PR DESCRIPTION
Customer has discovered that traffic sourced with ip from SDN subnet is
being sent out of the cluster non-masqueraded.

tcp --ctstate INVALID packets are escaping from the SDN
This change adds a FORWARD rule to DROP these packets.
filter chain
FORWARD -s n.clusterNetworkCIDR -m conntrack --ctstate INVALID -j DROP

bug 1438762
https://bugzilla.redhat.com/show_bug.cgi?id=1438762