### PR TITLE
Clean up a misleading comment in the ratelimiter code

### DIFF
--- a/pkg/util/ratelimiter/ratelimiter.go
+++ b/pkg/util/ratelimiter/ratelimiter.go
@@ -53,8 +53,7 @@ func (rlf *RateLimitedFunction) pop() {
 	}
 }
 
-// Invoke adds a request if its not already present and waits for the
-// background processor to execute it.
+// Invoke adds a request if its not already present and returns immediately
 func (rlf *RateLimitedFunction) Invoke(resource interface{}) {
 	rlf.queue.AddIfNotPresent(resource)
 }


### PR DESCRIPTION
The ratelimiter Invoke() function had a comment that implied the
Invoke() would block until the function called was run.  This clearly
does not match the behavior of the function.  Instead, Invoke() queues
the request and the background thread will pick it up when the
ratelimiter next allows it and handle the function.

I tested the behavior and the test code and results are at https://gist.github.com/knobunc/c03ec0c70ec23f79129b8d7f1584aaa1