### PR TITLE
switch openshift service account roles system:openshift:controllers and move to RBAC

### DIFF
--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -38,7 +38,7 @@ func TestSubjects(t *testing.T) {
 			"system:serviceaccount:adze:second", "system:serviceaccount:foo:default", "system:serviceaccount:other:first",
 			"system:serviceaccount:kube-system:deployment-controller", "system:serviceaccount:kube-system:endpoint-controller", "system:serviceaccount:kube-system:generic-garbage-collector",
 			"system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:kube-system:persistent-volume-binder", "system:serviceaccount:kube-system:statefulset-controller",
-			"system:admin", "system:kube-scheduler"),
+			"system:admin", "system:kube-scheduler", "system:serviceaccount:openshift-infra:build-controller"),
 		expectedGroups: sets.NewString("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:masters", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -1,0 +1,68 @@
+package bootstrappolicy
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+const saRolePrefix = "system:openshift:controller:"
+
+var (
+	// controllerRoles is a slice of roles used for controllers
+	controllerRoles = []rbac.ClusterRole{}
+	// controllerRoleBindings is a slice of roles used for controllers
+	controllerRoleBindings = []rbac.ClusterRoleBinding{}
+)
+
+func addControllerRole(role rbac.ClusterRole) {
+	if !strings.HasPrefix(role.Name, saRolePrefix) {
+		glog.Fatalf(`role %q must start with %q`, role.Name, saRolePrefix)
+	}
+
+	for _, existingRole := range controllerRoles {
+		if role.Name == existingRole.Name {
+			glog.Fatalf("role %q was already registered", role.Name)
+		}
+	}
+
+	if role.Annotations == nil {
+		role.Annotations = map[string]string{}
+	}
+	role.Annotations[roleSystemOnly] = roleIsSystemOnly
+
+	controllerRoles = append(controllerRoles, role)
+
+	controllerRoleBindings = append(controllerRoleBindings,
+		rbac.NewClusterBinding(role.Name).SAs(DefaultOpenShiftInfraNamespace, role.Name[len(saRolePrefix):]).BindingOrDie())
+}
+
+func eventsRule() rbac.PolicyRule {
+	return rbac.NewRule("create", "update", "patch").Groups(kapiGroup).Resources("events").RuleOrDie()
+}
+
+func init() {
+	addControllerRole(rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "build-controller"},
+		Rules: []rbac.PolicyRule{
+			rbac.NewRule("get", "list", "watch", "update").Groups(buildGroup, legacyBuildGroup).Resources("builds").RuleOrDie(),
+			rbac.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("builds/docker", "builds/source", "builds/custom", "builds/jenkinspipeline").RuleOrDie(),
+			rbac.NewRule("get").Groups(imageGroup, legacyImageGroup).Resources("imagestreams").RuleOrDie(),
+			rbac.NewRule("get", "list", "create", "delete").Groups(kapiGroup).Resources("pods").RuleOrDie(),
+			eventsRule(),
+		},
+	})
+}
+
+// ControllerRoles returns the cluster roles used by controllers
+func ControllerRoles() []rbac.ClusterRole {
+	return controllerRoles
+}
+
+// ControllerRoleBindings returns the role bindings used by controllers
+func ControllerRoleBindings() []rbac.ClusterRoleBinding {
+	return controllerRoleBindings
+}

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -46,12 +46,13 @@ func eventsRule() rbac.PolicyRule {
 
 func init() {
 	addControllerRole(rbac.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "build-controller"},
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraBuildControllerServiceAccountName},
 		Rules: []rbac.PolicyRule{
 			rbac.NewRule("get", "list", "watch", "update").Groups(buildGroup, legacyBuildGroup).Resources("builds").RuleOrDie(),
 			rbac.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("builds/docker", "builds/source", "builds/custom", "builds/jenkinspipeline").RuleOrDie(),
 			rbac.NewRule("get").Groups(imageGroup, legacyImageGroup).Resources("imagestreams").RuleOrDie(),
 			rbac.NewRule("get", "list", "create", "delete").Groups(kapiGroup).Resources("pods").RuleOrDie(),
+			rbac.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/pkg/cmd/server/bootstrappolicy/dead.go
+++ b/pkg/cmd/server/bootstrappolicy/dead.go
@@ -46,4 +46,8 @@ func init() {
 	addDeadClusterRole("system:gc-controller")
 	addDeadClusterRole("system:certificate-signing-controller")
 	addDeadClusterRole("system:statefulset-controller")
+
+	// these were moved under system:openshift:controller:*
+	addDeadClusterRole("system:build-controller")
+
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -959,6 +959,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 	if err != nil {
 		panic(err)
 	}
+	openshiftControllerRoles, err := GetOpenshiftControllerBootstrapClusterRoles()
+	// coder error
+	if err != nil {
+		panic(err)
+	}
 
 	// Eventually openshift controllers and kube controllers have different prefixes
 	// so we will only need to check conflicts on the "normal" cluster roles
@@ -990,6 +995,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 	finalClusterRoles := []authorizationapi.ClusterRole{}
 	finalClusterRoles = append(finalClusterRoles, openshiftClusterRoles...)
 	finalClusterRoles = append(finalClusterRoles, openshiftSAClusterRoles...)
+	finalClusterRoles = append(finalClusterRoles, openshiftControllerRoles...)
 	finalClusterRoles = append(finalClusterRoles, kubeSAClusterRoles...)
 	for i := range kubeClusterRoles {
 		if !clusterRoleConflicts.Has(kubeClusterRoles[i].Name) {
@@ -1189,7 +1195,12 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 	if err != nil {
 		panic(err)
 	}
-	kubeSAClusterRoleBindings, err := GetKubeControllerBootstrapClusterRoleBindings()
+	kubeControllerClusterRoleBindings, err := GetKubeControllerBootstrapClusterRoleBindings()
+	// coder error
+	if err != nil {
+		panic(err)
+	}
+	openshiftControllerClusterRoleBindings, err := GetOpenshiftControllerBootstrapClusterRoleBindings()
 	// coder error
 	if err != nil {
 		panic(err)
@@ -1220,7 +1231,8 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 
 	finalClusterRoleBindings := []authorizationapi.ClusterRoleBinding{}
 	finalClusterRoleBindings = append(finalClusterRoleBindings, openshiftClusterRoleBindings...)
-	finalClusterRoleBindings = append(finalClusterRoleBindings, kubeSAClusterRoleBindings...)
+	finalClusterRoleBindings = append(finalClusterRoleBindings, kubeControllerClusterRoleBindings...)
+	finalClusterRoleBindings = append(finalClusterRoleBindings, openshiftControllerClusterRoleBindings...)
 	for i := range kubeClusterRoleBindings {
 		if !clusterRoleBindingConflicts.Has(kubeClusterRoleBindings[i].Name) {
 			finalClusterRoleBindings = append(finalClusterRoleBindings, kubeClusterRoleBindings[i])
@@ -1263,6 +1275,10 @@ func GetKubeControllerBootstrapClusterRoleBindings() ([]authorizationapi.Cluster
 	return convertClusterRoleBindings(bootstrappolicy.ControllerRoleBindings())
 }
 
+func GetOpenshiftControllerBootstrapClusterRoleBindings() ([]authorizationapi.ClusterRoleBinding, error) {
+	return convertClusterRoleBindings(ControllerRoleBindings())
+}
+
 func convertClusterRoleBindings(in []rbac.ClusterRoleBinding) ([]authorizationapi.ClusterRoleBinding, error) {
 	out := []authorizationapi.ClusterRoleBinding{}
 	errs := []error{}
@@ -1285,6 +1301,10 @@ func GetKubeBootstrapClusterRoles() ([]authorizationapi.ClusterRole, error) {
 
 func GetKubeControllerBootstrapClusterRoles() ([]authorizationapi.ClusterRole, error) {
 	return convertClusterRoles(bootstrappolicy.ControllerRoles())
+}
+
+func GetOpenshiftControllerBootstrapClusterRoles() ([]authorizationapi.ClusterRole, error) {
+	return convertClusterRoles(ControllerRoles())
 }
 
 func convertClusterRoles(in []rbac.ClusterRole) ([]authorizationapi.ClusterRole, error) {

--- a/pkg/cmd/server/origin/controller.go
+++ b/pkg/cmd/server/origin/controller.go
@@ -1,0 +1,28 @@
+package origin
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/cmd/server/origin/controller"
+)
+
+func (c *MasterConfig) NewOpenshiftControllerInitializers() (map[string]controller.InitFunc, error) {
+	ret := map[string]controller.InitFunc{}
+
+	// initialize build controller
+	storageVersion := c.Options.EtcdStorageConfig.OpenShiftStorageVersion
+	groupVersion := schema.GroupVersion{Group: "", Version: storageVersion}
+	codec := kapi.Codecs.LegacyCodec(groupVersion)
+
+	buildControllerConfig := controller.BuildControllerConfig{
+		DockerImage:           c.ImageFor("docker-builder"),
+		STIImage:              c.ImageFor("sti-builder"),
+		AdmissionPluginConfig: c.Options.AdmissionConfig.PluginConfig,
+		Codec: codec,
+	}
+
+	ret["build"] = buildControllerConfig.RunController
+
+	return ret, nil
+}

--- a/pkg/cmd/server/origin/controller/build.go
+++ b/pkg/cmd/server/origin/controller/build.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+
+	builddefaults "github.com/openshift/origin/pkg/build/admission/defaults"
+	buildoverrides "github.com/openshift/origin/pkg/build/admission/overrides"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
+	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+)
+
+type BuildControllerConfig struct {
+	DockerImage           string
+	STIImage              string
+	AdmissionPluginConfig map[string]configapi.AdmissionPluginConfig
+
+	Codec runtime.Codec
+}
+
+// RunBuildController starts the build sync loop for builds and buildConfig processing.
+func (c *BuildControllerConfig) RunController(ctx ControllerContext) (bool, error) {
+	pluginInitializer := kubeadmission.NewPluginInitializer(
+		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraBuildControllerServiceAccountName),
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers(),
+		nil, // api authorizer, only used by PSP
+		nil, // cloud config
+	)
+	admissionControl, err := admission.InitPlugin("SecurityContextConstraint", nil, pluginInitializer)
+	if err != nil {
+		return true, err
+	}
+
+	buildDefaults, err := builddefaults.NewBuildDefaults(c.AdmissionPluginConfig)
+	if err != nil {
+		return true, err
+	}
+	buildOverrides, err := buildoverrides.NewBuildOverrides(c.AdmissionPluginConfig)
+	if err != nil {
+		return true, err
+	}
+
+	deprecatedOpenshiftClient, err := ctx.ClientBuilder.DeprecatedOpenshiftClient(bootstrappolicy.InfraBuildControllerServiceAccountName)
+	if err != nil {
+		return true, err
+	}
+
+	factory := buildcontrollerfactory.BuildControllerFactory{
+		KubeClient:         ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraBuildControllerServiceAccountName),
+		ExternalKubeClient: ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraBuildControllerServiceAccountName),
+		OSClient:           deprecatedOpenshiftClient,
+		BuildUpdater:       buildclient.NewOSClientBuildClient(deprecatedOpenshiftClient),
+		BuildLister:        buildclient.NewOSClientBuildClient(deprecatedOpenshiftClient),
+		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
+			Image: c.DockerImage,
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec: c.Codec,
+		},
+		SourceBuildStrategy: &buildstrategy.SourceBuildStrategy{
+			Image: c.STIImage,
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec:            c.Codec,
+			AdmissionControl: admissionControl,
+		},
+		CustomBuildStrategy: &buildstrategy.CustomBuildStrategy{
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec: c.Codec,
+		},
+		BuildDefaults:  buildDefaults,
+		BuildOverrides: buildOverrides,
+	}
+
+	controller := factory.Create()
+	controller.Run()
+	deleteController := factory.CreateDeleteController()
+	deleteController.Run()
+	return true, nil
+}

--- a/pkg/cmd/server/origin/controller/interfaces.go
+++ b/pkg/cmd/server/origin/controller/interfaces.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"github.com/golang/glog"
+
+	kubecontroller "k8s.io/kubernetes/cmd/kube-controller-manager/app"
+	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/controller"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/controller/shared"
+)
+
+type ControllerContext struct {
+	KubeControllerContext kubecontroller.ControllerContext
+
+	// ClientBuilder will provide a client for this controller to use
+	ClientBuilder ControllerClientBuilder
+
+	DeprecatedOpenshiftInformers shared.InformerFactory
+
+	// Stop is the stop channel
+	Stop <-chan struct{}
+}
+
+// TODO wire this up to something that handles the names.  The logic is available upstream, we just have to wire to it
+func (c ControllerContext) IsControllerEnabled(name string) bool {
+	return true
+}
+
+type ControllerClientBuilder interface {
+	controller.ControllerClientBuilder
+	KubeInternalClient(name string) (kclientsetinternal.Interface, error)
+	KubeInternalClientOrDie(name string) kclientsetinternal.Interface
+	DeprecatedOpenshiftClient(name string) (osclient.Interface, error)
+	DeprecatedOpenshiftClientOrDie(name string) osclient.Interface
+}
+
+// InitFunc is used to launch a particular controller.  It may run additional "should I activate checks".
+// Any error returned will cause the controller process to `Fatal`
+// The bool indicates whether the controller was enabled.
+type InitFunc func(ctx ControllerContext) (bool, error)
+
+type OpenshiftControllerClientBuilder struct {
+	controller.ControllerClientBuilder
+}
+
+func (b OpenshiftControllerClientBuilder) KubeInternalClient(name string) (kclientsetinternal.Interface, error) {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		return nil, err
+	}
+	return kclientsetinternal.NewForConfig(clientConfig)
+}
+
+func (b OpenshiftControllerClientBuilder) KubeInternalClientOrDie(name string) kclientsetinternal.Interface {
+	client, err := b.KubeInternalClient(name)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	return client
+}
+
+func (b OpenshiftControllerClientBuilder) DeprecatedOpenshiftClient(name string) (osclient.Interface, error) {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		return nil, err
+	}
+	return osclient.New(clientConfig)
+}
+
+func (b OpenshiftControllerClientBuilder) DeprecatedOpenshiftClientOrDie(name string) osclient.Interface {
+	client, err := b.DeprecatedOpenshiftClient(name)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	return client
+}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -12,7 +12,6 @@ import (
 	deployclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset/typed/deploy/internalversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/flowcontrol"
 	kctrlmgr "k8s.io/kubernetes/cmd/kube-controller-manager/app"
@@ -24,19 +23,15 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
 	sacontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
-	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	etcdallocator "k8s.io/kubernetes/pkg/registry/core/service/allocator/storage"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/authorization/controller/authorizationsync"
-	builddefaults "github.com/openshift/origin/pkg/build/admission/defaults"
-	buildoverrides "github.com/openshift/origin/pkg/build/admission/overrides"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildpodcontroller "github.com/openshift/origin/pkg/build/controller/buildpod"
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
-	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	osclient "github.com/openshift/origin/pkg/client"
 	oscache "github.com/openshift/origin/pkg/client/cache"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -44,7 +39,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/controller/shared"
 	deploycontroller "github.com/openshift/origin/pkg/deploy/controller/deployment"
 	deployconfigcontroller "github.com/openshift/origin/pkg/deploy/controller/deploymentconfig"
 	triggercontroller "github.com/openshift/origin/pkg/deploy/controller/generictrigger"
@@ -241,69 +235,6 @@ func (c *MasterConfig) RunDNSServer() {
 func (c *MasterConfig) RunProjectCache() {
 	glog.Infof("Using default project node label selector: %s", c.Options.ProjectConfig.DefaultNodeSelector)
 	c.ProjectCache.Run()
-}
-
-// RunBuildController starts the build sync loop for builds and buildConfig processing.
-func (c *MasterConfig) RunBuildController(informers shared.InformerFactory) error {
-	// initialize build controller
-	dockerImage := c.ImageFor("docker-builder")
-	stiImage := c.ImageFor("sti-builder")
-
-	storageVersion := c.Options.EtcdStorageConfig.OpenShiftStorageVersion
-	groupVersion := schema.GroupVersion{Group: "", Version: storageVersion}
-	codec := kapi.Codecs.LegacyCodec(groupVersion)
-
-	pluginInitializer := kubeadmission.NewPluginInitializer(
-		c.KubeClientsetInternal(),
-		c.Informers.InternalKubernetesInformers(),
-		nil, // api authorizer, only used by PSP
-		nil, // cloud config
-	)
-	admissionControl, err := admission.InitPlugin("SecurityContextConstraint", nil, pluginInitializer)
-	if err != nil {
-		return err
-	}
-
-	buildDefaults, err := builddefaults.NewBuildDefaults(c.Options.AdmissionConfig.PluginConfig)
-	if err != nil {
-		return err
-	}
-	buildOverrides, err := buildoverrides.NewBuildOverrides(c.Options.AdmissionConfig.PluginConfig)
-	if err != nil {
-		return err
-	}
-
-	osclient, internalKubeClientset, externalKubeClientset := c.BuildControllerClients()
-	factory := buildcontrollerfactory.BuildControllerFactory{
-		KubeClient:         internalKubeClientset,
-		ExternalKubeClient: externalKubeClientset,
-		OSClient:           osclient,
-		BuildUpdater:       buildclient.NewOSClientBuildClient(osclient),
-		BuildLister:        buildclient.NewOSClientBuildClient(osclient),
-		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
-			Image: dockerImage,
-			// TODO: this will be set to --storage-version (the internal schema we use)
-			Codec: codec,
-		},
-		SourceBuildStrategy: &buildstrategy.SourceBuildStrategy{
-			Image: stiImage,
-			// TODO: this will be set to --storage-version (the internal schema we use)
-			Codec:            codec,
-			AdmissionControl: admissionControl,
-		},
-		CustomBuildStrategy: &buildstrategy.CustomBuildStrategy{
-			// TODO: this will be set to --storage-version (the internal schema we use)
-			Codec: codec,
-		},
-		BuildDefaults:  buildDefaults,
-		BuildOverrides: buildOverrides,
-	}
-
-	controller := factory.Create()
-	controller.Run()
-	deleteController := factory.CreateDeleteController()
-	deleteController.Run()
-	return nil
 }
 
 // RunBuildPodController starts the build/pod status sync loop for build status

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
+	origincontrollers "github.com/openshift/origin/pkg/cmd/server/origin/controller"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
@@ -699,13 +700,57 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 
 	glog.Infof("Started Kubernetes Controllers")
 
-	// no special order
+	openshiftControllerContext := origincontrollers.ControllerContext{
+		KubeControllerContext: controllerContext,
+		ClientBuilder: origincontrollers.OpenshiftControllerClientBuilder{
+			ControllerClientBuilder: controller.SAControllerClientBuilder{
+				ClientConfig:         restclient.AnonymousClientConfig(&oc.PrivilegedLoopbackClientConfig),
+				CoreClient:           oc.PrivilegedLoopbackKubernetesClientsetExternal.Core(),
+				AuthenticationClient: oc.PrivilegedLoopbackKubernetesClientsetExternal.Authentication(),
+				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
+			},
+		},
+		DeprecatedOpenshiftInformers: oc.Informers,
+		Stop: controllerContext.Stop,
+	}
+	openshiftControllerInitializers, err := oc.NewOpenshiftControllerInitializers()
+
+	allowedOpenshiftControllers := sets.NewString()
 	if configapi.IsBuildEnabled(&oc.Options) {
-		err := oc.RunBuildController(oc.Informers)
+		allowedOpenshiftControllers.Insert("build")
+	}
+
+	if err != nil {
+		glog.Errorf("Could not start build controller: %v", err)
+		return err
+	}
+
+	for controllerName, initFn := range openshiftControllerInitializers {
+		// TODO remove this.  Only call one to start to prove the principle
+		if !allowedOpenshiftControllers.Has(controllerName) {
+			glog.Warningf("%q is skipped", controllerName)
+			continue
+		}
+		if !openshiftControllerContext.IsControllerEnabled(controllerName) {
+			glog.Warningf("%q is disabled", controllerName)
+			continue
+		}
+
+		glog.V(1).Infof("Starting %q", controllerName)
+		started, err := initFn(openshiftControllerContext)
 		if err != nil {
-			glog.Fatalf("Could not start build controller: %v", err)
+			glog.Errorf("Error starting %q", controllerName)
 			return err
 		}
+		if !started {
+			glog.Warningf("Skipping %q", controllerName)
+			continue
+		}
+		glog.Infof("Started %q", controllerName)
+	}
+
+	// no special order
+	if configapi.IsBuildEnabled(&oc.Options) {
 		oc.RunBuildPodController()
 		oc.RunBuildConfigChangeController()
 		oc.RunBuildImageChangeTriggerController()

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -4,12 +4,18 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
+	kctrlmgr "k8s.io/kubernetes/cmd/kube-controller-manager/app"
+	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
+	origincontrollers "github.com/openshift/origin/pkg/cmd/server/origin/controller"
 	"github.com/openshift/origin/test/common/build"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -106,8 +112,51 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (*client.Cli
 	// We don't want to proceed with the rest of the test until those are available
 	openshiftConfig.BuildControllerClients()
 
+	// this test wants to duplicate the controllers, so it needs to duplicate the wiring.
+	// TODO have this simply start the particular controller it wants multiple times
+	controllerManagerOptions := cmapp.NewCMServer()
+	rootClientBuilder := controller.SimpleControllerClientBuilder{
+		ClientConfig: &openshiftConfig.PrivilegedLoopbackClientConfig,
+	}
+	saClientBuilder := controller.SAControllerClientBuilder{
+		ClientConfig:         restclient.AnonymousClientConfig(&openshiftConfig.PrivilegedLoopbackClientConfig),
+		CoreClient:           openshiftConfig.PrivilegedLoopbackKubernetesClientsetExternal.Core(),
+		AuthenticationClient: openshiftConfig.PrivilegedLoopbackKubernetesClientsetExternal.Authentication(),
+		Namespace:            "kube-system",
+	}
+	availableResources, err := kctrlmgr.GetAvailableResources(rootClientBuilder)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controllerContext := kctrlmgr.ControllerContext{
+		ClientBuilder:      saClientBuilder,
+		InformerFactory:    openshiftConfig.Informers.KubernetesInformers(),
+		Options:            *controllerManagerOptions,
+		AvailableResources: availableResources,
+		Stop:               wait.NeverStop,
+	}
+
+	openshiftControllerContext := origincontrollers.ControllerContext{
+		KubeControllerContext: controllerContext,
+		ClientBuilder: origincontrollers.OpenshiftControllerClientBuilder{
+			ControllerClientBuilder: controller.SAControllerClientBuilder{
+				ClientConfig:         restclient.AnonymousClientConfig(&openshiftConfig.PrivilegedLoopbackClientConfig),
+				CoreClient:           openshiftConfig.PrivilegedLoopbackKubernetesClientsetExternal.Core(),
+				AuthenticationClient: openshiftConfig.PrivilegedLoopbackKubernetesClientsetExternal.Authentication(),
+				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
+			},
+		},
+		DeprecatedOpenshiftInformers: openshiftConfig.Informers,
+		Stop: controllerContext.Stop,
+	}
+	openshiftControllerInitializers, err := openshiftConfig.NewOpenshiftControllerInitializers()
+
 	for i := 0; i < counts.BuildControllers; i++ {
-		openshiftConfig.RunBuildController(openshiftConfig.Informers)
+		_, err := openshiftControllerInitializers["build"](openshiftControllerContext)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	for i := 0; i < counts.BuildPodControllers; i++ {
 		openshiftConfig.RunBuildPodController()

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -639,6 +639,20 @@ items:
   userNames:
   - system:serviceaccount:kube-system:certificate-controller
 - apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:build-controller
+  roleRef:
+    name: system:openshift:controller:build-controller
+  subjects:
+  - kind: ServiceAccount
+    name: build-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:build-controller
+- apiVersion: v1
   groupNames:
   - system:masters
   kind: ClusterRoleBinding

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2872,64 +2872,9 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
-    annotations:
-      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:build-controller
-  rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - builds
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - builds
-    verbs:
-    - update
-  - apiGroups:
-    - build.openshift.io
-    - ""
-    attributeRestrictions: null
-    resources:
-    - builds/custom
-    - builds/docker
-    - builds/jenkinspipeline
-    - builds/source
-    verbs:
-    - create
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - imagestreams
-    verbs:
-    - get
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
+  rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
@@ -3548,6 +3493,63 @@ items:
     - deploymentconfigs
     verbs:
     - get
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:build-controller
+  rules:
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - builds
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - builds/custom
+    - builds/docker
+    - builds/jenkinspipeline
+    - builds/source
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    - image.openshift.io
+    attributeRestrictions: null
+    resources:
+    - imagestreams
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
     - patch
     - update
 - apiVersion: v1

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3547,6 +3547,13 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - namespaces
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - events
     verbs:
     - create


### PR DESCRIPTION
This pull (currently second commit) moves our roles to `system:openshift:controller:*` prefixes so that we won't conflict with upstream system roles and switch initialization to RBAC since we're going there anyway.

Currently, this also pins the openshift-infra namespace to openshift-infra and eliminates the ability to configure it.  This mirrors the upstream approach with kube-system.

@liggitt @smarterclayton I think we only use this for our service accounts, so I don't see much reason to leave it configurable.  We're already stopping upgrade on conflicts with the name.

@mfojtik @soltysh so you can see the direction I'm going.  I'll create a clientbuilder to match tomorrow if things go well.