### PR TITLE
DEBUG: Unblacklist StateFul e2e test to debug watch-cache PR flake

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -293,7 +293,6 @@ var (
 		`\[Feature:Downgrade\]`,
 
 		// upstream flakes
-		`should provide basic identity`, // Basic StatefulSet functionality
 		`Scaling down before scale up is finished should wait until current pod will be running and ready before it will be removed`, // Basic StatefulSet functionality
 		`validates resource limits of pods that are allowed to run`,                                                                  // SchedulerPredicates
 		`should idle the service and DeploymentConfig properly`,                                                                      // idling with a single service and DeploymentConfig [Conformance]


### PR DESCRIPTION
If we see a flake in the unblacklisted test here related to reading /data, then https://github.com/openshift/origin/pull/14052 about watch cache size is not the reason and we can merge the later