### PR TITLE
Get the return code of `go test` with `$PIPESTATUS`

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -187,12 +187,11 @@ if [[ -n "${junit_report}" ]]; then
 
     go test -i ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${test_output_file}"
-
-    JUNIT_REPORT_OUTPUT="${test_output_file}" os::test::junit::generate_gotest_report
-
     test_return_code="${PIPESTATUS[0]}"
 
     set -o pipefail
+
+    JUNIT_REPORT_OUTPUT="${test_output_file}" os::test::junit::generate_gotest_report
 
     echo
     summary="$( junitreport summarize < "${junit_report_file}" )"


### PR DESCRIPTION
We need to determine the return code of the `go test` process to
determine if the unit tests have succeeded or not, and we only want
to `set +o pipefail` while that single command is running. Otherwise,
we aren't detecting when `go test` fails and potentially allowing
for other pipe failures than which we know we can ignore.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/origin/issues/14153

[test][merge]