### PR TITLE
disable RBAC post start hook

### DIFF
--- a/pkg/authorization/util/util.go
+++ b/pkg/authorization/util/util.go
@@ -14,6 +14,8 @@ import (
 // It returns the modified SubjectAccessReview.
 func AddUserToSAR(user user.Info, sar *authorization.SubjectAccessReview) *authorization.SubjectAccessReview {
 	sar.Spec.User = user.GetName()
+	// reminiscent of the bad old days of C.  Copies copy the min number of elements of both source and dest
+	sar.Spec.Groups = make([]string, len(user.GetGroups()), len(user.GetGroups()))
 	copy(sar.Spec.Groups, user.GetGroups())
 	sar.Spec.Extra = map[string]authorization.ExtraValue{}
 

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/endpoint"
 	endpointsstorage "k8s.io/kubernetes/pkg/registry/core/endpoint/storage"
+	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
 	kversion "k8s.io/kubernetes/pkg/version"
 	scheduleroptions "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"
 
@@ -427,6 +428,7 @@ func buildKubeApiserverConfig(
 	genericConfig.PublicAddress = publicAddress
 	genericConfig.Authenticator = originAuthenticator // this is used to fulfill the tokenreviews endpoint which is used by node authentication
 	genericConfig.Authorizer = kubeAuthorizer         // this is used to fulfill the kube SAR endpoints
+	genericConfig.DisabledPostStartHooks.Insert(rbacrest.PostStartHookName)
 	genericConfig.AdmissionControl = admissionControl
 	genericConfig.RequestContextMapper = requestContextMapper
 	genericConfig.OpenAPIConfig = DefaultOpenAPIConfig()

--- a/pkg/route/registry/route/strategy.go
+++ b/pkg/route/registry/route/strategy.go
@@ -79,14 +79,16 @@ func (s routeStrategy) allocateHost(ctx apirequest.Context, route *api.Route) fi
 		}
 		res, err := s.sarClient.CreateSubjectAccessReview(
 			ctx,
-			&authorizationapi.SubjectAccessReview{
-				User: user.GetName(),
-				Action: authorizationapi.Action{
-					Verb:     "create",
-					Group:    api.GroupName,
-					Resource: "routes/custom-host",
+			authorizationapi.AddUserToSAR(
+				user,
+				&authorizationapi.SubjectAccessReview{
+					Action: authorizationapi.Action{
+						Verb:     "create",
+						Group:    api.GroupName,
+						Resource: "routes/custom-host",
+					},
 				},
-			},
+			),
 		)
 		if err != nil {
 			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
@@ -169,14 +171,16 @@ func (s routeStrategy) validateHostUpdate(ctx apirequest.Context, route, older *
 	}
 	res, err := s.sarClient.CreateSubjectAccessReview(
 		ctx,
-		&authorizationapi.SubjectAccessReview{
-			User: user.GetName(),
-			Action: authorizationapi.Action{
-				Verb:     "update",
-				Group:    "route.openshift.io",
-				Resource: "routes/custom-host",
+		authorizationapi.AddUserToSAR(
+			user,
+			&authorizationapi.SubjectAccessReview{
+				Action: authorizationapi.Action{
+					Verb:     "update",
+					Group:    "route.openshift.io",
+					Resource: "routes/custom-host",
+				},
 			},
-		},
+		),
 	)
 	if err != nil {
 		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}

--- a/pkg/template/registry/templateinstance/strategy.go
+++ b/pkg/template/registry/templateinstance/strategy.go
@@ -136,7 +136,7 @@ func (s *templateInstanceStrategy) validateImpersonation(templateInstance *templ
 			Group:     templateapi.GroupName,
 			Resource:  "templateinstances",
 		}); err != nil {
-			return field.ErrorList{field.Forbidden(field.NewPath("spec.impersonateUser"), "impersonation forbidden")}
+			return field.ErrorList{field.Forbidden(field.NewPath("spec.impersonateUser"), fmt.Sprintf("impersonation forbidden: %v", err))}
 		}
 	}
 

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -851,10 +851,14 @@ func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, gett
 	}
 	masterConfig.EtcdClientInfo.URLs[0] = testutil.GetEtcdURL()
 
-	kubeConfigFile, err := testserver.StartConfiguredMasterAPI(masterConfig)
+	_, err = testserver.StartConfiguredMasterAPI(masterConfig)
 	if err != nil {
 		t.Fatalf("error starting server: %#v", err)
 	}
+	// use the loopback config because it identifies as having the group system:masters which is a "magic" do anything group
+	// for upstream kube.
+	kubeConfigFile := masterConfig.MasterClients.OpenShiftLoopbackKubeConfig
+
 	kubeClient, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
 	if err != nil {
 		t.Fatalf("error getting client: %#v", err)

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -85,7 +85,6 @@ var expectedIndex = []string{
 	"/healthz/poststarthook/bootstrap-controller",
 	"/healthz/poststarthook/ca-registration",
 	"/healthz/poststarthook/extensions/third-party-resources",
-	"/healthz/poststarthook/rbac/bootstrap-roles",
 	"/healthz/ready",
 	"/metrics",
 	"/oapi",


### PR DESCRIPTION
pulls in @sttts commit for disabling the hook. Switches @enj's test to use system:masters.  Fixes @smarterclayton's route strategy check to respect groups and tokens