### PR TITLE
deploy: set ownerRef from RC to grouped API version

### DIFF
--- a/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
+++ b/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
@@ -108,7 +108,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		}
 		return fresh, nil
 	})
-	cm := oscontroller.NewRCControllerRefManager(c.rcControl, config, selector, deployutil.ControllerKind, canAdoptFunc)
+	cm := oscontroller.NewRCControllerRefManager(c.rcControl, config, selector, deployutil.DeploymentConfigControllerRefKind, canAdoptFunc)
 	existingDeployments, err := cm.ClaimReplicationControllers(rcList)
 	if err != nil {
 		return fmt.Errorf("error while deploymentConfigController claiming replication controllers: %v", err)

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -18,14 +18,16 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kdeplutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 
-	osapiv1 "github.com/openshift/origin/pkg/api/v1"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapiv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 	"github.com/openshift/origin/pkg/util/namer"
 )
 
 var (
-	// ControllerKind contains the schema.GroupVersionKind for this controller type.
-	ControllerKind = osapiv1.SchemeGroupVersion.WithKind("DeploymentConfig")
+	// DeploymentConfigControllerRefKind contains the schema.GroupVersionKind for the
+	// deployment config. This is used in the ownerRef and GC client picks the appropriate
+	// client to get the deployment config.
+	DeploymentConfigControllerRefKind = deployapiv1.SchemeGroupVersion.WithKind("DeploymentConfig")
 )
 
 // NewDeploymentCondition creates a new deployment condition.
@@ -238,8 +240,8 @@ func NewControllerRef(config *deployapi.DeploymentConfig) *metav1.OwnerReference
 	blockOwnerDeletion := true
 	isController := true
 	return &metav1.OwnerReference{
-		APIVersion:         ControllerKind.Version,
-		Kind:               ControllerKind.Kind,
+		APIVersion:         DeploymentConfigControllerRefKind.GroupVersion().String(),
+		Kind:               DeploymentConfigControllerRefKind.Kind,
 		Name:               config.Name,
 		UID:                config.UID,
 		BlockOwnerDeletion: &blockOwnerDeletion,


### PR DESCRIPTION
@smarterclayton @sttts this should fix the deployer gone missing problem (I believe).

Some explanation:

When the GC cache is cold, the GC will try to use a live GET using the dynamic client to check if the resource specified in the ownerRef exists. In this case the RC is pointing to a DC. However, the dynamic client use wrong API prefix (/api instead of /oapi) it this will return 404 and the GC thinks that the DC is gone and mark the RC for deletion. The RC is deleted and since the deployer pod has an ownerRef pointing to this RC the pod is also terminated and deleted.
When the GC caches warm up, it will see the DC (UUID) and so it will not do live GET lookup and keep the RC untouched, allowing successfull rollout. I guess we were just lucky in our CI/CD and we warmed the cache fast enough to not hit this (the ipfailover flaked)...

What this patch does is to force API group version for the DC, which the dynamic client should handle (i can confirm it returns 200). 

Fixes: https://github.com/openshift/origin/issues/13995