### PR TITLE
registry: add --deployment option to oadm registry

### DIFF
--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -358,6 +358,11 @@ func AddServices(objects Objects, firstPortOnly bool) Objects {
 			if svc != nil {
 				svcs = append(svcs, svc)
 			}
+		case *extensions.Deployment:
+			svc := addServiceInternal(t.Spec.Template.Spec.Containers, t.ObjectMeta, t.Spec.Selector.MatchLabels, firstPortOnly)
+			if svc != nil {
+				svcs = append(svcs, svc)
+			}
 		case *extensions.DaemonSet:
 			svc := addServiceInternal(t.Spec.Template.Spec.Containers, t.ObjectMeta, t.Spec.Template.Labels, firstPortOnly)
 			if svc != nil {


### PR DESCRIPTION
@miminar @legionus @smarterclayton this will add `--deployment` option to `oc adm registry` command that will cause the registry being deployed using kubernetes deployment instead of deployment config.

benefits: no deployer pod, deployment will eventually succeed (no 10 min timeout), use replicaSet
cons: might not be great UI experience (?)