### PR TITLE
Add then resync then Delete cause Pop() panic

### DIFF
--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -290,16 +290,8 @@ func (eq *EventQueue) Pop() (watch.EventType, interface{}, error) {
 		key := eq.queue[0]
 		eq.queue = eq.queue[1:]
 
-		eventType, ok := eq.events[key]
-		if ok {
-			delete(eq.events, key)
-		} else {
-			// The event type has been removed by a previous call to
-			// Pop().  Since the object has already been seen and has
-			// not been deleted, and callers will need to be
-			// idempotent, watch.Modified can be safely assumed.
-			eventType = watch.Modified
-		}
+		eventType := eq.events[key]
+		delete(eq.events, key)
 
 		// Track the last replace key immediately after the store
 		// state has been changed to prevent subsequent errors from
@@ -400,6 +392,7 @@ func (eq *EventQueue) Resync() error {
 	for _, id := range eq.store.ListKeys() {
 		if !inQueue.Has(id) {
 			eq.queue = append(eq.queue, id)
+			eq.events[id] = watch.Modified
 		}
 	}
 

--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -152,6 +152,11 @@ func (eq *EventQueue) handleEvent(obj interface{}, newEventType watch.EventType)
 	case watchEventEffectDelete:
 		delete(eq.events, key)
 		eq.queue = eq.queueWithout(key)
+		// A delete means we added and deleted _before_ we popped, we need to clean up the store here
+		if err := eq.store.Delete(obj); err != nil {
+			panic(fmt.Sprintf("Delete of key not in store from handleEvent(): %v", key))
+		}
+
 	}
 	return nil
 }

--- a/pkg/client/cache/eventqueue_test.go
+++ b/pkg/client/cache/eventqueue_test.go
@@ -216,3 +216,21 @@ func TestEventQueue_PopAfterResyncShouldBeTypeModified(t *testing.T) {
 		t.Fatalf("Expected resynced event to be of type watch.Modified, got %q", eventType)
 	}
 }
+
+func TestEventQueue_ResyncsShouldNotCausePanics(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+	q.Add(cacheable{"foo", 10})
+	q.Pop()
+
+	q.Resync()
+
+	q.Delete(cacheable{key: "foo"})
+
+	q.Pop()
+
+	items := q.List()
+
+	if len(items) > 0 {
+		t.Fatalf("expected Resync() to not add a duplicate item to the event queue, but it did")
+	}
+}

--- a/pkg/client/cache/eventqueue_test.go
+++ b/pkg/client/cache/eventqueue_test.go
@@ -234,3 +234,17 @@ func TestEventQueue_ResyncsShouldNotCausePanics(t *testing.T) {
 		t.Fatalf("expected Resync() to not add a duplicate item to the event queue, but it did")
 	}
 }
+
+func TestEventQueue_ResyncsShouldNotRestoreDeletedItems(t *testing.T) {
+	q := NewEventQueue(keyFunc)
+	q.Add(cacheable{"foo", 10})
+	q.Delete(cacheable{key: "foo"})
+
+	q.Resync()
+
+	items := q.List()
+
+	if len(items) > 0 {
+		t.Fatalf("expected the list to be empty after an Add then Delete then Resync, but it was not")
+	}
+}


### PR DESCRIPTION
    The eventqueue did not properly handle the following sequence of
    operations:
    
    handleEvent ADD default/hello
    Pop         ADD default/hello
    Resync
    handleEvent DELETE default/hello
    Pop         DELETE default/hello
    Pop         MODIFIED default/hello  <<< this Pop should not happen
    
    The last Pop references the default/hello route which has been deleted.
    This results in a panic in Pop()
    
    The root cause of the problem is the resync adds the route to the queue
    with the default ADD state instead of MODIFY.
    
    The previous fix for this in Pop() (46a93289) was moved to Resync().
    
    Fixes 1447928
    https://bugzilla.redhat.com/show_bug.cgi?id=1447928

==================
    Don't allow deleted routes in resync list
    
    When handleEvent() is called to ADD a route, then called again to
    DELETE the route before Pop() processes the ADD, there is no need
    for the route to remain in store. handleEvent() can remove it from
    store. Deleted routes that are found in store during a Resync()
    are deleted by Pop() as they are encouneted.
    
    This limits the number of deleted routes in store and reduces the
    number of routes that Resync() adds to the queue.

