### PR TITLE
UPSTREAM: 44462: 44489: fix selfLink for cluster-scoped resources

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1236,6 +1236,60 @@ func TestSelfLinkSkipsEmptyName(t *testing.T) {
 	}
 }
 
+func TestRootSelfLink(t *testing.T) {
+	storage := map[string]rest.Storage{}
+	simpleStorage := SimpleTypedStorage{
+		baseType: &genericapitesting.SimpleRoot{}, // a root scoped type
+		item: &genericapitesting.SimpleRoot{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			Other:      "foo",
+		},
+	}
+	storage["simple"] = &simpleStorage
+	storage["simple/sub"] = &simpleStorage
+	handler := handle(storage)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	testCases := []struct {
+		url      string
+		selfLink string
+	}{
+		{
+			url:      server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo",
+			selfLink: "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo",
+		},
+		{
+			url:      server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo/sub",
+			selfLink: "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo/sub",
+		},
+	}
+
+	for _, test := range testCases {
+		resp, err := http.Get(test.url)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusOK, resp)
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			t.Logf("Data: %s", string(body))
+		}
+		var out genericapitesting.SimpleRoot
+		if _, err := extractBody(resp, &out); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if out.SelfLink != test.selfLink {
+			t.Errorf("unexpected self link: %#v", out.SelfLink)
+		}
+	}
+}
+
 func TestMetadata(t *testing.T) {
 	simpleStorage := &MetadataRESTStorage{&SimpleRESTStorage{}, []string{"text/plain"}}
 	h := handle(map[string]rest.Storage{"simple": simpleStorage})

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -394,7 +394,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		apiResource.Name = path
 		apiResource.Namespaced = false
 		apiResource.Kind = resourceKind
-		namer := rootScopeNaming{scope, a.group.Linker, gpath.Join(a.prefix, resourcePath, "/"), suffix}
+		namer := rootScopeNaming{scope, a.group.Linker, gpath.Join(a.prefix, resource) + "/", suffix}
 
 		// Handler for standard REST verbs (GET, PUT, POST and DELETE).
 		// Add actions at the resource path: /api/apiVersion/resource


### PR DESCRIPTION
This is a manual backport of the 2 kube PRs, as upstream has refactored a bit since 1.6.

We can drop this patch in the rebase to 1.7.

Fixes #12553 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1428707

cc @deads2k @sttts @liggitt @stefwalter