### PR TITLE
UPSTREAM: 46771 Allow pv-binder-controller to List Nodes/Zones Available in the Cluster

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -373,6 +373,13 @@ func init() {
 					Verbs:     sets.NewString("get"),
 					Resources: sets.NewString("secrets"),
 				},
+				// Cinder provisioner needs to get list of nodes in order
+				// to get list of available zones in the cluster in order to choose a zone
+				// in case it's not configured in corresponding Storage Class
+				{
+					Verbs:     sets.NewString("list", "watch"),
+					Resources: sets.NewString("nodes"),
+				},
 			},
 		},
 	)

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3161,6 +3161,14 @@ items:
     - secrets
     verbs:
     - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - nodes
+    verbs:
+    - list
+    - watch
 - apiVersion: v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
Cinder, AWS and GCE provisioners choose a zone from the list of zones available in the cluster in case no zone is specified in the corresponding Storage Class. However, currently the provisioner (pv-binder-controller) do not have right to get the list of nodes/zones available in the cluster.

That's why the pv-binder-controller is being given permission to list and watch nodes in the cluster.

IMPORTANT: this PR was NOT tested.

This PR should resolves this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1457092

This PR does not require any documentation changes.

@rootfs PTAL