### PR TITLE
Correctly place script output at _output/scripts

### DIFF
--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -5,11 +5,14 @@
 readonly OS_BUILD_ENV_GOLANG="${OS_BUILD_ENV_GOLANG:-1.7}"
 readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:golang-${OS_BUILD_ENV_GOLANG}}"
 
-readonly OS_OUTPUT_SUBPATH="${OS_OUTPUT_SUBPATH:-_output/local}"
+readonly OS_OUTPUT_BASEPATH="${OS_OUTPUT_BASEPATH:-_output}"
+readonly OS_BASE_OUTPUT="${OS_ROOT}/${OS_OUTPUT_BASEPATH}"
+readonly OS_OUTPUT_SCRIPTPATH="${OS_BASE_OUTPUT}/scripts"
+
+readonly OS_OUTPUT_SUBPATH="${OS_OUTPUT_SUBPATH:-${OS_OUTPUT_BASEPATH}/local}"
 readonly OS_OUTPUT="${OS_ROOT}/${OS_OUTPUT_SUBPATH}"
 readonly OS_OUTPUT_RELEASEPATH="${OS_OUTPUT}/releases"
 readonly OS_OUTPUT_RPMPATH="${OS_OUTPUT_RELEASEPATH}/rpms"
-readonly OS_OUTPUT_SCRIPTPATH="${OS_OUTPUT}/scripts"
 readonly OS_OUTPUT_BINPATH="${OS_OUTPUT}/bin"
 readonly OS_OUTPUT_PKGDIR="${OS_OUTPUT}/pkgdir"
 


### PR DESCRIPTION
The previous refactor to use `$OS_OUTPUT_SCRIPTPATH` had the unintended
consequence of moving the script output from `_output/scripts` to
`_output/local/scripts`. This patch moves it back to where it should be.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test][merge][severity: bug]