### PR TITLE
Cleaned up the matchPattern regex code

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -238,7 +238,7 @@ func matchValues(s string, allowedValues ...string) bool {
 
 func matchPattern(pattern, s string) bool {
 	glog.V(5).Infof("matchPattern called with %s and %s", pattern, s)
-	status, err := regexp.MatchString("^("+pattern+")$", s)
+	status, err := regexp.MatchString(`\A(?:`+pattern+`)\z`, s)
 	if err == nil {
 		glog.V(5).Infof("matchPattern returning status: %v", status)
 		return status
@@ -260,10 +260,10 @@ func genSubdomainWildcardRegexp(hostname, path string, exactPath bool) string {
 
 	expr := regexp.QuoteMeta(fmt.Sprintf(".%s%s", subdomain, path))
 	if exactPath {
-		return fmt.Sprintf("^[^\\.]*%s$", expr)
+		return fmt.Sprintf(`^[^\.]*%s$`, expr)
 	}
 
-	return fmt.Sprintf("^[^\\.]*%s(|/.*)$", expr)
+	return fmt.Sprintf(`^[^\.]*%s(|/.*)$`, expr)
 }
 
 // Generate a regular expression to match route hosts (and paths if any).
@@ -275,7 +275,7 @@ func generateRouteRegexp(hostname, path string, wildcard bool) string {
 			glog.Warningf("Generating subdomain wildcard regexp - invalid host name %s", hostname)
 		} else {
 			subdomainRE := regexp.QuoteMeta(fmt.Sprintf(".%s", subdomain))
-			hostRE = fmt.Sprintf("[^\\.]*%s", subdomainRE)
+			hostRE = fmt.Sprintf(`[^\.]*%s`, subdomainRE)
 		}
 	}
 

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -811,3 +811,88 @@ func TestGenerateRouteRegexp(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchPattern(t *testing.T) {
+	testMatches := []struct {
+		name    string
+		pattern string
+		input   string
+	}{
+		// Test that basic regex stuff works
+		{
+			name:    "exact match",
+			pattern: `asd`,
+			input:   "asd",
+		},
+		{
+			name:    "basic regex",
+			pattern: `.*asd.*`,
+			input:   "123asd123",
+		},
+		{
+			name:    "match newline",
+			pattern: `(?s).*asd.*`,
+			input:   "123\nasd123",
+		},
+		{
+			name:    "match multiline",
+			pattern: `(?m)(^asd\d$\n?)+`,
+			input:   "asd1\nasd2\nasd3\n",
+		},
+	}
+
+	testNoMatches := []struct {
+		name    string
+		pattern string
+		input   string
+	}{
+		// Make sure we are anchoring the regex at the start and end
+		{
+			name:    "no-substring",
+			pattern: `asd`,
+			input:   "123asd123",
+		},
+		// Make sure that we group their pattern separately from the anchors
+		{
+			name:    "prefix alternation",
+			pattern: `|asd`,
+			input:   "anything",
+		},
+		{
+			name:    "postfix alternation",
+			pattern: `asd|`,
+			input:   "anything",
+		},
+		// Make sure that a change in anchor behaviors doesn't break us
+		{
+			name:    "substring behavior",
+			pattern: `(?m)asd`,
+			input:   "asd\n123",
+		},
+		// Check some other regex things that should fail
+		{
+			name:    "don't match newline",
+			pattern: `.*asd.*`,
+			input:   "123\nasd123",
+		},
+		{
+			name:    "don't match multiline",
+			pattern: `(^asd\d$\n?)+`,
+			input:   "asd1\nasd2\nasd3\n",
+		},
+	}
+
+	for _, tt := range testMatches {
+		match := matchPattern(tt.pattern, tt.input)
+		if !match {
+			t.Errorf("%s: expected %s to match %s, but didn't", tt.name, tt.input, tt.pattern)
+		}
+	}
+
+	for _, tt := range testNoMatches {
+		match := matchPattern(tt.pattern, tt.input)
+		if match {
+			t.Errorf("%s: expected %s not to match %s, but did", tt.name, tt.input, tt.pattern)
+		}
+	}
+}


### PR DESCRIPTION
- Changed it to use raw strings to reduce the leaning-toothpick syndrome from all of the necessary escaping
- Changed it to use \A and \z around the regex, so that if the regex is put into multi-line mode with (?m) then it will match the whole string
- Changed it so that the () around their regex is (?:) to make it non-capturing
