### PR TITLE
UPSTREAM: 46127: Return MethodNotSupported when accessing unwatcheable resource with ?watch=true

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -308,7 +308,11 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope RequestScope, forceWatch
 			opts.FieldSelector = nameSelector
 		}
 
-		if (opts.Watch || forceWatch) && rw != nil {
+		if opts.Watch || forceWatch {
+			if rw == nil {
+				scope.err(errors.NewMethodNotSupported(scope.Resource.GroupResource(), "watch"), res.ResponseWriter, req.Request)
+				return
+			}
 			// TODO: Currently we explicitly ignore ?timeout= and use only ?timeoutSeconds=.
 			timeout := time.Duration(0)
 			if opts.TimeoutSeconds != nil {


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1452206