### PR TITLE
Document dependencies for build-base-images.sh

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -18,7 +18,8 @@ To build the base and release images, run:
 
     $ hack/build-base-images.sh
 
-hack/build-base-images.sh Depends on [imagebuilder](https://github.com/openshift/imagebuilder).
+Today, all of our container image builds require 
+[imagebuilder](https://github.com/openshift/imagebuilder).
 
 Once a release has been created, it can be pushed:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -18,6 +18,8 @@ To build the base and release images, run:
 
     $ hack/build-base-images.sh
 
+hack/build-base-images.sh Depends on [imagebuilder](https://github.com/openshift/imagebuilder).
+
 Once a release has been created, it can be pushed:
 
     $ hack/push-release.sh


### PR DESCRIPTION
Build-base-images depends on imagebuilder which won't be installed or pulled by default.