### PR TITLE
Add etcd3 dump tool

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -55,11 +55,39 @@ readonly -f os::cleanup::all
 #  None
 function os::cleanup::dump_etcd() {
 	if [[ -n "${API_SCHEME:-}" && -n "${API_HOST:-}" && -n "${ETCD_PORT:-}" ]]; then
-		os::log::info "[CLEANUP] Dumping etcd contents to $( os::util::repository_relative_path "${ARTIFACT_DIR}/etcd_dump.json" )"
-		os::util::curl_etcd "/v2/keys/?recursive=true" > "${ARTIFACT_DIR}/etcd_dump.json"
+		local dump_dir="${ARTIFACT_DIR}/etcd"
+		mkdir -p "${dump_dir}"
+		os::log::info "[CLEANUP] Dumping etcd contents to $( os::util::repository_relative_path "${dump_dir}" )"
+		os::util::curl_etcd "/v2/keys/?recursive=true" > "${dump_dir}/v2_dump.json"
+		os::cleanup::internal::dump_etcd_v3 > "${dump_dir}/v3_dump.json"
 	fi
 }
 readonly -f os::cleanup::dump_etcd
+
+# os::cleanup::internal::dump_etcd_v3 dumps the full contents of etcd v3 to a file.
+#
+# Globals:
+#  - ARTIFACT_DIR
+#  - API_SCHEME
+#  - API_HOST
+#  - ETCD_PORT
+# Arguments:
+#  None
+# Returns:
+#  None
+function os::cleanup::internal::dump_etcd_v3() {
+	local full_url="${API_SCHEME}://${API_HOST}:${ETCD_PORT}"
+
+	local etcd_client_cert="${MASTER_CONFIG_DIR}/master.etcd-client.crt"
+	local etcd_client_key="${MASTER_CONFIG_DIR}/master.etcd-client.key"
+	local ca_bundle="${MASTER_CONFIG_DIR}/ca-bundle.crt"
+
+	os::util::ensure::built_binary_exists 'etcdhelper' >&2
+
+	etcdhelper --cert "${etcd_client_cert}" --key "${etcd_client_key}" \
+	           --cacert "${ca_bundle}" --endpoint "${full_url}" dump
+}
+readonly -f os::cleanup::internal::dump_etcd_v3
 
 # os::cleanup::prune_etcd removes the etcd data store from disk.
 #


### PR DESCRIPTION
Simple CLI tool to dump everything from a running etcd3 server (handles decoding of API objects).  @stevekuznetsov could you write the BASH to use this?  I need to focus on some other stuff.

```
etcd3dump --endpoint='https://10.13.129.193:4001' --key-file="${BASE}/openshift.local.config/master/master.etcd-client.key" --cert-file="${BASE}/openshift.local.config/master/master.etcd-client.crt" --ca-file="${BASE}/openshift.local.config/master/ca.crt" > etcd3dump.json
```

cc @bparees 

xref: #14145 

[test]

Signed-off-by: Monis Khan <mkhan@redhat.com>