### PR TITLE
fix index out of range

### DIFF
--- a/images/egress/router/egress_router_test.go
+++ b/images/egress/router/egress_router_test.go
@@ -209,6 +209,10 @@ func TestEgressRouterBad(t *testing.T) {
 		}
 		out, err := cmd.CombinedOutput()
 		out_lines := strings.Split(string(out), "\n")
+
+		if len(out_lines) < 2 {
+			continue
+		}
 		got := out_lines[len(out_lines)-2]
 		if err == nil {
 			t.Fatalf("test %d expected error %q but got output %q", n+1, test.err, got)


### PR DESCRIPTION
When ***len(out_lines) < 2***, ***out_lines[len(out_lines)-2]*** is ***index out of range***

Signed-off-by: yupengzte <yu.peng36@zte.com.cn>