### PR TITLE
Use generic start utilities in test-cmd

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -283,10 +283,11 @@ function os::start::master() {
 
 	os::log::debug "Starting OpenShift server"
 	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
-	$(os::start::internal::openshift_executable) start master \
-		--config="${MASTER_CONFIG_DIR}/master-config.yaml" \
-		--loglevel=4 --logspec='*importer=5' \
-	&>"${LOG_DIR}/openshift.log" &
+	$(os::start::internal::openshift_executable) start master                                       \
+	                                             --loglevel=4                                       \
+	                                             --logspec='*importer=5'                            \
+	                                             --config="${MASTER_CONFIG_DIR}/master-config.yaml" \
+	                                             &>"${LOG_DIR}/openshift.log" &
 	export OS_PID=$!
 
 	os::log::debug "OpenShift server start at: $( date )"
@@ -334,13 +335,13 @@ function os::start::all_in_one() {
 	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable)"
-	${openshift_executable} start                                                       \
-		                      --loglevel=4                                              \
-		                      --logspec='*importer=5'                                   \
-		                      --latest-images="${use_latest_images}"                    \
-		                      --node-config="${NODE_CONFIG_DIR}/node-config.yaml"       \
-		                      --master-config="${MASTER_CONFIG_DIR}/master-config.yaml" \
-		                      &>"${LOG_DIR}/openshift.log" &
+	${openshift_executable} start                                                     \
+	                        --loglevel=4                                              \
+	                        --logspec='*importer=5'                                   \
+	                        --latest-images="${use_latest_images}"                    \
+	                        --node-config="${NODE_CONFIG_DIR}/node-config.yaml"       \
+	                        --master-config="${MASTER_CONFIG_DIR}/master-config.yaml" \
+	                        &>"${LOG_DIR}/openshift.log" &
 	export OS_PID=$!
 
 	os::log::debug "OpenShift server start at: $( date )"

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -284,7 +284,7 @@ function os::start::master() {
 	os::log::debug "$( ps -ef | grep openshift )"
 
 	os::log::debug "Starting OpenShift server"
-	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
+	local openshift_env=( "OPENSHIFT_PROFILE=${OPENSHIFT_PROFILE:-web}" "OPENSHIFT_ON_PANIC=crash" )
 	$(os::start::internal::openshift_executable) start master                                       \
 	                                             --loglevel=4                                       \
 	                                             --logspec='*importer=5'                            \
@@ -334,7 +334,7 @@ function os::start::all_in_one() {
 	fi
 
 	os::log::debug "Starting OpenShift server"
-	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
+	local openshift_env=( "OPENSHIFT_PROFILE=${OPENSHIFT_PROFILE:-web}" "OPENSHIFT_ON_PANIC=crash" )
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable)"
 	${openshift_executable} start                                                     \
@@ -410,7 +410,7 @@ readonly -f os::start::etcd
 function os::start::api_server() {
 	local api_server_version=${1:-}
 	local openshift_volumes=( "${MASTER_CONFIG_DIR}" )
-	local openshift_env=( "OPENSHIFT_PROFILE=web" "OPENSHIFT_ON_PANIC=crash" )
+	local openshift_env=( "OPENSHIFT_PROFILE=${OPENSHIFT_PROFILE:-web}" "OPENSHIFT_ON_PANIC=crash" )
 	local openshift_executable
 	openshift_executable="$(os::start::internal::openshift_executable "${api_server_version}")"
 

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -295,9 +295,9 @@ function os::start::master() {
 	os::log::debug "OpenShift server start at: $( date )"
 
 	os::test::junit::declare_suite_start "setup/start-master"
-	os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
-	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
-	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 160 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw /healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
+	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 
 	os::log::debug "OpenShift server health checks done at: $( date )"
@@ -349,11 +349,11 @@ function os::start::all_in_one() {
 	os::log::debug "OpenShift server start at: $( date )"
 
 	os::test::junit::declare_suite_start "setup/start-all_in_one"
-	os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
-	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 2 * minute )) 0.5
-	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
-	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 160 * second )) 0.25
-	os::cmd::try_until_success "oc get --raw /api/v1/nodes/${KUBELET_HOST} --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" $(( 80 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw /healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 80 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 2 * minute )) 0.5
+	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 80 * second )) 0.25
+	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
+	os::cmd::try_until_success "oc get --raw /api/v1/nodes/${KUBELET_HOST} --config='${ADMIN_KUBECONFIG}'" $(( 80 * second )) 0.25
 	os::test::junit::declare_suite_end
 
 	os::log::debug "OpenShift server health checks done at: $( date )"
@@ -423,8 +423,8 @@ function os::start::api_server() {
 	os::log::debug "OpenShift API server start at: $( date )"
 
 	os::test::junit::declare_suite_start "setup/start-api_server"
-	os::cmd::try_until_text "oc get --raw /healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
-	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 160 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw /healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 80 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 
 	os::log::debug "OpenShift API server health checks done at: $( date )"
@@ -493,7 +493,7 @@ function os::start::internal::start_node() {
 	os::log::debug "OpenShift node start at: $( date )"
 
 	os::test::junit::declare_suite_start "setup/start-node"
-	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${MASTER_CONFIG_DIR}/admin.kubeconfig'" 'ok' $(( 80 * second )) 0.25
+	os::cmd::try_until_text "oc get --raw ${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 80 * second )) 0.25
 	os::test::junit::declare_suite_end
 
 	os::log::debug "OpenShift node health checks done at: $( date )"

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -649,7 +649,7 @@ function os::start::registry() {
 	# For testing purposes, ensure the quota objects are always up to date in the registry by
 	# disabling project cache.
 	openshift admin registry --config="${ADMIN_KUBECONFIG}" --images="${USE_IMAGES}" --enforce-quota -o json | \
-		oc env -f - --output json "REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_PROJECTCACHETTL=0" | \
-		oc create -f -
+		oc env --config="${ADMIN_KUBECONFIG}" -f - --output json "REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_PROJECTCACHETTL=0" | \
+		oc create --config="${ADMIN_KUBECONFIG}" -f -
 }
 readonly -f os::start::registry

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -140,6 +140,7 @@ readonly -f os::start::internal::create_bootstrap_policy
 #  - API_BIND_HOST
 #  - API_PORT
 #  - PUBLIC_MASTER_HOST
+#  - NETWORK_PLUGIN
 # Arguments
 #  1 - alternate version for the config
 #  - MASTER_CONFIG_DIR
@@ -158,6 +159,7 @@ function os::start::internal::configure_master() {
 	                        --hostname="${KUBELET_HOST}"                            \
 	                        --volume-dir="${VOLUME_DIR}"                            \
 	                        --etcd-dir="${ETCD_DATA_DIR}"                           \
+	                        --network-plugin="${NETWORK_PLUGIN:-}"                  \
 	                        --write-config="${SERVER_CONFIG_DIR}"                   \
 	                        --listen="${API_SCHEME}://${API_BIND_HOST}:${API_PORT}" \
 	                        --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}"

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -68,7 +68,6 @@ readonly -f os::util::environment::setup_time_vars
 #  - export VOLUME_DIR
 #  - export ARTIFACT_DIR
 #  - export FAKE_HOME_DIR
-#  - export HOME
 #  - export KUBELET_SCHEME
 #  - export KUBELET_BIND_HOST
 #  - export KUBELET_HOST
@@ -129,7 +128,6 @@ readonly -f os::util::environment::update_path_var
 #  - export VOLUME_DIR
 #  - export ARTIFACT_DIR
 #  - export FAKE_HOME_DIR
-#  - export HOME
 #  - export OS_TMP_ENV_SET
 function os::util::environment::setup_tmpdir_vars() {
     local sub_dir=$1

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -39,8 +39,6 @@ function cleanup()
 trap "exit" INT TERM
 trap "cleanup" EXIT
 
-set -e
-
 function find_tests() {
     local test_regex="${1}"
     local full_test_list=()
@@ -61,8 +59,6 @@ function find_tests() {
     fi
 }
 tests=( $(find_tests ${1:-.*}) )
-
-# Setup environment
 
 # test-cmd specific defaults
 API_HOST=${API_HOST:-127.0.0.1}
@@ -100,14 +96,6 @@ if [[ -n "${profile}" ]]; then
 else
   export WEB_PROFILE=cpu
 fi
-
-# Check openshift version
-echo "openshift version:"
-openshift version
-
-# Check oc version
-echo "oc version:"
-oc version
 
 # profile the web
 export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
@@ -187,9 +175,6 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 # start up a registry for images tests
 ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" os::start::registry
 
-#
-# Begin tests
-#
 
 # check oc version with no config file
 os::test::junit::declare_suite_start "cmd/version"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -61,10 +61,7 @@ function find_tests() {
 tests=( $(find_tests ${1:-.*}) )
 
 # test-cmd specific defaults
-API_HOST=${API_HOST:-127.0.0.1}
 export API_PORT=${API_PORT:-28443}
-
-export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -25,6 +25,8 @@ project="$( oc project -q )"
 defaultimage="openshift/origin-\${component}:latest"
 USE_IMAGES=${USE_IMAGES:-$defaultimage}
 
+export NODECONFIG="${NODE_CONFIG_DIR}/node-config.yaml"
+
 os::test::junit::declare_suite_start "cmd/admin"
 # This test validates admin level commands including system policy
 


### PR DESCRIPTION
Use generic start utilities in test-cmd

There is no reason other than historical cruft that the command tests do
not use the generic and shared startup code in `hack/lib/start.sh`. This
patch finally converges the two startup scenarios.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Stop using loopback address for API_HOST

The original choice to use a loopback address instead of running
`openshift start --print-ip` was made for historical reasons before the
newer and more useful IP utility was available. We do not regress by not
forcing the loopback address for this test.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Start registry using administrative credentials

If a user has not exposed the `$ADMIN_KUBECONFIG` as the default
`$KUBECONFIG` to use for the `oc` client, `os::start::registry` will
need to pass the configuration file for all of the client calls, not
only the first one.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Dry out start code to use `$ADMIN_KUBECONFIG`

We provide the `$ADMIN_KUBECONFIG` variable for use after the server has
been run once to place it, so we should use it everywhere where we are
intending to use the administrative kubeconfig.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Allow for configuration of profiling with `$OPENSHIFT_PROFILE`

In order for the generic start utilities to support the command tests,
it is necessary for a user to be able to specify which profiling mode
they would like.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Allow for using network plugins with `$NETWORK_PLUGIN`

In order for the central start utilities to support the command tests,
it is necessary for a user to be able to optionally provide network
plugins to the configuration step.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Reformatted Bash and cleaned up cruft in scripts

All of the extra information that was printed by cruft in the command
test is available from more central locations. It is no longer necessary
to print this information in the test itself.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

supersedes https://github.com/openshift/origin/pull/10055

@liggitt could you please review the two commits with `[REVIEW]` prefixes
@deads2k @csrwng @smarterclayton PTAL/FYI

[test]