### PR TITLE
GSSAPI test: wait longer for config change

### DIFF
--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -113,7 +113,7 @@ function update_auth_proxy_config() {
     spec+='{.items[0].status.conditions[?(@.type=="Ready")].status}'
 
     os::cmd::expect_success "oc set env dc/gssapiproxy-server SERVER='${server_config}'"
-    os::cmd::try_until_text "oc get pods -l deploymentconfig=gssapiproxy-server -o jsonpath='${spec}'" "^${server_config}_True$"
+    os::cmd::try_until_text "oc get pods -l deploymentconfig=gssapiproxy-server -o jsonpath='${spec}'" "^${server_config}_True$" $(( 10 * minute ))
 }
 
 function run_gssapi_tests() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2429,6 +2429,9 @@ for file in /etc/krb5.conf /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/
   sed -i.bak2 -e "s/example\.com/${HOST}/g" $file
 done
 
+# Temporary hack to get around hairpin issue
+sed -i.bak3 -e "s/kdc = ${HOST}/kdc = localhost/g" /etc/krb5.conf
+
 # Create ticket database
 kdb5_util create -s -r "${REALM}" -P password
 

--- a/test/extended/testdata/gssapi/proxy/configure.sh
+++ b/test/extended/testdata/gssapi/proxy/configure.sh
@@ -15,6 +15,9 @@ for file in /etc/krb5.conf /var/kerberos/krb5kdc/kdc.conf /var/kerberos/krb5kdc/
   sed -i.bak2 -e "s/example\.com/${HOST}/g" $file
 done
 
+# Temporary hack to get around hairpin issue
+sed -i.bak3 -e "s/kdc = ${HOST}/kdc = localhost/g" /etc/krb5.conf
+
 # Create ticket database
 kdb5_util create -s -r "${REALM}" -P password
 


### PR DESCRIPTION
This may just be timing out because the rebase made things slower:

```
SUCCESS after 59.068s: test/extended/gssapi.sh:116: executing 'oc get pods -l deploymentconfig=gssapiproxy-server -o jsonpath='{.items[0].spec.containers[0].env[?(@.name=="SERVER")].value}_{.items[0].status.conditions[?(@.type=="Ready")].status}'' expecting any result and text '^SERVER_GSSAPI_BASIC_FALLBACK_True$'; re-trying every 0.2s until completion or 60.000s
```

[testextended][extended:gssapi]

Signed-off-by: Monis Khan <mkhan@redhat.com>