### PR TITLE
Fix negative unavailable replicas

### DIFF
--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -133,13 +133,12 @@ func handleEmptyImageReferences(template *kapi.PodTemplateSpec, triggers []deplo
 func ValidateDeploymentConfigStatus(status deployapi.DeploymentConfigStatus) field.ErrorList {
 	allErrs := field.ErrorList{}
 	statusPath := field.NewPath("status")
-	if status.LatestVersion < 0 {
-		allErrs = append(allErrs, field.Invalid(statusPath.Child("latestVersion"), status.LatestVersion, "latestVersion cannot be negative"))
-	}
-	if status.ObservedGeneration < int64(0) {
-		allErrs = append(allErrs, field.Invalid(statusPath.Child("observedGeneration"), status.ObservedGeneration, "observedGeneration cannot be negative"))
-	}
+	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.LatestVersion), statusPath.Child("latestVersion"))...)
+	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.ObservedGeneration), statusPath.Child("observedGeneration"))...)
+	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.Replicas), statusPath.Child("replicas"))...)
 	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.ReadyReplicas), statusPath.Child("readyReplicas"))...)
+	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.AvailableReplicas), statusPath.Child("availableReplicas"))...)
+	allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(status.UnavailableReplicas), statusPath.Child("unavailableReplicas"))...)
 	return allErrs
 }
 

--- a/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
+++ b/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/glog"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -275,10 +274,7 @@ func (c *DeploymentConfigController) reconcileDeployments(existingDeployments []
 // Update the status of the provided deployment config. Additional conditions will override any other condition in the
 // deployment config status.
 func (c *DeploymentConfigController) updateStatus(config *deployapi.DeploymentConfig, deployments []*kapi.ReplicationController, additional ...deployapi.DeploymentCondition) error {
-	newStatus, err := c.calculateStatus(*config, deployments, additional...)
-	if err != nil {
-		return err
-	}
+	newStatus := calculateStatus(config, deployments, additional...)
 
 	// NOTE: We should update the status of the deployment config only if we need to, otherwise
 	// we hotloop between updates.
@@ -305,36 +301,33 @@ func (c *DeploymentConfigController) updateStatus(config *deployapi.DeploymentCo
 	return nil
 }
 
-func (c *DeploymentConfigController) calculateStatus(config deployapi.DeploymentConfig, deployments []*kapi.ReplicationController, additional ...deployapi.DeploymentCondition) (deployapi.DeploymentConfigStatus, error) {
-	selector := labels.Set(config.Spec.Selector).AsSelector()
-	// TODO: Replace with using rc.status.availableReplicas that comes with the next rebase.
-	pods, err := c.podLister.Pods(config.Namespace).List(selector)
-	if err != nil {
-		return config.Status, err
-	}
-	available := deployutil.GetAvailablePods(pods, config.Spec.MinReadySeconds)
-
-	// UpdatedReplicas represents the replicas that use the deployment config template which means
+func calculateStatus(config *deployapi.DeploymentConfig, rcs []*kapi.ReplicationController, additional ...deployapi.DeploymentCondition) deployapi.DeploymentConfigStatus {
+	// UpdatedReplicas represents the replicas that use the current deployment config template which means
 	// we should inform about the replicas of the latest deployment and not the active.
 	latestReplicas := int32(0)
-	latestExists, latestRC := deployutil.LatestDeploymentInfo(&config, deployments)
+	latestExists, latestRC := deployutil.LatestDeploymentInfo(config, rcs)
 	if !latestExists {
 		latestRC = nil
 	} else {
 		latestReplicas = deployutil.GetStatusReplicaCountForDeployments([]*kapi.ReplicationController{latestRC})
 	}
 
-	total := deployutil.GetReplicaCountForDeployments(deployments)
+	available := deployutil.GetAvailableReplicaCountForReplicationControllers(rcs)
+	total := deployutil.GetReplicaCountForDeployments(rcs)
+	unavailableReplicas := total - available
+	if unavailableReplicas < 0 {
+		unavailableReplicas = 0
+	}
 
 	status := deployapi.DeploymentConfigStatus{
 		LatestVersion:       config.Status.LatestVersion,
 		Details:             config.Status.Details,
 		ObservedGeneration:  config.Generation,
-		Replicas:            deployutil.GetStatusReplicaCountForDeployments(deployments),
+		Replicas:            deployutil.GetStatusReplicaCountForDeployments(rcs),
 		UpdatedReplicas:     latestReplicas,
 		AvailableReplicas:   available,
-		ReadyReplicas:       deployutil.GetReadyReplicaCountForReplicationControllers(deployments),
-		UnavailableReplicas: total - available,
+		ReadyReplicas:       deployutil.GetReadyReplicaCountForReplicationControllers(rcs),
+		UnavailableReplicas: unavailableReplicas,
 		Conditions:          config.Status.Conditions,
 	}
 
@@ -343,10 +336,10 @@ func (c *DeploymentConfigController) calculateStatus(config deployapi.Deployment
 		deployutil.SetDeploymentCondition(&status, cond)
 	}
 
-	return status, nil
+	return status
 }
 
-func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.DeploymentConfigStatus, latestRC *kapi.ReplicationController) {
+func updateConditions(config *deployapi.DeploymentConfig, newStatus *deployapi.DeploymentConfigStatus, latestRC *kapi.ReplicationController) {
 	// Availability condition.
 	if newStatus.AvailableReplicas >= config.Spec.Replicas-deployutil.MaxUnavailable(config) && newStatus.AvailableReplicas > 0 {
 		minAvailability := deployutil.NewDeploymentCondition(deployapi.DeploymentAvailable, kapi.ConditionTrue, "", "Deployment config has minimum availability.")
@@ -364,7 +357,7 @@ func updateConditions(config deployapi.DeploymentConfig, newStatus *deployapi.De
 			condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionUnknown, "", msg)
 			deployutil.SetDeploymentCondition(newStatus, *condition)
 		case deployapi.DeploymentStatusRunning:
-			if deployutil.IsProgressing(config, *newStatus) {
+			if deployutil.IsProgressing(config, newStatus) {
 				deployutil.RemoveDeploymentCondition(newStatus, deployapi.DeploymentProgressing)
 				msg := fmt.Sprintf("replication controller %q is progressing", latestRC.Name)
 				condition := deployutil.NewDeploymentCondition(deployapi.DeploymentProgressing, kapi.ConditionTrue, deployapi.ReplicationControllerUpdatedReason, msg)


### PR DESCRIPTION
@mfojtik @tnozicka saw this in one of our jobs

https://ci.openshift.redhat.com/jenkins/view/All/job/ami_build_origin_int_rhel_fork/7/consoleFull#-169259343956c60d7be4b02b88ae8c268b
```
status:
  availableReplicas: 3
  conditions:
  - lastTransitionTime: 2017-05-03T15:38:41Z
    lastUpdateTime: 2017-05-03T15:38:41Z
    message: Deployment config has minimum availability.
    status: "True"
    type: Available
  - lastTransitionTime: 2017-05-03T15:41:36Z
    lastUpdateTime: 2017-05-03T15:41:38Z
    message: replication controller "history-limit-11" successfully rolled out
    reason: NewReplicationControllerAvailable
    status: "True"
    type: Progressing
  details:
    causes:
    - type: ConfigChange
    message: config change
  latestVersion: 11
  observedGeneration: 22
  readyReplicas: 1
  replicas: 1
  unavailableReplicas: -2
  updatedReplicas: 1
```
Similar fix to https://github.com/kubernetes/kubernetes/pull/38299

Also fixes https://github.com/openshift/origin/issues/11462

Still need to finish the unit test for calculateStatus but this is ready for reviews.