### PR TITLE
Add NormalizePolicyRules to authorizationsync

### DIFF
--- a/pkg/authorization/controller/authorizationsync/normalize.go
+++ b/pkg/authorization/controller/authorizationsync/normalize.go
@@ -1,0 +1,28 @@
+package authorizationsync
+
+import (
+	"strings"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+// NormalizePolicyRules mutates the given rules and lowercases verbs, resources and API groups.
+// Origin's authorizer is case-insensitive to these fields but Kubernetes RBAC is not.  Thus normalizing
+// the Origin rules before persisting them as RBAC will allow authorization to continue to work.
+func NormalizePolicyRules(rules []rbac.PolicyRule) {
+	for i := range rules {
+		rule := &rules[i]
+		toLowerSlice(rule.Verbs)
+		toLowerSlice(rule.APIGroups)
+		rule.Resources = authorizationapi.NormalizeResources(sets.NewString(rule.Resources...)).List()
+	}
+}
+
+func toLowerSlice(slice []string) {
+	for i, item := range slice {
+		slice[i] = strings.ToLower(item)
+	}
+}

--- a/pkg/authorization/controller/authorizationsync/origin_to_rbac_clusterrole_controller.go
+++ b/pkg/authorization/controller/authorizationsync/origin_to_rbac_clusterrole_controller.go
@@ -86,6 +86,9 @@ func (c *OriginClusterRoleToRBACClusterRoleController) syncClusterRole(name stri
 		return err
 	}
 
+	// normalize rules before persisting so RBAC's case sensitive authorizer will work
+	NormalizePolicyRules(equivalentClusterRole.Rules)
+
 	// there's one wrinkle.  If `openshift.io/reconcile-protect` is to true, then we must set rbac.authorization.kubernetes.io/autoupdate to false to
 	if equivalentClusterRole.Annotations["openshift.io/reconcile-protect"] == "true" {
 		equivalentClusterRole.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "false"

--- a/pkg/authorization/controller/authorizationsync/origin_to_rbac_clusterrole_controller_test.go
+++ b/pkg/authorization/controller/authorizationsync/origin_to_rbac_clusterrole_controller_test.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/apis/rbac"
@@ -53,6 +55,43 @@ func TestSyncClusterRole(t *testing.T) {
 				}
 				if e, a := "resource-01", action.GetObject().(*rbac.ClusterRole).Name; e != a {
 					return fmt.Errorf("expected %v, got %v", e, a)
+				}
+				return nil
+			},
+		},
+		{
+			name: "simple create with normalization",
+			key:  "resource-01",
+			startingOrigin: []*authorizationapi.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "resource-01"},
+					Rules: []authorizationapi.PolicyRule{
+						{
+							Verbs:     sets.NewString("CREATE"),
+							Resources: sets.NewString("NAMESPACE"),
+							APIGroups: []string{"V2"},
+						},
+					},
+				},
+			},
+			actionCheck: func(actions []clienttesting.Action) error {
+				action, err := ensureSingleCreateAction(actions)
+				if err != nil {
+					return err
+				}
+				rbacRole := action.GetObject().(*rbac.ClusterRole)
+				if e, a := "resource-01", rbacRole.Name; e != a {
+					return fmt.Errorf("expected %v, got %v", e, a)
+				}
+				expectedRBACRules := []rbac.PolicyRule{
+					{
+						Verbs:     []string{"create"},
+						Resources: []string{"namespace"},
+						APIGroups: []string{"v2"},
+					},
+				}
+				if !apiequality.Semantic.DeepEqual(expectedRBACRules, rbacRole.Rules) {
+					return fmt.Errorf("expected %v, got %v", expectedRBACRules, rbacRole.Rules)
 				}
 				return nil
 			},

--- a/pkg/authorization/controller/authorizationsync/origin_to_rbac_role_controller.go
+++ b/pkg/authorization/controller/authorizationsync/origin_to_rbac_role_controller.go
@@ -91,6 +91,9 @@ func (c *OriginRoleToRBACRoleController) syncRole(key string) error {
 		return err
 	}
 
+	// normalize rules before persisting so RBAC's case sensitive authorizer will work
+	NormalizePolicyRules(equivalentRole.Rules)
+
 	// if we're missing the rbacRole, create it
 	if apierrors.IsNotFound(rbacErr) {
 		equivalentRole.ResourceVersion = ""


### PR DESCRIPTION
`NormalizePolicyRules` lowercases `APIGroups`, `Verbs` and `Resources`.  By using it before persistence, all RBAC roles will work with Kubernetes' case sensitive authorizer.

Fixes #13429

Supersedes #14410

[test]

Signed-off-by: Monis Khan <mkhan@redhat.com>

cc @deads2k 