### PR TITLE
Reinstate "e2e test: remove PodCheckDns flake"

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -436,7 +436,10 @@ os::cmd::expect_success_and_text 'oc logs --previous dc/failing-dc-mid'  'test m
 
 os::log::info "Run pod diagnostics"
 # Requires a node to run the origin-deployer pod; expects registry deployed, deployer image pulled
-os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
+# TODO: Find out why this would flake expecting PodCheckDns to run
+# https://github.com/openshift/origin/issues/9888
+#os::cmd::expect_success_and_text 'oadm diagnostics DiagnosticPod --images='"'""${USE_IMAGES}""'" 'Running diagnostic: PodCheckDns'
+os::cmd::expect_success_and_not_text "oadm diagnostics DiagnosticPod --images='${USE_IMAGES}'" ERROR
 
 os::log::info "Applying STI application config"
 os::cmd::expect_success "oc create -f ${STI_CONFIG_FILE}"


### PR DESCRIPTION
This reinstates a workaround for test flake https://github.com/openshift/origin/issues/9888

@soltysh I was on leave and couldn't review https://github.com/openshift/origin/pull/12890 or my feedback would have been... how does this change the testing timing? It's just a change to what text it's expecting in order to fail/pass the test. I don't see how it would address the problem. Meanwhile the flake came back when this was reverted. What do you think, is there something I'm missing?