### PR TITLE
Allow route spec.host to be controlled by permission

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -355,6 +355,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(quotaGroup, legacyQuotaGroup).Resources("appliedclusterresourcequotas").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(routeGroup, legacyRouteGroup).Resources("routes").RuleOrDie(),
+				// admins can create routes with custom hosts
+				authorizationapi.NewRule("create").Groups(routeGroup, legacyRouteGroup).Resources("routes/custom-host").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(routeGroup, legacyRouteGroup).Resources("routes/status").RuleOrDie(),
 				// an admin can run routers that write back conditions to the route
 				authorizationapi.NewRule("update").Groups(routeGroup, legacyRouteGroup).Resources("routes/status").RuleOrDie(),
@@ -413,6 +415,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(quotaGroup, legacyQuotaGroup).Resources("appliedclusterresourcequotas").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(routeGroup, legacyRouteGroup).Resources("routes").RuleOrDie(),
+				// editors can create routes with custom hosts
+				authorizationapi.NewRule("create").Groups(routeGroup, legacyRouteGroup).Resources("routes/custom-host").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(routeGroup, legacyRouteGroup).Resources("routes/status").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -631,11 +631,6 @@ func (c *MasterConfig) GetRestStorage() map[schema.GroupVersion]map[string]rest.
 	checkStorageErr(err)
 	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage)
 
-	routeAllocator := c.RouteAllocator()
-
-	routeStorage, routeStatusStorage, err := routeetcd.NewREST(c.RESTOptionsGetter, routeAllocator)
-	checkStorageErr(err)
-
 	hostSubnetStorage, err := hostsubnetetcd.NewREST(c.RESTOptionsGetter)
 	checkStorageErr(err)
 	netNamespaceStorage, err := netnamespaceetcd.NewREST(c.RESTOptionsGetter)
@@ -720,6 +715,10 @@ func (c *MasterConfig) GetRestStorage() map[schema.GroupVersion]map[string]rest.
 	imageStreamImportStorage := imagestreamimport.NewREST(importerFn, imageStreamRegistry, internalImageStreamStorage, imageStorage, c.ImageStreamImportSecretClient(), importTransport, insecureImportTransport, importerDockerClientFn, c.Options.ImagePolicyConfig.AllowedRegistriesForImport, c.RegistryNameFn, c.ImageStreamImportSARClient().SubjectAccessReviews())
 	imageStreamImageStorage := imagestreamimage.NewREST(imageRegistry, imageStreamRegistry)
 	imageStreamImageRegistry := imagestreamimage.NewRegistry(imageStreamImageStorage)
+
+	routeAllocator := c.RouteAllocator()
+	routeStorage, routeStatusStorage, err := routeetcd.NewREST(c.RESTOptionsGetter, routeAllocator, subjectAccessReviewRegistry)
+	checkStorageErr(err)
 
 	buildGenerator := &buildgenerator.BuildGenerator{
 		Client: buildgenerator.Client{

--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -11,7 +11,6 @@ import (
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api/validation"
-	kval "k8s.io/kubernetes/pkg/api/validation"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -21,7 +20,7 @@ import (
 // ValidateRoute tests if required fields in the route are set.
 func ValidateRoute(route *routeapi.Route) field.ErrorList {
 	//ensure meta is set properly
-	result := kval.ValidateObjectMeta(&route.ObjectMeta, true, oapi.GetNameValidationFunc(kval.ValidatePodName), field.NewPath("metadata"))
+	result := validation.ValidateObjectMeta(&route.ObjectMeta, true, oapi.GetNameValidationFunc(validation.ValidatePodName), field.NewPath("metadata"))
 
 	specPath := field.NewPath("spec")
 
@@ -94,7 +93,6 @@ func ValidateRoute(route *routeapi.Route) field.ErrorList {
 
 func ValidateRouteUpdate(route *routeapi.Route, older *routeapi.Route) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&route.ObjectMeta, &older.ObjectMeta, field.NewPath("metadata"))
-	allErrs = append(allErrs, validation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(route.Spec.WildcardPolicy, older.Spec.WildcardPolicy, field.NewPath("spec", "wildcardPolicy"))...)
 	allErrs = append(allErrs, ValidateRoute(route)...)
 	return allErrs

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -1113,7 +1113,7 @@ func TestValidateRouteUpdate(t *testing.T) {
 				},
 			},
 			change:         func(route *api.Route) { route.Spec.Host = "" },
-			expectedErrors: 1,
+			expectedErrors: 0, // now controlled by rbac
 		},
 		{
 			route: &api.Route{
@@ -1131,7 +1131,7 @@ func TestValidateRouteUpdate(t *testing.T) {
 				},
 			},
 			change:         func(route *api.Route) { route.Spec.Host = "other" },
-			expectedErrors: 1,
+			expectedErrors: 0, // now controlled by rbac
 		},
 		{
 			route: &api.Route{

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -20,8 +20,8 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against routes.
-func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator) (*REST, *StatusREST, error) {
-	strategy := rest.NewStrategy(allocator)
+func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarClient rest.SubjectAccessReviewInterface) (*REST, *StatusREST, error) {
+	strategy := rest.NewStrategy(allocator, sarClient)
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,

--- a/pkg/route/registry/route/strategy.go
+++ b/pkg/route/registry/route/strategy.go
@@ -3,17 +3,17 @@ package route
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kvalidation "k8s.io/kubernetes/pkg/api/validation"
 
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/route"
 	"github.com/openshift/origin/pkg/route/api"
 	"github.com/openshift/origin/pkg/route/api/validation"
@@ -22,19 +22,26 @@ import (
 // HostGeneratedAnnotationKey is the key for an annotation set to "true" if the route's host was generated
 const HostGeneratedAnnotationKey = "openshift.io/host.generated"
 
+// Registry is an interface for performing subject access reviews
+type SubjectAccessReviewInterface interface {
+	CreateSubjectAccessReview(ctx apirequest.Context, subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
+}
+
 type routeStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 	route.RouteAllocator
+	sarClient SubjectAccessReviewInterface
 }
 
 // NewStrategy initializes the default logic that applies when creating and updating
 // Route objects via the REST API.
-func NewStrategy(allocator route.RouteAllocator) routeStrategy {
+func NewStrategy(allocator route.RouteAllocator, sarClient SubjectAccessReviewInterface) routeStrategy {
 	return routeStrategy{
-		kapi.Scheme,
-		names.SimpleNameGenerator,
-		allocator,
+		ObjectTyper:    kapi.Scheme,
+		NameGenerator:  names.SimpleNameGenerator,
+		RouteAllocator: allocator,
+		sarClient:      sarClient,
 	}
 }
 
@@ -45,11 +52,6 @@ func (routeStrategy) NamespaceScoped() bool {
 func (s routeStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 	route := obj.(*api.Route)
 	route.Status = api.RouteStatus{}
-	err := s.allocateHost(route)
-	if err != nil {
-		// TODO: this will be changed when moved to a controller
-		utilruntime.HandleError(errors.NewInternalError(fmt.Errorf("allocation error: %v for route: %#v", err, obj)))
-	}
 }
 
 func (s routeStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
@@ -67,7 +69,36 @@ func (s routeStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime
 // allocateHost allocates a host name ONLY if the route doesn't specify a subdomain wildcard policy and
 // the host name on the route is empty and an allocator is configured.
 // It must first allocate the shard and may return an error if shard allocation fails.
-func (s routeStrategy) allocateHost(route *api.Route) error {
+func (s routeStrategy) allocateHost(ctx apirequest.Context, route *api.Route) field.ErrorList {
+	hostSet := len(route.Spec.Host) > 0
+	certSet := route.Spec.TLS != nil && (len(route.Spec.TLS.CACertificate) > 0 || len(route.Spec.TLS.Certificate) > 0 || len(route.Spec.TLS.DestinationCACertificate) > 0 || len(route.Spec.TLS.Key) > 0)
+	if hostSet || certSet {
+		user, ok := apirequest.UserFrom(ctx)
+		if !ok {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be set"))}
+		}
+		res, err := s.sarClient.CreateSubjectAccessReview(
+			ctx,
+			&authorizationapi.SubjectAccessReview{
+				User: user.GetName(),
+				Action: authorizationapi.Action{
+					Verb:     "create",
+					Group:    api.GroupName,
+					Resource: "routes/custom-host",
+				},
+			},
+		)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+		}
+		if !res.Allowed {
+			if hostSet {
+				return field.ErrorList{field.Forbidden(field.NewPath("spec", "host"), "you do not have permission to set the host field of the route")}
+			}
+			return field.ErrorList{field.Forbidden(field.NewPath("spec", "tls"), "you do not have permission to set certificate fields on the route")}
+		}
+	}
+
 	if route.Spec.WildcardPolicy == api.WildcardPolicySubdomain {
 		// Don't allocate a host if subdomain wildcard policy.
 		return nil
@@ -77,7 +108,7 @@ func (s routeStrategy) allocateHost(route *api.Route) error {
 		// TODO: this does not belong here, and should be removed
 		shard, err := s.RouteAllocator.AllocateRouterShard(route)
 		if err != nil {
-			return errors.NewInternalError(fmt.Errorf("allocation error: %v for route: %#v", err, route))
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("allocation error: %v for route: %#v", err, route))}
 		}
 		route.Spec.Host = s.RouteAllocator.GenerateHostname(route, shard)
 		if route.Annotations == nil {
@@ -88,9 +119,11 @@ func (s routeStrategy) allocateHost(route *api.Route) error {
 	return nil
 }
 
-func (routeStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
+func (s routeStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
 	route := obj.(*api.Route)
-	return validation.ValidateRoute(route)
+	errs := s.allocateHost(ctx, route)
+	errs = append(errs, validation.ValidateRoute(route)...)
+	return errs
 }
 
 func (routeStrategy) AllowCreateOnUpdate() bool {
@@ -101,10 +134,64 @@ func (routeStrategy) AllowCreateOnUpdate() bool {
 func (routeStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (routeStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
+func (s routeStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
 	oldRoute := old.(*api.Route)
 	objRoute := obj.(*api.Route)
-	return validation.ValidateRouteUpdate(objRoute, oldRoute)
+	errs := s.validateHostUpdate(ctx, objRoute, oldRoute)
+	errs = append(errs, validation.ValidateRouteUpdate(objRoute, oldRoute)...)
+	return errs
+}
+
+func certificateChanged(route, older *api.Route) bool {
+	switch {
+	case route.Spec.TLS != nil && older.Spec.TLS != nil:
+		a, b := route.Spec.TLS, older.Spec.TLS
+		return a.CACertificate != b.CACertificate ||
+			a.Certificate != b.Certificate ||
+			a.DestinationCACertificate != b.DestinationCACertificate ||
+			a.Key != b.Key
+	case route.Spec.TLS == nil && older.Spec.TLS == nil:
+		return false
+	default:
+		return true
+	}
+}
+
+func (s routeStrategy) validateHostUpdate(ctx apirequest.Context, route, older *api.Route) field.ErrorList {
+	hostChanged := route.Spec.Host != older.Spec.Host
+	certChanged := certificateChanged(route, older)
+	if !hostChanged && !certChanged {
+		return nil
+	}
+	user, ok := apirequest.UserFrom(ctx)
+	if !ok {
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be changed"))}
+	}
+	res, err := s.sarClient.CreateSubjectAccessReview(
+		ctx,
+		&authorizationapi.SubjectAccessReview{
+			User: user.GetName(),
+			Action: authorizationapi.Action{
+				Verb:     "update",
+				Group:    "route.openshift.io",
+				Resource: "routes/custom-host",
+			},
+		},
+	)
+	if err != nil {
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+	}
+	if !res.Allowed {
+		if hostChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		errs := kvalidation.ValidateImmutableField(route.Spec.TLS.CACertificate, older.Spec.TLS.CACertificate, field.NewPath("spec", "tls", "caCertificate"))
+		errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Certificate, older.Spec.TLS.Certificate, field.NewPath("spec", "tls", "certificate"))...)
+		errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.DestinationCACertificate, older.Spec.TLS.DestinationCACertificate, field.NewPath("spec", "tls", "destinationCACertificate"))...)
+		errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Key, older.Spec.TLS.Key, field.NewPath("spec", "tls", "key"))...)
+		return errs
+	}
+	return nil
 }
 
 func (routeStrategy) AllowUnconditionalUpdate() bool {
@@ -115,7 +202,7 @@ type routeStatusStrategy struct {
 	routeStrategy
 }
 
-var StatusStrategy = routeStatusStrategy{NewStrategy(nil)}
+var StatusStrategy = routeStatusStrategy{NewStrategy(nil, nil)}
 
 func (routeStatusStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
 	newRoute := obj.(*api.Route)

--- a/pkg/route/registry/route/strategy_test.go
+++ b/pkg/route/registry/route/strategy_test.go
@@ -3,11 +3,15 @@ package route
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/route/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/route/api"
 )
 
 type testAllocator struct {
@@ -20,12 +24,23 @@ func (t testAllocator) GenerateHostname(*api.Route, *api.RouterShard) string {
 	return "mygeneratedhost.com"
 }
 
+type testSAR struct {
+	allow bool
+	err   error
+	sar   *authorizationapi.SubjectAccessReview
+}
+
+func (t *testSAR) CreateSubjectAccessReview(ctx apirequest.Context, subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+	t.sar = subjectAccessReview
+	return &authorizationapi.SubjectAccessReviewResponse{Allowed: t.allow}, t.err
+}
+
 func TestEmptyHostDefaulting(t *testing.T) {
 	ctx := apirequest.NewContext()
-	strategy := NewStrategy(testAllocator{})
+	strategy := NewStrategy(testAllocator{}, &testSAR{allow: true})
 
 	hostlessCreatedRoute := &api.Route{}
-	strategy.PrepareForCreate(ctx, hostlessCreatedRoute)
+	strategy.Validate(ctx, hostlessCreatedRoute)
 	if hostlessCreatedRoute.Spec.Host != "mygeneratedhost.com" {
 		t.Fatalf("Expected host to be allocated, got %s", hostlessCreatedRoute.Spec.Host)
 	}
@@ -52,48 +67,231 @@ func TestEmptyHostDefaulting(t *testing.T) {
 
 func TestHostWithWildcardPolicies(t *testing.T) {
 	ctx := apirequest.NewContext()
-	strategy := NewStrategy(testAllocator{})
+	ctx = apirequest.WithUser(ctx, &user.DefaultInfo{Name: "bob"})
 
 	tests := []struct {
 		name           string
-		host           string
+		host, oldHost  string
 		wildcardPolicy api.WildcardPolicyType
+		tls, oldTLS    *api.TLSConfig
 		expected       string
+		errs           int
+		allow          bool
 	}{
 		{
-			name:     "nohostemptypolicy",
+			name:     "no-host-empty-policy",
 			expected: "mygeneratedhost.com",
+			allow:    true,
 		},
 		{
-			name:           "nohostnopolicy",
+			name:           "no-host-nopolicy",
 			wildcardPolicy: api.WildcardPolicyNone,
 			expected:       "mygeneratedhost.com",
+			allow:          true,
 		},
 		{
-			name:           "nohostwildcardsubdomain",
+			name:           "no-host-wildcard-subdomain",
 			wildcardPolicy: api.WildcardPolicySubdomain,
 			expected:       "",
+			allow:          true,
+			errs:           1,
 		},
 		{
-			name:     "hostemptypolicy",
+			name:     "host-empty-policy",
 			host:     "empty.policy.test",
 			expected: "empty.policy.test",
+			allow:    true,
 		},
 		{
-			name:           "hostnopolicy",
+			name:           "host-no-policy",
 			host:           "no.policy.test",
 			wildcardPolicy: api.WildcardPolicyNone,
 			expected:       "no.policy.test",
+			allow:          true,
 		},
 		{
-			name:           "hostwildcardsubdomain",
+			name:           "host-wildcard-subdomain",
 			host:           "wildcard.policy.test",
 			wildcardPolicy: api.WildcardPolicySubdomain,
 			expected:       "wildcard.policy.test",
+			allow:          true,
+		},
+		{
+			name:           "custom-host-permission-denied",
+			host:           "another.test",
+			expected:       "another.test",
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-destination",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-cert",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-ca-cert",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-key",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "no-host-but-allowed",
+			expected:       "mygeneratedhost.com",
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+		},
+		{
+			name:           "update-changed-host-denied",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "update-changed-host-allowed",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          true,
+			errs:           0,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "b"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "b"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "destination-ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "destination-ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "b"},
+			wildcardPolicy: api.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
 		},
 	}
 
 	for _, tc := range tests {
+		sar := &testSAR{allow: tc.allow}
+		strategy := NewStrategy(testAllocator{}, sar)
+
 		route := &api.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:       "wildcard",
@@ -104,12 +302,44 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			Spec: api.RouteSpec{
 				Host:           tc.host,
 				WildcardPolicy: tc.wildcardPolicy,
+				TLS:            tc.tls,
+				To: api.RouteTargetReference{
+					Name: "test",
+					Kind: "Service",
+				},
 			},
 		}
 
-		strategy.PrepareForCreate(ctx, route)
+		var errs field.ErrorList
+		if len(tc.oldHost) > 0 {
+			oldRoute := &api.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "wildcard",
+					Name:            tc.name,
+					UID:             types.UID("wild"),
+					ResourceVersion: "1",
+				},
+				Spec: api.RouteSpec{
+					Host:           tc.oldHost,
+					WildcardPolicy: tc.wildcardPolicy,
+					TLS:            tc.oldTLS,
+					To: api.RouteTargetReference{
+						Name: "test",
+						Kind: "Service",
+					},
+				},
+			}
+			errs = strategy.ValidateUpdate(ctx, route, oldRoute)
+		} else {
+			errs = strategy.Validate(ctx, route)
+		}
+
 		if route.Spec.Host != tc.expected {
-			t.Fatalf("test case %s expected host %s, got %s", tc.name, tc.expected, route.Spec.Host)
+			t.Errorf("test case %s expected host %s, got %s", tc.name, tc.expected, route.Spec.Host)
+			continue
+		}
+		if len(errs) != tc.errs {
+			t.Errorf("test case %s unexpected errors: %v %#v", tc.name, errs, sar)
 		}
 	}
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -940,6 +940,14 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - routes/custom-host
+    verbs:
+    - create
+  - apiGroups:
+    - route.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
     - routes/status
     verbs:
     - get
@@ -1317,6 +1325,14 @@ items:
     - patch
     - update
     - watch
+  - apiGroups:
+    - route.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes/custom-host
+    verbs:
+    - create
   - apiGroups:
     - route.openshift.io
     - ""


### PR DESCRIPTION
A new virtual resource `routes/custom-host` controls whether spec.host can be set a user

* `create` is required to set a spec.host on creation
* `update` is required to change spec.host at any subsequent change

Project admins and editors by default get `create`. Only cluster admin has `update` by default.

API compatibility is preserved for the error message returned by immutable fields.