### PR TITLE
cluster up: set docker cgroup driver on kubelet config

### DIFF
--- a/pkg/bootstrap/docker/dockerhelper/helper.go
+++ b/pkg/bootstrap/docker/dockerhelper/helper.go
@@ -77,6 +77,14 @@ func (h *Helper) dockerInfo() (*dockertypes.Info, error) {
 	return h.info, nil
 }
 
+func (h *Helper) CgroupDriver() (string, error) {
+	info, err := h.dockerInfo()
+	if err != nil {
+		return "", err
+	}
+	return info.CgroupDriver, nil
+}
+
 // HasInsecureRegistryArg checks whether the docker daemon is configured with
 // the appropriate insecure registry argument
 func (h *Helper) HasInsecureRegistryArg() (bool, error) {

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -1071,7 +1071,7 @@ func (c *ClientStartConfig) Clients() (*client.Client, kclientset.Interface, err
 // OpenShiftHelper returns a helper object to work with OpenShift on the server
 func (c *CommonStartConfig) OpenShiftHelper() *openshift.Helper {
 	if c.openshiftHelper == nil {
-		c.openshiftHelper = openshift.NewHelper(c.dockerClient, c.HostHelper(), c.openshiftImage(), openshift.OpenShiftContainer, c.PublicHostname, c.RoutingSuffix)
+		c.openshiftHelper = openshift.NewHelper(c.dockerClient, c.DockerHelper(), c.HostHelper(), c.openshiftImage(), openshift.OpenShiftContainer, c.PublicHostname, c.RoutingSuffix)
 	}
 	return c.openshiftHelper
 }


### PR DESCRIPTION
Fixes issue which requires that cgroup driver be specified for kubelet post 1.6 kube rebase. 

Fixes https://github.com/openshift/origin/issues/14101