### PR TITLE
Use base64url to decode id_token

### DIFF
--- a/pkg/auth/oauth/external/openid/openid.go
+++ b/pkg/auth/oauth/external/openid/openid.go
@@ -266,7 +266,7 @@ func fetchUserInfo(url, accessToken string, transport http.RoundTripper) (map[st
 }
 
 // Decode JWT
-// http://openid.net/specs/draft-jones-json-web-token-07.html
+// https://tools.ietf.org/html/rfc7519
 func decodeJWT(jwt string) (map[string]interface{}, error) {
 	jwtParts := strings.Split(jwt, ".")
 	if len(jwtParts) != 3 {
@@ -279,8 +279,8 @@ func decodeJWT(jwt string) (map[string]interface{}, error) {
 		encodedPayload += strings.Repeat("=", 4-l)
 	}
 
-	// Decode base-64
-	decodedPayload, err := base64.StdEncoding.DecodeString(encodedPayload)
+	// Decode base64url
+	decodedPayload, err := base64.URLEncoding.DecodeString(encodedPayload)
 	if err != nil {
 		return nil, fmt.Errorf("Error decoding payload: %v", err)
 	}

--- a/pkg/auth/oauth/external/openid/openid_test.go
+++ b/pkg/auth/oauth/external/openid/openid_test.go
@@ -1,6 +1,7 @@
 package openid
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/openshift/origin/pkg/auth/oauth/external"
@@ -20,4 +21,75 @@ func TestOpenID(t *testing.T) {
 	}
 	_ = external.Provider(p)
 
+}
+
+func TestDecodeJWT(t *testing.T) {
+	testcases := []struct {
+		Name       string
+		JWT        string
+		ExpectData map[string]interface{}
+		ExpectErr  bool
+	}{
+		{
+			Name:      "missing parts",
+			JWT:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9",
+			ExpectErr: true,
+		},
+		{
+			Name:      "extra parts",
+			JWT:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.a.a",
+			ExpectErr: true,
+		},
+		{
+			Name: "normal",
+			JWT:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ",
+			ExpectData: map[string]interface{}{
+				"sub":   "1234567890",
+				"name":  "John Doe",
+				"admin": true,
+			},
+			ExpectErr: false,
+		},
+		{
+			Name: "unpadded",
+			JWT:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikphc29uIERvZSIsImFkbWluIjp0cnVlfQ.pd1Pp-LS00yNxHsUSPm2Ehz_o_Jt-lWJyeAKk3ObSIY",
+			ExpectData: map[string]interface{}{
+				"sub":   "1234567890",
+				"name":  "Jason Doe",
+				"admin": true,
+			},
+			ExpectErr: false,
+		},
+		{
+			Name: "padded",
+			JWT:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikphc29uIERvZSIsImFkbWluIjp0cnVlfQ==.pd1Pp-LS00yNxHsUSPm2Ehz_o_Jt-lWJyeAKk3ObSIY",
+			ExpectData: map[string]interface{}{
+				"sub":   "1234567890",
+				"name":  "Jason Doe",
+				"admin": true,
+			},
+			ExpectErr: false,
+		},
+		{
+			Name: "multibyte",
+			JWT:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikphc29uINC_0LjRgtC-0L3QsNC6IiwiYWRtaW4iOnRydWV9.Y3Vil-1kg_QFx_ZsI5XsNiVxtfr179M8qjEL8aheYKc",
+			ExpectData: map[string]interface{}{
+				"sub":   "1234567890",
+				"name":  "Jason питонак",
+				"admin": true,
+			},
+			ExpectErr: false,
+		},
+	}
+	for i, tc := range testcases {
+		data, err := decodeJWT(tc.JWT)
+		if tc.ExpectErr != (err != nil) {
+			t.Errorf("%d: expected error %v, got %v", i, tc.ExpectErr, err)
+			continue
+		}
+		if !reflect.DeepEqual(data, tc.ExpectData) {
+			t.Errorf("%d: expected\n\t%#v\ngot\n\t%#v", i, tc.ExpectData, data)
+			continue
+		}
+	}
 }


### PR DESCRIPTION
Uses the correct base64 scheme for decoding JWT tokens.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1455151

