### PR TITLE
openshift-sdn: ensure multicast rules are cleaned up when net namespace is deleted

### DIFF
--- a/pkg/sdn/plugin/vnids_node.go
+++ b/pkg/sdn/plugin/vnids_node.go
@@ -196,8 +196,9 @@ func (vmap *nodeVNIDMap) watchNetNamespaces() {
 				vmap.policy.UpdateNetNamespace(netns, oldNetID)
 			}
 		case cache.Deleted:
-			vmap.policy.DeleteNetNamespace(netns)
+			// Unset VNID first so further operations don't see the deleted VNID
 			vmap.unsetVNID(netns.NetName)
+			vmap.policy.DeleteNetNamespace(netns)
 		}
 		return nil
 	})


### PR DESCRIPTION
The VNID doesn't get removed from the internal map until after the deletion
handling is all done, but the code that handles cleaning out the MC rules
checks the VNID map, and of course finds the VNID still there with MC enabled.

Fix that by deleting the VNID from the map first.

https://bugzilla.redhat.com/show_bug.cgi?id=1449058

@openshift/networking @knobunc @danwinship 