### PR TITLE
[1.4] Install OpenVSwitch from the CentOS PaaS SIG Repos

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -10,14 +10,14 @@
 #
 FROM openshift/origin
 
+COPY centos-paas-sig-openshift-origin14.repo /etc/yum.repos.d/
 COPY usr/bin/* /usr/bin/
 COPY opt/cni/bin/* /opt/cni/bin/
 COPY etc/cni/net.d/* /etc/cni/net.d/
 COPY conf/openshift-sdn-ovs.conf /usr/lib/systemd/system/origin-node.service.d/
 COPY scripts/* /usr/local/bin/
 
-RUN curl -L -o /etc/yum.repos.d/origin-next-epel-7.repo https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo && \
-    INSTALL_PKGS="libmnl libnetfilter_conntrack openvswitch \
+RUN INSTALL_PKGS="libmnl libnetfilter_conntrack openvswitch \
       libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
       ceph-common iscsi-initiator-utils" && \

--- a/images/node/centos-paas-sig-openshift-origin14.repo
+++ b/images/node/centos-paas-sig-openshift-origin14.repo
@@ -4,3 +4,4 @@ baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin14/
 enabled = 1
 gpgcheck = 0
 sslverify = 0
+includepkgs = openvswitch

--- a/images/node/centos-paas-sig-openshift-origin14.repo
+++ b/images/node/centos-paas-sig-openshift-origin14.repo
@@ -1,0 +1,6 @@
+[centos-paas-sig-openshift-origin14]
+name = CentOS PaaS SIG Origin 1.4 Repository
+baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin14/
+enabled = 1
+gpgcheck = 0
+sslverify = 0


### PR DESCRIPTION
In the past, we were not able to install OpenVSwitch from the normal
CentOS repositories or the `epel-release` repositories as the version
there was too old. We were using Adam Miller's COPR to source a newer
version, however this was unstable and flaky. The CentOS PaaS SIG now
provides the `openshift-origin14` repository which has the dependencies
necessary for bleeding-edge builds of Origin on CentOS, including the
correct OpenVSwitch dependency RPM. We will use this repository from
now on.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @pweil- @eparis this is blocked until we have OVS 2.4 in this repo /cc @tdawson 