### PR TITLE
UPSTREAM: 46299: Fix in-cluster kubectl --namespace override

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -288,6 +288,14 @@ func canIdentifyUser(config restclient.Config) bool {
 
 // Namespace implements ClientConfig
 func (config *DirectClientConfig) Namespace() (string, bool, error) {
+	if config.overrides != nil && config.overrides.Context.Namespace != "" {
+		// In the event we have an empty config but we do have a namespace override, we should return
+		// the namespace override instead of having config.ConfirmUsable() return an error. This allows
+		// things like in-cluster clients to execute `kubectl get pods --namespace=foo` and have the
+		// --namespace flag honored instead of being ignored.
+		return config.overrides.Context.Namespace, true, nil
+	}
+
 	if err := config.ConfirmUsable(); err != nil {
 		return "", false, err
 	}
@@ -301,11 +309,7 @@ func (config *DirectClientConfig) Namespace() (string, bool, error) {
 		return api.NamespaceDefault, false, nil
 	}
 
-	overridden := false
-	if config.overrides != nil && config.overrides.Context.Namespace != "" {
-		overridden = true
-	}
-	return configContext.Namespace, overridden, nil
+	return configContext.Namespace, false, nil
 }
 
 // ConfigAccess implements ClientConfig

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -504,3 +504,25 @@ func matchByteArg(expected, got []byte, t *testing.T) {
 		t.Errorf("Expected %v, got %v", expected, got)
 	}
 }
+
+func TestNamespaceOverride(t *testing.T) {
+	config := &DirectClientConfig{
+		overrides: &ConfigOverrides{
+			Context: clientcmdapi.Context{
+				Namespace: "foo",
+			},
+		},
+	}
+
+	ns, overridden, err := config.Namespace()
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !overridden {
+		t.Errorf("Expected overridden = true")
+	}
+
+	matchStringArg("foo", ns, t)
+}


### PR DESCRIPTION
Fixes #13780