### PR TITLE
adding X-Forwarded-For header to reencrypt route

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -417,6 +417,7 @@ backend be_tcp:{{$cfgIdx}}
 backend be_secure:{{$cfgIdx}}
   mode http
   option redispatch
+  option forwardfor
     {{- with $balanceAlgo := index $cfg.Annotations "haproxy.router.openshift.io/balance" }}
       {{- with $matchValue := (matchValues $balanceAlgo "roundrobin" "leastconn" "source" ) }}
   balance {{ $balanceAlgo }}


### PR DESCRIPTION
add X-Forwarded-For header for reencrypt routes, just as it is for edge routes

Bug: 1449022 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1449022)