### PR TITLE
UPSTREAM: 42275: discovery restmapping should always prefer /v1

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/client/typed/discovery/restmapper.go
+++ b/vendor/k8s.io/kubernetes/pkg/client/typed/discovery/restmapper.go
@@ -42,8 +42,11 @@ func NewRESTMapper(groupResources []*APIGroupResources, versionInterfaces meta.V
 	unionMapper := meta.MultiRESTMapper{}
 
 	var groupPriority []string
-	var resourcePriority []unversioned.GroupVersionResource
-	var kindPriority []unversioned.GroupVersionKind
+
+	// New servers will report non-core apigroups for origin resources. Because this client does not know about
+	// them yet, we enforce that all origin resources resolve to /v1 kinds.
+	var resourcePriority = []unversioned.GroupVersionResource{{Group: "", Version: "v1", Resource: meta.AnyResource}}
+	var kindPriority = []unversioned.GroupVersionKind{{Group: "", Version: "v1", Kind: meta.AnyKind}}
 
 	for _, group := range groupResources {
 		groupPriority = append(groupPriority, group.Group.Name)


### PR DESCRIPTION
@liggitt @deads2k @sttts PTAL

I tested this manually and it returns the v1.Route object (so describer works as expected).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1441089