### PR TITLE
Use GC rather than refcounting for VNID policy rules

### DIFF
--- a/pkg/sdn/plugin/multitenant.go
+++ b/pkg/sdn/plugin/multitenant.go
@@ -15,13 +15,13 @@ type multiTenantPlugin struct {
 	node  *OsdnNode
 	vnids *nodeVNIDMap
 
-	vnidRefsLock sync.Mutex
-	vnidRefs     map[uint32]int
+	vnidInUseLock sync.Mutex
+	vnidInUse     map[uint32]bool
 }
 
 func NewMultiTenantPlugin() osdnPolicy {
 	return &multiTenantPlugin{
-		vnidRefs: make(map[uint32]int),
+		vnidInUse: make(map[uint32]bool),
 	}
 }
 
@@ -66,14 +66,10 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 	}
 
 	if oldNetID != netID {
-		movedVNIDRefs := 0
-
 		// Update OF rules for the existing/old pods in the namespace
 		for _, pod := range pods {
 			err = mp.node.UpdatePod(pod)
-			if err == nil {
-				movedVNIDRefs++
-			} else {
+			if err != nil {
 				glog.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err)
 			}
 		}
@@ -86,12 +82,9 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 
 			mp.node.DeleteServiceRules(&svc)
 			mp.node.AddServiceRules(&svc, netID)
-			movedVNIDRefs++
 		}
 
-		if movedVNIDRefs > 0 {
-			mp.moveVNIDRefs(movedVNIDRefs, oldNetID, netID)
-		}
+		mp.EnsureVNIDRules(netID)
 
 		// Update namespace references in egress firewall rules
 		mp.node.UpdateEgressNetworkPolicyVNID(namespace, oldNetID, netID)
@@ -126,18 +119,19 @@ func (mp *multiTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
 	return mp.vnids.GetMulticastEnabled(vnid)
 }
 
-func (mp *multiTenantPlugin) RefVNID(vnid uint32) {
+func (mp *multiTenantPlugin) EnsureVNIDRules(vnid uint32) {
 	if vnid == 0 {
 		return
 	}
 
-	mp.vnidRefsLock.Lock()
-	defer mp.vnidRefsLock.Unlock()
-	mp.vnidRefs[vnid] += 1
-	if mp.vnidRefs[vnid] > 1 {
+	mp.vnidInUseLock.Lock()
+	defer mp.vnidInUseLock.Unlock()
+	if mp.vnidInUse[vnid] {
 		return
 	}
-	glog.V(5).Infof("RefVNID %d adding rule", vnid)
+	mp.vnidInUse[vnid] = true
+
+	glog.V(5).Infof("EnsureVNIDRules %d - adding rules", vnid)
 
 	otx := mp.node.oc.NewTransaction()
 	otx.AddFlow("table=80, priority=100, reg0=%d, reg1=%d, actions=output:NXM_NX_REG2[]", vnid, vnid)
@@ -146,52 +140,19 @@ func (mp *multiTenantPlugin) RefVNID(vnid uint32) {
 	}
 }
 
-func (mp *multiTenantPlugin) UnrefVNID(vnid uint32) {
-	if vnid == 0 {
-		return
-	}
+func (mp *multiTenantPlugin) SyncVNIDRules() {
+	mp.vnidInUseLock.Lock()
+	defer mp.vnidInUseLock.Unlock()
 
-	mp.vnidRefsLock.Lock()
-	defer mp.vnidRefsLock.Unlock()
-	if mp.vnidRefs[vnid] == 0 {
-		glog.Warningf("refcounting error on vnid %d", vnid)
-		return
-	}
-	mp.vnidRefs[vnid] -= 1
-	if mp.vnidRefs[vnid] > 0 {
-		return
-	}
-	glog.V(5).Infof("UnrefVNID %d removing rule", vnid)
+	unused := mp.node.oc.FindUnusedVNIDs()
+	glog.Infof("SyncVNIDRules: %d unused VNIDs", len(unused))
 
 	otx := mp.node.oc.NewTransaction()
-	otx.DeleteFlows("table=80, reg0=%d, reg1=%d", vnid, vnid)
+	for _, vnid := range unused {
+		mp.vnidInUse[uint32(vnid)] = false
+		otx.DeleteFlows("table=80, reg1=%d", vnid)
+	}
 	if err := otx.EndTransaction(); err != nil {
-		glog.Errorf("Error deleting OVS flow for VNID: %v", err)
+		glog.Errorf("Error deleting syncing OVS VNID rules: %v", err)
 	}
-}
-
-func (mp *multiTenantPlugin) moveVNIDRefs(num int, oldVNID, newVNID uint32) {
-	glog.V(5).Infof("moveVNIDRefs %d -> %d", oldVNID, newVNID)
-
-	mp.vnidRefsLock.Lock()
-	defer mp.vnidRefsLock.Unlock()
-
-	otx := mp.node.oc.NewTransaction()
-	if mp.vnidRefs[oldVNID] <= num {
-		otx.DeleteFlows("table=80, reg0=%d, reg1=%d", oldVNID, oldVNID)
-	}
-	if mp.vnidRefs[newVNID] == 0 {
-		otx.AddFlow("table=80, priority=100, reg0=%d, reg1=%d, actions=output:NXM_NX_REG2[]", newVNID, newVNID)
-	}
-	err := otx.EndTransaction()
-	if err != nil {
-		glog.Errorf("Error modifying OVS flows for VNID: %v", err)
-	}
-
-	mp.vnidRefs[oldVNID] -= num
-	if mp.vnidRefs[oldVNID] < 0 {
-		glog.Warningf("refcounting error on vnid %d", oldVNID)
-		mp.vnidRefs[oldVNID] = 0
-	}
-	mp.vnidRefs[newVNID] += num
 }

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -314,7 +314,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 		return nil, nil, err
 	}
 
-	m.policy.RefVNID(vnid)
+	m.policy.EnsureVNIDRules(vnid)
 	success = true
 	return ipamResult, &runningPod{podPortMapping: podPortMapping, vnid: vnid, ofport: ofport}, nil
 }
@@ -353,9 +353,6 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 
 		if err := m.ovs.TearDownPod(hostVethName, podIP); err != nil {
 			errList = append(errList, err)
-		}
-		if vnid, err := m.policy.GetVNID(req.PodNamespace); err == nil {
-			m.policy.UnrefVNID(vnid)
 		}
 	}
 

--- a/pkg/sdn/plugin/singletenant.go
+++ b/pkg/sdn/plugin/singletenant.go
@@ -41,8 +41,8 @@ func (sp *singleTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
 	return false
 }
 
-func (sp *singleTenantPlugin) RefVNID(vnid uint32) {
+func (sp *singleTenantPlugin) EnsureVNIDRules(vnid uint32) {
 }
 
-func (sp *singleTenantPlugin) UnrefVNID(vnid uint32) {
+func (sp *singleTenantPlugin) SyncVNIDRules() {
 }


### PR DESCRIPTION
We currently count how many pods/services there are of each VNID on each node so we can delete VNID-related rules when they are no longer needed. But it's hard to guarantee our counts stay in sync, especially in the face of pod creation errors and the like. It would be safer to just periodically scan the OVS flows and remove any that are no longer being used.

(At the moment, we also don't bother to initialize the count correctly on restart if there are existing pods, so just restarting, creating a pod, and then deleting it can cause the VNID rules to get deleted. I'm not sure if this is the problem the reporters are seeing or not.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1454948
Fixes #14092

@openshift/networking PTAL