### PR TITLE
Remove shadowed variable checks from vetting script

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -34,50 +34,6 @@ for test_dir in ${test_dirs}; do
 	fi
 done
 
-# For the sake of slowly white-listing `shadow` checks, we need to keep track of which
-# directories we're searching through. The following are all of the directories we care about:
-# all top-level directories except for 'pkg', and all second-level subdirectories of 'pkg'.
-ALL_DIRS=$(find_files | grep -Eo "\./([^/]+|pkg/[^/]+)" | sort -u)
-
-DIR_BLACKLIST='./hack
-./pkg/api
-./pkg/authorization
-./pkg/bootstrap/run
-./pkg/build
-./pkg/client
-./pkg/cmd
-./pkg/deploy
-./pkg/diagnostics
-./pkg/dockerregistry
-./pkg/generate
-./pkg/gitserver
-./pkg/image
-./pkg/oauth
-./pkg/project
-./pkg/quota
-./pkg/router
-./pkg/sdn
-./pkg/security
-./pkg/serviceaccounts
-./pkg/template
-./pkg/user
-./pkg/util
-./test
-./third_party
-./tools'
-
-for test_dir in $ALL_DIRS
-do
-  # use `grep` failure to determine that a directory is not in the blacklist
-  if ! echo "${DIR_BLACKLIST}" | grep -q "${test_dir}"; then
-	go tool vet -shadow -shadowstrict $test_dir
-	if [ "$?" -ne "0" ]
-	then
-	  FAILURE=true
-	fi
-  fi
-done
-
 # We don't want to exit on the first failure of go vet, so just keep track of
 # whether a failure occurred or not.
 if [[ -n "${FAILURE:-}" ]]; then


### PR DESCRIPTION
Shadowed variable detection for the `go tool vet` tooling remains in
experimental state and development does not seem to be active on the
tool. Furthermore, no active work has been undertaken to remove the
existing shadowing in this codebase. The check is mostly useless,
therefore, and just iterates over the blacklist every time and flakes
once in a while. It therefore provides negative value and should simply
be removed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test][merge] 
/cc @smarterclayton @eparis 