### PR TITLE
Fix concurrency error in registry's pull-through

### DIFF
--- a/test/extended/registry/signature.go
+++ b/test/extended/registry/signature.go
@@ -21,8 +21,11 @@ var _ = g.Describe("[imageapis][registry] image signature workflow", func() {
 	)
 
 	g.It("can push a signed image to openshift registry and verify it", func() {
-		g.By("building an signer image that know how to sign images")
-		_, err := oc.Run("create").Args("-f", signerBuildFixture).Output()
+		g.By("building a signer image that knows how to sign images")
+		output, err := oc.Run("create").Args("-f", signerBuildFixture).Output()
+		if err != nil {
+			fmt.Fprintf(g.GinkgoWriter, "%s\n\n", output)
+		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = exutil.WaitForAnImageStreamTag(oc, oc.Namespace(), "signer", "latest")
 		containerLog, _ := oc.Run("logs").Args("builds/signer-1").Output()

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -6856,14 +6856,16 @@ items:
 - kind: BuildConfig
   apiVersion: v1
   metadata:
-    name: signer-build
+    name: signer
   spec:
     triggers:
       - type: ConfigChange
     source:
       dockerfile: |
         FROM openshift/origin:latest
-        RUN yum install -y skopeo && yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
+        RUN yum-config-manager --disable origin-local-release ||:
+        RUN yum install -y skopeo && \
+            yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: DSA \n\
             Key-Length: 1024 \n\

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -10,14 +10,16 @@ items:
 - kind: BuildConfig
   apiVersion: v1
   metadata:
-    name: signer-build
+    name: signer
   spec:
     triggers:
       - type: ConfigChange
     source:
       dockerfile: |
         FROM openshift/origin:latest
-        RUN yum install -y skopeo && yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
+        RUN yum-config-manager --disable origin-local-release ||:
+        RUN yum install -y skopeo && \
+            yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: DSA \n\
             Key-Length: 1024 \n\


### PR DESCRIPTION
Avoid the use of not thread-safe structures in the pull-through code. The mirroring code spawns a new go-routine that needs to have its own instances of thread-dangerous data.

Resolves: #14434