### PR TITLE
UPSTREAM: 45741: Fix discovery version for autoscaling to be v1

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/registry/autoscaling/rest/storage_autoscaling.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/autoscaling/rest/storage_autoscaling.go
@@ -33,13 +33,13 @@ type RESTStorageProvider struct{}
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(autoscaling.GroupName, api.Registry, api.Scheme, api.ParameterCodec, api.Codecs)
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
-		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
-		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv1.SchemeGroupVersion
-	}
 	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv2alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv2alpha1.SchemeGroupVersion.Version] = p.v2alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv2alpha1.SchemeGroupVersion
+	}
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
+		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
+		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv1.SchemeGroupVersion
 	}
 
 	return apiGroupInfo, true


### PR DESCRIPTION
The order of the storage setup blocks in the setup for the autoscaling
API group was accidentally inverted, meaning that if the v2alpha1 API
group was turned on, it would be set to the preferred API group-version
for discovery.

This was unintentional; the latest stable version should (v1) should be
preferred instead.

Fixes bug 1452021 (https://bugzilla.redhat.com/show_bug.cgi?id=1452021)