### PR TITLE
Narrow Travis config to only verify commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
   - make install-travis
 
 script:
-  - PROTO_OPTIONAL=1 make verify
   - make verify-commits
 
 notifications:


### PR DESCRIPTION
The free tier of Travis CI only allows for a couple of cores and 3GB of
RAM, which is not enough to compile the Golang binaries for the product
in less than thirty minutes. As we use Travis CI for quick responses to
pull requests, building the client and server is no longer viable.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @sttts 
supersedes https://github.com/openshift/origin/pull/13922