### PR TITLE
Refactor controller initialization (part 2)

### DIFF
--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -49,6 +49,9 @@ func TestSubjects(t *testing.T) {
 			"system:serviceaccount:openshift-infra:build-controller",
 			"system:serviceaccount:openshift-infra:deployer-controller",
 			"system:serviceaccount:openshift-infra:template-instance-controller",
+			"system:serviceaccount:openshift-infra:template-instance-controller",
+			"system:serviceaccount:openshift-infra:build-pod-controller",
+			"system:serviceaccount:openshift-infra:build-controller",
 		),
 		expectedGroups: sets.NewString("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:masters", "system:nodes"),
 	}

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -23,12 +23,18 @@ import (
 )
 
 const (
-	InfraBuildControllerServiceAccountName             = "build-controller"
-	InfraImageTriggerControllerServiceAccountName      = "imagetrigger-controller"
-	ImageTriggerControllerRoleName                     = "system:imagetrigger-controller"
-	InfraDeploymentConfigControllerServiceAccountName  = "deploymentconfig-controller"
-	InfraDeploymentTriggerControllerServiceAccountName = "deployment-trigger-controller"
-	InfraDeployerControllerServiceAccountName          = "deployer-controller"
+	InfraBuildControllerServiceAccountName                     = "build-controller"
+	InfraImageTriggerControllerServiceAccountName              = "imagetrigger-controller"
+	ImageTriggerControllerRoleName                             = "system:imagetrigger-controller"
+	InfraDeploymentConfigControllerServiceAccountName          = "deploymentconfig-controller"
+	InfraDeploymentTriggerControllerServiceAccountName         = "deployment-trigger-controller"
+	InfraDeployerControllerServiceAccountName                  = "deployer-controller"
+	InfraOriginNamespaceServiceAccountName                     = "origin-namespace-controller"
+	InfraServiceAccountControllerServiceAccountName            = "serviceaccount-controller"
+	InfraServiceAccountPullSecretsControllerServiceAccountName = "serviceaccount-pull-secrets-controller"
+	InfraServiceAccountTokensControllerServiceAccountName      = "serviceaccount-tokens-controller"
+	InfraBuildPodControllerServiceAccountName                  = "build-pod-controller"
+	InfraBuildConfigChangeControllerServiceAccountName         = "build-config-change-controller"
 
 	InfraPersistentVolumeBinderControllerServiceAccountName = "pv-binder-controller"
 	PersistentVolumeBinderControllerRoleName                = "system:pv-binder-controller"

--- a/pkg/cmd/server/origin/controller.go
+++ b/pkg/cmd/server/origin/controller.go
@@ -1,14 +1,89 @@
 package origin
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"fmt"
+	"io/ioutil"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/cert"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kubecontroller "k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/server/origin/controller"
 )
 
+// NewOpenShiftControllerPreStartInitializers returns list of initializers for controllers
+// that needed to be run before any other controller is started.
+// Typically this has to done for the serviceaccount-tokens controller as it provides
+// tokens to other controllers.
+func (c *MasterConfig) NewOpenShiftControllerPreStartInitializers() (map[string]controller.InitFunc, error) {
+	ret := map[string]controller.InitFunc{}
+
+	saTokens := controller.ServiceAccountTokensControllerOptions{
+		RootClientBuilder: kubecontroller.SimpleControllerClientBuilder{
+			ClientConfig: &c.PrivilegedLoopbackClientConfig,
+		},
+	}
+
+	if len(c.Options.ServiceAccountConfig.PrivateKeyFile) == 0 {
+		glog.Infof("Skipped starting Service Account Token Manager, no private key specified")
+		return nil, nil
+	}
+
+	var err error
+
+	saTokens.PrivateKey, err = serviceaccount.ReadPrivateKey(c.Options.ServiceAccountConfig.PrivateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading signing key for Service Account Token Manager: %v", err)
+	}
+
+	if len(c.Options.ServiceAccountConfig.MasterCA) > 0 {
+		saTokens.RootCA, err = ioutil.ReadFile(c.Options.ServiceAccountConfig.MasterCA)
+		if err != nil {
+			return nil, fmt.Errorf("error reading master ca file for Service Account Token Manager: %s: %v", c.Options.ServiceAccountConfig.MasterCA, err)
+		}
+		if _, err := cert.ParseCertsPEM(saTokens.RootCA); err != nil {
+			return nil, fmt.Errorf("error parsing master ca file for Service Account Token Manager: %s: %v", c.Options.ServiceAccountConfig.MasterCA, err)
+		}
+	}
+
+	if c.Options.ControllerConfig.ServiceServingCert.Signer != nil && len(c.Options.ControllerConfig.ServiceServingCert.Signer.CertFile) > 0 {
+		certFile := c.Options.ControllerConfig.ServiceServingCert.Signer.CertFile
+		serviceServingCA, err := ioutil.ReadFile(certFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading ca file for Service Serving Certificate Signer: %s: %v", certFile, err)
+		}
+		if _, err := crypto.CertsFromPEM(serviceServingCA); err != nil {
+			return nil, fmt.Errorf("error parsing ca file for Service Serving Certificate Signer: %s: %v", certFile, err)
+		}
+
+		// if we have a rootCA bundle add that too.  The rootCA will be used when hitting the default master service, since those are signed
+		// using a different CA by default.  The rootCA's key is more closely guarded than ours and if it is compromised, that power could
+		// be used to change the trusted signers for every pod anyway, so we're already effectively trusting it.
+		if len(saTokens.RootCA) > 0 {
+			saTokens.ServiceServingCA = append(saTokens.ServiceServingCA, saTokens.RootCA...)
+			saTokens.ServiceServingCA = append(saTokens.ServiceServingCA, []byte("\n")...)
+		}
+		saTokens.ServiceServingCA = append(saTokens.ServiceServingCA, serviceServingCA...)
+	}
+	ret["serviceaccount-tokens"] = saTokens.RunController
+
+	return ret, nil
+}
+
 func (c *MasterConfig) NewOpenshiftControllerInitializers() (map[string]controller.InitFunc, error) {
 	ret := map[string]controller.InitFunc{}
+
+	serviceAccount := controller.ServiceAccountControllerOptions{
+		ManagedNames: c.Options.ServiceAccountConfig.ManagedNames,
+	}
+	ret["serviceaccount"] = serviceAccount.RunController
+
+	ret["serviceaccount-pull-secrets"] = controller.RunServiceAccountPullSecretsController
+	ret["origin-namespace"] = controller.RunOriginNamespaceController
 
 	// initialize build controller
 	storageVersion := c.Options.EtcdStorageConfig.OpenShiftStorageVersion
@@ -23,6 +98,8 @@ func (c *MasterConfig) NewOpenshiftControllerInitializers() (map[string]controll
 		Codec: codec,
 	}
 	ret["build"] = buildControllerConfig.RunController
+	ret["build-pod"] = controller.RunBuildPodController
+	ret["build-config-change"] = controller.RunBuildConfigChangeController
 
 	// initialize apps.openshift.io controllers
 	vars, err := c.GetOpenShiftClientEnvVars()

--- a/pkg/cmd/server/origin/controller/build.go
+++ b/pkg/cmd/server/origin/controller/build.go
@@ -8,6 +8,7 @@ import (
 	builddefaults "github.com/openshift/origin/pkg/build/admission/defaults"
 	buildoverrides "github.com/openshift/origin/pkg/build/admission/overrides"
 	buildclient "github.com/openshift/origin/pkg/build/client"
+	buildpodcontroller "github.com/openshift/origin/pkg/build/controller/buildpod"
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -80,5 +81,32 @@ func (c *BuildControllerConfig) RunController(ctx ControllerContext) (bool, erro
 	controller.Run()
 	deleteController := factory.CreateDeleteController()
 	deleteController.Run()
+	return true, nil
+}
+
+func RunBuildPodController(ctx ControllerContext) (bool, error) {
+	go buildpodcontroller.NewBuildPodController(
+		ctx.DeprecatedOpenshiftInformers.Builds().Informer(),
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Pods(),
+		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraBuildPodControllerServiceAccountName),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraBuildPodControllerServiceAccountName),
+		ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(bootstrappolicy.InfraBuildPodControllerServiceAccountName),
+	).Run(5, ctx.Stop)
+	return true, nil
+}
+
+func RunBuildConfigChangeController(ctx ControllerContext) (bool, error) {
+	clientName := bootstrappolicy.InfraBuildConfigChangeControllerServiceAccountName
+	bcInstantiator := buildclient.NewOSClientBuildConfigInstantiatorClient(ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(clientName))
+	factory := buildcontrollerfactory.BuildConfigControllerFactory{
+		Client:                  ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(clientName),
+		KubeClient:              ctx.ClientBuilder.KubeInternalClientOrDie(clientName),
+		ExternalKubeClient:      ctx.ClientBuilder.ClientOrDie(clientName),
+		BuildConfigInstantiator: bcInstantiator,
+		BuildLister:             buildclient.NewOSClientBuildClient(ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(clientName)),
+		BuildConfigGetter:       buildclient.NewOSClientBuildConfigClient(ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(clientName)),
+		BuildDeleter:            buildclient.NewBuildDeleter(ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(clientName)),
+	}
+	go factory.Create().Run()
 	return true, nil
 }

--- a/pkg/cmd/server/origin/controller/project.go
+++ b/pkg/cmd/server/origin/controller/project.go
@@ -1,0 +1,15 @@
+package controller
+
+import (
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	projectcontroller "github.com/openshift/origin/pkg/project/controller"
+)
+
+func RunOriginNamespaceController(ctx ControllerContext) (bool, error) {
+	controller := projectcontroller.NewProjectFinalizerController(
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Namespaces(),
+		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraOriginNamespaceServiceAccountName),
+	)
+	go controller.Run(ctx.Stop, 5)
+	return true, nil
+}

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"github.com/golang/glog"
+
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/controller"
+	sacontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
+	"k8s.io/kubernetes/pkg/serviceaccount"
+
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	serviceaccountcontrollers "github.com/openshift/origin/pkg/serviceaccounts/controllers"
+)
+
+type ServiceAccountControllerOptions struct {
+	ManagedNames []string
+}
+
+func (c *ServiceAccountControllerOptions) RunController(ctx ControllerContext) (bool, error) {
+	if len(c.ManagedNames) == 0 {
+		glog.Infof("Skipped starting Service Account Manager, no managed names specified")
+		return false, nil
+	}
+
+	options := sacontroller.DefaultServiceAccountsControllerOptions()
+	options.ServiceAccounts = []kapiv1.ServiceAccount{}
+
+	for _, saName := range c.ManagedNames {
+		sa := kapiv1.ServiceAccount{}
+		sa.Name = saName
+
+		options.ServiceAccounts = append(options.ServiceAccounts, sa)
+	}
+
+	go sacontroller.NewServiceAccountsController(
+		ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Core().V1().ServiceAccounts(),
+		ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Core().V1().Namespaces(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountControllerServiceAccountName),
+		options).Run(3, ctx.Stop)
+
+	return true, nil
+}
+
+type ServiceAccountTokensControllerOptions struct {
+	RootCA           []byte
+	ServiceServingCA []byte
+	PrivateKey       interface{}
+
+	RootClientBuilder controller.SimpleControllerClientBuilder
+}
+
+func (c *ServiceAccountTokensControllerOptions) RunController(ctx ControllerContext) (bool, error) {
+	go sacontroller.NewTokensController(
+		ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Core().V1().ServiceAccounts(),
+		ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Core().V1().Secrets(),
+		c.RootClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountTokensControllerServiceAccountName),
+		sacontroller.TokensControllerOptions{
+			TokenGenerator:   serviceaccount.JWTTokenGenerator(c.PrivateKey),
+			RootCA:           c.RootCA,
+			ServiceServingCA: c.ServiceServingCA,
+		},
+	).Run(int(ctx.KubeControllerContext.Options.ConcurrentSATokenSyncs), ctx.Stop)
+	return true, nil
+}
+
+func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error) {
+	kc := ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
+
+	go serviceaccountcontrollers.NewDockercfgDeletedController(
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Secrets(),
+		kc,
+		serviceaccountcontrollers.DockercfgDeletedControllerOptions{},
+	).Run(ctx.Stop)
+
+	go serviceaccountcontrollers.NewDockercfgTokenDeletedController(
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Secrets(),
+		kc,
+		serviceaccountcontrollers.DockercfgTokenDeletedControllerOptions{},
+	).Run(ctx.Stop)
+
+	dockerURLsInitialized := make(chan struct{})
+	dockercfgController := serviceaccountcontrollers.NewDockercfgController(
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().ServiceAccounts(),
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Secrets(),
+		kc,
+		serviceaccountcontrollers.DockercfgControllerOptions{DockerURLsInitialized: dockerURLsInitialized},
+	)
+	go dockercfgController.Run(5, ctx.Stop)
+
+	dockerRegistryControllerOptions := serviceaccountcontrollers.DockerRegistryServiceControllerOptions{
+		RegistryNamespace:     "default",
+		RegistryServiceName:   "docker-registry",
+		DockercfgController:   dockercfgController,
+		DockerURLsInitialized: dockerURLsInitialized,
+	}
+	go serviceaccountcontrollers.NewDockerRegistryServiceController(
+		ctx.DeprecatedOpenshiftInformers.InternalKubernetesInformers().Core().InternalVersion().Secrets(),
+		kc,
+		dockerRegistryControllerOptions,
+	).Run(10, ctx.Stop)
+
+	return true, nil
+}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -159,13 +159,19 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (*client.Cli
 		}
 	}
 	for i := 0; i < counts.BuildPodControllers; i++ {
-		openshiftConfig.RunBuildPodController()
+		_, err := openshiftControllerInitializers["build-pod"](openshiftControllerContext)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	for i := 0; i < counts.ImageChangeControllers; i++ {
 		openshiftConfig.RunImageTriggerController()
 	}
 	for i := 0; i < counts.ConfigChangeControllers; i++ {
-		openshiftConfig.RunBuildConfigChangeController()
+		_, err := openshiftControllerInitializers["build-config-change"](openshiftControllerContext)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	return clusterAdminClient, clusterAdminKubeClientset
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -657,6 +657,34 @@ items:
   kind: ClusterRoleBinding
   metadata:
     creationTimestamp: null
+    name: system:openshift:controller:build-pod-controller
+  roleRef:
+    name: system:openshift:controller:build-pod-controller
+  subjects:
+  - kind: ServiceAccount
+    name: build-pod-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:build-pod-controller
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:build-config-change-controller
+  roleRef:
+    name: system:openshift:controller:build-config-change-controller
+  subjects:
+  - kind: ServiceAccount
+    name: build-config-change-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:build-config-change-controller
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
     name: system:openshift:controller:deployer-controller
   roleRef:
     name: system:openshift:controller:deployer-controller
@@ -722,6 +750,48 @@ items:
     namespace: openshift-infra
   userNames:
   - system:serviceaccount:openshift-infra:template-instance-controller
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:origin-namespace-controller
+  roleRef:
+    name: system:openshift:controller:origin-namespace-controller
+  subjects:
+  - kind: ServiceAccount
+    name: origin-namespace-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:origin-namespace-controller
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:serviceaccount-controller
+  roleRef:
+    name: system:openshift:controller:serviceaccount-controller
+  subjects:
+  - kind: ServiceAccount
+    name: serviceaccount-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:serviceaccount-controller
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:serviceaccount-pull-secrets-controller
+  roleRef:
+    name: system:openshift:controller:serviceaccount-pull-secrets-controller
+  subjects:
+  - kind: ServiceAccount
+    name: serviceaccount-pull-secrets-controller
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:serviceaccount-pull-secrets-controller
 - apiVersion: v1
   groupNames:
   - system:masters

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3561,6 +3561,7 @@ items:
     - builds/custom
     - builds/docker
     - builds/jenkinspipeline
+    - builds/optimizeddocker
     - builds/source
     verbs:
     - create
@@ -3586,9 +3587,104 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - namespaces
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:build-pod-controller
+  rules:
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - builds
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - secrets
     verbs:
     - get
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - builds/custom
+    - builds/docker
+    - builds/jenkinspipeline
+    - builds/optimizeddocker
+    - builds/source
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:build-config-change-controller
+  rules:
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - buildconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - buildconfigs/instantiate
+    verbs:
+    - create
   - apiGroups:
     - ""
     attributeRestrictions: null
@@ -3768,6 +3864,120 @@ items:
     resources:
     - templateinstances/status
     verbs:
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:origin-namespace-controller
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - namespaces/finalize
+    - namespaces/status
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:serviceaccount-controller
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:serviceaccount-pull-secrets-controller
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - secrets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
     - update
 - apiVersion: v1
   kind: ClusterRole


### PR DESCRIPTION
This is a follow up what started in https://github.com/openshift/origin/pull/13996 and is tracked here: https://trello.com/c/ZtOfFpFz/907-5-use-kubernetes-controller-roles

In a nutshell:

* We are switching to upstream RBAC roles for upstream controllers (should be already done)
* We are switching to new initialization of origin controllers (this PR)