### PR TITLE
Install OpenVSwitch from the CentOS PaaS SIG Repos

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -10,6 +10,7 @@
 #
 FROM openshift/origin
 
+COPY centos-paas-sig-openshift-future.repo /etc/yum.repos.d/
 COPY usr/bin/* /usr/bin/
 COPY opt/cni/bin/* /opt/cni/bin/
 COPY etc/cni/net.d/* /etc/cni/net.d/
@@ -18,8 +19,7 @@ COPY scripts/* /usr/local/bin/
 COPY system-container/system-container-wrapper.sh /usr/local/bin/
 COPY system-container/manifest.json system-container/config.json.template system-container/service.template system-container/tmpfiles.template /exports/
 
-RUN curl -L -o /etc/yum.repos.d/origin-next-epel-7.repo https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo && \
-    INSTALL_PKGS="libmnl libnetfilter_conntrack conntrack-tools openvswitch \
+RUN INSTALL_PKGS="libmnl libnetfilter_conntrack conntrack-tools openvswitch \
       libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
       iscsi-initiator-utils" && \

--- a/images/node/centos-paas-sig-openshift-future.repo
+++ b/images/node/centos-paas-sig-openshift-future.repo
@@ -1,0 +1,6 @@
+[centos-paas-sig-openshift-future]
+name = CentOS PaaS SIG Future Repository
+baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-future/
+enabled = 1 
+gpgcheck = 0
+sslverify = 0


### PR DESCRIPTION
In the past, we were not able to install OpenVSwitch from the normal
CentOS repositories or the `epel-release` repositories as the version
there was too old. We were using Adam Miller's COPR to source a newer
version, however this was unstable and flaky. The CentOS PaaS SIG now
provides the `openshift-future` repository which has the dependencies
necessary for bleeding-edge builds of Origin on CentOS, including the
correct OpenVSwitch dependency RPM. We will use this repository from
now on.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/origin/issues/13679
[test]