### PR TITLE
Don't ignore stderr when running integration tests with jUnit

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -67,7 +67,7 @@ function exectest() {
 		result=$?
 	elif [[ -n "${junit_report}" ]]; then
 		# run tests and generate jUnit xml
-		out=$("${testexec}" -test.v -test.timeout=4m -test.run="^$1$" "${@:2}" 2>/dev/null | tee -a "${JUNIT_REPORT_OUTPUT}" )
+		out=$("${testexec}" -test.v -test.timeout=4m -test.run="^$1$" "${@:2}" 2>&1 | tee -a "${JUNIT_REPORT_OUTPUT}" )
 		result=$?
 	else
 		# run tests normally


### PR DESCRIPTION
When we generate jUnit from the integration tests, we need to include
the server outut that comes from the same process as the test output.
This output comes from `stderr`, so we cannot discard it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/origin/issues/14376

[test]