### PR TITLE
Prefer legacy kinds

### DIFF
--- a/pkg/authorization/api/install/apigroup.go
+++ b/pkg/authorization/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/authorization/api/install/install.go
+++ b/pkg/authorization/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/build/api/install/apigroup.go
+++ b/pkg/build/api/install/apigroup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/origin/pkg/build/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/build/api/install/install.go
+++ b/pkg/build/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/deploy/api/install/apigroup.go
+++ b/pkg/deploy/api/install/apigroup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/origin/pkg/deploy/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/deploy/api/install/install.go
+++ b/pkg/deploy/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/image/api/install/apigroup.go
+++ b/pkg/image/api/install/apigroup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/origin/pkg/image/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName: api.GroupName,

--- a/pkg/image/api/install/install.go
+++ b/pkg/image/api/install/install.go
@@ -47,6 +47,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/oauth/api/install/apigroup.go
+++ b/pkg/oauth/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/oauth/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/oauth/api/install/install.go
+++ b/pkg/oauth/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/project/api/install/apigroup.go
+++ b/pkg/project/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/project/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/project/api/install/install.go
+++ b/pkg/project/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/quota/api/install/apigroup.go
+++ b/pkg/quota/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/quota/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/quota/api/install/install.go
+++ b/pkg/quota/api/install/install.go
@@ -45,6 +45,8 @@ func init() {
 		glog.V(4).Infof("%v", err)
 		return
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/route/api/install/apigroup.go
+++ b/pkg/route/api/install/apigroup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/origin/pkg/route/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/route/api/install/install.go
+++ b/pkg/route/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/sdn/api/install/apigroup.go
+++ b/pkg/sdn/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/sdn/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/sdn/api/install/install.go
+++ b/pkg/sdn/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/security/api/install/apigroup.go
+++ b/pkg/security/api/install/apigroup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/origin/pkg/security/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/security/api/install/install.go
+++ b/pkg/security/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/template/api/install/apigroup.go
+++ b/pkg/template/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/template/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/template/api/install/install.go
+++ b/pkg/template/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/pkg/user/api/install/apigroup.go
+++ b/pkg/user/api/install/apigroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/user/api/v1"
 )
 
-func init() {
+func installApiGroup() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  api.GroupName,

--- a/pkg/user/api/install/install.go
+++ b/pkg/user/api/install/install.go
@@ -43,6 +43,8 @@ func init() {
 	if err := enableVersions(externalVersions); err != nil {
 		panic(err)
 	}
+
+	installApiGroup()
 }
 
 // TODO: enableVersions should be centralized rather than spread in each API

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -80,8 +80,8 @@ os::cmd::expect_success 'oc new-app -f test/testdata/template-with-namespaces.js
 os::cmd::expect_success 'oc delete all -l app=ruby-helloworld-sample'
 
 # ensure non-duplicate invalid label errors show up
-os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'error: ImageStream.image.openshift.io "nginx" is invalid'
-os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'DeploymentConfig.apps.openshift.io "nginx" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'error: ImageStream "nginx" is invalid'
+os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'DeploymentConfig "nginx" is invalid'
 os::cmd::expect_failure_and_text 'oc new-app nginx -l qwer1345%$$#=self' 'Service "nginx" is invalid'
 
 # check if we can create from a stored template


### PR DESCRIPTION
We need to prefer legacy kinds so that calls to ObjectKinds(obj)
and resource.Mapper.InfoForObject() (used by oc run and oc expose)
return the legacy kinds for backwards compatibility against servers that
don't have the new api groups.

Fixes bug 1441755
https://bugzilla.redhat.com/show_bug.cgi?id=1441755