### PR TITLE
extended-tests: extended rebase flake patterns

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -293,8 +293,10 @@ var (
 		`\[Feature:Downgrade\]`,
 
 		// upstream flakes
-		`Basic StatefulSet functionality \[StatefulSetBasic\] should provide basic identity`,
-		`SchedulerPredicates \[Serial\] validates resource limits of pods that are allowed to run`,
+		`should provide basic identity`, // Basic StatefulSet functionality
+		`Scaling down before scale up is finished should wait until current pod will be running and ready before it will be removed`, // Basic StatefulSet functionality
+		`validates resource limits of pods that are allowed to run`,                                                                  // SchedulerPredicates
+		`should idle the service and DeploymentConfig properly`,                                                                      // idling with a single service and DeploymentConfig [Conformance]
 	}
 	excludedTestsFilter = regexp.MustCompile(strings.Join(excludedTests, `|`))
 


### PR DESCRIPTION
Not sure whether the old patterns actually matched, at least the StatefulSet one didn't.