### PR TITLE
don't start template informer unless templateservicebroker is enabled

### DIFF
--- a/pkg/cmd/server/origin/controller/apps.go
+++ b/pkg/cmd/server/origin/controller/apps.go
@@ -8,7 +8,6 @@ import (
 	deployercontroller "github.com/openshift/origin/pkg/deploy/controller/deployer"
 	deployconfigcontroller "github.com/openshift/origin/pkg/deploy/controller/deploymentconfig"
 	triggercontroller "github.com/openshift/origin/pkg/deploy/controller/generictrigger"
-	templatecontroller "github.com/openshift/origin/pkg/template/controller"
 )
 
 type DeployerControllerConfig struct {
@@ -24,9 +23,6 @@ type DeploymentConfigControllerConfig struct {
 
 type DeploymentTriggerControllerConfig struct {
 	Codec runtime.Codec
-}
-
-type TemplateInstanceControllerConfig struct {
 }
 
 func (c *DeployerControllerConfig) RunController(ctx ControllerContext) (bool, error) {
@@ -87,34 +83,6 @@ func (c *DeploymentTriggerControllerConfig) RunController(ctx ControllerContext)
 		ctx.ImageInformers.Image().InternalVersion().ImageStreams().Informer(),
 		deprecatedOcTriggerClient,
 		c.Codec,
-	).Run(5, ctx.Stop)
-
-	return true, nil
-}
-
-func (c *TemplateInstanceControllerConfig) RunController(ctx ControllerContext) (bool, error) {
-	saName := bootstrappolicy.InfraTemplateInstanceControllerServiceAccountName
-
-	internalKubeClient, err := ctx.ClientBuilder.KubeInternalClient(saName)
-	if err != nil {
-		return true, err
-	}
-
-	deprecatedOcClient, err := ctx.ClientBuilder.DeprecatedOpenshiftClient(saName)
-	if err != nil {
-		return true, err
-	}
-
-	templateClient, err := ctx.ClientBuilder.OpenshiftTemplateClient(saName)
-	if err != nil {
-		return true, err
-	}
-
-	go templatecontroller.NewTemplateInstanceController(
-		deprecatedOcClient,
-		internalKubeClient,
-		templateClient.Template(),
-		ctx.TemplateInformers.Template().InternalVersion().TemplateInstances(),
 	).Run(5, ctx.Stop)
 
 	return true, nil

--- a/pkg/cmd/server/origin/controller/template.go
+++ b/pkg/cmd/server/origin/controller/template.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	templatecontroller "github.com/openshift/origin/pkg/template/controller"
+)
+
+type TemplateInstanceControllerConfig struct {
+}
+
+func (c *TemplateInstanceControllerConfig) RunController(ctx ControllerContext) (bool, error) {
+	saName := bootstrappolicy.InfraTemplateInstanceControllerServiceAccountName
+
+	internalKubeClient, err := ctx.ClientBuilder.KubeInternalClient(saName)
+	if err != nil {
+		return true, err
+	}
+
+	deprecatedOcClient, err := ctx.ClientBuilder.DeprecatedOpenshiftClient(saName)
+	if err != nil {
+		return true, err
+	}
+
+	templateClient, err := ctx.ClientBuilder.OpenshiftTemplateClient(saName)
+	if err != nil {
+		return true, err
+	}
+
+	go templatecontroller.NewTemplateInstanceController(
+		deprecatedOcClient,
+		internalKubeClient,
+		templateClient.Template(),
+		ctx.TemplateInformers.Template().InternalVersion().TemplateInstances(),
+	).Run(5, ctx.Stop)
+
+	return true, nil
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -254,13 +254,15 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	templateInformers := templateinformer.NewSharedInformerFactory(templateClient, defaultInformerResyncPeriod)
 	informerFactory := shared.NewInformerFactory(internalkubeInformerFactory, externalkubeInformerFactory, privilegedLoopbackKubeClientsetInternal, privilegedLoopbackOpenShiftClient, customListerWatchers, defaultInformerResyncPeriod)
 
-	err = templateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
-		templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
-			return []string{string(obj.(*templateapi.Template).UID)}, nil
-		},
-	})
-	if err != nil {
-		return nil, err
+	if options.TemplateServiceBrokerConfig != nil {
+		err = templateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
+			templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
+				return []string{string(obj.(*templateapi.Template).UID)}, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	imageTemplate := variable.NewDefaultImageTemplate()


### PR DESCRIPTION
should resolve https://github.com/openshift/origin/issues/8229#issuecomment-307598720, https://github.com/openshift/origin/pull/14216#pullrequestreview-43308911

(also broken out TemplateInstanceControllerConfig into its own source file, didn't belong in apps.go)