### PR TITLE
Reorganize ClusterNetwork creating/updating/validating

### DIFF
--- a/pkg/sdn/api/validation/validation.go
+++ b/pkg/sdn/api/validation/validation.go
@@ -21,9 +21,11 @@ func ValidateClusterNetwork(clusterNet *sdnapi.ClusterNetwork) field.ErrorList {
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("network"), clusterNet.Network, err.Error()))
 	} else {
-		ones, bitSize := clusterIPNet.Mask.Size()
-		if uint32(bitSize-ones) <= clusterNet.HostSubnetLength {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "subnet length is greater than cluster Mask"))
+		maskLen, addrLen := clusterIPNet.Mask.Size()
+		if clusterNet.HostSubnetLength > uint32(addrLen-maskLen) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "subnet length is too large for clusterNetwork"))
+		} else if clusterNet.HostSubnetLength < 2 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "subnet length must be at least 2"))
 		}
 	}
 

--- a/pkg/sdn/api/validation/validation.go
+++ b/pkg/sdn/api/validation/validation.go
@@ -13,7 +13,14 @@ import (
 	"github.com/openshift/origin/pkg/util/netutils"
 )
 
-// ValidateClusterNetwork tests if required fields in the ClusterNetwork are set.
+var defaultClusterNetwork *sdnapi.ClusterNetwork
+
+// SetDefaultClusterNetwork sets the expected value of the default ClusterNetwork record
+func SetDefaultClusterNetwork(cn sdnapi.ClusterNetwork) {
+	defaultClusterNetwork = &cn
+}
+
+// ValidateClusterNetwork tests if required fields in the ClusterNetwork are set, and ensures that the "default" ClusterNetwork can only be set to the correct values
 func ValidateClusterNetwork(clusterNet *sdnapi.ClusterNetwork) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&clusterNet.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
 
@@ -41,47 +48,27 @@ func ValidateClusterNetwork(clusterNet *sdnapi.ClusterNetwork) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("network"), clusterNet.Network, "cluster network overlaps with service network"))
 	}
 
-	return allErrs
-}
+	if clusterNet.Name == sdnapi.ClusterNetworkDefault && defaultClusterNetwork != nil {
+		if clusterNet.Network != defaultClusterNetwork.Network {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("network"), clusterNet.Network, "cannot change the default ClusterNetwork record via API."))
+		}
+		if clusterNet.HostSubnetLength != defaultClusterNetwork.HostSubnetLength {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "cannot change the default ClusterNetwork record via API."))
+		}
+		if clusterNet.ServiceNetwork != defaultClusterNetwork.ServiceNetwork {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("serviceNetwork"), clusterNet.ServiceNetwork, "cannot change the default ClusterNetwork record via API."))
+		}
+		if clusterNet.PluginName != defaultClusterNetwork.PluginName {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("pluginName"), clusterNet.PluginName, "cannot change the default ClusterNetwork record via API."))
+		}
+	}
 
-func validateNewNetwork(obj *sdnapi.ClusterNetwork, old *sdnapi.ClusterNetwork) *field.Error {
-	oldNet, err := netutils.ParseCIDRMask(old.Network)
-	if err != nil {
-		// Shouldn't happen, but if the existing value is invalid, then any change should be an improvement...
-		return nil
-	}
-	oldSize, _ := oldNet.Mask.Size()
-	newNet, err := netutils.ParseCIDRMask(obj.Network)
-	if err != nil {
-		return field.Invalid(field.NewPath("network"), obj.Network, err.Error())
-	}
-	newSize, _ := newNet.Mask.Size()
-	// oldSize/newSize is, eg the "16" in "10.1.0.0/16", so "newSize < oldSize" means
-	// the new network is larger
-	if newSize < oldSize && newNet.Contains(oldNet.IP) {
-		return nil
-	} else {
-		return field.Invalid(field.NewPath("network"), obj.Network, "cannot change the cluster's network CIDR to a value that does not include the existing network.")
-	}
+	return allErrs
 }
 
 func ValidateClusterNetworkUpdate(obj *sdnapi.ClusterNetwork, old *sdnapi.ClusterNetwork) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClusterNetwork(obj)...)
-
-	if obj.Network != old.Network {
-		err := validateNewNetwork(obj, old)
-		if err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
-	if obj.HostSubnetLength != old.HostSubnetLength {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), obj.HostSubnetLength, "cannot change the cluster's hostSubnetLength midflight."))
-	}
-	if obj.ServiceNetwork != old.ServiceNetwork && old.ServiceNetwork != "" {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("serviceNetwork"), obj.ServiceNetwork, "cannot change the cluster's serviceNetwork CIDR midflight."))
-	}
-
 	return allErrs
 }
 

--- a/pkg/sdn/api/validation/validation_test.go
+++ b/pkg/sdn/api/validation/validation_test.go
@@ -47,11 +47,21 @@ func TestValidateClusterNetwork(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
-			name: "Invalid subnet length",
+			name: "Subnet length too large for network",
 			cn: &api.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.30.0/24",
 				HostSubnetLength: 16,
+				ServiceNetwork:   "172.30.0.0/16",
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Subnet length too small",
+			cn: &api.ClusterNetwork{
+				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
+				Network:          "10.20.30.0/24",
+				HostSubnetLength: 1,
 				ServiceNetwork:   "172.30.0.0/16",
 			},
 			expectedErrors: 1,

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -109,6 +109,47 @@ func (ni *NetworkInfo) checkHostNetworks(hostIPNets []*net.IPNet) error {
 	return kerrors.NewAggregate(errList)
 }
 
+func (ni *NetworkInfo) checkClusterObjects(subnets []osapi.HostSubnet, pods []kapi.Pod, services []kapi.Service) error {
+	var errList []error
+
+	for _, subnet := range subnets {
+		subnetIP, _, _ := net.ParseCIDR(subnet.Subnet)
+		if subnetIP == nil {
+			errList = append(errList, fmt.Errorf("failed to parse network address: %s", subnet.Subnet))
+		} else if !ni.ClusterNetwork.Contains(subnetIP) {
+			errList = append(errList, fmt.Errorf("existing node subnet: %s is not part of cluster network: %s", subnet.Subnet, ni.ClusterNetwork.String()))
+		}
+		if len(errList) >= 10 {
+			break
+		}
+	}
+	for _, pod := range pods {
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
+			continue
+		}
+		if pod.Status.PodIP != "" && !ni.ClusterNetwork.Contains(net.ParseIP(pod.Status.PodIP)) {
+			errList = append(errList, fmt.Errorf("existing pod %s:%s with IP %s is not part of cluster network %s", pod.Namespace, pod.Name, pod.Status.PodIP, ni.ClusterNetwork.String()))
+			if len(errList) >= 10 {
+				break
+			}
+		}
+	}
+	for _, svc := range services {
+		svcIP := net.ParseIP(svc.Spec.ClusterIP)
+		if svcIP != nil && !ni.ServiceNetwork.Contains(svcIP) {
+			errList = append(errList, fmt.Errorf("existing service %s:%s with IP %s is not part of service network %s", svc.Namespace, svc.Name, svc.Spec.ClusterIP, ni.ServiceNetwork.String()))
+			if len(errList) >= 10 {
+				break
+			}
+		}
+	}
+
+	if len(errList) >= 10 {
+		errList = append(errList, fmt.Errorf("too many errors... truncating"))
+	}
+	return kerrors.NewAggregate(errList)
+}
+
 func getNetworkInfo(osClient *osclient.Client) (*NetworkInfo, error) {
 	cn, err := osClient.ClusterNetwork().Get(osapi.ClusterNetworkDefault, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/sdn/plugin/common_test.go
+++ b/pkg/sdn/plugin/common_test.go
@@ -2,7 +2,13 @@ package plugin
 
 import (
 	"net"
+	"strings"
 	"testing"
+
+	osapi "github.com/openshift/origin/pkg/sdn/api"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 func mustParseCIDR(cidr string) *net.IPNet {
@@ -75,6 +81,101 @@ func Test_checkHostNetworks(t *testing.T) {
 		} else {
 			if err != nil {
 				t.Fatalf("unexpected error checking %q: %v", test.name, err)
+			}
+		}
+	}
+}
+
+func dummySubnet(hostip string, subnet string) osapi.HostSubnet {
+	return osapi.HostSubnet{HostIP: hostip, Subnet: subnet}
+}
+
+func dummyService(ip string) kapi.Service {
+	return kapi.Service{Spec: kapi.ServiceSpec{ClusterIP: ip}}
+}
+
+func dummyPod(ip string) kapi.Pod {
+	return kapi.Pod{Status: kapi.PodStatus{PodIP: ip}}
+}
+
+func Test_checkClusterObjects(t *testing.T) {
+	subnets := []osapi.HostSubnet{
+		dummySubnet("192.168.1.2", "10.128.0.0/23"),
+		dummySubnet("192.168.1.3", "10.129.0.0/23"),
+		dummySubnet("192.168.1.4", "10.130.0.0/23"),
+	}
+	pods := []kapi.Pod{
+		dummyPod("10.128.0.2"),
+		dummyPod("10.128.0.4"),
+		dummyPod("10.128.0.6"),
+		dummyPod("10.128.0.8"),
+		dummyPod("10.129.0.3"),
+		dummyPod("10.129.0.5"),
+		dummyPod("10.129.0.7"),
+		dummyPod("10.129.0.9"),
+		dummyPod("10.130.0.10"),
+	}
+	services := []kapi.Service{
+		dummyService("172.30.0.1"),
+		dummyService("172.30.0.128"),
+		dummyService("172.30.99.99"),
+		dummyService("None"),
+	}
+
+	tests := []struct {
+		name string
+		ni   *NetworkInfo
+		errs []string
+	}{
+		{
+			name: "valid",
+			ni: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/14"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+			},
+			errs: []string{},
+		},
+		{
+			name: "Subnet 10.130.0.0/23 and Pod 10.130.0.10 outside of ClusterNetwork",
+			ni: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/15"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+			},
+			errs: []string{"10.130.0.0/23", "10.130.0.10"},
+		},
+		{
+			name: "Service 172.30.99.99 outside of ServiceNetwork",
+			ni: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/14"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/24"),
+			},
+			errs: []string{"172.30.99.99"},
+		},
+		{
+			name: "Too-many-error truncation",
+			ni: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("1.2.3.0/24"),
+				ServiceNetwork: mustParseCIDR("4.5.6.0/24"),
+			},
+			errs: []string{"10.128.0.0/23", "10.129.0.0/23", "10.130.0.0/23", "10.128.0.2", "10.128.0.4", "10.128.0.6", "10.128.0.8", "10.129.0.3", "10.129.0.5", "10.129.0.7", "172.30.0.1", "too many errors"},
+		},
+	}
+
+	for _, test := range tests {
+		err := test.ni.checkClusterObjects(subnets, pods, services)
+		if err == nil {
+			if len(test.errs) > 0 {
+				t.Fatalf("test %q unexpectedly did not get an error", test.name)
+			}
+			continue
+		}
+		errs := err.(kerrors.Aggregate).Errors()
+		if len(errs) != len(test.errs) {
+			t.Fatalf("test %q expected %d errors, got %v", test.name, len(test.errs), err)
+		}
+		for i, match := range test.errs {
+			if !strings.Contains(errs[i].Error(), match) {
+				t.Fatalf("test %q: error %d did not match %q: %v", test.name, i, match, errs[i])
 			}
 		}
 	}

--- a/pkg/sdn/plugin/common_test.go
+++ b/pkg/sdn/plugin/common_test.go
@@ -1,0 +1,81 @@
+package plugin
+
+import (
+	"net"
+	"testing"
+)
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic("bad CIDR string constant " + cidr)
+	}
+	return net
+}
+
+func Test_checkHostNetworks(t *testing.T) {
+	hostIPNets := []*net.IPNet{
+		mustParseCIDR("10.0.0.0/9"),
+		mustParseCIDR("172.20.0.0/16"),
+	}
+
+	tests := []struct {
+		name        string
+		networkInfo *NetworkInfo
+		expectError bool
+	}{
+		{
+			name: "valid",
+			networkInfo: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/14"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+			},
+			expectError: false,
+		},
+		{
+			name: "hostIPNet inside ClusterNetwork",
+			networkInfo: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.0.0.0/8"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+			},
+			expectError: true,
+		},
+		{
+			name: "ClusterNetwork inside hostIPNet",
+			networkInfo: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.1.0.0/16"),
+				ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+			},
+			expectError: true,
+		},
+		{
+			name: "hostIPNet inside ServiceNetwork",
+			networkInfo: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/14"),
+				ServiceNetwork: mustParseCIDR("172.0.0.0/8"),
+			},
+			expectError: true,
+		},
+		{
+			name: "ServiceNetwork inside hostIPNet",
+			networkInfo: &NetworkInfo{
+				ClusterNetwork: mustParseCIDR("10.128.0.0/14"),
+				ServiceNetwork: mustParseCIDR("172.20.30.0/8"),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		err := test.networkInfo.checkHostNetworks(hostIPNets)
+		if test.expectError {
+			if err == nil {
+				t.Fatalf("unexpected lack of error checking %q", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("unexpected error checking %q: %v", test.name, err)
+			}
+		}
+	}
+}

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -1,14 +1,19 @@
 package plugin
 
 import (
+	"fmt"
+	"net"
+
 	log "github.com/golang/glog"
 
 	osclient "github.com/openshift/origin/pkg/client"
 	osconfigapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/controller/shared"
 	osapi "github.com/openshift/origin/pkg/sdn/api"
+	osapivalidation "github.com/openshift/origin/pkg/sdn/api/validation"
 	"github.com/openshift/origin/pkg/util/netutils"
 
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -47,48 +52,49 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 		return err
 	}
 
-	createConfig := false
-	updateConfig := false
-	cn, err := master.osClient.ClusterNetwork().Get(osapi.ClusterNetworkDefault, metav1.GetOptions{})
-	if err == nil {
-		if master.networkInfo.ClusterNetwork.String() != cn.Network ||
-			networkConfig.HostSubnetLength != cn.HostSubnetLength ||
-			master.networkInfo.ServiceNetwork.String() != cn.ServiceNetwork ||
-			networkConfig.NetworkPluginName != cn.PluginName {
-			updateConfig = true
-		}
-	} else {
-		cn = &osapi.ClusterNetwork{
-			TypeMeta:   metav1.TypeMeta{Kind: "ClusterNetwork"},
-			ObjectMeta: metav1.ObjectMeta{Name: osapi.ClusterNetworkDefault},
-		}
-		createConfig = true
+	configCN := &osapi.ClusterNetwork{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterNetwork"},
+		ObjectMeta: metav1.ObjectMeta{Name: osapi.ClusterNetworkDefault},
+
+		Network:          networkConfig.ClusterNetworkCIDR,
+		HostSubnetLength: networkConfig.HostSubnetLength,
+		ServiceNetwork:   networkConfig.ServiceNetworkCIDR,
+		PluginName:       networkConfig.NetworkPluginName,
 	}
-	if createConfig || updateConfig {
+	osapivalidation.SetDefaultClusterNetwork(*configCN)
+
+	existingCN, err := master.osClient.ClusterNetwork().Get(osapi.ClusterNetworkDefault, metav1.GetOptions{})
+	if err != nil {
+		if !kapierrors.IsNotFound(err) {
+			return err
+		}
 		if err = master.checkClusterNetworkAgainstLocalNetworks(); err != nil {
 			return err
 		}
-		if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-			return err
-		}
-		cn.Network = master.networkInfo.ClusterNetwork.String()
-		cn.HostSubnetLength = networkConfig.HostSubnetLength
-		cn.ServiceNetwork = master.networkInfo.ServiceNetwork.String()
-		cn.PluginName = networkConfig.NetworkPluginName
-	}
 
-	if createConfig {
-		cn, err := master.osClient.ClusterNetwork().Create(cn)
+		if _, err = master.osClient.ClusterNetwork().Create(configCN); err != nil {
+			return err
+		}
+		log.Infof("Created ClusterNetwork %s", clusterNetworkToString(configCN))
+
+		if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
+			log.Errorf("WARNING: cluster contains objects incompatible with new ClusterNetwork: %v", err)
+		}
+	} else {
+		configChanged, err := clusterNetworkChanged(configCN, existingCN)
 		if err != nil {
 			return err
 		}
-		log.Infof("Created ClusterNetwork %s", clusterNetworkToString(cn))
-	} else if updateConfig {
-		cn, err := master.osClient.ClusterNetwork().Update(cn)
-		if err != nil {
-			return err
+		if configChanged {
+			configCN.TypeMeta = existingCN.TypeMeta
+			configCN.ObjectMeta = existingCN.ObjectMeta
+			if _, err = master.osClient.ClusterNetwork().Update(configCN); err != nil {
+				return err
+			}
+			log.Infof("Updated ClusterNetwork %s", clusterNetworkToString(configCN))
+		} else {
+			log.V(5).Infof("No change to ClusterNetwork %s", clusterNetworkToString(configCN))
 		}
-		log.Infof("Updated ClusterNetwork %s", clusterNetworkToString(cn))
 	}
 
 	if err = master.SubnetStartMaster(master.networkInfo.ClusterNetwork, networkConfig.HostSubnetLength); err != nil {
@@ -134,4 +140,41 @@ func (master *OsdnMaster) checkClusterNetworkAgainstClusterObjects() error {
 	}
 
 	return master.networkInfo.checkClusterObjects(subnets, pods, services)
+}
+
+func clusterNetworkChanged(obj *osapi.ClusterNetwork, old *osapi.ClusterNetwork) (bool, error) {
+	changed := false
+
+	if old.Network != obj.Network {
+		changed = true
+
+		_, newNet, err := net.ParseCIDR(obj.Network)
+		if err != nil {
+			return true, err
+		}
+		newSize, _ := newNet.Mask.Size()
+		oldBase, oldNet, err := net.ParseCIDR(old.Network)
+		if err != nil {
+			// Shouldn't happen, but if the existing value is invalid, then any change should be an improvement...
+		} else {
+			oldSize, _ := oldNet.Mask.Size()
+
+			// oldSize and newSize are, eg the "16" in "10.1.0.0/16", so
+			// "newSize < oldSize" means the new network is larger
+			if !(newSize < oldSize && newNet.Contains(oldBase)) {
+				return true, fmt.Errorf("cannot change clusterNetworkCIDR to a value that does not include the existing network.")
+			}
+		}
+	}
+	if old.HostSubnetLength != obj.HostSubnetLength {
+		return true, fmt.Errorf("cannot change the hostSubnetLength of an already-deployed cluster")
+	}
+	if old.ServiceNetwork != obj.ServiceNetwork {
+		return true, fmt.Errorf("cannot change the serviceNetworkCIDR of an already-deployed cluster")
+	}
+	if old.PluginName != obj.PluginName {
+		changed = true
+	}
+
+	return changed, nil
 }

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -71,10 +71,6 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 		if err = master.validateNetworkConfig(); err != nil {
 			return err
 		}
-		size, len := master.networkInfo.ClusterNetwork.Mask.Size()
-		if networkConfig.HostSubnetLength < 1 || networkConfig.HostSubnetLength >= uint32(len-size) {
-			return fmt.Errorf("invalid HostSubnetLength %d for network %s (must be from 1 to %d)", networkConfig.HostSubnetLength, networkConfig.ClusterNetworkCIDR, len-size)
-		}
 		cn.Network = master.networkInfo.ClusterNetwork.String()
 		cn.HostSubnetLength = networkConfig.HostSubnetLength
 		cn.ServiceNetwork = master.networkInfo.ServiceNetwork.String()

--- a/pkg/sdn/plugin/master_test.go
+++ b/pkg/sdn/plugin/master_test.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"testing"
+
+	osapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+func Test_clusterNetworkChanged(t *testing.T) {
+	origCN := osapi.ClusterNetwork{
+		Network:          "10.128.0.0/14",
+		HostSubnetLength: 10,
+		ServiceNetwork:   "172.30.0.0/16",
+		PluginName:       "redhat/openshift-ovs-subnet",
+	}
+
+	tests := []struct {
+		name        string
+		changes     *osapi.ClusterNetwork
+		expectError bool
+	}{
+		{
+			name:        "no change",
+			changes:     &osapi.ClusterNetwork{},
+			expectError: false,
+		},
+		{
+			name: "larger Network",
+			changes: &osapi.ClusterNetwork{
+				Network: "10.128.0.0/12",
+			},
+			expectError: false,
+		},
+		{
+			name: "larger Network",
+			changes: &osapi.ClusterNetwork{
+				Network: "10.0.0.0/8",
+			},
+			expectError: false,
+		},
+		{
+			name: "smaller Network",
+			changes: &osapi.ClusterNetwork{
+				Network: "10.128.0.0/15",
+			},
+			expectError: true,
+		},
+		{
+			name: "moved Network",
+			changes: &osapi.ClusterNetwork{
+				Network: "10.1.0.0/16",
+			},
+			expectError: true,
+		},
+		{
+			name: "larger HostSubnetLength",
+			changes: &osapi.ClusterNetwork{
+				HostSubnetLength: 11,
+			},
+			expectError: true,
+		},
+		{
+			name: "smaller HostSubnetLength",
+			changes: &osapi.ClusterNetwork{
+				HostSubnetLength: 9,
+			},
+			expectError: true,
+		},
+		{
+			name: "larger ServiceNetwork",
+			changes: &osapi.ClusterNetwork{
+				ServiceNetwork: "172.30.0.0/15",
+			},
+			expectError: true,
+		},
+		{
+			name: "smaller ServiceNetwork",
+			changes: &osapi.ClusterNetwork{
+				ServiceNetwork: "172.30.0.0/17",
+			},
+			expectError: true,
+		},
+		{
+			name: "moved ServiceNetwork",
+			changes: &osapi.ClusterNetwork{
+				ServiceNetwork: "192.168.0.0/16",
+			},
+			expectError: true,
+		},
+		{
+			name: "changed PluginName",
+			changes: &osapi.ClusterNetwork{
+				PluginName: "redhat/openshift-ovs-multitenant",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		newCN := origCN
+		expectChanged := false
+		if test.changes.Network != "" {
+			newCN.Network = test.changes.Network
+			expectChanged = true
+		}
+		if test.changes.HostSubnetLength != 0 {
+			newCN.HostSubnetLength = test.changes.HostSubnetLength
+			expectChanged = true
+		}
+		if test.changes.ServiceNetwork != "" {
+			newCN.ServiceNetwork = test.changes.ServiceNetwork
+			expectChanged = true
+		}
+		if test.changes.PluginName != "" {
+			newCN.PluginName = test.changes.PluginName
+			expectChanged = true
+		}
+
+		changed, err := clusterNetworkChanged(&newCN, &origCN)
+		if changed != expectChanged {
+			t.Fatalf("unexpected result (%t instead of %t) on %q: %s -> %s", changed, expectChanged, test.name, clusterNetworkToString(&origCN), clusterNetworkToString(&newCN))
+		}
+		if (err != nil) != test.expectError {
+			t.Fatalf("unexpected error on %q: %s -> %s: %v", test.name, clusterNetworkToString(&origCN), clusterNetworkToString(&newCN), err)
+		}
+	}
+}

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -218,6 +218,15 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("failed to get network information: %v", err)
 	}
 
+	hostIPNets, _, err := netutils.GetHostIPNetworks([]string{TUN})
+	if err != nil {
+		return fmt.Errorf("failed to get host network information: %v", err)
+	}
+	if err := node.networkInfo.checkHostNetworks(hostIPNets); err != nil {
+		// checkHostNetworks() errors *should* be fatal, but we didn't used to check this, and we can't break (mostly-)working nodes on upgrade.
+		log.Errorf("Local networks conflict with SDN; this will eventually cause problems: %v", err)
+	}
+
 	node.localSubnetCIDR, err = node.getLocalSubnet()
 	if err != nil {
 		return err

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -281,11 +281,11 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 		expectedGVK:      gvkP("", "v1", "HostSubnet"), // expect the legacy group to be persisted
 	},
 	gvr("", "v1", "clusternetworks"): {
-		stub:             `{"metadata": {"name": "cn1"}, "network": "192.168.0.0/24", "serviceNetwork": "192.168.1.0/24"}`,
+		stub:             `{"metadata": {"name": "cn1"}, "network": "192.168.0.0/24", "hostsubnetlength": 4, "serviceNetwork": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1",
 	},
 	gvr("network.openshift.io", "v1", "clusternetworks"): {
-		stub:             `{"metadata": {"name": "cn1g"}, "network": "192.168.0.0/24", "serviceNetwork": "192.168.1.0/24"}`,
+		stub:             `{"metadata": {"name": "cn1g"}, "network": "192.168.0.0/24", "hostsubnetlength": 4, "serviceNetwork": "192.168.1.0/24"}`,
 		expectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1g",
 		expectedGVK:      gvkP("", "v1", "ClusterNetwork"), // expect the legacy group to be persisted
 	},


### PR DESCRIPTION
This is a spinoff of the work to document how to reconfigure the cluster network. The combination of the fact that (a) kubernetes automatically recreates the default:kubernetes service any time you delete it, and (b) the SDN master refuses to start up if you have any services whose IPs aren't inside serviceNetworkCIDR, makes it extra annoying to try to change serviceNetworkCIDR. (You have to restart the master with no network plugin at one point.) So this fixes that, along with a bunch of other cleanup/reorg/unit-test-adding

The 3 large commits each have commit messages explaining the details of what they change.

@openshift/networking PTAL