### PR TITLE
allow SA tokens via websockets

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -683,7 +683,7 @@ func newAuthenticator(config configapi.MasterConfig, restOptionsGetter restoptio
 			publicKeys = append(publicKeys, readPublicKeys...)
 		}
 		serviceAccountTokenAuthenticator := serviceaccount.JWTTokenAuthenticator(publicKeys, true, tokenGetter)
-		tokenAuthenticators = append(tokenAuthenticators, bearertoken.New(serviceAccountTokenAuthenticator, true))
+		tokenAuthenticators = append(tokenAuthenticators, bearertoken.New(serviceAccountTokenAuthenticator, true), paramtoken.New("access_token", serviceAccountTokenAuthenticator, true))
 	}
 
 	// OAuth token


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/13968

Looks like this was just an oversight.  The test to match it isn't obvious to me.

@liggitt 