### PR TITLE
Use kubernetes shared informers in OpenShift network plugins

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -203,7 +203,10 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse the provided ip-tables sync period (%s) : %v", options.IPTablesSyncPeriod, err)
 	}
-	sdnPlugin, err := sdnplugin.NewNodePlugin(options.NetworkConfig.NetworkPluginName, originClient, kubeClient, options.NodeName, options.NodeIP, iptablesSyncPeriod, options.NetworkConfig.MTU)
+
+	internalKubeInformers := kinternalinformers.NewSharedInformerFactory(kubeClient, proxyconfig.ConfigSyncPeriod)
+
+	sdnPlugin, err := sdnplugin.NewNodePlugin(options.NetworkConfig.NetworkPluginName, originClient, kubeClient, options.NodeName, options.NodeIP, iptablesSyncPeriod, options.NetworkConfig.MTU, internalKubeInformers)
 	if err != nil {
 		return nil, fmt.Errorf("SDN initialization failed: %v", err)
 	}
@@ -296,8 +299,6 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	if err != nil {
 		return nil, fmt.Errorf("SDN proxy initialization failed: %v", err)
 	}
-
-	internalKubeInformers := kinternalinformers.NewSharedInformerFactory(kubeClient, proxyconfig.ConfigSyncPeriod)
 
 	config := &NodeConfig{
 		BindAddress: options.ServingInfo.BindAddress,

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -397,7 +397,7 @@ func (c *MasterConfig) RunDeploymentTriggerController() {
 // RunSDNController runs openshift-sdn if the said network plugin is provided
 func (c *MasterConfig) RunSDNController() {
 	oClient, kClient := c.SDNControllerClients()
-	if err := sdnplugin.StartMaster(c.Options.NetworkConfig, oClient, kClient); err != nil {
+	if err := sdnplugin.StartMaster(c.Options.NetworkConfig, oClient, kClient, c.Informers); err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)
 	}
 }

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -190,6 +190,9 @@ func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.Shared
 	case Nodes:
 		informer = internalVersion.Nodes().Informer()
 		expectedObjType = &kapi.Node{}
+	case Namespaces:
+		informer = internalVersion.Namespaces().Informer()
+		expectedObjType = &kapi.Namespace{}
 	default:
 		glog.Errorf("Unknown resource name: %s", resourceName)
 		return

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
@@ -14,9 +15,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
 	kcache "k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
@@ -170,4 +173,50 @@ func RunNamespacedPodEventQueue(client kcache.Getter, namespace string, closeCha
 			eventQueue.Pop(process, &kapi.Pod{})
 		}
 	}
+}
+
+// RegisterSharedInformerEventHandlers registers addOrUpdateFunc and delFunc event handlers with
+// kubernetes shared informers for the given resource name.
+func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.SharedInformerFactory,
+	addOrUpdateFunc func(interface{}, interface{}, watch.EventType),
+	delFunc func(interface{}), resourceName ResourceName) {
+
+	var expectedObjType interface{}
+	var informer kcache.SharedIndexInformer
+
+	internalVersion := kubeInformers.Core().InternalVersion()
+
+	switch resourceName {
+	case Nodes:
+		informer = internalVersion.Nodes().Informer()
+		expectedObjType = &kapi.Node{}
+	default:
+		glog.Errorf("Unknown resource name: %s", resourceName)
+		return
+	}
+
+	informer.AddEventHandler(kcache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			addOrUpdateFunc(obj, nil, watch.Added)
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			addOrUpdateFunc(cur, old, watch.Modified)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if reflect.TypeOf(expectedObjType) != reflect.TypeOf(obj) {
+				tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
+				if !ok {
+					glog.Errorf("Couldn't get object from tombstone: %+v", obj)
+					return
+				}
+
+				obj = tombstone.Obj
+				if reflect.TypeOf(expectedObjType) != reflect.TypeOf(obj) {
+					glog.Errorf("Tombstone contained object that is not a %s: %+v", resourceName, obj)
+					return
+				}
+			}
+			delFunc(obj)
+		},
+	})
 }

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -160,21 +160,6 @@ func RunEventQueue(client kcache.Getter, resourceName ResourceName, process Proc
 	}
 }
 
-func RunNamespacedPodEventQueue(client kcache.Getter, namespace string, closeChan chan struct{}, process ProcessEventFunc) {
-	eventQueue := newEventQueue(client, Pods, &kapi.Pod{}, namespace)
-	// Loop calling eventQueue.Pop() until closeChan is closed. process() will be called
-	// once after closeChan is closed; this possibility is unavoidable anyway due to race
-	// conditions.
-	for {
-		select {
-		case <-closeChan:
-			return
-		default:
-			eventQueue.Pop(process, &kapi.Pod{})
-		}
-	}
-}
-
 // RegisterSharedInformerEventHandlers registers addOrUpdateFunc and delFunc event handlers with
 // kubernetes shared informers for the given resource name.
 func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.SharedInformerFactory,
@@ -196,6 +181,9 @@ func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.Shared
 	case Services:
 		informer = internalVersion.Services().Informer()
 		expectedObjType = &kapi.Service{}
+	case Pods:
+		informer = internalVersion.Pods().Informer()
+		expectedObjType = &kapi.Pod{}
 	default:
 		glog.Errorf("Unknown resource name: %s", resourceName)
 		return

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -193,6 +193,9 @@ func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.Shared
 	case Namespaces:
 		informer = internalVersion.Namespaces().Informer()
 		expectedObjType = &kapi.Namespace{}
+	case Services:
+		informer = internalVersion.Services().Informer()
+		expectedObjType = &kapi.Service{}
 	default:
 		glog.Errorf("Unknown resource name: %s", resourceName)
 		return

--- a/pkg/sdn/plugin/common.go
+++ b/pkg/sdn/plugin/common.go
@@ -138,14 +138,6 @@ func RunEventQueue(client kcache.Getter, resourceName ResourceName, process Proc
 		expectedType = &osapi.HostSubnet{}
 	case NetNamespaces:
 		expectedType = &osapi.NetNamespace{}
-	case Nodes:
-		expectedType = &kapi.Node{}
-	case Namespaces:
-		expectedType = &kapi.Namespace{}
-	case Services:
-		expectedType = &kapi.Service{}
-	case Pods:
-		expectedType = &kapi.Pod{}
 	case EgressNetworkPolicies:
 		expectedType = &osapi.EgressNetworkPolicy{}
 	case NetworkPolicies:

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -8,6 +8,7 @@ import (
 
 	osclient "github.com/openshift/origin/pkg/client"
 	osconfigapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/controller/shared"
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/util/netutils"
 
@@ -22,9 +23,10 @@ type OsdnMaster struct {
 	networkInfo     *NetworkInfo
 	subnetAllocator *netutils.SubnetAllocator
 	vnids           *masterVNIDMap
+	informers       shared.InformerFactory
 }
 
-func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclient.Client, kClient kclientset.Interface) error {
+func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclient.Client, kClient kclientset.Interface, informers shared.InformerFactory) error {
 	if !osapi.IsOpenShiftNetworkPlugin(networkConfig.NetworkPluginName) {
 		return nil
 	}
@@ -32,8 +34,9 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 	log.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
 
 	master := &OsdnMaster{
-		kClient:  kClient,
-		osClient: osClient,
+		kClient:   kClient,
+		osClient:  osClient,
+		informers: informers,
 	}
 
 	var err error

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/util/netutils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
@@ -24,6 +25,9 @@ type OsdnMaster struct {
 	subnetAllocator *netutils.SubnetAllocator
 	vnids           *masterVNIDMap
 	informers       shared.InformerFactory
+
+	// Holds Node IP used in creating host subnet for a node
+	hostSubnetNodeIPs map[ktypes.UID]string
 }
 
 func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclient.Client, kClient kclientset.Interface, informers shared.InformerFactory) error {
@@ -34,9 +38,10 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 	log.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
 
 	master := &OsdnMaster{
-		kClient:   kClient,
-		osClient:  osClient,
-		informers: informers,
+		kClient:           kClient,
+		osClient:          osClient,
+		informers:         informers,
+		hostSubnetNodeIPs: map[ktypes.UID]string{},
 	}
 
 	var err error

--- a/pkg/sdn/plugin/networkpolicy.go
+++ b/pkg/sdn/plugin/networkpolicy.go
@@ -16,9 +16,11 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 )
@@ -35,6 +37,8 @@ type networkPolicyPlugin struct {
 	lock        sync.Mutex
 	namespaces  map[uint32]*npNamespace
 	kNamespaces map[string]kapi.Namespace
+
+	kubeInformers kinternalinformers.SharedInformerFactory
 }
 
 // npNamespace tracks NetworkPolicy-related data for a Namespace
@@ -73,6 +77,7 @@ func (np *networkPolicyPlugin) Name() string {
 
 func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 	np.node = node
+	np.kubeInformers = node.kubeInformers
 	np.vnids = newNodeVNIDMap(np, node.osClient)
 	if err := np.vnids.Start(); err != nil {
 		return err
@@ -95,7 +100,7 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 		return err
 	}
 
-	go utilwait.Forever(np.watchNamespaces, 0)
+	np.watchNamespaces()
 	go utilwait.Forever(np.watchNetworkPolicies, 0)
 	return nil
 }
@@ -536,50 +541,59 @@ func namespaceIsIsolated(ns *kapi.Namespace) bool {
 }
 
 func (np *networkPolicyPlugin) watchNamespaces() {
-	RunEventQueue(np.node.kClient.Core().RESTClient(), Namespaces, func(delta cache.Delta) error {
-		ns := delta.Object.(*kapi.Namespace)
+	RegisterSharedInformerEventHandlers(np.kubeInformers,
+		np.handleAddOrUpdateNamespace, np.handleDeleteNamespace, Namespaces)
+}
 
-		glog.V(5).Infof("Watch %s event for Namespace %q", delta.Type, ns.Name)
-		switch delta.Type {
-		case cache.Sync, cache.Added, cache.Updated:
-			// Don't grab the lock yet since this may block
-			vnid, err := np.vnids.WaitAndGetVNID(ns.Name)
-			if err != nil {
-				return err
-			}
+func (np *networkPolicyPlugin) handleAddOrUpdateNamespace(obj, _ interface{}, eventType watch.EventType) {
+	ns := obj.(*kapi.Namespace)
+	glog.V(5).Infof("Watch %s event for Namespace %q", eventType, ns.Name)
+	// Don't grab the lock yet since this may block
+	vnid, err := np.vnids.WaitAndGetVNID(ns.Name)
+	if err != nil {
+		glog.Error(err)
+		return
+	}
 
-			np.lock.Lock()
-			defer np.lock.Unlock()
-			np.kNamespaces[ns.Name] = *ns
-			if npns, exists := np.namespaces[vnid]; exists {
-				npns.isolated = namespaceIsIsolated(ns)
-				np.syncNamespace(npns)
-			}
-			// else the NetNamespace doesn't exist yet, but we will initialize
-			// npns.isolated from the kapi.Namespace when it's created
+	np.lock.Lock()
+	defer np.lock.Unlock()
+	np.kNamespaces[ns.Name] = *ns
+	if npns, exists := np.namespaces[vnid]; exists {
+		npns.isolated = namespaceIsIsolated(ns)
+		np.syncNamespace(npns)
+	}
+	// else the NetNamespace doesn't exist yet, but we will initialize
+	// npns.isolated from the kapi.Namespace when it's created
 
-		case cache.Deleted:
-			np.lock.Lock()
-			defer np.lock.Unlock()
-			delete(np.kNamespaces, ns.Name)
+	np.refreshNetworkPolicies()
+}
 
-			// We don't need to np.syncNamespace() because if the NetNamespace
-			// still existed, it will be deleted as part of deleting the Namespace.
-		}
+func (np *networkPolicyPlugin) handleDeleteNamespace(obj interface{}) {
+	ns := obj.(*kapi.Namespace)
+	glog.V(5).Infof("Watch %s event for Namespace %q", watch.Deleted, ns.Name)
+	np.lock.Lock()
+	defer np.lock.Unlock()
+	delete(np.kNamespaces, ns.Name)
 
-		for _, npns := range np.namespaces {
-			changed := false
-			for _, npp := range npns.policies {
-				if npp.watchesNamespaces {
-					if np.updateNetworkPolicy(npns, &npp.policy) {
-						changed = true
-					}
+	// We don't need to np.syncNamespace() because if the NetNamespace
+	// still existed, it will be deleted as part of deleting the Namespace.
+
+	np.refreshNetworkPolicies()
+}
+
+func (np *networkPolicyPlugin) refreshNetworkPolicies() {
+	for _, npns := range np.namespaces {
+		changed := false
+		for _, npp := range npns.policies {
+			if npp.watchesNamespaces {
+				if np.updateNetworkPolicy(npns, &npp.policy) {
+					changed = true
+					break
 				}
 			}
-			if changed {
-				np.syncNamespace(npns)
-			}
 		}
-		return nil
-	})
+		if changed {
+			np.syncNamespace(npns)
+		}
+	}
 }

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
@@ -255,7 +255,7 @@ func (node *OsdnNode) Start() error {
 	if err = node.policy.Start(node); err != nil {
 		return err
 	}
-	go kwait.Forever(node.watchServices, 0)
+	node.watchServices()
 
 	log.V(5).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerSocketPath, node.host, node.localSubnetCIDR, node.networkInfo.ClusterNetwork); err != nil {
@@ -351,45 +351,45 @@ func isServiceChanged(oldsvc, newsvc *kapi.Service) bool {
 }
 
 func (node *OsdnNode) watchServices() {
-	services := make(map[string]*kapi.Service)
-	RunEventQueue(node.kClient.Core().RESTClient(), Services, func(delta cache.Delta) error {
-		serv := delta.Object.(*kapi.Service)
+	RegisterSharedInformerEventHandlers(node.kubeInformers,
+		node.handleAddOrUpdateService, node.handleDeleteService, Services)
+}
 
-		// Ignore headless services
-		if !kapi.IsServiceIPSet(serv) {
-			return nil
+func (node *OsdnNode) handleAddOrUpdateService(obj, oldObj interface{}, eventType watch.EventType) {
+	serv := obj.(*kapi.Service)
+	// Ignore headless services
+	if !kapi.IsServiceIPSet(serv) {
+		return
+	}
+
+	log.V(5).Infof("Watch %s event for Service %q", eventType, serv.Name)
+	oldServ, exists := oldObj.(*kapi.Service)
+	if exists {
+		if !isServiceChanged(oldServ, serv) {
+			return
 		}
+		node.DeleteServiceRules(oldServ)
+	}
 
-		log.V(5).Infof("Watch %s event for Service %q", delta.Type, serv.ObjectMeta.Name)
-		switch delta.Type {
-		case cache.Sync, cache.Added, cache.Updated:
-			oldsvc, exists := services[string(serv.UID)]
-			if exists {
-				if !isServiceChanged(oldsvc, serv) {
-					break
-				}
-				node.DeleteServiceRules(oldsvc)
-			}
+	netid, err := node.policy.GetVNID(serv.Namespace)
+	if err != nil {
+		log.Errorf("Skipped adding service rules for serviceEvent: %v, Error: %v", eventType, err)
+		return
+	}
 
-			netid, err := node.policy.GetVNID(serv.Namespace)
-			if err != nil {
-				return fmt.Errorf("skipped adding service rules for serviceEvent: %v, Error: %v", delta.Type, err)
-			}
+	node.AddServiceRules(serv, netid)
+	if !exists {
+		node.policy.RefVNID(netid)
+	}
+}
 
-			node.AddServiceRules(serv, netid)
-			services[string(serv.UID)] = serv
-			if !exists {
-				node.policy.RefVNID(netid)
-			}
-		case cache.Deleted:
-			delete(services, string(serv.UID))
-			node.DeleteServiceRules(serv)
+func (node *OsdnNode) handleDeleteService(obj interface{}) {
+	serv := obj.(*kapi.Service)
+	log.V(5).Infof("Watch %s event for Service %q", watch.Deleted, serv.Name)
+	node.DeleteServiceRules(serv)
 
-			netid, err := node.policy.GetVNID(serv.Namespace)
-			if err == nil {
-				node.policy.UnrefVNID(netid)
-			}
-		}
-		return nil
-	})
+	netid, err := node.policy.GetVNID(serv.Namespace)
+	if err == nil {
+		node.policy.UnrefVNID(netid)
+	}
 }

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 )
@@ -72,10 +73,12 @@ type OsdnNode struct {
 	kubeletCniPlugin knetwork.NetworkPlugin
 
 	clearLbr0IptablesRule bool
+
+	kubeInformers kinternalinformers.SharedInformerFactory
 }
 
 // Called by higher layers to create the plugin SDN node instance
-func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient kclientset.Interface, hostname string, selfIP string, iptablesSyncPeriod time.Duration, mtu uint32) (*OsdnNode, error) {
+func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient kclientset.Interface, hostname string, selfIP string, iptablesSyncPeriod time.Duration, mtu uint32, kubeInformers kinternalinformers.SharedInformerFactory) (*OsdnNode, error) {
 	var policy osdnPolicy
 	var pluginId int
 	var minOvsVersion string
@@ -139,6 +142,7 @@ func NewNodePlugin(pluginName string, osClient *osclient.Client, kClient kclient
 		mtu:                mtu,
 		egressPolicies:     make(map[uint32][]osapi.EgressNetworkPolicy),
 		egressDNS:          NewEgressDNS(),
+		kubeInformers:      kubeInformers,
 	}
 
 	if err := plugin.dockerPreCNICleanup(); err != nil {


### PR DESCRIPTION
Changed network policy plugin to do pod watch for all namespaces (one go routine for the cluster) instead of pod watch for each namespace (go routine for each namespace).