### PR TITLE
Eliminate nil/empty distinction for new v1 field

### DIFF
--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -9127,7 +9127,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"templateInstance", "secret", "bindingIDs"},
+					Required: []string{"templateInstance", "secret"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/template/api/v1/types.go
+++ b/pkg/template/api/v1/types.go
@@ -205,7 +205,7 @@ type BrokerTemplateInstanceSpec struct {
 
 	// bindingids is a list of 'binding_id's provided during successive bind
 	// calls to the template service broker.
-	BindingIDs []string `json:"bindingIDs" protobuf:"bytes,3,rep,name=bindingIDs"`
+	BindingIDs []string `json:"bindingIDs,omitempty" protobuf:"bytes,3,rep,name=bindingIDs"`
 }
 
 // BrokerTemplateInstanceList is a list of BrokerTemplateInstance objects.

--- a/pkg/template/api/v1/zz_generated.conversion.go
+++ b/pkg/template/api/v1/zz_generated.conversion.go
@@ -134,11 +134,7 @@ func autoConvert_api_BrokerTemplateInstanceSpec_To_v1_BrokerTemplateInstanceSpec
 	if err := api_v1.Convert_api_ObjectReference_To_v1_ObjectReference(&in.Secret, &out.Secret, s); err != nil {
 		return err
 	}
-	if in.BindingIDs == nil {
-		out.BindingIDs = make([]string, 0)
-	} else {
-		out.BindingIDs = *(*[]string)(unsafe.Pointer(&in.BindingIDs))
-	}
+	out.BindingIDs = *(*[]string)(unsafe.Pointer(&in.BindingIDs))
 	return nil
 }
 

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -142,7 +142,6 @@ var _ = g.Describe("[templates] templateservicebroker end-to-end test", func() {
 				Name:      secret.Name,
 				UID:       secret.UID,
 			},
-			BindingIDs: []string{},
 		}))
 
 		o.Expect(templateInstance.Spec).To(o.Equal(templateapi.TemplateInstanceSpec{


### PR DESCRIPTION
Ensure there is no internal or external distinction between nil and
empty BrokerTemplateInstanceSpec.BindingIDs to enable maximum
compatibility with stored serialized types (e.g. protobufs).

Part of https://github.com/openshift/origin/issues/13419.