### PR TITLE
fix the help text in the clear-route-status script

### DIFF
--- a/images/router/clear-route-status.sh
+++ b/images/router/clear-route-status.sh
@@ -63,9 +63,12 @@ To clear only the status set by a specific router on all routes in all namespace
 router_name is the name in the deployment config, not the name of the pod. If the router is running it will
 immediately update any cleared status.
 
-To clear the whole status field of the route by route name 
+To clear the status field of a route or all routes in a given namespace
 ./clear-route-status.sh [namespace] [route-name | ALL]
 
+
+Example Usage
+--------------
 To clear the status of all routes in all namespaces:
 oc get namespaces | awk '{if (NR!=1) print \$1}' | xargs -n 1 -I %% ./clear-route-status.sh %% ALL
 


### PR DESCRIPTION
QA reported that they felt the help text was not clear enough.
I Tagged the examples as examples and reworded a section

Bug: 1440620 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1440620)