### PR TITLE
Add debugging to the stacktrace dump

### DIFF
--- a/hack/lib/log/stacktrace.sh
+++ b/hack/lib/log/stacktrace.sh
@@ -54,6 +54,12 @@ function os::log::stacktrace::print() {
         return 0
     fi
 
+    # dump the entire stack for debugging purposes
+    os::log::debug "$( os::util::repository_relative_path "${BASH_SOURCE[0]}:${LINENO}: ${BASH_COMMAND}" )"
+    for (( i = 0; i < ${#BASH_LINENO[@]}; i++ )); do
+        os::log::debug "$( os::util::repository_relative_path "${BASH_SOURCE[$i+1]:-"$( os::util::repository_relative_path "$0" )"}" ):${BASH_LINENO[$i]}: ${FUNCNAME[$i]}"
+    done
+
     # iterate backwards through the stack until we leave library files, so we can be sure we start logging
     # actual script code and not this handler's call
     local stack_begin_index


### PR DESCRIPTION
We are seeing weird behavior with the stacktrace dump when it fires
during the execution of a trap. This debug message will hopefully give
us the information we need to fix the implementation to work in that
situation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test][merge]