### PR TITLE
Fix the OVS flow "note" to match 1.5 and earlier

### DIFF
--- a/pkg/sdn/plugin/ovscontroller.go
+++ b/pkg/sdn/plugin/ovscontroller.go
@@ -37,7 +37,7 @@ func (oc *ovsController) getVersionNote() string {
 	if VERSION > 254 {
 		panic("Version too large!")
 	}
-	return fmt.Sprintf("note:%02X.%02X", VERSION, oc.pluginId)
+	return fmt.Sprintf("note:%02X.%02X", oc.pluginId, VERSION)
 }
 
 func (oc *ovsController) AlreadySetUp() bool {


### PR DESCRIPTION
The fields got swapped accidentally in the ovscontroller split, and it's breaking some QE stuff.

@openshift/networking PTAL
@bmeng FYI
