### PR TITLE
Set DeleteStrategy for all Openshift resources

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
@@ -26,6 +26,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: clusterpolicy.Strategy,
 		UpdateStrategy: clusterpolicy.Strategy,
+		DeleteStrategy: clusterpolicy.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: clusterpolicy.GetAttrs}

--- a/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
@@ -26,6 +26,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: clusterpolicybinding.Strategy,
 		UpdateStrategy: clusterpolicybinding.Strategy,
+		DeleteStrategy: clusterpolicybinding.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: clusterpolicybinding.GetAttrs}

--- a/pkg/authorization/registry/policy/etcd/etcd.go
+++ b/pkg/authorization/registry/policy/etcd/etcd.go
@@ -26,6 +26,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: policy.Strategy,
 		UpdateStrategy: policy.Strategy,
+		DeleteStrategy: policy.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: policy.GetAttrs}

--- a/pkg/authorization/registry/policybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/policybinding/etcd/etcd.go
@@ -26,6 +26,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: policybinding.Strategy,
 		UpdateStrategy: policybinding.Strategy,
+		DeleteStrategy: policybinding.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: policybinding.GetAttrs}

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: image.Strategy,
 		UpdateStrategy: image.Strategy,
+		DeleteStrategy: image.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: image.GetAttrs}

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -41,6 +41,7 @@ func NewREST(optsGetter restoptions.Getter, defaultRegistry api.DefaultRegistry,
 
 	store.CreateStrategy = strategy
 	store.UpdateStrategy = strategy
+	store.DeleteStrategy = strategy
 	store.Decorator = strategy.Decorate
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: imagestream.GetAttrs}

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -40,6 +40,7 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter, bac
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: oauthaccesstoken.GetAttrs}

--- a/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
@@ -35,6 +35,7 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: oauthauthorizetoken.GetAttrs}

--- a/pkg/oauth/registry/oauthclient/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclient/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: oauthclient.Strategy,
 		UpdateStrategy: oauthclient.Strategy,
+		DeleteStrategy: oauthclient.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: oauthclient.GetAttrs}

--- a/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
@@ -19,6 +19,8 @@ type REST struct {
 
 // NewREST returns a RESTStorage object that will work against oauth clients
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*REST, error) {
+	strategy := oauthclientauthorization.NewStrategy(clientGetter)
+
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
 		NewFunc:           func() runtime.Object { return &api.OAuthClientAuthorization{} },
@@ -26,8 +28,9 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 		PredicateFunc:     oauthclientauthorization.Matcher,
 		QualifiedResource: api.Resource("oauthclientauthorizations"),
 
-		CreateStrategy: oauthclientauthorization.NewStrategy(clientGetter),
-		UpdateStrategy: oauthclientauthorization.NewStrategy(clientGetter),
+		CreateStrategy: strategy,
+		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: oauthclientauthorization.GetAttrs}

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -32,6 +32,7 @@ func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarC
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -28,6 +28,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: clusternetwork.Strategy,
 		UpdateStrategy: clusternetwork.Strategy,
+		DeleteStrategy: clusternetwork.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: user.GetAttrs}

--- a/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
+++ b/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: egressnetworkpolicy.Strategy,
 		UpdateStrategy: egressnetworkpolicy.Strategy,
+		DeleteStrategy: egressnetworkpolicy.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: egressnetworkpolicy.GetAttrs}

--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: hostsubnet.Strategy,
 		UpdateStrategy: hostsubnet.Strategy,
+		DeleteStrategy: hostsubnet.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: hostsubnet.GetAttrs}

--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: netnamespace.Strategy,
 		UpdateStrategy: netnamespace.Strategy,
+		DeleteStrategy: netnamespace.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: netnamespace.GetAttrs}

--- a/pkg/template/registry/template/etcd/etcd.go
+++ b/pkg/template/registry/template/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: rest.Strategy,
 		UpdateStrategy: rest.Strategy,
+		DeleteStrategy: rest.Strategy,
 
 		ReturnDeletedObject: true,
 	}

--- a/pkg/template/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/registry/templateinstance/etcd/etcd.go
@@ -33,6 +33,7 @@ func NewREST(optsGetter restoptions.Getter, kc kclientset.Interface) (*REST, *St
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}

--- a/pkg/user/registry/group/etcd/etcd.go
+++ b/pkg/user/registry/group/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: group.Strategy,
 		UpdateStrategy: group.Strategy,
+		DeleteStrategy: group.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: group.GetAttrs}

--- a/pkg/user/registry/identity/etcd/etcd.go
+++ b/pkg/user/registry/identity/etcd/etcd.go
@@ -27,6 +27,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: identity.Strategy,
 		UpdateStrategy: identity.Strategy,
+		DeleteStrategy: identity.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: identity.GetAttrs}

--- a/pkg/user/registry/user/etcd/etcd.go
+++ b/pkg/user/registry/user/etcd/etcd.go
@@ -37,6 +37,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 		CreateStrategy: user.Strategy,
 		UpdateStrategy: user.Strategy,
+		DeleteStrategy: user.Strategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: user.GetAttrs}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -841,15 +841,9 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 	if options.Preconditions != nil {
 		preconditions.UID = options.Preconditions.UID
 	}
-	// DeleteStrategy is doc'ed as optional, but without one you can't be graceful or you'll panic
-	// tolerate an optional field being optional
-	graceful := false
-	pendingGraceful := false
-	if e.DeleteStrategy != nil {
-		graceful, pendingGraceful, err = rest.BeforeDelete(e.DeleteStrategy, ctx, obj, options)
-		if err != nil {
-			return nil, false, err
-		}
+	graceful, pendingGraceful, err := rest.BeforeDelete(e.DeleteStrategy, ctx, obj, options)
+	if err != nil {
+		return nil, false, err
 	}
 	// this means finalizers cannot be updated via DeleteOptions if a deletion is already pending
 	if pendingGraceful {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -143,8 +143,7 @@ type Store struct {
 	// AfterUpdate implements a further operation to run after a resource is
 	// updated and before it is decorated, optional.
 	AfterUpdate ObjectFunc
-	// DeleteStrategy implements resource-specific behavior during deletion,
-	// optional.
+	// DeleteStrategy implements resource-specific behavior during deletion.
 	DeleteStrategy rest.RESTDeleteStrategy
 	// AfterDelete implements a further operation to run after a resource is
 	// deleted and before it is decorated, optional.
@@ -1138,6 +1137,10 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		isNamespaced = e.UpdateStrategy.NamespaceScoped()
 	default:
 		return fmt.Errorf("store for %s must have CreateStrategy or UpdateStrategy set", e.QualifiedResource.String())
+	}
+
+	if e.DeleteStrategy == nil {
+		return fmt.Errorf("store for %s must have DeleteStrategy set", e.QualifiedResource.String())
 	}
 
 	if options.RESTOptions == nil {


### PR DESCRIPTION
`DeleteStrategy` is no longer optional, and thus must be set by all resources.

Fixes #14198

[test]

Seeing a lot of this in master log so something is off:

```
E0524 20:01:04.267911   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all deployments.extensions in the cluster
E0524 20:01:04.280280   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all pods in the cluster
E0524 20:01:04.295723   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all statefulsets.apps in the cluster
E0524 20:01:04.329384   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all configmaps in the cluster
E0524 20:01:04.332520   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all poddisruptionbudgets.policy in the cluster
E0524 20:01:04.353559   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all cronjobs.batch in the cluster
E0524 20:01:04.354711   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all daemonsets.extensions in the cluster
E0524 20:01:04.354913   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all clusterrolebindings.rbac.authorization.k8s.io in the cluster
E0524 20:01:04.360645   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all groups.user.openshift.io in the cluster
E0524 20:01:04.391837   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all networkpolicies.extensions in the cluster
E0524 20:01:04.409736   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all serviceaccounts in the cluster
E0524 20:01:04.449994   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all netnamespaces.network.openshift.io in the cluster
E0524 20:01:04.465373   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all hostsubnets.network.openshift.io in the cluster
E0524 20:01:04.484305   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all podpresets.settings.k8s.io in the cluster
E0524 20:01:04.486138   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all deploymentconfigs.apps.openshift.io in the cluster
E0524 20:01:04.513420   27268 reflector.go:201] github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go:192: Failed to list <nil>: User "system:serviceaccount:kube-system:generic-garbage-collector" cannot list all buildconfigs.build.openshift.io in the cluster
```