### PR TITLE
UPSTREAM: 43945: Remove 'beta' from default storage class annotation

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/apis/storage/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/storage/util/helpers.go
@@ -20,8 +20,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
-//TODO: Update IsDefaultStorageClassannotation and remove Beta when no longer used
-const IsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+//TODO: remove Beta when no longer used
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 
 // IsDefaultAnnotationText returns a pretty Yes/No String if


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1450762
Upstream PR: https://github.com/kubernetes/kubernetes/pull/43945

This has been already merged in Kubernes 1.6.x in https://github.com/kubernetes/kubernetes/pull/44087

@childsb @eparis, PTAL