### PR TITLE
Bring image building logic into the Bash library

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -11,7 +11,7 @@ tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 os::util::ensure::gopath_binary_exists imagebuilder
 
 # Build the base image without the default image args
-OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/source" "${tag_prefix}-source"
-OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_BASE_ARGS-}" os::build::image "${OS_ROOT}/images/base" "${tag_prefix}-base"
+os::build::image "${tag_prefix}-source" "${OS_ROOT}/images/source"
+os::build::image "${tag_prefix}-base"   "${OS_ROOT}/images/base"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-dind-images.sh
+++ b/hack/build-dind-images.sh
@@ -8,8 +8,8 @@
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-os::build::image "${OS_ROOT}/images/dind"        openshift/dind
-os::build::image "${OS_ROOT}/images/dind/node"   openshift/dind-node
-os::build::image "${OS_ROOT}/images/dind/master" openshift/dind-master
+os::build::image openshift/dind        "${OS_ROOT}/images/dind"
+os::build::image openshift/dind-node   "${OS_ROOT}/images/dind/node"
+os::build::image openshift/dind-master "${OS_ROOT}/images/dind/master"
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -6,8 +6,14 @@
 # NOTE:  you only need to run this script if your code changes are part of
 # any images OpenShift runs internally such as origin-sti-builder, origin-docker-builder,
 # origin-deployer, etc.
-STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+function cleanup() {
+    return_code=$?
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
 os::util::ensure::gopath_binary_exists imagebuilder
 # image builds require RPMs to have been built
@@ -32,54 +38,6 @@ function ln_or_cp {
 	fi
 }
 
-
-# image-build is wrapped to allow output to be captured
-function image-build() {
-	local tag=$1
-	local dir=$2
-	local dest="${tag}"
-	local extra=
-	if [[ ! "${tag}" == *":"* ]]; then
-		dest="${tag}:latest"
-		# tag to release commit unless we specified a hardcoded tag
-		extra="${tag}:${OS_RELEASE_COMMIT}"
-	fi
-
-	local STARTTIME
-	local ENDTIME
-	STARTTIME="$(date +%s)"
-
-	# build the image
-	if ! os::build::image "${dir}" "${dest}" "" "${extra}"; then
-		os::log::warning "Retrying build once"
-		if ! os::build::image "${dir}" "${dest}" "" "${extra}"; then
-			return 1
-		fi
-	fi
-
-	# ensure the temporary contents are cleaned up
-	git clean -fdx "${dir}"
-
-	ENDTIME="$(date +%s)"
-	echo "Finished in $(($ENDTIME - $STARTTIME)) seconds"
-}
-
-# builds an image and tags it two ways - with latest, and with the release tag
-function image() {
-	local tag=$1
-	local dir=$2
-	local out
-	mkdir -p "${BASETMPDIR}"
-	out="$( mktemp "${BASETMPDIR}/imagelogs.XXXXX" )"
-	if ! image-build "${tag}" "${dir}" > "${out}" 2>&1; then
-		sed -e "s|^|$1: |" "${out}" 1>&2
-		os::log::error "Failed to build $1"
-		return 1
-	fi
-	sed -e "s|^|$1: |" "${out}"
-	return 0
-}
-
 # Link or copy image binaries to the appropriate locations.
 ln_or_cp "${OS_OUTPUT_BINPATH}/linux/amd64/hello-openshift" examples/hello-openshift/bin
 ln_or_cp "${OS_OUTPUT_BINPATH}/linux/amd64/gitserver"       examples/gitserver/bin
@@ -88,32 +46,28 @@ ln_or_cp "${OS_OUTPUT_BINPATH}/linux/amd64/gitserver"       examples/gitserver/b
 tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 
 # images that depend on "${tag_prefix}-source"
-image "${tag_prefix}-pod"                   images/pod
-image "${tag_prefix}-cluster-capacity"      images/cluster-capacity
-image "${tag_prefix}-service-catalog"       images/service-catalog
+os::build::image "${tag_prefix}-pod"                   images/pod
+os::build::image "${tag_prefix}-cluster-capacity"      images/cluster-capacity
+os::build::image "${tag_prefix}-service-catalog"       images/service-catalog
 
 # images that depend on "${tag_prefix}-base"
-image "${tag_prefix}"                       images/origin
-image "${tag_prefix}-haproxy-router"        images/router/haproxy
-image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived
-image "${tag_prefix}-docker-registry"       images/dockerregistry
-image "${tag_prefix}-egress-router"         images/egress/router
-image "${tag_prefix}-egress-http-proxy"     images/egress/http-proxy
-image "${tag_prefix}-federation"            images/federation
+os::build::image "${tag_prefix}"                       images/origin
+os::build::image "${tag_prefix}-haproxy-router"        images/router/haproxy
+os::build::image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived
+os::build::image "${tag_prefix}-docker-registry"       images/dockerregistry
+os::build::image "${tag_prefix}-egress-router"         images/egress/router
+os::build::image "${tag_prefix}-egress-http-proxy"     images/egress/http-proxy
+os::build::image "${tag_prefix}-federation"            images/federation
 # images that depend on "${tag_prefix}
-image "${tag_prefix}-gitserver"             examples/gitserver
-image "${tag_prefix}-deployer"              images/deployer
-image "${tag_prefix}-recycler"              images/recycler
-image "${tag_prefix}-docker-builder"        images/builder/docker/docker-builder
-image "${tag_prefix}-sti-builder"           images/builder/docker/sti-builder
-image "${tag_prefix}-f5-router"             images/router/f5
-image "openshift/node"                      images/node
+os::build::image "${tag_prefix}-gitserver"             examples/gitserver
+os::build::image "${tag_prefix}-deployer"              images/deployer
+os::build::image "${tag_prefix}-recycler"              images/recycler
+os::build::image "${tag_prefix}-docker-builder"        images/builder/docker/docker-builder
+os::build::image "${tag_prefix}-sti-builder"           images/builder/docker/sti-builder
+os::build::image "${tag_prefix}-f5-router"             images/router/f5
+os::build::image "openshift/node"                      images/node
 # images that depend on "openshift/node"
-image "openshift/openvswitch"               images/openvswitch
+os::build::image "openshift/openvswitch"               images/openvswitch
 
 # extra images (not part of infrastructure)
-image "openshift/hello-openshift"           examples/hello-openshift
-
-echo
-
-ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"
+os::build::image "openshift/hello-openshift"           examples/hello-openshift

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -526,7 +526,7 @@ function build-image() {
   local build_root=$1
   local image_name=$2
 
-  os::build::image "${build_root}" "${image_name}"
+  os::build::image "${image_name}" "${build_root}"
 }
 
 function os::build::get-bin-output-path() {


### PR DESCRIPTION
Previously, useful logic for building images like the choice to tag
images with `:latest` as well as `:sha`, automatic re-try logic, `git`
cleanup, nice output printing, etc, were all local to the top-level
`hack/build-images.sh` entrypoint. There's no reason for that to be the
case and as other people find themselves needing those features, we
should just expose all of that with `os::build::image`.

This is not an entirely backwards compatible patch. The following
changes were made:

 - support for explicitly providing a Dockerfile was removed from the
   signature of `os::build::image` as this was an entirely unused
   feature.
 - the order of arguments was re-arranged so that all of the image build
   utilites were in alignment -- first the tag, then the dir, etc.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Depends on #14435 

/cc @smarterclayton  PTAL last commit

[test]