### PR TITLE
respect system:masters like upstream

### DIFF
--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -113,7 +113,7 @@ func (m *VirtualStorage) Delete(ctx apirequest.Context, name string, options *me
 }
 
 func (m *VirtualStorage) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Object, error) {
-	return m.createRole(ctx, obj, false)
+	return m.createRole(ctx, obj, rulevalidation.EscalationAllowed(ctx))
 }
 
 func (m *VirtualStorage) CreateRoleWithEscalation(ctx apirequest.Context, obj *authorizationapi.Role) (*authorizationapi.Role, error) {
@@ -161,7 +161,7 @@ func (m *VirtualStorage) createRole(ctx apirequest.Context, obj runtime.Object, 
 }
 
 func (m *VirtualStorage) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	return m.updateRole(ctx, name, objInfo, false)
+	return m.updateRole(ctx, name, objInfo, rulevalidation.EscalationAllowed(ctx))
 }
 func (m *VirtualStorage) UpdateRoleWithEscalation(ctx apirequest.Context, obj *authorizationapi.Role) (*authorizationapi.Role, bool, error) {
 	return m.updateRole(ctx, obj.Name, rest.DefaultUpdatedObjectInfo(obj, kapi.Scheme), true)

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -119,7 +119,7 @@ func (m *VirtualStorage) Delete(ctx apirequest.Context, name string, options *me
 }
 
 func (m *VirtualStorage) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Object, error) {
-	return m.createRoleBinding(ctx, obj, false)
+	return m.createRoleBinding(ctx, obj, rulevalidation.EscalationAllowed(ctx))
 }
 
 func (m *VirtualStorage) CreateRoleBindingWithEscalation(ctx apirequest.Context, obj *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
@@ -171,7 +171,7 @@ func (m *VirtualStorage) createRoleBinding(ctx apirequest.Context, obj runtime.O
 }
 
 func (m *VirtualStorage) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	return m.updateRoleBinding(ctx, name, objInfo, false)
+	return m.updateRoleBinding(ctx, name, objInfo, rulevalidation.EscalationAllowed(ctx))
 }
 func (m *VirtualStorage) UpdateRoleBindingWithEscalation(ctx apirequest.Context, obj *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error) {
 	return m.updateRoleBinding(ctx, obj.Name, rest.DefaultUpdatedObjectInfo(obj, kapi.Scheme), true)

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -27,7 +27,10 @@ import (
 	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/headerrequest"
 	"k8s.io/apiserver/pkg/authentication/request/union"
+	"k8s.io/apiserver/pkg/authentication/user"
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -860,7 +863,12 @@ func newAuthorizer(ruleResolver rulevalidation.AuthorizationRuleResolver, inform
 	messageMaker := authorizer.NewForbiddenMessageResolver(projectRequestDenyMessage)
 	roleBasedAuthorizer, subjectLocator := authorizer.NewAuthorizer(ruleResolver, messageMaker)
 	scopeLimitedAuthorizer := scope.NewAuthorizer(roleBasedAuthorizer, informerFactory.ClusterPolicies().Lister().ClusterPolicies(), messageMaker)
-	return scopeLimitedAuthorizer, subjectLocator
+
+	authorizer := authorizerunion.New(
+		authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup), // authorizes system:masters to do anything, just like upstream
+		scopeLimitedAuthorizer)
+
+	return authorizer, subjectLocator
 }
 
 func newAuthorizationAttributeBuilder(requestContextMapper apirequest.RequestContextMapper) authorizer.AuthorizationAttributeBuilder {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -20,16 +20,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/golang/glog"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/healthz"
 	restclient "k8s.io/client-go/rest"
-	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 )
 
 // PostStartHookFunc is a function that is called after the server has started.
@@ -99,33 +95,6 @@ func (s *GenericAPIServer) RunPostStartHooks() {
 	s.postStartHooksCalled = true
 
 	context := PostStartHookContext{LoopbackClientConfig: s.LoopbackClientConfig}
-
-	// only wait for namespace in a real kube master setup. In unit tests, we don't have the namespace resource
-	// and therefore the wait loop would fail.
-	isKubeMaster := false
-	for _, ws := range s.HandlerContainer.RegisteredWebServices() {
-		if ws.RootPath() == "/api/v1" {
-			isKubeMaster = true
-		}
-	}
-	if isKubeMaster {
-		// we need to wait until our loopback client has enough rights to actually loopback
-		// the core APIs cannot be disabled, so we'll use that as a proxy for the information instead
-		// of attempting a SAR (which can be disabled, though that would be a very bad idea)
-		// TODO remove once openshift starts using the kube loopback connection.
-		err := wait.PollImmediate(30*time.Millisecond, 30*time.Second, func() (bool, error) {
-			client := coreclient.NewForConfigOrDie(s.LoopbackClientConfig)
-			// we can have other errors in our level, like etcd not being up. Treat them all the same
-			if _, err := client.Namespaces().List(metav1.ListOptions{}); err != nil {
-				fmt.Printf("loopback error: %v\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
-		if err != nil {
-			glog.Fatalf("LoopbackClient was unable to list namespaces: %v", err)
-		}
-	}
 
 	for hookName, hookEntry := range s.postStartHooks {
 		go runPostStartHook(hookName, hookEntry, context)


### PR DESCRIPTION
Prior to the rebase, I put in a hack to make post-starthooks work.  Now we have the privileged authorizer available.  This wires it together and removes the hack.

[test]