### PR TITLE
UPSTREAM: 46020: Enable customization of federation image

### DIFF
--- a/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
@@ -17,12 +17,14 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/federation/pkg/kubefed"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"
+	"k8s.io/kubernetes/pkg/version"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 )
 
@@ -30,6 +32,7 @@ func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
+	defaultImage := fmt.Sprintf("gcr.io/google_containers/hyperkube-amd64:%s", version.Get())
+	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, defaultImage)
 	return cmd.Execute()
 }

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
@@ -59,7 +59,6 @@ import (
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -132,8 +131,6 @@ var (
 		"app":    "federated-cluster",
 		"module": "federation-controller-manager",
 	}
-
-	hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
 )
 
 type initFederation struct {
@@ -160,9 +157,7 @@ type initFederationOptions struct {
 	apiServerEnableTokenAuth         bool
 }
 
-func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
-	defaultImage := fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
-
+func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultImage string) {
 	flags.StringVar(&o.dnsZoneName, "dns-zone-name", "", "DNS suffix for this federation. Federated Service DNS names are published with this suffix.")
 	flags.StringVar(&o.image, "image", defaultImage, "Image to use for federation API server and controller manager binaries.")
 	flags.StringVar(&o.dnsProvider, "dns-provider", "", "Dns provider to be used for this deployment.")
@@ -180,7 +175,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
 
 // NewCmdInit defines the `init` command that bootstraps a federation
 // control plane inside a set of host clusters.
-func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
+func NewCmdInit(cmdOut io.Writer, config util.AdminConfig, defaultImage string) *cobra.Command {
 	opts := &initFederation{}
 
 	cmd := &cobra.Command{
@@ -196,7 +191,7 @@ func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.commonOptions.Bind(flags)
-	opts.options.Bind(flags)
+	opts.options.Bind(flags, defaultImage)
 
 	return cmd
 }

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
-func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultImage string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "kubefed",
@@ -53,7 +53,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions()), defaultImage),
 				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},


### PR DESCRIPTION
This is a cherrypick to allow an origin-specific default for the image used to run the federation servers:

kubernetes/kubernetes#46020

Note: This hasn't merged upstream yet.