### PR TITLE
Fix NATting of external traffic with ovs-networkpolicy

### DIFF
--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -23,6 +23,11 @@ import (
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
+const (
+	// randomly-selected conntrack zone ID; FIXME, make this configurable
+	networkPolicyConntrackZone = 13877
+)
+
 type networkPolicyPlugin struct {
 	node  *OsdnNode
 	vnids *nodeVNIDMap
@@ -75,8 +80,8 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 
 	otx := node.oc.NewTransaction()
 	otx.AddFlow("table=21, priority=200, ip, nw_dst=%s, actions=goto_table:30", np.node.networkInfo.ServiceNetwork.String())
-	otx.AddFlow("table=21, priority=100, ip, actions=ct(commit,table=30)")
-	otx.AddFlow("table=80, priority=50, ip, actions=ct(commit,table=81)")
+	otx.AddFlow("table=21, priority=100, ip, actions=ct(zone=%d,commit,table=30)", networkPolicyConntrackZone)
+	otx.AddFlow("table=80, priority=50, ip, actions=ct(zone=%d,commit,table=81)", networkPolicyConntrackZone)
 	otx.AddFlow("table=81, priority=100, ip, ct_state=+trk+est, actions=output:NXM_NX_REG2[]")
 	otx.AddFlow("table=81, priority=0, actions=drop")
 	if err := otx.EndTransaction(); err != nil {


### PR DESCRIPTION
Traffic to external sites with ovs-networkpolicy was broken because calling `ct(commit)` for our own purposes blocked iptables from acting on the packets, so they wouldn't get NATted.

(This is part of the same breakage that caused #12837, but this part of the bug was never caught because we didn't put "external connectivity" in the acceptance criteria so it wasn't part of the QE tests. And we don't test ovs-networkpolicy at all in jenkins because of #13049.)

This patch just assumes that ct zone "1" is unused. Maybe we should use a randomer number? Making it configurable seems like overkill...

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1443765

@openshift/networking PTAL