### PR TITLE
Add web diag endpoint to the F5 and haproxy routers

### DIFF
--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -197,6 +197,8 @@ func (o *F5RouterOptions) F5RouteAdmitterFunc() controller.RouteAdmissionFunc {
 
 // Run launches an F5 route sync process using the provided options. It never exits.
 func (o *F5RouterOptions) Run() error {
+	startProfiler()
+
 	cfg := f5plugin.F5PluginConfig{
 		Host:            o.Host,
 		Username:        o.Username,

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -2,6 +2,8 @@ package router
 
 import (
 	"fmt"
+	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -300,4 +302,16 @@ func hostInDomainList(host string, domains sets.String) bool {
 	}
 
 	return false
+}
+
+func startProfiler() {
+	if cmdutil.Env("OPENSHIFT_PROFILE", "") == "web" {
+		go func() {
+			runtime.SetBlockProfileRate(1)
+			profilePort := cmdutil.Env("OPENSHIFT_PROFILE_PORT", "6061")
+			profileHost := cmdutil.Env("OPENSHIFT_PROFILE_HOST", "127.0.0.1")
+			glog.Infof(fmt.Sprintf("Starting profiling endpoint at http://%s:%s/debug/pprof/", profileHost, profilePort))
+			glog.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%s", profileHost, profilePort), nil))
+		}()
+	}
 }

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -205,6 +205,8 @@ func (o *TemplateRouterOptions) Validate() error {
 
 // Run launches a template router using the provided options. It never exits.
 func (o *TemplateRouterOptions) Run() error {
+	startProfiler()
+
 	var reloadCallbacks []func()
 	switch {
 	case o.MetricsType == "haproxy" && len(o.ListenAddr) > 0:


### PR DESCRIPTION
This implements an http endpoint controlled by setting
OPENSHIFT_PROFILE=web and then you can override the address it listens
on (default is 127.0.0.1) and the port (default 6061) using the
OPENSHIFT_PROFILE_HOST and OPENSHIFT_PROFILE_PORT environment
variables respectively.

With the default setup, you can do:
  curl http://127.0.0.1:6061/debug/pprof/goroutine?debug=1

This is tracked by feature https://trello.com/c/XY6NYILv