### PR TITLE
Removing i386 build

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -15,7 +15,6 @@ platforms=(
   linux/amd64
   darwin/amd64
   windows/amd64
-  linux/386
 )
 image_platforms=( )
 test_platforms=( "${host_platform}" )


### PR DESCRIPTION
ptal @smarterclayton 

origin will not presently build for i386
```
++ Building go targets for linux/amd64: cmd/openshift cmd/oc
++ Building go targets for darwin/amd64: cmd/openshift cmd/oc
++ Building go targets for windows/amd64: cmd/openshift cmd/oc
++ Building go targets for linux/386: cmd/openshift cmd/oc
# github.com/openshift/origin/pkg/util/strings
run compiler with -v for register allocation sites
pkg/util/strings/wildcard.go:21: internal compiler error: out of fixed registers
goroutine 1 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
	/usr/lib/golang/src/runtime/debug/stack.go:24 +0x79
cmd/compile/internal/gc.Fatalf(0x900ce5, 0x16, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/cmd/compile/internal/gc/subr.go:165 +0x248
cmd/compile/internal/gc.Regalloc(0xc4203dc2d0, 0xc420014b40, 0xc4203dc090)
	/usr/lib/golang/src/cmd/compile/internal/gc/gsubr.go:749 +0x16b
cmd/compile/internal/x86.ginscmp(0xc420449e3e, 0xc420014b40, 0xc4200ffb90, 0xc4203dc090, 0x1, 0xc420075880)
	/usr/lib/golang/src/cmd/compile/internal/x86/gsubr.go:657 +0x364
cmd/compile/internal/gc.Agenr(0xc42044a120, 0xc4204fdb00, 0xc4204fda70)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1245 +0x20e5
cmd/compile/internal/gc.Igen(0xc42044a120, 0xc4204fdb00, 0xc4204fda70)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1718 +0x279
cmd/compile/internal/gc.cgen_wb(0xc42044a120, 0xc4204fda70, 0x0)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:523 +0x2281
cmd/compile/internal/gc.Cgen(0xc42044a120, 0xc4204fda70)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:19 +0x3a
cmd/compile/internal/gc.bgenx(0xc42044a120, 0x0, 0xc420123300, 0x0, 0xc420123378)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1822 +0x599
cmd/compile/internal/gc.Bgen(0xc42044a120, 0xc420123400, 0x0, 0xc420123378)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1729 +0x51
cmd/compile/internal/gc.bgenx(0xc42044a3f0, 0x0, 0xc420123101, 0x0, 0xc420123018)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1890 +0x958
cmd/compile/internal/gc.Bgen(0xc42044a3f0, 0xc420123201, 0x0, 0xc420123018)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1729 +0x51
cmd/compile/internal/gc.bvgenjump(0xc42044a3f0, 0xc4204fd830, 0xc4204d0101)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1761 +0x102
cmd/compile/internal/gc.Bvgen(0xc42044a3f0, 0xc4204fd830, 0x1)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:1738 +0x90
cmd/compile/internal/gc.cgen_wb(0xc42044a3f0, 0xc4204fd830, 0x0)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:371 +0x1584
cmd/compile/internal/gc.Cgen(0xc42044a3f0, 0xc4204fd830)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:19 +0x3a
cmd/compile/internal/gc.cgen_wb(0xc42044a3f0, 0xc420449d40, 0xc420121a00)
	/usr/lib/golang/src/cmd/compile/internal/gc/cgen.go:102 +0x4280
cmd/compile/internal/gc.Cgen_as_wb(0xc420449d40, 0xc42044a3f0, 0x1500000800)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:1023 +0x17b
cmd/compile/internal/gc.Cgen_as(0xc420449d40, 0xc42044a3f0)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:979 +0x3a
cmd/compile/internal/gc.gen(0xc42044a480)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:926 +0xd69
cmd/compile/internal/gc.Genlist(0xc420498260)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:311 +0x50
cmd/compile/internal/gc.gen(0xc420449c20)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:875 +0x433
cmd/compile/internal/gc.Genlist(0xc4204982a0)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:311 +0x50
cmd/compile/internal/gc.gen(0xc420449680)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:860 +0x62c
cmd/compile/internal/gc.Genlist(0xc420498300)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:311 +0x50
cmd/compile/internal/gc.gen(0xc4204485a0)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:860 +0x62c
cmd/compile/internal/gc.Genlist(0xc420498360)
	/usr/lib/golang/src/cmd/compile/internal/gc/gen.go:311 +0x50
cmd/compile/internal/gc.genlegacy(0xc42010c278, 0xc4204b6a80, 0xc4204b6af0)
	/usr/lib/golang/src/cmd/compile/internal/gc/pgen.go:498 +0x4d
cmd/compile/internal/gc.compile(0xc420442510)
	/usr/lib/golang/src/cmd/compile/internal/gc/pgen.go:485 +0x7a4
cmd/compile/internal/gc.funccompile(0xc420442510)
	/usr/lib/golang/src/cmd/compile/internal/gc/dcl.go:1287 +0x186
cmd/compile/internal/gc.Main()
	/usr/lib/golang/src/cmd/compile/internal/gc/main.go:467 +0x1a02
cmd/compile/internal/x86.Main()
	/usr/lib/golang/src/cmd/compile/internal/x86/galign.go:80 +0x3ba
main.main()
	/usr/lib/golang/src/cmd/compile/main.go:31 +0x1d4
[ERROR] PID 16407: hack/common.sh:165: `local -a binaries=("$@")` exited with status 1.
[INFO] 		Stack Trace: 
[INFO] 		  1: hack/common.sh:165: `local -a binaries=("$@")`
[INFO] 		  2: hack/build-cross.sh:80: os::build::build_binaries
[INFO]   Exiting with code 1.
error: Bad exit status from /var/tmp/rpm-tmp.HqInJY (%build)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.HqInJY (%build)
Child returncode was: 1
EXCEPTION: Command failed. See logs for output.
 # ['bash', '--login', '-c', 'rpmbuild -bb --target x86_64 --nodeps builddir/build/SPECS/origin.spec']
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/mockbuild/trace_decorator.py", line 70, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.6/site-packages/mockbuild/util.py", line 345, in do
    raise mockbuild.exception.Error, ("Command failed. See logs for output.\n # %s" % (command,), child.returncode)
Error: Command failed. See logs for output.
```


