### PR TITLE
Increase max request size for HAProxy to be comparable to cloud LBs

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -17,6 +17,11 @@ global
   stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
   stats timeout 2m
 
+  # Increase the default request size to be comparable to modern cloud load balancers (ALB: 64kb), affects
+  # total memory use when large numbers of connections are open.
+  tune.maxrewrite 8192
+  tune.bufsize 32768
+
   # Prevent vulnerability to POODLE attacks
   # TODO: use when 1.5.14 is available
   # ssl-default-bind-options no-sslv3


### PR DESCRIPTION
Real world applications have larger request headers and URLs than the
HAProxy default of 8kb. Double the total buffer size and reserve more
for the request buffer.  This brings the default ootb router closer to
existing cloud LBs which have bigger buffer sizes.

This will increase peak memory use of highly contended servers, but is
more realistic than breaking normal applications.