### PR TITLE
Clean up a misleading comment in the ratelimiter code (take 2)

### DIFF
--- a/pkg/util/ratelimiter/ratelimiter.go
+++ b/pkg/util/ratelimiter/ratelimiter.go
@@ -54,6 +54,8 @@ func (rlf *RateLimitedFunction) pop() {
 }
 
 // Invoke adds a request if its not already present and returns immediately
+// unless the rate limited function is actually running, in which case it will
+// block until the current run completes
 func (rlf *RateLimitedFunction) Invoke(resource interface{}) {
 	rlf.queue.AddIfNotPresent(resource)
 }


### PR DESCRIPTION
The ratelimiter Invoke() function had a comment that implied the
Invoke() would block until the function called was run. This clearly
does not match the behavior of the function. Instead, Invoke() queues
the request and the background thread will pick it up when the
ratelimiter next allows it and handle the function.  BUT if the
background process is running, the Invoke() will be blocked until it
completes.

I tested the behavior and the test code and results are at https://gist.github.com/knobunc/c03ec0c70ec23f79129b8d7f1584aaa1