### PR TITLE
Use cluster IP for nip.io prefixing in extended tests

### DIFF
--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -60,6 +60,13 @@ var _ = g.Describe("[builds][Slow] can use private repositories as build input",
 		o.Expect(err).NotTo(o.HaveOccurred())
 		host, err := hostname(hostURL.Host)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		if ip := net.ParseIP(host); ip == nil {
+			// we have a hostname, not an IP, but need to prefix
+			// nip.io addresses with an IP
+			ips, err := net.LookupIP(host)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			host = ips[0].String()
+		}
 		routeSuffix := fmt.Sprintf("%s.%s", host, hostNameSuffix)
 
 		g.By(fmt.Sprintf("calling oc new-app -f %q -p ROUTE_SUFFIX=%s", gitServerYaml, routeSuffix))


### PR DESCRIPTION
In order for the `XXX.nip.io` URL to resolve correctly, we need to make
sure that we are prefixing the `.nip.io` with an IP address, not a host-
name, no matter what we have in our `$KUBECONFIG`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>