### PR TITLE
Handle "origin" container like a k8s container on cleanup

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -77,7 +77,7 @@ function os::cleanup::dump_container_logs() {
 readonly -f os::cleanup::dump_container_logs
 
 # os::cleanup::internal::list_our_containers returns a space-delimited list of
-# docker containers that belonging to some part of the Origin deployment.
+# docker containers that belonged to some part of the Origin deployment.
 #
 # Globals:
 #  None
@@ -92,7 +92,7 @@ function os::cleanup::internal::list_our_containers() {
 readonly -f os::cleanup::internal::list_our_containers
 
 # os::cleanup::internal::list_k8s_containers returns a space-delimited list of
-# docker containers that belonging to k8s.
+# docker containers that belonged to k8s.
 #
 # Globals:
 #  None

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -40,12 +40,7 @@ function cleanup()
 	os::cleanup::dump_etcd
 
 	if [[ -z "${SKIP_TEARDOWN-}" ]]; then
-		os::log::info "remove the openshift container"
-		docker stop origin
-		docker rm origin
-
 		os::cleanup::containers
-		set -u
 	fi
 
 	journalctl --unit docker.service --since -15minutes > "${LOG_DIR}/docker.log"
@@ -62,13 +57,6 @@ function cleanup()
 trap "cleanup" EXIT INT TERM
 
 os::log::system::start
-
-out=$(
-	set +e
-	docker stop origin 2>&1
-	docker rm origin 2>&1
-	set -e
-)
 
 # Setup
 os::log::info "openshift version: `openshift version`"

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -43,8 +43,6 @@ function cleanup()
 		os::cleanup::containers
 	fi
 
-	journalctl --unit docker.service --since -15minutes > "${LOG_DIR}/docker.log"
-
 	truncate_large_logs
 	os::test::junit::generate_oscmd_report
 	set -e

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -61,11 +61,6 @@ function cleanup_openshift() {
 		set -u
 	fi
 
-	if grep -q 'no Docker socket found' "${LOG_DIR}/openshift.log" && command -v journalctl >/dev/null 2>&1; then
-		# the Docker daemon crashed, we need the logs
-		journalctl --unit docker.service --since -4hours > "${LOG_DIR}/docker.log"
-	fi
-
 	truncate_large_logs
 
 	os::log::info "Cleanup complete"


### PR DESCRIPTION
Remove Docker journal gathering steps

The job scripts we use to wrap tests in Jenkins will gather the `docker`
system journal where necessary, so we do not need to be gathering it as
well explicitly in the test scripts themselves.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Handle "origin" container like a k8s container on cleanup

When we start the master using `oc cluster up`, we run a container
called "origin" that was previously not being considered a container
we needed to be getting logs for or stopping and cleaning up. We should
consider this container the same as any other and not have custom logic
for it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Fixes https://github.com/openshift/origin/issues/13949

@ncdc PTAL