### PR TITLE
Show SCC provider in error message

### DIFF
--- a/pkg/security/scc/matcher.go
+++ b/pkg/security/scc/matcher.go
@@ -75,7 +75,7 @@ func AssignSecurityContext(provider kscc.SecurityContextConstraintsProvider, pod
 
 	psc, generatedAnnotations, err := provider.CreatePodSecurityContext(pod)
 	if err != nil {
-		errs = append(errs, field.Invalid(field.NewPath("spec", "securityContext"), pod.Spec.SecurityContext, err.Error()))
+		errs = append(errs, field.Invalid(fldPath.Child("spec", "securityContext"), pod.Spec.SecurityContext, err.Error()))
 	}
 
 	// save the original PSC and validate the generated PSC.  Leave the generated PSC
@@ -86,11 +86,11 @@ func AssignSecurityContext(provider kscc.SecurityContextConstraintsProvider, pod
 
 	pod.Spec.SecurityContext = psc
 	pod.Annotations = generatedAnnotations
-	errs = append(errs, provider.ValidatePodSecurityContext(pod, field.NewPath("spec", "securityContext"))...)
+	errs = append(errs, provider.ValidatePodSecurityContext(pod, fldPath.Child("spec", "securityContext"))...)
 
 	// Note: this is not changing the original container, we will set container SCs later so long
 	// as all containers validated under the same SCC.
-	containerPath := field.NewPath("spec", "initContainers")
+	containerPath := fldPath.Child("spec", "initContainers")
 	for i, containerCopy := range pod.Spec.InitContainers {
 		csc, resolutionErrs := resolveContainerSecurityContext(provider, pod, &containerCopy, containerPath.Index(i))
 		errs = append(errs, resolutionErrs...)
@@ -104,7 +104,7 @@ func AssignSecurityContext(provider kscc.SecurityContextConstraintsProvider, pod
 
 	// Note: this is not changing the original container, we will set container SCs later so long
 	// as all containers validated under the same SCC.
-	containerPath = field.NewPath("spec", "containers")
+	containerPath = fldPath.Child("spec", "containers")
 	for i, containerCopy := range pod.Spec.Containers {
 		csc, resolutionErrs := resolveContainerSecurityContext(provider, pod, &containerCopy, containerPath.Index(i))
 		errs = append(errs, resolutionErrs...)


### PR DESCRIPTION
Let's use parameter `fldPath` in the `AssignSecurityContext` function. In this case provider name is included in the error message that is super helpful during debug.

Before:
> admission.go:125] unable to validate pod  (generate: es-master-2387585559-) against any security context constraint: [spec.initContainers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed capabilities.add: Invalid value: "IPC_LOCK": capability may not be added capabilities.add: Invalid value: "SYS_RESOURCE": capability may not be added]

After
> admission.go:125] unable to validate pod  (generate: es-master-2387585559-) against any security context constraint: [**provider restricted:** .spec.initContainers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed capabilities.add: Invalid value: "IPC_LOCK": capability may not be added capabilities.add: Invalid value: "SYS_RESOURCE": capability may not be added]

This message is also including in the `FailedCreate` event. The message still hard to read but now it contains helpful information.

PTAL @pweil- 