### PR TITLE
Override maximum message length in haproxy

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -11,7 +11,7 @@ global
 
   daemon
 {{- with (env "ROUTER_SYSLOG_ADDRESS" "") }}
-  log {{.}} {{env "ROUTER_LOG_FACILITY" "local1"}} {{env "ROUTER_LOG_LEVEL" "warning"}}
+  log {{.}} len {{env "ROUTER_MAX_MSG_LEN" "2048"}} {{env "ROUTER_LOG_FACILITY" "local1"}} {{env "ROUTER_LOG_LEVEL" "warning"}}
 {{- end}}
   ca-base /etc/ssl
   crt-base /etc/ssl


### PR DESCRIPTION
I some cases, HAProxy will log message lines with an important size.
The default maximum line size for a message log is 1024 [2] and could be overriden with the log len myvalue parameter [1]

when overriding this parameter, one should also take into account the max message length of the syslog/rsyslog/syslog-ng maximum message length which also may truncate it. For syslog-ng, this value is 2048 by default. This is why, we are also setting HAProxy max message length to this value


[1] https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#3.1-log
[2] https://github.com/joyent/haproxy-1.5/blob/master/include/common/defaults.h#L51

