### PR TITLE
Enable federation for origin clusters 

### DIFF
--- a/cmd/kubefed/kubefed.go
+++ b/cmd/kubefed/kubefed.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+
+	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
+	"k8s.io/kubernetes/pkg/util/logs"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+
+	"github.com/openshift/origin/pkg/federation/kubefed"
+)
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	cmd := kubefed.NewKubeFedCommand(os.Stdin, os.Stdout, os.Stderr)
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -95,6 +95,7 @@ image "${tag_prefix}-haproxy-router"        images/router/haproxy
 image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived
 image "${tag_prefix}-docker-registry"       images/dockerregistry
 image "${tag_prefix}-egress-router"         images/egress/router
+image "${tag_prefix}-federation"            images/federation
 # images that depend on "${tag_prefix}
 image "${tag_prefix}-gitserver"             examples/gitserver
 image "${tag_prefix}-deployer"              images/deployer

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -669,6 +669,8 @@ readonly -f os::build::save_version_vars
 function os::build::get_product_vars() {
   export OS_BUILD_LDFLAGS_IMAGE_PREFIX="${OS_IMAGE_PREFIX:-"openshift/origin"}"
   export OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS="${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS:-"centos7"}"
+  export OS_BUILD_LDFLAGS_FEDERATION_SERVER_IMAGE_NAME="${OS_BUILD_LDFLAGS_FEDERATION_SERVER_IMAGE_NAME:-"${OS_BUILD_LDFLAGS_IMAGE_PREFIX}-federation"}"
+  export OS_BUILD_LDFLAGS_FEDERATION_ETCD_IMAGE="${OS_BUILD_LDFLAGS_FEDERATION_ETCD_IMAGE:-"quay.io/coreos/etcd:v3.1.7"}"
 }
 
 # golang 1.5 wants `-X key=val`, but golang 1.4- REQUIRES `-X key val`
@@ -716,6 +718,8 @@ function os::build::ldflags() {
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.gitVersion" "${KUBE_GIT_VERSION}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.buildDate" "${buildDate}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.gitTreeState" "clean"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/federation/kubefed.serverImageName" "${OS_BUILD_LDFLAGS_FEDERATION_SERVER_IMAGE_NAME}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/federation/kubefed.defaultEtcdImage" "${OS_BUILD_LDFLAGS_FEDERATION_ETCD_IMAGE}"))
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -23,6 +23,7 @@ readonly OS_IMAGE_COMPILE_TARGETS_LINUX=(
   images/pod
   cmd/dockerregistry
   cmd/gitserver
+  vendor/k8s.io/kubernetes/cmd/hyperkube
   "${OS_SDN_COMPILE_TARGETS_LINUX[@]}"
 )
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX=(
@@ -33,6 +34,7 @@ readonly OS_IMAGE_COMPILE_BINARIES=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]
 readonly OS_CROSS_COMPILE_TARGETS=(
   cmd/openshift
   cmd/oc
+  cmd/kubefed
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 

--- a/images/federation/Dockerfile
+++ b/images/federation/Dockerfile
@@ -1,0 +1,16 @@
+#
+# This is the OpenShift Origin Federation image, used for running the
+# federation apiserver and controller manager components.
+#
+# The standard name for this image is openshift/origin-federation
+#
+FROM openshift/origin-base
+
+RUN INSTALL_PKGS="origin-federation-services" && \
+    yum install -y ${INSTALL_PKGS} && \
+    rpm -V ${INSTALL_PKGS} && \
+    yum clean all && \
+    ln -s /usr/bin/hyperkube /hyperkube
+
+LABEL io.k8s.display-name="OpenShift Origin Federation" \
+      io.k8s.description="This is a component of OpenShift Origin and contains the software for running federation servers."

--- a/origin.spec
+++ b/origin.spec
@@ -182,6 +182,13 @@ Obsoletes:        openshift-sdn-ovs < %{package_refector_version}
 %description sdn-ovs
 %{summary}
 
+%package federation-services
+Summary:        %{produce_name} Federation Services
+Requires:       %{name} = %{version}-%{release}
+
+%description federation-services
+%{summary}
+
 %package excluder
 Summary:   Exclude openshift packages from updates
 BuildArch: noarch
@@ -240,7 +247,7 @@ PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 install -d %{buildroot}%{_bindir}
 
 # Install linux components
-for bin in oc openshift dockerregistry
+for bin in oc openshift dockerregistry kubefed
 do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
@@ -255,6 +262,9 @@ install -p -m 755 _output/local/bin/linux/amd64/oc %{buildroot}%{_datadir}/%{nam
 install -p -m 755 _output/local/bin/darwin/amd64/oc %{buildroot}/%{_datadir}/%{name}/macosx/oc
 install -p -m 755 _output/local/bin/windows/amd64/oc.exe %{buildroot}/%{_datadir}/%{name}/windows/oc.exe
 %endif
+
+# Install federation services
+install -p -m 755 _output/local/bin/${PLATFORM}/hyperkube %{buildroot}%{_bindir}/
 
 # Install pod
 install -p -m 755 _output/local/bin/${PLATFORM}/pod %{buildroot}%{_bindir}/
@@ -541,6 +551,7 @@ fi
 %license LICENSE
 %{_bindir}/oc
 %{_bindir}/kubectl
+%{_bindir}/kubefed
 %{_sysconfdir}/bash_completion.d/oc
 %{_mandir}/man1/oc*
 
@@ -599,6 +610,9 @@ fi
 if [ "$1" -eq 0 ] ; then
   /usr/sbin/%{name}-docker-excluder unexclude
 fi
+
+%files federation-services
+%{_bindir}/hyperkube
 
 %changelog
 * Fri Sep 18 2015 Scott Dodson <sdodson@redhat.com> 0.2-9

--- a/pkg/federation/kubefed/kubefed.go
+++ b/pkg/federation/kubefed/kubefed.go
@@ -1,0 +1,87 @@
+package kubefed
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/federation/pkg/kubefed"
+	kubefedinit "k8s.io/kubernetes/federation/pkg/kubefed/init"
+	"k8s.io/kubernetes/federation/pkg/kubefed/util"
+	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+
+	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/version"
+)
+
+// This file was copied from vendor/k8s.io/kubernetes/federation/pkg/kubefed and
+// modified to support the openshift version command as per the inline comments.
+
+var (
+	// serverImageName is the name of the default image (without version)
+	// used for the federation services (api and controller manager).  It
+	// should be set during build via -ldflags.
+	serverImageName string
+
+	// defaultEtcImage is the default image (including version) used to run
+	// etcd for the federation apiserver.  It should be set during build via
+	// -ldflags.
+	defaultEtcdImage string
+)
+
+// NewKubeFedCommand creates the `kubefed` command and its nested children.
+func NewKubeFedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
+	defaultServerImage := fmt.Sprintf("%s:%s", serverImageName, version.Get())
+
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "kubefed",
+		Short: "kubefed controls an OpenShift Cluster Federation",
+		Long: templates.LongDesc(`
+      kubefed controls an OpenShift Cluster Federation.
+
+      Find more information at https://github.com/openshift/origin.`),
+		Run: runHelp,
+	}
+
+	// Use an openshift command factory to ensure CmdNewVersion will work.
+	// It is interface compatible with the kube equivalent, so any calls to
+	// kube code will continue to work.
+	f := osclientcmd.New(cmds.PersistentFlags())
+
+	// From this point and forward we get warnings on flags that contain "_" separators
+	cmds.SetGlobalNormalizationFunc(flag.WarnWordSepNormalizeFunc)
+
+	groups := templates.CommandGroups{
+		{
+			Message: "Basic Commands:",
+			Commands: []*cobra.Command{
+				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions()), defaultServerImage, defaultEtcdImage),
+				kubefed.NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+				kubefed.NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+			},
+		},
+	}
+	groups.Add(cmds)
+
+	filters := []string{
+		"options",
+	}
+	templates.ActsAsRootCommand(cmds, filters, groups...)
+
+	// Use the openshift-specific version command
+	cmds.AddCommand(cmd.NewCmdVersion("kubefed", f, out, cmd.VersionOptions{PrintClientFeatures: true}))
+
+	cmds.AddCommand(kubectl.NewCmdOptions(out))
+
+	return cmds
+}
+
+func runHelp(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}

--- a/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
@@ -17,19 +17,24 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/federation/pkg/kubefed"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/logs"
+	"k8s.io/kubernetes/pkg/version"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 )
+
+const hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
 
 func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
+	defaultImage := fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
+	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, defaultImage)
 	return cmd.Execute()
 }

--- a/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/cmd/kubefed/app/kubefed.go
@@ -28,13 +28,16 @@ import (
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 )
 
-const hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
+const (
+	hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
+	defaultEtcdImage   = "gcr.io/google_containers/etcd:3.0.17"
+)
 
 func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	defaultImage := fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
-	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, defaultImage)
+	defaultServerImage := fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
+	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, defaultServerImage, defaultEtcdImage)
 	return cmd.Execute()
 }

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
@@ -59,7 +59,6 @@ import (
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -132,8 +131,6 @@ var (
 		"app":    "federated-cluster",
 		"module": "federation-controller-manager",
 	}
-
-	hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
 )
 
 type initFederation struct {
@@ -160,9 +157,7 @@ type initFederationOptions struct {
 	apiServerEnableTokenAuth         bool
 }
 
-func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
-	defaultImage := fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
-
+func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultImage string) {
 	flags.StringVar(&o.dnsZoneName, "dns-zone-name", "", "DNS suffix for this federation. Federated Service DNS names are published with this suffix.")
 	flags.StringVar(&o.image, "image", defaultImage, "Image to use for federation API server and controller manager binaries.")
 	flags.StringVar(&o.dnsProvider, "dns-provider", "", "Dns provider to be used for this deployment.")
@@ -180,7 +175,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
 
 // NewCmdInit defines the `init` command that bootstraps a federation
 // control plane inside a set of host clusters.
-func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
+func NewCmdInit(cmdOut io.Writer, config util.AdminConfig, defaultImage string) *cobra.Command {
 	opts := &initFederation{}
 
 	cmd := &cobra.Command{
@@ -196,7 +191,7 @@ func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.commonOptions.Bind(flags)
-	opts.options.Bind(flags)
+	opts.options.Bind(flags, defaultImage)
 
 	return cmd
 }

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/init/init.go
@@ -145,6 +145,7 @@ type initFederationOptions struct {
 	dnsProviderConfig                string
 	etcdImage                        string
 	etcdPVCapacity                   string
+	etcdPVStorageClass               string
 	etcdPersistentStorage            bool
 	dryRun                           bool
 	apiServerOverridesString         string
@@ -165,6 +166,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultServerImage, d
 	flags.StringVar(&o.dnsProviderConfig, "dns-provider-config", "", "Config file path on local file system for configuring DNS provider.")
 	flags.StringVar(&o.etcdImage, "etcd-image", defaultEtcdImage, "Image to use for etcd server.")
 	flags.StringVar(&o.etcdPVCapacity, "etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
+	flags.StringVar(&o.etcdPVStorageClass, "etcd-pv-storage-class", "", "The storage class of the persistent volume claim used for etcd.   Must be provided if a default storage class is not enabled for the host cluster.")
 	flags.BoolVar(&o.etcdPersistentStorage, "etcd-persistent-storage", true, "Use persistent volume for etcd. Defaults to 'true'.")
 	flags.BoolVar(&o.dryRun, "dry-run", false, "dry run without sending commands to server.")
 	flags.StringVar(&o.apiServerOverridesString, "apiserver-arg-overrides", "", "comma separated list of federation-apiserver arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
@@ -324,7 +326,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 	// stores its data.
 	var pvc *api.PersistentVolumeClaim
 	if i.options.etcdPersistentStorage {
-		pvc, err = createPVC(hostClientset, i.commonOptions.FederationSystemNamespace, svc.Name, i.options.etcdPVCapacity, i.options.dryRun)
+		pvc, err = createPVC(hostClientset, i.commonOptions.FederationSystemNamespace, svc.Name, i.options.etcdPVCapacity, i.options.etcdPVStorageClass, i.options.dryRun)
 		if err != nil {
 			return err
 		}
@@ -620,20 +622,24 @@ func createControllerManagerKubeconfigSecret(clientset client.Interface, namespa
 	return util.CreateKubeconfigSecret(clientset, config, namespace, kubeconfigName, dryRun)
 }
 
-func createPVC(clientset client.Interface, namespace, svcName, etcdPVCapacity string, dryRun bool) (*api.PersistentVolumeClaim, error) {
+func createPVC(clientset client.Interface, namespace, svcName, etcdPVCapacity, etcdPVStorageClass string, dryRun bool) (*api.PersistentVolumeClaim, error) {
 	capacity, err := resource.ParseQuantity(etcdPVCapacity)
 	if err != nil {
 		return nil, err
 	}
 
+	annotations := map[string]string{}
+	if len(etcdPVStorageClass) > 0 {
+		annotations["volume.beta.kubernetes.io/storage-class"] = etcdPVStorageClass
+
+	}
+
 	pvc := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-etcd-claim", svcName),
-			Namespace: namespace,
-			Labels:    componentLabel,
-			Annotations: map[string]string{
-				"volume.alpha.kubernetes.io/storage-class": "yes",
-			},
+			Name:        fmt.Sprintf("%s-etcd-claim", svcName),
+			Namespace:   namespace,
+			Labels:      componentLabel,
+			Annotations: annotations,
 		},
 		Spec: api.PersistentVolumeClaimSpec{
 			AccessModes: []api.PersistentVolumeAccessMode{

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
-func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultImage string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "kubefed",
@@ -53,7 +53,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
+				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions()), defaultImage),
 				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},

--- a/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
+++ b/vendor/k8s.io/kubernetes/federation/pkg/kubefed/kubefed.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
-func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultImage string) *cobra.Command {
+func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultServerImage, defaultEtcdImage string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "kubefed",
@@ -53,7 +53,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defa
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions()), defaultImage),
+				kubefedinit.NewCmdInit(out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions()), defaultServerImage, defaultEtcdImage),
 				NewCmdJoin(f, out, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 				NewCmdUnjoin(f, out, err, util.NewAdminConfig(clientcmd.NewDefaultPathOptions())),
 			},


### PR DESCRIPTION
TODO
- [x] build openshift-specific server image
- [x] build kubefed that targets the openshift-specific server image 
- [x] update kubefed to report openshift version (e.g. 3.6) instead of kube version (e.g. 1.6)
- [x] update kubefed init to use rh-specific etcd image
- [x] test compatibility of kubefed init's PV annotation with openshift
