### PR TITLE
deploy: add cancel condition reason and move reasons to types

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -439,6 +439,36 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
+type DeploymentConditionReason string
+
+const (
+	// ReplicationControllerUpdatedReason is added in a deployment config when one of its replication
+	// controllers is updated as part of the rollout process.
+	ReplicationControllerUpdatedReason DeploymentConditionReason = "ReplicationControllerUpdated"
+	// FailedRcCreateReason is added in a deployment config when it cannot create a new replication
+	// controller.
+	FailedRcCreateReason DeploymentConditionReason = "ReplicationControllerCreateError"
+	// NewReplicationControllerReason is added in a deployment config when it creates a new replication
+	// controller.
+	NewReplicationControllerReason DeploymentConditionReason = "NewReplicationControllerCreated"
+	// NewRcAvailableReason is added in a deployment config when its newest replication controller is made
+	// available ie. the number of new pods that have passed readiness checks and run for at least
+	// minReadySeconds is at least the minimum available pods that need to run for the deployment config.
+	NewRcAvailableReason DeploymentConditionReason = "NewReplicationControllerAvailable"
+	// TimedOutReason is added in a deployment config when its newest replication controller fails to show
+	// any progress within the given deadline (progressDeadlineSeconds).
+	TimedOutReason DeploymentConditionReason = "ProgressDeadlineExceeded"
+	// PausedConfigReason is added in a deployment config when it is paused. Lack of progress shouldn't be
+	// estimated once a deployment config is paused.
+	PausedConfigReason DeploymentConditionReason = "DeploymentConfigPaused"
+	// ResumedConfigReason is added in a deployment config when it is resumed. Useful for not failing accidentally
+	// deployment configs that paused amidst a rollout.
+	ResumedConfigReason DeploymentConditionReason = "DeploymentConfigResumed"
+	// CancelledRolloutReason is added in a deployment config when its newest rollout was
+	// interrupted by cancellation.
+	CancelledRolloutReason DeploymentConditionReason = "RolloutCancelled"
+)
+
 // DeploymentCondition describes the state of a deployment config at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
@@ -450,7 +480,7 @@ type DeploymentCondition struct {
 	// The last time the condition transitioned from one status to another.
 	LastTransitionTime unversioned.Time
 	// The reason for the condition's last transition.
-	Reason string
+	Reason DeploymentConditionReason
 	// A human readable message indicating details about the transition.
 	Message string
 }

--- a/pkg/deploy/api/v1/zz_generated.conversion.go
+++ b/pkg/deploy/api/v1/zz_generated.conversion.go
@@ -174,7 +174,7 @@ func autoConvert_v1_DeploymentCondition_To_api_DeploymentCondition(in *Deploymen
 	out.Status = pkg_api.ConditionStatus(in.Status)
 	out.LastUpdateTime = in.LastUpdateTime
 	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
+	out.Reason = api.DeploymentConditionReason(in.Reason)
 	out.Message = in.Message
 	return nil
 }
@@ -188,7 +188,7 @@ func autoConvert_api_DeploymentCondition_To_v1_DeploymentCondition(in *api.Deplo
 	out.Status = api_v1.ConditionStatus(in.Status)
 	out.LastUpdateTime = in.LastUpdateTime
 	out.LastTransitionTime = in.LastTransitionTime
-	out.Reason = in.Reason
+	out.Reason = string(in.Reason)
 	out.Message = in.Message
 	return nil
 }

--- a/pkg/deploy/cmd/status.go
+++ b/pkg/deploy/cmd/status.go
@@ -49,16 +49,16 @@ func (s *DeploymentConfigStatusViewer) Status(namespace, name string, desiredRev
 
 	if config.Generation <= config.Status.ObservedGeneration {
 		switch {
-		case cond != nil && cond.Reason == deployutil.NewRcAvailableReason:
+		case cond != nil && cond.Reason == deployapi.NewRcAvailableReason:
 			return fmt.Sprintf("%s\n", cond.Message), true, nil
 
-		case cond != nil && cond.Reason == deployutil.TimedOutReason:
+		case cond != nil && cond.Reason == deployapi.TimedOutReason:
 			return "", true, errors.New(cond.Message)
 
-		case cond != nil && cond.Reason == deployutil.CancelledRolloutReason:
+		case cond != nil && cond.Reason == deployapi.CancelledRolloutReason:
 			return "", true, errors.New(cond.Message)
 
-		case cond != nil && cond.Reason == deployutil.PausedConfigReason:
+		case cond != nil && cond.Reason == deployapi.PausedConfigReason:
 			return "", true, fmt.Errorf("Deployment config %q is paused. Resume to continue watching the status of the rollout.\n", config.Name)
 
 		case config.Status.UpdatedReplicas < config.Spec.Replicas:

--- a/pkg/deploy/cmd/status.go
+++ b/pkg/deploy/cmd/status.go
@@ -55,7 +55,10 @@ func (s *DeploymentConfigStatusViewer) Status(namespace, name string, desiredRev
 		case cond != nil && cond.Reason == deployutil.TimedOutReason:
 			return "", true, errors.New(cond.Message)
 
-		case cond != nil && cond.Reason == deployutil.PausedDeployReason:
+		case cond != nil && cond.Reason == deployutil.CancelledRolloutReason:
+			return "", true, errors.New(cond.Message)
+
+		case cond != nil && cond.Reason == deployutil.PausedConfigReason:
 			return "", true, fmt.Errorf("Deployment config %q is paused. Resume to continue watching the status of the rollout.\n", config.Name)
 
 		case config.Status.UpdatedReplicas < config.Spec.Replicas:

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -189,7 +189,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		}
 		c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCreationFailed", "Couldn't deploy version %d: %s", config.Status.LatestVersion, err)
 		// We don't care about this error since we need to report the create failure.
-		cond := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.FailedRcCreateReason, err.Error())
+		cond := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployapi.FailedRcCreateReason, err.Error())
 		_ = c.updateStatus(config, existingDeployments, *cond)
 		return fmt.Errorf("couldn't create deployment for deployment config %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
@@ -203,7 +203,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		c.recorder.Eventf(config, kapi.EventTypeWarning, "DeploymentCleanupFailed", "Couldn't clean up deployments: %v", err)
 	}
 
-	cond := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployutil.NewReplicationControllerReason, msg)
+	cond := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployapi.NewReplicationControllerReason, msg)
 	return c.updateStatus(config, existingDeployments, *cond)
 }
 
@@ -366,7 +366,7 @@ func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.De
 			if deployutil.IsProgressing(config, *newStatus) {
 				deployutil.RemoveDeploymentCondition(newStatus, deployapi.DeploymentProgressing)
 				msg := fmt.Sprintf("replication controller %q is progressing", latestRC.Name)
-				condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployutil.ReplicationControllerUpdatedReason, msg)
+				condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployapi.ReplicationControllerUpdatedReason, msg)
 				// TODO: Right now, we use lastTransitionTime for storing the last time we had any progress instead
 				// of the last time the condition transitioned to a new status. We should probably change that.
 				deployutil.SetDeploymentCondition(newStatus, *condition)
@@ -375,15 +375,15 @@ func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.De
 			var condition *deployapi.DeploymentCondition
 			if deployutil.IsDeploymentCancelled(latestRC) {
 				msg := fmt.Sprintf("rollout of replication controller %q was cancelled", latestRC.Name)
-				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.CancelledRolloutReason, msg)
+				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployapi.CancelledRolloutReason, msg)
 			} else {
 				msg := fmt.Sprintf("replication controller %q has failed progressing", latestRC.Name)
-				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.TimedOutReason, msg)
+				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployapi.TimedOutReason, msg)
 			}
 			deployutil.SetDeploymentCondition(newStatus, *condition)
 		case deployapi.DeploymentStatusComplete:
 			msg := fmt.Sprintf("replication controller %q successfully rolled out", latestRC.Name)
-			condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployutil.NewRcAvailableReason, msg)
+			condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployapi.NewRcAvailableReason, msg)
 			deployutil.SetDeploymentCondition(newStatus, *condition)
 		}
 	}

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -372,8 +372,14 @@ func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.De
 				deployutil.SetDeploymentCondition(newStatus, *condition)
 			}
 		case deployapi.DeploymentStatusFailed:
-			msg := fmt.Sprintf("replication controller %q has failed progressing", latestRC.Name)
-			condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.TimedOutReason, msg)
+			var condition *deployapi.DeploymentCondition
+			if deployutil.IsDeploymentCancelled(latestRC) {
+				msg := fmt.Sprintf("rollout of replication controller %q was cancelled", latestRC.Name)
+				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.CancelledRolloutReason, msg)
+			} else {
+				msg := fmt.Sprintf("replication controller %q has failed progressing", latestRC.Name)
+				condition = deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionFalse, deployutil.TimedOutReason, msg)
+			}
 			deployutil.SetDeploymentCondition(newStatus, *condition)
 		case deployapi.DeploymentStatusComplete:
 			msg := fmt.Sprintf("replication controller %q successfully rolled out", latestRC.Name)

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -21,38 +21,8 @@ import (
 	"github.com/openshift/origin/pkg/util/namer"
 )
 
-const (
-	// Reasons for deployment config conditions:
-	//
-	// ReplicationControllerUpdatedReason is added in a deployment config when one of its replication
-	// controllers is updated as part of the rollout process.
-	ReplicationControllerUpdatedReason = "ReplicationControllerUpdated"
-	// FailedRcCreateReason is added in a deployment config when it cannot create a new replication
-	// controller.
-	FailedRcCreateReason = "ReplicationControllerCreateError"
-	// NewReplicationControllerReason is added in a deployment config when it creates a new replication
-	// controller.
-	NewReplicationControllerReason = "NewReplicationControllerCreated"
-	// NewRcAvailableReason is added in a deployment config when its newest replication controller is made
-	// available ie. the number of new pods that have passed readiness checks and run for at least
-	// minReadySeconds is at least the minimum available pods that need to run for the deployment config.
-	NewRcAvailableReason = "NewReplicationControllerAvailable"
-	// TimedOutReason is added in a deployment config when its newest replication controller fails to show
-	// any progress within the given deadline (progressDeadlineSeconds).
-	TimedOutReason = "ProgressDeadlineExceeded"
-	// PausedConfigReason is added in a deployment config when it is paused. Lack of progress shouldn't be
-	// estimated once a deployment config is paused.
-	PausedConfigReason = "DeploymentConfigPaused"
-	// ResumedConfigReason is added in a deployment config when it is resumed. Useful for not failing accidentally
-	// deployment configs that paused amidst a rollout.
-	ResumedConfigReason = "DeploymentConfigResumed"
-	// CancelledRolloutReason is added in a deployment config when its newest rollout was
-	// interrupted by cancellation.
-	CancelledRolloutReason = "RolloutCancelled"
-)
-
 // NewDeploymentCondition creates a new deployment condition.
-func NewDeploymentCondition(condType deployapi.DeploymentConditionType, status api.ConditionStatus, reason, message string) *deployapi.DeploymentCondition {
+func NewDeploymentCondition(condType deployapi.DeploymentConditionType, status api.ConditionStatus, reason deployapi.DeploymentConditionReason, message string) *deployapi.DeploymentCondition {
 	return &deployapi.DeploymentCondition{
 		Type:               condType,
 		Status:             status,

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -40,12 +40,15 @@ const (
 	// TimedOutReason is added in a deployment config when its newest replication controller fails to show
 	// any progress within the given deadline (progressDeadlineSeconds).
 	TimedOutReason = "ProgressDeadlineExceeded"
-	// PausedDeployReason is added in a deployment config when it is paused. Lack of progress shouldn't be
+	// PausedConfigReason is added in a deployment config when it is paused. Lack of progress shouldn't be
 	// estimated once a deployment config is paused.
-	PausedDeployReason = "DeploymentConfigPaused"
-	// ResumedDeployReason is added in a deployment config when it is resumed. Useful for not failing accidentally
+	PausedConfigReason = "DeploymentConfigPaused"
+	// ResumedConfigReason is added in a deployment config when it is resumed. Useful for not failing accidentally
 	// deployment configs that paused amidst a rollout.
-	ResumedDeployReason = "DeploymentConfigResumed"
+	ResumedConfigReason = "DeploymentConfigResumed"
+	// CancelledRolloutReason is added in a deployment config when its newest rollout was
+	// interrupted by cancellation.
+	CancelledRolloutReason = "RolloutCancelled"
 )
 
 // NewDeploymentCondition creates a new deployment condition.

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -363,7 +363,6 @@ var (
 			Type:               deployapi.DeploymentProgressing,
 			Status:             kapi.ConditionTrue,
 			LastTransitionTime: now,
-			Reason:             "ForSomeReason",
 		}
 	}
 
@@ -372,7 +371,6 @@ var (
 			Type:               deployapi.DeploymentProgressing,
 			Status:             kapi.ConditionTrue,
 			LastTransitionTime: later,
-			Reason:             "ForSomeReason",
 		}
 	}
 
@@ -381,7 +379,7 @@ var (
 			Type:               deployapi.DeploymentProgressing,
 			Status:             kapi.ConditionTrue,
 			LastTransitionTime: later,
-			Reason:             "BecauseItIs",
+			Reason:             deployapi.NewReplicationControllerReason,
 		}
 	}
 
@@ -391,7 +389,6 @@ var (
 			Status:             kapi.ConditionFalse,
 			LastUpdateTime:     earlier,
 			LastTransitionTime: earlier,
-			Reason:             "NotYet",
 		}
 	}
 
@@ -399,7 +396,6 @@ var (
 		return deployapi.DeploymentCondition{
 			Type:   deployapi.DeploymentAvailable,
 			Status: kapi.ConditionTrue,
-			Reason: "AwesomeController",
 		}
 	}
 )
@@ -417,7 +413,6 @@ func TestGetCondition(t *testing.T) {
 		status     deployapi.DeploymentConfigStatus
 		condType   deployapi.DeploymentConditionType
 		condStatus kapi.ConditionStatus
-		condReason string
 
 		expected bool
 	}{
@@ -515,7 +510,7 @@ func TestSetCondition(t *testing.T) {
 						// Note that LastTransitionTime stays the same.
 						LastTransitionTime: now,
 						// Only the reason changes.
-						Reason: "BecauseItIs",
+						Reason: deployapi.NewReplicationControllerReason,
 					},
 				},
 			},

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -889,7 +889,7 @@ var _ = g.Describe("deploymentconfigs", func() {
 				}
 				conditions = dc.Status.Conditions
 				cond := deployutil.GetDeploymentCondition(dc.Status, deployapi.DeploymentProgressing)
-				return cond != nil && cond.Reason == deployutil.NewReplicationControllerReason, nil
+				return cond != nil && cond.Reason == deployapi.NewReplicationControllerReason, nil
 			})
 			if err == wait.ErrWaitTimeout {
 				err = fmt.Errorf("deployment config %q never updated its conditions: %#v", name, conditions)

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -177,7 +177,7 @@ func deploymentReachedCompletion(dc *deployapi.DeploymentConfig, rcs []*kapi.Rep
 		return false, nil
 	}
 	cond := deployutil.GetDeploymentCondition(dc.Status, deployapi.DeploymentProgressing)
-	if cond == nil || cond.Reason != deployutil.NewRcAvailableReason {
+	if cond == nil || cond.Reason != deployapi.NewRcAvailableReason {
 		return false, nil
 	}
 	expectedReplicas := dc.Spec.Replicas
@@ -208,7 +208,7 @@ func deploymentFailed(dc *deployapi.DeploymentConfig, rcs []*kapi.ReplicationCon
 		return false, nil
 	}
 	cond := deployutil.GetDeploymentCondition(dc.Status, deployapi.DeploymentProgressing)
-	return cond != nil && cond.Reason == deployutil.TimedOutReason, nil
+	return cond != nil && cond.Reason == deployapi.TimedOutReason, nil
 }
 
 func deploymentRunning(dc *deployapi.DeploymentConfig, rcs []*kapi.ReplicationController, pods []kapi.Pod) (bool, error) {


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/13800

First commit introduces `RolloutCancelled` for rollouts that has been cancelled (and thus failed their progression) instead of having the `ProgressDeadlineExceeded` reason there.

Second commit moves the reasons from utils to types as they are not meant to be changed since changing them might violate the API backward compatibility.

@kargakis @openshift/api-review 