### PR TITLE
Fix `oc rollback <name> -o yaml`

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
@@ -128,13 +128,17 @@ func PrinterForCommand(cmd *cobra.Command, mapper meta.RESTMapper, typer runtime
 	}
 
 	// this function may be invoked by a command that did not call AddPrinterFlags first, so we need
-	// to be safe about how we access the allow-missing-template-keys flag
+	// to be safe about how we access the allow-missing-template-keys and no-headers flag
 	allowMissingTemplateKeys := false
 	if cmd.Flags().Lookup("allow-missing-template-keys") != nil {
 		allowMissingTemplateKeys = GetFlagBool(cmd, "allow-missing-template-keys")
 	}
+	noHeaders := false
+	if cmd.Flags().Lookup("no-headers") != nil {
+		noHeaders = GetFlagBool(cmd, "no-headers")
+	}
 	printer, generic, err := printers.GetStandardPrinter(
-		outputFormat, templateFile, GetFlagBool(cmd, "no-headers"), allowMissingTemplateKeys,
+		outputFormat, templateFile, noHeaders, allowMissingTemplateKeys,
 		mapper, typer, decoders,
 	)
 	if err != nil {


### PR DESCRIPTION
source: https://bugzilla.redhat.com/show_bug.cgi?id=1457799

cc: @mfojtik @kargakis

I was thinking about adding an extended test so it doesn't happen again.

UPSTREAM ref: https://github.com/kubernetes/kubernetes/pull/46852
 + backport to Kubernetes 1.6 - https://github.com/kubernetes/kubernetes/pull/47343
