### PR TITLE
ineffectual assignment to err, delete it

### DIFF
--- a/pkg/auth/oauth/external/handler.go
+++ b/pkg/auth/oauth/external/handler.go
@@ -214,8 +214,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *Handler) handleError(err error, w http.ResponseWriter, req *http.Request) {
-	handled, err := h.errorHandler.AuthenticationError(err, w, req)
-	if handled {
+	if handled, _ := h.errorHandler.AuthenticationError(err, w, req); handled {
 		return
 	}
 	w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Ineffectual assignment to err, delete it, and make the "if" sentence to fit the golang usage

Signed-off-by: yupengzte <yu.peng36@zte.com.cn>