### PR TITLE
change token scopes constant

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -22,7 +22,7 @@ const (
 	VerbAll        = "*"
 	NonResourceAll = "*"
 
-	ScopesKey           = "authorization.openshift.io/scopes"
+	ScopesKey           = "scopes.authorization.openshift.io"
 	ScopesAllNamespaces = "*"
 
 	UserKind           = "User"


### PR DESCRIPTION
Updates the token scopes key to be serializeable in an http header.

I came to the conclusion that I could simply change this value because:
1. openshift SAR has a separate scopes field, so old openshift-node (or other API caller) to new server is fine because the key never enters into it
2. openshift didn't expose authorization.k8s.io before 3.6, so there are no previous callers to consider who would be trying to set the old map key.
3. openshift impersonation sets a separate `Impersonate-User-Scope` field, so that will continue to work since the specific field name is unused.
4. openshift front proxy never worked and is new in 3.6, so there are no previous callers to consider

@liggitt ptal
