### PR TITLE
sdn traffic leaking out of the cluster

### DIFF
--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -106,7 +106,6 @@ func (n *NodeIPTables) getStaticNodeIPTablesRules() []FirewallRule {
 		{"filter", "INPUT", []string{"-i", TUN, "-m", "comment", "--comment", "traffic from SDN", "-j", "ACCEPT"}},
 		{"filter", "INPUT", []string{"-i", "docker0", "-m", "comment", "--comment", "traffic from docker", "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-d", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-s", n.clusterNetworkCIDR, "-j", "ACCEPT"}},
 		{"filter", "FORWARD", []string{"-i", TUN, "!", "-o", TUN, "-m", "comment", "--comment", "administrator overrides", "-j", string(OutputFilteringChain)}},
 	}
 }


### PR DESCRIPTION
Customer has discovered that traffic sourced with ip from SDN
subnet is being sent out of the cluster non-masqueraded.

tcp --ctstate INVALID packets are escaping from the SDN
This change deletes the FORWARD -s clusterNetworkCIDR rule to
DROP these packets.

bug 1438762
https://bugzilla.redhat.com/show_bug.cgi?id=1438762