### PR TITLE
Add default directories to the $OS_BUILD_ENV_PRESERVE path

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -97,7 +97,7 @@ os::build::release_sha
 if [[ "${OS_GIT_TREE_STATE:-dirty}" == "clean"  ]]; then
 	# only when we are building from a clean state can we claim to
 	# have created a valid set of binaries that can resemble a release
-	echo "${OS_GIT_COMMIT}" > "${OS_LOCAL_RELEASEPATH}/.commit"
+	echo "${OS_GIT_COMMIT}" > "${OS_OUTPUT_RELEASEPATH}/.commit"
 fi
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -19,7 +19,7 @@ os::build::detect_local_release_tars $(os::build::host_platform_friendly)
 readonly OS_GOFLAGS_TAGS="include_gcs include_oss"
 
 # we need to mount RPMs into the container builds for installation
-OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_ARGS:-} -mount ${OS_LOCAL_RPMPATH}/:/srv/origin-local-release/"
+OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_ARGS:-} -mount ${OS_OUTPUT_RPMPATH}/:/srv/origin-local-release/"
 
 # Create link to file if the FS supports hardlinks, otherwise copy the file
 function ln_or_cp {

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -13,7 +13,7 @@ export OS_BUILD_ENV_PRESERVE=_output/local
 context="${OS_ROOT}/_output/buildenv-context"
 
 # Clean existing output.
-rm -rf "${OS_LOCAL_RELEASEPATH}"
+rm -rf "${OS_OUTPUT_RELEASEPATH}"
 rm -rf "${context}"
 mkdir -p "${context}"
 mkdir -p "${OS_OUTPUT}"
@@ -28,6 +28,6 @@ trap "os::build::environment::cleanup ${container}" EXIT
   echo "++ Building release ${OS_GIT_VERSION}"
 )
 os::build::environment::withsource "${container}" "${OS_GIT_COMMIT:-HEAD}"
-echo "${OS_GIT_COMMIT}" > "${OS_LOCAL_RELEASEPATH}/.commit"
+echo "${OS_GIT_COMMIT}" > "${OS_OUTPUT_RELEASEPATH}/.commit"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -58,11 +58,11 @@ make clean
 # migrate the tito artifacts to the Origin directory
 mkdir -p "${OS_OUTPUT}"
 mv "${tito_output_directory}"/* "${OS_OUTPUT}"
-mkdir -p "${OS_LOCAL_RPMPATH}"
-mv "${tito_tmp_dir}"/*src.rpm "${OS_LOCAL_RPMPATH}"
-mv "${tito_tmp_dir}"/*/*.rpm "${OS_LOCAL_RPMPATH}"
+mkdir -p "${OS_OUTPUT_RPMPATH}"
+mv "${tito_tmp_dir}"/*src.rpm "${OS_OUTPUT_RPMPATH}"
+mv "${tito_tmp_dir}"/*/*.rpm "${OS_OUTPUT_RPMPATH}"
 
-repo_path="$( os::util::absolute_path "${OS_LOCAL_RPMPATH}" )"
+repo_path="$( os::util::absolute_path "${OS_OUTPUT_RPMPATH}" )"
 createrepo "${repo_path}"
 
 echo "[${OS_RPM_NAME}-local-release]

--- a/hack/env
+++ b/hack/env
@@ -33,4 +33,10 @@
 # NOTE:   only committed code is built.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+relative_bin_path="$( os::util::repository_relative_path "${OS_OUTPUT_BINPATH}" )"
+relative_release_path="$( os::util::repository_relative_path "${OS_OUTPUT_RELEASEPATH}" )"
+relative_script_path="$( os::util::repository_relative_path "${OS_OUTPUT_SCRIPTPATH}" )"
+default_preserve_paths="${relative_bin_path}:${relative_release_path}:${relative_script_path}"
+export OS_BUILD_ENV_PRESERVE="${OS_BUILD_ENV_PRESERVE:-"${default_preserve_paths}"}"
+
 os::build::environment::run "$@"

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -7,8 +7,9 @@ readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:gola
 
 readonly OS_OUTPUT_SUBPATH="${OS_OUTPUT_SUBPATH:-_output/local}"
 readonly OS_OUTPUT="${OS_ROOT}/${OS_OUTPUT_SUBPATH}"
-readonly OS_LOCAL_RELEASEPATH="${OS_OUTPUT}/releases"
-readonly OS_LOCAL_RPMPATH="${OS_LOCAL_RELEASEPATH}/rpms"
+readonly OS_OUTPUT_RELEASEPATH="${OS_OUTPUT}/releases"
+readonly OS_OUTPUT_RPMPATH="${OS_OUTPUT_RELEASEPATH}/rpms"
+readonly OS_OUTPUT_SCRIPTPATH="${OS_OUTPUT}/scripts"
 readonly OS_OUTPUT_BINPATH="${OS_OUTPUT}/bin"
 readonly OS_OUTPUT_PKGDIR="${OS_OUTPUT}/pkgdir"
 

--- a/hack/lib/build/release.sh
+++ b/hack/lib/build/release.sh
@@ -4,8 +4,8 @@
 
 # os::build::release::check_for_rpms checks that an RPM release has been built
 function os::build::release::check_for_rpms() {
-	if [[ ! -d "${OS_LOCAL_RPMPATH}" || ! -s "${OS_LOCAL_RELEASEPATH}/CHECKSUM" ]]; then
-		relative_release_path="$( os::util::repository_relative_path "${OS_LOCAL_RELEASEPATH}" )"
+	if [[ ! -d "${OS_OUTPUT_RPMPATH}" || ! -s "${OS_OUTPUT_RELEASEPATH}/CHECKSUM" ]]; then
+		relative_release_path="$( os::util::repository_relative_path "${OS_OUTPUT_RELEASEPATH}" )"
 		relative_bin_path="$( os::util::repository_relative_path "${OS_OUTPUT_BINPATH}" )"
 		os::log::fatal "No release RPMs have been built! RPMs are necessary to build container images.
 Build them with:

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -137,7 +137,7 @@ function os::util::environment::setup_tmpdir_vars() {
     VOLUME_DIR="${BASETMPDIR}/volumes"
     export VOLUME_DIR
 
-    BASEOUTDIR="${OS_ROOT}/_output/scripts/${sub_dir}"
+    BASEOUTDIR="${OS_OUTPUT_SCRIPTPATH}/${sub_dir}"
     export BASEOUTDIR
     LOG_DIR="${LOG_DIR:-${BASEOUTDIR}/logs}"
     export LOG_DIR


### PR DESCRIPTION
Users of `hack/env` almost always want to be retrieving build artifacts
and script output artifacts from whatever process they trigger in the
container. Instructing every user to set a `$OS_BUILD_ENV_PRESERVE`
field is tedious, so we can default it when it is unset to contain the
normal paths for binaries, releases, RPMs and script output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@smarterclayton PTAL

[test]