### PR TITLE
base-images: Use https for yum repo

### DIFF
--- a/images/source/centos-paas-sig-openshift-origin36.repo
+++ b/images/source/centos-paas-sig-openshift-origin36.repo
@@ -1,6 +1,6 @@
 [centos-paas-sig-openshift-origin36]
 name = CentOS PaaS SIG Origin 3.6 Repository
-baseurl = http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
+baseurl = https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/
 enabled = 1
 gpgcheck = 0
 sslverify = 0


### PR DESCRIPTION
buildlogs.centos.org is now on https.  yum failed to follow the
http to https redirect, so change the URL to https to avoid the redirect:

```
./hack/build-base-images.sh
--> FROM openshift/origin-source
--> RUN INSTALL_PKGS="bsdtar ceph-common device-mapper device-mapper-persistent-data e2fsprogs epel-release ethtool findutils git hostname iptables lsof nmap-ncat socat sysvinit-tools tar tree util-linux wget which xfsprogs" &&     yum --disablerepo=origin-local-release install -y ${INSTALL_PKGS} &&     rpm -V ${INSTALL_PKGS} &&     yum clean all &&     mkdir -p /var/lib/origin
Loaded plugins: fastestmirror, ovl
http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/repodata/repomd.xml: [Errno 14] HTTPS Error 302 - Found
Trying other mirror.


 One of the configured repositories failed (CentOS PaaS SIG Origin 3.6 Repository),
...
            yum-config-manager --save --setopt=centos-paas-sig-openshift-origin36.skip_if_unavailable=true

failure: repodata/repomd.xml from centos-paas-sig-openshift-origin36: [Errno 256] No more mirrors to try.
http://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin36/repodata/repomd.xml: [Errno 14] HTTPS Error 302 - Found
```