### PR TITLE
Emit XFS volume statistics on failure

### DIFF
--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -133,6 +133,7 @@ var _ = g.Describe("[Conformance][volumes] Test local storage quota", func() {
 			o.Expect(volDir).NotTo(o.Equal(""))
 			args := []string{"-f", "-c", "'%T'", volDir}
 			outBytes, _ := exec.Command("stat", args...).Output()
+			fmt.Fprintf(g.GinkgoWriter, "Volume directory status: \n%s\n", outBytes)
 			if !strings.Contains(string(outBytes), "xfs") {
 				g.Skip("Volume directory is not on an XFS filesystem, skipping...")
 			}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bparees PTAL

[testextended][extended: core(should be applied to XFS filesystem when a pod is created)]