### PR TITLE
Remove a duplicate deployment informer

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -343,6 +343,8 @@ func buildControllerManagerServer(masterConfig configapi.MasterConfig) (*cmapp.C
 		componentconfig.GroupResource{Group: "oauth.openshift.io", Resource: "oauthauthorizetokens"},
 		// exposed already as cronjobs
 		componentconfig.GroupResource{Group: "batch", Resource: "scheduledjobs"},
+		// exposed already as extensions v1beta1 by other controllers
+		componentconfig.GroupResource{Group: "apps", Resource: "deployments"},
 	)
 
 	// resolve extended arguments

--- a/pkg/cmd/server/origin/controller/image.go
+++ b/pkg/cmd/server/origin/controller/image.go
@@ -65,8 +65,8 @@ func (c *ImageTriggerControllerConfig) RunController(ctx ControllerContext) (boo
 	if !c.HasDeploymentsEnabled {
 		sources = append(sources, imagetriggercontroller.TriggerSource{
 			Resource:  schema.GroupResource{Group: "extensions", Resource: "deployments"},
-			Informer:  ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Apps().V1beta1().Deployments().Informer(),
-			Store:     ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Apps().V1beta1().Deployments().Informer().GetIndexer(),
+			Informer:  ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Extensions().V1beta1().Deployments().Informer(),
+			Store:     ctx.DeprecatedOpenshiftInformers.KubernetesInformers().Extensions().V1beta1().Deployments().Informer().GetIndexer(),
 			TriggerFn: triggerannotations.NewAnnotationTriggerIndexer,
 			Reactor:   &triggerannotations.AnnotationReactor{Updater: updater, Copier: kapi.Scheme},
 		})


### PR DESCRIPTION
Upstream is using extensions, we'll need to be using it until they switch.

Only the last commit is new

[test]