### PR TITLE
Updated `find` invocation not to use OSX-specific flags

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -118,7 +118,7 @@ function os::cleanup::tmpdir() {
 	fi
 
 	# delete any sub directory underneath BASETMPDIR
-	for directory in $( find "${BASETMPDIR}" -d 2 ); do
+	for directory in $( find "${BASETMPDIR}" -mindepth 2 -maxdepth 2 ); do
 		${USE_SUDO:+sudo} rm -rf "${directory}"
 	done
 }


### PR DESCRIPTION
The MacOS [`man` page](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/find.1.html) lists the following def:

```
     -d      Same as depth.  GNU find implements this as a primary in mistaken emulation of FreeBSD find(1).

     -depth n
             True if the depth of the file relative to the starting point of the traversal is n.
```

So what @smarterclayton originally wrote is identical to `-mindepth 2 -maxdepth 2`, which look to both be supported on OSX as well:
```
     -maxdepth n
             Always true; descend at most n directory levels below the command line arguments.  If any
             -maxdepth primary is specified, it applies to the entire expression even if it would not nor-
             mally be evaluated.  ``-maxdepth 0'' limits the whole search to the command line arguments.

     -mindepth n
             Always true; do not apply any tests or actions at levels less than n.  If any -mindepth primary
             is specified, it applies to the entire expression even if it would not normally be evaluated.
             ``-mindepth 1'' processes all but the command line arguments.
```

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 

fixes https://github.com/openshift/origin/issues/13453
supersedes https://github.com/openshift/origin/pull/13635