### PR TITLE
Drop "dnf clean all" from openshift/dind build to try to fix a flake

### DIFF
--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -57,8 +57,7 @@ RUN dnf -y update && dnf -y install\
  glibc-langpack-en\
  iptables\
  openssh-clients\
- openssh-server\
- && dnf clean all
+ openssh-server
 
 ## Configure docker
 

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -21,8 +21,7 @@ RUN dnf -y update && dnf -y install\
  bridge-utils\
  ethtool\
  iptables-services\
- openvswitch\
- && dnf clean all
+ openvswitch
 
 # A default deny firewall (either iptables or firewalld) is
 # installed by default on non-cloud fedora and rhel, so all


### PR DESCRIPTION
Attempt at fixing #11452 under the assumption that it's caused by a bug in dnf's "rebuild caches from scratch" code... (It should also make the dind build a little faster?)

@marun @stevekuznetsov @deads2k 