### PR TITLE
Restrict packages from CentOS to OVS only

### DIFF
--- a/images/node/centos-paas-sig-openshift-future.repo
+++ b/images/node/centos-paas-sig-openshift-future.repo
@@ -4,3 +4,4 @@ baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-future/
 enabled = 1 
 gpgcheck = 0
 sslverify = 0
+includepkgs = openvswitch


### PR DESCRIPTION
In order to make sure we do not pull in any unwanted package versions
from the new CentOS PaaS SIG repository, we can restrict the packages
that `yum` will consider this repository to only OpenVSwitch.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]
[merge]