### PR TITLE
Initial support for nested gotests

### DIFF
--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -10,13 +10,13 @@ func newTestDataParser() testDataParser {
 	return testDataParser{
 		// testStartPattern matches the line in verbose `go test` output that marks the declaration of a test.
 		// The first submatch of this regex is the name of the test
-		testStartPattern: regexp.MustCompile(`=== RUN\s+(.+)$`),
+		testStartPattern: regexp.MustCompile(`=== RUN\s+([^/]+)$`),
 
 		// testResultPattern matches the line in verbose `go test` output that marks the result of a test.
 		// The first submatch of this regex is the result of the test (PASS, FAIL, or SKIP)
 		// The second submatch of this regex is the name of the test
 		// The third submatch of this regex is the time taken in seconds for the test to finish
-		testResultPattern: regexp.MustCompile(`--- (PASS|FAIL|SKIP):\s+(.+)\s+\((\d+\.\d+)(s| seconds)\)`),
+		testResultPattern: regexp.MustCompile(`--- (PASS|FAIL|SKIP):\s+([^/]+)\s+\((\d+\.\d+)(s| seconds)\)`),
 	}
 }
 

--- a/tools/junitreport/test/gotest/reports/12_flat.xml
+++ b/tools/junitreport/test/gotest/reports/12_flat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="0" time="0.077">
+		<testcase name="TestAuthorizer" time="0"></testcase>
+		<testcase name="TestPopulationMemoryUsage" time="0">
+			<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;PASS"></skipped>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/12_nested.xml
+++ b/tools/junitreport/test/gotest/reports/12_nested.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="k8s.io" tests="2" skipped="1" failures="0" time="0.077">
+		<testsuite name="k8s.io/kubernetes" tests="2" skipped="1" failures="0" time="0.077">
+			<testsuite name="k8s.io/kubernetes/plugin" tests="2" skipped="1" failures="0" time="0.077">
+				<testsuite name="k8s.io/kubernetes/plugin/pkg" tests="2" skipped="1" failures="0" time="0.077">
+					<testsuite name="k8s.io/kubernetes/plugin/pkg/auth" tests="2" skipped="1" failures="0" time="0.077">
+						<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer" tests="2" skipped="1" failures="0" time="0.077">
+							<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="0" time="0.077">
+								<testcase name="TestAuthorizer" time="0"></testcase>
+								<testcase name="TestPopulationMemoryUsage" time="0">
+									<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;PASS"></skipped>
+								</testcase>
+							</testsuite>
+						</testsuite>
+					</testsuite>
+				</testsuite>
+			</testsuite>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/13_flat.xml
+++ b/tools/junitreport/test/gotest/reports/13_flat.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="1" time="0.078">
+		<testcase name="TestAuthorizer" time="0">
+			<failure message="">=== RUN   TestAuthorizer&#xA;=== RUN   TestAuthorizer/allowed_configmap&#xA;=== RUN   TestAuthorizer/allowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/allowed_pvc&#xA;=== RUN   TestAuthorizer/allowed_pv&#xA;=== RUN   TestAuthorizer/disallowed_configmap&#xA;=== RUN   TestAuthorizer/disallowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pv&#xA;--- FAIL: TestAuthorizer (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)&#xA;    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)&#xA;    &#x9;node_authorizer_test.go:125: expected true, got false&#xA;    --- PASS: TestAuthorizer/allowed_pv (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)&#xA;    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)&#xA;    &#x9;node_authorizer_test.go:121: disallowed pv</failure>
+		</testcase>
+		<testcase name="TestPopulationMemoryUsage" time="0">
+			<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;FAIL&#xA;exit status 1"></skipped>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/13_nested.xml
+++ b/tools/junitreport/test/gotest/reports/13_nested.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="k8s.io" tests="2" skipped="1" failures="1" time="0.078">
+		<testsuite name="k8s.io/kubernetes" tests="2" skipped="1" failures="1" time="0.078">
+			<testsuite name="k8s.io/kubernetes/plugin" tests="2" skipped="1" failures="1" time="0.078">
+				<testsuite name="k8s.io/kubernetes/plugin/pkg" tests="2" skipped="1" failures="1" time="0.078">
+					<testsuite name="k8s.io/kubernetes/plugin/pkg/auth" tests="2" skipped="1" failures="1" time="0.078">
+						<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer" tests="2" skipped="1" failures="1" time="0.078">
+							<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="1" time="0.078">
+								<testcase name="TestAuthorizer" time="0">
+									<failure message="">=== RUN   TestAuthorizer&#xA;=== RUN   TestAuthorizer/allowed_configmap&#xA;=== RUN   TestAuthorizer/allowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/allowed_pvc&#xA;=== RUN   TestAuthorizer/allowed_pv&#xA;=== RUN   TestAuthorizer/disallowed_configmap&#xA;=== RUN   TestAuthorizer/disallowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pv&#xA;--- FAIL: TestAuthorizer (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)&#xA;    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)&#xA;    &#x9;node_authorizer_test.go:125: expected true, got false&#xA;    --- PASS: TestAuthorizer/allowed_pv (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)&#xA;    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)&#xA;    &#x9;node_authorizer_test.go:121: disallowed pv</failure>
+								</testcase>
+								<testcase name="TestPopulationMemoryUsage" time="0">
+									<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;FAIL&#xA;exit status 1"></skipped>
+								</testcase>
+							</testsuite>
+						</testsuite>
+					</testsuite>
+				</testsuite>
+			</testsuite>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/summaries/12_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/12_summary.txt
@@ -1,0 +1,8 @@
+Of 2 tests executed in 0.077s, 1 succeeded, 0 failed, and 1 was skipped.
+
+In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestPopulationMemoryUsage" was skipped:
+=== RUN   TestPopulationMemoryUsage
+--- SKIP: TestPopulationMemoryUsage (0.00s)
+	node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
+PASS
+

--- a/tools/junitreport/test/gotest/summaries/13_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/13_summary.txt
@@ -1,0 +1,37 @@
+Of 2 tests executed in 0.078s, 0 succeeded, 1 failed, and 1 was skipped.
+
+In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestAuthorizer" failed:
+=== RUN   TestAuthorizer
+=== RUN   TestAuthorizer/allowed_configmap
+=== RUN   TestAuthorizer/allowed_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/allowed_pvc
+=== RUN   TestAuthorizer/allowed_pv
+=== RUN   TestAuthorizer/disallowed_configmap
+=== RUN   TestAuthorizer/disallowed_secret_via_pod
+=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/disallowed_pvc
+=== RUN   TestAuthorizer/disallowed_pv
+--- FAIL: TestAuthorizer (0.00s)
+    --- PASS: TestAuthorizer/allowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)
+    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)
+    	node_authorizer_test.go:125: expected true, got false
+    --- PASS: TestAuthorizer/allowed_pv (0.00s)
+    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)
+    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)
+    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)
+    	node_authorizer_test.go:121: disallowed pv
+
+In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestPopulationMemoryUsage" was skipped:
+=== RUN   TestPopulationMemoryUsage
+--- SKIP: TestPopulationMemoryUsage (0.00s)
+	node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
+FAIL
+exit status 1
+

--- a/tools/junitreport/test/gotest/testdata/12.txt
+++ b/tools/junitreport/test/gotest/testdata/12.txt
@@ -1,0 +1,29 @@
+=== RUN   TestAuthorizer
+=== RUN   TestAuthorizer/allowed_configmap
+=== RUN   TestAuthorizer/allowed_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/allowed_pvc
+=== RUN   TestAuthorizer/allowed_pv
+=== RUN   TestAuthorizer/disallowed_configmap
+=== RUN   TestAuthorizer/disallowed_secret_via_pod
+=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/disallowed_pvc
+=== RUN   TestAuthorizer/disallowed_pv
+--- PASS: TestAuthorizer (0.00s)
+    --- PASS: TestAuthorizer/allowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)
+    --- PASS: TestAuthorizer/allowed_pvc (0.00s)
+    --- PASS: TestAuthorizer/allowed_pv (0.00s)
+    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)
+    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)
+    --- PASS: TestAuthorizer/disallowed_pv (0.00s)
+=== RUN   TestPopulationMemoryUsage
+--- SKIP: TestPopulationMemoryUsage (0.00s)
+	node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
+PASS
+ok  	k8s.io/kubernetes/plugin/pkg/auth/authorizer/node	0.077s

--- a/tools/junitreport/test/gotest/testdata/13.txt
+++ b/tools/junitreport/test/gotest/testdata/13.txt
@@ -1,0 +1,32 @@
+=== RUN   TestAuthorizer
+=== RUN   TestAuthorizer/allowed_configmap
+=== RUN   TestAuthorizer/allowed_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pod
+=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/allowed_pvc
+=== RUN   TestAuthorizer/allowed_pv
+=== RUN   TestAuthorizer/disallowed_configmap
+=== RUN   TestAuthorizer/disallowed_secret_via_pod
+=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc
+=== RUN   TestAuthorizer/disallowed_pvc
+=== RUN   TestAuthorizer/disallowed_pv
+--- FAIL: TestAuthorizer (0.00s)
+    --- PASS: TestAuthorizer/allowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)
+    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)
+    	node_authorizer_test.go:125: expected true, got false
+    --- PASS: TestAuthorizer/allowed_pv (0.00s)
+    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)
+    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)
+    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)
+    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)
+    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)
+    	node_authorizer_test.go:121: disallowed pv
+=== RUN   TestPopulationMemoryUsage
+--- SKIP: TestPopulationMemoryUsage (0.00s)
+	node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
+FAIL
+exit status 1
+FAIL	k8s.io/kubernetes/plugin/pkg/auth/authorizer/node	0.078s


### PR DESCRIPTION
Fixes #14330

Nested tests have a different output format (see output of nested test in this PR) that puts output in a really different order.

Make the parser tolerate this for now by ignoring the lines starting and ending nested tests (you can tell the difference by the slash in the test name). With this change, all the nested tests appear in the parent test as a block.