### PR TITLE
Align DIND container image build with Orgin scripts

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -527,9 +527,7 @@ function build-image() {
   local build_root=$1
   local image_name=$2
 
-  pushd "${build_root}" > /dev/null
-    ${DOCKER_CMD} build -t "${image_name}" .
-  popd > /dev/null
+  os::build::image "${build_root}" "${image_name}"
 }
 
 


### PR DESCRIPTION
We are seeing Docker builds in the networking tests fail with message:

    Error response from daemon: Untar error on re-exec cmd: fork/exec
    /proc/self/exe: cannot allocate memory

Before looking into exactly why this is occurring, the build process
should first be aligned with how container images are built for Origin
in the `hack/` scripts.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

helps to debug https://github.com/openshift/origin/issues/14496
