### PR TITLE
sdn: fix single-node-cluster local multicast delivery

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -319,7 +319,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 
 	// Table 111: multicast delivery from local pods to the VXLAN; only one rule, updated by updateVXLANMulticastRules() in subnets.go
 	// eg, "table=111, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:${remote_node_ip_1}->tun_dst,output:1,set_field:${remote_node_ip_2}->tun_dst,output:1,goto_table:120"
-	otx.AddFlow("table=111, priority=0, actions=drop")
+	otx.AddFlow("table=111, priority=100, actions=goto_table:120")
 
 	// Table 120: multicast delivery to local pods (either from VXLAN or local pods); updated by updateLocalMulticastFlows() in pod.go
 	// eg, "table=120, priority=100, reg0=${tenant_id}, actions=output:${ovs_port_1},output:${ovs_port_2}"


### PR DESCRIPTION
Backports the relevant fix in:
be3c8416 ("Move multicast flow logic into ovsController, and fix a bug")

@openshift/networking @danwinship @smarterclayton 