### PR TITLE
UPSTREAM: 44068: Use Docker API Version instead of docker version

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -85,7 +85,7 @@ func (m *containerManager) doWork() {
 		glog.Errorf("Unable to get docker version: %v", err)
 		return
 	}
-	version, err := utilversion.ParseSemantic(v.APIVersion)
+	version, err := utilversion.ParseGeneric(v.APIVersion)
 	if err != nil {
 		glog.Errorf("Unable to parse docker version %q: %v", v.APIVersion, err)
 		return


### PR DESCRIPTION
Previous backport missed one case of Semantic -> Generic.

Fixes: https://github.com/openshift/origin/pull/14158

@soltysh @derekwaynecarr @knobunc 