### PR TITLE
When sorting SCCs by restrictions don't add a score if SCC allows volumes of projected type

### DIFF
--- a/pkg/security/scc/byrestrictions.go
+++ b/pkg/security/scc/byrestrictions.go
@@ -49,11 +49,11 @@ func pointValue(constraint *kapi.SecurityContextConstraints) int {
 	return points
 }
 
-// allowsHostPathVolume returns a score based on the volumes allowed by the SCC.
-// Allowing a host volume wil return a score of 10.  Allowance of anything other
-// than kapi.FSTypeSecret, kapi.FSTypeConfigMap, kapi.FSTypeConfigMap, kapi.FSTypeDownwardAPI
-// will result in a score of 5.  If the SCC only allows kapi.FSTypeSecret, kapi.FSTypeConfigMap,
-// kapi.FSTypeEmptyDir, kapi.FSTypeDownwardAPI it will have a score of 0.
+// volumePointValue returns a score based on the volumes allowed by the SCC.
+// Allowing a host volume will return a score of 10.  Allowance of anything other
+// than Secret, ConfigMap, EmptyDir, DownwardAPI, Projected, and None will result in
+// a score of 5.  If the SCC only allows these trivial types, it will have a
+// score of 0.
 func volumePointValue(scc *kapi.SecurityContextConstraints) int {
 	hasHostVolume := false
 	hasNonTrivialVolume := false
@@ -66,8 +66,8 @@ func volumePointValue(scc *kapi.SecurityContextConstraints) int {
 		// it is easier to specifically list the trivial volumes and allow the
 		// default case to be non-trivial so we don't have to worry about adding
 		// volumes in the future unless they're trivial.
-		case kapi.FSTypeSecret, kapi.FSTypeConfigMap,
-			kapi.FSTypeEmptyDir, kapi.FSTypeDownwardAPI, kapi.FSTypeNone:
+		case kapi.FSTypeSecret, kapi.FSTypeConfigMap, kapi.FSTypeEmptyDir,
+			kapi.FSTypeDownwardAPI, kapi.FSProjected, kapi.FSTypeNone:
 			// do nothing
 		default:
 			hasNonTrivialVolume = true

--- a/pkg/security/scc/byrestrictions_test.go
+++ b/pkg/security/scc/byrestrictions_test.go
@@ -144,6 +144,18 @@ func TestVolumePointValue(t *testing.T) {
 			},
 			expectedPoints: 0,
 		},
+		"trivial - projected": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSProjected},
+			},
+			expectedPoints: 0,
+		},
+		"trivial - none": {
+			scc: &kapi.SecurityContextConstraints{
+				Volumes: []kapi.FSType{kapi.FSTypeNone},
+			},
+			expectedPoints: 0,
+		},
 		"no volumes allowed": {
 			scc:            newSCC(false, false, false),
 			expectedPoints: 0,


### PR DESCRIPTION
After adding `projected` type to many of our SCCs in #14147, we accidentally changed their score. This PR corrects that by treating `projected` volume type as a trivial (that has a score of 0).

PTAL @pweil- 
CC @mfojtik 
JFYI @jpeeler 