### PR TITLE
Change version check on jq in clear route status script

### DIFF
--- a/images/router/clear-route-status.sh
+++ b/images/router/clear-route-status.sh
@@ -84,9 +84,14 @@ if [[ ${#} -ne 2 || "${@}" == *" help "* ]]; then
 fi
 
 if ! command -v jq >/dev/null 2>&1; then
-    printf "%s\n%s\n" "Command line JSON processor 'jq' not found." "please install 'jq' to use this script."
+    printf "%s\n%s\n" "Command line JSON processor 'jq' not found." "please install 'jq' version greater than 1.4 to use this script."
     exit 1
 fi
+
+if ! echo | jq '."status"."ingress"|=map(select(.routerName != "test"))' >/dev/null 2>&1; then
+    printf "%s\n%s\n" "Command line JSON processor 'jq' version is incorrect." "Please install 'jq' version greater than 1.4 to use this script"
+    exit 1
+fi    
 
 oc proxy > /dev/null &
 PROXY_PID="${!}"


### PR DESCRIPTION
jq is required for the JSON processing required for clearing the route status. During QA
it was found that the version of jq has to be greater than 1.4. Expand the check on jq
for the capabilities needed and the message to include the version number

Bug 1429398 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1429398)