### PR TITLE
UPSTREAM: 46036: retry clientCA post start hook on transient failures

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook_test.go
@@ -190,7 +190,7 @@ func TestWriteClientCAs(t *testing.T) {
 
 	for _, test := range tests {
 		client := fake.NewSimpleClientset(test.preexistingObjs...)
-		test.hook.writeClientCAs(client.Core())
+		test.hook.tryToWriteClientCAs(client.Core())
 
 		actualConfigMaps, updated := getFinalConfiMaps(client)
 		if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {


### PR DESCRIPTION
Improves reliability of establishing the certs needed for aggregation. Already [merge]d upstream