### PR TITLE
Fix integration test etcd dump

### DIFF
--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -33,7 +33,6 @@ type TestPluginConfig struct {
 func (obj *TestPluginConfig) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
 
 func setupAdmissionTest(t *testing.T, setupConfig func(*configapi.MasterConfig)) (kclientset.Interface, *client.Client) {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -189,7 +188,7 @@ func setupAdmissionPluginTestConfig(t *testing.T, value string) string {
 }
 
 func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
@@ -205,7 +204,7 @@ func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin1configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
@@ -224,7 +223,7 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
@@ -244,7 +243,7 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
@@ -260,7 +259,7 @@ func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin2configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
@@ -279,7 +278,7 @@ func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
@@ -299,8 +298,7 @@ func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
 }
 
 func TestAlwaysPullImagesOn(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
@@ -350,8 +348,7 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 }
 
 func TestAlwaysPullImagesOff(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, kubeConfigFile, err := testserver.StartTestMaster()
 	if err != nil {

--- a/test/integration/api_paths_test.go
+++ b/test/integration/api_paths_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRootAPIPaths(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, adminConfigFile, err := testserver.StartTestMaster()
 	if err != nil {

--- a/test/integration/audit_test.go
+++ b/test/integration/audit_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func setupAuditTest(t *testing.T) (kclientset.Interface, *client.Client) {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -35,8 +34,8 @@ func setupAuditTest(t *testing.T) (kclientset.Interface, *client.Client) {
 }
 
 func TestBasicFunctionalityWithAudit(t *testing.T) {
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kubeClient, _ := setupAuditTest(t)
-	defer testutil.DumpEtcdOnFailure(t)
 
 	if _, err := kubeClient.Core().Pods(metav1.NamespaceDefault).Watch(metav1.ListOptions{}); err != nil {
 		t.Errorf("Unexpected error watching pods: %v", err)

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -31,8 +31,7 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 	idp.Provider = &configapi.RequestHeaderIdentityProvider{Headers: []string{"X-Remote-User"}}
 	idp.MappingMethod = "claim"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -90,8 +90,7 @@ func prettyPrintReviewResponse(resp *authorizationapi.ResourceAccessReviewRespon
 }
 
 func TestClusterReaderCoverage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -197,8 +196,7 @@ func TestClusterReaderCoverage(t *testing.T) {
 }
 
 func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -270,8 +268,7 @@ func waitForProject(t *testing.T, client client.Interface, projectName string, d
 }
 
 func TestAuthorizationResolution(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -506,8 +503,7 @@ func (test localResourceAccessReviewTest) run(t *testing.T) {
 }
 
 func TestAuthorizationResourceAccessReview(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -844,8 +840,7 @@ func toKubeClusterSAR(sar *authorizationapi.SubjectAccessReview) *kubeauthorizat
 }
 
 func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
@@ -988,8 +983,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 }
 
 func TestAuthorizationSubjectAccessReview(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -1432,8 +1426,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 // TestOldLocalSubjectAccessReviewEndpoint checks to make sure that the old subject access review endpoint still functions properly
 // this is needed to support old docker registry images
 func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -1561,8 +1554,7 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 // TestOldLocalResourceAccessReviewEndpoint checks to make sure that the old resource access review endpoint still functions properly
 // this is needed to support old who-can client
 func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -78,8 +77,7 @@ func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T
 }
 
 func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -125,8 +123,7 @@ func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
 }
 
 func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
@@ -175,8 +172,7 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 }
 
 func TestSelfSubjectAccessReviewsNonExistingNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -27,7 +27,7 @@ func buildStrategyTypesRestricted() []string {
 }
 
 func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, false)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
@@ -103,7 +103,7 @@ func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
 }
 
 func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, true)
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
@@ -179,7 +179,6 @@ func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *te
 }
 
 func setupBuildStrategyTest(t *testing.T, includeControllers bool) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client) {
-	testutil.RequireEtcd(t)
 	namespace := testutil.Namespace()
 	var clusterAdminKubeConfig string
 	var err error

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -31,7 +31,7 @@ type controllerCount struct {
 // TestConcurrentBuildControllers tests the transition of a build from new to pending. Ensures that only a single New -> Pending
 // transition happens and that only a single pod is created during a set period of time.
 func TestConcurrentBuildControllers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Start a master with multiple BuildControllers
 	osClient, kClient := setupBuildControllerTest(controllerCount{BuildControllers: 5}, t)
 	build.RunBuildControllerTest(t, osClient, kClient)
@@ -39,45 +39,44 @@ func TestConcurrentBuildControllers(t *testing.T) {
 
 // TestConcurrentBuildPodControllers tests the lifecycle of a build pod when running multiple controllers.
 func TestConcurrentBuildPodControllers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Start a master with multiple BuildPodControllers
 	osClient, kClient := setupBuildControllerTest(controllerCount{BuildPodControllers: 5}, t)
 	build.RunBuildPodControllerTest(t, osClient, kClient)
 }
 
 func TestConcurrentBuildImageChangeTriggerControllers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Start a master with multiple ImageChangeTrigger controllers
 	osClient, _ := setupBuildControllerTest(controllerCount{ImageChangeControllers: 5}, t)
 	build.RunImageChangeTriggerTest(t, osClient)
 }
 
 func TestBuildDeleteController(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	build.RunBuildDeleteTest(t, osClient, kClient)
 }
 
 func TestBuildRunningPodDeleteController(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	build.RunBuildRunningPodDeleteTest(t, osClient, kClient)
 }
 
 func TestBuildCompletePodDeleteController(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	osClient, kClient := setupBuildControllerTest(controllerCount{}, t)
 	build.RunBuildCompletePodDeleteTest(t, osClient, kClient)
 }
 
 func TestConcurrentBuildConfigControllers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	osClient, kClient := setupBuildControllerTest(controllerCount{ConfigChangeControllers: 5}, t)
 	build.RunBuildConfigChangeControllerTest(t, osClient, kClient)
 }
 
 func setupBuildControllerTest(counts controllerCount, t *testing.T) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
 	master, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -26,7 +26,7 @@ import (
 var buildPodAdmissionTestTimeout time.Duration = 30 * time.Second
 
 func TestBuildDefaultGitHTTPProxy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	httpProxy := "http://my.test.proxy:12345"
 	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPProxy: httpProxy,
@@ -38,7 +38,7 @@ func TestBuildDefaultGitHTTPProxy(t *testing.T) {
 }
 
 func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	httpsProxy := "https://my.test.proxy:12345"
 	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPSProxy: httpsProxy,
@@ -50,7 +50,7 @@ func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
 }
 
 func TestBuildDefaultEnvironment(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	env := []kapi.EnvVar{
 		{
 			Name:  "VAR1",
@@ -71,7 +71,7 @@ func TestBuildDefaultEnvironment(t *testing.T) {
 }
 
 func TestBuildDefaultLabels(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	labels := []buildapi.ImageLabel{{Name: "KEY", Value: "VALUE"}}
 	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		ImageLabels: labels,
@@ -83,7 +83,7 @@ func TestBuildDefaultLabels(t *testing.T) {
 }
 
 func TestBuildDefaultNodeSelectors(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	selectors := map[string]string{"KEY": "VALUE"}
 	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		NodeSelector: selectors,
@@ -95,7 +95,7 @@ func TestBuildDefaultNodeSelectors(t *testing.T) {
 }
 
 func TestBuildDefaultAnnotations(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	annotations := map[string]string{"KEY": "VALUE"}
 	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		Annotations: annotations,
@@ -107,7 +107,7 @@ func TestBuildDefaultAnnotations(t *testing.T) {
 }
 
 func TestBuildOverrideForcePull(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})
@@ -118,7 +118,7 @@ func TestBuildOverrideForcePull(t *testing.T) {
 }
 
 func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})
@@ -132,7 +132,7 @@ func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
 }
 
 func TestBuildOverrideLabels(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	labels := []buildapi.ImageLabel{{Name: "KEY", Value: "VALUE"}}
 	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ImageLabels: labels,
@@ -144,7 +144,7 @@ func TestBuildOverrideLabels(t *testing.T) {
 }
 
 func TestBuildOverrideNodeSelectors(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	selectors := map[string]string{"KEY": "VALUE"}
 	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		NodeSelector: selectors,
@@ -156,7 +156,7 @@ func TestBuildOverrideNodeSelectors(t *testing.T) {
 }
 
 func TestBuildOverrideAnnotations(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	annotations := map[string]string{"KEY": "VALUE"}
 	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		Annotations: annotations,
@@ -258,7 +258,6 @@ func setupBuildOverridesAdmissionTest(t *testing.T, overridesConfig *overridesap
 }
 
 func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.AdmissionPluginConfig) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestCLIGetToken(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestClientSet_v1_3(t *testing.T) {
 	const namespace = "test-clientset-v13"
-	testutil.RequireEtcd(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestClusterQuota(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestClusterResourceOverridePluginWithNoLimits(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	config := &overrideapi.ClusterResourceOverrideConfig{
 		LimitCPUToMemoryPercent:     100,
 		CPURequestToLimitPercent:    50,
@@ -49,7 +49,7 @@ func TestClusterResourceOverridePluginWithNoLimits(t *testing.T) {
 }
 
 func TestClusterResourceOverridePluginWithLimits(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	config := &overrideapi.ClusterResourceOverrideConfig{
 		LimitCPUToMemoryPercent:     100,
 		CPURequestToLimitPercent:    50,
@@ -106,7 +106,6 @@ func TestClusterResourceOverridePluginWithLimits(t *testing.T) {
 }
 
 func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.ClusterResourceOverrideConfig) kclientset.Interface {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -18,8 +18,7 @@ import (
 func TestDeployScale(t *testing.T) {
 	const namespace = "test-deploy-scale"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -24,8 +24,7 @@ const maxUpdateRetries = 10
 func TestTriggers_manual(t *testing.T) {
 	const namespace = "test-triggers-manual"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
@@ -105,8 +104,7 @@ func TestTriggers_manual(t *testing.T) {
 // TestTriggers_imageChange ensures that a deployment config with an ImageChange trigger
 // will start a new deployment when an image change happens.
 func TestTriggers_imageChange(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -211,8 +209,7 @@ waitForNewConfig:
 // TestTriggers_imageChange_nonAutomatic ensures that a deployment config with a non-automatic
 // trigger will have its image updated when a deployment is started manually.
 func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -391,8 +388,7 @@ loop:
 // TestTriggers_MultipleICTs ensures that a deployment config with more than one ImageChange trigger
 // will start a new deployment iff all images are resolved.
 func TestTriggers_MultipleICTs(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -556,8 +552,7 @@ out:
 func TestTriggers_configChange(t *testing.T) {
 	const namespace = "test-triggers-configchange"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/diag_nodes_test.go
+++ b/test/integration/diag_nodes_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestDiagNodeConditions(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, nodeConfig, clientFile, err := testserver.StartTestAllInOne()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestDiscoveryGroupVersions(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error starting test master: %v", err)

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestDNS(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, clientFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/dockerregistry_pullthrough_test.go
+++ b/test/integration/dockerregistry_pullthrough_test.go
@@ -130,8 +130,7 @@ func testPullThroughStatBlob(stream *imageapi.ImageStreamImport, user, token, di
 }
 
 func TestPullThroughInsecure(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -52,8 +52,7 @@ func testOne(t *testing.T, client kclientset.Interface, namespace, addrType stri
 }
 
 func TestEndpointAdmission(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-	etcdtest "k8s.io/apiserver/pkg/storage/etcd/testing"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/flowcontrol"
@@ -807,8 +806,8 @@ const testNamespace = "etcdstoragepathtestnamespace"
 // It will also fail when a type gets moved to a different location. Be very careful in this situation because
 // it essentially means that you will be break old clusters unless you create some migration path for the old data.
 func TestEtcd2StoragePath(t *testing.T) {
-	etcdServer := testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	etcdServer := testutil.RequireEtcd2(t)
+	defer etcdServer.DumpEtcdOnFailure()
 
 	getter := &etcd2Getter{
 		keys: etcd.NewKeysAPI(etcdServer.Client),
@@ -825,8 +824,8 @@ func TestEtcd2StoragePath(t *testing.T) {
 // OpenShift don't seem to work with that right now.
 /*
 func TestEtcd3StoragePath(t *testing.T) {
-	etcdServer, _ := testutil.RequireEtcd3(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	etcdServer := testutil.RequireEtcd3(t)
+	defer etcdServer.DumpEtcdOnFailure()
 
 	getter := &etcd3Getter{
 		kv: etcdServer.V3Client,
@@ -835,7 +834,7 @@ func TestEtcd3StoragePath(t *testing.T) {
 }
 */
 
-func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, getter etcdGetter) {
+func testEtcdStoragePath(t *testing.T, etcdServer testutil.EtcdTestServer, getter etcdGetter) {
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error getting master config: %#v", err)

--- a/test/integration/extension_apiserver_test.go
+++ b/test/integration/extension_apiserver_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestExtensionAPIServerConfigMap(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -19,8 +19,7 @@ import (
 func TestExtensionsAPIDeletion(t *testing.T) {
 	const projName = "ext-deletion-proj"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -17,8 +17,7 @@ import (
 func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 	const projName = "ext-disabled-batch-enabled-proj"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -140,8 +139,7 @@ func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 func TestExtensionsAPIDisabled(t *testing.T) {
 	const projName = "ext-disabled-proj"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestFrontProxy(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/gc_default_test.go
+++ b/test/integration/gc_default_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestGCDefaults(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestBasicUserBasedGroupManipulation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -108,8 +107,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 }
 
 func TestBasicGroupManipulation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -179,8 +177,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 }
 
 func TestGroupCommands(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -22,7 +22,7 @@ const (
 )
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, _ := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -32,7 +32,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, _ := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -42,7 +42,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, _ := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -52,7 +52,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, _ := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
@@ -62,7 +62,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, clusterAdminClient := setup(t)
 
 	clusterRoleBindingAccessor := policy.NewClusterRoleBindingAccessor(clusterAdminClient)
@@ -92,7 +92,7 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	projectAdminClient, _ := setup(t)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(testutil.GetBaseDir() + "/openshift.local.config/master/admin.kubeconfig")
@@ -229,7 +229,6 @@ func mockImageStreamMapping(stream, image, tag, reference string) *imageapi.Imag
 }
 
 func setup(t *testing.T) (*client.Client, *client.Client) {
-	testutil.RequireEtcd(t)
 	_, clusterAdminKubeConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -415,7 +414,7 @@ func runTest(t *testing.T, testname string, projectAdminClient *client.Client, i
 }
 
 func TestMultipleImageChangeBuildTriggers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	mockImageStream := func(name, tag string) *imageapi.ImageStream {
 		return &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{Name: name},

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -32,8 +32,7 @@ import (
 )
 
 func TestImageStreamImport(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -233,8 +232,7 @@ func testImageStreamImportWithPath(t *testing.T, reponame string) {
 		imageSize += size
 	}
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	// start regular HTTP servers
 	requireAuth := false
@@ -356,8 +354,7 @@ func TestImageStreamImportOfMultiSegmentDockerReference(t *testing.T) {
 }
 
 func TestImageStreamImportAuthenticated(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, true, &count))
@@ -523,8 +520,7 @@ func TestImageStreamImportAuthenticated(t *testing.T) {
 // Verifies that individual errors for particular tags are handled properly when pulling all tags from a
 // repository.
 func TestImageStreamImportTagsFromRepository(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, false, &count))
@@ -624,8 +620,7 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 // test controller interval), updates the image stream only when there are changes, and if an
 // error occurs writes the error only once (instead of every interval)
 func TestImageStreamImportScheduled(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	written := make(chan struct{}, 1)
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -993,49 +988,49 @@ func TestImageStreamImportRedHatRegistry(t *testing.T) {
 
 const etcdDigest = "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238"
 const etcdManifest = `{
-   "schemaVersion": 1, 
-   "tag": "latest", 
-   "name": "coreos/etcd", 
-   "architecture": "amd64", 
+   "schemaVersion": 1,
+   "tag": "latest",
+   "name": "coreos/etcd",
+   "architecture": "amd64",
    "fsLayers": [
       {
          "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
-      }, 
+      },
       {
          "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
-      }, 
+      },
       {
          "blobSum": "sha256:2560187847cadddef806eaf244b7755af247a9dbabb90ca953dd2703cf423766"
-      }, 
+      },
       {
          "blobSum": "sha256:744b46d0ac8636c45870a03830d8d82c20b75fbfb9bc937d5e61005d23ad4cfe"
       }
-   ], 
+   ],
    "history": [
       {
          "v1Compatibility": "{\"id\":\"fe50ac14986497fa6b5d2cc24feb4a561d01767bc64413752c0988cb70b0b8b9\",\"parent\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"created\":\"2015-12-30T22:29:13.967754365Z\",\"container\":\"c8d0f1a274b5f52fa5beb280775ef07cf18ec0f95e5ae42fbad01157e2614d42\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ENTRYPOINT \\u0026{[\\\"/etcd\\\"]}\"],\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
-      }, 
+      },
       {
          "v1Compatibility": "{\"id\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"parent\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"created\":\"2015-12-30T22:29:13.504159783Z\",\"container\":\"080708d544f85052a46fab72e701b4358c1b96cb4b805a5b2d66276fc2aaf85d\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) EXPOSE 2379/tcp 2380/tcp 4001/tcp 7001/tcp\"],\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
-      }, 
+      },
       {
          "v1Compatibility": "{\"id\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"parent\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.912813629Z\",\"container\":\"f28be899c9b8680d4cf8585e663ad20b35019db062526844e7cfef117ce9037f\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:e330b1da49d993059975e46560b3bd360691498b0f2f6e00f39fc160cf8d4ec3 in /\"],\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":13502144}"
-      }, 
+      },
       {
          "v1Compatibility": "{\"id\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.346834862Z\",\"container\":\"1b97abade59e4b5b935aede236980a54fb500cd9ee5bd4323c832c6d7b3ffc6e\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:74912593c6783292c4520514f5cc9313acbd1da0f46edee0fdbed2a24a264d6f in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":15141568}"
       }
-   ], 
+   ],
    "signatures": [
       {
          "header": {
-            "alg": "RS256", 
+            "alg": "RS256",
             "jwk": {
-               "e": "AQAB", 
-               "kty": "RSA", 
+               "e": "AQAB",
+               "kty": "RSA",
                "n": "yB40ou1GMvIxYs1jhxWaeoDiw3oa0_Q2UJThUPtArvO0tRzaun9FnSphhOEHIGcezfq95jy-3MN-FIjmsWgbPHY8lVDS38fF75aCw6qkholwqjmMtUIgPNYoMrg0rLUE5RRyJ84-hKf9Fk7V3fItp1mvCTGKaS3ze-y5dTTrfbNGE7qG638Dla2Fuz-9CNgRQj0JH54o547WkKJC-pG-j0jTDr8lzsXhrZC7lJas4yc-vpt3D60iG4cW_mkdtIj52ZFEgHZ56sUj7AhnNVly0ZP9W1hmw4xEHDn9WLjlt7ivwARVeb2qzsNdguUitcI5hUQNwpOVZ_O3f1rUIL_kRw"
             }
-         }, 
-         "protected": "eyJmb3JtYXRUYWlsIjogIkNuMCIsICJmb3JtYXRMZW5ndGgiOiA1OTI2LCAidGltZSI6ICIyMDE2LTAxLTAyVDAyOjAxOjMzWiJ9", 
+         },
+         "protected": "eyJmb3JtYXRUYWlsIjogIkNuMCIsICJmb3JtYXRMZW5ndGgiOiA1OTI2LCAidGltZSI6ICIyMDE2LTAxLTAyVDAyOjAxOjMzWiJ9",
          "signature": "DrQ43UWeit-thDoRGTCP0Gd2wL5K2ecyPhHo_au0FoXwuKODja0tfwHexB9ypvFWngk-ijXuwO02x3aRIZqkWpvKLxxzxwkrZnPSje4o_VrFU4z5zwmN8sJw52ODkQlW38PURIVksOxCrb0zRl87yTAAsUAJ_4UUPNltZSLnhwy-qPb2NQ8ghgsONcBxRQrhPFiWNkxDKZ3kjvzYyrXDxTcvwK3Kk_YagZ4rCOhH1B7mAdVSiSHIvvNV5grPshw_ipAoqL2iNMsxWxLjYZl9xSJQI2asaq3fvh8G8cZ7T-OahDUos_GyhnIj39C-9ouqdJqMUYFETqbzRCR6d36CpQ"
       }
    ]

--- a/test/integration/imagesigning_test.go
+++ b/test/integration/imagesigning_test.go
@@ -21,6 +21,7 @@ import (
 const testUserName = "bob"
 
 func TestImageAddSignature(t *testing.T) {
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	adminClient, userClient, image := testSetupImageSignatureTest(t, testUserName)
 
 	if len(image.Signatures) != 0 {
@@ -96,6 +97,7 @@ func TestImageAddSignature(t *testing.T) {
 }
 
 func TestImageRemoveSignature(t *testing.T) {
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	adminClient, userClient, image := testSetupImageSignatureTest(t, testUserName)
 	makeUserAnImageSigner(adminClient, userClient, testUserName)
 
@@ -194,7 +196,6 @@ func TestImageRemoveSignature(t *testing.T) {
 }
 
 func testSetupImageSignatureTest(t *testing.T, userName string) (adminClient *client.Client, userClient *client.Client, image *imageapi.Image) {
-	testutil.RequireEtcd(t)
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/imagestream_admission_test.go
+++ b/test/integration/imagestream_admission_test.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func TestImageStreamTagsAdmission(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kClient, client := setupImageStreamAdmissionTest(t)
 
 	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest, imagetest.MiscImageDigest} {
@@ -236,7 +236,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 }
 
 func TestImageStreamAdmitSpecUpdate(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kClient, client := setupImageStreamAdmissionTest(t)
 
 	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest} {
@@ -350,7 +350,7 @@ func TestImageStreamAdmitSpecUpdate(t *testing.T) {
 }
 
 func TestImageStreamAdmitStatusUpdate(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kClient, client := setupImageStreamAdmissionTest(t)
 	images := []*imageapi.Image{}
 
@@ -471,8 +471,6 @@ func TestImageStreamAdmitStatusUpdate(t *testing.T) {
 }
 
 func setupImageStreamAdmissionTest(t *testing.T) (kclientset.Interface, *client.Client) {
-	testutil.RequireEtcd(t)
-
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestImageStreamList(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -50,8 +49,7 @@ func mockImageStream() *imageapi.ImageStream {
 }
 
 func TestImageStreamCreate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -98,8 +96,7 @@ func TestImageStreamCreate(t *testing.T) {
 }
 
 func TestImageStreamMappingCreate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -286,8 +283,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 }
 
 func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -384,8 +380,7 @@ func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
 }
 
 func TestImageStreamTagLifecycleHook(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/ingressip_test.go
+++ b/test/integration/ingressip_test.go
@@ -26,7 +26,7 @@ const sentinelName = "sentinel"
 // TestIngressIPAllocation validates that ingress ip allocation is
 // performed correctly even when multiple controllers are running.
 func TestIngressIPAllocation(t *testing.T) {
-	testutil.RequireEtcd(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -14,13 +14,9 @@ import (
 )
 
 func TestLeaderLeaseAcquire(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	c, err := testutil.MakeNewEtcdClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := etcdclient.NewKeysAPI(c)
+	etcdServer := testutil.RequireEtcd2(t)
+	defer etcdServer.DumpEtcdOnFailure()
+	client := etcdclient.NewKeysAPI(etcdServer.Client)
 
 	key := "/random/key"
 	held := make(chan struct{})
@@ -32,7 +28,7 @@ func TestLeaderLeaseAcquire(t *testing.T) {
 		glog.Infof("Deleted key")
 	}()
 
-	lease := leaderlease.NewEtcd(c, key, "holder", 10)
+	lease := leaderlease.NewEtcd(etcdServer.Client, key, "holder", 10)
 	ch := make(chan error, 1)
 	go lease.AcquireAndHold(ch)
 
@@ -56,13 +52,10 @@ func TestLeaderLeaseAcquire(t *testing.T) {
 }
 
 func TestLeaderLeaseWait(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	c, err := testutil.MakeNewEtcdClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := etcdclient.NewKeysAPI(c)
+	etcdServer := testutil.RequireEtcd2(t)
+	defer etcdServer.DumpEtcdOnFailure()
+	client := etcdclient.NewKeysAPI(etcdServer.Client)
+
 	key := "/random/key"
 
 	if _, err := client.Set(context.Background(), key, "other", &etcdclient.SetOptions{TTL: time.Second, PrevExist: etcdclient.PrevNoExist}); err != nil {
@@ -78,7 +71,7 @@ func TestLeaderLeaseWait(t *testing.T) {
 		glog.Infof("Deleted key")
 	}()
 
-	lease := leaderlease.NewEtcd(c, key, "holder", 10)
+	lease := leaderlease.NewEtcd(etcdServer.Client, key, "holder", 10)
 	ch := make(chan error, 1)
 	go lease.AcquireAndHold(ch)
 
@@ -102,13 +95,10 @@ func TestLeaderLeaseWait(t *testing.T) {
 }
 
 func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	c, err := testutil.MakeNewEtcdClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := etcdclient.NewKeysAPI(c)
+	etcdServer := testutil.RequireEtcd2(t)
+	defer etcdServer.DumpEtcdOnFailure()
+	client := etcdclient.NewKeysAPI(etcdServer.Client)
+
 	key := "/random/key"
 
 	if _, err := client.Set(context.Background(), key, "holder", &etcdclient.SetOptions{TTL: 10 * time.Second, PrevExist: etcdclient.PrevNoExist}); err != nil {
@@ -123,7 +113,7 @@ func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 		glog.Infof("Changed key ownership")
 	}()
 
-	lease := leaderlease.NewEtcd(c, key, "other", 10)
+	lease := leaderlease.NewEtcd(etcdServer.Client, key, "other", 10)
 	ch := make(chan error, 1)
 	go lease.AcquireAndHold(ch)
 
@@ -138,13 +128,10 @@ func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 }
 
 func TestLeaderLeaseReacquire(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	c, err := testutil.MakeNewEtcdClient()
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := etcdclient.NewKeysAPI(c)
+	etcdServer := testutil.RequireEtcd2(t)
+	defer etcdServer.DumpEtcdOnFailure()
+	client := etcdclient.NewKeysAPI(etcdServer.Client)
+
 	key := "/random/key"
 
 	if _, err := client.Set(context.Background(), key, "holder", &etcdclient.SetOptions{TTL: time.Second, PrevExist: etcdclient.PrevNoExist}); err != nil {
@@ -160,7 +147,7 @@ func TestLeaderLeaseReacquire(t *testing.T) {
 		glog.Infof("Deleted key")
 	}()
 
-	lease := leaderlease.NewEtcd(c, key, "holder", 1)
+	lease := leaderlease.NewEtcd(etcdServer.Client, key, "holder", 1)
 	ch := make(chan error, 1)
 	go lease.AcquireAndHold(ch)
 

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -96,8 +96,7 @@ var expectedIndex = []string{
 }
 
 func TestRootRedirect(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -152,8 +151,7 @@ func TestRootRedirect(t *testing.T) {
 }
 
 func TestWellKnownOAuth(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -183,8 +181,7 @@ func TestWellKnownOAuth(t *testing.T) {
 }
 
 func TestWellKnownOAuthOff(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -212,8 +209,7 @@ func TestWellKnownOAuthOff(t *testing.T) {
 }
 
 func TestApiGroups(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestNamespaceLifecycleAdmission(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -29,8 +29,7 @@ type testRequest struct {
 }
 
 func TestNodeAuth(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Server config
 	masterConfig, nodeConfig, adminKubeConfigFile, err := testserver.StartTestAllInOne()
 	if err != nil {

--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -307,8 +307,7 @@ func TestOAuthBasicAuthPassword(t *testing.T) {
 	}()
 
 	// Build master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -38,8 +38,7 @@ func TestOAuthCertFallback(t *testing.T) {
 		anonymousError    = `User "system:anonymous" cannot get users at the cluster scope`
 	)
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_disabled_test.go
+++ b/test/integration/oauth_disabled_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestOAuthDisabled(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -22,8 +22,7 @@ func TestOAuthHTPasswd(t *testing.T) {
 	}
 	defer os.Remove(htpasswdFile.Name())
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -80,8 +80,7 @@ func TestOAuthLDAP(t *testing.T) {
 	ldapServer.Start(ldapAddress)
 	defer ldapServer.Stop()
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -65,8 +65,7 @@ func TestOAuthOIDC(t *testing.T) {
 	}
 
 	// Get master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -44,8 +44,7 @@ func TestOAuthRequestHeader(t *testing.T) {
 	}
 
 	// Get master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -37,8 +37,7 @@ import (
 )
 
 func TestOAuthServiceAccountClient(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -53,8 +53,7 @@ func (u *testUser) ConvertFromAccessToken(*api.OAuthAccessToken) (interface{}, e
 }
 
 func TestOAuthStorage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/ownerrefs_test.go
+++ b/test/integration/ownerrefs_test.go
@@ -15,8 +15,7 @@ import (
 
 func TestOwnerRefRestriction(t *testing.T) {
 	// functionality of the plugin has a unit test, we just need to make sure its called.
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/patch_test.go
+++ b/test/integration/patch_test.go
@@ -23,8 +23,7 @@ import (
 
 func TestPatchConflicts(t *testing.T) {
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -21,20 +21,20 @@ import (
 )
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameClusterAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	oclient, kclientset := setupClusterAdminPodNodeConstraintsTest(t, &pluginapi.PodNodeConstraintsConfig{})
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, cluster admin", kclientset, oclient, "nodename.example.com", nil, false)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameNonAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	config := &pluginapi.PodNodeConstraintsConfig{}
 	oclient, kclientset := setupUserPodNodeConstraintsTest(t, config, "derples")
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, regular user", kclientset, oclient, "nodename.example.com", nil, true)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorClusterAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}
@@ -43,7 +43,7 @@ func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorClusterAdmin(t *testing
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorNonAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}
@@ -52,7 +52,6 @@ func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorNonAdmin(t *testing.T) 
 }
 
 func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -90,7 +89,6 @@ func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *plugina
 }
 
 func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig, user string) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestPolicyCommands(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/project_reqlimit_test.go
+++ b/test/integration/project_reqlimit_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func setupProjectRequestLimitTest(t *testing.T, pluginConfig *requestlimit.ProjectRequestLimitConfig) (kclientset.Interface, client.Interface, *restclient.Config) {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -125,7 +124,7 @@ func projectRequestLimitUsers() map[string]labels.Set {
 }
 
 func TestProjectRequestLimitMultiLevelConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitMultiLevelConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -141,7 +140,7 @@ func TestProjectRequestLimitMultiLevelConfig(t *testing.T) {
 }
 
 func TestProjectRequestLimitEmptyConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitEmptyConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -157,7 +156,7 @@ func TestProjectRequestLimitEmptyConfig(t *testing.T) {
 }
 
 func TestProjectRequestLimitSingleConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	kclient, oclient, clientConfig := setupProjectRequestLimitTest(t, projectRequestLimitSingleDefaultConfig())
 	setupProjectRequestLimitUsers(t, oclient, projectRequestLimitUsers())
 	setupProjectRequestLimitNamespaces(t, kclient, map[string]int{
@@ -175,7 +174,7 @@ func TestProjectRequestLimitSingleConfig(t *testing.T) {
 // we had a bug where this failed on ` uenxpected error: metadata.name: Invalid value: "system:admin": may not contain ":"`
 // make sure we never have that bug again and that project limits for them work
 func TestProjectRequestLimitAsSystemAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, oclient, _ := setupProjectRequestLimitTest(t, projectRequestLimitSingleDefaultConfig())
 
 	if _, err := oclient.ProjectRequests().Create(&projectapi.ProjectRequest{

--- a/test/integration/project_request_test.go
+++ b/test/integration/project_request_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestProjectRequestError(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	const (
 		ns                = "testns"

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -29,8 +29,7 @@ import (
 
 // TestProjectIsNamespace verifies that a project is a namespace, and a namespace is a project
 func TestProjectIsNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -98,7 +97,7 @@ func TestProjectIsNamespace(t *testing.T) {
 // and that openshift content is cleaned up when a project is deleted.
 func TestProjectLifecycle(t *testing.T) {
 	etcdServer := testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer etcdServer.DumpEtcdOnFailure()
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -211,8 +210,7 @@ func TestProjectLifecycle(t *testing.T) {
 }
 
 func TestProjectWatch(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -358,8 +356,7 @@ func waitForOnlyDelete(projectName string, w watch.Interface, t *testing.T) {
 }
 
 func TestScopedProjectAccess(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -487,8 +484,7 @@ func TestScopedProjectAccess(t *testing.T) {
 }
 
 func TestInvalidRoleRefs(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestRestrictUsers(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/router_without_haproxy_test.go
+++ b/test/integration/router_without_haproxy_test.go
@@ -34,7 +34,7 @@ const waitInterval = 50 * time.Millisecond
 // will match a router's selector will expose routes in that namespace
 // after the subsequent namespace sync.
 func TestRouterNamespaceSync(t *testing.T) {
-	testutil.RequireEtcd(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	oc, kc, err := launchApi()
 	if err != nil {
@@ -93,7 +93,7 @@ func TestRouterNamespaceSync(t *testing.T) {
 // processed.  Reload should similarly suppressed on subsequent
 // resyncs.
 func TestRouterReloadSuppressionOnSync(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	stressRouter(
 		t,
 		// Allow the test to be configured to enable experimentation
@@ -106,8 +106,6 @@ func TestRouterReloadSuppressionOnSync(t *testing.T) {
 }
 
 func stressRouter(t *testing.T, namespaceCount, routesPerNamespace, routerCount, maxRouterDelay int32) {
-	testutil.RequireEtcd(t)
-
 	oc, kc, err := launchApi()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -44,7 +44,7 @@ func testPodDuration(t *testing.T, name string, kclientset kclientset.Interface,
 }
 
 func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsLimit: &secs,
@@ -57,7 +57,7 @@ func TestRunOnceDurationAdmissionPlugin(t *testing.T) {
 }
 
 func TestRunOnceDurationAdmissionPluginProjectLimit(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	var secs int64 = 3600
 	config := &pluginapi.RunOnceDurationConfig{
 		ActiveDeadlineSecondsLimit: &secs,
@@ -72,7 +72,6 @@ func TestRunOnceDurationAdmissionPluginProjectLimit(t *testing.T) {
 }
 
 func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurationConfig, nsAnnotations map[string]string) kclientset.Interface {
-	testutil.RequireEtcd(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestPodUpdateSCCEnforcement(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestScopedTokens(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -99,8 +98,7 @@ func TestScopedTokens(t *testing.T) {
 }
 
 func TestScopedImpersonation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -144,8 +142,7 @@ func TestScopedImpersonation(t *testing.T) {
 }
 
 func TestScopeEscalations(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -225,8 +222,7 @@ func TestScopeEscalations(t *testing.T) {
 }
 
 func TestTokensWithIllegalScopes(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/sdn_test.go
+++ b/test/integration/sdn_test.go
@@ -75,8 +75,7 @@ func updateNetNamespace(osClient *osclient.Client, netns *sdnapi.NetNamespace, a
 }
 
 func TestOadmPodNetwork(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestServiceAccountAuthorization(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	saNamespace := api.NamespaceDefault
 	saName := serviceaccountadmission.DefaultServiceAccountName
 	saUsername := apiserverserviceaccount.MakeUsername(saNamespace, saName)
@@ -167,8 +166,7 @@ func TestAutomaticCreationOfPullSecrets(t *testing.T) {
 	saNamespace := api.NamespaceDefault
 	saName := serviceaccountadmission.DefaultServiceAccountName
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -225,8 +223,7 @@ func getServiceAccountPullSecret(client kclientset.Interface, ns, name string) (
 }
 
 func TestEnforcingServiceAccount(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, err := testserver.DefaultMasterOptions()
 	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
 	if err != nil {

--- a/test/integration/service_serving_cert_signer_test.go
+++ b/test/integration/service_serving_cert_signer_test.go
@@ -18,8 +18,7 @@ import (
 func TestServiceServingCertSigner(t *testing.T) {
 	ns := "service-serving-cert-signer"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {

--- a/test/integration/shortcut_expansion_test.go
+++ b/test/integration/shortcut_expansion_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestCachingDiscoveryClient(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, originKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -27,8 +27,7 @@ const (
 )
 
 func TestSNI(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	// Create tempfiles with certs and keys we're going to use
 	certNames := map[string]string{}
 	for certName, certContents := range sniCerts {

--- a/test/integration/storage_versions_test.go
+++ b/test/integration/storage_versions_test.go
@@ -98,8 +98,8 @@ func TestStorageVersions(t *testing.T) {
 	autoscalingVersion := autoscaling_v1.SchemeGroupVersion
 	batchVersion := batch_v1.SchemeGroupVersion
 
-	defer testutil.DumpEtcdOnFailure(t)
 	etcdServer := testutil.RequireEtcd(t)
+	defer etcdServer.DumpEtcdOnFailure()
 	masterConfig, kubeClient := setupStorageTests(t, ns)
 
 	jobTestcases := map[string]struct {
@@ -190,8 +190,8 @@ func TestStorageMigration(t *testing.T) {
 	hpaName := "extensionsv1beta1hpa"
 	autoscalingVersion := autoscaling_v1.SchemeGroupVersion
 
-	defer testutil.DumpEtcdOnFailure(t)
 	etcdServer := testutil.RequireEtcd(t)
+	defer etcdServer.DumpEtcdOnFailure()
 	masterConfig, kubeClient := setupStorageTests(t, ns)
 
 	// Save an extensions/v1beta1.HorizontalPodAutoscaler directly in etcd

--- a/test/integration/template_test.go
+++ b/test/integration/template_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, path, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,8 +118,7 @@ func walkJSONFiles(inDir string, fn func(name, path string, data []byte)) error 
 }
 
 func TestTemplateTransformationFromConfig(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/tls_test.go
+++ b/test/integration/tls_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestTLSDefaults(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	master, node, components, err := testserver.DefaultAllInOneOptions()
 	if err != nil {
 		t.Fatal(err)
@@ -83,8 +82,7 @@ func TestTLSDefaults(t *testing.T) {
 }
 
 func TestTLSOverrides(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	master, node, components, err := testserver.DefaultAllInOneOptions()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -45,8 +45,7 @@ import (
 )
 
 func TestUnprivilegedNewProject(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -116,8 +115,7 @@ func TestUnprivilegedNewProject(t *testing.T) {
 
 }
 func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	namespace := "foo"
 	templateName := "bar"
 
@@ -212,8 +210,7 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 }
 
 func TestUnprivilegedNewProjectDenied(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -68,8 +68,7 @@ func makeMapping(user, identity string) *api.UserIdentityMapping {
 }
 
 func TestUserInitialization(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -77,8 +77,7 @@ func signedManifest(name string, blobs []digest.Digest) ([]byte, digest.Digest, 
 }
 
 func TestV2RegistryGetTags(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)

--- a/test/integration/watch_cache_test.go
+++ b/test/integration/watch_cache_test.go
@@ -114,8 +114,7 @@ func testWatchCacheWithConfig(t *testing.T, master *configapi.MasterConfig, expe
 }
 
 func TestDefaultWatchCacheSize(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
@@ -132,8 +131,7 @@ func TestDefaultWatchCacheSize(t *testing.T) {
 }
 
 func TestWatchCacheSizeWithFlag(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -82,8 +82,7 @@ func tryAccessURL(t *testing.T, url string, expectedStatus int, expectedRedirect
 }
 
 func TestAccessOriginWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -110,8 +109,7 @@ func TestAccessOriginWebConsole(t *testing.T) {
 }
 
 func TestAccessDisabledWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -149,8 +147,7 @@ func TestAccessDisabledWebConsole(t *testing.T) {
 }
 
 func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -243,8 +240,7 @@ func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 }
 
 func TestAccessStandaloneOriginWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -52,8 +52,7 @@ func TestWebConsoleExtensions(t *testing.T) {
 	}
 
 	// Build master config.
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("Failed creating master configuration: %v", err)

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -21,8 +21,7 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unable to start master: %v", err)
@@ -132,8 +131,7 @@ func TestWebhook(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -246,8 +244,7 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImageStream(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -347,8 +344,7 @@ func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 }
 
 func TestWebhookGitHubPing(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure()
 	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unable to start master: %v", err)

--- a/test/util/etcd.go
+++ b/test/util/etcd.go
@@ -16,11 +16,8 @@ import (
 	etcdclientv3 "github.com/coreos/etcd/clientv3"
 
 	etcdtest "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/apiserver/pkg/storage/storagebackend"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/capabilities"
-
-	serveretcd "github.com/openshift/origin/pkg/cmd/server/etcd"
 )
 
 func init() {
@@ -42,6 +39,7 @@ var url string
 
 type EtcdTestServer struct {
 	*etcdtest.EtcdTestServer
+	t *testing.T
 }
 
 // RequireEtcd verifies if the etcd is running and accessible for testing
@@ -55,49 +53,13 @@ func RequireEtcd(t *testing.T) EtcdTestServer {
 func RequireEtcd2(t *testing.T) EtcdTestServer {
 	s := etcdtest.NewUnsecuredEtcdTestClientServer(t)
 	url = s.Client.Endpoints()[0]
-	return EtcdTestServer{s}
+	return EtcdTestServer{EtcdTestServer: s, t: t}
 }
 
-func RequireEtcd3(t *testing.T) (*etcdtest.EtcdTestServer, *storagebackend.Config) {
-	s, c := etcdtest.NewUnsecuredEtcd3TestClientServer(t, kapi.Scheme)
+func RequireEtcd3(t *testing.T) EtcdTestServer {
+	s, _ := etcdtest.NewUnsecuredEtcd3TestClientServer(t, kapi.Scheme)
 	url = s.V3Client.Endpoints()[0]
-	return s, c
-}
-
-func NewEtcdClient() etcdclient.Client {
-	client, _ := MakeNewEtcdClient()
-	return client
-}
-
-func MakeNewEtcdClient() (etcdclient.Client, error) {
-	etcdServers := []string{GetEtcdURL()}
-
-	cfg := etcdclient.Config{
-		Endpoints: etcdServers,
-	}
-	client, err := etcdclient.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return client, serveretcd.TestEtcdClient(client)
-}
-
-func NewEtcd3Client() *etcdclientv3.Client {
-	client, _ := MakeNewEtcd3Client()
-	return client
-}
-
-func MakeNewEtcd3Client() (*etcdclientv3.Client, error) {
-	etcdServers := []string{GetEtcdURL()}
-
-	cfg := etcdclientv3.Config{
-		Endpoints: etcdServers,
-	}
-	client, err := etcdclientv3.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return client, serveretcd.TestEtcdClientV3(client)
+	return EtcdTestServer{EtcdTestServer: s, t: t}
 }
 
 func GetEtcdURL() string {
@@ -107,48 +69,89 @@ func GetEtcdURL() string {
 	return url
 }
 
-func (s EtcdTestServer) DumpEtcdOnFailure(t *testing.T) {
+func (s EtcdTestServer) DumpEtcdOnFailure() {
 	defer func() {
-		s.Terminate(t)
+		s.Terminate(s.t)
 		os.RemoveAll(s.DataDir)
 	}()
-	if !t.Failed() {
+	if !s.t.Failed() {
 		return
 	}
-
-	pc := make([]uintptr, 10)
-	goruntime.Callers(2, pc)
-	f := goruntime.FuncForPC(pc[0])
-	last := strings.LastIndex(f.Name(), "Test")
-	if last == -1 {
-		last = 0
+	v3 := s.V3Client != nil
+	if v3 {
+		s.dumpEtcd3()
+	} else {
+		s.dumpEtcd2()
 	}
-	name := f.Name()[last:]
-	client := NewEtcdClient()
-	keyClient := etcdclient.NewKeysAPI(client)
+}
 
-	response, err := keyClient.Get(context.Background(), "/", &etcdclient.GetOptions{Recursive: true, Sort: true})
+func (s EtcdTestServer) dumpEtcd2() {
+	response, err := etcdclient.NewKeysAPI(s.Client).Get(context.Background(), "/", &etcdclient.GetOptions{Recursive: true, Sort: true})
 	if err != nil {
-		t.Logf("error dumping etcd: %v", err)
-		return
-	}
-	jsonResponse, err := json.Marshal(response.Node)
-	if err != nil {
-		t.Logf("error encoding etcd dump: %v", err)
+		s.t.Logf("error dumping etcd: %v", err)
 		return
 	}
 
-	t.Logf("dumping etcd to %q", GetBaseDir()+"/etcd-dump-"+name+".json")
+	s.writeEtcdDump(response.Node)
+}
+
+func (s EtcdTestServer) dumpEtcd3() {
+	response, err := s.V3Client.KV.Get(context.Background(), "/", etcdclientv3.WithPrefix(), etcdclientv3.WithSort(etcdclientv3.SortByKey, etcdclientv3.SortDescend))
+	if err != nil {
+		s.t.Logf("error dumping etcd: %v", err)
+		return
+	}
+
+	kvData := []etcd3kv{}
+	for _, kvs := range response.Kvs {
+		obj, _, err := kapi.Codecs.UniversalDeserializer().Decode(kvs.Value, nil, nil)
+		if err != nil {
+			s.t.Logf("error decoding value %s: %v", string(kvs.Value), err)
+			continue
+		}
+		objJSON, err := json.Marshal(obj)
+		if err != nil {
+			s.t.Logf("error encoding object %#v as JSON: %v", obj, err)
+			continue
+		}
+		kvData = append(kvData, etcd3kv{string(kvs.Key), string(objJSON)})
+	}
+
+	s.writeEtcdDump(kvData)
+}
+
+func (s EtcdTestServer) writeEtcdDump(data interface{}) {
+	jsonResponse, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		s.t.Logf("error encoding etcd dump: %v", err)
+		return
+	}
+	name := getCallingTestName()
+	s.t.Logf("dumping etcd to %q", GetBaseDir()+"/etcd-dump-"+name+".json")
 	dumpFile, err := os.OpenFile(GetBaseDir()+"/etcd-dump-"+name+".json", os.O_WRONLY|os.O_CREATE, 0444)
 	if err != nil {
-		t.Logf("error writing etcd dump: %v", err)
+		s.t.Logf("error writing etcd dump: %v", err)
 		return
 	}
 	defer dumpFile.Close()
 	_, err = dumpFile.Write(jsonResponse)
 	if err != nil {
-		t.Logf("error writing etcd dump: %v", err)
+		s.t.Logf("error writing etcd dump: %v", err)
 		return
 	}
+}
 
+func getCallingTestName() string {
+	pc := make([]uintptr, 10)
+	goruntime.Callers(5, pc)
+	f := goruntime.FuncForPC(pc[0])
+	last := strings.LastIndex(f.Name(), "Test")
+	if last == -1 {
+		last = 0
+	}
+	return f.Name()[last:]
+}
+
+type etcd3kv struct {
+	Key, Value string
 }

--- a/test/util/etcd.go
+++ b/test/util/etcd.go
@@ -7,6 +7,7 @@ import (
 	goruntime "runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -71,6 +72,7 @@ func GetEtcdURL() string {
 
 func (s EtcdTestServer) DumpEtcdOnFailure() {
 	defer func() {
+		time.Sleep(time.Second) // push Terminate's race forward
 		s.Terminate(s.t)
 		os.RemoveAll(s.DataDir)
 	}()


### PR DESCRIPTION
Also adds etcd3 dump support which is not yet enabled.  Once #14095 is merged I will look at what things break if we start defaulting to etcd3.

[test]

cc @stevekuznetsov @bparees @sttts 