### PR TITLE
Route security management by end user

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -6,6 +6,20 @@
 {{- define "/var/lib/haproxy/conf/haproxy.config" }}
 {{- $workingDir := .WorkingDir }}
 {{- $defaultDestinationCA := .DefaultDestinationCA }}
+
+{{/* A bunch of regular expressions.  Each should be wrapped in (?:) so that it is safe to include bare */}}
+{{/* quadPattern: Match a quad in an IP address; e.g. 123 */}}
+{{- $quadPattern := `(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])` -}}
+
+{{/* ipPattern: Match an IPv4 address; e.g. 192.168.21.23 */}}
+{{- $ipPattern := printf `(?:%s\.%s\.%s\.%s)` $quadPattern $quadPattern $quadPattern $quadPattern -}}
+
+{{/* cidrPattern: Match an IP and network size in CIDR form; e.g. 192.168.21.23/24 */}}
+{{- $cidrPattern := printf `(?:%s(?:/(?:[0-9]|[1-2][0-9]|3[0-2]))?)` $ipPattern -}}
+
+{{/* cidrListPattern: Match a space separated list of CIDRs; e.g. 192.168.21.23/24 192.10.2.12 */}}
+{{- $cidrListPattern := printf `(?:%s(?: +%s)*)` $cidrPattern $cidrPattern -}}
+
 global
   maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
 
@@ -293,6 +307,12 @@ backend be_secure:{{$cfgIdx}}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}leastconn{{ end }}
       {{- end }}
     {{- end }}
+    {{- with $ip_whiteList := index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist" }}
+      {{- if (matchPattern $cidrListPattern $ip_whiteList) }}
+  acl whitelist src {{ $ip_whiteList }}
+  tcp-request content reject if !whitelist
+      {{- end }}
+    {{- end }}
     {{- with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}
       {{- if (matchPattern "[1-9][0-9]*(us|ms|s|m|h|d)?" $value) }}
   timeout server  {{$value}}
@@ -388,6 +408,12 @@ backend be_tcp:{{$cfgIdx}}
   balance {{ env "ROUTER_TCP_BALANCE_SCHEME" "source"}}
       {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}
+      {{- end }}
+    {{- end }}
+    {{- with $ip_whiteList := index $cfg.Annotations "haproxy.router.openshift.io/ip_whitelist" }}
+      {{- if (matchPattern $cidrListPattern $ip_whiteList) }}
+  acl whitelist src {{$ip_whiteList}}
+  tcp-request content reject if !whitelist
       {{- end }}
     {{- end }}
     {{- with $value := index $cfg.Annotations "haproxy.router.openshift.io/timeout"}}


### PR DESCRIPTION
Add a new route annotation "haproxy.router.openshift.io/ip_whitelist"
that specifies a space separated list of white listed source IP
addresses and/or CIDRs. Requests from IP addresses that are not in
the whitelist are dropped.

When the annotation is present for a route a acl is set up in the
backend with the whitelist.

This PR addresses issue #13709

Some examples:

When editing a route add the following annotation to define the desired
source ip's.

1) allow only one ip

haproxy.router.openshift.io/whitelist:
192.168.1.10

2) several ip's

haproxy.router.openshift.io/whitelist:
192.168.1.10 192.168.1.11 192.168.1.12

3) ip ranges

haproxy.router.openshift.io/whitelist:
192.168.1.0/24

4) ip's and ranges

haproxy.router.openshift.io/whitelist:
180.5.61.153 192.168.1.0/24 10.0.0.0/8

Trello: TbZPhHKE Route security management by end user
https://trello.com/c/TbZPhHKE/

Bug: 1426562
https://bugzilla.redhat.com/show_bug.cgi?id=1426562

This was ported from PR 13729

Committer: pcameron@redhat.com
Author: aranda@redhat.com