### PR TITLE
master: only one place for storage GVRs

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -173,7 +173,7 @@ func BuildKubeAPIserverOptions(masterConfig configapi.MasterConfig) (*kapiserver
 
 // BuildStorageFactory builds a storage factory based on server.Etcd.StorageConfig with overrides from masterConfig.
 // This storage factory is used for kubernetes and origin registries. Compare pkg/util/restoptions/configgetter.go.
-func BuildStorageFactory(masterConfig configapi.MasterConfig, server *kapiserveroptions.ServerRunOptions, enforcedStorageVersions []schema.GroupVersionResource) (*apiserverstorage.DefaultStorageFactory, error) {
+func BuildStorageFactory(masterConfig configapi.MasterConfig, server *kapiserveroptions.ServerRunOptions, enforcedStorageVersions map[schema.GroupResource]schema.GroupVersion) (*apiserverstorage.DefaultStorageFactory, error) {
 	resourceEncodingConfig := apiserverstorage.NewDefaultResourceEncodingConfig(kapi.Registry)
 
 	storageGroupsToEncodingVersion, err := server.StorageSerialization.StorageGroupsToEncodingVersion()
@@ -185,9 +185,8 @@ func BuildStorageFactory(masterConfig configapi.MasterConfig, server *kapiserver
 	}
 	resourceEncodingConfig.SetResourceEncoding(batch.Resource("cronjobs"), batchv2alpha1.SchemeGroupVersion, batch.SchemeGroupVersion)
 
-	// use legacy group name "" for all resources that existed when apigroups were introduced
-	for _, gvr := range enforcedStorageVersions {
-		resourceEncodingConfig.SetResourceEncoding(gvr.GroupResource(), schema.GroupVersion{Version: gvr.Version}, schema.GroupVersion{Version: runtime.APIVersionInternal})
+	for gr, storageGV := range enforcedStorageVersions {
+		resourceEncodingConfig.SetResourceEncoding(gr, storageGV, schema.GroupVersion{Group: storageGV.Group, Version: runtime.APIVersionInternal})
 	}
 
 	storageFactory := apiserverstorage.NewDefaultStorageFactory(

--- a/pkg/cmd/server/origin/rest/storage_options.go
+++ b/pkg/cmd/server/origin/rest/storage_options.go
@@ -11,6 +11,7 @@ import (
 // StorageOptions returns the appropriate storage configuration for the origin rest APIs, including
 // overiddes.
 func StorageOptions(options configapi.MasterConfig) (restoptions.Getter, error) {
+	legacyCoreV1 := schema.GroupVersion{Group: "", Version: "v1"}
 	return restoptions.NewConfigGetter(
 		options,
 		&serverstorage.ResourceConfig{},
@@ -46,33 +47,33 @@ func StorageOptions(options configapi.MasterConfig) (restoptions.Getter, error) 
 			{Resource: "netnamespaces"}:                                        "registry/sdnnetnamespaces",
 			{Resource: "netnamespaces", Group: "network.openshift.io"}:         "registry/sdnnetnamespaces",
 		},
-		// storage versions:
-		[]schema.GroupVersionResource{
-			{"authorization.openshift.io", "v1", "clusterpolicybindings"},
-			{"authorization.openshift.io", "v1", "clusterpolicies"},
-			{"authorization.openshift.io", "v1", "policybindings"},
-			{"authorization.openshift.io", "v1", "rolebindingrestrictions"},
-			{"authorization.openshift.io", "v1", "policies"},
-			{"build.openshift.io", "v1", "builds"},
-			{"build.openshift.io", "v1", "buildconfigs"},
-			{"apps.openshift.io", "v1", "deploymentconfigs"},
-			{"image.openshift.io", "v1", "imagestreams"},
-			{"image.openshift.io", "v1", "images"},
-			{"oauth.openshift.io", "v1", "oauthclientauthorizations"},
-			{"oauth.openshift.io", "v1", "oauthaccesstokens"},
-			{"oauth.openshift.io", "v1", "oauthauthorizetokens"},
-			{"oauth.openshift.io", "v1", "oauthclients"},
-			{"project.openshift.io", "v1", "projects"},
-			{"quota.openshift.io", "v1", "clusterresourcequotas"},
-			{"route.openshift.io", "v1", "routes"},
-			{"network.openshift.io", "v1", "netnamespaces"},
-			{"network.openshift.io", "v1", "hostsubnets"},
-			{"network.openshift.io", "v1", "clusternetworks"},
-			{"network.openshift.io", "v1", "egressnetworkpolicies"},
-			{"template.openshift.io", "v1", "templates"},
-			{"user.openshift.io", "v1", "groups"},
-			{"user.openshift.io", "v1", "users"},
-			{"user.openshift.io", "v1", "identities"},
+		// storage versions: use legacy group name "" for all resources that existed when apigroups were introduced
+		map[schema.GroupResource]schema.GroupVersion{
+			{Group: "authorization.openshift.io", Resource: "clusterpolicybindings"}:   legacyCoreV1,
+			{Group: "authorization.openshift.io", Resource: "clusterpolicies"}:         legacyCoreV1,
+			{Group: "authorization.openshift.io", Resource: "policybindings"}:          legacyCoreV1,
+			{Group: "authorization.openshift.io", Resource: "rolebindingrestrictions"}: legacyCoreV1,
+			{Group: "authorization.openshift.io", Resource: "policies"}:                legacyCoreV1,
+			{Group: "build.openshift.io", Resource: "builds"}:                          legacyCoreV1,
+			{Group: "build.openshift.io", Resource: "buildconfigs"}:                    legacyCoreV1,
+			{Group: "apps.openshift.io", Resource: "deploymentconfigs"}:                legacyCoreV1,
+			{Group: "image.openshift.io", Resource: "imagestreams"}:                    legacyCoreV1,
+			{Group: "image.openshift.io", Resource: "images"}:                          legacyCoreV1,
+			{Group: "oauth.openshift.io", Resource: "oauthclientauthorizations"}:       legacyCoreV1,
+			{Group: "oauth.openshift.io", Resource: "oauthaccesstokens"}:               legacyCoreV1,
+			{Group: "oauth.openshift.io", Resource: "oauthauthorizetokens"}:            legacyCoreV1,
+			{Group: "oauth.openshift.io", Resource: "oauthclients"}:                    legacyCoreV1,
+			{Group: "project.openshift.io", Resource: "projects"}:                      legacyCoreV1,
+			{Group: "quota.openshift.io", Resource: "clusterresourcequotas"}:           legacyCoreV1,
+			{Group: "route.openshift.io", Resource: "routes"}:                          legacyCoreV1,
+			{Group: "network.openshift.io", Resource: "netnamespaces"}:                 legacyCoreV1,
+			{Group: "network.openshift.io", Resource: "hostsubnets"}:                   legacyCoreV1,
+			{Group: "network.openshift.io", Resource: "clusternetworks"}:               legacyCoreV1,
+			{Group: "network.openshift.io", Resource: "egressnetworkpolicies"}:         legacyCoreV1,
+			{Group: "template.openshift.io", Resource: "templates"}:                    legacyCoreV1,
+			{Group: "user.openshift.io", Resource: "groups"}:                           legacyCoreV1,
+			{Group: "user.openshift.io", Resource: "users"}:                            legacyCoreV1,
+			{Group: "user.openshift.io", Resource: "identities"}:                       legacyCoreV1,
 		},
 		// quorum resources:
 		map[schema.GroupResource]struct{}{

--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -46,7 +46,7 @@ type configRESTOptionsGetter struct {
 // NewConfigGetter returns a restoptions.Getter implemented using information from the provided master config.
 // By default, the etcd watch cache is enabled with a size of 1000 per resource type.
 // TODO: this class should either not need to know about configapi.MasterConfig, or not be in pkg/util
-func NewConfigGetter(masterOptions configapi.MasterConfig, defaultResourceConfig *serverstorage.ResourceConfig, resourcePrefixOverrides map[schema.GroupResource]string, enforcedStorageVersions []schema.GroupVersionResource, quorumResources map[schema.GroupResource]struct{}) (Getter, error) {
+func NewConfigGetter(masterOptions configapi.MasterConfig, defaultResourceConfig *serverstorage.ResourceConfig, resourcePrefixOverrides map[schema.GroupResource]string, enforcedStorageVersions map[schema.GroupResource]schema.GroupVersion, quorumResources map[schema.GroupResource]struct{}) (Getter, error) {
 	apiserverOptions, err := kubernetes.BuildKubeAPIserverOptions(masterOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We were overwriting the pkg/cmd/server/origin/rest.StorageOptions values in master_config.go's BuildStorageFactory.