### PR TITLE
Router bug fix: allow access with mixedcase/uppercase hostnames

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -171,6 +171,10 @@ frontend public
   {{- if (eq .StatsPort -1) }}
   monitor-uri /_______internal_router_healthz
   {{- end }}
+  
+  # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
+  # before matching, or any requests containing uppercase characters will never match.
+  http-request set-header Host %[req.hdr(Host),lower]
 
   # check if we need to redirect/force using https.
   acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_redirect.map) -m found
@@ -197,9 +201,10 @@ frontend public_ssl
   tcp-request content accept if { req_ssl_hello_type 1 }
 
   # if the connection is SNI and the route is a passthrough don't use the termination backend, just use the tcp backend
+  # for the SNI case, we also need to compare it in case-insensitive mode (by converting it to lowercase) as RFC 4343 says
   acl sni req.ssl_sni -m found
-  acl sni_passthrough req.ssl_sni,map_reg(/var/lib/haproxy/conf/os_sni_passthrough.map) -m found
-  use_backend be_tcp:%[req.ssl_sni,map_reg(/var/lib/haproxy/conf/os_tcp_be.map)] if sni sni_passthrough
+  acl sni_passthrough req.ssl_sni,lower,map_reg(/var/lib/haproxy/conf/os_sni_passthrough.map) -m found
+  use_backend be_tcp:%[req.ssl_sni,lower,map_reg(/var/lib/haproxy/conf/os_tcp_be.map)] if sni sni_passthrough
 
   # if the route is SNI and NOT passthrough enter the termination flow
   use_backend be_sni if sni
@@ -229,6 +234,10 @@ frontend fe_sni
     {{- if gt (len .DefaultCertificate) 0 }} crt {{.DefaultCertificate}}{{ else }} crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }}
     {{- ""}} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
   mode http
+
+  # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
+  # before matching, or any requests containing uppercase characters will never match.
+  http-request set-header Host %[req.hdr(Host),lower]
 
   # check re-encrypt backends first - from most specific to general path.
   acl reencrypt base,map_reg(/var/lib/haproxy/conf/os_reencrypt.map) -m found
@@ -263,6 +272,10 @@ frontend fe_no_sni
   # terminate ssl on edge
   bind 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} ssl no-sslv3 {{ if gt (len .DefaultCertificate) 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
   mode http
+
+  # DNS labels are case insensitive (RFC 4343), we need to convert the hostname into lowercase
+  # before matching, or any requests containing uppercase characters will never match.
+  http-request set-header Host %[req.hdr(Host),lower]
 
   # check re-encrypt backends first - path or host based.
   acl reencrypt base,map_reg(/var/lib/haproxy/conf/os_reencrypt.map) -m found

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -541,6 +541,11 @@ os::cmd::expect_success "oc create route edge --service=frontend --cert=${MASTER
                                               --ca-cert=${MASTER_CONFIG_DIR}/ca.crt                 \
                                               --hostname=www.example.com -n test"
 os::cmd::try_until_text "curl -s -k --resolve 'www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST}' https://www.example.com" "Hello from OpenShift" "$((10*TIME_SEC))"
+# Ensure mixedcase requests work properly for edge/reencrypt routes (SNI-enabled)
+os::cmd::try_until_text "curl -s -k --resolve 'www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST}' https://wWw.ExAmPlE.cOm" "Hello from OpenShift" "$((10*TIME_SEC))"
+# Ensure mixedcase requests work properly for edge/reencrypt routes (SNI-disabled)
+os::cmd::try_until_text "curl -s -k -H 'Host: wWw.ExAmPlE.cOm' https://${CONTAINER_ACCESSIBLE_API_HOST}" "Hello from OpenShift" "$((10*TIME_SEC))"
+# TODO: Ensure mixedcase requests work properly for passthrough routes
 
 # Pod node selection
 os::log::info "Validating pod.spec.nodeSelector rejections"


### PR DESCRIPTION
The router currently does not accept accesses through non-lowercase hostnames.

Although this is not a problem when user access applications through a browser which transparently converts the host part into lowercase internally, it could cause problems when non-browser clients try to access an application through non-lowercase hostnames.

For example, if one create a router to serve hostname `app.test.svc.cluster.local` and path `/path`, then:
1. If one accesses through the command `curl http://app.test.svc.cluster.local/path`, then everything is ok;
2. If one accesses through the command `curl http://APP.test.svc.cluster.local/path`, then a 503 error will be received;
3. If one accesses through the command `curl http://APP.TEST.SVC.CLUSTER.LOCAL/path`, then  a 503 error will also be received;

To fix this, the commit does the following things:
1. For plain HTTP frontend/SSL proxy frontend, it converts the value of 'Host' header into lowercase form
2. For HTTPS SNI frontend, it converts the value of `req.ssl_sni` into lowercase form before it is passed into `map_reg`.

bug 1461466