### PR TITLE
Allow users to create bindings to roles

### DIFF
--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -146,9 +146,13 @@ func (m *VirtualStorage) createRoleBinding(ctx apirequest.Context, obj runtime.O
 		}
 	}
 
+	// get or auto create policy binding so we can deprecate policy and policy binding objects in 3.6
+	// thus normal users can always create a role binding referring to a role in the current namespace
+	allowAutoProvision := allowEscalation || roleBinding.RoleRef.Namespace == apirequest.NamespaceValue(ctx)
+
 	// Retry if we hit a conflict on the underlying PolicyBinding object
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		policyBinding, err := m.getPolicyBindingForPolicy(ctx, roleBinding.RoleRef.Namespace, allowEscalation)
+		policyBinding, err := m.getPolicyBindingForPolicy(ctx, roleBinding.RoleRef.Namespace, allowAutoProvision)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change makes it so that you no longer need cluster admin privileges to create a role binding that references a role in your namespace.  In the past we required a cluster admin to create the policy binding object before a normal user could perform these bindings.  This change is required for us to deprecate policy and policy binding objects in 3.6.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes #14078

cc @liggitt @deads2k PTAL

cc @benjaminapetersen @bparees @jfchevrette since you have encountered this before.

[test]