### PR TITLE
Make integration test able to generate a jUnit report 

### DIFF
--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -170,12 +170,47 @@ function os::test::junit::generate_oscmd_report() {
     os::test::junit::check_test_counters
 
     # use the junitreport tool to generate us a report
-    os::util::ensure::built_binary_exists 'junitreport'
+    os::test::junit::generate_report "oscmd"
 
-    junitreport --type oscmd                          \
+    junitreport summarize <"${ARTIFACT_DIR}/report.xml"
+}
+
+# os::test::junit::generate_gotest_report generats an XML jUnit report
+# for the `go test` suite from the raw test output.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - ARTIFACT_DIR
+# Arguments:
+#  None
+# Returns:
+#  None
+function os::test::junit::generate_gotest_report() {
+    if [[ -z "${JUNIT_REPORT_OUTPUT:-}" ||
+          -n "${JUNIT_REPORT_OUTPUT:-}" && ! -s "${JUNIT_REPORT_OUTPUT:-}" ]]; then
+          # we can't generate a report
+          return
+    fi
+    os::test::junit::generate_report "gotest"
+
+    os::log::info "Full output from \`go test\` logged at ${JUNIT_REPORT_OUTPUT}"
+    os::log::info "jUnit XML report placed at ${ARTIFACT_DIR}/report.xml"
+}
+
+# os::test::junit::generate_report generats an XML jUnit report
+# for either `os::cmd` or `go test`, based on the passed argument.
+# If the `junitreport` binary is not present, it will be built.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - ARTIFACT_DIR
+# Arguments:
+#  - 1: specify which type of tests command output should junitreport read
+function os::test::junit::generate_report() {
+    os::util::ensure::built_binary_exists 'junitreport'
+    junitreport --type "${1}"         \
                 --suites nested                       \
                 --roots github.com/openshift/origin   \
                 --output "${ARTIFACT_DIR}/report.xml" \
                 <"${JUNIT_REPORT_OUTPUT}"
-    junitreport summarize <"${ARTIFACT_DIR}/report.xml"
 }

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -186,13 +186,9 @@ if [[ -n "${junit_report}" ]]; then
     set +o pipefail
 
     go test -i ${gotest_flags} ${test_packages}
-    go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" \
-        | tee "${test_output_file}"                                 \
-        | junitreport --type gotest                                 \
-                      --suites nested                               \
-                      --roots github.com/openshift/origin           \
-                      --stream                                      \
-                      --output "${junit_report_file}"
+    go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${test_output_file}"
+
+    JUNIT_REPORT_OUTPUT="${test_output_file}" os::test::junit::generate_gotest_report
 
     test_return_code="${PIPESTATUS[0]}"
 
@@ -225,8 +221,6 @@ if [[ -n "${junit_report}" ]]; then
         fi
     fi
 
-    os::log::info "Full output from \`go test\` logged at ${test_output_file}"
-    os::log::info "jUnit XML report placed at ${junit_report_file}"
     exit "${test_return_code}"
 
 elif [[ -n "${coverage_output_dir}" ]]; then


### PR DESCRIPTION
By adding starting the integration tests with `JUNIT_REPORT` variable, all tests will be run in and produce `intergration-test.log`, which in the end will be used by `junitreport` tool to generate a jUnit report - `report.xml`  

@stevekuznetsov PTAL