### PR TITLE
sdn: don't require netns on Update action

### DIFF
--- a/pkg/sdn/plugin/ovscontroller.go
+++ b/pkg/sdn/plugin/ovscontroller.go
@@ -1,8 +1,11 @@
 package plugin
 
 import (
+	"encoding/hex"
 	"fmt"
+	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -183,11 +186,11 @@ func (oc *ovsController) ensureOvsPort(hostVeth string) (int, error) {
 	return oc.ovs.AddPort(hostVeth, -1)
 }
 
-func (oc *ovsController) setupPodFlows(ofport int, podIP, podMAC string, vnid uint32) error {
+func (oc *ovsController) setupPodFlows(ofport int, podIP, podMAC, note string, vnid uint32) error {
 	otx := oc.ovs.NewTransaction()
 
 	// ARP/IP traffic from container
-	otx.AddFlow("table=20, priority=100, in_port=%d, arp, nw_src=%s, arp_sha=%s, actions=load:%d->NXM_NX_REG0[], goto_table:21", ofport, podIP, podMAC, vnid)
+	otx.AddFlow("table=20, priority=100, in_port=%d, arp, nw_src=%s, arp_sha=%s, actions=load:%d->NXM_NX_REG0[], note:%s, goto_table:21", ofport, podIP, podMAC, vnid, note)
 	otx.AddFlow("table=20, priority=100, in_port=%d, ip, nw_src=%s, actions=load:%d->NXM_NX_REG0[], goto_table:21", ofport, podIP, vnid)
 
 	// ARP request/response to container (not isolated)
@@ -208,12 +211,34 @@ func (oc *ovsController) cleanupPodFlows(podIP string) error {
 	return otx.EndTransaction()
 }
 
-func (oc *ovsController) SetUpPod(hostVeth, podIP, podMAC string, vnid uint32) (int, error) {
+func getPodNote(containerID string) (string, error) {
+	bytes, err := hex.DecodeString(containerID)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode container ID %q: %v", containerID, err)
+	}
+	if len(bytes) != 32 {
+		return "", fmt.Errorf("invalid container ID %q length; expected 32 bytes", containerID)
+	}
+	var note string
+	for _, b := range bytes {
+		if len(note) > 0 {
+			note += "."
+		}
+		note += fmt.Sprintf("%02x", b)
+	}
+	return note, nil
+}
+
+func (oc *ovsController) SetUpPod(hostVeth, podIP, podMAC, containerID string, vnid uint32) (int, error) {
+	note, err := getPodNote(containerID)
+	if err != nil {
+		return -1, err
+	}
 	ofport, err := oc.ensureOvsPort(hostVeth)
 	if err != nil {
 		return -1, err
 	}
-	return ofport, oc.setupPodFlows(ofport, podIP, podMAC, vnid)
+	return ofport, oc.setupPodFlows(ofport, podIP, podMAC, note, vnid)
 }
 
 func (oc *ovsController) SetPodBandwidth(hostVeth string, ingressBPS, egressBPS int64) error {
@@ -255,8 +280,54 @@ func (oc *ovsController) SetPodBandwidth(hostVeth string, ingressBPS, egressBPS 
 	return nil
 }
 
-func (oc *ovsController) UpdatePod(hostVeth, podIP, podMAC string, vnid uint32) error {
-	ofport, err := oc.ensureOvsPort(hostVeth)
+func getPodDetailsByContainerID(flows []string, containerID string) (int, string, string, string, error) {
+	note, err := getPodNote(containerID)
+	if err != nil {
+		return 0, "", "", "", err
+	}
+
+	// Find the table=20 flow with the given note and extract the podIP, ofport, and MAC from them
+	for _, flow := range flows {
+		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flow)
+		if err != nil {
+			return 0, "", "", "", err
+		}
+		if parsed.Table != 20 || !parsed.NoteHasPrefix(note) {
+			continue
+		}
+
+		macField, macOk := parsed.FindField("arp_sha")
+		portField, pOk := parsed.FindField("in_port")
+		ipField, ipOk := parsed.FindField("arp_spa")
+		if !macOk || !pOk || !ipOk {
+			continue
+		}
+
+		ofport, err := strconv.Atoi(portField.Value)
+		if err != nil {
+			return 0, "", "", "", fmt.Errorf("failed to parse ofport %q: %v", portField.Value, err)
+		}
+		if _, err := net.ParseMAC(macField.Value); err != nil {
+			return 0, "", "", "", fmt.Errorf("failed to parse arp_sha %q: %v", macField.Value, err)
+		}
+		podMAC := macField.Value
+		if net.ParseIP(ipField.Value) == nil {
+			return 0, "", "", "", fmt.Errorf("failed to parse arp_spa %q", ipField.Value)
+		}
+		podIP := ipField.Value
+
+		return ofport, podIP, podMAC, note, nil
+	}
+
+	return 0, "", "", "", fmt.Errorf("failed to find pod details from OVS flows")
+}
+
+func (oc *ovsController) UpdatePod(containerID string, vnid uint32) error {
+	flows, err := oc.ovs.DumpFlows()
+	if err != nil {
+		return err
+	}
+	ofport, podIP, podMAC, note, err := getPodDetailsByContainerID(flows, containerID)
 	if err != nil {
 		return err
 	}
@@ -264,7 +335,7 @@ func (oc *ovsController) UpdatePod(hostVeth, podIP, podMAC string, vnid uint32) 
 	if err != nil {
 		return err
 	}
-	return oc.setupPodFlows(ofport, podIP, podMAC, vnid)
+	return oc.setupPodFlows(ofport, podIP, podMAC, note, vnid)
 }
 
 func (oc *ovsController) TearDownPod(hostVeth, podIP string) error {

--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -126,7 +126,7 @@ func TestOVSHostSubnet(t *testing.T) {
 		},
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=50", "arp", "nw_dst=10.129.0.0/23", "192.168.1.2->tun_dst"},
+			match: []string{"table=50", "arp", "arp_tpa=10.129.0.0/23", "192.168.1.2->tun_dst"},
 		},
 		flowChange{
 			kind:  flowAdded,

--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -213,11 +213,17 @@ func TestOVSService(t *testing.T) {
 	}
 }
 
+const (
+	containerID         string = "bcb5d8d287fcf97458c48ad643b101079e3bc265a94e097e7407440716112f69"
+	containerNote       string = "bc.b5.d8.d2.87.fc.f9.74.58.c4.8a.d6.43.b1.01.07.9e.3b.c2.65.a9.4e.09.7e.74.07.44.07.16.11.2f.69"
+	containerNoteAction string = "note:" + containerNote
+)
+
 func TestOVSPod(t *testing.T) {
 	ovsif, oc, origFlows := setup(t)
 
 	// Add
-	ofport, err := oc.SetUpPod("veth1", "10.128.0.2", "11:22:33:44:55:66", 42)
+	ofport, err := oc.SetUpPod("veth1", "10.128.0.2", "11:22:33:44:55:66", containerID, 42)
 	if err != nil {
 		t.Fatalf("Unexpected error adding pod rules: %v", err)
 	}
@@ -229,7 +235,7 @@ func TestOVSPod(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66"},
+			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66", containerNoteAction},
 		},
 		flowChange{
 			kind:  flowAdded,
@@ -251,7 +257,7 @@ func TestOVSPod(t *testing.T) {
 	}
 
 	// Update
-	err = oc.UpdatePod("veth1", "10.128.0.2", "11:22:33:44:55:66", 43)
+	err = oc.UpdatePod(containerID, 43)
 	if err != nil {
 		t.Fatalf("Unexpected error adding pod rules: %v", err)
 	}
@@ -263,7 +269,7 @@ func TestOVSPod(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66"},
+			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66", containerNoteAction},
 		},
 		flowChange{
 			kind:  flowAdded,
@@ -297,6 +303,111 @@ func TestOVSPod(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
+	}
+}
+
+func TestGetPodDetails(t *testing.T) {
+	type testcase struct {
+		containerID string
+		flows       []string
+		ofport      int
+		ip          string
+		mac         string
+		note        string
+		errStr      string
+	}
+
+	testcases := []testcase{
+		{
+			containerID: containerID,
+			flows: []string{
+				"cookie=0x0, duration=12.243s, table=0, n_packets=0, n_bytes=0, priority=250,ip,in_port=2,nw_dst=224.0.0.0/4 actions=drop",
+				"cookie=0x0, duration=12.258s, table=0, n_packets=0, n_bytes=0, priority=200,arp,in_port=1,arp_spa=10.128.0.0/14,arp_tpa=10.130.0.0/23 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+				"cookie=0x0, duration=12.255s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=1,nw_src=10.128.0.0/14,nw_dst=10.130.0.0/23 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+				"cookie=0x0, duration=12.252s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=1,nw_src=10.128.0.0/14,nw_dst=224.0.0.0/4 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+				"cookie=0x0, duration=12.237s, table=0, n_packets=0, n_bytes=0, priority=200,arp,in_port=2,arp_spa=10.130.0.1,arp_tpa=10.128.0.0/14 actions=goto_table:30",
+				"cookie=0x0, duration=12.234s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=2 actions=goto_table:30",
+				"cookie=0x0, duration=12.248s, table=0, n_packets=0, n_bytes=0, priority=150,in_port=1 actions=drop",
+				"cookie=0x0, duration=12.230s, table=0, n_packets=7, n_bytes=586, priority=150,in_port=2 actions=drop",
+				"cookie=0x0, duration=12.222s, table=0, n_packets=0, n_bytes=0, priority=100,arp actions=goto_table:20",
+				"cookie=0x0, duration=12.218s, table=0, n_packets=0, n_bytes=0, priority=100,ip actions=goto_table:20",
+				"cookie=0x0, duration=12.215s, table=0, n_packets=5, n_bytes=426, priority=0 actions=drop",
+				"cookie=0x0, duration=12.063s, table=10, n_packets=0, n_bytes=0, priority=100,tun_src=172.17.0.3 actions=goto_table:30",
+				"cookie=0x0, duration=12.041s, table=10, n_packets=0, n_bytes=0, priority=100,tun_src=172.17.0.4 actions=goto_table:30",
+				"cookie=0x0, duration=12.211s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=3.202s, table=20, n_packets=0, n_bytes=0, priority=100,arp,in_port=3,arp_spa=10.130.0.2,arp_sha=4a:77:32:e4:ab:9d actions=load:0->NXM_NX_REG0[],note:bc.b5.d8.d2.87.fc.f9.74.58.c4.8a.d6.43.b1.01.07.9e.3b.c2.65.a9.4e.09.7e.74.07.44.07.16.11.2f.69.00.00.00.00.00.00,goto_table:21",
+				"cookie=0x0, duration=3.197s, table=20, n_packets=0, n_bytes=0, priority=100,ip,in_port=3,nw_src=10.130.0.2 actions=load:0->NXM_NX_REG0[],goto_table:21",
+				"cookie=0x0, duration=12.205s, table=20, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.201s, table=21, n_packets=0, n_bytes=0, priority=0 actions=goto_table:30",
+				"cookie=0x0, duration=12.196s, table=30, n_packets=0, n_bytes=0, priority=300,arp,arp_tpa=10.130.0.1 actions=output:2",
+				"cookie=0x0, duration=12.182s, table=30, n_packets=0, n_bytes=0, priority=300,ip,nw_dst=10.130.0.1 actions=output:2",
+				"cookie=0x0, duration=12.190s, table=30, n_packets=0, n_bytes=0, priority=200,arp,arp_tpa=10.130.0.0/23 actions=goto_table:40",
+				"cookie=0x0, duration=12.173s, table=30, n_packets=0, n_bytes=0, priority=200,ip,nw_dst=10.130.0.0/23 actions=goto_table:70",
+				"cookie=0x0, duration=12.186s, table=30, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.128.0.0/14 actions=goto_table:50",
+				"cookie=0x0, duration=12.169s, table=30, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.128.0.0/14 actions=goto_table:90",
+				"cookie=0x0, duration=12.178s, table=30, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=172.30.0.0/16 actions=goto_table:60",
+				"cookie=0x0, duration=12.165s, table=30, n_packets=0, n_bytes=0, priority=50,ip,in_port=1,nw_dst=224.0.0.0/4 actions=goto_table:120",
+				"cookie=0x0, duration=12.160s, table=30, n_packets=0, n_bytes=0, priority=25,ip,nw_dst=224.0.0.0/4 actions=goto_table:110",
+				"cookie=0x0, duration=12.154s, table=30, n_packets=0, n_bytes=0, priority=0,ip actions=goto_table:100",
+				"cookie=0x0, duration=12.150s, table=30, n_packets=0, n_bytes=0, priority=0,arp actions=drop",
+				"cookie=0x0, duration=3.190s, table=40, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.130.0.2 actions=output:3",
+				"cookie=0x0, duration=12.147s, table=40, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.058s, table=50, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.128.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1",
+				"cookie=0x0, duration=12.037s, table=50, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.129.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.4->tun_dst,output:1",
+				"cookie=0x0, duration=12.143s, table=50, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.139s, table=60, n_packets=0, n_bytes=0, priority=200,reg0=0 actions=output:2",
+				"cookie=0x0, duration=11.938s, table=60, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=172.30.0.1,nw_frag=later actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"cookie=0x0, duration=11.929s, table=60, n_packets=0, n_bytes=0, priority=100,tcp,nw_dst=172.30.0.1,tp_dst=443 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"cookie=0x0, duration=11.926s, table=60, n_packets=0, n_bytes=0, priority=100,udp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"cookie=0x0, duration=11.922s, table=60, n_packets=0, n_bytes=0, priority=100,tcp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"cookie=0x0, duration=12.136s, table=60, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=3.179s, table=70, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.130.0.2 actions=load:0->NXM_NX_REG1[],load:0x3->NXM_NX_REG2[],goto_table:80",
+				"cookie=0x0, duration=12.133s, table=70, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.129s, table=80, n_packets=0, n_bytes=0, priority=300,ip,nw_src=10.130.0.1 actions=output:NXM_NX_REG2[]",
+				"cookie=0x0, duration=12.062s, table=80, n_packets=0, n_bytes=0, priority=200,reg0=0 actions=output:NXM_NX_REG2[]",
+				"cookie=0x0, duration=12.055s, table=80, n_packets=0, n_bytes=0, priority=200,reg1=0 actions=output:NXM_NX_REG2[]",
+				"cookie=0x0, duration=12.124s, table=80, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.053s, table=90, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.128.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1",
+				"cookie=0x0, duration=12.030s, table=90, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.129.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.4->tun_dst,output:1",
+				"cookie=0x0, duration=12.120s, table=90, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.116s, table=100, n_packets=0, n_bytes=0, priority=0 actions=output:2",
+				"cookie=0x0, duration=12.112s, table=110, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.024s, table=111, n_packets=0, n_bytes=0, priority=100 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1,set_field:172.17.0.4->tun_dst,output:1,goto_table:120",
+				"cookie=0x0, duration=12.105s, table=120, n_packets=0, n_bytes=0, priority=0 actions=drop",
+				"cookie=0x0, duration=12.101s, table=253, n_packets=0, n_bytes=0, actions=note:01.03.00.00.00.00",
+			},
+			ofport: 3,
+			ip:     "10.130.0.2",
+			mac:    "4a:77:32:e4:ab:9d",
+			note:   containerNote,
+		},
+	}
+
+	for _, tc := range testcases {
+		ofport, ip, mac, note, err := getPodDetailsByContainerID(tc.flows, tc.containerID)
+		if err != nil {
+			if tc.errStr != "" {
+				if !strings.Contains(err.Error(), tc.errStr) {
+					t.Fatalf("unexpected error %v (expected %q)", err, tc.errStr)
+				}
+			} else {
+				t.Fatalf("unexpected failure %v", err)
+			}
+		} else if tc.errStr != "" {
+			t.Fatalf("expected error %q", tc.errStr)
+		}
+		if ofport != tc.ofport {
+			t.Fatalf("unexpected ofport %d (expected %d)", ofport, tc.ofport)
+		}
+		if ip != tc.ip {
+			t.Fatalf("unexpected ip %q (expected %q)", ip, tc.ip)
+		}
+		if mac != tc.mac {
+			t.Fatalf("unexpected mac %q (expected %q)", mac, tc.mac)
+		}
+		if note != tc.note {
+			t.Fatalf("unexpected note %q (expected %q)", note, tc.note)
+		}
 	}
 }
 

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -432,11 +432,6 @@ func (m *podManager) update(req *cniserver.PodRequest) (uint32, error) {
 		req.Netns = netns
 	}
 
-	pod, err := m.kClient.Core().Pods(req.PodNamespace).Get(req.PodName, metav1.GetOptions{})
-	if err != nil {
-		return 0, err
-	}
-
 	hostVethName, contVethMac, podIP, err := getVethInfo(req.Netns, podInterfaceName)
 	if err != nil {
 		return 0, err
@@ -447,9 +442,6 @@ func (m *podManager) update(req *cniserver.PodRequest) (uint32, error) {
 	}
 
 	if err := m.ovs.UpdatePod(hostVethName, podIP, contVethMac, vnid); err != nil {
-		return 0, err
-	}
-	if err := setupPodBandwidth(m.ovs, pod, hostVethName); err != nil {
 		return 0, err
 	}
 

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -23,7 +23,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/hostport"
 	kbandwidth "k8s.io/kubernetes/pkg/util/bandwidth"
@@ -398,7 +397,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 		return nil, nil, err
 	}
 
-	ofport, err := m.ovs.SetUpPod(hostVethName, podIP.String(), contVethMac, vnid)
+	ofport, err := m.ovs.SetUpPod(hostVethName, podIP.String(), contVethMac, req.ContainerId, vnid)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -411,37 +410,14 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 	return ipamResult, &runningPod{podPortMapping: podPortMapping, vnid: vnid, ofport: ofport}, nil
 }
 
-func (m *podManager) getContainerNetnsPath(id string) (string, error) {
-	runtime, ok := m.host.GetRuntime().(*dockertools.DockerManager)
-	if !ok {
-		return "", fmt.Errorf("openshift-sdn execution called on non-docker runtime")
-	}
-	return runtime.GetNetNS(kcontainer.DockerID(id).ContainerID())
-}
-
 // Update OVS flows when something (like the pod's namespace VNID) changes
 func (m *podManager) update(req *cniserver.PodRequest) (uint32, error) {
-	// Updates may come at startup and thus we may not have the pod's
-	// netns from kubelet (since kubelet doesn't have UPDATE actions).
-	// Read the missing netns from the pod's file.
-	if req.Netns == "" {
-		netns, err := m.getContainerNetnsPath(req.ContainerId)
-		if err != nil {
-			return 0, err
-		}
-		req.Netns = netns
-	}
-
-	hostVethName, contVethMac, podIP, err := getVethInfo(req.Netns, podInterfaceName)
-	if err != nil {
-		return 0, err
-	}
 	vnid, err := m.policy.GetVNID(req.PodNamespace)
 	if err != nil {
 		return 0, err
 	}
 
-	if err := m.ovs.UpdatePod(hostVethName, podIP, contVethMac, vnid); err != nil {
+	if err := m.ovs.UpdatePod(req.ContainerId, vnid); err != nil {
 		return 0, err
 	}
 

--- a/pkg/util/ovs/fake_ovs.go
+++ b/pkg/util/ovs/fake_ovs.go
@@ -3,9 +3,6 @@ package ovs
 import (
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // ovsFake implements a fake ovs.Interface for testing purposes
@@ -19,29 +16,8 @@ type ovsFake struct {
 	bridge string
 
 	ports map[string]int
-	flows []ovsFlow
+	flows ovsFlows
 }
-
-// ovsFlow represents an OVS flow
-type ovsFlow struct {
-	table    int
-	priority int
-	created  time.Time
-	cookie   string
-	fields   []ovsField
-	actions  string
-}
-
-type ovsField struct {
-	name  string
-	value string
-}
-
-const (
-	minPriority     = 0
-	defaultPriority = 32768
-	maxPriority     = 65535
-)
 
 // NewFake returns a new ovs.Interface
 func NewFake(bridge string) Interface {
@@ -50,7 +26,7 @@ func NewFake(bridge string) Interface {
 
 func (fake *ovsFake) AddBridge(properties ...string) error {
 	fake.ports = make(map[string]int)
-	fake.flows = make([]ovsFlow, 0)
+	fake.flows = make([]OvsFlow, 0)
 	return nil
 }
 
@@ -150,253 +126,50 @@ func (fake *ovsFake) NewTransaction() Transaction {
 	return &ovsFakeTx{fake: fake, err: fake.ensureExists()}
 }
 
-type parseCmd string
-
-const (
-	parseForAdd    parseCmd = "add-flow"
-	parseForDelete parseCmd = "del-flows"
-)
-
-func fieldSet(parsed *ovsFlow, field string) bool {
-	for _, f := range parsed.fields {
-		if f.name == field {
-			return true
-		}
-	}
-	return false
-}
-
-func checkNotAllowedField(flow string, parsed *ovsFlow, field string, cmd parseCmd) error {
-	if fieldSet(parsed, field) {
-		return fmt.Errorf("bad flow %q (field %q not allowed in %s)", flow, field, cmd)
-	}
-	return nil
-}
-
-func checkUnsupportedField(flow string, parsed *ovsFlow, field string) error {
-	if fieldSet(parsed, field) {
-		return fmt.Errorf("bad flow %q (field %q not supported)", flow, field)
-	}
-	return nil
-}
-
-func parseFlow(cmd parseCmd, flow string, args ...interface{}) (*ovsFlow, error) {
-	if len(args) > 0 {
-		flow = fmt.Sprintf(flow, args...)
-	}
-
-	// According to the man page, "flow descriptions comprise a series of field=value
-	// assignments, separated by commas or white space." However, you can also have
-	// fields with no value (eg, "ip"), and the "actions" field can also have internal
-	// commas, whitespace, and equals signs (but if it is present, it must be the
-	// last field specified).
-
-	parsed := &ovsFlow{
-		table:    0,
-		priority: defaultPriority,
-		fields:   make([]ovsField, 0),
-		created:  time.Now(),
-		cookie:   "0",
-	}
-	flow = strings.Trim(flow, " ")
-	origFlow := flow
-	for flow != "" {
-		field := ""
-		value := ""
-
-		end := strings.IndexAny(flow, ", ")
-		if end == -1 {
-			end = len(flow)
-		}
-		eq := strings.Index(flow, "=")
-		if eq == -1 || eq > end {
-			field = flow[:end]
-		} else {
-			field = flow[:eq]
-			if field == "actions" {
-				end = len(flow)
-				value = flow[eq+1:]
-			} else {
-				valueEnd := end - 1
-				for flow[valueEnd] == ' ' || flow[valueEnd] == ',' {
-					valueEnd--
-				}
-				value = strings.Trim(flow[eq+1:end], ", ")
-			}
-			if value == "" {
-				return nil, fmt.Errorf("bad flow definition %q (empty field %q)", origFlow, field)
-			}
-		}
-
-		switch field {
-		case "table":
-			table, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, fmt.Errorf("bad flow %q (bad table number %q)", origFlow, value)
-			} else if table < 0 || table > 255 {
-				return nil, fmt.Errorf("bad flow %q (table number %q out of range)", origFlow, value)
-			}
-			parsed.table = table
-		case "priority":
-			priority, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, fmt.Errorf("bad flow %q (bad priority %q)", origFlow, value)
-			} else if priority < minPriority || priority > maxPriority {
-				return nil, fmt.Errorf("bad flow %q (priority %q out of range)", origFlow, value)
-			}
-			parsed.priority = priority
-		case "actions":
-			parsed.actions = value
-		case "cookie":
-			parsed.cookie = value
-		default:
-			parsed.fields = append(parsed.fields, ovsField{field, value})
-		}
-
-		for end < len(flow) && (flow[end] == ',' || flow[end] == ' ') {
-			end++
-		}
-		flow = flow[end:]
-	}
-
-	// Sanity-checking
-	switch cmd {
-	case parseForAdd:
-		if err := checkNotAllowedField(flow, parsed, "out_port", cmd); err != nil {
-			return nil, err
-		}
-		if err := checkNotAllowedField(flow, parsed, "out_group", cmd); err != nil {
-			return nil, err
-		}
-
-		if parsed.actions == "" {
-			return nil, fmt.Errorf("bad flow %q (empty actions)", flow)
-		}
-
-	case parseForDelete:
-		if err := checkNotAllowedField(flow, parsed, "priority", cmd); err != nil {
-			return nil, err
-		}
-		if err := checkNotAllowedField(flow, parsed, "actions", cmd); err != nil {
-			return nil, err
-		}
-		if err := checkUnsupportedField(flow, parsed, "out_port"); err != nil {
-			return nil, err
-		}
-		if err := checkUnsupportedField(flow, parsed, "out_group"); err != nil {
-			return nil, err
-		}
-	}
-
-	if (fieldSet(parsed, "nw_src") || fieldSet(parsed, "nw_dst")) &&
-		!(fieldSet(parsed, "ip") || fieldSet(parsed, "arp") || fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
-		return nil, fmt.Errorf("bad flow %q (specified nw_src/nw_dst without ip/arp/tcp/udp)", flow)
-	}
-	if (fieldSet(parsed, "arp_spa") || fieldSet(parsed, "arp_tpa") || fieldSet(parsed, "arp_sha") || fieldSet(parsed, "arp_tha")) && !fieldSet(parsed, "arp") {
-		return nil, fmt.Errorf("bad flow %q (specified arp_spa/arp_tpa/arp_sha/arp_tpa without arp)", flow)
-	}
-	if (fieldSet(parsed, "tcp_src") || fieldSet(parsed, "tcp_dst")) && !fieldSet(parsed, "tcp") {
-		return nil, fmt.Errorf("bad flow %q (specified tcp_src/tcp_dst without tcp)", flow)
-	}
-	if (fieldSet(parsed, "udp_src") || fieldSet(parsed, "udp_dst")) && !fieldSet(parsed, "udp") {
-		return nil, fmt.Errorf("bad flow %q (specified udp_src/udp_dst without udp)", flow)
-	}
-	if (fieldSet(parsed, "tp_src") || fieldSet(parsed, "tp_dst")) && !(fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
-		return nil, fmt.Errorf("bad flow %q (specified tp_src/tp_dst without tcp/udp)", flow)
-	}
-	if fieldSet(parsed, "ip_frag") && (fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
-		return nil, fmt.Errorf("bad flow %q (specified ip_frag with tcp/udp)", flow)
-	}
-
-	return parsed, nil
-}
-
-// flowMatches tests if flow matches match. If exact is true, then the table, priority,
-// and all fields much match. If exact is false, then the table and any fields specified
-// in match must match, but priority is not checked, and there can be additional fields
-// in flow that are not in match.
-func flowMatches(flow, match *ovsFlow, exact bool) bool {
-	if flow.table != match.table && (exact || match.table != 0) {
-		return false
-	}
-	if exact && flow.priority != match.priority {
-		return false
-	}
-	if exact && len(flow.fields) != len(match.fields) {
-		return false
-	}
-	if match.cookie != "" && !fieldMatches(flow.cookie, match.cookie, exact) {
-		return false
-	}
-	for _, matchField := range match.fields {
-		var flowValue *string
-		for _, flowField := range flow.fields {
-			if flowField.name == matchField.name {
-				flowValue = &flowField.value
-				break
-			}
-		}
-		if flowValue == nil || !fieldMatches(*flowValue, matchField.value, exact) {
-			return false
-		}
-	}
-	return true
-}
-
-func fieldMatches(val, match string, exact bool) bool {
-	if val == match {
-		return true
-	}
-	if exact {
-		return false
-	}
-
-	// Handle bitfield/mask matches. (Some other syntax like "10.128.0.0/14" might
-	// get examined here, but it will fail the first ParseUint call and so not
-	// reach the final check.)
-	split := strings.Split(match, "/")
-	if len(split) == 2 {
-		matchNum, err1 := strconv.ParseUint(split[0], 0, 32)
-		mask, err2 := strconv.ParseUint(split[1], 0, 32)
-		valNum, err3 := strconv.ParseUint(val, 0, 32)
-		if err1 == nil && err2 == nil && err3 == nil {
-			if (matchNum & mask) == (valNum & mask) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // sort.Interface support
-type ovsFlows []ovsFlow
+type ovsFlows []OvsFlow
 
 func (f ovsFlows) Len() int      { return len(f) }
 func (f ovsFlows) Swap(i, j int) { f[i], f[j] = f[j], f[i] }
 func (f ovsFlows) Less(i, j int) bool {
-	if f[i].table != f[j].table {
-		return f[i].table < f[j].table
+	if f[i].Table != f[j].Table {
+		return f[i].Table < f[j].Table
 	}
-	if f[i].priority != f[j].priority {
-		return f[i].priority > f[j].priority
+	if f[i].Priority != f[j].Priority {
+		return f[i].Priority > f[j].Priority
 	}
-	return f[i].created.Before(f[j].created)
+	return f[i].Created.Before(f[j].Created)
+}
+
+func fixFlowFields(flow *OvsFlow) {
+	// Fix up field names to match what dump-flows prints.  Some fields
+	// have aliases or deprecated names that can be used for add/del flows,
+	// but dump always reports the canonical name
+	if _, isArp := flow.FindField("arp"); isArp {
+		for i := range flow.Fields {
+			if flow.Fields[i].Name == "nw_src" {
+				flow.Fields[i].Name = "arp_spa"
+			} else if flow.Fields[i].Name == "nw_dst" {
+				flow.Fields[i].Name = "arp_tpa"
+			}
+		}
+	}
 }
 
 func (tx *ovsFakeTx) AddFlow(flow string, args ...interface{}) {
 	if tx.err != nil {
 		return
 	}
-	parsed, err := parseFlow(parseForAdd, flow, args...)
+	parsed, err := ParseFlow(ParseForAdd, flow, args...)
 	if err != nil {
 		tx.err = err
 		return
 	}
+	fixFlowFields(parsed)
 
 	// If there is already an exact match for this flow, then the new flow replaces it.
 	for i := range tx.fake.flows {
-		if flowMatches(&tx.fake.flows[i], parsed, true) {
+		if FlowMatches(&tx.fake.flows[i], parsed, true) {
 			tx.fake.flows[i] = *parsed
 			return
 		}
@@ -410,15 +183,16 @@ func (tx *ovsFakeTx) DeleteFlows(flow string, args ...interface{}) {
 	if tx.err != nil {
 		return
 	}
-	parsed, err := parseFlow(parseForDelete, flow, args...)
+	parsed, err := ParseFlow(ParseForDelete, flow, args...)
 	if err != nil {
 		tx.err = err
 		return
 	}
+	fixFlowFields(parsed)
 
-	newFlows := make([]ovsFlow, 0, len(tx.fake.flows))
+	newFlows := make([]OvsFlow, 0, len(tx.fake.flows))
 	for _, flow := range tx.fake.flows {
-		if !flowMatches(&flow, parsed, false) {
+		if !FlowMatches(&flow, parsed, false) {
 			newFlows = append(newFlows, flow)
 		}
 	}
@@ -438,19 +212,33 @@ func (fake *ovsFake) DumpFlows() ([]string, error) {
 
 	flows := make([]string, 0, len(fake.flows))
 	for _, flow := range fake.flows {
-		str := fmt.Sprintf(" cookie=%s, table=%d", flow.cookie, flow.table)
-		if flow.priority != defaultPriority {
-			str += fmt.Sprintf(", priority=%d", flow.priority)
+		str := fmt.Sprintf(" cookie=%s, table=%d", flow.Cookie, flow.Table)
+		if flow.Priority != defaultPriority {
+			str += fmt.Sprintf(", priority=%d", flow.Priority)
 		}
-		for _, field := range flow.fields {
-			if field.value == "" {
-				str += fmt.Sprintf(", %s", field.name)
+		for _, field := range flow.Fields {
+			if field.Value == "" {
+				str += fmt.Sprintf(", %s", field.Name)
 			} else {
-				str += fmt.Sprintf(", %s=%s", field.name, field.value)
+				str += fmt.Sprintf(", %s=%s", field.Name, field.Value)
 			}
 		}
-		if flow.actions != "" {
-			str += fmt.Sprintf(", actions=%s", flow.actions)
+		actionStr := ""
+		for _, action := range flow.Actions {
+			if len(actionStr) > 0 {
+				actionStr += ","
+			}
+			actionStr += action.Name
+			if action.Value != "" {
+				if action.Value[0] != '(' {
+					actionStr += ":" + action.Value
+				} else {
+					actionStr += action.Value
+				}
+			}
+		}
+		if len(actionStr) > 0 {
+			str += fmt.Sprintf(", actions=%s", actionStr)
 		}
 		flows = append(flows, str)
 	}

--- a/pkg/util/ovs/fake_ovs_test.go
+++ b/pkg/util/ovs/fake_ovs_test.go
@@ -38,258 +38,6 @@ func TestFakePorts(t *testing.T) {
 	}
 }
 
-type flowTest struct {
-	input string
-	match ovsFlow
-}
-
-func TestParseFlows(t *testing.T) {
-	parseTests := []flowTest{
-		{
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    0,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: "1"},
-					{name: "arp", value: ""},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-		{
-			input: "table=10, priority=0, actions=drop",
-			match: ovsFlow{
-				table:    10,
-				priority: 0,
-				fields:   []ovsField{},
-				actions:  "drop",
-			},
-		},
-		{
-			input: "table=50, priority=100, arp, nw_dst=10.128.0.0/23, actions=load:0x1234->NXM_NX_TUN_ID[0..31],set_field:172.17.0.2->tun_dst,match:1",
-			match: ovsFlow{
-				table:    50,
-				priority: 100,
-				fields: []ovsField{
-					{name: "arp", value: ""},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "load:0x1234->NXM_NX_TUN_ID[0..31],set_field:172.17.0.2->tun_dst,match:1",
-			},
-		},
-		{
-			input: "table=21, priority=100, ip, actions=ct(commit,table=30)",
-			match: ovsFlow{
-				table:    21,
-				priority: 100,
-				fields: []ovsField{
-					{name: "ip", value: ""},
-				},
-				actions: "ct(commit,table=30)",
-			},
-		},
-		{
-			// everything after actions is considered part of actions; this would be a syntax error if we actually parsed actions
-			input: "table=10, priority=0, actions=drop, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23",
-			match: ovsFlow{
-				table:    10,
-				priority: 0,
-				fields:   []ovsField{},
-				actions:  "drop, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23",
-			},
-		},
-	}
-
-	for i, test := range parseTests {
-		parsed, err := parseFlow(parseForAdd, test.input)
-		if err != nil {
-			t.Fatalf("unexpected error from parseFlow: %v", err)
-		}
-		if !flowMatches(parsed, &test.match, true) {
-			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
-		}
-	}
-}
-
-func TestParseFlowsDefaults(t *testing.T) {
-	parseTests := []flowTest{
-		{
-			// Default table is 0
-			input: "actions=drop",
-			match: ovsFlow{
-				table:    0,
-				priority: 32768,
-				fields:   []ovsField{},
-				actions:  "drop",
-			},
-		},
-	}
-
-	for i, test := range parseTests {
-		parsed, err := parseFlow(parseForAdd, test.input)
-		if err != nil {
-			t.Fatalf("unexpected error from parseFlow: %v", err)
-		}
-		if !flowMatches(parsed, &test.match, true) {
-			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
-		}
-	}
-}
-
-func TestParseFlowsBad(t *testing.T) {
-	parseTests := []flowTest{
-		{
-			// table is empty
-			input: "table=, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// table is non-numeric
-			input: "table=foo, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// table out of range
-			input: "table=-1, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// table out of range
-			input: "table=1000, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// priority is empty
-			input: "table=0, priority=, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// priority is non-numeric
-			input: "table=0, priority=high, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// priority is out of range
-			input: "table=0, priority=-1, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// priority is out of range
-			input: "table=0, priority=200000, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// field value is empty
-			input: "table=0, priority=200, in_port=, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-		{
-			// actions is empty
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=",
-		},
-		{
-			// actions is empty
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions",
-		},
-		{
-			// nw_src/nw_dst without arp/ip
-			input: "table=0, priority=200, in_port=1, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		},
-	}
-
-	for i, test := range parseTests {
-		_, err := parseFlow(parseForAdd, test.input)
-		if err == nil {
-			t.Fatalf("unexpected lack of error from parseFlow on %d %q", i, test.input)
-		}
-	}
-}
-
-func TestFlowMatchesBad(t *testing.T) {
-	parseTests := []flowTest{
-		{
-			// Table is wrong
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    10,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: "1"},
-					{name: "arp", value: ""},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-		{
-			// field value is incorrect
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    0,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: "2"},
-					{name: "arp", value: ""},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-		{
-			// present field is matched against empty field
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    0,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: ""},
-					{name: "arp", value: ""},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-		{
-			// empty field is matched against present field
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    0,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: "1"},
-					{name: "arp", value: "jean"},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-		{
-			// match field is not present in input
-			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			match: ovsFlow{
-				table:    0,
-				priority: 200,
-				fields: []ovsField{
-					{name: "in_port", value: "1"},
-					{name: "arp", value: ""},
-					{name: "nw_src", value: "10.128.0.0/14"},
-					{name: "nw_dst", value: "10.128.0.0/23"},
-					{name: "today", value: "wednesday"},
-				},
-				actions: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-			},
-		},
-	}
-
-	for i, test := range parseTests {
-		parsed, err := parseFlow(parseForAdd, test.input)
-		if err != nil {
-			t.Fatalf("unexpected error from parseFlow: %v", err)
-		}
-		if flowMatches(parsed, &test.match, false) {
-			t.Fatalf("parsed flow %d (%#v) unexpectedly matches output (%#v)", i, parsed, &test.match)
-		}
-	}
-}
-
 func TestFakeDumpFlows(t *testing.T) {
 	ovsif := NewFake("br0")
 	err := ovsif.AddBridge()
@@ -341,6 +89,7 @@ func TestFakeDumpFlows(t *testing.T) {
 	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
 	otx.AddFlow("table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120")
 	otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
+	otx.AddFlow("table=35, priority=300, ip, nw_dst=%s, actions=ct(commit,exec(set_field:1->ct_mark),table=70)", localSubnetGateway)
 
 	err = otx.EndTransaction()
 	if err != nil {
@@ -357,9 +106,9 @@ func TestFakeDumpFlows(t *testing.T) {
 		" cookie=0, table=0, priority=250, in_port=2, ip, nw_dst=224.0.0.0/4, actions=drop",
 		" cookie=0, table=0, priority=200, in_port=2, ip, actions=goto_table:30",
 		" cookie=0, table=0, priority=200, in_port=1, ip, nw_src=10.128.0.0/14, nw_dst=10.129.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		" cookie=0, table=0, priority=200, in_port=2, arp, nw_src=10.129.0.1, nw_dst=10.128.0.0/14, actions=goto_table:30",
+		" cookie=0, table=0, priority=200, in_port=2, arp, arp_spa=10.129.0.1, arp_tpa=10.128.0.0/14, actions=goto_table:30",
 		" cookie=0, table=0, priority=200, in_port=1, ip, nw_src=10.128.0.0/14, nw_dst=224.0.0.0/4, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-		" cookie=0, table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.129.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		" cookie=0, table=0, priority=200, in_port=1, arp, arp_spa=10.128.0.0/14, arp_tpa=10.129.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
 		" cookie=0, table=0, priority=150, in_port=2, actions=drop",
 		" cookie=0, table=0, priority=150, in_port=1, actions=drop",
 		" cookie=0, table=0, priority=100, arp, actions=goto_table:20",
@@ -368,17 +117,18 @@ func TestFakeDumpFlows(t *testing.T) {
 		" cookie=0, table=10, priority=0, actions=drop",
 		" cookie=0, table=20, priority=0, actions=drop",
 		" cookie=0, table=21, priority=0, actions=goto_table:30",
-		" cookie=0, table=30, priority=300, arp, nw_dst=10.129.0.1, actions=output:2",
+		" cookie=0, table=30, priority=300, arp, arp_tpa=10.129.0.1, actions=output:2",
 		" cookie=0, table=30, priority=300, ip, nw_dst=10.129.0.1, actions=output:2",
-		" cookie=0, table=30, priority=200, arp, nw_dst=10.129.0.0/23, actions=goto_table:40",
+		" cookie=0, table=30, priority=200, arp, arp_tpa=10.129.0.0/23, actions=goto_table:40",
 		" cookie=0, table=30, priority=200, ip, nw_dst=10.129.0.0/23, actions=goto_table:70",
 		" cookie=0, table=30, priority=100, ip, nw_dst=172.30.0.0/16, actions=goto_table:60",
 		" cookie=0, table=30, priority=100, ip, nw_dst=10.128.0.0/14, actions=goto_table:90",
-		" cookie=0, table=30, priority=100, arp, nw_dst=10.128.0.0/14, actions=goto_table:50",
+		" cookie=0, table=30, priority=100, arp, arp_tpa=10.128.0.0/14, actions=goto_table:50",
 		" cookie=0, table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120",
 		" cookie=0, table=30, priority=25, ip, nw_dst=224.0.0.0/4, actions=goto_table:110",
 		" cookie=0, table=30, priority=0, arp, actions=drop",
 		" cookie=0, table=30, priority=0, ip, actions=goto_table:100",
+		" cookie=0, table=35, priority=300, ip, nw_dst=10.129.0.1, actions=ct(commit,exec(set_field:1->ct_mark),table=70)",
 		" cookie=0, table=40, priority=0, actions=drop",
 		" cookie=0, table=50, priority=0, actions=drop",
 		" cookie=0, table=60, priority=200, reg0=0, actions=output:2",

--- a/pkg/util/ovs/parse.go
+++ b/pkg/util/ovs/parse.go
@@ -1,0 +1,352 @@
+package ovs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ovsFlow represents an OVS flow
+type OvsFlow struct {
+	Table    int
+	Priority int
+	Created  time.Time
+	Cookie   string
+	Fields   []OvsField
+	Actions  []OvsField
+}
+
+type OvsField struct {
+	Name  string
+	Value string
+}
+
+const (
+	minPriority     = 0
+	defaultPriority = 32768
+	maxPriority     = 65535
+)
+
+type ParseCmd string
+
+const (
+	ParseForAdd    ParseCmd = "add-flow"
+	ParseForDelete ParseCmd = "del-flows"
+	ParseForDump   ParseCmd = "dump-flows"
+)
+
+func fieldSet(parsed *OvsFlow, field string) bool {
+	for _, f := range parsed.Fields {
+		if f.Name == field {
+			return true
+		}
+	}
+	return false
+}
+
+func checkNotAllowedField(flow string, parsed *OvsFlow, field string, cmd ParseCmd) error {
+	if fieldSet(parsed, field) {
+		return fmt.Errorf("bad flow %q (field %q not allowed in %s)", flow, field, cmd)
+	}
+	return nil
+}
+
+func checkUnimplementedField(flow string, parsed *OvsFlow, field string) error {
+	if fieldSet(parsed, field) {
+		return fmt.Errorf("bad flow %q (field %q not implemented)", flow, field)
+	}
+	return nil
+}
+
+func actionToOvsField(action string) (*OvsField, error) {
+	if action == "" {
+		return nil, fmt.Errorf("cannot make field from empty action")
+	}
+	sep := strings.IndexAny(action, ":(")
+	if sep == -1 {
+		return &OvsField{Name: strings.TrimSpace(action)}, nil
+	} else if sep == len(action)-1 {
+		return nil, fmt.Errorf("action %q has no value", action)
+	}
+	return &OvsField{
+		Name:  strings.TrimSpace(action[:sep]),
+		Value: strings.Trim(action[sep:], ": "),
+	}, nil
+}
+
+func parseActions(actions string) ([]OvsField, error) {
+	fields := make([]OvsField, 0)
+	var parenLevel, braceLevel, idx int
+	origActions := actions
+	for actions != "" {
+		token := strings.IndexAny(actions[idx:], ",([])")
+		if token == -1 {
+			if parenLevel > 0 {
+				return nil, fmt.Errorf("mismatched parentheses in actions %q", origActions)
+			} else if braceLevel > 0 {
+				return nil, fmt.Errorf("mismatched braces in actions %q", origActions)
+			}
+			field, err := actionToOvsField(actions)
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, *field)
+			break
+		}
+		idx += token
+
+		switch actions[idx] {
+		case ',':
+			if parenLevel == 0 && braceLevel == 0 {
+				field, err := actionToOvsField(actions[:idx])
+				if err != nil {
+					return nil, err
+				}
+				fields = append(fields, *field)
+				actions = actions[idx+1:]
+				idx = 0
+			}
+		case '(':
+			parenLevel += 1
+		case '[':
+			braceLevel += 1
+		case ')':
+			parenLevel -= 1
+			if parenLevel < 0 {
+				return nil, fmt.Errorf("mismatched parentheses in actions %q", origActions)
+			}
+		case ']':
+			braceLevel -= 1
+			if braceLevel < 0 {
+				return nil, fmt.Errorf("mismatched braces in actions %q", origActions)
+			}
+		}
+		// Advance past token
+		idx += 1
+	}
+	return fields, nil
+}
+
+func findField(name string, fields *[]OvsField) (*OvsField, bool) {
+	for _, f := range *fields {
+		if f.Name == name {
+			return &f, true
+		}
+	}
+	return nil, false
+}
+
+func (of *OvsFlow) FindField(name string) (*OvsField, bool) {
+	return findField(name, &of.Fields)
+}
+
+func (of *OvsFlow) FindAction(name string) (*OvsField, bool) {
+	return findField(name, &of.Actions)
+}
+
+func (of *OvsFlow) NoteHasPrefix(prefix string) bool {
+	note, ok := of.FindAction("note")
+	return ok && strings.HasPrefix(strings.ToLower(note.Value), strings.ToLower(prefix))
+}
+
+func ParseFlow(cmd ParseCmd, flow string, args ...interface{}) (*OvsFlow, error) {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+
+	// According to the man page, "flow descriptions comprise a series of field=value
+	// assignments, separated by commas or white space." However, you can also have
+	// fields with no value (eg, "ip"), and the "actions" field can also have internal
+	// commas, whitespace, and equals signs (but if it is present, it must be the
+	// last field specified).
+
+	actions := ""
+
+	parsed := &OvsFlow{
+		Table:    0,
+		Priority: defaultPriority,
+		Fields:   make([]OvsField, 0),
+		Actions:  make([]OvsField, 0),
+		Created:  time.Now(),
+		Cookie:   "0",
+	}
+	flow = strings.Trim(flow, " ")
+	origFlow := flow
+	for flow != "" {
+		field := ""
+		value := ""
+
+		end := strings.IndexAny(flow, ", ")
+		if end == -1 {
+			end = len(flow)
+		}
+		eq := strings.Index(flow, "=")
+		if eq == -1 || eq > end {
+			field = flow[:end]
+		} else {
+			field = flow[:eq]
+			if field == "actions" {
+				end = len(flow)
+				value = flow[eq+1:]
+			} else {
+				valueEnd := end - 1
+				for flow[valueEnd] == ' ' || flow[valueEnd] == ',' {
+					valueEnd--
+				}
+				value = strings.Trim(flow[eq+1:end], ", ")
+			}
+			if value == "" {
+				return nil, fmt.Errorf("bad flow definition %q (empty field %q)", origFlow, field)
+			}
+		}
+
+		switch field {
+		case "table":
+			table, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("bad flow %q (bad table number %q)", origFlow, value)
+			} else if table < 0 || table > 255 {
+				return nil, fmt.Errorf("bad flow %q (table number %q out of range)", origFlow, value)
+			}
+			parsed.Table = table
+		case "priority":
+			priority, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("bad flow %q (bad priority %q)", origFlow, value)
+			} else if priority < minPriority || priority > maxPriority {
+				return nil, fmt.Errorf("bad flow %q (priority %q out of range)", origFlow, value)
+			}
+			parsed.Priority = priority
+		case "actions":
+			actions = value
+		case "cookie":
+			parsed.Cookie = value
+		default:
+			parsed.Fields = append(parsed.Fields, OvsField{field, value})
+		}
+
+		for end < len(flow) && (flow[end] == ',' || flow[end] == ' ') {
+			end++
+		}
+		flow = flow[end:]
+	}
+
+	if actions != "" {
+		var err error
+		parsed.Actions, err = parseActions(actions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sanity-checking
+	switch cmd {
+	case ParseForDump:
+		fallthrough
+	case ParseForAdd:
+		if err := checkNotAllowedField(flow, parsed, "out_port", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkNotAllowedField(flow, parsed, "out_group", cmd); err != nil {
+			return nil, err
+		}
+
+		if len(parsed.Actions) == 0 {
+			return nil, fmt.Errorf("bad flow %q (empty actions)", flow)
+		}
+	case ParseForDelete:
+		if err := checkNotAllowedField(flow, parsed, "priority", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkNotAllowedField(flow, parsed, "actions", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkUnimplementedField(flow, parsed, "out_port"); err != nil {
+			return nil, err
+		}
+		if err := checkUnimplementedField(flow, parsed, "out_group"); err != nil {
+			return nil, err
+		}
+	}
+
+	if (fieldSet(parsed, "nw_src") || fieldSet(parsed, "nw_dst")) &&
+		!(fieldSet(parsed, "ip") || fieldSet(parsed, "arp") || fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified nw_src/nw_dst without ip/arp/tcp/udp)", flow)
+	}
+	if (fieldSet(parsed, "arp_spa") || fieldSet(parsed, "arp_tpa") || fieldSet(parsed, "arp_sha") || fieldSet(parsed, "arp_tha")) && !fieldSet(parsed, "arp") {
+		return nil, fmt.Errorf("bad flow %q (specified arp_spa/arp_tpa/arp_sha/arp_tpa without arp)", flow)
+	}
+	if (fieldSet(parsed, "tcp_src") || fieldSet(parsed, "tcp_dst")) && !fieldSet(parsed, "tcp") {
+		return nil, fmt.Errorf("bad flow %q (specified tcp_src/tcp_dst without tcp)", flow)
+	}
+	if (fieldSet(parsed, "udp_src") || fieldSet(parsed, "udp_dst")) && !fieldSet(parsed, "udp") {
+		return nil, fmt.Errorf("bad flow %q (specified udp_src/udp_dst without udp)", flow)
+	}
+	if (fieldSet(parsed, "tp_src") || fieldSet(parsed, "tp_dst")) && !(fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified tp_src/tp_dst without tcp/udp)", flow)
+	}
+	if fieldSet(parsed, "ip_frag") && (fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified ip_frag with tcp/udp)", flow)
+	}
+
+	return parsed, nil
+}
+
+// flowMatches tests if flow matches match. If exact is true, then the table, priority,
+// and all fields much match. If exact is false, then the table and any fields specified
+// in match must match, but priority is not checked, and there can be additional fields
+// in flow that are not in match.
+func FlowMatches(flow, match *OvsFlow, exact bool) bool {
+	if flow.Table != match.Table && (exact || match.Table != 0) {
+		return false
+	}
+	if exact && flow.Priority != match.Priority {
+		return false
+	}
+	if exact && len(flow.Fields) != len(match.Fields) {
+		return false
+	}
+	if match.Cookie != "" && !fieldMatches(flow.Cookie, match.Cookie, exact) {
+		return false
+	}
+	for _, matchField := range match.Fields {
+		var flowValue *string
+		for _, flowField := range flow.Fields {
+			if flowField.Name == matchField.Name {
+				flowValue = &flowField.Value
+				break
+			}
+		}
+		if flowValue == nil || !fieldMatches(*flowValue, matchField.Value, exact) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldMatches(val, match string, exact bool) bool {
+	if val == match {
+		return true
+	}
+	if exact {
+		return false
+	}
+
+	// Handle bitfield/mask matches. (Some other syntax like "10.128.0.0/14" might
+	// get examined here, but it will fail the first ParseUint call and so not
+	// reach the final check.)
+	split := strings.Split(match, "/")
+	if len(split) == 2 {
+		matchNum, err1 := strconv.ParseUint(split[0], 0, 32)
+		mask, err2 := strconv.ParseUint(split[1], 0, 32)
+		valNum, err3 := strconv.ParseUint(val, 0, 32)
+		if err1 == nil && err2 == nil && err3 == nil {
+			if (matchNum & mask) == (valNum & mask) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/ovs/parse_test.go
+++ b/pkg/util/ovs/parse_test.go
@@ -1,0 +1,429 @@
+package ovs
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type flowTest struct {
+	input string
+	match OvsFlow
+}
+
+func TestParseFlows(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			input: "table=10, priority=0, actions=drop",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 0,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+				},
+			},
+		},
+		{
+			input: "table=50, priority=100, arp, nw_dst=10.128.0.0/23, actions=load:0x1234->NXM_NX_TUN_ID[0..31],set_field:172.17.0.2->tun_dst,match:1",
+			match: OvsFlow{
+				Table:    50,
+				Priority: 100,
+				Fields: []OvsField{
+					{Name: "arp", Value: ""},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "load", Value: "0x1234->NXM_NX_TUN_ID[0..31]"},
+					{Name: "set_field", Value: "172.17.0.2->tun_dst"},
+					{Name: "match", Value: "1"},
+				},
+			},
+		},
+		{
+			input: "table=21, priority=100, ip, actions=ct(commit,table=30)",
+			match: OvsFlow{
+				Table:    21,
+				Priority: 100,
+				Fields: []OvsField{
+					{Name: "ip", Value: ""},
+				},
+				Actions: []OvsField{
+					{Name: "ct(commit,table=30)"},
+				},
+			},
+		},
+		{
+			// everything after actions is considered part of actions; this would be a syntax error if we actually parsed actions
+			input: "table=10, priority=0, actions=drop, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 0,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+					{Name: "in_port=1"},
+					{Name: "arp"},
+					{Name: "nw_src=10.128.0.0/14"},
+					{Name: "nw_dst=10.128.0.0/23"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if !FlowMatches(parsed, &test.match, true) {
+			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseFlowsDefaults(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// Default table is 0
+			input: "actions=drop",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 32768,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if !FlowMatches(parsed, &test.match, true) {
+			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseFlowsBad(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// table is empty
+			input: "table=, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table is non-numeric
+			input: "table=foo, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table out of range
+			input: "table=-1, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table out of range
+			input: "table=1000, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is empty
+			input: "table=0, priority=, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is non-numeric
+			input: "table=0, priority=high, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is out of range
+			input: "table=0, priority=-1, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is out of range
+			input: "table=0, priority=200000, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// field value is empty
+			input: "table=0, priority=200, in_port=, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// actions is empty
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=",
+		},
+		{
+			// actions is empty
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions",
+		},
+		{
+			// nw_src/nw_dst without arp/ip
+			input: "table=0, priority=200, in_port=1, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+	}
+
+	for i, test := range parseTests {
+		_, err := ParseFlow(ParseForAdd, test.input)
+		if err == nil {
+			t.Fatalf("unexpected lack of error from ParseFlow on %d %q", i, test.input)
+		}
+	}
+}
+
+func TestFlowMatchesBad(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// Table is wrong
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// field value is incorrect
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "2"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// present field is matched against empty field
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: ""},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// empty field is matched against present field
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: "jean"},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// match field is not present in input
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+					{Name: "today", Value: "wednesday"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if FlowMatches(parsed, &test.match, false) {
+			t.Fatalf("parsed flow %d (%#v) unexpectedly matches output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseActions(t *testing.T) {
+	parseTests := []struct {
+		input  string
+		match  []OvsField
+		errStr string
+	}{
+		{
+			input: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: []OvsField{
+				{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+				{Name: "goto_table", Value: "10"},
+			},
+		},
+		{
+			input: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],ct(commit,table=30),goto_table:10",
+			match: []OvsField{
+				{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+				{Name: "ct", Value: "(commit,table=30)"},
+				{Name: "goto_table", Value: "10"},
+			},
+		},
+		{
+			// Test that spaces are stripped from name/value
+			input: "load:4->NXM_NX_REG0[], note:adsfasdfasdf, goto_table:21",
+			match: []OvsField{
+				{Name: "load", Value: "4->NXM_NX_REG0[]"},
+				{Name: "note", Value: "adsfasdfasdf"},
+				{Name: "goto_table", Value: "21"},
+			},
+		},
+		{
+			input: "ct(commit,exec(set_field:1->ct_mark),table=70)",
+			match: []OvsField{
+				{Name: "ct", Value: "(commit,exec(set_field:1->ct_mark),table=70)"},
+			},
+		},
+		{
+			input: "drop",
+			match: []OvsField{
+				{Name: "drop"},
+			},
+		},
+		{
+			input: "goto_table:30",
+			match: []OvsField{
+				{Name: "goto_table", Value: "30"},
+			},
+		},
+		{
+			input:  "move:NXM_NX_TUN_ID[0..31]]]],goto_table:10",
+			errStr: "mismatched braces in actions",
+		},
+		{
+			input:  "move:NXM_NX_TUN_ID[[[[[0..31],goto_table:10",
+			errStr: "mismatched braces in actions",
+		},
+		{
+			input:  "ct(commit,table=30))))),goto_table:10",
+			errStr: "mismatched parentheses in action",
+		},
+		{
+			input:  "ct(((((commit,table=30),goto_table:10",
+			errStr: "mismatched parentheses in action",
+		},
+		{
+			input:  "goto_table:",
+			errStr: "has no value",
+		},
+		{
+			input:  ",,",
+			errStr: "cannot make field from empty action",
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := parseActions(test.input)
+		if err != nil {
+			if test.errStr != "" && !strings.Contains(err.Error(), test.errStr) {
+				t.Fatalf("unexpected error from parseActions: %v", err)
+			}
+		} else if test.errStr != "" {
+			t.Fatalf("expected error %q from parseActions", test.errStr)
+		}
+		if !reflect.DeepEqual(parsed, test.match) {
+			t.Fatalf("parsed action %d (%#v) does not match expected output (%#v)", i, parsed, test.match)
+		}
+	}
+}
+
+func TestMatchNote(t *testing.T) {
+	noteTests := []struct {
+		input   string
+		prefix  string
+		success bool
+		errStr  string
+	}{
+		{
+			// Prefix match
+			input:   "table=10,actions=note:00.33.22.33.00.00.00",
+			prefix:  "00.33.22.33.00",
+			success: true,
+		},
+		{
+			input:   "table=10,actions=note:00.33.22.33.00.00.00",
+			prefix:  "00.bb.dd.ee",
+			success: false,
+		},
+		{
+			// Case insensitive match
+			input:   "table=10,actions=note:00.aA.Aa.bB.Bb.00.00",
+			prefix:  "00.aa.aa.bb.bb.00",
+			success: true,
+		},
+		{
+			// missing note
+			input:   "table=10,actions=goto_table:50",
+			prefix:  "00.aa.aa.bb.bb.00",
+			success: false,
+		},
+	}
+
+	for i, test := range noteTests {
+		flow, err := ParseFlow(ParseForDump, test.input)
+		if err != nil {
+			if test.errStr != "" && !strings.Contains(err.Error(), test.errStr) {
+				t.Fatalf("unexpected error from ParseFlow: %v", err)
+			}
+		} else if test.errStr != "" {
+			t.Fatalf("expected error %q from ParseFlow", test.errStr)
+		}
+		if success := flow.NoteHasPrefix(test.prefix); success != test.success {
+			t.Fatalf("note prefix %d success (%v) does not match expected success (%v)", i, success, test.success)
+		}
+	}
+}


### PR DESCRIPTION
With the move to CRI, we don't get a Docker runtime from which we
can grab the container's NetNS on update.  But we don't actually
need one, we can scrape OVS flows and grab the required details
from there.

The one downside is that if OpenShift crashed before pod flows
were added, we cannot read the pod details on restart, and the pod
will be left "ready" (because Docker started it) but with broken
networking (because we can't fix it), but that's something that
should be fixed upstream by ensuring that pods which have not
successfully completed network setup are not considered "ready"
by the runtime.

@openshift/networking @danwinship 

Fixes: https://trello.com/c/IP58IhfF/504-fix-pod-update-after-kube-16-rebase