### PR TITLE
Prevent the router from deadlocking itself when calling Commit()

### DIFF
--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -13,6 +13,17 @@ func NewFakeTemplateRouter() *templateRouter {
 	}
 }
 
+// FakeReloadHandler implements the minimal changes needed to make the locking behavior work
+// This MUST match the behavior with the stateChanged of commitAndReload
+func (r *templateRouter) FakeReloadHandler() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.stateChanged = false
+
+	return
+}
+
 // fakeCertWriter is a certificate writer that records actions but is a no-op
 type fakeCertWriter struct {
 	addedCerts   []string


### PR DESCRIPTION
The router reload function (Commit()) was changed so that it could be
rate limited.  The rate limiter tracks changes in a kcache.Queue
object.  It will coalesce changes to the same call so that if three
calls to Invoke() the rate limited function happen before the next
time it is allowed to process, then only one will occur.

Our problem was that we were doing:
 Thread 1 (the rate-limiter background process):
   - Wake up
   - Ratelimit sees there is work to be done and calls fifo.go's Pop() function
   - Fifo.go acquires a fifo lock and call the processing function
   - Router.go's commitAndReload() function acquires a lock on the router object

 Thread 2 (triggered by the event handler that commit's changes to the router):
   - Get the event and process it
   - Since there are changes to be made, call router.Commit()
   - Commit() grabs a lock on the router object
   - Then calls the rate-limiter wrapper around commitAndReload() using Invoke() to queue work
   - In order to queue the work... it acquires a lock on the fifo

In summary: thread 1 locks fifo then router; thread 2 locks router then fifo.
If you get unlucky, those threads deadlock and you never process
another event.

The fix is to release the lock on the router object in our Commit()
function before we call Invoke on the rate limited function.  The lock
is not actually protecting anything at that point since the rate
limited function does its own locking, and is run in a separate thread
anyway.

Fixes bug 1440977 (https://bugzilla.redhat.com/show_bug.cgi?id=1440977)