### PR TITLE
Add pod-watcher role

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -57,6 +57,7 @@ const (
 	BasicUserRoleName          = "basic-user"
 	StatusCheckerRoleName      = "cluster-status"
 	SelfAccessReviewerRoleName = "self-access-reviewer"
+	PodWatcherRoleName         = "pod-watcher"
 
 	RegistryAdminRoleName  = "registry-admin"
 	RegistryViewerRoleName = "registry-viewer"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -509,6 +509,17 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
+				Name: PodWatcherRoleName,
+				Annotations: map[string]string{
+					roleSystemOnly: roleIsSystemOnly,
+				},
+			},
+			Rules: []authorizationapi.PolicyRule{
+				authorizationapi.NewRule("list", "watch").Groups(authzGroup, legacyAuthzGroup).Resources("pods").RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: SelfProvisionerRoleName,
 				Annotations: map[string]string{
 					oapi.OpenShiftDescription: "A user that can request projects.",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1720,6 +1720,23 @@ items:
   metadata:
     annotations:
       authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: pod-watcher
+  rules:
+  - apiGroups:
+    - authorization.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
+    - pods
+    verbs:
+    - list
+    - watch
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
       openshift.io/description: A user that can request projects.
     creationTimestamp: null
     name: self-provisioner


### PR DESCRIPTION
The new role can list and watch all pods in the cluster.