### PR TITLE
Add new annotation withelist to routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -269,6 +269,12 @@ backend be_edge_http:{{$cfgIdx}}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{- end }}
     {{- end }}
+    {{- with $whiteList := index $cfg.Annotations "haproxy.router.openshift.io/whitelist" }}
+      {{- if (matchPattern "([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?( ([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?)*" $whiteList) }}
+  acl whitelist src {{$whiteList}}
+  tcp-request content reject if !whitelist
+      {{- end }}
+    {{- end }}
     {{- with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout server  {{$value}}
@@ -355,6 +361,12 @@ backend be_tcp:{{$cfgIdx}}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}
       {{- end }}
     {{- end }}
+    {{- with $whiteList := index $cfg.Annotations "haproxy.router.openshift.io/whitelist" }}
+      {{- if (matchPattern "([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?( ([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?)*" $whiteList) }}
+  acl whitelist src {{$whiteList}}
+  tcp-request content reject if !whitelist
+      {{- end }}
+    {{- end }}
     {{- with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout tunnel  {{$value}}
@@ -421,6 +433,12 @@ backend be_secure:{{$cfgIdx}}
   balance {{ env "ROUTER_LOAD_BALANCE_ALGORITHM" "leastconn"}}
       {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
+      {{- end }}
+    {{- end }}
+    {{- with $whiteList := index $cfg.Annotations "haproxy.router.openshift.io/whitelist" }}
+      {{- if (matchPattern "([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?( ([0-9]?[0-9]?[0-9].){3}[0-9]?[0-9]?[0-9](/[0-9]?[0-9]?[0-9])?)*" $whiteList) }}
+  acl whitelist src {{$whiteList}}
+  tcp-request content reject if !whitelist
       {{- end }}
     {{- end }}
     {{- with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}


### PR DESCRIPTION
Add a new annotation "haproxy.router.openshift.io/whitelist" available for routes.

This annotation expects a space-separated string of ip's and/or ip ranges, and sets up an acl to prevent access to the backend from other sources.

This PR attends to issue https://github.com/openshift/origin/issues/13709

Some examples:

When editing a route add the following annotation to define the desired source ip's.

### allow only one ip
haproxy.router.openshift.io/whitelist: "192.168.1.10"

### several ip's
haproxy.router.openshift.io/whitelist: "192.168.1.10 192.168.1.11 192.168.1.12"

### ip ranges
haproxy.router.openshift.io/whitelist: "192.168.1.0/24"

### ip's and ranges
haproxy.router.openshift.io/whitelist: "180.5.61.153 192.168.1.0/24 10.0.0.0/8"

@jorgemoralespou take a look!

PS: I had to rebuild my previous PR: https://github.com/openshift/origin/pull/13710
Sorry for the inconveniences!