### PR TITLE
Annotate roles with systemOnly

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -1321,8 +1321,24 @@ func convertClusterRoles(in []rbac.ClusterRole) ([]authorizationapi.ClusterRole,
 			errs = append(errs, fmt.Errorf("error converting %q: %v", in[i].Name, err))
 			continue
 		}
+		// adding annotation to any role not explicitly in the whitelist below
+		if !rolesToShow.Has(newRole.Name) {
+			newRole.Annotations[roleSystemOnly] = roleIsSystemOnly
+		}
 		out = append(out, *newRole)
 	}
 
 	return out, kutilerrors.NewAggregate(errs)
 }
+
+// The current list of roles considered useful for normal users (non-admin)
+var rolesToShow = sets.NewString(
+	"admin",
+	"basic-user",
+	"edit",
+	"system:deployer",
+	"system:image-builder",
+	"system:image-puller",
+	"system:image-pusher",
+	"view",
+)

--- a/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
+++ b/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
@@ -1,0 +1,98 @@
+package bootstrappolicy
+
+import (
+	"strings"
+	"testing"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NOTE: If this test fails, talk to the web console team to decide if your
+// new role(s) should be visible to an end user in the web console.
+
+var rolesToHide = sets.NewString(
+	"cluster-admin",
+	"cluster-debugger",
+	"cluster-reader",
+	"cluster-status",
+	"registry-admin",
+	"registry-editor",
+	"registry-viewer",
+	"self-access-reviewer",
+	"self-provisioner",
+	"storage-admin",
+	"sudoer",
+	"system:auth-delegator",
+	"system:basic-user",
+	"system:build-strategy-custom",
+	"system:build-strategy-docker",
+	"system:build-strategy-jenkinspipeline",
+	"system:build-strategy-source",
+	"system:discovery",
+	"system:heapster",
+	"system:image-auditor",
+	"system:image-pruner",
+	"system:image-signer",
+	"system:kube-aggregator",
+	"system:kube-controller-manager",
+	"system:kube-dns",
+	"system:kube-scheduler",
+	"system:master",
+	"system:node",
+	"system:node-admin",
+	"system:node-bootstrapper",
+	"system:node-problem-detector",
+	"system:node-proxier",
+	"system:node-reader",
+	"system:oauth-token-deleter",
+	"system:openshift:template-service-broker",
+	"system:openshift:templateservicebroker-client",
+	"system:persistent-volume-provisioner",
+	"system:registry",
+	"system:router",
+	"system:sdn-manager",
+	"system:sdn-reader",
+	"system:webhook",
+)
+
+func TestSystemOnlyRoles(t *testing.T) {
+	show := sets.NewString()
+	hide := sets.NewString()
+
+	for _, role := range GetBootstrapClusterRoles() {
+		if isControllerRole(&role) {
+			continue // assume all controller roles can be ignored
+		}
+		if isSystemOnlyRole(role) {
+			hide.Insert(role.Name)
+		} else {
+			show.Insert(role.Name)
+		}
+	}
+
+	if !show.Equal(rolesToShow) || !hide.Equal(rolesToHide) {
+		shouldNotShow := show.Difference(rolesToShow).List()
+		shouldNotHide := hide.Difference(rolesToHide).List()
+		t.Error("The list of expected end user roles has been changed.  Please discuss with the web console team to update role annotations.")
+		if len(shouldNotShow) > 0 {
+			t.Errorf("These roles are visible but not in rolesToShow: %v", shouldNotShow)
+		}
+		if len(shouldNotHide) > 0 {
+			t.Errorf("These roles are hidden but not in rolesToHide: %v", shouldNotHide)
+		}
+	}
+}
+
+// this logic must stay in sync w/the web console for this test to be valid/valuable
+// it is the same logic that is run on the membership page
+func isSystemOnlyRole(role authorizationapi.ClusterRole) bool {
+	return role.Annotations[roleSystemOnly] == roleIsSystemOnly
+}
+
+// helper so that roles following this pattern do not need to be manaully added
+// to the hide list
+func isControllerRole(role *authorizationapi.ClusterRole) bool {
+	return strings.HasPrefix(role.Name, "system:controller:") ||
+		strings.HasSuffix(role.Name, "-controller")
+}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -4007,6 +4007,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4060,6 +4061,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4116,6 +4118,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4177,6 +4180,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4238,6 +4242,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4310,6 +4315,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4357,6 +4363,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4388,6 +4395,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4476,6 +4484,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4522,6 +4531,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4560,6 +4570,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4612,6 +4623,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4711,6 +4723,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4737,6 +4750,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4784,6 +4798,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4831,6 +4846,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4865,6 +4881,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4899,6 +4916,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4925,6 +4943,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -4968,6 +4987,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5030,6 +5050,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5059,6 +5080,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5095,6 +5117,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5112,6 +5135,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5134,6 +5158,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5167,6 +5192,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5191,6 +5217,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5211,6 +5238,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5278,6 +5306,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:
@@ -5379,6 +5408,7 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:


### PR DESCRIPTION
Fixes #14411 

Update the bootstrap/policy convertClusterRoles function to annotate systemOnly roles

A short whitelist is included in this file defining the expected roles that
should be visible to an end user.  All other roles should receive the
systemOnly annotation allowing the web console (or other clients) to
filter and provide a friendly user experience.

Future roles should be considered against this whitelist and discussed
with the web console team.

- updates bootstrappolicy/policy convertClusterRoles
- adds web_console_role_test.go to bootstrappolicy package


Example of test failure:

![screen shot 2017-06-07 at 1 37 38 pm](https://user-images.githubusercontent.com/280512/26892944-df595a24-4b87-11e7-8ee5-be333898197a.png)

current whitelist:

```go
var rolesToShow = sets.NewString(
	"admin",
	"basic-user",
	"edit",
	"system:deployer",
	"system:image-builder",
	"system:image-puller",
	"system:image-pusher",
	"view",
)
```

current blacklist:

```go
var rolesToHide = sets.NewString(
	"cluster-admin",
	"cluster-debugger",
	"cluster-reader",
	"cluster-status",
	"registry-admin",
	"registry-editor",
	"registry-viewer",
	"self-access-reviewer",
	"self-provisioner",
	"storage-admin",
	"sudoer",
	"system:auth-delegator",
	"system:build-strategy-custom",
	"system:build-strategy-docker",
	"system:build-strategy-jenkinspipeline",
	"system:build-strategy-source",
	"system:discovery",
	"system:heapster",
	"system:image-auditor",
	"system:image-pruner",
	"system:image-signer",
	"system:kube-aggregator",
	"system:kube-controller-manager",
	"system:kube-dns",
	"system:kube-scheduler",
	"system:master",
	"system:node",
	"system:node-admin",
	"system:node-bootstrapper",
	"system:node-problem-detector",
	"system:node-proxier",
	"system:node-reader",
	"system:oauth-token-deleter",
	"system:openshift:template-service-broker",
	"system:openshift:templateservicebroker-client",
	"system:persistent-volume-provisioner",
	"system:registry",
	"system:router",
	"system:sdn-manager",
	"system:sdn-reader",
	"system:webhook",
)
```

Much thanks to @enj for assistance in this PR.