### PR TITLE
Bump largest tolerable log size to 200M

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -307,7 +307,7 @@ readonly -f os::cleanup::dump_pprof_output
 # Returns:
 #  None
 function os::cleanup::truncate_large_logs() {
-	local max_file_size="100M"
+	local max_file_size="200M"
 	os::log::info "[CLEANUP] Truncating log files over ${max_file_size}"
 	for file in $(find "${ARTIFACT_DIR}" "${LOG_DIR}" -type f -name '*.log' \( -size +${max_file_size} \)); do
 		mv "${file}" "${file}.tmp"


### PR DESCRIPTION
Master logs from a recent extended test run with many failures sized in
at 168M, so it seems like we need to bump the largest log size that we
tolerate so we're not truncating valuable test output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @bparees 