### PR TITLE
Fixes oc status for external name svc

### DIFF
--- a/pkg/api/graph/test/external-name-service.json
+++ b/pkg/api/graph/test/external-name-service.json
@@ -1,0 +1,30 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "external-name-service",
+        "creationTimestamp": null,
+        "labels": {
+          "template": "external-name-service"
+        }
+      },
+      "spec": {
+        "externalName": "external.com",
+        "ports": null,
+       "selector": {
+          "name": "external-name-service"
+        },
+        "type": "ExternalName",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -1154,6 +1154,7 @@ func describeDeploymentConfigTriggers(config *deployapi.DeploymentConfig) (strin
 func describeServiceInServiceGroup(f formatter, svc graphview.ServiceGroup, exposed ...string) []string {
 	spec := svc.Service.Spec
 	ip := spec.ClusterIP
+	externalName := spec.ExternalName
 	port := describeServicePorts(spec)
 	switch {
 	case len(exposed) > 1:
@@ -1164,8 +1165,10 @@ func describeServiceInServiceGroup(f formatter, svc graphview.ServiceGroup, expo
 		return []string{fmt.Sprintf("%s (all nodes)%s", f.ResourceName(svc.Service), port)}
 	case ip == "None":
 		return []string{fmt.Sprintf("%s (headless)%s", f.ResourceName(svc.Service), port)}
-	case len(ip) == 0:
+	case len(ip) == 0 && len(externalName) == 0:
 		return []string{fmt.Sprintf("%s <initializing>%s", f.ResourceName(svc.Service), port)}
+	case len(ip) == 0:
+		return []string{fmt.Sprintf("%s - %s", f.ResourceName(svc.Service), externalName)}
 	default:
 		return []string{fmt.Sprintf("%s - %s%s", f.ResourceName(svc.Service), ip, port)}
 	}

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -84,6 +84,20 @@ func TestProjectStatus(t *testing.T) {
 				"View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.",
 			},
 		},
+		"external name service": {
+			File: "external-name-service.json",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example on server https://example.com:8443\n",
+				"svc/external-name-service - external.com",
+				"View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.",
+			},
+		},
 		"rc with unmountable and missing secrets": {
 			File: "bad_secret_with_just_rc.yaml",
 			Extra: []runtime.Object{


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14269

```
$ oc status
In project My Project (myproject) on server https://127.0.0.1:8443

svc/my-svc - yo.com

View details with 'oc describe <resource>/<name>' or list everything with 'oc get all'.

```

@smarterclayton ptal