### PR TITLE
switch to upstream controller roles and init functions where easily possible

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/dead.go
+++ b/pkg/cmd/server/bootstrappolicy/dead.go
@@ -33,5 +33,17 @@ func GetDeadClusterRoles() []authorizationapi.ClusterRole {
 }
 
 func init() {
+	// these were replaced by kube controller roles
 	addDeadClusterRole("system:replication-controller")
+	addDeadClusterRole("system:endpoint-controller")
+	addDeadClusterRole("system:replicaset-controller")
+	addDeadClusterRole("system:garbage-collector-controller")
+	addDeadClusterRole("system:job-controller")
+	addDeadClusterRole("system:hpa-controller")
+	addDeadClusterRole("system:daemonset-controller")
+	addDeadClusterRole("system:disruption-controller")
+	addDeadClusterRole("system:namespace-controller")
+	addDeadClusterRole("system:gc-controller")
+	addDeadClusterRole("system:certificate-signing-controller")
+	addDeadClusterRole("system:statefulset-controller")
 }

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -37,6 +37,7 @@ import (
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	apiserverstorage "k8s.io/apiserver/pkg/server/storage"
+	"k8s.io/apiserver/pkg/storage"
 	storagefactory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	kapiserveroptions "k8s.io/kubernetes/cmd/kube-apiserver/app/options"
@@ -740,4 +741,10 @@ func readCAorNil(file string) ([]byte, error) {
 		return nil, nil
 	}
 	return ioutil.ReadFile(file)
+}
+
+func newMasterLeases(storage storage.Interface) election.Leases {
+	// leaseTTL is in seconds, i.e. 15 means 15 seconds; do NOT do 15*time.Second!
+	leaseTTL := uint64((master.DefaultEndpointReconcilerInterval + 5*time.Second) / time.Second) // add 5 seconds for wiggle room
+	return election.NewLeases(storage, "/masterleases/", leaseTTL)
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -16,19 +16,11 @@ import (
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
 	kctrlmgr "k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
-	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	"k8s.io/kubernetes/pkg/apis/batch"
-	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/controller"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -605,205 +597,106 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 	oc.RunServiceAccountPullSecretsControllers()
 	oc.RunSecurityAllocationController()
 
-	if kc != nil {
-		_, _, _, rsClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraReplicaSetControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for replication controller: %v", err)
+	_, _, _, binderClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraPersistentVolumeBinderControllerServiceAccountName)
+	if err != nil {
+		glog.Fatalf("Could not get client for persistent volume binder controller: %v", err)
+	}
+
+	_, _, _, attachDetachControllerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraPersistentVolumeAttachDetachControllerServiceAccountName)
+	if err != nil {
+		glog.Fatalf("Could not get client for attach detach controller: %v", err)
+	}
+
+	_, _, _, serviceLoadBalancerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraServiceLoadBalancerControllerServiceAccountName)
+	if err != nil {
+		glog.Fatalf("Could not get client for pod gc controller: %v", err)
+	}
+
+	rootClientBuilder := controller.SimpleControllerClientBuilder{
+		ClientConfig: &oc.PrivilegedLoopbackClientConfig,
+	}
+	saClientBuilder := controller.SAControllerClientBuilder{
+		ClientConfig:         restclient.AnonymousClientConfig(&oc.PrivilegedLoopbackClientConfig),
+		CoreClient:           oc.PrivilegedLoopbackKubernetesClientsetExternal.Core(),
+		AuthenticationClient: oc.PrivilegedLoopbackKubernetesClientsetExternal.Authentication(),
+		Namespace:            "kube-system",
+	}
+	availableResources, err := kctrlmgr.GetAvailableResources(rootClientBuilder)
+	if err != nil {
+		return err
+	}
+
+	controllerContext := kctrlmgr.ControllerContext{
+		ClientBuilder:      saClientBuilder,
+		InformerFactory:    oc.Informers.KubernetesInformers(),
+		Options:            *controllerManagerOptions,
+		AvailableResources: availableResources,
+		Stop:               utilwait.NeverStop,
+	}
+	controllerInitializers := kctrlmgr.NewControllerInitializers()
+
+	// TODO I think this should become a blacklist kept in sync during rebases with a unit test.
+	allowedControllers := sets.NewString(
+		"endpoint",
+		"replicationcontroller",
+		"podgc",
+		"namespace",
+		"garbagecollector",
+		"daemonset",
+		"job",
+		"deployment",
+		"replicaset",
+		"horizontalpodautoscaling",
+		"disruption",
+		"statefuleset",
+		"cronjob",
+		"certificatesigningrequests",
+
+		// not used in openshift.  Yet?
+		// "ttl",
+		// "bootstrapsigner",
+		// "tokencleaner",
+
+		// These controllers need to have their own init functions until we extend the upstream controller config
+		// TODO we have a different set of managed names which need to be plumbed through.
+		// "serviceaccount",
+		// TODO this controller takes different evaluators.
+		// "resourcequota",
+	)
+
+	for controllerName, initFn := range controllerInitializers {
+		// TODO remove this.  Only call one to start to prove the principle
+		if !allowedControllers.Has(controllerName) {
+			glog.Warningf("%q is skipped", controllerName)
+			continue
 		}
-		_, _, _, deploymentClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraDeploymentControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for deployment controller: %v", err)
+		if !controllerContext.IsControllerEnabled(controllerName) {
+			glog.Warningf("%q is disabled", controllerName)
+			continue
 		}
 
-		// TODO there has to be a better way to do this!
-		// Make a copy of the client config because we need to modify it
-		jobClientConfig := oc.PrivilegedLoopbackClientConfig
-		jobClientConfig.ContentConfig.GroupVersion = &schema.GroupVersion{Group: "batch", Version: "v2alpha1"}
-		_, _, _, jobClient, err := oc.GetServiceAccountClientsWithConfig(bootstrappolicy.InfraJobControllerServiceAccountName, jobClientConfig)
+		glog.V(1).Infof("Starting %q", controllerName)
+		started, err := initFn(controllerContext)
 		if err != nil {
-			glog.Fatalf("Could not get client for job controller: %v", err)
-		}
-
-		_, hpaOClient, _, hpaKClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraHPAControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for HPA controller: %v", err)
-		}
-
-		_, _, _, binderClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraPersistentVolumeBinderControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for persistent volume binder controller: %v", err)
-		}
-
-		_, _, _, attachDetachControllerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraPersistentVolumeAttachDetachControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for attach detach controller: %v", err)
-		}
-
-		_, _, _, daemonSetClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraDaemonSetControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for daemonset controller: %v", err)
-		}
-
-		_, _, _, disruptionClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraDisruptionControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for disruption budget controller: %v", err)
-		}
-
-		_, _, _, gcClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraGCControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for pod gc controller: %v", err)
-		}
-
-		_, _, _, serviceLoadBalancerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraServiceLoadBalancerControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for pod gc controller: %v", err)
-		}
-
-		_, _, _, statefulSetClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraStatefulSetControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for pet set controller: %v", err)
-		}
-
-		_, _, _, certificateSigningClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraCertificateSigningControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for disruption budget controller: %v", err)
-		}
-
-		namespaceControllerClientConfig, _, _, namespaceControllerKubeClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraNamespaceControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for namespace controller: %v", err)
-		}
-		// TODO: should use a dynamic RESTMapper built from the discovery results.
-		restMapper := kapi.Registry.RESTMapper()
-		namespaceControllerClientPool := dynamic.NewClientPool(namespaceControllerClientConfig, restMapper, dynamic.LegacyAPIPathResolverFunc)
-
-		_, _, _, endpointControllerClient, err := oc.GetServiceAccountClients(bootstrappolicy.InfraEndpointControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for endpoint controller: %v", err)
-		}
-
-		garbageCollectorControllerConfig, garbageCollectorControllerClient, _, _, err := oc.GetServiceAccountClients(bootstrappolicy.InfraGarbageCollectorControllerServiceAccountName)
-		if err != nil {
-			glog.Fatalf("Could not get client for garbage collector controller: %v", err)
-		}
-
-		rootClientBuilder := controller.SimpleControllerClientBuilder{
-			ClientConfig: &oc.PrivilegedLoopbackClientConfig,
-		}
-		saClientBuilder := controller.SAControllerClientBuilder{
-			ClientConfig:         restclient.AnonymousClientConfig(&oc.PrivilegedLoopbackClientConfig),
-			CoreClient:           oc.PrivilegedLoopbackKubernetesClientsetExternal.Core(),
-			AuthenticationClient: oc.PrivilegedLoopbackKubernetesClientsetExternal.Authentication(),
-			Namespace:            "kube-system",
-		}
-		availableResources, err := kctrlmgr.GetAvailableResources(rootClientBuilder)
-		if err != nil {
+			glog.Errorf("Error starting %q", controllerName)
 			return err
 		}
-
-		controllerContext := kctrlmgr.ControllerContext{
-			ClientBuilder:      saClientBuilder,
-			InformerFactory:    oc.Informers.KubernetesInformers(),
-			Options:            *controllerManagerOptions,
-			AvailableResources: availableResources,
-			Stop:               utilwait.NeverStop,
+		if !started {
+			glog.Warningf("Skipping %q", controllerName)
+			continue
 		}
-		controllerInitializers := kctrlmgr.NewControllerInitializers()
-
-		// TODO remove this.  Using it now to control the migration
-		allowedControllers := sets.NewString(
-			// "endpoint",
-			"replicationcontroller",
-			// "podgc",
-			// "resourcequota",
-			// "namespace",
-			// "serviceaccount",
-			// "garbagecollector",
-			// "daemonset",
-			// "job",
-			// "deployment",
-			// "replicaset",
-			// "horizontalpodautoscaling",
-			// "disruption",
-			// "statefuleset",
-			// "cronjob",
-			// "certificatesigningrequests",
-			// "ttl",
-			// "bootstrapsigner",
-			// "tokencleaner",
-		)
-
-		for controllerName, initFn := range controllerInitializers {
-			// TODO remove this.  Only call one to start to prove the principle
-			if !allowedControllers.Has(controllerName) {
-				glog.Warningf("%q is skipped", controllerName)
-				continue
-			}
-			if !controllerContext.IsControllerEnabled(controllerName) {
-				glog.Warningf("%q is disabled", controllerName)
-				continue
-			}
-
-			glog.V(1).Infof("Starting %q", controllerName)
-			started, err := initFn(controllerContext)
-			if err != nil {
-				glog.Errorf("Error starting %q", controllerName)
-				return err
-			}
-			if !started {
-				glog.Warningf("Skipping %q", controllerName)
-				continue
-			}
-			glog.Infof("Started %q", controllerName)
-		}
-
-		// no special order
-		kc.RunNodeController()
-		kc.RunScheduler()
-		kc.RunReplicaSetController(rsClient)
-		kc.RunDeploymentController(deploymentClient)
-		kc.RunGarbageCollectorController(garbageCollectorControllerClient, garbageCollectorControllerConfig)
-
-		extensionsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, extensions.GroupName)) > 0
-
-		batchEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, batch.GroupName)) > 0
-		if extensionsEnabled || batchEnabled {
-			kc.RunJobController(jobClient)
-		}
-		if batchEnabled {
-			kc.RunCronJobController(jobClient)
-		}
-		// TODO: enable this check once the HPA controller can use the autoscaling API if the extensions API is disabled
-		autoscalingEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, autoscaling.GroupName)) > 0
-		if extensionsEnabled || autoscalingEnabled {
-			kc.RunHPAController(hpaOClient, hpaKClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
-		}
-		if extensionsEnabled {
-			kc.RunDaemonSetsController(daemonSetClient)
-		}
-
-		policyEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, policy.GroupName)) > 0
-		if policyEnabled {
-			kc.RunDisruptionBudgetController(disruptionClient)
-		}
-
-		kc.RunEndpointController(endpointControllerClient)
-		kc.RunNamespaceController(namespaceControllerKubeClient, namespaceControllerClientPool, oc.Informers.KubernetesInformers().Core().V1().Namespaces())
-		kc.RunPersistentVolumeController(binderClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace, oc.ImageFor("recycler"), bootstrappolicy.InfraPersistentVolumeRecyclerControllerServiceAccountName)
-		kc.RunPersistentVolumeAttachDetachController(attachDetachControllerClient)
-		kc.RunGCController(gcClient)
-
-		kc.RunServiceLoadBalancerController(serviceLoadBalancerClient)
-
-		kc.RunCertificateSigningController(certificateSigningClient)
-
-		appsEnabled := len(configapi.GetEnabledAPIVersionsForGroup(kc.Options, apps.GroupName)) > 0
-		if appsEnabled {
-			kc.RunStatefulSetController(statefulSetClient)
-		}
-
-		glog.Infof("Started Kubernetes Controllers")
+		glog.Infof("Started %q", controllerName)
 	}
+
+	// These controllers are special-cased upstream.  We'll need custom init functions for them downstream.
+	// As we make them less special, we should re-visit this
+	kc.RunNodeController()
+	kc.RunScheduler()
+	kc.RunPersistentVolumeController(binderClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace, oc.ImageFor("recycler"), bootstrappolicy.InfraPersistentVolumeRecyclerControllerServiceAccountName)
+	kc.RunPersistentVolumeAttachDetachController(attachDetachControllerClient)
+	kc.RunServiceLoadBalancerController(serviceLoadBalancerClient)
+
+	glog.Infof("Started Kubernetes Controllers")
 
 	// no special order
 	if configapi.IsBuildEnabled(&oc.Options) {

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -375,13 +375,12 @@ var globalClusterAdminUsers = sets.NewString("system:admin")
 var globalClusterAdminGroups = sets.NewString("system:cluster-admins", "system:masters")
 
 // This list includes the admins from above, plus users or groups known to have global view access
-var globalClusterReaderUsers = sets.NewString("system:serviceaccount:openshift-infra:namespace-controller", "system:admin")
+var globalClusterReaderUsers = sets.NewString("system:admin")
 var globalClusterReaderGroups = sets.NewString("system:cluster-readers", "system:cluster-admins", "system:masters")
 
 // this list includes any other users who can get DeploymentConfigs
 var globalDeploymentConfigGetterUsers = sets.NewString(
 	"system:serviceaccount:openshift-infra:unidling-controller",
-	"system:serviceaccount:openshift-infra:garbage-collector-controller",
 	"system:serviceaccount:kube-system:generic-garbage-collector",
 	"system:serviceaccount:kube-system:namespace-controller",
 )
@@ -1599,7 +1598,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
-			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-infra:garbage-collector-controller", "system:serviceaccount:hammer-project:builder", "system:serviceaccount:openshift-infra:namespace-controller", "system:admin"),
+			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:hammer-project:builder", "system:admin"),
 			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||
@@ -1626,7 +1625,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
-			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-infra:garbage-collector-controller", "system:serviceaccount:hammer-project:builder", "system:serviceaccount:openshift-infra:namespace-controller", "system:admin"),
+			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:hammer-project:builder", "system:admin"),
 			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -7,7 +7,6 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	serviceadmit "github.com/openshift/origin/pkg/service/admission"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -90,7 +89,7 @@ func TestEndpointAdmission(t *testing.T) {
 	testOne(t, clusterAdminKubeClient, "default", "external", true)
 
 	// Endpoint controller service account
-	_, serviceAccountClient, _, err := testutil.GetClientForServiceAccount(clusterAdminKubeClient, *clientConfig, bootstrappolicy.DefaultOpenShiftInfraNamespace, bootstrappolicy.InfraEndpointControllerServiceAccountName)
+	_, serviceAccountClient, _, err := testutil.GetClientForServiceAccount(clusterAdminKubeClient, *clientConfig, "kube-system", "endpoint-controller")
 	if err != nil {
 		t.Fatalf("error getting endpoint controller service account: %v", err)
 	}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2790,6 +2790,72 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    creationTimestamp: null
+    name: system:endpoint-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:replicaset-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:garbage-collector-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:job-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:hpa-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:daemonset-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:disruption-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:namespace-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:gc-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:certificate-signing-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: system:statefulset-controller
+  rules: []
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
     annotations:
       authorization.openshift.io/system-only: "true"
     creationTimestamp: null
@@ -2839,95 +2905,6 @@ items:
     - delete
     - get
     - list
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:certificate-signing-controller
-  rules:
-  - apiGroups:
-    - certificates.k8s.io
-    attributeRestrictions: null
-    resources:
-    - certificatesigningrequests
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - certificates.k8s.io
-    attributeRestrictions: null
-    resources:
-    - certificatesigningrequests/approval
-    - certificatesigningrequests/status
-    verbs:
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:daemonset-controller
-  rules:
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - nodes
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - daemonsets/status
-    verbs:
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-    - patch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods/binding
-    verbs:
-    - create
   - apiGroups:
     - ""
     attributeRestrictions: null
@@ -3039,318 +3016,6 @@ items:
     - create
     - patch
     - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:disruption-controller
-  rules:
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - deployments
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - replicasets
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - statefulsets
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - policy
-    attributeRestrictions: null
-    resources:
-    - poddisruptionbudgets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - policy
-    attributeRestrictions: null
-    resources:
-    - poddisruptionbudgets/status
-    verbs:
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:endpoint-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    - services
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - endpoints
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - endpoints/restricted
-    verbs:
-    - create
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:garbage-collector-controller
-  rules:
-  - apiGroups:
-    - '*'
-    attributeRestrictions: null
-    resources:
-    - '*'
-    verbs:
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:gc-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - nodes
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - delete
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:hpa-controller
-  rules:
-  - apiGroups:
-    - extensions
-    - autoscaling
-    attributeRestrictions: null
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    - autoscaling
-    attributeRestrictions: null
-    resources:
-    - horizontalpodautoscalers/status
-    verbs:
-    - update
-  - apiGroups:
-    - extensions
-    - ""
-    attributeRestrictions: null
-    resources:
-    - replicationcontrollers/scale
-    verbs:
-    - get
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - deploymentconfigs/scale
-    verbs:
-    - get
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resourceNames:
-    - 'https:heapster:'
-    resources:
-    - services
-    verbs:
-    - proxy
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:job-controller
-  rules:
-  - apiGroups:
-    - extensions
-    - batch
-    attributeRestrictions: null
-    resources:
-    - cronjobs
-    - jobs
-    - scheduledjobs
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    - batch
-    attributeRestrictions: null
-    resources:
-    - cronjobs/status
-    - jobs/status
-    - scheduledjobs/status
-    verbs:
-    - update
-  - apiGroups:
-    - extensions
-    - batch
-    attributeRestrictions: null
-    resources:
-    - jobs
-    verbs:
-    - create
-    - delete
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:namespace-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - namespaces
-    verbs:
-    - delete
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - namespaces/finalize
-    - namespaces/status
-    verbs:
-    - update
-  - apiGroups:
-    - '*'
-    attributeRestrictions: null
-    resources:
-    - '*'
-    verbs:
-    - delete
-    - deletecollection
-    - get
-    - list
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -3693,50 +3358,6 @@ items:
     annotations:
       authorization.openshift.io/system-only: "true"
     creationTimestamp: null
-    name: system:replicaset-controller
-  rules:
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - replicasets
-    verbs:
-    - get
-    - list
-    - update
-    - watch
-  - apiGroups:
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - replicasets/status
-    verbs:
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
     name: system:service-ingress-ip-controller
   rules:
   - apiGroups:
@@ -3845,72 +3466,6 @@ items:
     - list
     - update
     - watch
-- apiVersion: v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
-    creationTimestamp: null
-    name: system:statefulset-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - statefulsets
-    verbs:
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - statefulsets
-    verbs:
-    - get
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - statefulsets/status
-    verbs:
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-    - get
-    - patch
-    - update
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - persistentvolumeclaims
-    verbs:
-    - create
-    - get
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
 - apiVersion: v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
@mfojtik I've tried to the keep the changes small-ish and easy to follow. There are no behavior or flow changes.  This simply removes unnecessary roles and switches to upstream initialization where its zero change.

There are more changes to make that involve changes to the flow of controller init function creation.  I'll save those for later.

Now that I have fewer `infra_sa_policy.go` roles to deal with, I'm going to convert them to the upstream construction style.