### PR TITLE
Randomize endpoints function for the router template : bz1447115

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -337,7 +337,7 @@ backend be_secure:{{$cfgIdx}}
   {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
     {{- if ne $weight 0 }}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
-        {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+        {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
@@ -366,7 +366,7 @@ backend be_secure:{{$cfgIdx}}
 
 
           {{- end }}{{/* end if cg.TLSTermination */}}
-        {{- end }}{{/* end range endpointsForAlias */}}
+        {{- end }}{{/* end range processEndpointsForAlias */}}
       {{- end }}{{/* end get serviceUnit from its name */}}
   {{- end }}{{/* end range over serviceUnitNames */}}
 
@@ -417,7 +417,7 @@ backend be_tcp:{{$cfgIdx}}
     {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
       {{- if ne $weight 0 }}
         {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
-          {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+          {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
             {{- if not $endpoint.NoHealthCheck }}
               {{- with $healthIntv := index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval" }}
@@ -430,7 +430,7 @@ backend be_tcp:{{$cfgIdx}}
                 {{- end }}
               {{- end }}{{/* end get health interval annotation */}}
             {{- end }}{{/* end else no health check */}}
-          {{- end }}{{/* end range endpointsForAlias */}}
+          {{- end }}{{/* end range processEndpointsForAlias */}}
         {{- end }}{{/* end get ServiceUnit from serviceUnitName */}}
       {{- end }}{{/* end if weight != 0 */}}
     {{- end }}{{/* end iterate over services*/}}

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -101,11 +101,12 @@ func env(name, defaultValue string) string {
 func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*TemplatePlugin, error) {
 	templateBaseName := filepath.Base(cfg.TemplatePath)
 	globalFuncs := template.FuncMap{
-		"endpointsForAlias": endpointsForAlias, //returns the list of valid endpoints
-		"env":               env,               //tries to get an environment variable if it can't return a default
-		"matchPattern":      matchPattern,      //anchors provided regular expression and evaluates against given string
-		"isInteger":         isInteger,         //determines if a given variable is an integer
-		"matchValues":       matchValues,       //compares a given string to a list of allowed strings
+		"endpointsForAlias":        endpointsForAlias,        //returns the list of valid endpoints
+		"processEndpointsForAlias": processEndpointsForAlias, //returns the list of valid endpoints after processing them
+		"env":          env,          //tries to get an environment variable if it can't return a default
+		"matchPattern": matchPattern, //anchors provided regular expression and evaluates against given string
+		"isInteger":    isInteger,    //determines if a given variable is an integer
+		"matchValues":  matchValues,  //compares a given string to a list of allowed strings
 
 		"genSubdomainWildcardRegexp": genSubdomainWildcardRegexp, //generates a regular expression matching the subdomain for hosts (and paths) with a wildcard policy
 		"generateRouteRegexp":        generateRouteRegexp,        //generates a regular expression matching the route hosts (and paths)

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -308,6 +309,21 @@ func genCertificateHostName(hostname string, wildcard bool) string {
 	}
 
 	return hostname
+}
+
+// Returns the list of endpoints for the given route's service
+// action argument further processes the list e.g. shuffle
+// The default action is in-order traversal of internal data structure that stores
+//   the endpoints (does not change the return order if the data structure did not mutate)
+func processEndpointsForAlias(alias ServiceAliasConfig, svc ServiceUnit, action string) []Endpoint {
+	endpoints := endpointsForAlias(alias, svc)
+	if strings.ToLower(action) == "shuffle" {
+		for i := len(endpoints) - 1; i >= 0; i-- {
+			rIndex := rand.Intn(i + 1)
+			endpoints[i], endpoints[rIndex] = endpoints[rIndex], endpoints[i]
+		}
+	}
+	return endpoints
 }
 
 func endpointsForAlias(alias ServiceAliasConfig, svc ServiceUnit) []Endpoint {


### PR DESCRIPTION
RFE https://bugzilla.redhat.com/show_bug.cgi?id=1447115

Inspite of roundrobin/leastconn and other balancing algorithms, some pods are observed as hot. This patch allows the haproxy config to print servers in random order so that a reset spoils any hotness from the previous run.

@openshift/networking Reviews please

/cc @brenton @knobunc