### PR TITLE
Support local domain resolution(/etc/hosts) for egress network policy

### DIFF
--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -9,6 +9,7 @@ FROM openshift/dind
 ## Install packages
 RUN dnf -y update && dnf -y install\
  bind-utils\
+ glibc-common\
  findutils\
  hostname\
  iproute\

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -22,7 +22,7 @@ COPY system-container/manifest.json system-container/config.json.template system
 RUN INSTALL_PKGS="libmnl libnetfilter_conntrack conntrack-tools openvswitch \
       libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
-      iscsi-initiator-utils bind-utils" && \
+      iscsi-initiator-utils bind-utils glibc-common" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/images/node/Dockerfile.centos7
+++ b/images/node/Dockerfile.centos7
@@ -17,7 +17,7 @@ COPY system-container/manifest.json system-container/config.json.template system
 RUN INSTALL_PKGS="origin-sdn-ovs libmnl libnetfilter_conntrack conntrack-tools openvswitch \
       libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
-      iscsi-initiator-utils bind-utils" && \
+      iscsi-initiator-utils bind-utils glibc-common" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/origin.spec
+++ b/origin.spec
@@ -174,6 +174,7 @@ Requires:         openvswitch >= %{openvswitch_version}
 Requires:         %{name}-node = %{version}-%{release}
 Requires:         bridge-utils
 Requires:         bind-utils
+Requires:         glibc-common
 Requires:         ethtool
 Requires:         procps-ng
 Requires:         iproute


### PR DESCRIPTION
We use dig to query nameservers for domain resolution unlike ping
which looks at /etc/nsswitch.conf, /etc/hosts, nameservers to resolve
IP addrs.
Local domain resolution with /etc/hosts is helpful in some
specific use cases like testing dns name changes. To support this,
now we also query /etc/hosts using getent when dig fails to resolve.