### PR TITLE
Dockerregistry metrics master api

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -43,6 +43,7 @@ import (
 	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 	registryconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/metrics"
 	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
@@ -64,6 +65,13 @@ func Execute(configFile io.Reader) {
 
 	registryClient := oapi.NewRegistryClient(clientcmd.NewConfig().BindToFile())
 	ctx = server.WithRegistryClient(ctx, registryClient)
+
+	if extraConfig.Metrics.Enabled {
+		if len(extraConfig.Metrics.Secret) == 0 {
+			log.Fatalf("openshift.metrics.secret field cannot be empty when metrics are enabled")
+		}
+		registryClient = metrics.NewRegistryClient(registryClient)
+	}
 
 	log.Infof("version=%s", version.Version)
 	// inject a logger into the uuid library. warns us if there is a problem
@@ -126,9 +134,6 @@ func Execute(configFile io.Reader) {
 
 	// Registry extensions endpoint provides prometheus metrics.
 	if extraConfig.Metrics.Enabled {
-		if len(extraConfig.Metrics.Secret) == 0 {
-			context.GetLogger(app).Fatalf("openshift.metrics.secret field cannot be empty when metrics are enabled")
-		}
 		server.RegisterMetricHandler(app)
 	}
 

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -43,6 +43,7 @@ import (
 	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 	registryconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
 // Execute runs the Docker registry.
@@ -61,7 +62,7 @@ func Execute(configFile io.Reader) {
 		log.Fatalf("error configuring logger: %v", err)
 	}
 
-	registryClient := server.NewRegistryClient(clientcmd.NewConfig().BindToFile())
+	registryClient := oapi.NewRegistryClient(clientcmd.NewConfig().BindToFile())
 	ctx = server.WithRegistryClient(ctx, registryClient)
 
 	log.Infof("version=%s", version.Version)
@@ -75,8 +76,8 @@ func Execute(configFile io.Reader) {
 			dockerConfig.Auth[server.OpenShiftAuth] = make(configuration.Parameters)
 		}
 		dockerConfig.Auth[server.OpenShiftAuth][server.AccessControllerOptionParams] = server.AccessControllerParams{
-			Logger:           context.GetLogger(ctx),
-			SafeClientConfig: registryClient.SafeClientConfig(),
+			Logger:         context.GetLogger(ctx),
+			RegistryClient: registryClient,
 		}
 	}
 

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -3,8 +3,8 @@ package server
 import (
 	"github.com/docker/distribution/context"
 
-	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
 type contextKey string
@@ -61,25 +61,25 @@ func remoteBlobAccessCheckEnabledFrom(ctx context.Context) bool {
 }
 
 // WithRegistryClient returns a new Context with provided registry client.
-func WithRegistryClient(ctx context.Context, client RegistryClient) context.Context {
+func WithRegistryClient(ctx context.Context, client oapi.RegistryClient) context.Context {
 	return context.WithValue(ctx, registryClientKey, client)
 }
 
 // RegistryClientFrom returns the registry client stored in ctx if present.
 // It will panic otherwise.
-func RegistryClientFrom(ctx context.Context) RegistryClient {
-	return ctx.Value(registryClientKey).(RegistryClient)
+func RegistryClientFrom(ctx context.Context) oapi.RegistryClient {
+	return ctx.Value(registryClientKey).(oapi.RegistryClient)
 }
 
 // withUserClient returns a new Context with the origin's client.
 // This client should have the current user's credentials
-func withUserClient(parent context.Context, userClient client.Interface) context.Context {
+func withUserClient(parent context.Context, userClient oapi.ClientInterface) context.Context {
 	return context.WithValue(parent, userClientKey, userClient)
 }
 
 // userClientFrom returns the origin's client stored in ctx, if any.
-func userClientFrom(ctx context.Context) (client.Interface, bool) {
-	userClient, ok := ctx.Value(userClientKey).(client.Interface)
+func userClientFrom(ctx context.Context) (oapi.ClientInterface, bool) {
+	userClient, ok := ctx.Value(userClientKey).(oapi.ClientInterface)
 	return userClient, ok
 }
 

--- a/pkg/dockerregistry/server/metrichandler.go
+++ b/pkg/dockerregistry/server/metrichandler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/auth"
 	"github.com/docker/distribution/registry/handlers"
 
@@ -29,4 +30,6 @@ func RegisterMetricHandler(app *handlers.App) {
 		handlers.NameNotRequired,
 		getMetricsAccess,
 	)
+
+	context.GetLogger(app).Debug("configured metrics endpoint")
 }

--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -12,14 +12,14 @@ const (
 )
 
 var (
-	RegistryAPIRequests *prometheus.SummaryVec
-	MasterAPIRequests   *prometheus.SummaryVec
+	RegistryAPIRequests *prometheus.HistogramVec
+	MasterAPIRequests   *prometheus.HistogramVec
 )
 
 // Register the metrics.
 func Register() {
-	RegistryAPIRequests = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	RegistryAPIRequests = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: registryNamespace,
 			Subsystem: registrySubsystem,
 			Name:      "request_duration_seconds",
@@ -29,8 +29,8 @@ func Register() {
 	)
 	prometheus.MustRegister(RegistryAPIRequests)
 
-	MasterAPIRequests = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	MasterAPIRequests = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: registryNamespace,
 			Subsystem: registrySubsystem,
 			Name:      "masterapi_request_duration_seconds",
@@ -41,8 +41,8 @@ func Register() {
 	prometheus.MustRegister(MasterAPIRequests)
 }
 
-// NewTimer wraps the SummaryVec and used to track amount of time passed since the Timer was created.
-func NewTimer(collector *prometheus.SummaryVec, labels []string) *metricTimer {
+// NewTimer wraps the HistogramVec and used to track amount of time passed since the Timer was created.
+func NewTimer(collector *prometheus.HistogramVec, labels []string) *metricTimer {
 	return &metricTimer{
 		collector: collector,
 		labels:    labels,
@@ -51,12 +51,12 @@ func NewTimer(collector *prometheus.SummaryVec, labels []string) *metricTimer {
 }
 
 type metricTimer struct {
-	collector *prometheus.SummaryVec
+	collector *prometheus.HistogramVec
 	labels    []string
 	startTime time.Time
 }
 
 // Stop records the duration passed since the Timer was created with NewTimer.
 func (m *metricTimer) Stop() {
-	m.collector.WithLabelValues(m.labels...).Observe(float64(time.Since(m.startTime) / time.Second))
+	m.collector.WithLabelValues(m.labels...).Observe(float64(time.Since(m.startTime)) / float64(time.Second))
 }

--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -13,6 +13,7 @@ const (
 
 var (
 	RegistryAPIRequests *prometheus.SummaryVec
+	MasterAPIRequests   *prometheus.SummaryVec
 )
 
 // Register the metrics.
@@ -27,6 +28,17 @@ func Register() {
 		[]string{"operation", "name"},
 	)
 	prometheus.MustRegister(RegistryAPIRequests)
+
+	MasterAPIRequests = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: registryNamespace,
+			Subsystem: registrySubsystem,
+			Name:      "masterapi_request_duration_seconds",
+			Help:      "Master API request latency summary in microseconds for each operation",
+		},
+		[]string{"operation"},
+	)
+	prometheus.MustRegister(MasterAPIRequests)
 }
 
 // NewTimer wraps the SummaryVec and used to track amount of time passed since the Timer was created.

--- a/pkg/dockerregistry/server/metrics/oapi.go
+++ b/pkg/dockerregistry/server/metrics/oapi.go
@@ -1,0 +1,175 @@
+package metrics
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+type oapiClient struct {
+	client oapi.ClientInterface
+}
+
+// NewOAPIClient wraps c with the Prometheus instrumentation.
+func NewOAPIClient(c oapi.ClientInterface) oapi.ClientInterface {
+	return &oapiClient{
+		client: c,
+	}
+}
+
+func (c *oapiClient) Users() oapi.ClientUserInterface {
+	return &oapiClientUsers{client: c.client.Users()}
+}
+
+func (c *oapiClient) Images() oapi.ClientImageInterface {
+	return &oapiClientImages{client: c.client.Images()}
+}
+
+func (c *oapiClient) ImageSignatures() oapi.ClientImageSignatureInterface {
+	return &oapiClientImageSignatures{client: c.client.ImageSignatures()}
+}
+
+func (c *oapiClient) ImageStreamImages(namespace string) oapi.ClientImageStreamImageInterface {
+	return &oapiClientImageStreamImages{client: c.client.ImageStreamImages(namespace)}
+}
+
+func (c *oapiClient) ImageStreams(namespace string) oapi.ClientImageStreamInterface {
+	return &oapiClientImageStreams{client: c.client.ImageStreams(namespace)}
+}
+
+func (c *oapiClient) ImageStreamMappings(namespace string) oapi.ClientImageStreamMappingInterface {
+	return &oapiClientImageStreamMappings{client: c.client.ImageStreamMappings(namespace)}
+}
+
+func (c *oapiClient) ImageStreamSecrets(namespace string) oapi.ClientImageStreamSecretInterface {
+	return &oapiClientImageStreamSecrets{client: c.client.ImageStreamSecrets(namespace)}
+}
+
+func (c *oapiClient) ImageStreamTags(namespace string) oapi.ClientImageStreamTagInterface {
+	return &oapiClientImageStreamTags{client: c.client.ImageStreamTags(namespace)}
+}
+
+func (c *oapiClient) LimitRanges(namespace string) oapi.ClientLimitRangeInterface {
+	return &oapiClientLimitRanges{client: c.client.LimitRanges(namespace)}
+}
+
+func (c *oapiClient) LocalSubjectAccessReviews(namespace string) oapi.ClientLocalSubjectAccessReviewInterface {
+	return &oapiClientLocalSubjectAccessReviews{client: c.client.LocalSubjectAccessReviews(namespace)}
+}
+
+func (c *oapiClient) SubjectAccessReviews() oapi.ClientSubjectAccessReviewInterface {
+	return &oapiClientSubjectAccessReviews{client: c.client.SubjectAccessReviews()}
+}
+
+type oapiClientImages struct {
+	client oapi.ClientImageInterface
+}
+
+func (c *oapiClientImages) Get(name string, options metav1.GetOptions) (*imageapi.Image, error) {
+	defer NewTimer(MasterAPIRequests, []string{"images.get"}).Stop()
+	return c.client.Get(name, options)
+}
+
+func (c *oapiClientImages) Update(image *imageapi.Image) (*imageapi.Image, error) {
+	defer NewTimer(MasterAPIRequests, []string{"images.update"}).Stop()
+	return c.client.Update(image)
+}
+
+type oapiClientImageSignatures struct {
+	client oapi.ClientImageSignatureInterface
+}
+
+func (c *oapiClientImageSignatures) Create(signature *imageapi.ImageSignature) (*imageapi.ImageSignature, error) {
+	defer NewTimer(MasterAPIRequests, []string{"imagesignatures.create"}).Stop()
+	return c.client.Create(signature)
+}
+
+type oapiClientImageStreamImages struct {
+	client oapi.ClientImageStreamImageInterface
+}
+
+func (c *oapiClientImageStreamImages) Get(name, id string) (*imageapi.ImageStreamImage, error) {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreamimages.get"}).Stop()
+	return c.client.Get(name, id)
+}
+
+type oapiClientImageStreams struct {
+	client oapi.ClientImageStreamInterface
+}
+
+func (c *oapiClientImageStreams) Get(name string, options metav1.GetOptions) (*imageapi.ImageStream, error) {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreams.get"}).Stop()
+	return c.client.Get(name, options)
+}
+
+func (c *oapiClientImageStreams) Create(stream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreams.create"}).Stop()
+	return c.client.Create(stream)
+}
+
+type oapiClientImageStreamMappings struct {
+	client oapi.ClientImageStreamMappingInterface
+}
+
+func (c *oapiClientImageStreamMappings) Create(mapping *imageapi.ImageStreamMapping) error {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreammapping.create"}).Stop()
+	return c.client.Create(mapping)
+}
+
+type oapiClientImageStreamSecrets struct {
+	client oapi.ClientImageStreamSecretInterface
+}
+
+func (c *oapiClientImageStreamSecrets) Secrets(name string, options metav1.ListOptions) (*kapi.SecretList, error) {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreamsecrets.secrets"}).Stop()
+	return c.client.Secrets(name, options)
+}
+
+type oapiClientImageStreamTags struct {
+	client oapi.ClientImageStreamTagInterface
+}
+
+func (c *oapiClientImageStreamTags) Delete(name, tag string) error {
+	defer NewTimer(MasterAPIRequests, []string{"imagestreamtags.delete"}).Stop()
+	return c.client.Delete(name, tag)
+}
+
+type oapiClientLimitRanges struct {
+	client oapi.ClientLimitRangeInterface
+}
+
+func (c *oapiClientLimitRanges) List(opts metav1.ListOptions) (*kapi.LimitRangeList, error) {
+	defer NewTimer(MasterAPIRequests, []string{"limitranges.list"}).Stop()
+	return c.client.List(opts)
+}
+
+type oapiClientUsers struct {
+	client oapi.ClientUserInterface
+}
+
+func (c *oapiClientUsers) Get(name string, options metav1.GetOptions) (*userapi.User, error) {
+	defer NewTimer(MasterAPIRequests, []string{"users.get"}).Stop()
+	return c.client.Get(name, options)
+}
+
+type oapiClientLocalSubjectAccessReviews struct {
+	client oapi.ClientLocalSubjectAccessReviewInterface
+}
+
+func (c *oapiClientLocalSubjectAccessReviews) Create(policy *authorizationapi.LocalSubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+	defer NewTimer(MasterAPIRequests, []string{"localsubjectaccessreviews.create"}).Stop()
+	return c.client.Create(policy)
+}
+
+type oapiClientSubjectAccessReviews struct {
+	client oapi.ClientSubjectAccessReviewInterface
+}
+
+func (c *oapiClientSubjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+	defer NewTimer(MasterAPIRequests, []string{"subjectaccessreviews.create"}).Stop()
+	return c.client.Create(policy)
+}

--- a/pkg/dockerregistry/server/oapi/doc.go
+++ b/pkg/dockerregistry/server/oapi/doc.go
@@ -1,0 +1,2 @@
+// Package oapi provides functions to make requests to Openshift Master API.
+package oapi

--- a/pkg/dockerregistry/server/oapi/oapi.go
+++ b/pkg/dockerregistry/server/oapi/oapi.go
@@ -19,8 +19,6 @@ type RegistryClient interface {
 	Client() (ClientInterface, error)
 	// UserClient returns the user client.
 	UserClient(token string) (ClientInterface, error)
-	// SafeClientConfig returns a client config without authentication info.
-	SafeClientConfig() restclient.Config
 }
 
 type ClientInterface interface {
@@ -207,7 +205,7 @@ func (c *registryClient) UserClient(token string) (ClientInterface, error) {
 		return nil, err
 	}
 
-	cfg := c.SafeClientConfig()
+	cfg := c.safeClientConfig()
 	cfg.BearerToken = token
 
 	oc, err := client.New(&cfg)
@@ -218,7 +216,7 @@ func (c *registryClient) UserClient(token string) (ClientInterface, error) {
 	return NewAPIClient(oc, kc.Core()), nil
 }
 
-// SafeClientConfig returns a client config without authentication info.
-func (с *registryClient) SafeClientConfig() restclient.Config {
+// safeClientConfig returns a client config without authentication info.
+func (с *registryClient) safeClientConfig() restclient.Config {
 	return clientcmd.AnonymousClientConfig(с.config.OpenShiftConfig())
 }

--- a/pkg/dockerregistry/server/oapi/oapi.go
+++ b/pkg/dockerregistry/server/oapi/oapi.go
@@ -1,0 +1,224 @@
+package oapi
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	restclient "k8s.io/client-go/rest"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+type RegistryClient interface {
+	// Client returns the authenticated client to use with the server.
+	Client() (ClientInterface, error)
+	// UserClient returns the user client.
+	UserClient(token string) (ClientInterface, error)
+	// SafeClientConfig returns a client config without authentication info.
+	SafeClientConfig() restclient.Config
+}
+
+type ClientInterface interface {
+	ClientImageSignaturesInterfacer
+	ClientImagesInterfacer
+	ClientImageStreamImagesNamespacer
+	ClientImageStreamMappingsNamespacer
+	ClientImageStreamSecretsNamespacer
+	ClientImageStreamsNamespacer
+	ClientImageStreamTagsNamespacer
+	ClientLimitRangesGetter
+	ClientLocalSubjectAccessReviewsNamespacer
+	ClientSubjectAccessReviews
+	ClientUsersInterfacer
+}
+
+type ClientUsersInterfacer interface {
+	Users() ClientUserInterface
+}
+
+type ClientImagesInterfacer interface {
+	Images() ClientImageInterface
+}
+
+type ClientImageSignaturesInterfacer interface {
+	ImageSignatures() ClientImageSignatureInterface
+}
+
+type ClientImageStreamImagesNamespacer interface {
+	ImageStreamImages(namespace string) ClientImageStreamImageInterface
+}
+
+type ClientImageStreamsNamespacer interface {
+	ImageStreams(namespace string) ClientImageStreamInterface
+}
+
+type ClientImageStreamMappingsNamespacer interface {
+	ImageStreamMappings(namespace string) ClientImageStreamMappingInterface
+}
+
+type ClientImageStreamSecretsNamespacer interface {
+	ImageStreamSecrets(namespace string) ClientImageStreamSecretInterface
+}
+
+type ClientImageStreamTagsNamespacer interface {
+	ImageStreamTags(namespace string) ClientImageStreamTagInterface
+}
+
+type ClientLimitRangesGetter interface {
+	LimitRanges(namespace string) ClientLimitRangeInterface
+}
+
+type ClientLocalSubjectAccessReviewsNamespacer interface {
+	LocalSubjectAccessReviews(namespace string) ClientLocalSubjectAccessReviewInterface
+}
+
+type ClientSubjectAccessReviews interface {
+	SubjectAccessReviews() ClientSubjectAccessReviewInterface
+}
+
+type ClientImageSignatureInterface interface {
+	Create(signature *imageapi.ImageSignature) (*imageapi.ImageSignature, error)
+}
+
+type ClientImageStreamImageInterface interface {
+	Get(name, id string) (*imageapi.ImageStreamImage, error)
+}
+
+type ClientUserInterface interface {
+	Get(name string, options metav1.GetOptions) (*userapi.User, error)
+}
+
+type ClientImageInterface interface {
+	Get(name string, options metav1.GetOptions) (*imageapi.Image, error)
+	Update(image *imageapi.Image) (*imageapi.Image, error)
+}
+
+type ClientImageStreamInterface interface {
+	Get(name string, options metav1.GetOptions) (*imageapi.ImageStream, error)
+	Create(stream *imageapi.ImageStream) (*imageapi.ImageStream, error)
+}
+
+type ClientImageStreamMappingInterface interface {
+	Create(mapping *imageapi.ImageStreamMapping) error
+}
+
+type ClientImageStreamSecretInterface interface {
+	Secrets(name string, options metav1.ListOptions) (*kapi.SecretList, error)
+}
+
+type ClientImageStreamTagInterface interface {
+	Delete(name, tag string) error
+}
+
+type ClientLimitRangeInterface interface {
+	List(opts metav1.ListOptions) (*kapi.LimitRangeList, error)
+}
+
+type ClientLocalSubjectAccessReviewInterface interface {
+	Create(policy *authorizationapi.LocalSubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
+}
+
+type ClientSubjectAccessReviewInterface interface {
+	Create(policy *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
+}
+
+type oapiClient struct {
+	osClient client.Interface
+	kClient  kcoreclient.CoreInterface
+}
+
+func NewAPIClient(c client.Interface, kc kcoreclient.CoreInterface) ClientInterface {
+	return &oapiClient{
+		osClient: c,
+		kClient:  kc,
+	}
+}
+
+func (c *oapiClient) Users() ClientUserInterface {
+	return c.osClient.Users()
+}
+
+func (c *oapiClient) Images() ClientImageInterface {
+	return c.osClient.Images()
+}
+
+func (c *oapiClient) ImageSignatures() ClientImageSignatureInterface {
+	return c.osClient.ImageSignatures()
+}
+
+func (c *oapiClient) ImageStreams(namespace string) ClientImageStreamInterface {
+	return c.osClient.ImageStreams(namespace)
+}
+
+func (c *oapiClient) ImageStreamImages(namespace string) ClientImageStreamImageInterface {
+	return c.osClient.ImageStreamImages(namespace)
+}
+
+func (c *oapiClient) ImageStreamMappings(namespace string) ClientImageStreamMappingInterface {
+	return c.osClient.ImageStreamMappings(namespace)
+}
+
+func (c *oapiClient) ImageStreamSecrets(namespace string) ClientImageStreamSecretInterface {
+	return c.osClient.ImageStreamSecrets(namespace)
+}
+
+func (c *oapiClient) ImageStreamTags(namespace string) ClientImageStreamTagInterface {
+	return c.osClient.ImageStreamTags(namespace)
+}
+
+func (c *oapiClient) LimitRanges(namespace string) ClientLimitRangeInterface {
+	return c.kClient.LimitRanges(namespace)
+}
+
+func (c *oapiClient) LocalSubjectAccessReviews(namespace string) ClientLocalSubjectAccessReviewInterface {
+	return c.osClient.LocalSubjectAccessReviews(namespace)
+}
+
+func (c *oapiClient) SubjectAccessReviews() ClientSubjectAccessReviewInterface {
+	return c.osClient.SubjectAccessReviews()
+}
+
+type registryClient struct {
+	config *clientcmd.Config
+}
+
+func NewRegistryClient(config *clientcmd.Config) RegistryClient {
+	return &registryClient{config: config}
+}
+
+// Client returns the authenticated client to use with the server.
+func (c *registryClient) Client() (ClientInterface, error) {
+	oc, kc, err := c.config.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewAPIClient(oc, kc.Core()), nil
+}
+
+func (c *registryClient) UserClient(token string) (ClientInterface, error) {
+	_, kc, err := c.config.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := c.SafeClientConfig()
+	cfg.BearerToken = token
+
+	oc, err := client.New(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewAPIClient(oc, kc.Core()), nil
+}
+
+// SafeClientConfig returns a client config without authentication info.
+func (с *registryClient) SafeClientConfig() restclient.Config {
+	return clientcmd.AnonymousClientConfig(с.config.OpenShiftConfig())
+}

--- a/pkg/dockerregistry/server/oapi/testutil/oapi.go
+++ b/pkg/dockerregistry/server/oapi/testutil/oapi.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
+)
+
+type fakeRegistryClient struct {
+	oapi.RegistryClient
+
+	client client.Interface
+}
+
+func NewRegistryClient(c client.Interface) oapi.RegistryClient {
+	return &fakeRegistryClient{
+		RegistryClient: oapi.NewRegistryClient(nil),
+		client:         c,
+	}
+}
+
+func (c *fakeRegistryClient) Client() (oapi.ClientInterface, error) {
+	return oapi.NewAPIClient(c.client, nil), nil
+}

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -135,7 +136,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepository(t, namespace, name, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: true,
 		})
 		ptbs := &pullthroughBlobStore{
@@ -286,7 +287,7 @@ func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 
 	ctx := WithTestPassthroughToUpstream(context.Background(), false)
 	repo := newTestRepository(t, namespace, name, testRepositoryOptions{
-		client:            client,
+		client:            oapi.NewAPIClient(client, nil),
 		enablePullThrough: true,
 	})
 	ptbs := &pullthroughBlobStore{
@@ -605,7 +606,7 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 
 		repo := newTestRepository(t, namespace, repo1, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: true,
 		})
 

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/distribution/registry/handlers"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -134,7 +135,7 @@ func TestPullthroughManifests(t *testing.T) {
 		localManifestService := newTestManifestService(repoName, tc.localData)
 
 		repo := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: true,
 		})
 
@@ -357,7 +358,7 @@ func TestPullthroughManifestInsecure(t *testing.T) {
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: true,
 		})
 		ctx = withRepository(ctx, repo)
@@ -491,7 +492,7 @@ func TestPullthroughManifestDockerReference(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, tc.repoName, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: true,
 		})
 

--- a/pkg/dockerregistry/server/quotarestrictedblobstore.go
+++ b/pkg/dockerregistry/server/quotarestrictedblobstore.go
@@ -20,8 +20,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 )
 
@@ -134,7 +134,7 @@ func (bw *quotaRestrictedBlobWriter) Commit(ctx context.Context, provisional dis
 }
 
 // getLimitRangeList returns list of limit ranges for repo.
-func getLimitRangeList(ctx context.Context, limitClient kcoreclient.LimitRangesGetter, namespace string) (*kapi.LimitRangeList, error) {
+func getLimitRangeList(ctx context.Context, limitClient oapi.ClientLimitRangesGetter, namespace string) (*kapi.LimitRangeList, error) {
 	if quotaEnforcing.limitRanges != nil {
 		obj, exists, _ := quotaEnforcing.limitRanges.get(namespace)
 		if exists {
@@ -167,7 +167,7 @@ func admitBlobWrite(ctx context.Context, repo *repository, size int64) error {
 		return nil
 	}
 
-	lrs, err := getLimitRangeList(ctx, repo.limitClient, repo.namespace)
+	lrs, err := getLimitRangeList(ctx, repo.registryOSClient, repo.namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/dockerregistry/server/remoteblobgetter.go
+++ b/pkg/dockerregistry/server/remoteblobgetter.go
@@ -11,9 +11,10 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	disterrors "github.com/docker/distribution/registry/api/v2"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/importer"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
 // BlobGetterService combines the operations to access and read blobs.
@@ -32,7 +33,7 @@ type remoteBlobGetterService struct {
 	name                string
 	cacheTTL            time.Duration
 	getImageStream      ImageStreamGetter
-	isSecretsNamespacer osclient.ImageStreamSecretsNamespacer
+	isSecretsNamespacer oapi.ClientImageStreamSecretsNamespacer
 	cachedLayers        digestToRepositoryCache
 	digestToStore       map[string]distribution.BlobStore
 }
@@ -45,7 +46,7 @@ func NewBlobGetterService(
 	namespace, name string,
 	cacheTTL time.Duration,
 	imageStreamGetter ImageStreamGetter,
-	isSecretsNamespacer osclient.ImageStreamSecretsNamespacer,
+	isSecretsNamespacer oapi.ClientImageStreamSecretsNamespacer,
 	cachedLayers digestToRepositoryCache,
 ) BlobGetterService {
 	return &remoteBlobGetterService{

--- a/pkg/dockerregistry/server/repository_test.go
+++ b/pkg/dockerregistry/server/repository_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
 type testRepository struct {
@@ -29,7 +31,7 @@ func (r *testRepository) Blobs(ctx context.Context) distribution.BlobStore {
 }
 
 type testRepositoryOptions struct {
-	client            *testclient.Fake
+	client            oapi.ClientInterface
 	enablePullThrough bool
 	blobs             distribution.BlobStore
 }
@@ -73,6 +75,7 @@ func newTestRepository(
 		registryOSClient:  opts.client,
 		imageStreamGetter: isGetter,
 		cachedImages:      make(map[digest.Digest]*imageapi.Image),
+		config:            &configuration.Configuration{},
 	}
 
 	if opts.enablePullThrough {

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -166,10 +166,6 @@ func newRepositoryWithClient(
 ) (distribution.Repository, error) {
 	registryConfig := ConfigurationFrom(ctx)
 
-	if registryConfig.Metrics.Enabled {
-		registryOSClient = metrics.NewOAPIClient(registryOSClient)
-	}
-
 	registryAddr := os.Getenv(DockerRegistryURLEnvVar)
 	if len(registryAddr) == 0 {
 		return nil, fmt.Errorf("%s is required", DockerRegistryURLEnvVar)

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -18,11 +18,11 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	"github.com/openshift/origin/pkg/dockerregistry/server/metrics"
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
@@ -105,15 +105,15 @@ func init() {
 				panic(fmt.Sprintf("Configuration error: OpenShift storage driver middleware not activated"))
 			}
 
-			registryOSClient, kCoreClient, errClients := RegistryClientFrom(ctx).Clients()
-			if errClients != nil {
-				return nil, errClients
+			registryOSClient, errClient := RegistryClientFrom(ctx).Client()
+			if errClient != nil {
+				return nil, errClient
 			}
 			if quotaEnforcing == nil {
 				quotaEnforcing = newQuotaEnforcingConfig(ctx, os.Getenv(EnforceQuotaEnvVar), os.Getenv(ProjectCacheTTLEnvVar), options)
 			}
 
-			return newRepositoryWithClient(ctx, registryOSClient, kCoreClient, repo, options)
+			return newRepositoryWithClient(ctx, registryOSClient, repo, options)
 		},
 	)
 
@@ -130,11 +130,11 @@ type repository struct {
 	distribution.Repository
 
 	ctx              context.Context
-	limitClient      kcoreclient.LimitRangesGetter
-	registryOSClient client.Interface
+	registryOSClient oapi.ClientInterface
 	registryAddr     string
 	namespace        string
 	name             string
+	config           *configuration.Configuration
 
 	// if true, the repository will check remote references in the image stream to support pulling "through"
 	// from a remote repository
@@ -160,11 +160,16 @@ type repository struct {
 // newRepositoryWithClient returns a new repository middleware.
 func newRepositoryWithClient(
 	ctx context.Context,
-	registryOSClient client.Interface,
-	limitClient kcoreclient.LimitRangesGetter,
+	registryOSClient oapi.ClientInterface,
 	repo distribution.Repository,
 	options map[string]interface{},
 ) (distribution.Repository, error) {
+	registryConfig := ConfigurationFrom(ctx)
+
+	if registryConfig.Metrics.Enabled {
+		registryOSClient = metrics.NewOAPIClient(registryOSClient)
+	}
+
 	registryAddr := os.Getenv(DockerRegistryURLEnvVar)
 	if len(registryAddr) == 0 {
 		return nil, fmt.Errorf("%s is required", DockerRegistryURLEnvVar)
@@ -204,7 +209,6 @@ func newRepositoryWithClient(
 		Repository: repo,
 
 		ctx:                    ctx,
-		limitClient:            limitClient,
 		registryOSClient:       registryOSClient,
 		registryAddr:           registryAddr,
 		namespace:              nameParts[0],
@@ -216,6 +220,7 @@ func newRepositoryWithClient(
 		imageStreamGetter:      imageStreamGetter,
 		cachedImages:           make(map[digest.Digest]*imageapi.Image),
 		cachedLayers:           cachedLayers,
+		config:                 registryConfig,
 	}
 
 	if pullthrough {
@@ -264,9 +269,7 @@ func (r *repository) Manifests(ctx context.Context, options ...distribution.Mani
 		ms = audit.NewManifestService(ctx, ms)
 	}
 
-	config := ConfigurationFrom(ctx)
-
-	if config.Metrics.Enabled {
+	if r.config.Metrics.Enabled {
 		ms = &metrics.ManifestService{
 			Manifests: ms,
 			Reponame:  r.Named().Name(),
@@ -306,9 +309,7 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		bs = audit.NewBlobStore(ctx, bs)
 	}
 
-	config := ConfigurationFrom(ctx)
-
-	if config.Metrics.Enabled {
+	if r.config.Metrics.Enabled {
 		bs = &metrics.BlobStore{
 			Store:    bs,
 			Reponame: r.Named().Name(),
@@ -336,9 +337,7 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 		ts = audit.NewTagService(ctx, ts)
 	}
 
-	config := ConfigurationFrom(ctx)
-
-	if config.Metrics.Enabled {
+	if r.config.Metrics.Enabled {
 		ts = &metrics.TagService{
 			Tags:     ts,
 			Reponame: r.Named().Name(),

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -22,6 +22,8 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 
 	"github.com/openshift/origin/pkg/client/testclient"
+	regconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	oapitest "github.com/openshift/origin/pkg/dockerregistry/server/oapi/testutil"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -50,9 +52,15 @@ func TestSignatureGet(t *testing.T) {
 	})
 	registrytest.AddImage(t, fos, testImage, "user", "app", "latest")
 
+	osclient, err := oapitest.NewRegistryClient(client).Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx := context.Background()
-	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, nil))
-	ctx = withUserClient(ctx, client)
+	ctx = WithRegistryClient(ctx, oapitest.NewRegistryClient(client))
+	ctx = WithConfiguration(ctx, &regconfig.Configuration{})
+	ctx = withUserClient(ctx, osclient)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{
@@ -153,9 +161,15 @@ func TestSignaturePut(t *testing.T) {
 		return true, sign, nil
 	})
 
+	osclient, err := oapitest.NewRegistryClient(client).Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctx := context.Background()
-	ctx = WithRegistryClient(ctx, makeFakeRegistryClient(client, nil))
-	ctx = withUserClient(ctx, client)
+	ctx = WithRegistryClient(ctx, oapitest.NewRegistryClient(client))
+	ctx = WithConfiguration(ctx, &regconfig.Configuration{})
+	ctx = withUserClient(ctx, osclient)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -68,7 +69,7 @@ func TestTagGet(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -109,7 +110,7 @@ func TestTagGetWithoutImageStream(t *testing.T) {
 	_, client := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: oapi.NewAPIClient(client, nil),
 	})
 
 	ts := &tagService{
@@ -173,7 +174,7 @@ func TestTagCreation(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -210,7 +211,7 @@ func TestTagCreationWithoutImageStream(t *testing.T) {
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: oapi.NewAPIClient(client, nil),
 	})
 
 	ts := &tagService{
@@ -284,7 +285,7 @@ func TestTagDeletion(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -321,7 +322,7 @@ func TestTagDeletionWithoutImageStream(t *testing.T) {
 	_, client := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: oapi.NewAPIClient(client, nil),
 	})
 
 	ts := &tagService{
@@ -380,7 +381,7 @@ func TestTagGetAll(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -408,7 +409,7 @@ func TestTagGetAllWithoutImageStream(t *testing.T) {
 	_, client := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: oapi.NewAPIClient(client, nil),
 	})
 
 	ts := &tagService{
@@ -478,7 +479,7 @@ func TestTagLookup(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            oapi.NewAPIClient(client, nil),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -515,7 +516,7 @@ func TestTagLookupWithoutImageStream(t *testing.T) {
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: oapi.NewAPIClient(client, nil),
 	})
 
 	ts := &tagService{

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -17,9 +17,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/importer"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/oapi"
 )
 
 func getOptionValue(
@@ -163,7 +164,7 @@ func wrapKStatusErrorOnGetImage(repoName string, dgst digest.Digest, err error) 
 // to remote repositories.
 func getImportContext(
 	ctx context.Context,
-	osClient osclient.ImageStreamSecretsNamespacer,
+	osClient oapi.ClientImageStreamSecretsNamespacer,
 	namespace, name string,
 ) importer.RepositoryRetriever {
 	secrets, err := osClient.ImageStreamSecrets(namespace).Secrets(name, metav1.ListOptions{})
@@ -180,7 +181,7 @@ type cachedImageStreamGetter struct {
 	ctx               context.Context
 	namespace         string
 	name              string
-	isNamespacer      osclient.ImageStreamsNamespacer
+	isNamespacer      oapi.ClientImageStreamsNamespacer
 	cachedImageStream *imageapi.ImageStream
 }
 

--- a/test/integration/dockerregistry_metrics_test.go
+++ b/test/integration/dockerregistry_metrics_test.go
@@ -1,0 +1,92 @@
+package integration
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/cmd/dockerregistry"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+)
+
+const integrationTestSecret = "integration-test-secret"
+
+func runRegistryWithMetrics() error {
+	config := `version: 0.1
+log:
+  level: debug
+http:
+  addr: 127.0.0.1:5000
+storage:
+  inmemory: {}
+auth:
+  openshift: {}
+middleware:
+  registry:
+    - name: openshift
+  repository:
+    - name: openshift
+  storage:
+    - name: openshift
+openshift:
+  version: 1.0
+  metrics:
+    enabled: true
+    secret: ` + integrationTestSecret + `
+`
+	os.Setenv("DOCKER_REGISTRY_URL", "127.0.0.1:5000")
+
+	go dockerregistry.Execute(strings.NewReader(config))
+
+	if err := cmdutil.WaitForSuccessfulDial(false, "tcp", "127.0.0.1:5000", 100*time.Millisecond, 1*time.Second, 35); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestDockerRegistryMetrics(t *testing.T) {
+	if err := runRegistryWithMetrics(); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", "http://127.0.0.1:5000/v2/foo/bar/manifests/latest", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+	req.Header.Add("Authorization", "Bearer check-me")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error sending token to registry: %s", err)
+	}
+	resp.Body.Close()
+
+	req, err = http.NewRequest("GET", "http://127.0.0.1:5000/extensions/v2/metrics", nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+integrationTestSecret)
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("error receiving metrics from registry: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	metrics, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading metrics from registry: %s", err)
+	}
+
+	if !bytes.Contains(metrics, []byte("openshift_registry_masterapi_request_duration_seconds")) {
+		t.Errorf("no metrics for master api found\n%s", metrics)
+	}
+}


### PR DESCRIPTION
This PR made as follow up for #12711 

It adds monitoring master API calls. Also it collects in one place all the work with the client library. Code no longer works with client library directly. It will also allow in the future to migrate to clientsets.

Bunch of `Client*Namespacer` interfaces has been added to not make wrappers for every function in client api and limit code using only the allowed functions.

@smarterclayton what do you think about [this](https://github.com/openshift/origin/commit/81d6b205bcfde05936572112313ee114cfbcdddb#diff-2b8338c0b59e2aba25deba84cba8ee9b)?
