### PR TITLE
UPSTREAM: 47060: Fix etcd storage location for CRs

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -41,9 +41,9 @@ type EtcdOptions struct {
 	EnableGarbageCollection bool
 
 	// Set EnableWatchCache to false to disable all watch caches
-	EnableWatchCache        bool
+	EnableWatchCache bool
 	// Set DefaultWatchCacheSize to zero to disable watch caches for those resources that have no explicit cache size set
-	DefaultWatchCacheSize   int
+	DefaultWatchCacheSize int
 }
 
 func NewEtcdOptions(backendConfig *storagebackend.Config) *EtcdOptions {
@@ -131,7 +131,7 @@ func (f *SimpleRestOptionsFactory) GetRESTOptions(resource schema.GroupResource)
 		Decorator:               generic.UndecoratedStorage,
 		EnableGarbageCollection: f.Options.EnableGarbageCollection,
 		DeleteCollectionWorkers: f.Options.DeleteCollectionWorkers,
-		ResourcePrefix:          f.Options.StorageConfig.Prefix + "/" + resource.Group + "/" + resource.Resource,
+		ResourcePrefix:          resource.Group + "/" + resource.Resource,
 	}
 	if f.Options.EnableWatchCache {
 		ret.Decorator = genericregistry.StorageWithCacher(f.Options.DefaultWatchCacheSize)
@@ -163,4 +163,3 @@ func (f *storageFactoryRestOptionsFactory) GetRESTOptions(resource schema.GroupR
 
 	return ret, nil
 }
-


### PR DESCRIPTION
Found this upstream in 1.7 (just before we shipped).  We need to make sure that we're storing etcd data in the correct location.

@sttts @liggitt the promised pick.
@pmorie @derekwaynecarr You probably want to pick this into all the different sub-repos that have been propagating around.