### PR TITLE
admin and editor should cover image builder

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -337,6 +337,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("builds/log").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+				authorizationapi.NewRule("update").Groups(buildGroup, legacyBuildGroup).Resources("builds/details").RuleOrDie(),
 				// access to jenkins.  multiple values to ensure that covers relationships
 				authorizationapi.NewRule("admin", "edit", "view").Groups(buildapi.GroupName).Resources("jenkins").RuleOrDie(),
 
@@ -397,6 +398,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("builds/log").RuleOrDie(),
 				authorizationapi.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/clone").RuleOrDie(),
+				authorizationapi.NewRule("update").Groups(buildGroup, legacyBuildGroup).Resources("builds/details").RuleOrDie(),
 				// access to jenkins.  multiple values to ensure that covers relationships
 				authorizationapi.NewRule("edit", "view").Groups(buildapi.GroupName).Resources("jenkins").RuleOrDie(),
 

--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -107,6 +107,7 @@ func TestCovers(t *testing.T) {
 	var systemDiscovery *authorizationapi.ClusterRole
 	var clusterAdmin *authorizationapi.ClusterRole
 	var storageAdmin *authorizationapi.ClusterRole
+	var imageBuilder *authorizationapi.ClusterRole
 
 	for i := range allRoles {
 		role := allRoles[i]
@@ -131,6 +132,8 @@ func TestCovers(t *testing.T) {
 			clusterAdmin = &role
 		case bootstrappolicy.StorageAdminRoleName:
 			storageAdmin = &role
+		case bootstrappolicy.ImageBuilderRoleName:
+			imageBuilder = &role
 		}
 	}
 
@@ -153,6 +156,14 @@ func TestCovers(t *testing.T) {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(registryAdmin.Rules, registryViewer.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+
+	// admin and editor should cover imagebuilder
+	if covers, miss := rulevalidation.Covers(admin.Rules, imageBuilder.Rules); !covers {
+		t.Errorf("failed to cover: %#v", miss)
+	}
+	if covers, miss := rulevalidation.Covers(editor.Rules, imageBuilder.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -809,6 +809,14 @@ items:
     - create
   - apiGroups:
     - build.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/details
+    verbs:
+    - update
+  - apiGroups:
+    - build.openshift.io
     attributeRestrictions: null
     resources:
     - jenkins
@@ -1201,6 +1209,14 @@ items:
     - builds/clone
     verbs:
     - create
+  - apiGroups:
+    - build.openshift.io
+    - ""
+    attributeRestrictions: null
+    resources:
+    - builds/details
+    verbs:
+    - update
   - apiGroups:
     - build.openshift.io
     attributeRestrictions: null


### PR DESCRIPTION
project editors already have equivalent powers for image-builders since the role is assigned to a local SA.  This make the covers relationship required by unit tests and fixes up the roles.