### PR TITLE
UPSTREAM: 46608: fixes kubectl cached discovery on Windows

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/cached_discovery.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/cached_discovery.go
@@ -195,7 +195,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	err = f.Chmod(0755)
+	err = os.Chmod(f.Name(), 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1452073
Upstream PR: https://github.com/kubernetes/kubernetes/pull/46608

The `kubectl` cached discovery makes use of `func (f *File) Chmod(mode FileMode) error` which is not supported and errors out on Windows, making `oc get` and potentially a number of other commands to fail miserably on that platform. `os.Chmod` by file name, on the other hand, does not error out and should be used instead.

@ncdc up to you, but this breaks `oc` on Windows pretty badly. Was reported on 3.6.0.