### PR TITLE
Migrate to use openshift-origin36 repo from openshift-future

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -10,7 +10,7 @@
 #
 FROM openshift/origin
 
-COPY centos-paas-sig-openshift-future.repo /etc/yum.repos.d/
+COPY centos-paas-sig-openshift-origin36.repo /etc/yum.repos.d/
 COPY usr/bin/* /usr/bin/
 COPY opt/cni/bin/* /opt/cni/bin/
 COPY etc/cni/net.d/* /etc/cni/net.d/

--- a/images/node/centos-paas-sig-openshift-future.repo
+++ b/images/node/centos-paas-sig-openshift-future.repo
@@ -1,7 +1,0 @@
-[centos-paas-sig-openshift-future]
-name = CentOS PaaS SIG Future Repository
-baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-future/
-enabled = 1 
-gpgcheck = 0
-sslverify = 0
-includepkgs = openvswitch

--- a/images/node/centos-paas-sig-openshift-origin36.repo
+++ b/images/node/centos-paas-sig-openshift-origin36.repo
@@ -1,0 +1,7 @@
+[centos-paas-sig-openshift-origin36]
+name = CentOS PaaS SIG Origin 3.6 Repository
+baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
+enabled = 1 
+gpgcheck = 0
+sslverify = 0
+includepkgs = openvswitch


### PR DESCRIPTION
Migrate to use openshift-origin36 repo from openshift-future

Once OpenVSwitch 2.6.1 is available in the CentOS PaaS SIG repo for
Origin 3.6, we should switch to use that instead of the less stable
`openshift-future` repository.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>


blocked on the repo having the package, needs #13685 