### PR TITLE
prove the clientbuilder works with RC controller

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/dead.go
+++ b/pkg/cmd/server/bootstrappolicy/dead.go
@@ -1,0 +1,37 @@
+package bootstrappolicy
+
+import (
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+var (
+	deadClusterRoles = []authorizationapi.ClusterRole{}
+)
+
+func addDeadClusterRole(name string) {
+	for _, existingRole := range deadClusterRoles {
+		if name == existingRole.Name {
+			glog.Fatalf("role %q was already registered", name)
+		}
+	}
+
+	deadClusterRoles = append(deadClusterRoles,
+		authorizationapi.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		},
+	)
+}
+
+// GetDeadClusterRoles returns cluster roles which should no longer have any permissions.
+// These are enumerated so that a reconcile that tightens permissions will properly.
+func GetDeadClusterRoles() []authorizationapi.ClusterRole {
+	return deadClusterRoles
+}
+
+func init() {
+	addDeadClusterRole("system:replication-controller")
+}

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -26,9 +26,6 @@ const (
 	InfraBuildControllerServiceAccountName = "build-controller"
 	BuildControllerRoleName                = "system:build-controller"
 
-	InfraReplicationControllerServiceAccountName = "replication-controller"
-	ReplicationControllerRoleName                = "system:replication-controller"
-
 	InfraReplicaSetControllerServiceAccountName = "replicaset-controller"
 	ReplicaSetControllerRoleName                = "system:replicaset-controller"
 
@@ -280,51 +277,6 @@ func init() {
 				},
 				{
 					APIGroups: []string{""},
-					Verbs:     sets.NewString("create", "update", "patch"),
-					Resources: sets.NewString("events"),
-				},
-			},
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	err = InfraSAs.addServiceAccount(
-		InfraReplicationControllerServiceAccountName,
-		authorizationapi.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ReplicationControllerRoleName,
-			},
-			Rules: []authorizationapi.PolicyRule{
-				// ReplicationManager.rcController.ListWatch
-				{
-					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("replicationcontrollers"),
-				},
-				// ReplicationManager.syncReplicationController() -> updateReplicaCount()
-				{
-					// TODO: audit/remove those, 1.0 controllers needed get, update
-					Verbs:     sets.NewString("get", "update"),
-					Resources: sets.NewString("replicationcontrollers"),
-				},
-				// ReplicationManager.syncReplicationController() -> updateReplicaCount()
-				{
-					Verbs:     sets.NewString("update"),
-					Resources: sets.NewString("replicationcontrollers/status"),
-				},
-				// ReplicationManager.podController.ListWatch
-				{
-					Verbs:     sets.NewString("list", "watch"),
-					Resources: sets.NewString("pods"),
-				},
-				// ReplicationManager.podControl (RealPodControl)
-				{
-					Verbs:     sets.NewString("create", "delete", "patch"),
-					Resources: sets.NewString("pods"),
-				},
-				// ReplicationManager.podControl.recorder
-				{
 					Verbs:     sets.NewString("create", "update", "patch"),
 					Resources: sets.NewString("events"),
 				},

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -941,6 +941,9 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 	openshiftClusterRoles := GetOpenshiftBootstrapClusterRoles()
+	// dead cluster roles need to be checked for conflicts (in case something new comes up)
+	// so add them to this list.
+	openshiftClusterRoles = append(openshiftClusterRoles, GetDeadClusterRoles()...)
 	openshiftSAClusterRoles := InfraSAs.AllRoles()
 	kubeClusterRoles, err := GetKubeBootstrapClusterRoles()
 	// coder error

--- a/pkg/cmd/server/kubernetes/master/master.go
+++ b/pkg/cmd/server/kubernetes/master/master.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
 	gccontroller "k8s.io/kubernetes/pkg/controller/podgc"
 	replicasetcontroller "k8s.io/kubernetes/pkg/controller/replicaset"
-	replicationcontroller "k8s.io/kubernetes/pkg/controller/replication"
 	servicecontroller "k8s.io/kubernetes/pkg/controller/service"
 	statefulsetcontroller "k8s.io/kubernetes/pkg/controller/statefulset"
 	attachdetachcontroller "k8s.io/kubernetes/pkg/controller/volume/attachdetach"
@@ -205,17 +204,6 @@ func (c *MasterConfig) RunReplicaSetController(client kclientset.Interface) {
 		replicasetcontroller.BurstReplicas,
 	)
 	go controller.Run(int(c.ControllerManager.ConcurrentRSSyncs), utilwait.NeverStop)
-}
-
-// RunReplicationController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunReplicationController(client kclientset.Interface) {
-	controllerManager := replicationcontroller.NewReplicationManager(
-		c.Informers.KubernetesInformers().Core().V1().Pods(),
-		c.Informers.KubernetesInformers().Core().V1().ReplicationControllers(),
-		client,
-		replicationcontroller.BurstReplicas,
-	)
-	go controllerManager.Run(int(c.ControllerManager.ConcurrentRCSyncs), utilwait.NeverStop)
 }
 
 func (c *MasterConfig) RunDeploymentController(client kclientset.Interface) {

--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -29,7 +29,10 @@ os::cmd::expect_success 'oc new-project asmail --as=deads@deads.io'
 os::cmd::try_until_text 'oc get appliedclusterresourcequota -n bar --as deads -o name' "for-deads-by-annotation"
 os::cmd::try_until_text 'oc get appliedclusterresourcequota -n foo --as deads -o name' "for-deads-by-annotation"
 os::cmd::try_until_text 'oc get appliedclusterresourcequota -n asmail --as deads@deads.io -o name' "for-deads-email-by-annotation"
-os::cmd::try_until_text 'oc describe appliedclusterresourcequota/for-deads-by-annotation -n bar --as deads' "secrets.*1[0-9]"
+# the point of the test is to make sure that clusterquota is counting correct and secrets are auto-created and countable
+# the create_dockercfg controller can issue multiple creates if the token controller doesn't fill them in, but the creates are duplicates
+# since an annotation tracks the intended secrets to be created.  That results in multi-counting quota until reconciliation runs
+os::cmd::try_until_text 'oc describe appliedclusterresourcequota/for-deads-by-annotation -n bar --as deads' "secrets.*(1[0-9]|20|21|22)"
 os::cmd::expect_success 'oc delete project foo'
 os::cmd::try_until_not_text 'oc get clusterresourcequota/for-deads-by-annotation -o jsonpath="{.status.namespaces[*].namespace}"' 'foo'
 os::cmd::expect_success 'oc delete project bar'

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2784,6 +2784,12 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    creationTimestamp: null
+    name: system:replication-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
     annotations:
       authorization.openshift.io/system-only: "true"
     creationTimestamp: null
@@ -3716,63 +3722,6 @@ items:
     - delete
     - list
     - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:replication-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers
-    verbs:
-    - get
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers/status
-    verbs:
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-    - patch
   - apiGroups:
     - ""
     attributeRestrictions: null

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -177,7 +177,7 @@ func Run(s *options.CMServer) error {
 			clientBuilder = rootClientBuilder
 		}
 
-		err := StartControllers(newControllerInitializers(), s, rootClientBuilder, clientBuilder, stop)
+		err := StartControllers(NewControllerInitializers(), s, rootClientBuilder, clientBuilder, stop)
 		glog.Fatalf("error running controllers: %v", err)
 		panic("unreachable")
 	}
@@ -272,7 +272,7 @@ func IsControllerEnabled(name string, disabledByDefaultControllers sets.String, 
 type InitFunc func(ctx ControllerContext) (bool, error)
 
 func KnownControllers() []string {
-	ret := sets.StringKeySet(newControllerInitializers())
+	ret := sets.StringKeySet(NewControllerInitializers())
 
 	ret.Insert(
 		saTokenControllerName,
@@ -292,7 +292,7 @@ var ControllersDisabledByDefault = sets.NewString(
 	"tokencleaner",
 )
 
-func newControllerInitializers() map[string]InitFunc {
+func NewControllerInitializers() map[string]InitFunc {
 	controllers := map[string]InitFunc{}
 	controllers["endpoint"] = startEndpointController
 	controllers["replicationcontroller"] = startReplicationController
@@ -319,7 +319,7 @@ func newControllerInitializers() map[string]InitFunc {
 
 // TODO: In general, any controller checking this needs to be dynamic so
 //  users don't have to restart their controller manager if they change the apiserver.
-func getAvailableResources(clientBuilder controller.ControllerClientBuilder) (map[schema.GroupVersionResource]bool, error) {
+func GetAvailableResources(clientBuilder controller.ControllerClientBuilder) (map[schema.GroupVersionResource]bool, error) {
 	var discoveryClient discovery.DiscoveryInterface
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
@@ -403,7 +403,7 @@ func StartControllers(controllers map[string]InitFunc, s *options.CMServer, root
 		glog.Warningf("%q is disabled", saTokenControllerName)
 	}
 
-	availableResources, err := getAvailableResources(clientBuilder)
+	availableResources, err := GetAvailableResources(clientBuilder)
 	if err != nil {
 		return err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller.go
@@ -266,15 +266,15 @@ func (e *TokensController) syncServiceAccount() {
 		// service account no longer exists, so delete related tokens
 		glog.V(4).Infof("syncServiceAccount(%s/%s), service account deleted, removing tokens", saInfo.namespace, saInfo.name)
 		sa = &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: saInfo.namespace, Name: saInfo.name, UID: saInfo.uid}}
-		if retriable, err := e.deleteTokens(sa); err != nil {
+		retry, err = e.deleteTokens(sa)
+		if err != nil {
 			glog.Errorf("error deleting serviceaccount tokens for %s/%s: %v", saInfo.namespace, saInfo.name, err)
-			retry = retriable
 		}
 	default:
 		// ensure a token exists and is referenced by this service account
-		if retriable, err := e.ensureReferencedToken(sa); err != nil {
+		retry, err = e.ensureReferencedToken(sa)
+		if err != nil {
 			glog.Errorf("error synchronizing serviceaccount %s/%s: %v", saInfo.namespace, saInfo.name, err)
-			retry = retriable
 		}
 	}
 }
@@ -374,19 +374,12 @@ func (e *TokensController) deleteToken(ns, name string, uid types.UID) ( /*retry
 
 // ensureReferencedToken makes sure at least one ServiceAccountToken secret exists, and is included in the serviceAccount's Secrets list
 func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccount) ( /* retry */ bool, error) {
-	if len(serviceAccount.Secrets) > 0 {
-		allSecrets, err := e.listTokenSecrets(serviceAccount)
-		if err != nil {
-			// Don't retry cache lookup errors
-			return false, err
-		}
-		referencedSecrets := getSecretReferences(serviceAccount)
-		for _, secret := range allSecrets {
-			if referencedSecrets.Has(secret.Name) {
-				// A service account token already exists, and is referenced, short-circuit
-				return false, nil
-			}
-		}
+	if hasToken, err := e.hasReferencedToken(serviceAccount); err != nil {
+		// Don't retry cache lookup errors
+		return false, err
+	} else if hasToken {
+		// A service account token already exists, and is referenced, short-circuit
+		return false, nil
 	}
 
 	// We don't want to update the cache's copy of the service account
@@ -394,14 +387,13 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 	serviceAccounts := e.client.Core().ServiceAccounts(serviceAccount.Namespace)
 	liveServiceAccount, err := serviceAccounts.Get(serviceAccount.Name, metav1.GetOptions{})
 	if err != nil {
-		// Retry for any error other than a NotFound
-		return !apierrors.IsNotFound(err), err
+		// Retry if we cannot fetch the live service account (for a NotFound error, either the live lookup or our cache are stale)
+		return true, err
 	}
 	if liveServiceAccount.ResourceVersion != serviceAccount.ResourceVersion {
-		// our view of the service account is not up to date
-		// we'll get notified of an update event later and get to try again
-		glog.V(2).Infof("serviceaccount %s/%s is not up to date, skipping token creation", serviceAccount.Namespace, serviceAccount.Name)
-		return false, nil
+		// Retry if our liveServiceAccount doesn't match our cache's resourceVersion (either the live lookup or our cache are stale)
+		glog.V(4).Infof("liveServiceAccount.ResourceVersion (%s) does not match cache (%s), retrying", liveServiceAccount.ResourceVersion, serviceAccount.ResourceVersion)
+		return true, nil
 	}
 
 	// Build the secret
@@ -443,16 +435,53 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 	// This prevents the service account update (below) triggering another token creation, if the referenced token couldn't be found in the store
 	e.secrets.Add(createdToken)
 
-	liveServiceAccount.Secrets = append(liveServiceAccount.Secrets, v1.ObjectReference{Name: secret.Name})
+	// Try to add a reference to the newly created token to the service account
+	addedReference := false
+	err = clientretry.RetryOnConflict(clientretry.DefaultRetry, func() error {
+		// refresh liveServiceAccount on every retry
+		defer func() { liveServiceAccount = nil }()
 
-	if _, err = serviceAccounts.Update(liveServiceAccount); err != nil {
+		// fetch the live service account if needed, and verify the UID matches and that we still need a token
+		if liveServiceAccount == nil {
+			liveServiceAccount, err = serviceAccounts.Get(serviceAccount.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			if liveServiceAccount.UID != serviceAccount.UID {
+				// If we don't have the same service account, stop trying to add a reference to the token made for the old service account.
+				return nil
+			}
+
+			if hasToken, err := e.hasReferencedToken(liveServiceAccount); err != nil {
+				// Don't retry cache lookup errors
+				return nil
+			} else if hasToken {
+				// A service account token already exists, and is referenced, short-circuit
+				return nil
+			}
+		}
+
+		// Try to add a reference to the token
+		liveServiceAccount.Secrets = append(liveServiceAccount.Secrets, v1.ObjectReference{Name: secret.Name})
+		if _, err := serviceAccounts.Update(liveServiceAccount); err != nil {
+			return err
+		}
+
+		addedReference = true
+		return nil
+	})
+
+	if !addedReference {
 		// we weren't able to use the token, try to clean it up.
 		glog.V(2).Infof("deleting secret %s/%s because reference couldn't be added (%v)", secret.Namespace, secret.Name, err)
 		deleteOpts := &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &createdToken.UID}}
 		if deleteErr := e.client.Core().Secrets(createdToken.Namespace).Delete(createdToken.Name, deleteOpts); deleteErr != nil {
 			glog.Error(deleteErr) // if we fail, just log it
 		}
+	}
 
+	if err != nil {
 		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
 			// if we got a Conflict error, the service account was updated by someone else, and we'll get an update notification later
 			// if we got a NotFound error, the service account no longer exists, and we don't need to create a token for it
@@ -463,6 +492,24 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 	}
 
 	// success!
+	return false, nil
+}
+
+// hasReferencedToken returns true if the serviceAccount references a service account token secret
+func (e *TokensController) hasReferencedToken(serviceAccount *v1.ServiceAccount) (bool, error) {
+	if len(serviceAccount.Secrets) == 0 {
+		return false, nil
+	}
+	allSecrets, err := e.listTokenSecrets(serviceAccount)
+	if err != nil {
+		return false, err
+	}
+	referencedSecrets := getSecretReferences(serviceAccount)
+	for _, secret := range allSecrets {
+		if referencedSecrets.Has(secret.Name) {
+			return true, nil
+		}
+	}
 	return false, nil
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -325,9 +325,12 @@ func TestTokenCreation(t *testing.T) {
 		},
 		"new serviceaccount with no secrets with resource conflict": {
 			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences()), createdTokenSecret()},
+			IsAsync:       true,
+			MaxRetries:    1,
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []core.Action{
+				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 			},
 		},
@@ -369,9 +372,12 @@ func TestTokenCreation(t *testing.T) {
 		},
 		"updated serviceaccount with no secrets with resource conflict": {
 			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences())},
+			IsAsync:       true,
+			MaxRetries:    1,
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []core.Action{
+				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 			},
 		},


### PR DESCRIPTION
This pull plumbs in the client builder and controller initializer to our kube launch to start using the upstream roles and bindings.

@liggitt fyi
@enj please review 