### PR TITLE
Add SSL information to the backend

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -182,7 +182,7 @@ frontend public_ssl
 # traffic
 ##########################################################################
 backend be_sni
-  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy
+  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy-v2-ssl
 
 frontend fe_sni
   # terminate ssl on edge

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -182,7 +182,7 @@ frontend public_ssl
 # traffic
 ##########################################################################
 backend be_sni
-  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy-v2-ssl
+  server fe_sni 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}} weight 1 send-proxy-v2-ssl-cn
 
 frontend fe_sni
   # terminate ssl on edge
@@ -216,7 +216,7 @@ frontend fe_sni
 ##########################################################################
 # backend for when sni does not exist, or ssl term needs to happen on the edge
 backend be_no_sni
-  server fe_no_sni 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} weight 1 send-proxy
+  server fe_no_sni 127.0.0.1:{{env "ROUTER_SERVICE_NO_SNI_PORT" "10443"}} weight 1 send-proxy-v2-ssl
 
 frontend fe_no_sni
   # terminate ssl on edge


### PR DESCRIPTION
Send PROXY protocol version 2 over connections for the internal connections so we pass more information to ourselves.
cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-send-proxy-v2-ssl

Created this PR as a copy of this one:
https://github.com/openshift/origin/pull/5974
Because it needed to be rebased and I can't edit it.