### PR TITLE
UPSTREAM: <drop>: Set the log level for iptables rule dump to 5

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -1312,7 +1312,7 @@ func (proxier *Proxier) syncProxyRules() {
 	natLines := append(natChains.Bytes(), natRules.Bytes()...)
 	lines := append(filterLines, natLines...)
 
-	glog.V(3).Infof("Restoring iptables rules: %s", lines)
+	glog.V(5).Infof("Restoring iptables rules: %s", lines)
 	err = proxier.iptables.RestoreAll(lines, utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
 		glog.Errorf("Failed to execute iptables-restore: %v\nRules:\n%s", err, lines)


### PR DESCRIPTION
PR 46201 (https://github.com/kubernetes/kubernetes/pull/46201) and
others recently have changed the log level at which the complete
iptables rules are printed out.  They were at log level 3, and
Kubernetes now logs them at 5.  This brings us in sync with that.

Fixes bug 1455655 (https://bugzilla.redhat.com/show_bug.cgi?id=1455655)