### PR TITLE
Bug 1454535 - Use created project name over namespace name in project template

### DIFF
--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -179,7 +179,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 		After: stopOnErr,
 		Op:    configcmd.Create,
 	}
-	if err := utilerrors.NewAggregate(bulk.Run(objectsToCreate, projectName)); err != nil {
+	if err := utilerrors.NewAggregate(bulk.Run(objectsToCreate, createdProject.Name)); err != nil {
 		utilruntime.HandleError(fmt.Errorf("error creating items in requested project %q: %v", createdProject.Name, err))
 		// We have to clean up the project if any part of the project request template fails
 		if deleteErr := r.openshiftClient.Projects().Delete(createdProject.Name); deleteErr != nil {
@@ -190,10 +190,10 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 
 	// wait for a rolebinding if we created one
 	if lastRoleBinding != nil {
-		r.waitForRoleBinding(projectName, lastRoleBinding.Name)
+		r.waitForRoleBinding(createdProject.Name, lastRoleBinding.Name)
 	}
 
-	return r.openshiftClient.Projects().Get(projectName, metav1.GetOptions{})
+	return r.openshiftClient.Projects().Get(createdProject.Name, metav1.GetOptions{})
 }
 
 func (r *REST) waitForRoleBinding(namespace, name string) {


### PR DESCRIPTION
@liggitt this will allow to use:

```
    name: ${PROJECT_NAME}-${PROJECT_REQUESTING_USER}
```

in the project template (however you will need to use this in **all** objects created by that template in the namespace (or service account name), etc...

There is also bug in `new-project` code which causes that command to pick the given project name instead of "created project" name, so the new-project will fail with:

```
[@dev] .../openshift/origin # oc new-project test
Error from server: namespaces "test" not found
```

however:

```
[@dev] .../openshift/origin # oc get projects
NAME                              DISPLAY NAME                      STATUS
test-test-admin                                                              Active
```
