### PR TITLE
Increase networking test endpoint wait to 3 minutes

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -96,7 +96,7 @@ func waitForPodSuccessInNamespace(c kclientset.Interface, podName string, contNa
 }
 
 func waitForEndpoint(c kclientset.Interface, ns, name string) error {
-	for t := time.Now(); time.Since(t) < time.Minute; time.Sleep(poll) {
+	for t := time.Now(); time.Since(t) < 3*time.Minute; time.Sleep(poll) {
 		endpoint, err := c.Core().Endpoints(ns).Get(name, metav1.GetOptions{})
 		if kapierrs.IsNotFound(err) {
 			e2e.Logf("Endpoint %s/%s is not ready yet", ns, name)


### PR DESCRIPTION
There are existing issues where we see the kubelet misses a sync loop
and needs to re-try one or two minutes later, so it is not appropriate
to wait for an endpoint for less than three minutes as this wait does
not guarantee that a correctly-functioning system will converge on the
correct behavior.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

addresses https://github.com/openshift/origin/pull/14167#issuecomment-301320711

/cc @smarterclayton @danwinship 

[test]