### PR TITLE
Ignore SELinux attributes when creating release tarball

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -426,7 +426,7 @@ function os::build::archive_tar() {
   if [[ -n "$(which bsdtar)" ]]; then
     bsdtar -czf "${OS_LOCAL_RELEASEPATH}/${archive_name}" -s ",^\.,${base_name}," $@
   else
-    tar -czf "${OS_LOCAL_RELEASEPATH}/${archive_name}" --transform="s,^\.,${base_name}," $@
+    tar -czf --xattrs-exclude='LIBARCHIVE.xattr.security.selinux' "${OS_LOCAL_RELEASEPATH}/${archive_name}" --transform="s,^\.,${base_name}," $@
   fi
   popd &>/dev/null
 }


### PR DESCRIPTION
When we are creating release tarballs we not only create them for
systems with SELinux but also for ones that do not use it or cannot
use it (like OSX). We don't gain anything by adding the SELinux
extended attributes to the tarball, so we should ignore them.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]
doesn't seem like `bsdtar` exposes this as an option ...