### PR TITLE
Add defaults and env control of the fin timeouts in the router

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -64,10 +64,20 @@ defaults
 {{- else }}
   timeout client 30s
 {{- end }}
+{{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_CLIENT_FIN_TIMEOUT" "")) }}
+  timeout client-fin {{env "ROUTER_CLIENT_FIN_TIMEOUT" "1s"}}
+{{- else }}
+  timeout client-fin 1s
+{{- end }}
 {{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_SERVER_TIMEOUT" "")) }}
   timeout server {{env "ROUTER_DEFAULT_SERVER_TIMEOUT" "30s"}}
 {{- else }}
   timeout server 30s
+{{- end }}
+{{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_DEFAULT_SERVER_FIN_TIMEOUT" "")) }}
+  timeout server-fin {{env "ROUTER_DEFAULT_SERVER_FIN_TIMEOUT" "1s"}}
+{{- else }}
+  timeout server-fin 1s
 {{- end }}
 {{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" (env "ROUTER_SLOWLORIS_TIMEOUT" "")) }}
   timeout http-request {{env "ROUTER_SLOWLORIS_TIMEOUT" "10s" }}


### PR DESCRIPTION
Set defaults for the fin timeouts and expose them as environment
variable controls to the user.

The new environment variables are:
 - ROUTER_CLIENT_FIN_TIMEOUT: Controls the fin timeout to the client of haproxy (default 1s)
 - ROUTER_DEFAULT_SERVER_FIN_TIMEOUT: Controls the fin timeout to the server haproxy contacts, i.e. in the cluster (default 1s)