### PR TITLE
Publish generated junit in integration test

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -185,6 +185,8 @@ if [[ -n "${junit_report}" ]]; then
     go test -i ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${test_output_file}"
 
+    os::test::junit::generate_report
+
     test_return_code="${PIPESTATUS[0]}"
 
     set -o pipefail

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -122,6 +122,7 @@ test_end_time=$(date +%s%3N)
 test_duration=$((test_end_time - test_start_time))
 
 echo "${test_result}        github.com/openshift/origin/test/integration    $((test_duration / 1000)).$((test_duration % 1000))s" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
+os::test::junit::generate_report
 
 popd &>/dev/null
 


### PR DESCRIPTION
@stevekuznetsov this fixes the issue with integration tests.
The issue was that you removed the junit generation in https://github.com/openshift/origin/pull/14116

Specifically the call of `os::test::junit::generate_gotest_report` which you replaced with `os::test::junit::generate_report` but forgot to bring it back into the script.

PTAL