### PR TITLE
UPSTREAM: <carry>: Fix to avoid REST API calls at log level 2.

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/log.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/log.go
@@ -158,7 +158,7 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 // Log is intended to be called once at the end of your request handler, via defer
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
-	if glog.V(2) {
+	if glog.V(3) {
 		if !rl.hijacked {
 			glog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v%v%v [%s %s]", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo, rl.req.Header["User-Agent"], rl.req.RemoteAddr))
 		} else {


### PR DESCRIPTION
@derekwaynecarr @eparis 

Fix https://bugzilla.redhat.com/show_bug.cgi?id=1414813