### PR TITLE
Node DNS should answer PTR records for stateful sets

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -360,13 +360,18 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 			return nil, fmt.Errorf("could not start DNS: failed to add ClusterIP index: %v", err)
 		}
 
+		endpoints, err := dns.NewCachedEndpointsAccessor(internalKubeInformers.Core().InternalVersion().Endpoints())
+		if err != nil {
+			return nil, fmt.Errorf("could not start DNS: failed to add HostnameIP index: %v", err)
+		}
+
 		// TODO: use kubeletConfig.ResolverConfig as an argument to etcd in the event the
 		//   user sets it, instead of passing it to the kubelet.
 		glog.Infof("DNS Bind to %s", options.DNSBindAddress)
 		config.DNSServer = dns.NewServer(
 			dnsConfig,
 			services,
-			internalKubeInformers.Core().InternalVersion().Endpoints().Lister(),
+			endpoints,
 			"node",
 		)
 	}

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -92,14 +92,14 @@ func (c *MasterConfig) RunDNSServer() {
 		glog.Fatalf("Could not start DNS: failed to add ClusterIP index: %v", err)
 	}
 
+	endpoints, err := dns.NewCachedEndpointsAccessor(c.InternalKubeInformers.Core().InternalVersion().Endpoints())
+	if err != nil {
+		glog.Fatalf("Could not start DNS: failed to add endpoints index: %v", err)
+	}
+
 	go func() {
-		s := dns.NewServer(
-			config,
-			services,
-			c.InternalKubeInformers.Core().InternalVersion().Endpoints().Lister(),
-			"apiserver",
-		)
-		err = s.ListenAndServe()
+		s := dns.NewServer(config, services, endpoints, "apiserver")
+		err := s.ListenAndServe()
 		glog.Fatalf("Could not start DNS: %v", err)
 	}()
 

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/skynetservices/skydns/metrics"
 	"github.com/skynetservices/skydns/server"
-
-	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 )
 
 // NewServerDefaults returns the default SkyDNS server configuration for a DNS server.
@@ -22,14 +20,14 @@ func NewServerDefaults() (*server.Config, error) {
 type Server struct {
 	Config      *server.Config
 	Services    ServiceAccessor
-	Endpoints   kcorelisters.EndpointsLister
+	Endpoints   EndpointsAccessor
 	MetricsName string
 
 	Stop chan struct{}
 }
 
 // NewServer creates a server.
-func NewServer(config *server.Config, services ServiceAccessor, endpoints kcorelisters.EndpointsLister, metricsName string) *Server {
+func NewServer(config *server.Config, services ServiceAccessor, endpoints EndpointsAccessor, metricsName string) *Server {
 	stop := make(chan struct{})
 	return &Server{
 		Config:      config,

--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -113,6 +113,26 @@ func digForARecords(records map[string][]string, expect sets.String) string {
 	return probeCmd
 }
 
+func reverseIP(ip string) string {
+	a := strings.Split(ip, ".")
+	for i, j := 0, len(a)-1; i < j; i, j = i+1, j-1 {
+		a[i], a[j] = a[j], a[i]
+	}
+	return strings.Join(a, ".")
+}
+
+func digForPTRRecords(records map[string]string, expect sets.String) string {
+	var probeCmd string
+	fileNamePrefix := "test"
+	for ip, name := range records {
+		fileName := fmt.Sprintf("%s_ptr@%s", fileNamePrefix, ip)
+		probeCmd += fmt.Sprintf(`[ "$(dig +short +notcp +noall +answer +search %s.in-addr.arpa PTR)" = "%s" ] && echo %q;`, reverseIP(ip), name, fileName)
+		//probeCmd += fmt.Sprintf(`echo "$(dig +short +notcp +noall +answer +search %s.in-addr.arpa PTR)" "# %s %s" %q;`, reverseIP(ip), reverseIP(ip), name, fileName)
+		expect.Insert(fileName)
+	}
+	return probeCmd
+}
+
 func digForPod(namespace string, expect sets.String) string {
 	var probeCmd string
 	fileNamePrefix := "test"
@@ -336,6 +356,13 @@ var _ = Describe("DNS", func() {
 
 				fmt.Sprintf("endpoint1.headless.%s.endpoints", f.Namespace.Name):  {"1.1.1.1"},
 				fmt.Sprintf("endpoint1.clusterip.%s.endpoints", f.Namespace.Name): {"1.1.1.1"},
+			}, expect),
+
+			// the DNS pod should be able to find an endpoint hostname via a PTR record for the IP
+			digForPTRRecords(map[string]string{
+				"1.1.1.1": fmt.Sprintf("endpoint1.headless.%s.svc.cluster.local.", f.Namespace.Name),
+				"1.1.1.2": "", // has no hostname
+				"2.1.1.1": "", // has no hostname
 			}, expect),
 
 			// the DNS pod should respond to its own request


### PR DESCRIPTION
A stateful set pod should be able to perform a PTR lookup on its IP and
get its hostname (from the pod value) pointing back to its entry in the
stateful set. Because multiple services can exist for a pod, we choose
the oldest cached entry.

This does *not* support the PTR lookup from the master due to the impact
of keeping those objects in memory. We are in the process of
transitioning to remove the master from the DNS chain.

Fixes #13866