### PR TITLE
Bug 1445694 - Fix locking in syncEgressDNSPolicyRules()

### DIFF
--- a/pkg/sdn/plugin/egress_network_policy.go
+++ b/pkg/sdn/plugin/egress_network_policy.go
@@ -108,8 +108,11 @@ func (plugin *OsdnNode) syncEgressDNSPolicyRules() {
 			continue
 		}
 
-		plugin.egressPoliciesLock.Lock()
-		defer plugin.egressPoliciesLock.Unlock()
-		plugin.updateEgressNetworkPolicyRules(vnid)
+		func() {
+			plugin.egressPoliciesLock.Lock()
+			defer plugin.egressPoliciesLock.Unlock()
+
+			plugin.updateEgressNetworkPolicyRules(vnid)
+		}()
 	}
 }


### PR DESCRIPTION
Deferred unlocking of egress policy lock is in a loop.
Since unlock is not performed in the first iteration, it won't get the lock in the next iteration.
This change ensures unlock is called once it is done with the current iteration.