### PR TITLE
Panic server on watch errors in test environment

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -227,10 +227,16 @@ readonly -f os::util::environment::setup_etcd_vars
 #  - export SERVER_CONFIG_DIR
 #  - export MASTER_CONFIG_DIR
 #  - export NODE_CONFIG_DIR
+#  - export KUBE_CACHE_MUTATION_DETECTOR
+#  - export KUBE_PANIC_WATCH_DECODE_ERROR
 function os::util::environment::setup_server_vars() {
     # turn on cache mutation detector every time we start a server
     KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
     export KUBE_CACHE_MUTATION_DETECTOR
+
+    # panic the server on watch decode errors since they are considered coder mistakes
+    KUBE_PANIC_WATCH_DECODE_ERROR="${KUBE_PANIC_WATCH_DECODE_ERROR:-true}"
+    export KUBE_PANIC_WATCH_DECODE_ERROR
 
     API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip || echo "127.0.0.1")}"
     export API_BIND_HOST

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -17,8 +17,11 @@ limitations under the License.
 package etcd3
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -39,6 +42,24 @@ const (
 	incomingBufSize = 100
 	outgoingBufSize = 100
 )
+
+// fatalOnDecodeError is used during testing to panic the server if watcher encounters a decoding error
+var fatalOnDecodeError = false
+
+// errTestingDecode is the only error that testingDeferOnDecodeError catches during a panic
+var errTestingDecode = errors.New("sentinel error only used during testing to indicate watch decoding error")
+
+// testingDeferOnDecodeError is used during testing to recover from a panic caused by errTestingDecode, all other values continue to panic
+func testingDeferOnDecodeError() {
+	if r := recover(); r != nil && r != errTestingDecode {
+		panic(r)
+	}
+}
+
+func init() {
+	// check to see if we are running in a test environment
+	fatalOnDecodeError, _ = strconv.ParseBool(os.Getenv("KUBE_PANIC_WATCH_DECODE_ERROR"))
+}
 
 type watcher struct {
 	client      *clientv3.Client
@@ -373,9 +394,18 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 	return curObj, oldObj, nil
 }
 
-func decodeObj(codec runtime.Codec, versioner storage.Versioner, data []byte, rev int64) (runtime.Object, error) {
+func decodeObj(codec runtime.Codec, versioner storage.Versioner, data []byte, rev int64) (_ runtime.Object, err error) {
 	obj, err := runtime.Decode(codec, []byte(data))
 	if err != nil {
+		if fatalOnDecodeError {
+			// catch watch decode error iff we caused it on
+			// purpose during a unit test
+			defer testingDeferOnDecodeError()
+			// we are running in a test environment and thus an
+			// error here is due to a coder mistake if the defer
+			// does not catch it
+			panic(err)
+		}
 		return nil, err
 	}
 	// ensure resource version is set on the object we load from etcd


### PR DESCRIPTION
This change makes it so that errors during watch decoding panic the server if it is in a test environment.  This allows us to catch coder errors related to storing incompatible types at the same location in etcd.

[test]

cc @stevekuznetsov for BASH