### PR TITLE
Fix Services-vs-NetworkPolicy

### DIFF
--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -23,6 +23,11 @@ RUN dnf -y update && dnf -y install\
  iptables-services\
  openvswitch
 
+# Upgrade to a newer OVS. (This can go away when the base image is upgraded to F26.)
+RUN dnf -y install dnf-plugins-core &&\
+ dnf -y copr enable danw/origin-dind-ovs &&\
+ dnf -y update openvswitch
+
 # A default deny firewall (either iptables or firewalld) is
 # installed by default on non-cloud fedora and rhel, so all
 # network plugins need to be able to work with one enabled.

--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -234,15 +234,10 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 		return nil, err
 	}
 
-	// Initialize SDN before building kubelet config so it can modify options
-	iptablesSyncPeriod, err := time.ParseDuration(options.IPTablesSyncPeriod)
-	if err != nil {
-		return nil, fmt.Errorf("Cannot parse the provided ip-tables sync period (%s) : %v", options.IPTablesSyncPeriod, err)
-	}
-
 	internalKubeInformers := kinternalinformers.NewSharedInformerFactory(kubeClient, proxyconfig.ConfigSyncPeriod)
 
-	sdnPlugin, err := sdnplugin.NewNodePlugin(options.NetworkConfig.NetworkPluginName, originClient, kubeClient, options.NodeName, options.NodeIP, iptablesSyncPeriod, options.NetworkConfig.MTU, internalKubeInformers)
+	// Initialize SDN before building kubelet config so it can modify option
+	sdnPlugin, err := sdnplugin.NewNodePlugin(options.NetworkConfig.NetworkPluginName, originClient, kubeClient, internalKubeInformers, options.NodeName, options.NodeIP, options.NetworkConfig.MTU, proxyconfig.KubeProxyConfiguration)
 	if err != nil {
 		return nil, fmt.Errorf("SDN initialization failed: %v", err)
 	}

--- a/pkg/sdn/plugin/ovscontroller.go
+++ b/pkg/sdn/plugin/ovscontroller.go
@@ -18,8 +18,9 @@ import (
 )
 
 type ovsController struct {
-	ovs      ovs.Interface
-	pluginId int
+	ovs          ovs.Interface
+	pluginId     int
+	useConnTrack bool
 }
 
 const (
@@ -28,13 +29,13 @@ const (
 	VXLAN = "vxlan0"
 
 	// rule versioning; increment each time flow rules change
-	VERSION = 3
+	VERSION = 4
 
 	VERSION_TABLE = 253
 )
 
-func NewOVSController(ovsif ovs.Interface, pluginId int) *ovsController {
-	return &ovsController{ovs: ovsif, pluginId: pluginId}
+func NewOVSController(ovsif ovs.Interface, pluginId int, useConnTrack bool) *ovsController {
+	return &ovsController{ovs: ovsif, pluginId: pluginId, useConnTrack: useConnTrack}
 }
 
 func (oc *ovsController) getVersionNote() string {
@@ -81,12 +82,19 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localS
 
 	otx := oc.ovs.NewTransaction()
 	// Table 0: initial dispatch based on in_port
+	if oc.useConnTrack {
+		otx.AddFlow("table=0, priority=300, ip, ct_state=-trk, actions=ct(table=0)")
+	}
 	// vxlan0
 	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
 	otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
 	otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, nw_dst=224.0.0.0/4, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR)
 	otx.AddFlow("table=0, priority=150, in_port=1, actions=drop")
 	// tun0
+	if oc.useConnTrack {
+		otx.AddFlow("table=0, priority=400, in_port=2, ip, nw_src=%s, actions=goto_table:30", localSubnetGateway)
+		otx.AddFlow("table=0, priority=300, in_port=2, ip, nw_src=%s, nw_dst=%s, actions=goto_table:25", localSubnetCIDR, clusterNetworkCIDR)
+	}
 	otx.AddFlow("table=0, priority=250, in_port=2, ip, nw_dst=224.0.0.0/4, actions=drop")
 	otx.AddFlow("table=0, priority=200, in_port=2, arp, nw_src=%s, nw_dst=%s, actions=goto_table:30", localSubnetGateway, clusterNetworkCIDR)
 	otx.AddFlow("table=0, priority=200, in_port=2, ip, actions=goto_table:30")
@@ -109,12 +117,21 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localS
 	// Table 21: from OpenShift container; NetworkPolicy plugin uses this for connection tracking
 	otx.AddFlow("table=21, priority=0, actions=goto_table:30")
 
+	if oc.useConnTrack {
+		// Table 25: IP from OpenShift container via Service IP; reload tenant-id; filled in by openshift-sdn-ovs
+		// eg, "table=25, priority=100, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:30"
+		otx.AddFlow("table=25, priority=0, actions=drop")
+	}
+
 	// Table 30: general routing
 	otx.AddFlow("table=30, priority=300, arp, nw_dst=%s, actions=output:2", localSubnetGateway)
 	otx.AddFlow("table=30, priority=200, arp, nw_dst=%s, actions=goto_table:40", localSubnetCIDR)
 	otx.AddFlow("table=30, priority=100, arp, nw_dst=%s, actions=goto_table:50", clusterNetworkCIDR)
 	otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:60", serviceNetworkCIDR)
+	if oc.useConnTrack {
+		otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, ct_state=+rpl, actions=ct(nat),goto_table:70", localSubnetCIDR)
+	}
 	otx.AddFlow("table=30, priority=200, ip, nw_dst=%s, actions=goto_table:70", localSubnetCIDR)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:90", clusterNetworkCIDR)
 
@@ -134,9 +151,14 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localS
 	// eg, "table=50, priority=100, arp, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
 	otx.AddFlow("table=50, priority=0, actions=drop")
 
-	// Table 60: IP to service: vnid/port mappings; filled in by AddServiceRules()
-	otx.AddFlow("table=60, priority=200, reg0=0, actions=output:2")
-	// eg, "table=60, priority=100, reg0=${tenant_id}, ${service_proto}, nw_dst=${service_ip}, tp_dst=${service_port}, actions=load:${tenant_id}->NXM_NX_REG1[], load:2->NXM_NX_REG2[], goto_table:80"
+	// Table 60: IP to service from pod
+	if oc.useConnTrack {
+		otx.AddFlow("table=60, priority=200, actions=output:2")
+	} else {
+		otx.AddFlow("table=60, priority=200, reg0=0, actions=output:2")
+		// vnid/port mappings; filled in by AddServiceRules()
+		// eg, "table=60, priority=100, reg0=${tenant_id}, ${service_proto}, nw_dst=${service_ip}, tp_dst=${service_port}, actions=load:${tenant_id}->NXM_NX_REG1[], load:2->NXM_NX_REG2[], goto_table:80"
+	}
 	otx.AddFlow("table=60, priority=0, actions=drop")
 
 	// Table 70: IP to local container: vnid/port mappings; filled in by setupPodFlows
@@ -193,6 +215,9 @@ func (oc *ovsController) setupPodFlows(ofport int, podIP, podMAC, note string, v
 	// ARP/IP traffic from container
 	otx.AddFlow("table=20, priority=100, in_port=%d, arp, nw_src=%s, arp_sha=%s, actions=load:%d->NXM_NX_REG0[], note:%s, goto_table:21", ofport, podIP, podMAC, vnid, note)
 	otx.AddFlow("table=20, priority=100, in_port=%d, ip, nw_src=%s, actions=load:%d->NXM_NX_REG0[], goto_table:21", ofport, podIP, vnid)
+	if oc.useConnTrack {
+		otx.AddFlow("table=25, priority=100, ip, nw_src=%s, actions=load:%d->NXM_NX_REG0[], goto_table:30", podIP, vnid)
+	}
 
 	// ARP request/response to container (not isolated)
 	otx.AddFlow("table=40, priority=100, arp, nw_dst=%s, actions=output:%d", podIP, ofport)


### PR DESCRIPTION
This fixes the "you can't use service IPs to connect to a pod if that connection is only allowed by a NetworkPolicy with a podSelector" bug, by making it so that we don't masquerade pod->service connections when using the networkpolicy plugin, so that we can do the policy checks *after* the service IP rewrite rather than before like we do now (and like we do in the multitenant plugin).

----

To recap: suppose pod 1 (10.128.0.2) wants to connect to service 172.30.99.99:1234, which is implemented by pod 2 (10.128.0.3) on port 80. If we just used kubernetes' default masquerading rules, we'd get:

- pod1 sends a SYN 10.128.0.2:49152 -> 172.30.99.99:1234
- ovs outputs it to tun0 because 172.30.99.99 is not in the cluster network
- iptables DNATs the packet to 10.128.0.3:80
- the packet is then routed back to tun0 because of the new dest IP
- ovs outputs it to pod2
- pod2 then responds with an ACK 10.128.0.3:80 -> 10.128.0.2:49152
- ovs outputs it to pod1
- pod1 rejects the packet because it doesn't have a pending SYN to 10.128.0.3:80

So we add another iptables rule, causing the packet to get masqueraded:

- pod1 sends a SYN 10.128.0.2:49152 -> 172.30.99.99:1234
- ovs outputs it to tun0 because 172.30.99.99 is not in the cluster network
- **iptables masquerades the packet**, making it **10.128.0.1:9999** -> 10.128.0.3:80
- the packet is then routed back to tun0 because of the new dest IP
- ovs outputs it to pod2
- pod2 then responds with an ACK 10.128.0.3:80 -> **10.128.0.1:9999**
- **ovs outputs it to tun0** (because it's addressed to the node)
- **iptables unmasquerades the packet**, making it 172.30.99.99:1234 -> 10.128.0.2:49152
- **the packet is routed back to tun0** because of the new dest IP
- **ovs outputs it to pod1**
- **pod1 accepts the packet** and continues the TCP handshake

The original plan was to change this to:

- pod1 sends a SYN 10.128.0.2:49152 -> 172.30.99.99:1234
- ovs outputs it to tun0 because 172.30.99.99 is not in the cluster network
- iptables **DNATs** the packet to 10.128.0.3:80
- the packet is then routed back to tun0 because of the new dest IP
- ovs outputs it to pod2
- pod2 then responds with an ACK 10.128.0.3:80 -> **10.128.0.2:49152**
- **ovs bounces the packet to tun0** because it knows, via conntrack state, that the packet needs to be un-DNATted
- iptables **un-DNATs** the packet, making it 172.30.99.99:1234 -> 10.128.0.2:49152
- the packet is routed back to tun0 because of the new dest IP
- ovs outputs it to pod1
- pod1 accepts the packet and continues the TCP handshake

But we were never able to get that to work right. Eventually we settled on:

- pod1 sends a SYN 10.128.0.2:49152 -> 172.30.99.99:1234
- ovs outputs it to tun0 because 172.30.99.99 is not in the cluster network
- iptables DNATs the packet to 10.128.0.3:80
- the packet is then routed back to tun0 because of the new dest IP
- ovs outputs it to pod2
- pod2 then responds with an ACK 10.128.0.3:80 -> 10.128.0.2:49152
- **ovs un-DNATs the packet itself**, via `actions=ct(nat)`, making it 172.30.99.99:1234 -> 10.128.0.2:49152
- ovs outputs it to pod1
- pod1 accepts the packet and continues the TCP handshake

----

After discussion in the scrum yesterday, this only changes the masquerading behavior when using the networkpolicy plugin; we'll change it for subnet/multitenant in 3.7 after the code has gotten a little more testing.

Also, there is one piece missing here: if you use this with the userspace proxier, then all pod->service connections will be allowed, even if they shouldn't be; this is because we no longer check the policy before passing the connection to the proxier, and when it comes back, if you're using the userspace proxier, the source IP will be the node's IP, and in that case we'll accept it unconditionally (because you have to do that, in order for health checks to work, etc). So we need to do one of:

1. Require the iptables proxier when using the networkpolicy plugin
2. Tweak things so that you get the old broken "always fail" behavior rather than the new broken "always succeed" behavior.

It seems like neither of those solutions works for the case of the hybrid proxier on routers though... right?