### PR TITLE
UPSTREAM: 44068: Use Docker API Version instead of docker version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -18,6 +18,7 @@
 		"github.com/aws/aws-sdk-go/service/route53",
 		"github.com/codegangsta/negroni",
 		"github.com/cpuguy83/go-md2man/md2man",
+		"github.com/google/cadvisor/client/v2",
 		"github.com/go-openapi/loads",
 		"github.com/go-openapi/strfmt",
 		"github.com/go-openapi/validate",
@@ -1826,198 +1827,208 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
+		},
+		{
+			"ImportPath": "github.com/google/cadvisor/client/v2",
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.25.0",
-			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
+		},
+		{
+			"ImportPath": "github.com/google/cadvisor/zfs",
+			"Comment": "v0.25.0-14-g2ddeb5f",
+			"Rev": "2ddeb5f60e22d86c8d1eeb654dfb8bfadf93374c"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/vendor/github.com/google/cadvisor/client/v2/README.md
+++ b/vendor/github.com/google/cadvisor/client/v2/README.md
@@ -1,0 +1,69 @@
+# Example REST API Client
+
+This is an implementation of a cAdvisor REST API in Go.  You can use it like this:
+
+```go
+client, err := client.NewClient("http://192.168.59.103:8080/")
+```
+
+Obviously, replace the URL with the path to your actual cAdvisor REST endpoint.
+
+
+### MachineInfo
+
+```go
+client.MachineInfo()
+```
+
+There is no v2 MachineInfo API, so the v2 client exposes the [v1 MachineInfo](../../info/v1/machine.go#L131)
+
+```
+(*v1.MachineInfo)(0xc208022b10)({
+ NumCores: (int) 4,
+ MemoryCapacity: (int64) 2106028032,
+ Filesystems: ([]v1.FsInfo) (len=1 cap=4) {
+  (v1.FsInfo) {
+   Device: (string) (len=9) "/dev/sda1",
+   Capacity: (uint64) 19507089408
+  }
+ }
+})
+```
+
+You can see the full specification of the [MachineInfo struct in the source](../../info/v1/machine.go#L131)
+
+### VersionInfo
+
+```go
+client.VersionInfo()
+```
+
+This method returns the cAdvisor version.
+
+### Attributes
+
+```go
+client.Attributes()
+```
+
+This method returns a [cadvisor/info/v2/Attributes](../../info/v2/machine.go#L24) struct with all the fields filled in. Attributes includes hardware attributes (as returned by MachineInfo) as well as software attributes (eg. software versions). Here is an example return value:
+
+```
+(*v2.Attributes)({
+ KernelVersion: (string) (len=17) "3.13.0-44-generic"
+ ContainerOsVersion: (string) (len=18) "Ubuntu 14.04.1 LTS"
+ DockerVersion: (string) (len=9) "1.5.0-rc4"
+ CadvisorVersion: (string) (len=6) "0.10.1"
+ NumCores: (int) 4,
+ MemoryCapacity: (int64) 2106028032,
+ Filesystems: ([]v2.FsInfo) (len=1 cap=4) {
+  (v2.FsInfo) {
+   Device: (string) (len=9) "/dev/sda1",
+   Capacity: (uint64) 19507089408
+  }
+ }
+})
+```
+
+You can see the full specification of the [Attributes struct in the source](../../info/v2/machine.go#L24)
+

--- a/vendor/github.com/google/cadvisor/client/v2/client.go
+++ b/vendor/github.com/google/cadvisor/client/v2/client.go
@@ -1,0 +1,176 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Client library to programmatically access cAdvisor API.
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	v1 "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/info/v2"
+)
+
+// Client represents the base URL for a cAdvisor client.
+type Client struct {
+	baseUrl string
+}
+
+// NewClient returns a new client with the specified base URL.
+func NewClient(url string) (*Client, error) {
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+
+	return &Client{
+		baseUrl: fmt.Sprintf("%sapi/v2.1/", url),
+	}, nil
+}
+
+// MachineInfo returns the JSON machine information for this client.
+// A non-nil error result indicates a problem with obtaining
+// the JSON machine information data.
+func (self *Client) MachineInfo() (minfo *v1.MachineInfo, err error) {
+	u := self.machineInfoUrl()
+	ret := new(v1.MachineInfo)
+	if err = self.httpGetJsonData(ret, nil, u, "machine info"); err != nil {
+		return
+	}
+	minfo = ret
+	return
+}
+
+// MachineStats returns the JSON machine statistics for this client.
+// A non-nil error result indicates a problem with obtaining
+// the JSON machine information data.
+func (self *Client) MachineStats() ([]v2.MachineStats, error) {
+	var ret []v2.MachineStats
+	u := self.machineStatsUrl()
+	err := self.httpGetJsonData(&ret, nil, u, "machine stats")
+	return ret, err
+}
+
+// VersionInfo returns the version info for cAdvisor.
+func (self *Client) VersionInfo() (version string, err error) {
+	u := self.versionInfoUrl()
+	version, err = self.httpGetString(u, "version info")
+	return
+}
+
+// Attributes returns hardware and software attributes of the machine.
+func (self *Client) Attributes() (attr *v2.Attributes, err error) {
+	u := self.attributesUrl()
+	ret := new(v2.Attributes)
+	if err = self.httpGetJsonData(ret, nil, u, "attributes"); err != nil {
+		return
+	}
+	attr = ret
+	return
+}
+
+// Stats returns stats for the requested container.
+func (self *Client) Stats(name string, request *v2.RequestOptions) (map[string]v2.ContainerInfo, error) {
+	u := self.statsUrl(name)
+	ret := make(map[string]v2.ContainerInfo)
+	data := url.Values{
+		"type":      []string{request.IdType},
+		"count":     []string{strconv.Itoa(request.Count)},
+		"recursive": []string{strconv.FormatBool(request.Recursive)},
+	}
+
+	u = fmt.Sprintf("%s?%s", u, data.Encode())
+	if err := self.httpGetJsonData(&ret, nil, u, "stats"); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (self *Client) machineInfoUrl() string {
+	return self.baseUrl + path.Join("machine")
+}
+
+func (self *Client) machineStatsUrl() string {
+	return self.baseUrl + path.Join("machinestats")
+}
+
+func (self *Client) versionInfoUrl() string {
+	return self.baseUrl + path.Join("version")
+}
+
+func (self *Client) attributesUrl() string {
+	return self.baseUrl + path.Join("attributes")
+}
+
+func (self *Client) statsUrl(name string) string {
+	return self.baseUrl + path.Join("stats", name)
+}
+
+func (self *Client) httpGetResponse(postData interface{}, urlPath, infoName string) ([]byte, error) {
+	var resp *http.Response
+	var err error
+
+	if postData != nil {
+		data, marshalErr := json.Marshal(postData)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("unable to marshal data: %v", marshalErr)
+		}
+		resp, err = http.Post(urlPath, "application/json", bytes.NewBuffer(data))
+	} else {
+		resp, err = http.Get(urlPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to post %q to %q: %v", infoName, urlPath, err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received empty response for %q from %q", infoName, urlPath)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("unable to read all %q from %q: %v", infoName, urlPath, err)
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("request %q failed with error: %q", urlPath, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func (self *Client) httpGetString(url, infoName string) (string, error) {
+	body, err := self.httpGetResponse(nil, url, infoName)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (self *Client) httpGetJsonData(data, postData interface{}, url, infoName string) error {
+	body, err := self.httpGetResponse(postData, url, infoName)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(body, data); err != nil {
+		err = fmt.Errorf("unable to unmarshal %q (Body: %q) from %q with error: %v", infoName, string(body), url, err)
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/google/cadvisor/client/v2/client_test.go
+++ b/vendor/github.com/google/cadvisor/client/v2/client_test.go
@@ -1,0 +1,218 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/info/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kr/pretty"
+)
+
+func testGetJsonData(
+	expected interface{},
+	f func() (interface{}, error),
+) error {
+	reply, err := f()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve data: %v", err)
+	}
+	if !reflect.DeepEqual(reply, expected) {
+		return pretty.Errorf("retrieved wrong data: %# v != %# v", reply, expected)
+	}
+	return nil
+}
+
+func cadvisorTestClient(path string, expectedPostObj *v1.ContainerInfoRequest, replyObj interface{}, t *testing.T) (*Client, *httptest.Server, error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			if expectedPostObj != nil {
+				expectedPostObjEmpty := new(v1.ContainerInfoRequest)
+				decoder := json.NewDecoder(r.Body)
+				if err := decoder.Decode(expectedPostObjEmpty); err != nil {
+					t.Errorf("Received invalid object: %v", err)
+				}
+				if expectedPostObj.NumStats != expectedPostObjEmpty.NumStats ||
+					expectedPostObj.Start.Unix() != expectedPostObjEmpty.Start.Unix() ||
+					expectedPostObj.End.Unix() != expectedPostObjEmpty.End.Unix() {
+					t.Errorf("Received unexpected object: %+v, expected: %+v", expectedPostObjEmpty, expectedPostObj)
+				}
+			}
+			encoder := json.NewEncoder(w)
+			encoder.Encode(replyObj)
+		} else if r.URL.Path == "/api/v2.1/version" {
+			fmt.Fprintf(w, "0.1.2")
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, "Page not found.")
+		}
+	}))
+	client, err := NewClient(ts.URL)
+	if err != nil {
+		ts.Close()
+		return nil, nil, err
+	}
+	return client, ts, err
+}
+
+// TestGetMachineInfo performs one test to check if MachineInfo()
+// in a cAdvisor client returns the correct result.
+func TestGetMachineInfo(t *testing.T) {
+	mv1 := &v1.MachineInfo{
+		NumCores:       8,
+		MemoryCapacity: 31625871360,
+		DiskMap: map[string]v1.DiskInfo{
+			"8:0": {
+				Name:  "sda",
+				Major: 8,
+				Minor: 0,
+				Size:  10737418240,
+			},
+		},
+	}
+	client, server, err := cadvisorTestClient("/api/v2.1/machine", nil, mv1, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.MachineInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(returned, mv1) {
+		t.Fatalf("received unexpected machine v1")
+	}
+}
+
+// TestGetVersionV1 performs one test to check if VersionV1()
+// in a cAdvisor client returns the correct result.
+func TestGetVersionv1(t *testing.T) {
+	version := "0.1.2"
+	client, server, err := cadvisorTestClient("", nil, version, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.VersionInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if returned != version {
+		t.Fatalf("received unexpected version v1")
+	}
+}
+
+// TestAttributes performs one test to check if Attributes()
+// in a cAdvisor client returns the correct result.
+func TestGetAttributes(t *testing.T) {
+	attr := &v2.Attributes{
+		KernelVersion:      "3.3.0",
+		ContainerOsVersion: "Ubuntu 14.4",
+		DockerVersion:      "Docker 1.5",
+		CadvisorVersion:    "0.1.2",
+		NumCores:           8,
+		MemoryCapacity:     31625871360,
+		DiskMap: map[string]v1.DiskInfo{
+			"8:0": {
+				Name:  "sda",
+				Major: 8,
+				Minor: 0,
+				Size:  10737418240,
+			},
+		},
+	}
+	client, server, err := cadvisorTestClient("/api/v2.1/attributes", nil, attr, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.Attributes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(returned, attr) {
+		t.Fatalf("received unexpected attributes")
+	}
+}
+
+// TestMachineStats performs one test to check if MachineStats()
+// in a cAdvisor client returns the correct result.
+func TestMachineStats(t *testing.T) {
+	machineStats := []v2.MachineStats{
+		{
+			Timestamp: time.Now(),
+			Cpu: &v1.CpuStats{
+				Usage: v1.CpuUsage{
+					Total: 100000,
+				},
+				LoadAverage: 10,
+			},
+			Filesystem: []v2.MachineFsStats{
+				{
+					Device: "sda1",
+				},
+			},
+		},
+	}
+	client, server, err := cadvisorTestClient("/api/v2.1/machinestats", nil, &machineStats, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.MachineStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, returned, len(machineStats))
+	if !reflect.DeepEqual(returned[0].Cpu, machineStats[0].Cpu) {
+		t.Fatalf("received unexpected machine stats\nExp: %+v\nAct: %+v", machineStats, returned)
+	}
+	if !reflect.DeepEqual(returned[0].Filesystem, machineStats[0].Filesystem) {
+		t.Fatalf("received unexpected machine stats\nExp: %+v\nAct: %+v", machineStats, returned)
+	}
+}
+
+func TestRequestFails(t *testing.T) {
+	errorText := "there was an error"
+	// Setup a server that simply fails.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, errorText, 500)
+	}))
+	client, err := NewClient(ts.URL)
+	if err != nil {
+		ts.Close()
+		t.Fatal(err)
+	}
+	defer ts.Close()
+
+	_, err = client.MachineInfo()
+	if err == nil {
+		t.Fatalf("Expected non-nil error")
+	}
+	expectedError := fmt.Sprintf("request failed with error: %q", errorText)
+	if strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("Expected error %q but received %q", expectedError, err)
+	}
+}

--- a/vendor/github.com/google/cadvisor/container/docker/docker.go
+++ b/vendor/github.com/google/cadvisor/container/docker/docker.go
@@ -17,6 +17,7 @@ package docker
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -39,6 +40,7 @@ func Status() (v1.DockerStatus, error) {
 
 	out := v1.DockerStatus{}
 	out.Version = VersionString()
+	out.APIVersion = APIVersionString()
 	out.KernelVersion = machine.KernelVersion()
 	out.OS = dockerInfo.OperatingSystem
 	out.Hostname = dockerInfo.Name
@@ -105,7 +107,7 @@ func ValidateInfo() (*dockertypes.Info, error) {
 		}
 		dockerInfo.ServerVersion = version.Version
 	}
-	version, err := parseDockerVersion(dockerInfo.ServerVersion)
+	version, err := parseVersion(dockerInfo.ServerVersion, version_re, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +131,11 @@ func ValidateInfo() (*dockertypes.Info, error) {
 }
 
 func Version() ([]int, error) {
-	return parseDockerVersion(VersionString())
+	return parseVersion(VersionString(), version_re, 3)
+}
+
+func APIVersion() ([]int, error) {
+	return parseVersion(APIVersionString(), apiversion_re, 2)
 }
 
 func VersionString() string {
@@ -144,18 +150,29 @@ func VersionString() string {
 	return docker_version
 }
 
-// TODO: switch to a semantic versioning library.
-func parseDockerVersion(full_version_string string) ([]int, error) {
-	matches := version_re.FindAllStringSubmatch(full_version_string, -1)
+func APIVersionString() string {
+	docker_api_version := "Unknown"
+	client, err := Client()
+	if err == nil {
+		version, err := client.ServerVersion(context.Background())
+		if err == nil {
+			docker_api_version = version.APIVersion
+		}
+	}
+	return docker_api_version
+}
+
+func parseVersion(version_string string, regex *regexp.Regexp, length int) ([]int, error) {
+	matches := regex.FindAllStringSubmatch(version_string, -1)
 	if len(matches) != 1 {
-		return nil, fmt.Errorf("version string \"%v\" doesn't match expected regular expression: \"%v\"", full_version_string, version_regexp_string)
+		return nil, fmt.Errorf("version string \"%v\" doesn't match expected regular expression: \"%v\"", version_string, regex.String())
 	}
 	version_string_array := matches[0][1:]
-	version_array := make([]int, 3)
-	for index, version_string := range version_string_array {
-		version, err := strconv.Atoi(version_string)
+	version_array := make([]int, length)
+	for index, version_str := range version_string_array {
+		version, err := strconv.Atoi(version_str)
 		if err != nil {
-			return nil, fmt.Errorf("error while parsing \"%v\" in \"%v\"", version_string, full_version_string)
+			return nil, fmt.Errorf("error while parsing \"%v\" in \"%v\"", version_str, version_string)
 		}
 		version_array[index] = version
 	}

--- a/vendor/github.com/google/cadvisor/container/docker/docker_test.go
+++ b/vendor/github.com/google/cadvisor/container/docker/docker_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestParseDockerAPIVersion(t *testing.T) {
+	tests := []struct {
+		version       string
+		regex         *regexp.Regexp
+		length        int
+		expected      []int
+		expectedError string
+	}{
+		{"17.03.0", version_re, 3, []int{17, 03, 0}, ""},
+		{"17.a3.0", version_re, 3, []int{}, `version string "17.a3.0" doesn't match expected regular expression: "(\d+)\.(\d+)\.(\d+)"`},
+		{"1.20", apiversion_re, 2, []int{1, 20}, ""},
+		{"1.a", apiversion_re, 2, []int{}, `version string "1.a" doesn't match expected regular expression: "(\d+)\.(\d+)"`},
+	}
+
+	for _, test := range tests {
+		actual, err := parseVersion(test.version, test.regex, test.length)
+		if err != nil {
+			if len(test.expectedError) == 0 {
+				t.Errorf("%s: expected no error, got %v", test.version, err)
+			} else if err.Error() != test.expectedError {
+				t.Errorf("%s: expected error %v, got %v", test.version, test.expectedError, err)
+			}
+		} else {
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("%s: expected array %v, got %v", test.version, test.expected, actual)
+			}
+		}
+	}
+}

--- a/vendor/github.com/google/cadvisor/container/docker/factory.go
+++ b/vendor/github.com/google/cadvisor/container/docker/factory.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/cadvisor/machine"
 	"github.com/google/cadvisor/manager/watcher"
 	dockerutil "github.com/google/cadvisor/utils/docker"
+	"github.com/google/cadvisor/zfs"
 
 	docker "github.com/docker/engine-api/client"
 	"github.com/golang/glog"
@@ -102,9 +103,13 @@ type dockerFactory struct {
 
 	dockerVersion []int
 
+	dockerAPIVersion []int
+
 	ignoreMetrics container.MetricSet
 
 	thinPoolWatcher *devicemapper.ThinPoolWatcher
+
+	zfsWatcher *zfs.ZfsWatcher
 }
 
 func (self *dockerFactory) String() string {
@@ -132,6 +137,7 @@ func (self *dockerFactory) NewContainerHandler(name string, inHostNamespace bool
 		self.dockerVersion,
 		self.ignoreMetrics,
 		self.thinPoolWatcher,
+		self.zfsWatcher,
 	)
 	return
 }
@@ -181,8 +187,10 @@ func (self *dockerFactory) DebugInfo() map[string][]string {
 }
 
 var (
-	version_regexp_string = `(\d+)\.(\d+)\.(\d+)`
-	version_re            = regexp.MustCompile(version_regexp_string)
+	version_regexp_string    = `(\d+)\.(\d+)\.(\d+)`
+	version_re               = regexp.MustCompile(version_regexp_string)
+	apiversion_regexp_string = `(\d+)\.(\d+)`
+	apiversion_re            = regexp.MustCompile(apiversion_regexp_string)
 )
 
 func startThinPoolWatcher(dockerInfo *dockertypes.Info) (*devicemapper.ThinPoolWatcher, error) {
@@ -216,6 +224,21 @@ func startThinPoolWatcher(dockerInfo *dockertypes.Info) (*devicemapper.ThinPoolW
 
 	go thinPoolWatcher.Start()
 	return thinPoolWatcher, nil
+}
+
+func startZfsWatcher(dockerInfo *dockertypes.Info) (*zfs.ZfsWatcher, error) {
+	filesystem, err := dockerutil.DockerZfsFilesystem(*dockerInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	zfsWatcher, err := zfs.NewZfsWatcher(filesystem)
+	if err != nil {
+		return nil, err
+	}
+
+	go zfsWatcher.Start()
+	return zfsWatcher, nil
 }
 
 func ensureThinLsKernelVersion(kernelVersion string) error {
@@ -291,7 +314,9 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 	}
 
 	// Version already validated above, assume no error here.
-	dockerVersion, _ := parseDockerVersion(dockerInfo.ServerVersion)
+	dockerVersion, _ := parseVersion(dockerInfo.ServerVersion, version_re, 3)
+
+	dockerAPIVersion, _ := APIVersion()
 
 	cgroupSubsystems, err := libcontainer.GetCgroupSubsystems()
 	if err != nil {
@@ -306,17 +331,27 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 		}
 	}
 
+	var zfsWatcher *zfs.ZfsWatcher
+	if storageDriver(dockerInfo.Driver) == zfsStorageDriver {
+		zfsWatcher, err = startZfsWatcher(dockerInfo)
+		if err != nil {
+			glog.Errorf("zfs filesystem stats will not be reported: %v", err)
+		}
+	}
+
 	glog.Infof("Registering Docker factory")
 	f := &dockerFactory{
 		cgroupSubsystems:   cgroupSubsystems,
 		client:             client,
 		dockerVersion:      dockerVersion,
+		dockerAPIVersion:   dockerAPIVersion,
 		fsInfo:             fsInfo,
 		machineInfoFactory: factory,
 		storageDriver:      storageDriver(dockerInfo.Driver),
 		storageDir:         RootDir(),
 		ignoreMetrics:      ignoreMetrics,
 		thinPoolWatcher:    thinPoolWatcher,
+		zfsWatcher:         zfsWatcher,
 	}
 
 	container.RegisterContainerHandlerFactory(f, []watcher.ContainerWatchSource{watcher.Raw})

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	dockerutil "github.com/google/cadvisor/utils/docker"
+	"github.com/google/cadvisor/zfs"
 
 	docker "github.com/docker/engine-api/client"
 	dockercontainer "github.com/docker/engine-api/types/container"
@@ -42,6 +43,7 @@ import (
 const (
 	// The read write layers exist here.
 	aufsRWLayer = "diff"
+
 	// Path to the directory where docker stores log files if the json logging driver is enabled.
 	pathToContainersDir = "containers"
 )
@@ -72,6 +74,12 @@ type dockerContainerHandler struct {
 	// the devicemapper device id for the container
 	deviceID string
 
+	// zfs Filesystem
+	zfsFilesystem string
+
+	// zfsParent is the parent for docker zfs
+	zfsParent string
+
 	// Time at which this container was created.
 	creationTime time.Time
 
@@ -101,6 +109,9 @@ type dockerContainerHandler struct {
 
 	// thin pool watcher
 	thinPoolWatcher *devicemapper.ThinPoolWatcher
+
+	// zfs watcher
+	zfsWatcher *zfs.ZfsWatcher
 }
 
 var _ container.ContainerHandler = &dockerContainerHandler{}
@@ -136,6 +147,7 @@ func newDockerContainerHandler(
 	dockerVersion []int,
 	ignoreMetrics container.MetricSet,
 	thinPoolWatcher *devicemapper.ThinPoolWatcher,
+	zfsWatcher *zfs.ZfsWatcher,
 ) (container.ContainerHandler, error) {
 	// Create the cgroup paths.
 	cgroupPaths := make(map[string]string, len(cgroupSubsystems.MountPoints))
@@ -172,12 +184,21 @@ func newDockerContainerHandler(
 	var (
 		rootfsStorageDir string
 		poolName         string
+		zfsFilesystem    string
+		zfsParent        string
 	)
 	switch storageDriver {
 	case aufsStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
 	case overlayStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(overlayStorageDriver), rwLayerID)
+	case zfsStorageDriver:
+		status, err := Status()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine docker status: %v", err)
+		}
+		zfsParent = status.DriverStatus[dockerutil.DriverStatusParentDataset]
+		zfsFilesystem = path.Join(zfsParent, rwLayerID)
 	case devicemapperStorageDriver:
 		status, err := Status()
 		if err != nil {
@@ -199,10 +220,13 @@ func newDockerContainerHandler(
 		fsInfo:             fsInfo,
 		rootFs:             rootFs,
 		poolName:           poolName,
+		zfsFilesystem:      zfsFilesystem,
 		rootfsStorageDir:   rootfsStorageDir,
 		envs:               make(map[string]string),
 		ignoreMetrics:      ignoreMetrics,
 		thinPoolWatcher:    thinPoolWatcher,
+		zfsWatcher:         zfsWatcher,
+		zfsParent:          zfsParent,
 	}
 
 	// We assume that if Inspect fails then the container is not known to docker.
@@ -245,7 +269,9 @@ func newDockerContainerHandler(
 		handler.fsHandler = &dockerFsHandler{
 			fsHandler:       common.NewFsHandler(common.DefaultPeriod, rootfsStorageDir, otherStorageDir, fsInfo),
 			thinPoolWatcher: thinPoolWatcher,
+			zfsWatcher:      zfsWatcher,
 			deviceID:        handler.deviceID,
+			zfsFilesystem:   zfsFilesystem,
 		}
 	}
 
@@ -265,7 +291,7 @@ func newDockerContainerHandler(
 }
 
 // dockerFsHandler is a composite FsHandler implementation the incorporates
-// the common fs handler and a devicemapper ThinPoolWatcher.
+// the common fs handler, a devicemapper ThinPoolWatcher, and a zfsWatcher
 type dockerFsHandler struct {
 	fsHandler common.FsHandler
 
@@ -273,6 +299,11 @@ type dockerFsHandler struct {
 	thinPoolWatcher *devicemapper.ThinPoolWatcher
 	// deviceID is the id of the container's fs device
 	deviceID string
+
+	// zfsWatcher is the zfs filesystem watcher
+	zfsWatcher *zfs.ZfsWatcher
+	// zfsFilesystem is the docker zfs filesystem
+	zfsFilesystem string
 }
 
 var _ common.FsHandler = &dockerFsHandler{}
@@ -306,6 +337,15 @@ func (h *dockerFsHandler) Usage() common.FsUsage {
 		}
 	}
 
+	if h.zfsWatcher != nil {
+		zfsUsage, err := h.zfsWatcher.GetUsage(h.zfsFilesystem)
+		if err != nil {
+			glog.V(5).Infof("unable to get fs usage from zfs for filesystem %s: %v", h.zfsFilesystem, err)
+		} else {
+			usage.BaseUsageBytes = zfsUsage
+			usage.TotalUsageBytes += zfsUsage
+		}
+	}
 	return usage
 }
 
@@ -368,12 +408,14 @@ func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error
 		// Device has to be the pool name to correlate with the device name as
 		// set in the machine info filesystems.
 		device = self.poolName
-	case aufsStorageDriver, overlayStorageDriver, zfsStorageDriver:
+	case aufsStorageDriver, overlayStorageDriver:
 		deviceInfo, err := self.fsInfo.GetDirFsDevice(self.rootfsStorageDir)
 		if err != nil {
 			return fmt.Errorf("unable to determine device info for dir: %v: %v", self.rootfsStorageDir, err)
 		}
 		device = deviceInfo.Device
+	case zfsStorageDriver:
+		device = self.zfsParent
 	default:
 		return nil
 	}

--- a/vendor/github.com/google/cadvisor/info/v1/docker.go
+++ b/vendor/github.com/google/cadvisor/info/v1/docker.go
@@ -17,6 +17,7 @@ package v1
 
 type DockerStatus struct {
 	Version       string            `json:"version"`
+	APIVersion    string            `json:"api_version"`
 	KernelVersion string            `json:"kernel_version"`
 	OS            string            `json:"os"`
 	Hostname      string            `json:"hostname"`

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -200,6 +200,9 @@ type VersionInfo struct {
 	// Docker version.
 	DockerVersion string `json:"docker_version"`
 
+	// Docker API Version
+	DockerAPIVersion string `json:"docker_api_version"`
+
 	// cAdvisor version.
 	CadvisorVersion string `json:"cadvisor_version"`
 	// cAdvisor git revision.

--- a/vendor/github.com/google/cadvisor/info/v2/conversion.go
+++ b/vendor/github.com/google/cadvisor/info/v2/conversion.go
@@ -133,7 +133,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 				}
 			} else if len(val.Filesystem) > 1 && containerName != "/" {
 				// Cannot handle multiple devices per container.
-				glog.V(2).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
+				glog.V(4).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
 			}
 		}
 		if spec.HasDiskIo {

--- a/vendor/github.com/google/cadvisor/info/v2/conversion.go
+++ b/vendor/github.com/google/cadvisor/info/v2/conversion.go
@@ -133,7 +133,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 				}
 			} else if len(val.Filesystem) > 1 && containerName != "/" {
 				// Cannot handle multiple devices per container.
-				glog.V(4).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
+				glog.V(2).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
 			}
 		}
 		if spec.HasDiskIo {

--- a/vendor/github.com/google/cadvisor/info/v2/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v2/machine.go
@@ -31,6 +31,9 @@ type Attributes struct {
 	// Docker version.
 	DockerVersion string `json:"docker_version"`
 
+	// Docker API version.
+	DockerAPIVersion string `json:"docker_api_version"`
+
 	// cAdvisor version.
 	CadvisorVersion string `json:"cadvisor_version"`
 
@@ -74,6 +77,7 @@ func GetAttributes(mi *v1.MachineInfo, vi *v1.VersionInfo) Attributes {
 		KernelVersion:      vi.KernelVersion,
 		ContainerOsVersion: vi.ContainerOsVersion,
 		DockerVersion:      vi.DockerVersion,
+		DockerAPIVersion:   vi.DockerAPIVersion,
 		CadvisorVersion:    vi.CadvisorVersion,
 		NumCores:           mi.NumCores,
 		CpuFrequency:       mi.CpuFrequency,

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -1255,11 +1255,13 @@ func getVersionInfo() (*info.VersionInfo, error) {
 	kernel_version := machine.KernelVersion()
 	container_os := machine.ContainerOsVersion()
 	docker_version := docker.VersionString()
+	docker_api_version := docker.APIVersionString()
 
 	return &info.VersionInfo{
 		KernelVersion:      kernel_version,
 		ContainerOsVersion: container_os,
 		DockerVersion:      docker_version,
+		DockerAPIVersion:   docker_api_version,
 		CadvisorVersion:    version.Info["version"],
 		CadvisorRevision:   version.Info["revision"],
 	}, nil

--- a/vendor/github.com/google/cadvisor/pages/docker.go
+++ b/vendor/github.com/google/cadvisor/pages/docker.go
@@ -40,6 +40,7 @@ func toStatusKV(status info.DockerStatus) ([]keyVal, []keyVal) {
 	}
 	return []keyVal{
 		{Key: "Docker Version", Value: status.Version},
+		{Key: "Docker API Version", Value: status.APIVersion},
 		{Key: "Kernel Version", Value: status.KernelVersion},
 		{Key: "OS Version", Value: status.OS},
 		{Key: "Host Name", Value: status.Hostname},

--- a/vendor/github.com/google/cadvisor/utils/docker/docker.go
+++ b/vendor/github.com/google/cadvisor/utils/docker/docker.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	DockerInfoDriver         = "Driver"
-	DockerInfoDriverStatus   = "DriverStatus"
-	DriverStatusPoolName     = "Pool Name"
-	DriverStatusDataLoopFile = "Data loop file"
-	DriverStatusMetadataFile = "Metadata file"
+	DockerInfoDriver          = "Driver"
+	DockerInfoDriverStatus    = "DriverStatus"
+	DriverStatusPoolName      = "Pool Name"
+	DriverStatusDataLoopFile  = "Data loop file"
+	DriverStatusMetadataFile  = "Metadata file"
+	DriverStatusParentDataset = "Parent Dataset"
 )
 
 func DriverStatusValue(status [][2]string, target string) string {
@@ -67,4 +68,13 @@ func DockerMetadataDevice(info dockertypes.Info) (string, error) {
 	}
 
 	return metadataDevice, nil
+}
+
+func DockerZfsFilesystem(info dockertypes.Info) (string, error) {
+	filesystem := DriverStatusValue(info.DriverStatus, DriverStatusParentDataset)
+	if len(filesystem) == 0 {
+		return "", fmt.Errorf("Could not get zfs filesystem")
+	}
+
+	return filesystem, nil
 }

--- a/vendor/github.com/google/cadvisor/utils/sysfs/sysfs.go
+++ b/vendor/github.com/google/cadvisor/utils/sysfs/sysfs.go
@@ -70,8 +70,8 @@ type SysFs interface {
 
 type realSysFs struct{}
 
-func NewRealSysFs() (SysFs, error) {
-	return &realSysFs{}, nil
+func NewRealSysFs() SysFs {
+	return &realSysFs{}
 }
 
 func (self *realSysFs) GetBlockDevices() ([]os.FileInfo, error) {

--- a/vendor/github.com/google/cadvisor/utils/sysinfo/sysinfo.go
+++ b/vendor/github.com/google/cadvisor/utils/sysinfo/sysinfo.go
@@ -155,10 +155,7 @@ func GetCacheInfo(sysFs sysfs.SysFs, id int) ([]sysfs.CacheInfo, error) {
 
 func GetNetworkStats(name string) (info.InterfaceStats, error) {
 	// TODO(rjnagal): Take syfs as an argument.
-	sysFs, err := sysfs.NewRealSysFs()
-	if err != nil {
-		return info.InterfaceStats{}, err
-	}
+	sysFs := sysfs.NewRealSysFs()
 	return getNetworkStats(name, sysFs)
 }
 

--- a/vendor/github.com/google/cadvisor/zfs/watcher.go
+++ b/vendor/github.com/google/cadvisor/zfs/watcher.go
@@ -1,0 +1,113 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package zfs
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	zfs "github.com/mistifyio/go-zfs"
+)
+
+// zfsWatcher maintains a cache of filesystem -> usage stats for a
+// zfs filesystem
+type ZfsWatcher struct {
+	filesystem string
+	lock       *sync.RWMutex
+	cache      map[string]uint64
+	period     time.Duration
+	stopChan   chan struct{}
+}
+
+// NewThinPoolWatcher returns a new ThinPoolWatcher for the given devicemapper
+// thin pool name and metadata device or an error.
+func NewZfsWatcher(filesystem string) (*ZfsWatcher, error) {
+
+	return &ZfsWatcher{
+		filesystem: filesystem,
+		lock:       &sync.RWMutex{},
+		cache:      make(map[string]uint64),
+		period:     15 * time.Second,
+		stopChan:   make(chan struct{}),
+	}, nil
+}
+
+// Start starts the ZfsWatcher.
+func (w *ZfsWatcher) Start() {
+	err := w.Refresh()
+	if err != nil {
+		glog.Errorf("encountered error refreshing zfs watcher: %v", err)
+	}
+
+	for {
+		select {
+		case <-w.stopChan:
+			return
+		case <-time.After(w.period):
+			start := time.Now()
+			err = w.Refresh()
+			if err != nil {
+				glog.Errorf("encountered error refreshing zfs watcher: %v", err)
+			}
+
+			// print latency for refresh
+			duration := time.Since(start)
+			glog.V(5).Infof("zfs(%d) took %s", start.Unix(), duration)
+		}
+	}
+}
+
+// Stop stops the ZfsWatcher.
+func (w *ZfsWatcher) Stop() {
+	close(w.stopChan)
+}
+
+// GetUsage gets the cached usage value of the given filesystem.
+func (w *ZfsWatcher) GetUsage(filesystem string) (uint64, error) {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+
+	v, ok := w.cache[filesystem]
+	if !ok {
+		return 0, fmt.Errorf("no cached value for usage of filesystem %v", filesystem)
+	}
+
+	return v, nil
+}
+
+// Refresh performs a zfs get
+func (w *ZfsWatcher) Refresh() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	newCache := make(map[string]uint64)
+	parent, err := zfs.GetDataset(w.filesystem)
+	if err != nil {
+		glog.Errorf("encountered error getting zfs filesystem: %s: %v", w.filesystem, err)
+		return err
+	}
+	children, err := parent.Children(0)
+	if err != nil {
+		glog.Errorf("encountered error getting children of zfs filesystem: %s: %v", w.filesystem, err)
+		return err
+	}
+
+	for _, ds := range children {
+		newCache[ds.Name] = ds.Used
+	}
+
+	w.cache = newCache
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -95,10 +95,7 @@ func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
 func New(port uint, runtime string, rootPath string) (Interface, error) {
-	sysFs, err := sysfs.NewRealSysFs()
-	if err != nil {
-		return nil, err
-	}
+	sysFs := sysfs.NewRealSysFs()
 
 	// Create and start the cAdvisor container manager.
 	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}}, http.DefaultClient)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -85,9 +85,9 @@ func (m *containerManager) doWork() {
 		glog.Errorf("Unable to get docker version: %v", err)
 		return
 	}
-	version, err := utilversion.ParseSemantic(v.Version)
+	version, err := utilversion.ParseSemantic(v.APIVersion)
 	if err != nil {
-		glog.Errorf("Unable to parse docker version %q: %v", v.Version, err)
+		glog.Errorf("Unable to parse docker version %q: %v", v.APIVersion, err)
 		return
 	}
 	// EnsureDockerInConatiner does two things.


### PR DESCRIPTION
Fixes #13281 but builds on top of #14121 which fixes godeps, so that needs to land first when queue opens next week, so only 3 last commits count.

@derekwaynecarr ptal