### PR TITLE
DO_NOT_MERGE template service broker: remove requester username from catalog schema

### DIFF
--- a/pkg/openservicebroker/api/types.go
+++ b/pkg/openservicebroker/api/types.go
@@ -1,7 +1,8 @@
 package api
 
-// from https://github.com/openservicebrokerapi/servicebroker/blob/1d301105c66187b5aa2e061a1264ecf3cbc3d2a0/_spec.md
-// and https://github.com/avade/servicebroker/blob/8c340c610c6085c1aa32144faef0d1600c21576c/_spec.md
+// from https://github.com/openservicebrokerapi/servicebroker/blob/b33070e07cea53b9540b1d5ab8d1f62ddc556eb5/spec.md
+// and https://github.com/openservicebrokerapi/servicebroker/blob/b33070e07cea53b9540b1d5ab8d1f62ddc556eb5/profile.md
+// and https://github.com/avade/servicebroker/blob/9165f14ce6c54c3f81fba760cca53bd781febd6f/spec.md
 
 import (
 	jsschema "github.com/lestrrat/go-jsschema"
@@ -73,13 +74,20 @@ const (
 )
 
 type ProvisionRequest struct {
-	ServiceID         string            `json:"service_id"`
-	PlanID            string            `json:"plan_id"`
-	Parameters        map[string]string `json:"parameters,omitempty"`
-	AcceptsIncomplete bool              `json:"accepts_incomplete,omitempty"`
-	OrganizationID    string            `json:"organization_guid"`
-	SpaceID           string            `json:"space_guid"`
+	ServiceID      string            `json:"service_id"`
+	PlanID         string            `json:"plan_id"`
+	Context        KubernetesContext `json:"context,omitempty"`
+	OrganizationID string            `json:"organization_guid"`
+	SpaceID        string            `json:"space_guid"`
+	Parameters     map[string]string `json:"parameters,omitempty"`
 }
+
+type KubernetesContext struct {
+	Platform  string `json:"platform"`
+	Namespace string `json:"namespace"`
+}
+
+const ContextPlatformKubernetes = "kubernetes"
 
 type ProvisionResponse struct {
 	DashboardURL string    `json:"dashboard_url,omitempty"`
@@ -89,11 +97,11 @@ type ProvisionResponse struct {
 type Operation string
 
 type UpdateRequest struct {
-	ServiceID         string            `json:"service_id"`
-	PlanID            string            `json:"plan_id,omitempty"`
-	Parameters        map[string]string `json:"parameters,omitempty"`
-	AcceptsIncomplete bool              `json:"accepts_incomplete,omitempty"`
-	PreviousValues    struct {
+	Context        KubernetesContext `json:"context,omitempty"`
+	ServiceID      string            `json:"service_id"`
+	PlanID         string            `json:"plan_id,omitempty"`
+	Parameters     map[string]string `json:"parameters,omitempty"`
+	PreviousValues struct {
 		ServiceID      string `json:"service_id,omitempty"`
 		PlanID         string `json:"plan_id,omitempty"`
 		OrganizationID string `json:"organization_id,omitempty"`

--- a/pkg/openservicebroker/api/validation_test.go
+++ b/pkg/openservicebroker/api/validation_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -10,66 +11,132 @@ const validUUID = "fe6e44ea-377a-457c-9fa1-ba06ad356839"
 
 func TestValidateProvisionRequest(t *testing.T) {
 	tests := []struct {
-		name        string
-		preq        ProvisionRequest
-		expectError string
+		name              string
+		preq              ProvisionRequest
+		expectErrorPrefix string
 	}{
+		{
+			name: "missing context platform",
+			preq: ProvisionRequest{
+				ServiceID: validUUID,
+				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Namespace: "test",
+				},
+			},
+			expectErrorPrefix: `context.platform: Required value`,
+		},
+		{
+			name: "bad context platform",
+			preq: ProvisionRequest{
+				ServiceID: validUUID,
+				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Platform:  "b@d",
+					Namespace: "test",
+				},
+			},
+			expectErrorPrefix: `context.platform: Invalid value: "b@d": must equal kubernetes`,
+		},
+		{
+			name: "missing context namespace",
+			preq: ProvisionRequest{
+				ServiceID: validUUID,
+				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Platform: ContextPlatformKubernetes,
+				},
+			},
+			expectErrorPrefix: `context.namespace: Required value`,
+		},
+		{
+			name: "bad context namespace",
+			preq: ProvisionRequest{
+				ServiceID: validUUID,
+				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "b@d",
+				},
+			},
+			expectErrorPrefix: `context.namespace: Invalid value: "b@d": `, // a DNS-1123 label must consist of ...
+		},
 		{
 			name: "empty ServiceID",
 			preq: ProvisionRequest{
 				PlanID: validUUID,
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
-			expectError: `service_id: Invalid value: "": must be a valid UUID`,
+			expectErrorPrefix: `service_id: Invalid value: "": must be a valid UUID`,
 		},
 		{
 			name: "bad ServiceID",
 			preq: ProvisionRequest{
 				ServiceID: "bad",
 				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
-			expectError: `service_id: Invalid value: "bad": must be a valid UUID`,
+			expectErrorPrefix: `service_id: Invalid value: "bad": must be a valid UUID`,
 		},
 		{
 			name: "empty PlanID",
 			preq: ProvisionRequest{
 				ServiceID: validUUID,
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
-			expectError: `plan_id: Invalid value: "": must be a valid UUID`,
+			expectErrorPrefix: `plan_id: Invalid value: "": must be a valid UUID`,
 		},
 		{
 			name: "bad PlanID",
 			preq: ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    "bad",
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
-			expectError: `plan_id: Invalid value: "bad": must be a valid UUID`,
+			expectErrorPrefix: `plan_id: Invalid value: "bad": must be a valid UUID`,
 		},
 		{
 			name: "good",
 			preq: ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
+				Context: KubernetesContext{
+					Platform:  ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
-			expectError: ``,
+			expectErrorPrefix: ``,
 		},
 	}
 
 	for _, test := range tests {
 		errors := ValidateProvisionRequest(&test.preq)
-		if test.expectError == "" {
+		if test.expectErrorPrefix == "" {
 			if len(errors) > 0 {
-				t.Errorf("%q: expectError was %q but errors was %q", test.name, test.expectError, errors)
+				t.Errorf("%q: expectErrorPrefix was %q but errors was %q", test.name, test.expectErrorPrefix, errors)
 			}
 		} else {
 			found := false
 			for _, err := range errors {
-				if err.Error() == test.expectError {
+				if strings.HasPrefix(err.Error(), test.expectErrorPrefix) {
 					found = true
 					break
 				}
 			}
 			if !found {
-				t.Errorf("%q: expectError was %q but errors was %q", test.name, test.expectError, errors)
+				t.Errorf("%q: expectErrorPrefix was %q but errors was %q", test.name, test.expectErrorPrefix, errors)
 			}
 		}
 	}

--- a/pkg/openservicebroker/client/client.go
+++ b/pkg/openservicebroker/client/client.go
@@ -85,15 +85,13 @@ func (c *client) Provision(ctx context.Context, instanceID string, preq *api.Pro
 		return nil, errs.ToAggregate()
 	}
 
-	preq.AcceptsIncomplete = true
-
 	pr, pw := io.Pipe()
 	go func() {
 		e := json.NewEncoder(pw)
 		pw.CloseWithError(e.Encode(preq))
 	}()
 
-	req, err := http.NewRequest(http.MethodPut, c.root+"/v2/service_instances/"+instanceID, pr)
+	req, err := http.NewRequest(http.MethodPut, c.root+"/v2/service_instances/"+instanceID+"?accepts_incomplete=true", pr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openservicebroker/server/route.go
+++ b/pkg/openservicebroker/server/route.go
@@ -109,8 +109,8 @@ func provision(b api.Broker, req *restful.Request) *api.Response {
 		return api.BadRequest(errors.ToAggregate())
 	}
 
-	if !preq.AcceptsIncomplete {
-		return api.NewResponse(http.StatusUnprocessableEntity, api.AsyncRequired, nil)
+	if req.QueryParameter("accepts_incomplete") != "true" {
+		return api.NewResponse(http.StatusUnprocessableEntity, &api.AsyncRequired, nil)
 	}
 
 	return b.Provision(instanceID, &preq)

--- a/pkg/openservicebroker/server/route_test.go
+++ b/pkg/openservicebroker/server/route_test.go
@@ -244,6 +244,10 @@ func TestProvision(t *testing.T) {
 			body: &api.ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
+				Context: api.KubernetesContext{
+					Platform:  api.ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
 			expectCode:  http.StatusUnprocessableEntity,
 			expectError: `This service plan requires client support for asynchronous service operations.`,
@@ -251,12 +255,15 @@ func TestProvision(t *testing.T) {
 		{
 			name: "good",
 			req: http.Request{
-				URL: parseUrl(t, "/v2/service_instances/"+validUUID),
+				URL: parseUrl(t, "/v2/service_instances/"+validUUID+"?accepts_incomplete=true"),
 			},
 			body: &api.ProvisionRequest{
-				ServiceID:         validUUID,
-				PlanID:            validUUID,
-				AcceptsIncomplete: true,
+				ServiceID: validUUID,
+				PlanID:    validUUID,
+				Context: api.KubernetesContext{
+					Platform:  api.ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 			},
 			expectCode: http.StatusOK,
 		},

--- a/pkg/template/api/constants.go
+++ b/pkg/template/api/constants.go
@@ -23,18 +23,12 @@ const (
 	// TemplateInstance API.
 	TemplateInstanceLabel = "template.openshift.io/template-instance"
 
-	// NamespaceParameterKey is the name of the key in the Open Service Broker API
-	// ProvisionRequest Parameters object where we receive the name of the
-	// namespace into which a template should be provisioned.  The '/' and '.'
-	// characters in the name happen to make this an invalid template parameter
-	// name so there is no immediate overlap with passed template parameters in
-	// the same object.
-	NamespaceParameterKey = "template.openshift.io/namespace"
-
 	// RequesterUsernameParameterKey is the name of the key in the Open Service
 	// Broker API ProvisionRequest Parameters object where we receive the user
-	// name which will be impersonated during template provisioning.  See above
-	// note.
+	// name which will be impersonated during template provisioning.  The '/'
+	// and '.' characters in the name happen to make this an invalid template
+	// parameter name so there is no immediate overlap with passed template
+	// parameters in the same object.
 	RequesterUsernameParameterKey = "template.openshift.io/requester-username"
 
 	// ServiceBrokerRoot is the API root of the template service broker.

--- a/pkg/template/servicebroker/catalog.go
+++ b/pkg/template/servicebroker/catalog.go
@@ -46,18 +46,13 @@ func serviceFromTemplate(template *templateapi.Template) *api.Service {
 	}
 
 	properties := map[string]*jsschema.Schema{
-		templateapi.NamespaceParameterKey: {
-			Title:       namespaceTitle,
-			Description: namespaceDescription,
-			Type:        []jsschema.PrimitiveType{jsschema.StringType},
-		},
 		templateapi.RequesterUsernameParameterKey: {
 			Title:       requesterUsernameTitle,
 			Description: requesterUsernameDescription,
 			Type:        []jsschema.PrimitiveType{jsschema.StringType},
 		},
 	}
-	required := []string{templateapi.NamespaceParameterKey, templateapi.RequesterUsernameParameterKey}
+	required := []string{templateapi.RequesterUsernameParameterKey}
 	for _, param := range template.Parameters {
 		properties[param.Name] = &jsschema.Schema{
 			Title:       param.DisplayName,

--- a/pkg/template/servicebroker/catalog.go
+++ b/pkg/template/servicebroker/catalog.go
@@ -14,16 +14,6 @@ import (
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
-const (
-	namespaceTitle       = "Template service broker: namespace"
-	namespaceDescription = "OpenShift namespace in which to provision service"
-
-	// the following should go away with catalog<->broker support for passing
-	// identity information.
-	requesterUsernameTitle       = "Template service broker: requester username"
-	requesterUsernameDescription = "OpenShift user requesting provision/bind"
-)
-
 // Map OpenShift template annotations to open service broker metadata field
 // community standards.
 var annotationMap = map[string]string{
@@ -45,14 +35,8 @@ func serviceFromTemplate(template *templateapi.Template) *api.Service {
 		}
 	}
 
-	properties := map[string]*jsschema.Schema{
-		templateapi.RequesterUsernameParameterKey: {
-			Title:       requesterUsernameTitle,
-			Description: requesterUsernameDescription,
-			Type:        []jsschema.PrimitiveType{jsschema.StringType},
-		},
-	}
-	required := []string{templateapi.RequesterUsernameParameterKey}
+	properties := map[string]*jsschema.Schema{}
+	required := []string{}
 	for _, param := range template.Parameters {
 		properties[param.Name] = &jsschema.Schema{
 			Title:       param.DisplayName,
@@ -85,16 +69,10 @@ func serviceFromTemplate(template *templateapi.Template) *api.Service {
 			ServiceBinding: api.ServiceBindings{
 				Create: map[string]*jsschema.Schema{
 					"parameters": {
-						SchemaRef: jsschema.SchemaURL,
-						Type:      []jsschema.PrimitiveType{jsschema.ObjectType},
-						Properties: map[string]*jsschema.Schema{
-							templateapi.RequesterUsernameParameterKey: {
-								Title:       requesterUsernameTitle,
-								Description: requesterUsernameDescription,
-								Type:        []jsschema.PrimitiveType{jsschema.StringType},
-							},
-						},
-						Required: []string{templateapi.RequesterUsernameParameterKey},
+						SchemaRef:  jsschema.SchemaURL,
+						Type:       []jsschema.PrimitiveType{jsschema.ObjectType},
+						Properties: map[string]*jsschema.Schema{},
+						Required:   []string{},
 					},
 				},
 			},

--- a/pkg/template/servicebroker/catalog_test.go
+++ b/pkg/template/servicebroker/catalog_test.go
@@ -76,16 +76,10 @@ func TestServiceFromTemplate(t *testing.T) {
 								Type:      schema.PrimitiveTypes{schema.ObjectType},
 								SchemaRef: "http://json-schema.org/draft-04/schema",
 								Required: []string{
-									"template.openshift.io/namespace",
 									"template.openshift.io/requester-username",
 									"param1",
 								},
 								Properties: map[string]*schema.Schema{
-									"template.openshift.io/namespace": {
-										Title:       "Template service broker: namespace",
-										Description: "OpenShift namespace in which to provision service",
-										Type:        schema.PrimitiveTypes{schema.StringType},
-									},
 									"template.openshift.io/requester-username": {
 										Title:       "Template service broker: requester username",
 										Description: "OpenShift user requesting provision/bind",

--- a/pkg/template/servicebroker/catalog_test.go
+++ b/pkg/template/servicebroker/catalog_test.go
@@ -76,15 +76,9 @@ func TestServiceFromTemplate(t *testing.T) {
 								Type:      schema.PrimitiveTypes{schema.ObjectType},
 								SchemaRef: "http://json-schema.org/draft-04/schema",
 								Required: []string{
-									"template.openshift.io/requester-username",
 									"param1",
 								},
 								Properties: map[string]*schema.Schema{
-									"template.openshift.io/requester-username": {
-										Title:       "Template service broker: requester username",
-										Description: "OpenShift user requesting provision/bind",
-										Type:        schema.PrimitiveTypes{schema.StringType},
-									},
 									"param1": {
 										Default: "",
 										Type:    schema.PrimitiveTypes{schema.StringType},
@@ -108,16 +102,10 @@ func TestServiceFromTemplate(t *testing.T) {
 					ServiceBinding: api.ServiceBindings{
 						Create: map[string]*schema.Schema{
 							"parameters": {
-								Type:      schema.PrimitiveTypes{schema.ObjectType},
-								SchemaRef: "http://json-schema.org/draft-04/schema",
-								Required:  []string{"template.openshift.io/requester-username"},
-								Properties: map[string]*schema.Schema{
-									"template.openshift.io/requester-username": {
-										Title:       "Template service broker: requester username",
-										Description: "OpenShift user requesting provision/bind",
-										Type:        schema.PrimitiveTypes{schema.StringType},
-									},
-								},
+								Type:       schema.PrimitiveTypes{schema.ObjectType},
+								SchemaRef:  "http://json-schema.org/draft-04/schema",
+								Required:   []string{},
+								Properties: map[string]*schema.Schema{},
 							},
 						},
 					},

--- a/pkg/template/servicebroker/provision.go
+++ b/pkg/template/servicebroker/provision.go
@@ -28,7 +28,7 @@ func (b *Broker) ensureSecret(u user.Info, namespace string, instanceID string, 
 	}
 
 	for k, v := range preq.Parameters {
-		if k != templateapi.NamespaceParameterKey && k != templateapi.RequesterUsernameParameterKey {
+		if k != templateapi.RequesterUsernameParameterKey {
 			secret.Data[k] = []byte(v)
 		}
 	}
@@ -201,7 +201,7 @@ func (b *Broker) Provision(instanceID string, preq *api.ProvisionRequest) *api.R
 		return api.BadRequest(errs.ToAggregate())
 	}
 
-	namespace := preq.Parameters[templateapi.NamespaceParameterKey]
+	namespace := preq.Context.Namespace
 	impersonate := preq.Parameters[templateapi.RequesterUsernameParameterKey]
 	u := &user.DefaultInfo{Name: impersonate}
 

--- a/pkg/template/servicebroker/test-scripts/provision.sh
+++ b/pkg/template/servicebroker/test-scripts/provision.sh
@@ -7,9 +7,12 @@ serviceUUID=${serviceUUID-$(oc get template cakephp-mysql-example -n openshift -
 req="{
   \"plan_id\": \"$planUUID\",
   \"service_id\": \"$serviceUUID\",
+  \"context\": {
+    \"platform\": \"kubernetes\",
+    \"namespace\": \"$namespace\"
+  },
   \"parameters\": {
     \"MYSQL_USER\": \"username\",
-    \"template.openshift.io/namespace\": \"$namespace\",
     \"template.openshift.io/requester-username\": \"$requesterUsername\"
   },
   \"accepts_incomplete\": true

--- a/pkg/template/servicebroker/test-scripts/provision.sh
+++ b/pkg/template/servicebroker/test-scripts/provision.sh
@@ -14,8 +14,7 @@ req="{
   \"parameters\": {
     \"MYSQL_USER\": \"username\",
     \"template.openshift.io/requester-username\": \"$requesterUsername\"
-  },
-  \"accepts_incomplete\": true
+  }
 }"
 
 curl \
@@ -25,4 +24,4 @@ curl \
   -d "$req" \
   -v \
   $curlargs \
-  $endpoint/v2/service_instances/$instanceUUID
+  $endpoint/v2/service_instances/$instanceUUID'?accepts_incomplete=true'

--- a/pkg/template/servicebroker/validation.go
+++ b/pkg/template/servicebroker/validation.go
@@ -3,7 +3,6 @@ package servicebroker
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/origin/pkg/openservicebroker/api"
@@ -19,13 +18,11 @@ func ValidateProvisionRequest(preq *api.ProvisionRequest) field.ErrorList {
 
 	for key := range preq.Parameters {
 		if !templatevalidation.ParameterNameRegexp.MatchString(key) &&
-			key != templateapi.NamespaceParameterKey &&
 			key != templateapi.RequesterUsernameParameterKey {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("parameters."+key), key, fmt.Sprintf("does not match %v", templatevalidation.ParameterNameRegexp)))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("parameters", key), key, fmt.Sprintf("does not match %v", templatevalidation.ParameterNameRegexp)))
 		}
 	}
 
-	allErrs = append(allErrs, validateParameter(templateapi.NamespaceParameterKey, preq.Parameters[templateapi.NamespaceParameterKey], validation.ValidateNamespaceName)...)
 	allErrs = append(allErrs, validateParameter(templateapi.RequesterUsernameParameterKey, preq.Parameters[templateapi.RequesterUsernameParameterKey], uservalidation.ValidateUserName)...)
 
 	return allErrs

--- a/pkg/template/servicebroker/validation_test.go
+++ b/pkg/template/servicebroker/validation_test.go
@@ -1,7 +1,6 @@
 package servicebroker
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/openshift/origin/pkg/openservicebroker/api"
@@ -21,31 +20,24 @@ func TestValidateProvisionRequest(t *testing.T) {
 			preq: api.ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
-				Parameters: map[string]string{
-					templateapi.NamespaceParameterKey: "test",
+				Context: api.KubernetesContext{
+					Platform:  api.ContextPlatformKubernetes,
+					Namespace: "test",
 				},
 			},
 			expectError: `parameters.` + templateapi.RequesterUsernameParameterKey + `: Required value`,
-		},
-		{
-			name: "missing NamespaceParameterKey key",
-			preq: api.ProvisionRequest{
-				ServiceID: validUUID,
-				PlanID:    validUUID,
-				Parameters: map[string]string{
-					templateapi.RequesterUsernameParameterKey: "test",
-				},
-			},
-			expectError: `parameters.` + templateapi.NamespaceParameterKey + `: Required value`,
 		},
 		{
 			name: "bad key",
 			preq: api.ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
+				Context: api.KubernetesContext{
+					Platform:  api.ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 				Parameters: map[string]string{
 					"b@d": "",
-					templateapi.NamespaceParameterKey:         "test",
 					templateapi.RequesterUsernameParameterKey: "test",
 				},
 			},
@@ -56,9 +48,12 @@ func TestValidateProvisionRequest(t *testing.T) {
 			preq: api.ProvisionRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
+				Context: api.KubernetesContext{
+					Platform:  api.ContextPlatformKubernetes,
+					Namespace: "test",
+				},
 				Parameters: map[string]string{
-					"azAZ09_":                                 "",
-					templateapi.NamespaceParameterKey:         "test",
+					"azAZ09_": "",
 					templateapi.RequesterUsernameParameterKey: "test",
 				},
 			},
@@ -102,7 +97,7 @@ func TestValidateBindRequest(t *testing.T) {
 			expectError: `parameters.` + templateapi.RequesterUsernameParameterKey + `: Required value`,
 		},
 		{
-			name: "bad key 1",
+			name: "bad key",
 			breq: api.BindRequest{
 				ServiceID: validUUID,
 				PlanID:    validUUID,
@@ -112,18 +107,6 @@ func TestValidateBindRequest(t *testing.T) {
 				},
 			},
 			expectError: `parameters.b@d: Invalid value: "b@d": does not match ^[a-zA-Z0-9_]+$`,
-		},
-		{
-			name: "bad key 2",
-			breq: api.BindRequest{
-				ServiceID: validUUID,
-				PlanID:    validUUID,
-				Parameters: map[string]string{
-					templateapi.NamespaceParameterKey:         "test",
-					templateapi.RequesterUsernameParameterKey: "test",
-				},
-			},
-			expectError: fmt.Sprintf(`parameters.%[1]s: Invalid value: "%[1]s": does not match ^[a-zA-Z0-9_]+$`, templateapi.NamespaceParameterKey),
 		},
 		{
 			name: "good",

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -103,8 +103,11 @@ var _ = g.Describe("[templates] templateservicebroker end-to-end test", func() {
 		_, err := brokercli.Provision(context.Background(), instanceID, &api.ProvisionRequest{
 			ServiceID: string(privatetemplate.UID),
 			PlanID:    plan.ID,
+			Context: api.KubernetesContext{
+				Platform:  api.ContextPlatformKubernetes,
+				Namespace: cli.Namespace(),
+			},
 			Parameters: map[string]string{
-				templateapi.NamespaceParameterKey:         cli.Namespace(),
 				templateapi.RequesterUsernameParameterKey: cli.Username(),
 			},
 		})
@@ -114,8 +117,11 @@ var _ = g.Describe("[templates] templateservicebroker end-to-end test", func() {
 		_, err = brokercli.Provision(context.Background(), instanceID, &api.ProvisionRequest{
 			ServiceID: service.ID,
 			PlanID:    plan.ID,
+			Context: api.KubernetesContext{
+				Platform:  api.ContextPlatformKubernetes,
+				Namespace: cli.Namespace(),
+			},
 			Parameters: map[string]string{
-				templateapi.NamespaceParameterKey:         cli.Namespace(),
 				templateapi.RequesterUsernameParameterKey: cli.Username(),
 				"DATABASE_USER":                           "test",
 			},

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -103,8 +103,11 @@ var _ = g.Describe("[templates] templateservicebroker security test", func() {
 		_, err := brokercli.Provision(context.Background(), instanceID, &api.ProvisionRequest{
 			ServiceID: service.ID,
 			PlanID:    plan.ID,
+			Context: api.KubernetesContext{
+				Platform:  api.ContextPlatformKubernetes,
+				Namespace: cli.Namespace(),
+			},
 			Parameters: map[string]string{
-				templateapi.NamespaceParameterKey:         cli.Namespace(),
 				templateapi.RequesterUsernameParameterKey: username,
 			},
 		})


### PR DESCRIPTION
builds upon https://github.com/openshift/origin/pull/14586 and removes the requester username from catalog schema (the parameter it is still needed on provision and bind calls)