### PR TITLE
junitreport integration test compatability with older versions of diff-utils (for Mac OSX)

### DIFF
--- a/tools/junitreport/test/integration.sh
+++ b/tools/junitreport/test/integration.sh
@@ -9,7 +9,7 @@ set -o pipefail
 JUNITREPORT_ROOT=$(dirname "${BASH_SOURCE}")/..
 pushd "${JUNITREPORT_ROOT}" > /dev/null
 
-diff_args='-yd --tabsize=4 --suppress-common-lines'
+diff_args='-ydb --suppress-common-lines'
 
 TMPDIR="/tmp/junitreport/test/integration"
 mkdir -p "${TMPDIR}"


### PR DESCRIPTION
simple change to fix "make test" for darwin. 

Mac OSX has an ancient version of diff-utils, that does not have the tabsize flag.