### PR TITLE
sdn: fix initialization order to prevent crash on node startup

### DIFF
--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -120,6 +120,7 @@ func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient *kclien
 		osClient:           osClient,
 		ovs:                ovsif,
 		localIP:            selfIP,
+		podManager:         newPodManager(kClient, policy, mtu, ovsif),
 		hostName:           hostname,
 		podNetworkReady:    make(chan struct{}),
 		kubeletInitReady:   make(chan struct{}),
@@ -201,14 +202,16 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("Failed to get network information: %v", err)
 	}
 
-	nodeIPTables := newNodeIPTables(node.networkInfo.ClusterNetwork.String(), node.iptablesSyncPeriod)
-	if err = nodeIPTables.Setup(); err != nil {
-		return fmt.Errorf("Failed to set up iptables: %v", err)
-	}
-
 	node.localSubnetCIDR, err = node.getLocalSubnet()
 	if err != nil {
 		return err
+	}
+
+	//**** After this point, all OsdnNode fields except node.host have been initialized
+
+	nodeIPTables := newNodeIPTables(node.networkInfo.ClusterNetwork.String(), node.iptablesSyncPeriod)
+	if err = nodeIPTables.Setup(); err != nil {
+		return fmt.Errorf("Failed to set up iptables: %v", err)
 	}
 
 	networkChanged, err := node.SetupSDN()
@@ -238,12 +241,8 @@ func (node *OsdnNode) Start() error {
 			return true, nil
 		})
 
-	log.V(5).Infof("Creating and initializing openshift-sdn pod manager")
-	node.podManager, err = newPodManager(node.host, node.localSubnetCIDR, node.networkInfo, node.kClient, node.policy, node.mtu, node.ovs)
-	if err != nil {
-		return err
-	}
-	if err := node.podManager.Start(cniserver.CNIServerSocketPath); err != nil {
+	log.V(5).Infof("Starting openshift-sdn pod manager")
+	if err := node.podManager.Start(cniserver.CNIServerSocketPath, node.host, node.localSubnetCIDR, node.networkInfo.ClusterNetwork); err != nil {
 		return err
 	}
 

--- a/pkg/sdn/plugin/pod_test.go
+++ b/pkg/sdn/plugin/pod_test.go
@@ -368,9 +368,10 @@ func TestPodManager(t *testing.T) {
 
 	for k, tc := range testcases {
 		podTester := newPodTester(t, k, socketPath)
-		podManager := newDefaultPodManager(newFakeHost())
+		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
-		podManager.Start(socketPath)
+		_, net, _ := net.ParseCIDR("1.2.0.0/16")
+		podManager.Start(socketPath, newFakeHost(), "1.2.3.0/24", net)
 
 		// Add pods to our expected pod list before kicking off the
 		// actual pod setup to ensure we don't concurrently access
@@ -463,9 +464,10 @@ func TestDirectPodUpdate(t *testing.T) {
 	socketPath := filepath.Join(tmpDir, "cni-server.sock")
 
 	podTester := newPodTester(t, "update", socketPath)
-	podManager := newDefaultPodManager(newFakeHost())
+	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
-	podManager.Start(socketPath)
+	_, net, _ := net.ParseCIDR("1.2.0.0/16")
+	podManager.Start(socketPath, newFakeHost(), "1.2.3.0/24", net)
 
 	op := &operation{
 		command:   cniserver.CNI_UPDATE,


### PR DESCRIPTION
OsdnNode.Start()
   (node.pm == nil at this point)
   -> node.policy.Start()  (which is multitenant policy)
   -> mp.vnids.Start()
   -> go vmap.watchNetNamespaces()
   -> (net namespace event happens)
   -> watchNetNamespaces()
   -> vmap.policy.AddNetNamespace() (policy is multitenant)
   -> mp.updatePodNetwork()
   -> mp.node.podManager.UpdateLocalMulticastRules() (and podManager is still nil)

Create the PodManager earlier so it's not nil if we get early events.

Fixes: https://github.com/openshift/origin/issues/13742
(cherry picked from commit fc95b866ef474c7363ae78373035d12ee1ed1a5b)

@openshift/networking @smarterclayton