### PR TITLE
Fix service IP validation to handle "ClusterIP: None"

### DIFF
--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -155,7 +155,8 @@ func (master *OsdnMaster) validateNetworkConfig() error {
 		return err
 	}
 	for _, svc := range services.Items {
-		if !ni.ServiceNetwork.Contains(net.ParseIP(svc.Spec.ClusterIP)) {
+		svcIP := net.ParseIP(svc.Spec.ClusterIP)
+		if svcIP != nil && !ni.ServiceNetwork.Contains(svcIP) {
 			errList = append(errList, fmt.Errorf("existing service with IP: %s is not part of service network: %s", svc.Spec.ClusterIP, ni.ServiceNetwork.String()))
 		}
 	}


### PR DESCRIPTION
The SDN master's validateNetworkConfig() (which runs any time the default ClusterNetwork object is about to be changed) doesn't handle services with "ClusterIP: None". So, if you have such a service, and then, say, you try to switch from the multitenant plugin to the networkpolicy plugin, the master won't start.

I have a pending PR to clean up the master startup validation code a bunch, and not die on errors that don't really need to be fatal, but for backporting purposes, let's stick with a simple change for now

@openshift/networking @rajatchopra PTAL