### PR TITLE
Set version tags for client-go

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -730,6 +730,10 @@ function os::build::ldflags() {
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/kubernetes/pkg/version.gitVersion" "${KUBE_GIT_VERSION}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/kubernetes/pkg/version.buildDate" "${buildDate}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/kubernetes/pkg/version.gitTreeState" "clean"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.gitCommit" "${KUBE_GIT_COMMIT}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.gitVersion" "${KUBE_GIT_VERSION}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.buildDate" "${buildDate}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.gitTreeState" "clean"))
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -46,29 +46,28 @@ os::cmd::expect_success_and_not_text "curl -k '${API_SCHEME}://${API_HOST}:${API
 # 3. oadm (kube and openshift resources)
 # 4  openshift cli (kube and openshift resources)
 
-# TODO restore this test.  We somehow broke the user agent, but we can merge without it
-# # example User-Agent: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# os::cmd::expect_success_and_text 'oc get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "oc/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# os::cmd::expect_success_and_text 'oc get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "oc/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# # this is probably broken and should be `kubectl/<kube version> kubernetes/...`
-# os::cmd::expect_success_and_text 'openshift kubectl get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# # this is probably broken and should be `kubectl/<kube version> kubernetes/...`
-# os::cmd::expect_success_and_text 'openshift kubectl get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# # this is probably broken and should be `oadm/<oc version>... openshift/...`
-# os::cmd::expect_success_and_text 'oadm policy reconcile-sccs --loglevel=7  2>&1 | grep -A4 "securitycontextconstraints" | grep User-Agent' "oadm/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: oadm/v1.1.3 (linux/amd64) openshift/b348c2f
-# # TODO: figure out why this is reporting openshift and not kubernetes
-# os::cmd::expect_success_and_text 'oadm policy who-can get pods --loglevel=7  2>&1 | grep -A4 "localresourceaccessreviews" | grep User-Agent' "oadm/${os_git_regex} .* openshift/"
-# # example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# # this is probably broken and should be `oc/<oc version>... kubernetes/...`
-# os::cmd::expect_success_and_text 'openshift cli get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
-# # example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
-# os::cmd::expect_success_and_text 'openshift cli get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
-# echo "version reporting: ok"
+# example User-Agent: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d
+os::cmd::expect_success_and_text 'oc get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "oc/${kube_git_regex} .* kubernetes/"
+# example User-Agent: oc/v1.2.0 (linux/amd64) kubernetes/bc4550d
+os::cmd::expect_success_and_text 'oc get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "oc/${kube_git_regex} .* kubernetes/"
+# example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+# this is probably broken and should be `kubectl/<kube version> kubernetes/...`
+os::cmd::expect_success_and_text 'openshift kubectl get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
+# example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+# this is probably broken and should be `kubectl/<kube version> kubernetes/...`
+os::cmd::expect_success_and_text 'openshift kubectl get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
+# example User-Agent: oadm/v1.2.0 (linux/amd64) kubernetes/bc4550d
+# this is probably broken and should be `oadm/<oc version>... openshift/...`
+os::cmd::expect_success_and_text 'oadm policy reconcile-sccs --loglevel=7  2>&1 | grep -A4 "securitycontextconstraints" | grep User-Agent' "oadm/${kube_git_regex} .* kubernetes/"
+# example User-Agent: oadm/v1.1.3 (linux/amd64) openshift/b348c2f
+# TODO: figure out why this is reporting openshift and not kubernetes
+os::cmd::expect_success_and_text 'oadm policy who-can get pods --loglevel=7  2>&1 | grep -A4 "localresourceaccessreviews" | grep User-Agent' "oadm/${os_git_regex} .* openshift/"
+# example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+# this is probably broken and should be `oc/<oc version>... kubernetes/...`
+os::cmd::expect_success_and_text 'openshift cli get pods --loglevel=7  2>&1 | grep -A4 "pods" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
+# example User-Agent: openshift/v1.2.0 (linux/amd64) kubernetes/bc4550d
+os::cmd::expect_success_and_text 'openshift cli get dc --loglevel=7  2>&1 | grep -A4 "deploymentconfig" | grep User-Agent' "openshift/${kube_git_regex} .* kubernetes/"
+echo "version reporting: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/basicresources/status"


### PR DESCRIPTION
Fixes `User-Agent: oc/v1.6.1+$Format:%h$ (darwin/amd64) kubernetes/$Format` headers to build in the right git commit.

follow up from #13653 