### PR TITLE
UPSTREAM: 47003: Remove duplicate errors from an aggregate error input.

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/generic_scheduler.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/generic_scheduler.go
@@ -168,7 +168,7 @@ func findNodesThatFit(
 		// Create filtered list with enough space to avoid growing it
 		// and allow assigning.
 		filtered = make([]*v1.Node, len(nodes))
-		errs := []error{}
+		errs := errors.MessageCountMap{}
 		var predicateResultLock sync.Mutex
 		var filteredLen int32
 
@@ -179,7 +179,7 @@ func findNodesThatFit(
 			fits, failedPredicates, err := podFitsOnNode(pod, meta, nodeNameToInfo[nodeName], predicateFuncs)
 			if err != nil {
 				predicateResultLock.Lock()
-				errs = append(errs, err)
+				errs[err.Error()]++
 				predicateResultLock.Unlock()
 				return
 			}
@@ -194,7 +194,7 @@ func findNodesThatFit(
 		workqueue.Parallelize(16, len(nodes), checkNode)
 		filtered = filtered[:filteredLen]
 		if len(errs) > 0 {
-			return []*v1.Node{}, FailedPredicateMap{}, errors.NewAggregate(errs)
+			return []*v1.Node{}, FailedPredicateMap{}, errors.CreateAggregateFromMessageCountMap(errs)
 		}
 	}
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 )
 
+// MessagesgCountMap contains occurance for each error message.
+type MessageCountMap map[string]int
+
 // Aggregate represents an object that contains multiple errors, but does not
 // necessarily have singular semantic meaning.
 type Aggregate interface {
@@ -143,6 +146,22 @@ func Flatten(agg Aggregate) Aggregate {
 				result = append(result, err)
 			}
 		}
+	}
+	return NewAggregate(result)
+}
+
+// CreateAggregateFromMessageCountMap converts MessageCountMap Aggregate
+func CreateAggregateFromMessageCountMap(m MessageCountMap) Aggregate {
+	if m == nil {
+		return nil
+	}
+	result := make([]error, 0, len(m))
+	for errStr, count := range m {
+		var countStr string
+		if count > 1 {
+			countStr = fmt.Sprintf(" (repeated %v times)", count)
+		}
+		result = append(result, fmt.Errorf("%v%v", errStr, countStr))
 	}
 	return NewAggregate(result)
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -80,6 +80,13 @@ func (agg aggregate) Errors() []error {
 	return []error(agg)
 }
 
+// Len, Swap, and Less needed for Sorting
+func (agg aggregate) Len() int      { return len(agg) }
+func (agg aggregate) Swap(i, j int) { agg[i], agg[j] = agg[j], agg[i] }
+func (agg aggregate) Less(i, j int) bool {
+	return agg[i].Error() < agg[j].Error()
+}
+
 // Matcher is used to match errors.  Returns true if the error matches.
 type Matcher func(error) bool
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -286,11 +286,11 @@ func TestCreateAggregateFromMessageCountMap(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.expected != nil {
 				expected = testCase.expected.Errors()
-				sort.Slice(expected, func(i, j int) bool { return expected[i].Error() < expected[j].Error() })
+				sort.Sort(aggregate(expected))
 			}
 			if testCase.mcp != nil {
 				agg = CreateAggregateFromMessageCountMap(testCase.mcp).Errors()
-				sort.Slice(agg, func(i, j int) bool { return agg[i].Error() < agg[j].Error() })
+				sort.Sort(aggregate(agg))
 			}
 			if !reflect.DeepEqual(expected, agg) {
 				t.Errorf("expected %v, got %v", expected, agg)


### PR DESCRIPTION
@derekwaynecarr 

As the upstream PR https://github.com/kubernetes/kubernetes/pull/47003 is merged now, I have updated this PR.