### PR TITLE
orphan resources by default for SOME resourced under /oapi

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -963,6 +963,8 @@ type ImageLabel struct {
 	Value string
 }
 
+// +genclient=true
+
 // BuildConfig is a template which can be used to create new builds.
 type BuildConfig struct {
 	metav1.TypeMeta

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -839,6 +839,8 @@ type ImageLabel struct {
 	Value string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 }
 
+// +genclient=true
+
 // Build configurations define a build process for new Docker images. There are three types of builds possible - a Docker build using a Dockerfile, a Source-to-Image build that uses a specially prepared base image that accepts source code that it can make runnable, and a custom build that can run // arbitrary Docker images as a base and accept the build parameters. Builds run on the cluster and on completion are pushed to the Docker registry specified in the "output" section. A build can be triggered via a webhook, when the base image changes, or when a user manually requests a new build be // created.
 //
 // Each build created by a build configuration is numbered and refers back to its parent configuration. Multiple builds can be triggered at once. Builds that do not have "output" set can be used to test code or run a verification build.

--- a/pkg/build/generated/clientset/typed/build/v1/build_client.go
+++ b/pkg/build/generated/clientset/typed/build/v1/build_client.go
@@ -10,6 +10,7 @@ import (
 type BuildV1Interface interface {
 	RESTClient() rest.Interface
 	BuildsGetter
+	BuildConfigsGetter
 }
 
 // BuildV1Client is used to interact with features provided by the build.openshift.io group.
@@ -19,6 +20,10 @@ type BuildV1Client struct {
 
 func (c *BuildV1Client) Builds(namespace string) BuildResourceInterface {
 	return newBuilds(c, namespace)
+}
+
+func (c *BuildV1Client) BuildConfigs(namespace string) BuildConfigInterface {
+	return newBuildConfigs(c, namespace)
 }
 
 // NewForConfig creates a new BuildV1Client for the given config.

--- a/pkg/build/generated/clientset/typed/build/v1/buildconfig.go
+++ b/pkg/build/generated/clientset/typed/build/v1/buildconfig.go
@@ -1,0 +1,156 @@
+package v1
+
+import (
+	v1 "github.com/openshift/origin/pkg/build/api/v1"
+	scheme "github.com/openshift/origin/pkg/build/generated/clientset/scheme"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	rest "k8s.io/client-go/rest"
+)
+
+// BuildConfigsGetter has a method to return a BuildConfigInterface.
+// A group's client should implement this interface.
+type BuildConfigsGetter interface {
+	BuildConfigs(namespace string) BuildConfigInterface
+}
+
+// BuildConfigInterface has methods to work with BuildConfig resources.
+type BuildConfigInterface interface {
+	Create(*v1.BuildConfig) (*v1.BuildConfig, error)
+	Update(*v1.BuildConfig) (*v1.BuildConfig, error)
+	UpdateStatus(*v1.BuildConfig) (*v1.BuildConfig, error)
+	Delete(name string, options *meta_v1.DeleteOptions) error
+	DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
+	Get(name string, options meta_v1.GetOptions) (*v1.BuildConfig, error)
+	List(opts meta_v1.ListOptions) (*v1.BuildConfigList, error)
+	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.BuildConfig, err error)
+	BuildConfigExpansion
+}
+
+// buildConfigs implements BuildConfigInterface
+type buildConfigs struct {
+	client rest.Interface
+	ns     string
+}
+
+// newBuildConfigs returns a BuildConfigs
+func newBuildConfigs(c *BuildV1Client, namespace string) *buildConfigs {
+	return &buildConfigs{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a buildConfig and creates it.  Returns the server's representation of the buildConfig, and an error, if there is any.
+func (c *buildConfigs) Create(buildConfig *v1.BuildConfig) (result *v1.BuildConfig, err error) {
+	result = &v1.BuildConfig{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a buildConfig and updates it. Returns the server's representation of the buildConfig, and an error, if there is any.
+func (c *buildConfigs) Update(buildConfig *v1.BuildConfig) (result *v1.BuildConfig, err error) {
+	result = &v1.BuildConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(buildConfig.Name).
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
+func (c *buildConfigs) UpdateStatus(buildConfig *v1.BuildConfig) (result *v1.BuildConfig, err error) {
+	result = &v1.BuildConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(buildConfig.Name).
+		SubResource("status").
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the buildConfig and deletes it. Returns an error if one occurs.
+func (c *buildConfigs) Delete(name string, options *meta_v1.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *buildConfigs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the buildConfig, and returns the corresponding buildConfig object, and an error if there is any.
+func (c *buildConfigs) Get(name string, options meta_v1.GetOptions) (result *v1.BuildConfig, err error) {
+	result = &v1.BuildConfig{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of BuildConfigs that match those selectors.
+func (c *buildConfigs) List(opts meta_v1.ListOptions) (result *v1.BuildConfigList, err error) {
+	result = &v1.BuildConfigList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested buildConfigs.
+func (c *buildConfigs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched buildConfig.
+func (c *buildConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.BuildConfig, err error) {
+	result = &v1.BuildConfig{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/build/generated/clientset/typed/build/v1/fake/fake_build_client.go
+++ b/pkg/build/generated/clientset/typed/build/v1/fake/fake_build_client.go
@@ -14,6 +14,10 @@ func (c *FakeBuildV1) Builds(namespace string) v1.BuildResourceInterface {
 	return &FakeBuilds{c, namespace}
 }
 
+func (c *FakeBuildV1) BuildConfigs(namespace string) v1.BuildConfigInterface {
+	return &FakeBuildConfigs{c, namespace}
+}
+
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeBuildV1) RESTClient() rest.Interface {

--- a/pkg/build/generated/clientset/typed/build/v1/fake/fake_buildconfig.go
+++ b/pkg/build/generated/clientset/typed/build/v1/fake/fake_buildconfig.go
@@ -1,0 +1,112 @@
+package fake
+
+import (
+	v1 "github.com/openshift/origin/pkg/build/api/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeBuildConfigs implements BuildConfigInterface
+type FakeBuildConfigs struct {
+	Fake *FakeBuildV1
+	ns   string
+}
+
+var buildconfigsResource = schema.GroupVersionResource{Group: "build.openshift.io", Version: "v1", Resource: "buildconfigs"}
+
+func (c *FakeBuildConfigs) Create(buildConfig *v1.BuildConfig) (result *v1.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(buildconfigsResource, c.ns, buildConfig), &v1.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) Update(buildConfig *v1.BuildConfig) (result *v1.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(buildconfigsResource, c.ns, buildConfig), &v1.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) UpdateStatus(buildConfig *v1.BuildConfig) (*v1.BuildConfig, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(buildconfigsResource, "status", c.ns, buildConfig), &v1.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) Delete(name string, options *meta_v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(buildconfigsResource, c.ns, name), &v1.BuildConfig{})
+
+	return err
+}
+
+func (c *FakeBuildConfigs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(buildconfigsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1.BuildConfigList{})
+	return err
+}
+
+func (c *FakeBuildConfigs) Get(name string, options meta_v1.GetOptions) (result *v1.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(buildconfigsResource, c.ns, name), &v1.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) List(opts meta_v1.ListOptions) (result *v1.BuildConfigList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(buildconfigsResource, c.ns, opts), &v1.BuildConfigList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1.BuildConfigList{}
+	for _, item := range obj.(*v1.BuildConfigList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested buildConfigs.
+func (c *FakeBuildConfigs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(buildconfigsResource, c.ns, opts))
+
+}
+
+// Patch applies the patch and returns the patched buildConfig.
+func (c *FakeBuildConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(buildconfigsResource, c.ns, name, data, subresources...), &v1.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.BuildConfig), err
+}

--- a/pkg/build/generated/clientset/typed/build/v1/generated_expansion.go
+++ b/pkg/build/generated/clientset/typed/build/v1/generated_expansion.go
@@ -1,3 +1,5 @@
 package v1
 
 type BuildResourceExpansion interface{}
+
+type BuildConfigExpansion interface{}

--- a/pkg/build/generated/internalclientset/typed/build/internalversion/build_client.go
+++ b/pkg/build/generated/internalclientset/typed/build/internalversion/build_client.go
@@ -8,6 +8,7 @@ import (
 type BuildInterface interface {
 	RESTClient() rest.Interface
 	BuildsGetter
+	BuildConfigsGetter
 }
 
 // BuildClient is used to interact with features provided by the build.openshift.io group.
@@ -17,6 +18,10 @@ type BuildClient struct {
 
 func (c *BuildClient) Builds(namespace string) BuildResourceInterface {
 	return newBuilds(c, namespace)
+}
+
+func (c *BuildClient) BuildConfigs(namespace string) BuildConfigInterface {
+	return newBuildConfigs(c, namespace)
 }
 
 // NewForConfig creates a new BuildClient for the given config.

--- a/pkg/build/generated/internalclientset/typed/build/internalversion/buildconfig.go
+++ b/pkg/build/generated/internalclientset/typed/build/internalversion/buildconfig.go
@@ -1,0 +1,156 @@
+package internalversion
+
+import (
+	api "github.com/openshift/origin/pkg/build/api"
+	scheme "github.com/openshift/origin/pkg/build/generated/internalclientset/scheme"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	rest "k8s.io/client-go/rest"
+)
+
+// BuildConfigsGetter has a method to return a BuildConfigInterface.
+// A group's client should implement this interface.
+type BuildConfigsGetter interface {
+	BuildConfigs(namespace string) BuildConfigInterface
+}
+
+// BuildConfigInterface has methods to work with BuildConfig resources.
+type BuildConfigInterface interface {
+	Create(*api.BuildConfig) (*api.BuildConfig, error)
+	Update(*api.BuildConfig) (*api.BuildConfig, error)
+	UpdateStatus(*api.BuildConfig) (*api.BuildConfig, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
+	Get(name string, options v1.GetOptions) (*api.BuildConfig, error)
+	List(opts v1.ListOptions) (*api.BuildConfigList, error)
+	Watch(opts v1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *api.BuildConfig, err error)
+	BuildConfigExpansion
+}
+
+// buildConfigs implements BuildConfigInterface
+type buildConfigs struct {
+	client rest.Interface
+	ns     string
+}
+
+// newBuildConfigs returns a BuildConfigs
+func newBuildConfigs(c *BuildClient, namespace string) *buildConfigs {
+	return &buildConfigs{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a buildConfig and creates it.  Returns the server's representation of the buildConfig, and an error, if there is any.
+func (c *buildConfigs) Create(buildConfig *api.BuildConfig) (result *api.BuildConfig, err error) {
+	result = &api.BuildConfig{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a buildConfig and updates it. Returns the server's representation of the buildConfig, and an error, if there is any.
+func (c *buildConfigs) Update(buildConfig *api.BuildConfig) (result *api.BuildConfig, err error) {
+	result = &api.BuildConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(buildConfig.Name).
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
+func (c *buildConfigs) UpdateStatus(buildConfig *api.BuildConfig) (result *api.BuildConfig, err error) {
+	result = &api.BuildConfig{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(buildConfig.Name).
+		SubResource("status").
+		Body(buildConfig).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the buildConfig and deletes it. Returns an error if one occurs.
+func (c *buildConfigs) Delete(name string, options *v1.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *buildConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Body(options).
+		Do().
+		Error()
+}
+
+// Get takes name of the buildConfig, and returns the corresponding buildConfig object, and an error if there is any.
+func (c *buildConfigs) Get(name string, options v1.GetOptions) (result *api.BuildConfig, err error) {
+	result = &api.BuildConfig{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of BuildConfigs that match those selectors.
+func (c *buildConfigs) List(opts v1.ListOptions) (result *api.BuildConfigList, err error) {
+	result = &api.BuildConfigList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested buildConfigs.
+func (c *buildConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
+// Patch applies the patch and returns the patched buildConfig.
+func (c *buildConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *api.BuildConfig, err error) {
+	result = &api.BuildConfig{}
+	err = c.client.Patch(pt).
+		Namespace(c.ns).
+		Resource("buildconfigs").
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/build/generated/internalclientset/typed/build/internalversion/fake/fake_build_client.go
+++ b/pkg/build/generated/internalclientset/typed/build/internalversion/fake/fake_build_client.go
@@ -14,6 +14,10 @@ func (c *FakeBuild) Builds(namespace string) internalversion.BuildResourceInterf
 	return &FakeBuilds{c, namespace}
 }
 
+func (c *FakeBuild) BuildConfigs(namespace string) internalversion.BuildConfigInterface {
+	return &FakeBuildConfigs{c, namespace}
+}
+
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
 func (c *FakeBuild) RESTClient() rest.Interface {

--- a/pkg/build/generated/internalclientset/typed/build/internalversion/fake/fake_buildconfig.go
+++ b/pkg/build/generated/internalclientset/typed/build/internalversion/fake/fake_buildconfig.go
@@ -1,0 +1,112 @@
+package fake
+
+import (
+	api "github.com/openshift/origin/pkg/build/api"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeBuildConfigs implements BuildConfigInterface
+type FakeBuildConfigs struct {
+	Fake *FakeBuild
+	ns   string
+}
+
+var buildconfigsResource = schema.GroupVersionResource{Group: "build.openshift.io", Version: "", Resource: "buildconfigs"}
+
+func (c *FakeBuildConfigs) Create(buildConfig *api.BuildConfig) (result *api.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(buildconfigsResource, c.ns, buildConfig), &api.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) Update(buildConfig *api.BuildConfig) (result *api.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(buildconfigsResource, c.ns, buildConfig), &api.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) UpdateStatus(buildConfig *api.BuildConfig) (*api.BuildConfig, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(buildconfigsResource, "status", c.ns, buildConfig), &api.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(buildconfigsResource, c.ns, name), &api.BuildConfig{})
+
+	return err
+}
+
+func (c *FakeBuildConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(buildconfigsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.BuildConfigList{})
+	return err
+}
+
+func (c *FakeBuildConfigs) Get(name string, options v1.GetOptions) (result *api.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(buildconfigsResource, c.ns, name), &api.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.BuildConfig), err
+}
+
+func (c *FakeBuildConfigs) List(opts v1.ListOptions) (result *api.BuildConfigList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(buildconfigsResource, c.ns, opts), &api.BuildConfigList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &api.BuildConfigList{}
+	for _, item := range obj.(*api.BuildConfigList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested buildConfigs.
+func (c *FakeBuildConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(buildconfigsResource, c.ns, opts))
+
+}
+
+// Patch applies the patch and returns the patched buildConfig.
+func (c *FakeBuildConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *api.BuildConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(buildconfigsResource, c.ns, name, data, subresources...), &api.BuildConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.BuildConfig), err
+}

--- a/pkg/build/generated/internalclientset/typed/build/internalversion/generated_expansion.go
+++ b/pkg/build/generated/internalclientset/typed/build/internalversion/generated_expansion.go
@@ -1,3 +1,5 @@
 package internalversion
 
 type BuildResourceExpansion interface{}
+
+type BuildConfigExpansion interface{}

--- a/pkg/cmd/server/origin/legacy.go
+++ b/pkg/cmd/server/origin/legacy.go
@@ -4,6 +4,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/registry/rest"
+
+	buildconfigetcd "github.com/openshift/origin/pkg/build/registry/buildconfig/etcd"
+	deploymentconfigetcd "github.com/openshift/origin/pkg/deploy/registry/deployconfig/etcd"
 )
 
 var (
@@ -186,9 +189,40 @@ func LegacyStorage(storage map[schema.GroupVersion]map[string]rest.Storage) map[
 	for _, gvStorage := range storage {
 		for resource, s := range gvStorage {
 			if OriginLegacyResources.Has(resource) || OriginLegacySubresources.Has(resource) {
-				legacyStorage[resource] = s
+				// We want *some* our legacy resources to orphan by default instead of garbage collecting.
+				// Kube only did this for a select few resources which were controller managed and established links
+				// via a workload controller.  In openshift, these will all conform to registry.Store so we
+				// can actually wrap the "normal" storage here.
+				switch resource {
+				case "buildConfigs":
+					restStorage := s.(*buildconfigetcd.REST)
+					store := *restStorage.Store
+					store.DeleteStrategy = orphanByDefault(store.DeleteStrategy)
+					legacyStorage[resource] = &buildconfigetcd.REST{Store: &store}
+				case "deploymentConfigs":
+					restStorage := s.(*deploymentconfigetcd.REST)
+					store := *restStorage.Store
+					restStorage.DeleteStrategy = orphanByDefault(store.DeleteStrategy)
+					legacyStorage[resource] = &deploymentconfigetcd.REST{Store: &store}
+
+				default:
+					legacyStorage[resource] = s
+				}
+
 			}
 		}
 	}
 	return legacyStorage
+}
+
+type orphaningDeleter struct {
+	rest.RESTDeleteStrategy
+}
+
+func (o orphaningDeleter) DefaultGarbageCollectionPolicy() rest.GarbageCollectionPolicy {
+	return rest.OrphanDependents
+}
+
+func orphanByDefault(in rest.RESTDeleteStrategy) rest.RESTDeleteStrategy {
+	return orphaningDeleter{in}
 }

--- a/test/integration/gc_default_test.go
+++ b/test/integration/gc_default_test.go
@@ -1,0 +1,125 @@
+package integration
+
+import (
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestGCDefaults(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterAdminConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBuildClient, err := buildclient.NewForConfig(clusterAdminConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := "some-ns-old"
+	if _, err := testserver.CreateNewProject(originClient, *clusterAdminConfig, ns, "adminUser"); err != nil {
+		t.Fatal(err)
+	}
+
+	buildConfig := &buildapi.BuildConfig{}
+	buildConfig.Name = "bc"
+	buildConfig.Spec.RunPolicy = buildapi.BuildRunPolicyParallel
+	buildConfig.GenerateName = "buildconfig-"
+	buildConfig.Spec.Strategy = strategyForType(t, "source")
+	buildConfig.Spec.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	firstBuildConfig, err := newBuildClient.Build().BuildConfigs(ns).Create(buildConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	childConfigMap := &kapi.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "child"},
+	}
+	childConfigMap.OwnerReferences = append(childConfigMap.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "build.openshift.io/v1",
+		Kind:       "BuildConfig",
+		Name:       firstBuildConfig.Name,
+		UID:        firstBuildConfig.UID,
+	})
+
+	if _, err := kubeClient.Core().ConfigMaps(ns).Create(childConfigMap); err != nil {
+		t.Fatal(err)
+	}
+
+	// this looks weird, but we want no new dependencies on the old client
+	if err := newBuildClient.Build().RESTClient().Delete().AbsPath("/oapi/v1/namespaces/" + ns + "/buildconfigs/" + buildConfig.Name).Do().Error(); err != nil {
+		t.Fatal(err)
+	}
+
+	// the /oapi endpoints should orphan by default
+	// wait for a bit and make sure that the build is still there
+	time.Sleep(2 * time.Second)
+	childConfigMap, err = kubeClient.Core().ConfigMaps(ns).Get(childConfigMap.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bc, err := newBuildClient.BuildConfigs(ns).Get(buildConfig.Name, metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("%v and %#v", err, bc)
+	}
+
+	secondBuildConfig, err := newBuildClient.BuildConfigs(ns).Create(buildConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	childConfigMap.OwnerReferences = append(childConfigMap.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "build.openshift.io/v1",
+		Kind:       "BuildConfig",
+		Name:       secondBuildConfig.Name,
+		UID:        secondBuildConfig.UID,
+	})
+	if _, err := kubeClient.Core().ConfigMaps(ns).Update(childConfigMap); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := newBuildClient.Build().BuildConfigs(ns).Delete(secondBuildConfig.Name, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	err = wait.PollImmediate(30*time.Millisecond, 10*time.Second, func() (bool, error) {
+		_, err := kubeClient.Core().ConfigMaps(ns).Get(childConfigMap.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14120

When kube introduced the new GC, *some* resources were made orphaning by default.  Only those which had controller driven aspects that set up GC refs automatically like deployments and replicasets.  I think our congruent resources are buildconfigs and deploymentconfigs.  Going forward, kube expects the default for new resources to be GC, not orphan.

This pull updates our legacy endpoints for buildconfigs and deploymentconfigs to orphan, but the groupified endpoints will *not* orphan by default since they are net new.

@openshift/api-review This seems pretty reasonable to me.  I would even have been ok with changing the default, but this is.... marginally acceptable.

@bparees @spadgett 