### PR TITLE
backward compatibility for old EgressNetworkPolicy bug

### DIFF
--- a/pkg/sdn/plugin/ovscontroller.go
+++ b/pkg/sdn/plugin/ovscontroller.go
@@ -335,6 +335,9 @@ func (oc *ovsController) UpdateEgressNetworkPolicyRules(policies []osapi.EgressN
 				var dst string
 				if selector == "0.0.0.0/0" {
 					dst = ""
+				} else if selector == "0.0.0.0/32" {
+					glog.Warningf("Correcting CIDRSelector '0.0.0.0/32' to '0.0.0.0/0' in EgressNetworkPolicy %s:%s", policies[0].Namespace, policies[0].Name)
+					dst = ""
 				} else {
 					dst = fmt.Sprintf(", nw_dst=%s", selector)
 				}

--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -470,7 +470,8 @@ var enp2 = osapi.EgressNetworkPolicy{
 			{
 				Type: osapi.EgressNetworkPolicyRuleDeny,
 				To: osapi.EgressNetworkPolicyPeer{
-					CIDRSelector: "0.0.0.0/0",
+					// "/32" is wrong but accepted for backward-compatibility
+					CIDRSelector: "0.0.0.0/32",
 				},
 			},
 		},
@@ -512,7 +513,7 @@ func assertENPFlowAdditions(origFlows, newFlows []string, additions ...enpFlowAd
 				fmt.Sprintf("reg0=%d", addition.vnid),
 				fmt.Sprintf("priority=%d", len(addition.policy.Spec.Egress)-i),
 			}
-			if rule.To.CIDRSelector == "0.0.0.0/0" {
+			if rule.To.CIDRSelector == "0.0.0.0/0" || rule.To.CIDRSelector == "0.0.0.0/32" {
 				change.noMatch = []string{"nw_dst"}
 			} else {
 				change.match = append(change.match, fmt.Sprintf("nw_dst=%s", rule.To.CIDRSelector))

--- a/pkg/sdn/plugin/proxy.go
+++ b/pkg/sdn/plugin/proxy.go
@@ -151,7 +151,12 @@ func (proxy *OsdnProxy) updateEgressNetworkPolicy(policy osapi.EgressNetworkPoli
 	dnsFound := false
 	for _, rule := range policy.Spec.Egress {
 		if len(rule.To.CIDRSelector) > 0 {
-			_, cidr, err := net.ParseCIDR(rule.To.CIDRSelector)
+			selector := rule.To.CIDRSelector
+			if selector == "0.0.0.0/32" {
+				// ovscontroller.go already logs a warning about this
+				selector = "0.0.0.0/0"
+			}
+			_, cidr, err := net.ParseCIDR(selector)
 			if err != nil {
 				// should have been caught by validation
 				glog.Errorf("illegal CIDR value %q in EgressNetworkPolicy rule for policy: %v", rule.To.CIDRSelector, policy.UID)


### PR DESCRIPTION
In addition to backporting https://github.com/openshift/origin/pull/11673 to OCP 3.3, we should also add backward compatibility for old buggy EgressNetworkPolicies to later releases so people don't get an unannounced behavior change when they upgrade. Here's the fix for master, which I'll cherry-pick to older releases once it's in.

In theory, this could be messing up people who actually did want to match against "0.0.0.0/32" in their EgressNetworkPolicies, but there's really no reason you'd want to do that, so...

@openshift/networking PTAL