### PR TITLE
Add proxy protocol status to reload script output

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -23,7 +23,8 @@ function haproxyHealthCheck() {
 
   local end_ts=$((start_ts + wait_time))
 
-  echo " - Checking HAProxy /healthz on port $port ..."
+  local proxy_proto="${ROUTER_USE_PROXY_PROTOCOL:-FALSE}"
+  echo " - Proxy protocol '${proxy_proto}'.  Checking HAProxy /healthz on port $port ..."
   while true; do
     local httpcode=$(curl $timeout_opts -s -o /dev/null -I -w "%{http_code}" http://localhost:${port}/healthz)
 


### PR DESCRIPTION
Proxy protocol errors are painful to debug.  I added the router proxy
protocol status to the reload message so that people will see it and
it may jog the thought to check that the upstream load balancer (if
present) is correctly configured.