### PR TITLE
fix imports to the canonical packages

### DIFF
--- a/pkg/auth/userregistry/identitymapper/lookup_test.go
+++ b/pkg/auth/userregistry/identitymapper/lookup_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	authapi "github.com/openshift/origin/pkg/auth/api"
-	"github.com/openshift/origin/pkg/user/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 	mappingregistry "github.com/openshift/origin/pkg/user/registry/useridentitymapping"
@@ -106,11 +105,11 @@ func TestLookup(t *testing.T) {
 	for k, tc := range testcases {
 		actions := []test.Action{}
 		identityRegistry := &test.IdentityRegistry{
-			Get:     map[string]*api.Identity{},
+			Get:     map[string]*userapi.Identity{},
 			Actions: &actions,
 		}
 		userRegistry := &test.UserRegistry{
-			Get:     map[string]*api.User{},
+			Get:     map[string]*userapi.User{},
 			Actions: &actions,
 		}
 		if tc.ExistingIdentity != nil {

--- a/pkg/auth/userregistry/identitymapper/provision_test.go
+++ b/pkg/auth/userregistry/identitymapper/provision_test.go
@@ -9,7 +9,6 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	authapi "github.com/openshift/origin/pkg/auth/api"
-	"github.com/openshift/origin/pkg/user/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 )
@@ -35,7 +34,7 @@ func (t *testNewIdentityGetter) UserForNewIdentity(ctx apirequest.Context, prefe
 }
 
 func TestGetPreferredUsername(t *testing.T) {
-	identity := &api.Identity{}
+	identity := &userapi.Identity{}
 
 	identity.ProviderUserName = "foo"
 	if preferred := getPreferredUserName(identity); preferred != "foo" {
@@ -238,11 +237,11 @@ func TestProvision(t *testing.T) {
 	for k, tc := range testcases {
 		actions := []test.Action{}
 		identityRegistry := &test.IdentityRegistry{
-			Get:     map[string]*api.Identity{},
+			Get:     map[string]*userapi.Identity{},
 			Actions: &actions,
 		}
 		userRegistry := &test.UserRegistry{
-			Get:     map[string]*api.User{},
+			Get:     map[string]*userapi.User{},
 			Actions: &actions,
 		}
 		if tc.ExistingIdentity != nil {

--- a/pkg/auth/userregistry/identitymapper/strategy_add_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_add_test.go
@@ -3,7 +3,7 @@ package identitymapper
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
@@ -28,7 +28,7 @@ func TestStrategyAdd(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
 			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
 
 			ExpectedActions: []test.Action{
@@ -43,7 +43,7 @@ func TestStrategyAdd(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
 			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
 
 			ExpectedActions: []test.Action{

--- a/pkg/auth/userregistry/identitymapper/strategy_claim_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_claim_test.go
@@ -3,7 +3,7 @@ package identitymapper
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
@@ -28,7 +28,7 @@ func TestStrategyClaim(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
 			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
 
 			ExpectedActions: []test.Action{
@@ -43,7 +43,7 @@ func TestStrategyClaim(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
 			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
 
 			ExpectedActions: []test.Action{

--- a/pkg/auth/userregistry/identitymapper/strategy_generate_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_generate_test.go
@@ -3,7 +3,7 @@ package identitymapper
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
@@ -28,7 +28,7 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
 			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
 
 			ExpectedActions: []test.Action{
@@ -44,7 +44,7 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
 			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
 
 			ExpectedActions: []test.Action{
@@ -60,7 +60,7 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers: []*api.User{
+			ExistingUsers: []*userapi.User{
 				makeUser("bobUserUID", "bob", "otheridp:user"),
 				makeUser("bob2UserUID", "bob2", "otheridp:user2"),
 			},

--- a/pkg/auth/userregistry/identitymapper/strategy_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_test.go
@@ -10,7 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/user"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 	userregistry "github.com/openshift/origin/pkg/user/registry/user"
 )
@@ -19,7 +19,7 @@ type testInitializer struct {
 	called bool
 }
 
-func (t *testInitializer) InitializeUser(identity *api.Identity, user *api.User) error {
+func (t *testInitializer) InitializeUser(identity *userapi.Identity, user *userapi.User) error {
 	t.called = true
 	return nil
 }
@@ -29,12 +29,12 @@ type strategyTestCase struct {
 
 	// Inputs
 	PreferredUsername string
-	Identity          *api.Identity
+	Identity          *userapi.Identity
 
 	// User registry setup
-	ExistingUsers  []*api.User
-	CreateResponse *api.User
-	UpdateResponse *api.User
+	ExistingUsers  []*userapi.User
+	CreateResponse *userapi.User
+	UpdateResponse *userapi.User
 
 	// Expectations
 	ExpectedActions    []test.Action
@@ -43,8 +43,8 @@ type strategyTestCase struct {
 	ExpectedInitialize bool
 }
 
-func makeUser(uid string, name string, identities ...string) *api.User {
-	return &api.User{
+func makeUser(uid string, name string, identities ...string) *userapi.User {
+	return &userapi.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			UID:  types.UID(uid),
@@ -52,8 +52,8 @@ func makeUser(uid string, name string, identities ...string) *api.User {
 		Identities: identities,
 	}
 }
-func makeIdentity(uid string, providerName string, providerUserName string, userUID string, userName string) *api.Identity {
-	return &api.Identity{
+func makeIdentity(uid string, providerName string, providerUserName string, userUID string, userName string) *userapi.Identity {
+	return &userapi.Identity{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: providerName + ":" + providerUserName,
 			UID:  types.UID(uid),
@@ -71,7 +71,7 @@ func makeIdentity(uid string, providerName string, providerUserName string, user
 func (tc strategyTestCase) run(k string, t *testing.T) {
 	actions := []test.Action{}
 	userRegistry := &test.UserRegistry{
-		Get:     map[string]*api.User{},
+		Get:     map[string]*userapi.User{},
 		Actions: &actions,
 	}
 	for _, u := range tc.ExistingUsers {

--- a/pkg/authorization/api/install/apigroup.go
+++ b/pkg/authorization/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/authorization/api"
-	"github.com/openshift/origin/pkg/authorization/api/v1"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  authorizationapi.GroupName,
+			VersionPreferenceOrder:     []string{authorizationapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: authorizationapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			authorizationapiv1.SchemeGroupVersion.Version: authorizationapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/authorization/api/install/install.go
+++ b/pkg/authorization/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/authorization/api"
-	"github.com/openshift/origin/pkg/authorization/api/v1"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/authorization/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/authorization/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{authorizationapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.GroupName)
+		glog.Infof("No version is registered for group %v", authorizationapi.GroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	authorizationapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case authorizationapiv1.LegacySchemeGroupVersion:
+			authorizationapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case authorizationapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.GroupName)
+		g, _ := kapi.Registry.Group(authorizationapi.GroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/authorization/api/v1/conversion_test.go
+++ b/pkg/authorization/api/v1/conversion_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/authorization/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	_ "github.com/openshift/origin/pkg/authorization/api/install"
 	testutil "github.com/openshift/origin/test/util/api"
 )
@@ -11,32 +11,32 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicy",
 		// Ensure all currently returned labels are supported
-		api.ClusterPolicyToSelectableFields(&api.ClusterPolicy{}),
+		authorizationapi.ClusterPolicyToSelectableFields(&authorizationapi.ClusterPolicy{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "ClusterPolicyBinding",
 		// Ensure all currently returned labels are supported
-		api.ClusterPolicyBindingToSelectableFields(&api.ClusterPolicyBinding{}),
+		authorizationapi.ClusterPolicyBindingToSelectableFields(&authorizationapi.ClusterPolicyBinding{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "Policy",
 		// Ensure all currently returned labels are supported
-		api.PolicyToSelectableFields(&api.Policy{}),
+		authorizationapi.PolicyToSelectableFields(&authorizationapi.Policy{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "PolicyBinding",
 		// Ensure all currently returned labels are supported
-		api.PolicyBindingToSelectableFields(&api.PolicyBinding{}),
+		authorizationapi.PolicyBindingToSelectableFields(&authorizationapi.PolicyBinding{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "Role",
 		// Ensure all currently returned labels are supported
-		api.RoleToSelectableFields(&api.Role{}),
+		authorizationapi.RoleToSelectableFields(&authorizationapi.Role{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "RoleBinding",
 		// Ensure all currently returned labels are supported
-		api.RoleBindingToSelectableFields(&api.RoleBinding{}),
+		authorizationapi.RoleBindingToSelectableFields(&authorizationapi.RoleBinding{}),
 	)
 
 }

--- a/pkg/authorization/api/v1/defaults_test.go
+++ b/pkg/authorization/api/v1/defaults_test.go
@@ -6,24 +6,24 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/authorization/api"
-	"github.com/openshift/origin/pkg/authorization/api/v1"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 func TestDefaults(t *testing.T) {
-	obj := &v1.PolicyRule{
+	obj := &authorizationapiv1.PolicyRule{
 		APIGroups: nil,
-		Verbs:     []string{api.VerbAll},
-		Resources: []string{api.ResourceAll},
+		Verbs:     []string{authorizationapi.VerbAll},
+		Resources: []string{authorizationapi.ResourceAll},
 	}
-	out := &api.PolicyRule{}
+	out := &authorizationapi.PolicyRule{}
 	if err := kapi.Scheme.Convert(obj, out, nil); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(out.APIGroups, []string{api.APIGroupAll}) {
+	if !reflect.DeepEqual(out.APIGroups, []string{authorizationapi.APIGroupAll}) {
 		t.Errorf("did not default api groups: %#v", out)
 	}
 }

--- a/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/authorization/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -19,10 +19,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ClusterPolicyBinding{} },
-		NewListFunc:       func() runtime.Object { return &api.ClusterPolicyBindingList{} },
+		NewFunc:           func() runtime.Object { return &authorizationapi.ClusterPolicyBinding{} },
+		NewListFunc:       func() runtime.Object { return &authorizationapi.ClusterPolicyBindingList{} },
 		PredicateFunc:     clusterpolicybinding.Matcher,
-		QualifiedResource: api.Resource("clusterpolicybindings"),
+		QualifiedResource: authorizationapi.Resource("clusterpolicybindings"),
 
 		CreateStrategy: clusterpolicybinding.Strategy,
 		UpdateStrategy: clusterpolicybinding.Strategy,

--- a/pkg/authorization/rulevalidation/compact_rules_test.go
+++ b/pkg/authorization/rulevalidation/compact_rules_test.go
@@ -9,20 +9,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/authorization/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
 func TestCompactRules(t *testing.T) {
 	testcases := map[string]struct {
-		Rules    []api.PolicyRule
-		Expected []api.PolicyRule
+		Rules    []authorizationapi.PolicyRule
+		Expected []authorizationapi.PolicyRule
 	}{
 		"empty": {
-			Rules:    []api.PolicyRule{},
-			Expected: []api.PolicyRule{},
+			Rules:    []authorizationapi.PolicyRule{},
+			Expected: []authorizationapi.PolicyRule{},
 		},
 		"simple": {
-			Rules: []api.PolicyRule{
+			Rules: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 				{Verbs: sets.NewString("update", "patch"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
@@ -40,7 +40,7 @@ func TestCompactRules(t *testing.T) {
 				{Verbs: nil, APIGroups: []string{""}, Resources: sets.NewString("pods")},
 				{Verbs: sets.NewString("create"), APIGroups: []string{""}, Resources: sets.NewString("pods")},
 			},
-			Expected: []api.PolicyRule{
+			Expected: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("create", "delete"), APIGroups: []string{"extensions"}, Resources: sets.NewString("daemonsets")},
 				{Verbs: sets.NewString("get", "list", "update", "patch"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 				{Verbs: sets.NewString("educate"), APIGroups: []string{""}, Resources: sets.NewString("dolphins")},
@@ -49,57 +49,57 @@ func TestCompactRules(t *testing.T) {
 			},
 		},
 		"complex multi-group": {
-			Rules: []api.PolicyRule{
+			Rules: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
 			},
-			Expected: []api.PolicyRule{
+			Expected: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{"", "builds.openshift.io"}, Resources: sets.NewString("builds")},
 			},
 		},
 
 		"complex multi-resource": {
-			Rules: []api.PolicyRule{
+			Rules: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
 			},
-			Expected: []api.PolicyRule{
+			Expected: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
 			},
 		},
 
 		"complex named-resource": {
-			Rules: []api.PolicyRule{
+			Rules: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild2")},
 			},
-			Expected: []api.PolicyRule{
+			Expected: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild")},
 				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("mybuild2")},
 			},
 		},
 
 		"complex non-resource": {
-			Rules: []api.PolicyRule{
+			Rules: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/foo")},
 			},
-			Expected: []api.PolicyRule{
+			Expected: []authorizationapi.PolicyRule{
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
 				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/foo")},
 			},
 		},
 
 		"complex attributes": {
-			Rules: []api.PolicyRule{
-				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
-				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			Rules: []authorizationapi.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			},
-			Expected: []api.PolicyRule{
-				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
-				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			Expected: []authorizationapi.PolicyRule{
+				{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
+				{Verbs: sets.NewString("list"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			},
 		},
 	}
@@ -129,8 +129,8 @@ func TestCompactRules(t *testing.T) {
 			continue
 		}
 
-		sort.Stable(api.SortableRuleSlice(compacted))
-		sort.Stable(api.SortableRuleSlice(tc.Expected))
+		sort.Stable(authorizationapi.SortableRuleSlice(compacted))
+		sort.Stable(authorizationapi.SortableRuleSlice(tc.Expected))
 		if !reflect.DeepEqual(compacted, tc.Expected) {
 			t.Errorf("%s: Expected\n%#v\ngot\n%#v", k, tc.Expected, compacted)
 			continue
@@ -140,63 +140,63 @@ func TestCompactRules(t *testing.T) {
 
 func TestIsSimpleResourceRule(t *testing.T) {
 	testcases := map[string]struct {
-		Rule     api.PolicyRule
+		Rule     authorizationapi.PolicyRule
 		Simple   bool
 		Resource schema.GroupResource
 	}{
 		"simple, no verbs": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString(), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString(), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 			Simple:   true,
 			Resource: schema.GroupResource{Group: "", Resource: "builds"},
 		},
 		"simple, one verb": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 			Simple:   true,
 			Resource: schema.GroupResource{Group: "", Resource: "builds"},
 		},
 		"simple, multi verb": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get", "list"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get", "list"), APIGroups: []string{""}, Resources: sets.NewString("builds")},
 			Simple:   true,
 			Resource: schema.GroupResource{Group: "", Resource: "builds"},
 		},
 
 		"complex, empty": {
-			Rule:     api.PolicyRule{},
+			Rule:     authorizationapi.PolicyRule{},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, no group": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{}, Resources: sets.NewString("builds")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{}, Resources: sets.NewString("builds")},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, multi group": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{"a", "b"}, Resources: sets.NewString("builds")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{"a", "b"}, Resources: sets.NewString("builds")},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, no resource": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString()},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString()},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, multi resource": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds", "images")},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, resource names": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("foo")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), ResourceNames: sets.NewString("foo")},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, attribute restrictions": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &api.IsPersonalSubjectAccessReview{}},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},
 		"complex, non-resource urls": {
-			Rule:     api.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
+			Rule:     authorizationapi.PolicyRule{Verbs: sets.NewString("get"), APIGroups: []string{""}, Resources: sets.NewString("builds"), NonResourceURLs: sets.NewString("/")},
 			Simple:   false,
 			Resource: schema.GroupResource{},
 		},

--- a/pkg/build/api/install/apigroup.go
+++ b/pkg/build/api/install/apigroup.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
-	"github.com/openshift/origin/pkg/build/api/v1"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 )
 
 func installApiGroup() {
@@ -18,13 +18,13 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  buildapi.GroupName,
+			VersionPreferenceOrder:     []string{buildapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: buildapi.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			buildapiv1.SchemeGroupVersion.Version: buildapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/build/api/install/install.go
+++ b/pkg/build/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
-	"github.com/openshift/origin/pkg/build/api/v1"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/build/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/build/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{buildapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", buildapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	buildapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case buildapiv1.LegacySchemeGroupVersion:
+			buildapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case buildapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(buildapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/build/api/v1/defaults_test.go
+++ b/pkg/build/api/v1/defaults_test.go
@@ -8,7 +8,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
-	"github.com/openshift/origin/pkg/build/api/v1"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -20,17 +20,17 @@ func TestDefaults(t *testing.T) {
 		Ok       func(runtime.Object) bool
 	}{
 		{
-			External: &v1.Build{
-				Spec: v1.BuildSpec{
-					CommonSpec: v1.CommonSpec{
-						Strategy: v1.BuildStrategy{
-							Type: v1.DockerBuildStrategyType,
+			External: &buildapiv1.Build{
+				Spec: buildapiv1.BuildSpec{
+					CommonSpec: buildapiv1.CommonSpec{
+						Strategy: buildapiv1.BuildStrategy{
+							Type: buildapiv1.DockerBuildStrategyType,
 						},
 					},
 				},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.Build)
+				obj, ok := out.(*buildapiv1.Build)
 				if !ok {
 					return false
 				}
@@ -38,17 +38,17 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			External: &v1.Build{
-				Spec: v1.BuildSpec{
-					CommonSpec: v1.CommonSpec{
-						Strategy: v1.BuildStrategy{
-							SourceStrategy: &v1.SourceBuildStrategy{},
+			External: &buildapiv1.Build{
+				Spec: buildapiv1.BuildSpec{
+					CommonSpec: buildapiv1.CommonSpec{
+						Strategy: buildapiv1.BuildStrategy{
+							SourceStrategy: &buildapiv1.SourceBuildStrategy{},
 						},
 					},
 				},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.Build)
+				obj, ok := out.(*buildapiv1.Build)
 				if !ok {
 					return false
 				}
@@ -56,19 +56,19 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			External: &v1.Build{
-				Spec: v1.BuildSpec{
-					CommonSpec: v1.CommonSpec{
-						Strategy: v1.BuildStrategy{
-							DockerStrategy: &v1.DockerBuildStrategy{
-								From: &kapiv1.ObjectReference{},
+			External: &buildapiv1.Build{
+				Spec: buildapiv1.BuildSpec{
+					CommonSpec: buildapiv1.CommonSpec{
+						Strategy: buildapiv1.BuildStrategy{
+							DockerStrategy: &buildapiv1.DockerBuildStrategy{
+								From: &kapibuildapiv1.ObjectReference{},
 							},
 						},
 					},
 				},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.Build)
+				obj, ok := out.(*buildapiv1.Build)
 				if !ok {
 					return false
 				}
@@ -76,17 +76,17 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			External: &v1.Build{
-				Spec: v1.BuildSpec{
-					CommonSpec: v1.CommonSpec{
-						Strategy: v1.BuildStrategy{
-							CustomStrategy: &v1.CustomBuildStrategy{},
+			External: &buildapiv1.Build{
+				Spec: buildapiv1.BuildSpec{
+					CommonSpec: buildapiv1.CommonSpec{
+						Strategy: buildapiv1.BuildStrategy{
+							CustomStrategy: &buildapiv1.CustomBuildStrategy{},
 						},
 					},
 				},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.Build)
+				obj, ok := out.(*buildapiv1.Build)
 				if !ok {
 					return false
 				}
@@ -94,44 +94,44 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			External: &v1.BuildConfig{
-				Spec: v1.BuildConfigSpec{Triggers: []v1.BuildTriggerPolicy{{Type: v1.ImageChangeBuildTriggerType}}},
+			External: &buildapiv1.BuildConfig{
+				Spec: buildapiv1.BuildConfigSpec{Triggers: []buildapiv1.BuildTriggerPolicy{{Type: buildapiv1.ImageChangeBuildTriggerType}}},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.BuildConfig)
+				obj, ok := out.(*buildapiv1.BuildConfig)
 				if !ok {
 					return false
 				}
 				// conversion drops this trigger because it has no type
-				return (len(obj.Spec.Triggers) == 0) && (obj.Spec.RunPolicy == v1.BuildRunPolicySerial)
+				return (len(obj.Spec.Triggers) == 0) && (obj.Spec.RunPolicy == buildapiv1.BuildRunPolicySerial)
 			},
 		},
 		{
-			External: &v1.BuildConfig{
-				Spec: v1.BuildConfigSpec{
-					CommonSpec: v1.CommonSpec{
-						Source: v1.BuildSource{
-							Type: v1.BuildSourceBinary,
+			External: &buildapiv1.BuildConfig{
+				Spec: buildapiv1.BuildConfigSpec{
+					CommonSpec: buildapiv1.CommonSpec{
+						Source: buildapiv1.BuildSource{
+							Type: buildapiv1.BuildSourceBinary,
 						},
-						Strategy: v1.BuildStrategy{
-							Type: v1.DockerBuildStrategyType,
+						Strategy: buildapiv1.BuildStrategy{
+							Type: buildapiv1.DockerBuildStrategyType,
 						},
 					},
 				},
 			},
 			Ok: func(out runtime.Object) bool {
-				obj, ok := out.(*v1.BuildConfig)
+				obj, ok := out.(*buildapiv1.BuildConfig)
 				if !ok {
 					return false
 				}
 				binary := obj.Spec.Source.Binary
-				if binary == (*v1.BinaryBuildSource)(nil) || *binary != (v1.BinaryBuildSource{}) {
+				if binary == (*buildapiv1.BinaryBuildSource)(nil) || *binary != (buildapiv1.BinaryBuildSource{}) {
 					return false
 				}
 
 				dockerStrategy := obj.Spec.Strategy.DockerStrategy
 				// DeepEqual needed because DockerBuildStrategy contains slices
-				if dockerStrategy == (*v1.DockerBuildStrategy)(nil) || !reflect.DeepEqual(*dockerStrategy, v1.DockerBuildStrategy{}) {
+				if dockerStrategy == (*buildapiv1.DockerBuildStrategy)(nil) || !reflect.DeepEqual(*dockerStrategy, buildapiv1.DockerBuildStrategy{}) {
 					return false
 				}
 				return true
@@ -148,7 +148,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
-	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.LegacySchemeGroupVersion), obj)
+	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(buildapiv1.LegacySchemeGroupVersion), obj)
 	if err != nil {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil

--- a/pkg/build/api/v1/defaults_test.go
+++ b/pkg/build/api/v1/defaults_test.go
@@ -61,7 +61,7 @@ func TestDefaults(t *testing.T) {
 					CommonSpec: buildapiv1.CommonSpec{
 						Strategy: buildapiv1.BuildStrategy{
 							DockerStrategy: &buildapiv1.DockerBuildStrategy{
-								From: &kapibuildapiv1.ObjectReference{},
+								From: &kapiv1.ObjectReference{},
 							},
 						},
 					},

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
-	"github.com/openshift/origin/pkg/build/api/v1"
+	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	imageapivalidation "github.com/openshift/origin/pkg/image/api/validation"
@@ -744,7 +744,7 @@ func diffBuildSpec(newer, older buildapi.BuildSpec) (string, error) {
 }
 
 func CreateBuildPatch(older, newer *buildapi.Build) ([]byte, error) {
-	codec := kapi.Codecs.LegacyCodec(v1.LegacySchemeGroupVersion)
+	codec := kapi.Codecs.LegacyCodec(buildapiv1.LegacySchemeGroupVersion)
 
 	newerJSON, err := runtime.Encode(codec, newer)
 	if err != nil {
@@ -754,7 +754,7 @@ func CreateBuildPatch(older, newer *buildapi.Build) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error encoding older: %v", err)
 	}
-	patch, err := strategicpatch.CreateTwoWayMergePatch(olderJSON, newerJSON, &v1.Build{})
+	patch, err := strategicpatch.CreateTwoWayMergePatch(olderJSON, newerJSON, &buildapiv1.Build{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating a strategic patch: %v", err)
 	}
@@ -762,8 +762,8 @@ func CreateBuildPatch(older, newer *buildapi.Build) ([]byte, error) {
 }
 
 func ApplyBuildPatch(build *buildapi.Build, patch []byte) (*buildapi.Build, error) {
-	codec := kapi.Codecs.LegacyCodec(v1.LegacySchemeGroupVersion)
-	versionedBuild, err := kapi.Scheme.ConvertToVersion(build, v1.SchemeGroupVersion)
+	codec := kapi.Codecs.LegacyCodec(buildapiv1.LegacySchemeGroupVersion)
+	versionedBuild, err := kapi.Scheme.ConvertToVersion(build, buildapiv1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -771,7 +771,7 @@ func ApplyBuildPatch(build *buildapi.Build, patch []byte) (*buildapi.Build, erro
 	if err != nil {
 		return nil, err
 	}
-	patchedJSON, err := strategicpatch.StrategicMergePatch(buildJSON, patch, &v1.Build{})
+	patchedJSON, err := strategicpatch.StrategicMergePatch(buildJSON, patch, &buildapiv1.Build{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -19,7 +19,7 @@ import (
 
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/api/validation"
 	bld "github.com/openshift/origin/pkg/build/builder"
 	"github.com/openshift/origin/pkg/build/builder/cmd/scmauth"
@@ -30,12 +30,12 @@ import (
 )
 
 type builder interface {
-	Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *api.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error
+	Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *buildapi.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error
 }
 
 type builderConfig struct {
 	out             io.Writer
-	build           *api.Build
+	build           *buildapi.Build
 	sourceSecretDir string
 	dockerClient    *docker.Client
 	dockerEndpoint  string
@@ -49,14 +49,14 @@ func newBuilderConfigFromEnvironment(out io.Writer) (*builderConfig, error) {
 	cfg.out = out
 
 	buildStr := os.Getenv("BUILD")
-	cfg.build = &api.Build{}
+	cfg.build = &buildapi.Build{}
 
 	obj, groupVersionKind, err := kapi.Codecs.UniversalDecoder().Decode([]byte(buildStr), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse build string: %v", err)
 	}
 	ok := false
-	cfg.build, ok = obj.(*api.Build)
+	cfg.build, ok = obj.(*buildapi.Build)
 	if !ok {
 		return nil, fmt.Errorf("build string is not a build: %v", err)
 	}
@@ -75,7 +75,7 @@ func newBuilderConfigFromEnvironment(out io.Writer) (*builderConfig, error) {
 		return nil, errors.NewInvalid(schema.GroupKind{Kind: "Build"}, cfg.build.Name, errs)
 	}
 
-	masterVersion := os.Getenv(api.OriginVersion)
+	masterVersion := os.Getenv(buildapi.OriginVersion)
 	thisVersion := version.Get().String()
 	if len(masterVersion) != 0 && masterVersion != thisVersion {
 		glog.V(3).Infof("warning: OpenShift server version %q differs from this image %q\n", masterVersion, thisVersion)
@@ -213,14 +213,14 @@ func fixSecretPermissions(secretsDir string) (string, error) {
 type dockerBuilder struct{}
 
 // Build starts a Docker build.
-func (dockerBuilder) Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *api.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error {
+func (dockerBuilder) Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *buildapi.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error {
 	return bld.NewDockerBuilder(dockerClient, buildsClient, build, gitClient, cgLimits).Build()
 }
 
 type s2iBuilder struct{}
 
 // Build starts an S2I build.
-func (s2iBuilder) Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *api.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error {
+func (s2iBuilder) Build(dockerClient bld.DockerClient, sock string, buildsClient client.BuildInterface, build *buildapi.Build, gitClient bld.GitClient, cgLimits *s2iapi.CGroupLimits) error {
 	return bld.NewS2IBuilder(dockerClient, sock, buildsClient, build, gitClient, cgLimits).Build()
 }
 

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/fsouza/go-dockerclient"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/generate/git"
 	utilglog "github.com/openshift/origin/pkg/util/glog"
@@ -49,7 +49,7 @@ type GitClient interface {
 
 // buildInfo returns a slice of KeyValue pairs with build metadata to be
 // inserted into Docker images produced by build.
-func buildInfo(build *api.Build, sourceInfo *git.SourceInfo) []KeyValue {
+func buildInfo(build *buildapi.Build, sourceInfo *git.SourceInfo) []KeyValue {
 	kv := []KeyValue{
 		{"OPENSHIFT_BUILD_NAME", build.Name},
 		{"OPENSHIFT_BUILD_NAMESPACE", build.Namespace},
@@ -105,7 +105,7 @@ func containerName(strategyName, buildName, namespace, containerPurpose string) 
 // postCommitSpec in a new ephemeral Docker container running the given image.
 // It returns an error if the hook cannot be run or returns a non-zero exit
 // code.
-func execPostCommitHook(client DockerClient, postCommitSpec api.BuildPostCommitSpec, image, containerName string) error {
+func execPostCommitHook(client DockerClient, postCommitSpec buildapi.BuildPostCommitSpec, image, containerName string) error {
 	command := postCommitSpec.Command
 	args := postCommitSpec.Args
 	script := postCommitSpec.Script
@@ -162,19 +162,19 @@ func execPostCommitHook(client DockerClient, postCommitSpec api.BuildPostCommitS
 	})
 }
 
-func updateBuildRevision(build *api.Build, sourceInfo *git.SourceInfo) *api.SourceRevision {
+func updateBuildRevision(build *buildapi.Build, sourceInfo *git.SourceInfo) *buildapi.SourceRevision {
 	if build.Spec.Revision != nil {
 		return build.Spec.Revision
 	}
-	return &api.SourceRevision{
-		Git: &api.GitSourceRevision{
+	return &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
 			Commit:  sourceInfo.CommitID,
 			Message: sourceInfo.Message,
-			Author: api.SourceControlUser{
+			Author: buildapi.SourceControlUser{
 				Name:  sourceInfo.AuthorName,
 				Email: sourceInfo.AuthorEmail,
 			},
-			Committer: api.SourceControlUser{
+			Committer: buildapi.SourceControlUser{
 				Name:  sourceInfo.CommitterName,
 				Email: sourceInfo.CommitterEmail,
 			},
@@ -182,7 +182,7 @@ func updateBuildRevision(build *api.Build, sourceInfo *git.SourceInfo) *api.Sour
 	}
 }
 
-func retryBuildStatusUpdate(build *api.Build, client client.BuildInterface, sourceRev *api.SourceRevision) error {
+func retryBuildStatusUpdate(build *buildapi.Build, client client.BuildInterface, sourceRev *buildapi.SourceRevision) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// before updating, make sure we are using the latest version of the build
 		latestBuild, err := client.Get(build.Name, metav1.GetOptions{})
@@ -208,7 +208,7 @@ func retryBuildStatusUpdate(build *api.Build, client client.BuildInterface, sour
 	})
 }
 
-func handleBuildStatusUpdate(build *api.Build, client client.BuildInterface, sourceRev *api.SourceRevision) {
+func handleBuildStatusUpdate(build *buildapi.Build, client client.BuildInterface, sourceRev *buildapi.SourceRevision) {
 	if updateErr := retryBuildStatusUpdate(build, client, sourceRev); updateErr != nil {
 		glog.Infof("error: Unable to update build status: %v", updateErr)
 	}

--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -9,26 +9,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/generate/git"
 )
 
 func TestBuildInfo(t *testing.T) {
-	b := &api.Build{
+	b := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sample-app",
 			Namespace: "default",
 		},
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						URI: "github.com/openshift/sample-app",
 						Ref: "master",
 					},
 				},
-				Strategy: api.BuildStrategy{
-					SourceStrategy: &api.SourceBuildStrategy{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
 						Env: []kapi.EnvVar{
 							{Name: "RAILS_ENV", Value: "production"},
 						},
@@ -52,8 +52,8 @@ func TestBuildInfo(t *testing.T) {
 		t.Errorf("buildInfo(%+v) = %+v; want %+v", b, got, want)
 	}
 
-	b.Spec.Revision = &api.SourceRevision{
-		Git: &api.GitSourceRevision{
+	b.Spec.Revision = &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
 			Commit: "1575a90c569a7cc0eea84fbd3304d9df37c9f5ee",
 		},
 	}

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/util"
 	s2iutil "github.com/openshift/source-to-image/pkg/util"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"
 	"github.com/openshift/origin/pkg/build/builder/timing"
 	"github.com/openshift/origin/pkg/build/controller/strategy"
@@ -39,13 +39,13 @@ type DockerBuilder struct {
 	dockerClient DockerClient
 	gitClient    GitClient
 	tar          tar.Tar
-	build        *api.Build
+	build        *buildapi.Build
 	client       client.BuildInterface
 	cgLimits     *s2iapi.CGroupLimits
 }
 
 // NewDockerBuilder creates a new instance of DockerBuilder
-func NewDockerBuilder(dockerClient DockerClient, buildsClient client.BuildInterface, build *api.Build, gitClient GitClient, cgLimits *s2iapi.CGroupLimits) *DockerBuilder {
+func NewDockerBuilder(dockerClient DockerClient, buildsClient client.BuildInterface, build *buildapi.Build, gitClient GitClient, cgLimits *s2iapi.CGroupLimits) *DockerBuilder {
 	return &DockerBuilder{
 		dockerClient: dockerClient,
 		build:        build,
@@ -62,7 +62,7 @@ func (d *DockerBuilder) Build() error {
 	var err error
 	ctx := timing.NewContext(context.Background())
 	defer func() {
-		d.build.Status.Stages = api.AppendStageAndStepInfo(d.build.Status.Stages, timing.GetStages(ctx))
+		d.build.Status.Stages = buildapi.AppendStageAndStepInfo(d.build.Status.Stages, timing.GetStages(ctx))
 		handleBuildStatusUpdate(d.build, d.client, nil)
 	}()
 
@@ -82,13 +82,13 @@ func (d *DockerBuilder) Build() error {
 	if err != nil {
 		switch err.(type) {
 		case contextDirNotFoundError:
-			d.build.Status.Phase = api.BuildPhaseFailed
-			d.build.Status.Reason = api.StatusReasonInvalidContextDirectory
-			d.build.Status.Message = api.StatusMessageInvalidContextDirectory
+			d.build.Status.Phase = buildapi.BuildPhaseFailed
+			d.build.Status.Reason = buildapi.StatusReasonInvalidContextDirectory
+			d.build.Status.Message = buildapi.StatusMessageInvalidContextDirectory
 		default:
-			d.build.Status.Phase = api.BuildPhaseFailed
-			d.build.Status.Reason = api.StatusReasonFetchSourceFailed
-			d.build.Status.Message = api.StatusMessageFetchSourceFailed
+			d.build.Status.Phase = buildapi.BuildPhaseFailed
+			d.build.Status.Reason = buildapi.StatusReasonFetchSourceFailed
+			d.build.Status.Message = buildapi.StatusMessageFetchSourceFailed
 		}
 
 		handleBuildStatusUpdate(d.build, d.client, nil)
@@ -142,12 +142,12 @@ func (d *DockerBuilder) Build() error {
 			startTime := metav1.Now()
 			err = pullImage(d.dockerClient, imageName, pullAuthConfig)
 
-			timing.RecordNewStep(ctx, api.StagePullImages, api.StepPullBaseImage, startTime, metav1.Now())
+			timing.RecordNewStep(ctx, buildapi.StagePullImages, buildapi.StepPullBaseImage, startTime, metav1.Now())
 
 			if err != nil {
-				d.build.Status.Phase = api.BuildPhaseFailed
-				d.build.Status.Reason = api.StatusReasonPullBuilderImageFailed
-				d.build.Status.Message = api.StatusMessagePullBuilderImageFailed
+				d.build.Status.Phase = buildapi.BuildPhaseFailed
+				d.build.Status.Reason = buildapi.StatusReasonPullBuilderImageFailed
+				d.build.Status.Message = buildapi.StatusMessagePullBuilderImageFailed
 				handleBuildStatusUpdate(d.build, d.client, nil)
 				return fmt.Errorf("failed to pull image: %v", err)
 			}
@@ -158,12 +158,12 @@ func (d *DockerBuilder) Build() error {
 	startTime := metav1.Now()
 	err = d.dockerBuild(buildDir, buildTag, d.build.Spec.Source.Secrets)
 
-	timing.RecordNewStep(ctx, api.StageBuild, api.StepDockerBuild, startTime, metav1.Now())
+	timing.RecordNewStep(ctx, buildapi.StageBuild, buildapi.StepDockerBuild, startTime, metav1.Now())
 
 	if err != nil {
-		d.build.Status.Phase = api.BuildPhaseFailed
-		d.build.Status.Reason = api.StatusReasonDockerBuildFailed
-		d.build.Status.Message = api.StatusMessageDockerBuildFailed
+		d.build.Status.Phase = buildapi.BuildPhaseFailed
+		d.build.Status.Reason = buildapi.StatusReasonDockerBuildFailed
+		d.build.Status.Message = buildapi.StatusMessageDockerBuildFailed
 		handleBuildStatusUpdate(d.build, d.client, nil)
 		return err
 	}
@@ -172,12 +172,12 @@ func (d *DockerBuilder) Build() error {
 	startTime = metav1.Now()
 	err = execPostCommitHook(d.dockerClient, d.build.Spec.PostCommit, buildTag, cname)
 
-	timing.RecordNewStep(ctx, api.StagePostCommit, api.StepExecPostCommitHook, startTime, metav1.Now())
+	timing.RecordNewStep(ctx, buildapi.StagePostCommit, buildapi.StepExecPostCommitHook, startTime, metav1.Now())
 
 	if err != nil {
-		d.build.Status.Phase = api.BuildPhaseFailed
-		d.build.Status.Reason = api.StatusReasonPostCommitHookFailed
-		d.build.Status.Message = api.StatusMessagePostCommitHookFailed
+		d.build.Status.Phase = buildapi.BuildPhaseFailed
+		d.build.Status.Reason = buildapi.StatusReasonPostCommitHookFailed
+		d.build.Status.Message = buildapi.StatusMessagePostCommitHookFailed
 		handleBuildStatusUpdate(d.build, d.client, nil)
 		return err
 	}
@@ -205,18 +205,18 @@ func (d *DockerBuilder) Build() error {
 		startTime = metav1.Now()
 		digest, err := pushImage(d.dockerClient, pushTag, pushAuthConfig)
 
-		timing.RecordNewStep(ctx, api.StagePushImage, api.StepPushDockerImage, startTime, metav1.Now())
+		timing.RecordNewStep(ctx, buildapi.StagePushImage, buildapi.StepPushDockerImage, startTime, metav1.Now())
 
 		if err != nil {
-			d.build.Status.Phase = api.BuildPhaseFailed
-			d.build.Status.Reason = api.StatusReasonPushImageToRegistryFailed
-			d.build.Status.Message = api.StatusMessagePushImageToRegistryFailed
+			d.build.Status.Phase = buildapi.BuildPhaseFailed
+			d.build.Status.Reason = buildapi.StatusReasonPushImageToRegistryFailed
+			d.build.Status.Message = buildapi.StatusMessagePushImageToRegistryFailed
 			handleBuildStatusUpdate(d.build, d.client, nil)
 			return reportPushFailure(err, authPresent, pushAuthConfig)
 		}
 
 		if len(digest) > 0 {
-			d.build.Status.Output.To = &api.BuildStatusOutputTo{
+			d.build.Status.Output.To = &buildapi.BuildStatusOutputTo{
 				ImageDigest: digest,
 			}
 			handleBuildStatusUpdate(d.build, d.client, nil)
@@ -229,7 +229,7 @@ func (d *DockerBuilder) Build() error {
 // copySecrets copies all files from the directory where the secret is
 // mounted in the builder pod to a directory where the is the Dockerfile, so
 // users can ADD or COPY the files inside their Dockerfile.
-func (d *DockerBuilder) copySecrets(secrets []api.SecretBuildSource, buildDir string) error {
+func (d *DockerBuilder) copySecrets(secrets []buildapi.SecretBuildSource, buildDir string) error {
 	for _, s := range secrets {
 		dstDir := filepath.Join(buildDir, s.DestinationDir)
 		if err := os.MkdirAll(dstDir, 0777); err != nil {
@@ -355,7 +355,7 @@ func (d *DockerBuilder) buildLabels(sourceInfo *git.SourceInfo) []dockerfile.Key
 	if len(d.build.Spec.Source.ContextDir) > 0 {
 		sourceInfo.ContextDir = d.build.Spec.Source.ContextDir
 	}
-	labels = util.GenerateLabelsFromSourceInfo(labels, &sourceInfo.SourceInfo, api.DefaultDockerLabelNamespace)
+	labels = util.GenerateLabelsFromSourceInfo(labels, &sourceInfo.SourceInfo, buildapi.DefaultDockerLabelNamespace)
 	addBuildLabels(labels, d.build)
 
 	kv := make([]dockerfile.KeyValue, 0, len(labels)+len(d.build.Spec.Output.ImageLabels))
@@ -389,7 +389,7 @@ func (d *DockerBuilder) setupPullSecret() (*docker.AuthConfigurations, error) {
 }
 
 // dockerBuild performs a docker build on the source that has been retrieved
-func (d *DockerBuilder) dockerBuild(dir string, tag string, secrets []api.SecretBuildSource) error {
+func (d *DockerBuilder) dockerBuild(dir string, tag string, secrets []buildapi.SecretBuildSource) error {
 	var noCache bool
 	var forcePull bool
 	var buildArgs []docker.BuildArg
@@ -443,9 +443,9 @@ func (d *DockerBuilder) dockerBuild(dir string, tag string, secrets []api.Secret
 	if s := d.build.Spec.Strategy.DockerStrategy; s != nil {
 		if policy := s.ImageOptimizationPolicy; policy != nil {
 			switch *policy {
-			case api.ImageOptimizationSkipLayers:
+			case buildapi.ImageOptimizationSkipLayers:
 				return buildDirectImage(dir, false, &opts)
-			case api.ImageOptimizationSkipLayersAndWarn:
+			case buildapi.ImageOptimizationSkipLayersAndWarn:
 				return buildDirectImage(dir, true, &opts)
 			}
 		}

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/tar"
 	s2iutil "github.com/openshift/source-to-image/pkg/util"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/util/dockerfile"
 	"github.com/openshift/origin/pkg/client/testclient"
 	"github.com/openshift/origin/pkg/generate/git"
@@ -145,24 +145,24 @@ func TestDockerfilePath(t *testing.T) {
 	tests := []struct {
 		contextDir     string
 		dockerfilePath string
-		dockerStrategy *api.DockerBuildStrategy
+		dockerStrategy *buildapi.DockerBuildStrategy
 	}{
 		// default Dockerfile path
 		{
 			dockerfilePath: "Dockerfile",
-			dockerStrategy: &api.DockerBuildStrategy{},
+			dockerStrategy: &buildapi.DockerBuildStrategy{},
 		},
 		// custom Dockerfile path in the root context
 		{
 			dockerfilePath: "mydockerfile",
-			dockerStrategy: &api.DockerBuildStrategy{
+			dockerStrategy: &buildapi.DockerBuildStrategy{
 				DockerfilePath: "mydockerfile",
 			},
 		},
 		// custom Dockerfile path in a sub directory
 		{
 			dockerfilePath: "dockerfiles/mydockerfile",
-			dockerStrategy: &api.DockerBuildStrategy{
+			dockerStrategy: &buildapi.DockerBuildStrategy{
 				DockerfilePath: "dockerfiles/mydockerfile",
 			},
 		},
@@ -171,7 +171,7 @@ func TestDockerfilePath(t *testing.T) {
 		{
 			contextDir:     "somedir",
 			dockerfilePath: "dockerfiles/mydockerfile",
-			dockerStrategy: &api.DockerBuildStrategy{
+			dockerStrategy: &buildapi.DockerBuildStrategy{
 				DockerfilePath: "dockerfiles/mydockerfile",
 			},
 		},
@@ -217,19 +217,19 @@ func TestDockerfilePath(t *testing.T) {
 			continue
 		}
 
-		build := &api.Build{
-			Spec: api.BuildSpec{
-				CommonSpec: api.CommonSpec{
-					Source: api.BuildSource{
-						Git: &api.GitBuildSource{
+		build := &buildapi.Build{
+			Spec: buildapi.BuildSpec{
+				CommonSpec: buildapi.CommonSpec{
+					Source: buildapi.BuildSource{
+						Git: &buildapi.GitBuildSource{
 							URI: "http://github.com/openshift/origin.git",
 						},
 						ContextDir: test.contextDir,
 					},
-					Strategy: api.BuildStrategy{
+					Strategy: buildapi.BuildStrategy{
 						DockerStrategy: test.dockerStrategy,
 					},
-					Output: api.BuildOutput{
+					Output: buildapi.BuildOutput{
 						To: &kapi.ObjectReference{
 							Kind: "DockerImage",
 							Name: "test/test-result:latest",
@@ -285,7 +285,7 @@ func TestDockerfilePath(t *testing.T) {
 		}
 
 		// check that the docker client is called with the right Dockerfile parameter
-		if err = dockerBuilder.dockerBuild(buildDir, "", []api.SecretBuildSource{}); err != nil {
+		if err = dockerBuilder.dockerBuild(buildDir, "", []buildapi.SecretBuildSource{}); err != nil {
 			t.Errorf("failed to build: %v", err)
 			continue
 		}
@@ -294,18 +294,18 @@ func TestDockerfilePath(t *testing.T) {
 }
 
 func TestEmptySource(t *testing.T) {
-	build := &api.Build{
+	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buildid",
 			Namespace: "default",
 		},
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{},
-				Strategy: api.BuildStrategy{
-					DockerStrategy: &api.DockerBuildStrategy{},
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
-				Output: api.BuildOutput{
+				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "test/test-result:latest",
@@ -348,19 +348,19 @@ USER 1001`
 		},
 	}
 
-	build := &api.Build{
+	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buildid",
 			Namespace: "default",
 		},
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
 					ContextDir: "",
 					Dockerfile: &dockerFile,
 				},
-				Strategy: api.BuildStrategy{
-					DockerStrategy: &api.DockerBuildStrategy{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{
 						DockerfilePath: "",
 						From: &kapi.ObjectReference{
 							Kind: "DockerImage",
@@ -368,7 +368,7 @@ USER 1001`
 						},
 					},
 				},
-				Output: api.BuildOutput{
+				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "ImageStreamTag",
 						Name: "scratch",

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -16,7 +16,7 @@ import (
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
 	s2iutil "github.com/openshift/source-to-image/pkg/util"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"
 	"github.com/openshift/origin/pkg/build/builder/timing"
 	"github.com/openshift/origin/pkg/generate/git"
@@ -55,7 +55,7 @@ func (e contextDirNotFoundError) Error() string {
 
 // fetchSource retrieves the inputs defined by the build source into the
 // provided directory, or returns an error if retrieval is not possible.
-func fetchSource(ctx context.Context, dockerClient DockerClient, dir string, build *api.Build, urlTimeout time.Duration, in io.Reader, gitClient GitClient) (*git.SourceInfo, error) {
+func fetchSource(ctx context.Context, dockerClient DockerClient, dir string, build *buildapi.Build, urlTimeout time.Duration, in io.Reader, gitClient GitClient) (*git.SourceInfo, error) {
 	hasGitSource := false
 
 	// expect to receive input from STDIN
@@ -179,7 +179,7 @@ func checkSourceURI(gitClient GitClient, rawurl string, timeout time.Duration) e
 
 // extractInputBinary processes the provided input stream as directed by BinaryBuildSource
 // into dir.
-func extractInputBinary(in io.Reader, source *api.BinaryBuildSource, dir string) error {
+func extractInputBinary(in io.Reader, source *buildapi.BinaryBuildSource, dir string) error {
 	if source == nil {
 		return nil
 	}
@@ -214,7 +214,7 @@ func extractInputBinary(in io.Reader, source *api.BinaryBuildSource, dir string)
 	return nil
 }
 
-func extractGitSource(ctx context.Context, gitClient GitClient, gitSource *api.GitBuildSource, revision *api.SourceRevision, dir string, timeout time.Duration) (bool, error) {
+func extractGitSource(ctx context.Context, gitClient GitClient, gitSource *buildapi.GitBuildSource, revision *buildapi.SourceRevision, dir string, timeout time.Duration) (bool, error) {
 	if gitSource == nil {
 		return false, nil
 	}
@@ -248,7 +248,7 @@ func extractGitSource(ctx context.Context, gitClient GitClient, gitSource *api.G
 		return true, err
 	}
 
-	timing.RecordNewStep(ctx, api.StageFetchInputs, api.StepFetchGitSource, startTime, metav1.Now())
+	timing.RecordNewStep(ctx, buildapi.StageFetchInputs, buildapi.StepFetchGitSource, startTime, metav1.Now())
 
 	// if we specify a commit, ref, or branch to checkout, do so, and update submodules
 	if usingRef {
@@ -332,7 +332,7 @@ func copyImageSource(dockerClient DockerClient, containerID, sourceDir, destDir 
 	return tarHelper.ExtractTarStreamWithLogging(destDir, file, tarOutput)
 }
 
-func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, image, buildDir string, imageSecretIndex int, paths []api.ImageSourcePath, forcePull bool) error {
+func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, image, buildDir string, imageSecretIndex int, paths []buildapi.ImageSourcePath, forcePull bool) error {
 	glog.V(4).Infof("Extracting image source from %s", image)
 	dockerAuth := docker.AuthConfiguration{}
 	if imageSecretIndex != -1 {
@@ -370,7 +370,7 @@ func extractSourceFromImage(ctx context.Context, dockerClient DockerClient, imag
 			return fmt.Errorf("error pulling image %v: %v", image, err)
 		}
 
-		timing.RecordNewStep(ctx, api.StagePullImages, api.StepPullInputImage, startTime, metav1.Now())
+		timing.RecordNewStep(ctx, buildapi.StagePullImages, buildapi.StepPullInputImage, startTime, metav1.Now())
 
 	}
 

--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/builder/timing"
 	"github.com/openshift/origin/pkg/generate/git"
 )
@@ -179,8 +179,8 @@ func TestUnqualifiedClone(t *testing.T) {
 	destDir, err := ioutil.TempDir("", "clone-dest-")
 	defer os.RemoveAll(destDir)
 	client := git.NewRepositoryWithEnv([]string{})
-	source := &api.GitBuildSource{URI: "file://" + repo.Path}
-	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	source := &buildapi.GitBuildSource{URI: "file://" + repo.Path}
+	revision := buildapi.SourceRevision{Git: &buildapi.GitSourceRevision{}}
 	ctx := timing.NewContext(context.Background())
 	if _, err = extractGitSource(ctx, client, source, &revision, destDir, 10*time.Second); err != nil {
 		t.Errorf("%v", err)
@@ -223,11 +223,11 @@ func TestCloneFromRef(t *testing.T) {
 	if err != nil {
 		t.Errorf("%v", err)
 	}
-	source := &api.GitBuildSource{
+	source := &buildapi.GitBuildSource{
 		URI: "file://" + repo.Path,
 		Ref: firstCommitRef,
 	}
-	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	revision := buildapi.SourceRevision{Git: &buildapi.GitSourceRevision{}}
 	ctx := timing.NewContext(context.Background())
 	if _, err = extractGitSource(ctx, client, source, &revision, destDir, 10*time.Second); err != nil {
 		t.Errorf("%v", err)
@@ -278,11 +278,11 @@ func TestCloneFromBranch(t *testing.T) {
 	destDir, err := ioutil.TempDir("", "branch-dest-")
 	defer os.RemoveAll(destDir)
 	client := git.NewRepositoryWithEnv([]string{})
-	source := &api.GitBuildSource{
+	source := &buildapi.GitBuildSource{
 		URI: "file://" + repo.Path,
 		Ref: "test",
 	}
-	revision := api.SourceRevision{Git: &api.GitSourceRevision{}}
+	revision := buildapi.SourceRevision{Git: &buildapi.GitSourceRevision{}}
 	ctx := timing.NewContext(context.Background())
 	if _, err = extractGitSource(ctx, client, source, &revision, destDir, 10*time.Second); err != nil {
 		t.Errorf("%v", err)

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -19,7 +19,7 @@ import (
 	s2i "github.com/openshift/source-to-image/pkg/build/strategies"
 	"github.com/openshift/source-to-image/pkg/docker"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"
 	"github.com/openshift/origin/pkg/build/builder/timing"
 	"github.com/openshift/origin/pkg/build/controller/strategy"
@@ -70,20 +70,20 @@ type S2IBuilder struct {
 	gitClient    GitClient
 	dockerClient DockerClient
 	dockerSocket string
-	build        *api.Build
+	build        *buildapi.Build
 	client       client.BuildInterface
 	cgLimits     *s2iapi.CGroupLimits
 }
 
 // NewS2IBuilder creates a new STIBuilder instance
-func NewS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient client.BuildInterface, build *api.Build,
+func NewS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient client.BuildInterface, build *buildapi.Build,
 	gitClient GitClient, cgLimits *s2iapi.CGroupLimits) *S2IBuilder {
 	// delegate to internal implementation passing default implementation of builderFactory and validator
 	return newS2IBuilder(dockerClient, dockerSocket, buildsClient, build, gitClient, runtimeBuilderFactory{}, runtimeConfigValidator{}, cgLimits)
 }
 
 // newS2IBuilder is the internal factory function to create STIBuilder based on parameters. Used for testing.
-func newS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient client.BuildInterface, build *api.Build,
+func newS2IBuilder(dockerClient DockerClient, dockerSocket string, buildsClient client.BuildInterface, build *buildapi.Build,
 	gitClient GitClient, builder builderFactory, validator validator, cgLimits *s2iapi.CGroupLimits) *S2IBuilder {
 	// just create instance
 	return &S2IBuilder{
@@ -105,7 +105,7 @@ func (s *S2IBuilder) Build() error {
 	var err error
 	ctx := timing.NewContext(context.Background())
 	defer func() {
-		s.build.Status.Stages = api.AppendStageAndStepInfo(s.build.Status.Stages, timing.GetStages(ctx))
+		s.build.Status.Stages = buildapi.AppendStageAndStepInfo(s.build.Status.Stages, timing.GetStages(ctx))
 		handleBuildStatusUpdate(s.build, s.client, nil)
 	}()
 
@@ -138,13 +138,13 @@ func (s *S2IBuilder) Build() error {
 	if err != nil {
 		switch err.(type) {
 		case contextDirNotFoundError:
-			s.build.Status.Phase = api.BuildPhaseFailed
-			s.build.Status.Reason = api.StatusReasonInvalidContextDirectory
-			s.build.Status.Message = api.StatusMessageInvalidContextDirectory
+			s.build.Status.Phase = buildapi.BuildPhaseFailed
+			s.build.Status.Reason = buildapi.StatusReasonInvalidContextDirectory
+			s.build.Status.Message = buildapi.StatusMessageInvalidContextDirectory
 		default:
-			s.build.Status.Phase = api.BuildPhaseFailed
-			s.build.Status.Reason = api.StatusReasonFetchSourceFailed
-			s.build.Status.Message = api.StatusMessageFetchSourceFailed
+			s.build.Status.Phase = buildapi.BuildPhaseFailed
+			s.build.Status.Reason = buildapi.StatusReasonFetchSourceFailed
+			s.build.Status.Message = buildapi.StatusMessageFetchSourceFailed
 		}
 		handleBuildStatusUpdate(s.build, s.client, nil)
 		return err
@@ -208,7 +208,7 @@ func (s *S2IBuilder) Build() error {
 		WorkingDir:         buildDir,
 		DockerConfig:       &s2iapi.DockerConfig{Endpoint: s.dockerSocket},
 		DockerCfgPath:      os.Getenv(dockercfg.PullAuthType),
-		LabelNamespace:     api.DefaultDockerLabelNamespace,
+		LabelNamespace:     buildapi.DefaultDockerLabelNamespace,
 
 		ScriptsURL: s.build.Spec.Strategy.SourceStrategy.Scripts,
 
@@ -244,16 +244,16 @@ func (s *S2IBuilder) Build() error {
 	}
 	config.PreviousImagePullPolicy = s2iapi.PullAlways
 
-	allowedUIDs := os.Getenv(api.AllowedUIDs)
-	glog.V(4).Infof("The value of %s is [%s]", api.AllowedUIDs, allowedUIDs)
+	allowedUIDs := os.Getenv(buildapi.AllowedUIDs)
+	glog.V(4).Infof("The value of %s is [%s]", buildapi.AllowedUIDs, allowedUIDs)
 	if len(allowedUIDs) > 0 {
 		err = config.AllowedUIDs.Set(allowedUIDs)
 		if err != nil {
 			return err
 		}
 	}
-	dropCaps := os.Getenv(api.DropCapabilities)
-	glog.V(4).Infof("The value of %s is [%s]", api.DropCapabilities, dropCaps)
+	dropCaps := os.Getenv(buildapi.DropCapabilities)
+	glog.V(4).Infof("The value of %s is [%s]", buildapi.DropCapabilities, dropCaps)
 	if len(dropCaps) > 0 {
 		config.DropCapabilities = strings.Split(dropCaps, ",")
 	}
@@ -265,7 +265,7 @@ func (s *S2IBuilder) Build() error {
 		config.RuntimeAuthentication = s2iapi.AuthConfig{Username: t.Username, Password: t.Password, Email: t.Email, ServerAddress: t.ServerAddress}
 		config.RuntimeArtifacts = copyToVolumeList(s.build.Spec.Strategy.SourceStrategy.RuntimeArtifacts)
 	}
-	// If DockerCfgPath is provided in api.Config, then attempt to read the
+	// If DockerCfgPath is provided in buildapi.Config, then attempt to read the
 	// dockercfg file and get the authentication for pulling the builder image.
 	t, _ := dockercfg.NewHelper().GetDockerAuth(config.BuilderImage, dockercfg.PullAuthType)
 	config.PullAuthentication = s2iapi.AuthConfig{Username: t.Username, Password: t.Password, Email: t.Email, ServerAddress: t.ServerAddress}
@@ -291,7 +291,7 @@ func (s *S2IBuilder) Build() error {
 	}
 	builder, buildInfo, err := s.builder.Builder(config, s2ibuild.Overrides{Downloader: nil})
 	if err != nil {
-		s.build.Status.Phase = api.BuildPhaseFailed
+		s.build.Status.Phase = buildapi.BuildPhaseFailed
 		s.build.Status.Reason, s.build.Status.Message = convertS2IFailureType(
 			buildInfo.FailureReason.Reason,
 			buildInfo.FailureReason.Message,
@@ -306,12 +306,12 @@ func (s *S2IBuilder) Build() error {
 
 	for _, stage := range result.BuildInfo.Stages {
 		for _, step := range stage.Steps {
-			timing.RecordNewStep(ctx, api.StageName(stage.Name), api.StepName(step.Name), metav1.NewTime(step.StartTime), metav1.NewTime(step.StartTime.Add(time.Duration(step.DurationMilliseconds)*time.Millisecond)))
+			timing.RecordNewStep(ctx, buildapi.StageName(stage.Name), buildapi.StepName(step.Name), metav1.NewTime(step.StartTime), metav1.NewTime(step.StartTime.Add(time.Duration(step.DurationMilliseconds)*time.Millisecond)))
 		}
 	}
 
 	if err != nil {
-		s.build.Status.Phase = api.BuildPhaseFailed
+		s.build.Status.Phase = buildapi.BuildPhaseFailed
 		s.build.Status.Reason, s.build.Status.Message = convertS2IFailureType(
 			result.BuildInfo.FailureReason.Reason,
 			result.BuildInfo.FailureReason.Message,
@@ -325,12 +325,12 @@ func (s *S2IBuilder) Build() error {
 	startTime = metav1.Now()
 	err = execPostCommitHook(s.dockerClient, s.build.Spec.PostCommit, buildTag, cName)
 
-	timing.RecordNewStep(ctx, api.StagePostCommit, api.StepExecPostCommitHook, startTime, metav1.Now())
+	timing.RecordNewStep(ctx, buildapi.StagePostCommit, buildapi.StepExecPostCommitHook, startTime, metav1.Now())
 
 	if err != nil {
-		s.build.Status.Phase = api.BuildPhaseFailed
-		s.build.Status.Reason = api.StatusReasonPostCommitHookFailed
-		s.build.Status.Message = api.StatusMessagePostCommitHookFailed
+		s.build.Status.Phase = buildapi.BuildPhaseFailed
+		s.build.Status.Reason = buildapi.StatusReasonPostCommitHookFailed
+		s.build.Status.Message = buildapi.StatusMessagePostCommitHookFailed
 		handleBuildStatusUpdate(s.build, s.client, nil)
 		return err
 	}
@@ -360,18 +360,18 @@ func (s *S2IBuilder) Build() error {
 		startTime = metav1.Now()
 		digest, err := pushImage(s.dockerClient, pushTag, pushAuthConfig)
 
-		timing.RecordNewStep(ctx, api.StagePushImage, api.StepPushImage, startTime, metav1.Now())
+		timing.RecordNewStep(ctx, buildapi.StagePushImage, buildapi.StepPushImage, startTime, metav1.Now())
 
 		if err != nil {
-			s.build.Status.Phase = api.BuildPhaseFailed
-			s.build.Status.Reason = api.StatusReasonPushImageToRegistryFailed
-			s.build.Status.Message = api.StatusMessagePushImageToRegistryFailed
+			s.build.Status.Phase = buildapi.BuildPhaseFailed
+			s.build.Status.Reason = buildapi.StatusReasonPushImageToRegistryFailed
+			s.build.Status.Message = buildapi.StatusMessagePushImageToRegistryFailed
 			handleBuildStatusUpdate(s.build, s.client, nil)
 			return reportPushFailure(err, authPresent, pushAuthConfig)
 		}
 
 		if len(digest) > 0 {
-			s.build.Status.Output.To = &api.BuildStatusOutputTo{
+			s.build.Status.Output.To = &buildapi.BuildStatusOutputTo{
 				ImageDigest: digest,
 			}
 			handleBuildStatusUpdate(s.build, s.client, nil)
@@ -401,7 +401,7 @@ func (d *downloader) Download(config *s2iapi.Config) (*s2iapi.SourceInfo, error)
 // 2. In case of repeated Keys, the last Value takes precedence right here,
 //    instead of deferring what to do with repeated environment variables to the
 //    Docker runtime.
-func buildEnvVars(build *api.Build, sourceInfo *git.SourceInfo) s2iapi.EnvironmentList {
+func buildEnvVars(build *buildapi.Build, sourceInfo *git.SourceInfo) s2iapi.EnvironmentList {
 	bi := buildInfo(build, sourceInfo)
 	envVars := &s2iapi.EnvironmentList{}
 	for _, item := range bi {
@@ -410,7 +410,7 @@ func buildEnvVars(build *api.Build, sourceInfo *git.SourceInfo) s2iapi.Environme
 	return *envVars
 }
 
-func buildLabels(build *api.Build) map[string]string {
+func buildLabels(build *buildapi.Build) map[string]string {
 	labels := make(map[string]string)
 	addBuildLabels(labels, build)
 	for _, lbl := range build.Spec.Output.ImageLabels {
@@ -423,7 +423,7 @@ func buildLabels(build *api.Build) map[string]string {
 // scripts from a URL. For now, it uses environment variables passed in
 // the strategy's environment. There is no preference given to either lowercase
 // or uppercase form of the variable.
-func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
+func scriptProxyConfig(build *buildapi.Build) (*s2iapi.ProxyConfig, error) {
 	httpProxy := ""
 	httpsProxy := ""
 	for _, env := range build.Spec.Strategy.SourceStrategy.Env {
@@ -457,7 +457,7 @@ func scriptProxyConfig(build *api.Build) (*s2iapi.ProxyConfig, error) {
 
 // copyToVolumeList copies the artifacts set in the build config to the
 // VolumeList struct in the s2iapi.Config
-func copyToVolumeList(artifactsMapping []api.ImageSourcePath) (volumeList s2iapi.VolumeList) {
+func copyToVolumeList(artifactsMapping []buildapi.ImageSourcePath) (volumeList s2iapi.VolumeList) {
 	for _, mappedPath := range artifactsMapping {
 		volumeList = append(volumeList, s2iapi.VolumeSpec{
 			Source:      mappedPath.SourcePath,
@@ -467,6 +467,6 @@ func copyToVolumeList(artifactsMapping []api.ImageSourcePath) (volumeList s2iapi
 	return
 }
 
-func convertS2IFailureType(reason s2iapi.StepFailureReason, message s2iapi.StepFailureMessage) (api.StatusReason, string) {
-	return api.StatusReason(reason), fmt.Sprintf("%s", message)
+func convertS2IFailureType(reason s2iapi.StepFailureReason, message s2iapi.StepFailureMessage) (buildapi.StatusReason, string) {
+	return buildapi.StatusReason(reason), fmt.Sprintf("%s", message)
 }

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -8,7 +8,7 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client/testclient"
 	"github.com/openshift/origin/pkg/generate/git"
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
@@ -69,14 +69,14 @@ func newTestS2IBuilder(config testS2IBuilderConfig) *S2IBuilder {
 	)
 }
 
-func makeBuild() *api.Build {
+func makeBuild() *buildapi.Build {
 	t := true
-	return &api.Build{
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{},
-				Strategy: api.BuildStrategy{
-					SourceStrategy: &api.SourceBuildStrategy{
+	return &buildapi.Build{
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{},
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
 						Env: append([]kapi.EnvVar{},
 							kapi.EnvVar{
 								Name:  "HTTPS_PROXY",
@@ -91,7 +91,7 @@ func makeBuild() *api.Build {
 						},
 						Incremental: &t,
 					}},
-				Output: api.BuildOutput{
+				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "test/test-result:latest",
@@ -99,7 +99,7 @@ func makeBuild() *api.Build {
 				},
 			},
 		},
-		Status: api.BuildStatus{
+		Status: buildapi.BuildStatus{
 			OutputDockerImageReference: "test/test-result:latest",
 		},
 	}
@@ -136,7 +136,7 @@ func TestGetStrategyError(t *testing.T) {
 }
 
 func TestCopyToVolumeList(t *testing.T) {
-	newArtifacts := []api.ImageSourcePath{
+	newArtifacts := []buildapi.ImageSourcePath{
 		{
 			SourcePath:     "/path/to/source",
 			DestinationDir: "path/to/destination",
@@ -188,7 +188,7 @@ func TestBuildEnvVars(t *testing.T) {
 	mockBuild := makeBuild()
 	mockBuild.Name = "openshift-test-1-build"
 	mockBuild.Namespace = "openshift-demo"
-	mockBuild.Spec.Source.Git = &api.GitBuildSource{URI: "http://localhost/123"}
+	mockBuild.Spec.Source.Git = &buildapi.GitBuildSource{URI: "http://localhost/123"}
 	sourceInfo := &git.SourceInfo{}
 	sourceInfo.CommitID = "1575a90c569a7cc0eea84fbd3304d9df37c9f5ee"
 	resultedEnvList := buildEnvVars(mockBuild, sourceInfo)
@@ -204,11 +204,11 @@ func TestBuildEnvVars(t *testing.T) {
 }
 
 func TestScriptProxyConfig(t *testing.T) {
-	newBuild := &api.Build{
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Strategy: api.BuildStrategy{
-					SourceStrategy: &api.SourceBuildStrategy{
+	newBuild := &buildapi.Build{
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
 						Env: append([]kapi.EnvVar{}, kapi.EnvVar{
 							Name:  "HTTPS_PROXY",
 							Value: "https://test/secure",

--- a/pkg/build/builder/timing/context.go
+++ b/pkg/build/builder/timing/context.go
@@ -3,7 +3,7 @@ package timing
 import (
 	"context"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -14,23 +14,23 @@ var timingKey key
 
 // NewContext returns a context initialised for use
 func NewContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, timingKey, &[]api.StageInfo{})
+	return context.WithValue(ctx, timingKey, &[]buildapi.StageInfo{})
 }
 
 // fromContext returns the existing data stored in the context
-func fromContext(ctx context.Context) *[]api.StageInfo {
-	return ctx.Value(timingKey).(*[]api.StageInfo)
+func fromContext(ctx context.Context) *[]buildapi.StageInfo {
+	return ctx.Value(timingKey).(*[]buildapi.StageInfo)
 }
 
 // RecordNewStep adds a new timing step to the context
-func RecordNewStep(ctx context.Context, stageName api.StageName, stepName api.StepName, startTime metav1.Time, endTime metav1.Time) {
+func RecordNewStep(ctx context.Context, stageName buildapi.StageName, stepName buildapi.StepName, startTime metav1.Time, endTime metav1.Time) {
 	stages := fromContext(ctx)
-	newStages := api.RecordStageAndStepInfo(*stages, stageName, stepName, startTime, endTime)
+	newStages := buildapi.RecordStageAndStepInfo(*stages, stageName, stepName, startTime, endTime)
 	*stages = newStages
 }
 
 // GetStages returns all stages and steps currently stored in the context
-func GetStages(ctx context.Context) []api.StageInfo {
+func GetStages(ctx context.Context) []buildapi.StageInfo {
 	stages := fromContext(ctx)
 	return *stages
 }

--- a/pkg/build/builder/timing/timing_test.go
+++ b/pkg/build/builder/timing/timing_test.go
@@ -6,20 +6,20 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 func TestRecordStageAndStepInfo(t *testing.T) {
-	var stages []api.StageInfo
+	var stages []buildapi.StageInfo
 
-	stages = api.RecordStageAndStepInfo(stages, api.StageFetchInputs, api.StepFetchGitSource, metav1.Now(), metav1.Now())
+	stages = buildapi.RecordStageAndStepInfo(stages, buildapi.StageFetchInputs, buildapi.StepFetchGitSource, metav1.Now(), metav1.Now())
 
 	if len(stages) != 1 || len(stages[0].Steps) != 1 {
 		t.Errorf("There should be 1 stage and 1 step, but instead there were %v stage(s) and %v step(s).", len(stages), len(stages[0].Steps))
 	}
 
-	stages = api.RecordStageAndStepInfo(stages, api.StagePullImages, api.StepPullBaseImage, metav1.Now(), metav1.Now())
-	stages = api.RecordStageAndStepInfo(stages, api.StagePullImages, api.StepPullInputImage, metav1.Now(), metav1.Now())
+	stages = buildapi.RecordStageAndStepInfo(stages, buildapi.StagePullImages, buildapi.StepPullBaseImage, metav1.Now(), metav1.Now())
+	stages = buildapi.RecordStageAndStepInfo(stages, buildapi.StagePullImages, buildapi.StepPullInputImage, metav1.Now(), metav1.Now())
 
 	if len(stages) != 2 || len(stages[1].Steps) != 2 {
 		t.Errorf("There should be 2 stages and 2 steps under the second stage, but instead there were %v stage(s) and %v step(s).", len(stages), len(stages[1].Steps))
@@ -28,16 +28,16 @@ func TestRecordStageAndStepInfo(t *testing.T) {
 }
 
 func TestAppendStageAndStepInfo(t *testing.T) {
-	var stages []api.StageInfo
-	var stagesToMerge []api.StageInfo
+	var stages []buildapi.StageInfo
+	var stagesToMerge []buildapi.StageInfo
 
-	stages = api.RecordStageAndStepInfo(stages, api.StagePullImages, api.StepPullBaseImage, metav1.Now(), metav1.Now())
-	stages = api.RecordStageAndStepInfo(stages, api.StagePullImages, api.StepPullInputImage, metav1.Now(), metav1.Now())
+	stages = buildapi.RecordStageAndStepInfo(stages, buildapi.StagePullImages, buildapi.StepPullBaseImage, metav1.Now(), metav1.Now())
+	stages = buildapi.RecordStageAndStepInfo(stages, buildapi.StagePullImages, buildapi.StepPullInputImage, metav1.Now(), metav1.Now())
 
-	stagesToMerge = api.RecordStageAndStepInfo(stagesToMerge, api.StagePushImage, api.StepPushImage, metav1.Now(), metav1.Now())
-	stagesToMerge = api.RecordStageAndStepInfo(stagesToMerge, api.StagePostCommit, api.StepExecPostCommitHook, metav1.Now(), metav1.Now())
+	stagesToMerge = buildapi.RecordStageAndStepInfo(stagesToMerge, buildapi.StagePushImage, buildapi.StepPushImage, metav1.Now(), metav1.Now())
+	stagesToMerge = buildapi.RecordStageAndStepInfo(stagesToMerge, buildapi.StagePostCommit, buildapi.StepExecPostCommitHook, metav1.Now(), metav1.Now())
 
-	stages = api.AppendStageAndStepInfo(stages, stagesToMerge)
+	stages = buildapi.AppendStageAndStepInfo(stages, stagesToMerge)
 
 	if len(stages) != 3 {
 		t.Errorf("There should be 3 stages, but instead there were %v stage(s).", len(stages))
@@ -48,9 +48,9 @@ func TestAppendStageAndStepInfo(t *testing.T) {
 func TestTimingContextGetStages(t *testing.T) {
 	ctx := NewContext(context.Background())
 
-	RecordNewStep(ctx, api.StagePullImages, api.StepPullBaseImage, metav1.Now(), metav1.Now())
-	RecordNewStep(ctx, api.StageFetchInputs, api.StepFetchGitSource, metav1.Now(), metav1.Now())
-	RecordNewStep(ctx, api.StagePostCommit, api.StepExecPostCommitHook, metav1.Now(), metav1.Now())
+	RecordNewStep(ctx, buildapi.StagePullImages, buildapi.StepPullBaseImage, metav1.Now(), metav1.Now())
+	RecordNewStep(ctx, buildapi.StageFetchInputs, buildapi.StepFetchGitSource, metav1.Now(), metav1.Now())
+	RecordNewStep(ctx, buildapi.StagePostCommit, buildapi.StepExecPostCommitHook, metav1.Now(), metav1.Now())
 
 	stages := GetStages(ctx)
 	if len(stages) != 3 {

--- a/pkg/build/graph/edges_test.go
+++ b/pkg/build/graph/edges_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	nodes "github.com/openshift/origin/pkg/build/graph/nodes"
 )
 
@@ -22,16 +22,16 @@ func TestNamespaceEdgeMatching(t *testing.T) {
 	g := osgraph.New()
 
 	fn := func(namespace string, g osgraph.Interface) {
-		bc := &api.BuildConfig{}
+		bc := &buildapi.BuildConfig{}
 		bc.Namespace = namespace
 		bc.Name = "the-bc"
 		nodes.EnsureBuildConfigNode(g, bc)
 
-		b := &api.Build{}
+		b := &buildapi.Build{}
 		b.Namespace = namespace
 		b.Name = "the-build"
-		b.Labels = map[string]string{api.BuildConfigLabel: "the-bc"}
-		b.Annotations = map[string]string{api.BuildConfigAnnotation: "the-bc"}
+		b.Labels = map[string]string{buildapi.BuildConfigLabel: "the-bc"}
+		b.Annotations = map[string]string{buildapi.BuildConfigAnnotation: "the-bc"}
 		nodes.EnsureBuildNode(g, b)
 	}
 

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/registry/build"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -21,10 +21,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Build{} },
-		NewListFunc:       func() runtime.Object { return &api.BuildList{} },
+		NewFunc:           func() runtime.Object { return &buildapi.Build{} },
+		NewListFunc:       func() runtime.Object { return &buildapi.BuildList{} },
 		PredicateFunc:     build.Matcher,
-		QualifiedResource: api.Resource("builds"),
+		QualifiedResource: buildapi.Resource("builds"),
 
 		CreateStrategy: build.Strategy,
 		UpdateStrategy: build.Strategy,

--- a/pkg/build/registry/build/etcd/etcd_test.go
+++ b/pkg/build/registry/build/etcd/etcd_test.go
@@ -10,7 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/install"
 	"github.com/openshift/origin/pkg/build/registry/build"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -30,20 +30,20 @@ func TestStorage(t *testing.T) {
 	build.NewRegistry(storage)
 }
 
-func validBuild() *api.Build {
-	return &api.Build{
+func validBuild() *buildapi.Build {
+	return &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{Name: "buildid"},
-		Spec: api.BuildSpec{
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						URI: "http://github.com/my/repository",
 					},
 				},
-				Strategy: api.BuildStrategy{
-					DockerStrategy: &api.DockerBuildStrategy{},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
-				Output: api.BuildOutput{
+				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "repository/data",
@@ -65,7 +65,7 @@ func TestCreate(t *testing.T) {
 	test.TestCreate(
 		valid,
 		// invalid
-		&api.Build{},
+		&buildapi.Build{},
 	)
 }
 

--- a/pkg/build/registry/build/strategy.go
+++ b/pkg/build/registry/build/strategy.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/api/validation"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 )
@@ -43,21 +43,21 @@ func (strategy) AllowUnconditionalUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	build := obj.(*api.Build)
+	build := obj.(*buildapi.Build)
 	if len(build.Status.Phase) == 0 {
-		build.Status.Phase = api.BuildPhaseNew
+		build.Status.Phase = buildapi.BuildPhaseNew
 	}
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newBuild := obj.(*api.Build)
-	oldBuild := old.(*api.Build)
+	newBuild := obj.(*buildapi.Build)
+	oldBuild := old.(*buildapi.Build)
 	// If the build is already in a failed state, do not allow an update
 	// of the reason and message. This is to prevent the build controller from
 	// overwriting the reason and message that was set by the builder pod
 	// when it updated the build's details.
-	if oldBuild.Status.Phase == api.BuildPhaseFailed {
+	if oldBuild.Status.Phase == buildapi.BuildPhaseFailed {
 		newBuild.Status.Reason = oldBuild.Status.Reason
 		newBuild.Status.Message = oldBuild.Status.Message
 	}
@@ -69,12 +69,12 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new policy.
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateBuild(obj.(*api.Build))
+	return validation.ValidateBuild(obj.(*buildapi.Build))
 }
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateBuildUpdate(obj.(*api.Build), old.(*api.Build))
+	return validation.ValidateBuildUpdate(obj.(*buildapi.Build), old.(*buildapi.Build))
 }
 
 // CheckGracefulDelete allows a build to be gracefully deleted.
@@ -84,11 +84,11 @@ func (strategy) CheckGracefulDelete(obj runtime.Object, options *metav1.DeleteOp
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	build, ok := obj.(*api.Build)
+	build, ok := obj.(*buildapi.Build)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a Build")
 	}
-	return labels.Set(build.ObjectMeta.Labels), api.BuildToSelectableFields(build), nil
+	return labels.Set(build.ObjectMeta.Labels), buildapi.BuildToSelectableFields(build), nil
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
@@ -108,8 +108,8 @@ type detailsStrategy struct {
 // Build details currently consists of: Spec.Revision, Status.Reason, and
 // Status.Message, all of which are updated from within the build pod
 func (detailsStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newBuild := obj.(*api.Build)
-	oldBuild := old.(*api.Build)
+	newBuild := obj.(*buildapi.Build)
+	oldBuild := old.(*buildapi.Build)
 
 	// ignore phase updates unless the caller is updating the build to
 	// a completed phase.
@@ -133,8 +133,8 @@ func (detailsStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime
 
 // Validates that an update is valid by ensuring that no Revision exists and that it's not getting updated to blank
 func (detailsStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	newBuild := obj.(*api.Build)
-	oldBuild := old.(*api.Build)
+	newBuild := obj.(*buildapi.Build)
+	oldBuild := old.(*buildapi.Build)
 	oldRevision := oldBuild.Spec.Revision
 	newRevision := newBuild.Spec.Revision
 	errors := field.ErrorList{}

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/registry/buildconfig"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -19,9 +19,9 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.BuildConfig{} },
-		NewListFunc:       func() runtime.Object { return &api.BuildConfigList{} },
-		QualifiedResource: api.Resource("buildconfigs"),
+		NewFunc:           func() runtime.Object { return &buildapi.BuildConfig{} },
+		NewListFunc:       func() runtime.Object { return &buildapi.BuildConfigList{} },
+		QualifiedResource: buildapi.Resource("buildconfigs"),
 		PredicateFunc:     buildconfig.Matcher,
 
 		CreateStrategy: buildconfig.Strategy,

--- a/pkg/build/registry/buildconfig/etcd/etcd_test.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd_test.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/install"
 	"github.com/openshift/origin/pkg/build/registry/buildconfig"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -31,21 +31,21 @@ func TestStorage(t *testing.T) {
 	buildconfig.NewRegistry(storage)
 }
 
-func validBuildConfig() *api.BuildConfig {
-	return &api.BuildConfig{
+func validBuildConfig() *buildapi.BuildConfig {
+	return &buildapi.BuildConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "configid"},
-		Spec: api.BuildConfigSpec{
-			RunPolicy: api.BuildRunPolicySerial,
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						URI: "http://github.com/my/repository",
 					},
 				},
-				Strategy: api.BuildStrategy{
-					DockerStrategy: &api.DockerBuildStrategy{},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
-				Output: api.BuildOutput{
+				Output: buildapi.BuildOutput{
 					To: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "repository/data",
@@ -67,7 +67,7 @@ func TestCreate(t *testing.T) {
 	test.TestCreate(
 		valid,
 		// invalid
-		&api.BuildConfig{},
+		&buildapi.BuildConfig{},
 	)
 }
 
@@ -80,13 +80,13 @@ func TestUpdate(t *testing.T) {
 		validBuildConfig(),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.BuildConfig)
+			object := obj.(*buildapi.BuildConfig)
 			object.Spec.CommonSpec.Source.Git.URI = "http://github.com/my/otherrepo"
 			return object
 		},
 		// invalid updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.BuildConfig)
+			object := obj.(*buildapi.BuildConfig)
 			object.Spec.CommonSpec.Source.Git.URI = ""
 			return object
 		},

--- a/pkg/build/registry/buildconfig/registry.go
+++ b/pkg/build/registry/buildconfig/registry.go
@@ -1,7 +1,7 @@
 package buildconfig
 
 import (
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -13,13 +13,13 @@ import (
 // Registry is an interface for things that know how to store BuildConfigs.
 type Registry interface {
 	// ListBuildConfigs obtains list of buildConfigs that match a selector.
-	ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*api.BuildConfigList, error)
+	ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*buildapi.BuildConfigList, error)
 	// GetBuildConfig retrieves a specific buildConfig.
-	GetBuildConfig(ctx apirequest.Context, id string, options *metav1.GetOptions) (*api.BuildConfig, error)
+	GetBuildConfig(ctx apirequest.Context, id string, options *metav1.GetOptions) (*buildapi.BuildConfig, error)
 	// CreateBuildConfig creates a new buildConfig.
-	CreateBuildConfig(ctx apirequest.Context, buildConfig *api.BuildConfig) error
+	CreateBuildConfig(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error
 	// UpdateBuildConfig updates a buildConfig.
-	UpdateBuildConfig(ctx apirequest.Context, buildConfig *api.BuildConfig) error
+	UpdateBuildConfig(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error
 	// DeleteBuildConfig deletes a buildConfig.
 	DeleteBuildConfig(ctx apirequest.Context, id string) error
 	// WatchBuildConfigs watches buildConfigs.
@@ -37,32 +37,32 @@ func NewRegistry(s rest.StandardStorage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*api.BuildConfigList, error) {
+func (s *storage) ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*buildapi.BuildConfigList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.BuildConfigList), nil
+	return obj.(*buildapi.BuildConfigList), nil
 }
 
 func (s *storage) WatchBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (watch.Interface, error) {
 	return s.Watch(ctx, options)
 }
 
-func (s *storage) GetBuildConfig(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.BuildConfig, error) {
+func (s *storage) GetBuildConfig(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.BuildConfig), nil
+	return obj.(*buildapi.BuildConfig), nil
 }
 
-func (s *storage) CreateBuildConfig(ctx apirequest.Context, build *api.BuildConfig) error {
+func (s *storage) CreateBuildConfig(ctx apirequest.Context, build *buildapi.BuildConfig) error {
 	_, err := s.Create(ctx, build)
 	return err
 }
 
-func (s *storage) UpdateBuildConfig(ctx apirequest.Context, build *api.BuildConfig) error {
+func (s *storage) UpdateBuildConfig(ctx apirequest.Context, build *buildapi.BuildConfig) error {
 	_, _, err := s.Update(ctx, build.Name, rest.DefaultUpdatedObjectInfo(build, kapi.Scheme))
 	return err
 }

--- a/pkg/build/registry/buildconfig/strategy.go
+++ b/pkg/build/registry/buildconfig/strategy.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/api/validation"
 )
 
@@ -41,7 +41,7 @@ func (strategy) AllowUnconditionalUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	bc := obj.(*api.BuildConfig)
+	bc := obj.(*buildapi.BuildConfig)
 	dropUnknownTriggers(bc)
 }
 
@@ -51,8 +51,8 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newBC := obj.(*api.BuildConfig)
-	oldBC := old.(*api.BuildConfig)
+	newBC := obj.(*buildapi.BuildConfig)
+	oldBC := old.(*buildapi.BuildConfig)
 	dropUnknownTriggers(newBC)
 	// Do not allow the build version to go backwards or we'll
 	// get conflicts with existing builds.
@@ -63,21 +63,21 @@ func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object
 
 // Validate validates a new policy.
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateBuildConfig(obj.(*api.BuildConfig))
+	return validation.ValidateBuildConfig(obj.(*buildapi.BuildConfig))
 }
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateBuildConfigUpdate(obj.(*api.BuildConfig), old.(*api.BuildConfig))
+	return validation.ValidateBuildConfigUpdate(obj.(*buildapi.BuildConfig), old.(*buildapi.BuildConfig))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	buildConfig, ok := obj.(*api.BuildConfig)
+	buildConfig, ok := obj.(*buildapi.BuildConfig)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a BuildConfig")
 	}
-	return labels.Set(buildConfig.ObjectMeta.Labels), api.BuildConfigToSelectableFields(buildConfig), nil
+	return labels.Set(buildConfig.ObjectMeta.Labels), buildapi.BuildConfigToSelectableFields(buildConfig), nil
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
@@ -95,10 +95,10 @@ func (strategy) CheckGracefulDelete(obj runtime.Object, options *metav1.DeleteOp
 }
 
 // dropUnknownTriggers drops any triggers that are of an unknown type
-func dropUnknownTriggers(bc *api.BuildConfig) {
-	triggers := []api.BuildTriggerPolicy{}
+func dropUnknownTriggers(bc *buildapi.BuildConfig) {
+	triggers := []buildapi.BuildTriggerPolicy{}
 	for _, t := range bc.Spec.Triggers {
-		if api.KnownTriggerTypes.Has(string(t.Type)) {
+		if buildapi.KnownTriggerTypes.Has(string(t.Type)) {
 			triggers = append(triggers, t)
 		}
 	}

--- a/pkg/build/registry/buildconfig/webhook_test.go
+++ b/pkg/build/registry/buildconfig/webhook_test.go
@@ -18,7 +18,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	_ "github.com/openshift/origin/pkg/api/install"
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildapiv1 "github.com/openshift/origin/pkg/build/api/v1"
 	"github.com/openshift/origin/pkg/build/registry/test"
 	"github.com/openshift/origin/pkg/build/webhook"
@@ -29,17 +29,17 @@ import (
 )
 
 type buildConfigInstantiator struct {
-	Build   *api.Build
+	Build   *buildapi.Build
 	Err     error
-	Request *api.BuildRequest
+	Request *buildapi.BuildRequest
 }
 
-func (i *buildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
+func (i *buildConfigInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
 	i.Request = request
 	if i.Build != nil {
 		return i.Build, i.Err
 	}
-	return &api.Build{
+	return &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      request.Name,
 			Namespace: namespace,
@@ -51,11 +51,11 @@ type plugin struct {
 	Secret, Path          string
 	Err                   error
 	Env                   []kapi.EnvVar
-	DockerStrategyOptions *api.DockerStrategyOptions
+	DockerStrategyOptions *buildapi.DockerStrategyOptions
 	Proceed               bool
 }
 
-func (p *plugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (*api.SourceRevision, []kapi.EnvVar, *api.DockerStrategyOptions, bool, error) {
+func (p *plugin) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (*buildapi.SourceRevision, []kapi.EnvVar, *buildapi.DockerStrategyOptions, bool, error) {
 	p.Secret, p.Path = secret, path
 	return nil, p.Env, p.DockerStrategyOptions, p.Proceed, p.Err
 }
@@ -83,7 +83,7 @@ func newStorage() (*rest.WebHook, *buildConfigInstantiator, *test.BuildConfigReg
 
 func TestNewWebHook(t *testing.T) {
 	hook, _, _ := newStorage()
-	if out, ok := hook.New().(*api.Build); !ok {
+	if out, ok := hook.New().(*buildapi.Build); !ok {
 		t.Errorf("unexpected new: %#v", out)
 	}
 }
@@ -116,7 +116,7 @@ func TestConnectWebHook(t *testing.T) {
 	testCases := map[string]struct {
 		Name        string
 		Path        string
-		Obj         *api.BuildConfig
+		Obj         *buildapi.BuildConfig
 		RegErr      error
 		ErrFn       func(error) bool
 		WFn         func(*httptest.ResponseRecorder) bool
@@ -126,7 +126,7 @@ func TestConnectWebHook(t *testing.T) {
 		"hook returns generic error": {
 			Name: "test",
 			Path: "secret/err",
-			Obj:  &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:  &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn: func(err error) bool {
 				return strings.Contains(err.Error(), "Internal error occurred: hook failed: test error")
 			},
@@ -135,21 +135,21 @@ func TestConnectWebHook(t *testing.T) {
 		"hook returns unauthorized for bad secret": {
 			Name:        "test",
 			Path:        "secret/errsecret",
-			Obj:         &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:         &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn:       kerrors.IsUnauthorized,
 			Instantiate: false,
 		},
 		"hook returns unauthorized for bad hook": {
 			Name:        "test",
 			Path:        "secret/errhook",
-			Obj:         &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:         &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn:       kerrors.IsUnauthorized,
 			Instantiate: false,
 		},
 		"hook returns unauthorized for missing build config": {
 			Name:        "test",
 			Path:        "secret/errhook",
-			Obj:         &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:         &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			RegErr:      fmt.Errorf("any old error"),
 			ErrFn:       kerrors.IsUnauthorized,
 			Instantiate: false,
@@ -157,7 +157,7 @@ func TestConnectWebHook(t *testing.T) {
 		"hook returns 200 for ok hook": {
 			Name:  "test",
 			Path:  "secret/ok",
-			Obj:   &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:   &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn: func(err error) bool { return err == nil },
 			WFn: func(w *httptest.ResponseRecorder) bool {
 				body, _ := ioutil.ReadAll(w.Body)
@@ -178,7 +178,7 @@ func TestConnectWebHook(t *testing.T) {
 		"hook returns 200 for okenv hook": {
 			Name:  "test",
 			Path:  "secret/okenv",
-			Obj:   &api.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
+			Obj:   &buildapi.BuildConfig{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}},
 			ErrFn: func(err error) bool { return err == nil },
 			WFn: func(w *httptest.ResponseRecorder) bool {
 				return w.Code == http.StatusOK
@@ -234,8 +234,8 @@ func TestConnectWebHook(t *testing.T) {
 
 type okBuildConfigInstantiator struct{}
 
-func (*okBuildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
-	return &api.Build{
+func (*okBuildConfigInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
+	return &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      request.Name,
@@ -245,19 +245,19 @@ func (*okBuildConfigInstantiator) Instantiate(namespace string, request *api.Bui
 
 type errorBuildConfigInstantiator struct{}
 
-func (*errorBuildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
+func (*errorBuildConfigInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
 	return nil, errors.New("Build error!")
 }
 
 type errorBuildConfigGetter struct{}
 
-func (*errorBuildConfigGetter) Get(namespace, name string) (*api.BuildConfig, error) {
-	return &api.BuildConfig{}, errors.New("BuildConfig error!")
+func (*errorBuildConfigGetter) Get(namespace, name string) (*buildapi.BuildConfig, error) {
+	return &buildapi.BuildConfig{}, errors.New("BuildConfig error!")
 }
 
 type errorBuildConfigUpdater struct{}
 
-func (*errorBuildConfigUpdater) Update(buildConfig *api.BuildConfig) error {
+func (*errorBuildConfigUpdater) Update(buildConfig *buildapi.BuildConfig) error {
 	return errors.New("BuildConfig error!")
 }
 
@@ -265,43 +265,43 @@ type pathPlugin struct {
 	Path string
 }
 
-func (p *pathPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (*api.SourceRevision, []kapi.EnvVar, *api.DockerStrategyOptions, bool, error) {
+func (p *pathPlugin) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (*buildapi.SourceRevision, []kapi.EnvVar, *buildapi.DockerStrategyOptions, bool, error) {
 	p.Path = path
 	return nil, []kapi.EnvVar{}, nil, true, nil
 }
 
 type errPlugin struct{}
 
-func (*errPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (*api.SourceRevision, []kapi.EnvVar, *api.DockerStrategyOptions, bool, error) {
+func (*errPlugin) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (*buildapi.SourceRevision, []kapi.EnvVar, *buildapi.DockerStrategyOptions, bool, error) {
 	return nil, []kapi.EnvVar{}, nil, false, errors.New("Plugin error!")
 }
 
-var testBuildConfig = &api.BuildConfig{
+var testBuildConfig = &buildapi.BuildConfig{
 	ObjectMeta: metav1.ObjectMeta{Name: "build100"},
-	Spec: api.BuildConfigSpec{
-		Triggers: []api.BuildTriggerPolicy{
+	Spec: buildapi.BuildConfigSpec{
+		Triggers: []buildapi.BuildTriggerPolicy{
 			{
-				Type: api.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitHubWebHookBuildTriggerType,
+				GitHubWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret101",
 				},
 			},
 			{
-				Type: api.GitLabWebHookBuildTriggerType,
-				GitLabWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitLabWebHookBuildTriggerType,
+				GitLabWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret201",
 				},
 			},
 			{
-				Type: api.BitbucketWebHookBuildTriggerType,
-				BitbucketWebHook: &api.WebHookTrigger{
+				Type: buildapi.BitbucketWebHookBuildTriggerType,
+				BitbucketWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret301",
 				},
 			},
 		},
-		CommonSpec: api.CommonSpec{
-			Source: api.BuildSource{
-				Git: &api.GitBuildSource{
+		CommonSpec: buildapi.CommonSpec{
+			Source: buildapi.BuildSource{
+				Git: &buildapi.GitBuildSource{
 					URI: "git://github.com/my/repo.git",
 				},
 			},
@@ -309,8 +309,8 @@ var testBuildConfig = &api.BuildConfig{
 		},
 	},
 }
-var mockBuildStrategy = api.BuildStrategy{
-	SourceStrategy: &api.SourceBuildStrategy{
+var mockBuildStrategy = buildapi.BuildStrategy{
+	SourceStrategy: &buildapi.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Kind: "DockerImage",
 			Name: "repository/image",
@@ -447,13 +447,13 @@ func TestInvokeWebhookErrorCreateBuild(t *testing.T) {
 }
 
 func TestGeneratedBuildTriggerInfoGenericWebHook(t *testing.T) {
-	revision := &api.SourceRevision{
-		Git: &api.GitSourceRevision{
-			Author: api.SourceControlUser{
+	revision := &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
+			Author: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
-			Committer: api.SourceControlUser{
+			Committer: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
@@ -470,20 +470,20 @@ func TestGeneratedBuildTriggerInfoGenericWebHook(t *testing.T) {
 		if cause.GenericWebHook.Secret != hiddenSecret {
 			t.Errorf("Expected obfuscated secret to be: %s", hiddenSecret)
 		}
-		if cause.Message != api.BuildTriggerCauseGenericMsg {
+		if cause.Message != buildapi.BuildTriggerCauseGenericMsg {
 			t.Errorf("Expected build reason to be 'Generic WebHook, go %s'", cause.Message)
 		}
 	}
 }
 
 func TestGeneratedBuildTriggerInfoGitHubWebHook(t *testing.T) {
-	revision := &api.SourceRevision{
-		Git: &api.GitSourceRevision{
-			Author: api.SourceControlUser{
+	revision := &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
+			Author: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
-			Committer: api.SourceControlUser{
+			Committer: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
@@ -500,20 +500,20 @@ func TestGeneratedBuildTriggerInfoGitHubWebHook(t *testing.T) {
 		if cause.GitHubWebHook.Secret != hiddenSecret {
 			t.Errorf("Expected obfuscated secret to be: %s", hiddenSecret)
 		}
-		if cause.Message != api.BuildTriggerCauseGithubMsg {
+		if cause.Message != buildapi.BuildTriggerCauseGithubMsg {
 			t.Errorf("Expected build reason to be 'GitHub WebHook, go %s'", cause.Message)
 		}
 	}
 }
 
 func TestGeneratedBuildTriggerInfoGitLabWebHook(t *testing.T) {
-	revision := &api.SourceRevision{
-		Git: &api.GitSourceRevision{
-			Author: api.SourceControlUser{
+	revision := &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
+			Author: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
-			Committer: api.SourceControlUser{
+			Committer: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
@@ -530,20 +530,20 @@ func TestGeneratedBuildTriggerInfoGitLabWebHook(t *testing.T) {
 		if cause.GitLabWebHook.Secret != hiddenSecret {
 			t.Errorf("Expected obfuscated secret to be: %s", hiddenSecret)
 		}
-		if cause.Message != api.BuildTriggerCauseGitLabMsg {
+		if cause.Message != buildapi.BuildTriggerCauseGitLabMsg {
 			t.Errorf("Expected build reason to be 'GitLab WebHook, go %s'", cause.Message)
 		}
 	}
 }
 
 func TestGeneratedBuildTriggerInfoBitbucketWebHook(t *testing.T) {
-	revision := &api.SourceRevision{
-		Git: &api.GitSourceRevision{
-			Author: api.SourceControlUser{
+	revision := &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
+			Author: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
-			Committer: api.SourceControlUser{
+			Committer: buildapi.SourceControlUser{
 				Name:  "John Doe",
 				Email: "john.doe@test.com",
 			},
@@ -560,7 +560,7 @@ func TestGeneratedBuildTriggerInfoBitbucketWebHook(t *testing.T) {
 		if cause.BitbucketWebHook.Secret != hiddenSecret {
 			t.Errorf("Expected obfuscated secret to be: %s", hiddenSecret)
 		}
-		if cause.Message != api.BuildTriggerCauseBitbucketMsg {
+		if cause.Message != buildapi.BuildTriggerCauseBitbucketMsg {
 			t.Errorf("Expected build reason to be 'Bitbucket WebHook, go %s'", cause.Message)
 		}
 	}

--- a/pkg/build/registry/rest.go
+++ b/pkg/build/registry/rest.go
@@ -10,7 +10,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 var (
@@ -22,7 +22,7 @@ var (
 // WaitForRunningBuild waits until the specified build is no longer New or Pending. Returns true if
 // the build ran within timeout, false if it did not, and an error if any other error state occurred.
 // The last observed Build state is returned.
-func WaitForRunningBuild(watcher rest.Watcher, ctx apirequest.Context, build *api.Build, timeout time.Duration) (*api.Build, bool, error) {
+func WaitForRunningBuild(watcher rest.Watcher, ctx apirequest.Context, build *buildapi.Build, timeout time.Duration) (*buildapi.Build, bool, error) {
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", build.Name)
 	options := &metainternal.ListOptions{FieldSelector: fieldSelector, ResourceVersion: build.ResourceVersion}
 	w, err := watcher.Watch(ctx, options)
@@ -37,7 +37,7 @@ func WaitForRunningBuild(watcher rest.Watcher, ctx apirequest.Context, build *ap
 	for {
 		select {
 		case event := <-ch:
-			obj, ok := event.Object.(*api.Build)
+			obj, ok := event.Object.(*buildapi.Build)
 			if !ok {
 				return observed, false, fmt.Errorf("received unknown object while watching for builds")
 			}
@@ -47,9 +47,9 @@ func WaitForRunningBuild(watcher rest.Watcher, ctx apirequest.Context, build *ap
 				return observed, false, ErrBuildDeleted
 			}
 			switch obj.Status.Phase {
-			case api.BuildPhaseRunning, api.BuildPhaseComplete, api.BuildPhaseFailed, api.BuildPhaseError, api.BuildPhaseCancelled:
+			case buildapi.BuildPhaseRunning, buildapi.BuildPhaseComplete, buildapi.BuildPhaseFailed, buildapi.BuildPhaseError, buildapi.BuildPhaseCancelled:
 				return observed, true, nil
-			case api.BuildPhaseNew, api.BuildPhasePending:
+			case buildapi.BuildPhaseNew, buildapi.BuildPhasePending:
 			default:
 				return observed, false, ErrUnknownBuildPhase
 			}

--- a/pkg/build/registry/test/buildconfig.go
+++ b/pkg/build/registry/test/buildconfig.go
@@ -9,40 +9,40 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 type BuildConfigRegistry struct {
 	Err             error
-	BuildConfigs    *api.BuildConfigList
-	BuildConfig     *api.BuildConfig
+	BuildConfigs    *buildapi.BuildConfigList
+	BuildConfig     *buildapi.BuildConfig
 	DeletedConfigID string
 	sync.Mutex
 }
 
-func (r *BuildConfigRegistry) ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*api.BuildConfigList, error) {
+func (r *BuildConfigRegistry) ListBuildConfigs(ctx apirequest.Context, options *metainternal.ListOptions) (*buildapi.BuildConfigList, error) {
 	r.Lock()
 	defer r.Unlock()
 	return r.BuildConfigs, r.Err
 }
 
-func (r *BuildConfigRegistry) GetBuildConfig(ctx apirequest.Context, id string, options *metav1.GetOptions) (*api.BuildConfig, error) {
+func (r *BuildConfigRegistry) GetBuildConfig(ctx apirequest.Context, id string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.BuildConfig != nil && r.BuildConfig.Name == id {
 		return r.BuildConfig, r.Err
 	}
-	return nil, kapierrors.NewNotFound(api.Resource("buildconfig"), id)
+	return nil, kapierrors.NewNotFound(buildapi.Resource("buildconfig"), id)
 }
 
-func (r *BuildConfigRegistry) CreateBuildConfig(ctx apirequest.Context, config *api.BuildConfig) error {
+func (r *BuildConfigRegistry) CreateBuildConfig(ctx apirequest.Context, config *buildapi.BuildConfig) error {
 	r.Lock()
 	defer r.Unlock()
 	r.BuildConfig = config
 	return r.Err
 }
 
-func (r *BuildConfigRegistry) UpdateBuildConfig(ctx apirequest.Context, config *api.BuildConfig) error {
+func (r *BuildConfigRegistry) UpdateBuildConfig(ctx apirequest.Context, config *buildapi.BuildConfig) error {
 	r.Lock()
 	defer r.Unlock()
 	r.BuildConfig = config

--- a/pkg/build/webhook/generic/generic.go
+++ b/pkg/build/webhook/generic/generic.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 )
 
@@ -26,8 +26,8 @@ func New() *WebHookPlugin {
 }
 
 // Extract services generic webhooks.
-func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (revision *api.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *api.DockerStrategyOptions, proceed bool, err error) {
-	triggers, err := webhook.FindTriggerPolicy(api.GenericWebHookBuildTriggerType, buildCfg)
+func (p *WebHookPlugin) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (revision *buildapi.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *buildapi.DockerStrategyOptions, proceed bool, err error) {
+	triggers, err := webhook.FindTriggerPolicy(buildapi.GenericWebHookBuildTriggerType, buildCfg)
 	if err != nil {
 		return revision, envvars, dockerStrategyOptions, false, err
 	}
@@ -69,7 +69,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 		return revision, envvars, dockerStrategyOptions, true, nil
 	}
 
-	var data api.GenericWebHookEvent
+	var data buildapi.GenericWebHookEvent
 	if contentType == "application/yaml" {
 		body, err = yaml.ToJSON(body)
 		if err != nil {
@@ -99,7 +99,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 	if data.Git.Refs != nil {
 		for _, ref := range data.Git.Refs {
 			if webhook.GitRefMatches(ref.Ref, webhook.DefaultConfigRef, &buildCfg.Spec.Source) {
-				revision = &api.SourceRevision{
+				revision = &buildapi.SourceRevision{
 					Git: &ref.GitSourceRevision,
 				}
 				return revision, envvars, dockerStrategyOptions, true, nil
@@ -112,7 +112,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 		warning := webhook.NewWarning(fmt.Sprintf("skipping build. Branch reference from %q does not match configuration", data.Git.Ref))
 		return revision, envvars, dockerStrategyOptions, false, warning
 	}
-	revision = &api.SourceRevision{
+	revision = &buildapi.SourceRevision{
 		Git: &data.Git.GitSourceRevision,
 	}
 	return revision, envvars, dockerStrategyOptions, true, nil

--- a/pkg/build/webhook/generic/generic_test.go
+++ b/pkg/build/webhook/generic/generic_test.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
-var mockBuildStrategy = api.BuildStrategy{
-	SourceStrategy: &api.SourceBuildStrategy{
+var mockBuildStrategy = buildapi.BuildStrategy{
+	SourceStrategy: &buildapi.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Name: "repository/image",
 		},
@@ -74,12 +74,12 @@ func matchWarning(t *testing.T, err error, message string) {
 
 func TestVerifyRequestForMethod(t *testing.T) {
 	req := GivenRequest("GET")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
@@ -102,24 +102,24 @@ func TestVerifyRequestForMethod(t *testing.T) {
 
 func TestWrongSecretMultipleGenericWebHooks(t *testing.T) {
 	req := GivenRequest("GET")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret101",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret102",
 					},
 				},
@@ -145,31 +145,31 @@ func TestWrongSecretMultipleGenericWebHooks(t *testing.T) {
 
 func TestMatchSecretMultipleGenericWebHooks(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret101",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret102",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -196,32 +196,32 @@ func TestMatchSecretMultipleGenericWebHooks(t *testing.T) {
 
 func TestEnvVarsMultipleGenericWebHooks(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic-envs.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret:   "secret101",
 						AllowEnv: true,
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret102",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -253,12 +253,12 @@ func TestEnvVarsMultipleGenericWebHooks(t *testing.T) {
 
 func TestWrongSecret(t *testing.T) {
 	req := GivenRequest("POST")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
@@ -288,20 +288,20 @@ func (_ emptyReader) Read(p []byte) (n int, err error) {
 func TestExtractWithEmptyPayload(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", emptyReader{})
 	req.Header.Add("Content-Type", "application/json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
 
-			Triggers: []api.BuildTriggerPolicy{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -324,19 +324,19 @@ func TestExtractWithEmptyPayload(t *testing.T) {
 
 func TestExtractWithUnmatchedRefGitPayload(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "asdfkasdfasdfasdfadsfkjhkhkh",
 					},
 				},
@@ -358,19 +358,19 @@ func TestExtractWithUnmatchedRefGitPayload(t *testing.T) {
 
 func TestExtractWithGitPayload(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -394,19 +394,19 @@ func TestExtractWithGitPayload(t *testing.T) {
 
 func TestExtractWithGitPayloadAndUTF8Charset(t *testing.T) {
 	req := GivenRequestWithPayloadAndContentType(t, "push-generic.json", "application/json; charset=utf-8")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -430,19 +430,19 @@ func TestExtractWithGitPayloadAndUTF8Charset(t *testing.T) {
 
 func TestExtractWithGitRefsPayload(t *testing.T) {
 	req := GivenRequestWithRefsPayload(t)
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -466,19 +466,19 @@ func TestExtractWithGitRefsPayload(t *testing.T) {
 
 func TestExtractWithUnmatchedGitRefsPayload(t *testing.T) {
 	req := GivenRequestWithRefsPayload(t)
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "other",
 					},
 				},
@@ -500,20 +500,20 @@ func TestExtractWithUnmatchedGitRefsPayload(t *testing.T) {
 
 func TestExtractWithKeyValuePairsJSON(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic-envs.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret:   "secret100",
 						AllowEnv: true,
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -541,20 +541,20 @@ func TestExtractWithKeyValuePairsJSON(t *testing.T) {
 
 func TestExtractWithKeyValuePairsYAML(t *testing.T) {
 	req := GivenRequestWithPayloadAndContentType(t, "push-generic-envs.yaml", "application/yaml")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret:   "secret100",
 						AllowEnv: true,
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -582,19 +582,19 @@ func TestExtractWithKeyValuePairsYAML(t *testing.T) {
 
 func TestExtractWithKeyValuePairsDisabled(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-generic-envs.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "master",
 					},
 				},
@@ -622,19 +622,19 @@ func TestExtractWithKeyValuePairsDisabled(t *testing.T) {
 
 func TestGitlabPush(t *testing.T) {
 	req := GivenRequestWithPayload(t, "push-gitlab.json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{},
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{},
 				},
 				Strategy: mockBuildStrategy,
 			},
@@ -652,19 +652,19 @@ func TestNonJsonPush(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", nil)
 	req.Header.Add("Content-Type", "*/*")
 
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{},
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{},
 				},
 				Strategy: mockBuildStrategy,
 			},
@@ -691,19 +691,19 @@ func (_ errJSON) Read(p []byte) (n int, err error) {
 func TestExtractWithUnmarshalError(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", errJSON{})
 	req.Header.Add("Content-Type", "application/json")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "other",
 					},
 				},
@@ -725,19 +725,19 @@ func TestExtractWithUnmarshalError(t *testing.T) {
 func TestExtractWithUnmarshalErrorYAML(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", errJSON{})
 	req.Header.Add("Content-Type", "application/yaml")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "other",
 					},
 				},
@@ -759,19 +759,19 @@ func TestExtractWithUnmarshalErrorYAML(t *testing.T) {
 func TestExtractWithBadContentType(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", errJSON{})
 	req.Header.Add("Content-Type", "bad")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "other",
 					},
 				},
@@ -793,19 +793,19 @@ func TestExtractWithBadContentType(t *testing.T) {
 func TestExtractWithUnparseableContentType(t *testing.T) {
 	req, _ := http.NewRequest("POST", "http://someurl.com", errJSON{})
 	req.Header.Add("Content-Type", "bad//bad")
-	buildConfig := &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+	buildConfig := &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret100",
 					},
 				},
 			},
-			CommonSpec: api.CommonSpec{
-				Source: api.BuildSource{
-					Git: &api.GitBuildSource{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
 						Ref: "other",
 					},
 				},

--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 )
 
@@ -24,10 +24,10 @@ func New() *WebHook {
 }
 
 type commit struct {
-	ID        string                `json:"id,omitempty"`
-	Author    api.SourceControlUser `json:"author,omitempty"`
-	Committer api.SourceControlUser `json:"committer,omitempty"`
-	Message   string                `json:"message,omitempty"`
+	ID        string                     `json:"id,omitempty"`
+	Author    buildapi.SourceControlUser `json:"author,omitempty"`
+	Committer buildapi.SourceControlUser `json:"committer,omitempty"`
+	Message   string                     `json:"message,omitempty"`
 }
 
 type pushEvent struct {
@@ -37,8 +37,8 @@ type pushEvent struct {
 }
 
 // Extract services webhooks from github.com
-func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (revision *api.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *api.DockerStrategyOptions, proceed bool, err error) {
-	triggers, err := webhook.FindTriggerPolicy(api.GitHubWebHookBuildTriggerType, buildCfg)
+func (p *WebHook) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (revision *buildapi.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *buildapi.DockerStrategyOptions, proceed bool, err error) {
+	triggers, err := webhook.FindTriggerPolicy(buildapi.GitHubWebHookBuildTriggerType, buildCfg)
 	if err != nil {
 		return revision, envvars, dockerStrategyOptions, proceed, err
 	}
@@ -72,8 +72,8 @@ func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 		return revision, envvars, dockerStrategyOptions, proceed, err
 	}
 
-	revision = &api.SourceRevision{
-		Git: &api.GitSourceRevision{
+	revision = &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
 			Commit:    event.HeadCommit.ID,
 			Author:    event.HeadCommit.Author,
 			Committer: event.HeadCommit.Committer,

--- a/pkg/build/webhook/github/github_test.go
+++ b/pkg/build/webhook/github/github_test.go
@@ -10,35 +10,35 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 )
 
-var testBuildConfig = &api.BuildConfig{
-	Spec: api.BuildConfigSpec{
-		Triggers: []api.BuildTriggerPolicy{
+var testBuildConfig = &buildapi.BuildConfig{
+	Spec: buildapi.BuildConfigSpec{
+		Triggers: []buildapi.BuildTriggerPolicy{
 			{
-				Type: api.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitHubWebHookBuildTriggerType,
+				GitHubWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret101",
 				},
 			},
 			{
-				Type: api.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitHubWebHookBuildTriggerType,
+				GitHubWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret100",
 				},
 			},
 			{
-				Type: api.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitHubWebHookBuildTriggerType,
+				GitHubWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret102",
 				},
 			},
 		},
-		CommonSpec: api.CommonSpec{
-			Source: api.BuildSource{
-				Git: &api.GitBuildSource{
+		CommonSpec: buildapi.CommonSpec{
+			Source: buildapi.BuildSource{
+				Git: &buildapi.GitBuildSource{
 					URI: "git://github.com/my/repo.git",
 				},
 			},
@@ -47,8 +47,8 @@ var testBuildConfig = &api.BuildConfig{
 	},
 }
 
-var mockBuildStrategy = api.BuildStrategy{
-	SourceStrategy: &api.SourceBuildStrategy{
+var mockBuildStrategy = buildapi.BuildStrategy{
+	SourceStrategy: &buildapi.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Kind: "DockerImage",
 			Name: "repository/image",
@@ -58,8 +58,8 @@ var mockBuildStrategy = api.BuildStrategy{
 
 type okBuildConfigInstantiator struct{}
 
-func (*okBuildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
-	return &api.Build{}, nil
+func (*okBuildConfigInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
+	return &buildapi.Build{}, nil
 }
 
 type fakeResponder struct {
@@ -86,19 +86,19 @@ func (r *fakeResponder) Error(err error) {
 	r.err = err
 }
 
-var buildConfig = &api.BuildConfig{
-	Spec: api.BuildConfigSpec{
-		Triggers: []api.BuildTriggerPolicy{
+var buildConfig = &buildapi.BuildConfig{
+	Spec: buildapi.BuildConfigSpec{
+		Triggers: []buildapi.BuildTriggerPolicy{
 			{
-				Type: api.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitHubWebHookBuildTriggerType,
+				GitHubWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret100",
 				},
 			},
 		},
-		CommonSpec: api.CommonSpec{
-			Source: api.BuildSource{
-				Git: &api.GitBuildSource{},
+		CommonSpec: buildapi.CommonSpec{
+			Source: buildapi.BuildSource{
+				Git: &buildapi.GitBuildSource{},
 			},
 		},
 	},
@@ -275,7 +275,7 @@ func postWithCharset(eventHeader, eventName string, data []byte, url, charset st
 
 type testContext struct {
 	plugin   WebHook
-	buildCfg *api.BuildConfig
+	buildCfg *buildapi.BuildConfig
 	req      *http.Request
 	path     string
 }
@@ -283,31 +283,31 @@ type testContext struct {
 func setup(t *testing.T, filename, eventType, ref string) *testContext {
 	context := testContext{
 		plugin: WebHook{},
-		buildCfg: &api.BuildConfig{
-			Spec: api.BuildConfigSpec{
-				Triggers: []api.BuildTriggerPolicy{
+		buildCfg: &buildapi.BuildConfig{
+			Spec: buildapi.BuildConfigSpec{
+				Triggers: []buildapi.BuildTriggerPolicy{
 					{
-						Type: api.GitHubWebHookBuildTriggerType,
-						GitHubWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitHubWebHookBuildTriggerType,
+						GitHubWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret101",
 						},
 					},
 					{
-						Type: api.GitHubWebHookBuildTriggerType,
-						GitHubWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitHubWebHookBuildTriggerType,
+						GitHubWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret100",
 						},
 					},
 					{
-						Type: api.GitHubWebHookBuildTriggerType,
-						GitHubWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitHubWebHookBuildTriggerType,
+						GitHubWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret102",
 						},
 					},
 				},
-				CommonSpec: api.CommonSpec{
-					Source: api.BuildSource{
-						Git: &api.GitBuildSource{
+				CommonSpec: buildapi.CommonSpec{
+					Source: buildapi.BuildSource{
+						Git: &buildapi.GitBuildSource{
 							URI: "git://github.com/my/repo.git",
 							Ref: ref,
 						},

--- a/pkg/build/webhook/gitlab/gitlab.go
+++ b/pkg/build/webhook/gitlab/gitlab.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 )
 
@@ -25,9 +25,9 @@ func New() *WebHook {
 
 // NOTE - unlike github, there is no separate commiter, just the author
 type commit struct {
-	ID      string                `json:"id,omitempty"`
-	Author  api.SourceControlUser `json:"author,omitempty"`
-	Message string                `json:"message,omitempty"`
+	ID      string                     `json:"id,omitempty"`
+	Author  buildapi.SourceControlUser `json:"author,omitempty"`
+	Message string                     `json:"message,omitempty"`
 }
 
 // NOTE - unlike github, the head commit is not highlighted ... only the commit array is provided,
@@ -39,8 +39,8 @@ type pushEvent struct {
 }
 
 // Extract services webhooks from GitLab server
-func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (revision *api.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *api.DockerStrategyOptions, proceed bool, err error) {
-	triggers, err := webhook.FindTriggerPolicy(api.GitLabWebHookBuildTriggerType, buildCfg)
+func (p *WebHook) Extract(buildCfg *buildapi.BuildConfig, secret, path string, req *http.Request) (revision *buildapi.SourceRevision, envvars []kapi.EnvVar, dockerStrategyOptions *buildapi.DockerStrategyOptions, proceed bool, err error) {
+	triggers, err := webhook.FindTriggerPolicy(buildapi.GitLabWebHookBuildTriggerType, buildCfg)
 	if err != nil {
 		return revision, envvars, dockerStrategyOptions, proceed, err
 	}
@@ -73,8 +73,8 @@ func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 
 	lastCommit := event.Commits[len(event.Commits)-1]
 
-	revision = &api.SourceRevision{
-		Git: &api.GitSourceRevision{
+	revision = &buildapi.SourceRevision{
+		Git: &buildapi.GitSourceRevision{
 			Commit:    lastCommit.ID,
 			Author:    lastCommit.Author,
 			Committer: lastCommit.Author,

--- a/pkg/build/webhook/gitlab/gitlab_test.go
+++ b/pkg/build/webhook/gitlab/gitlab_test.go
@@ -10,35 +10,35 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
 )
 
-var testBuildConfig = &api.BuildConfig{
-	Spec: api.BuildConfigSpec{
-		Triggers: []api.BuildTriggerPolicy{
+var testBuildConfig = &buildapi.BuildConfig{
+	Spec: buildapi.BuildConfigSpec{
+		Triggers: []buildapi.BuildTriggerPolicy{
 			{
-				Type: api.GitLabWebHookBuildTriggerType,
-				GitLabWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitLabWebHookBuildTriggerType,
+				GitLabWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret101",
 				},
 			},
 			{
-				Type: api.GitLabWebHookBuildTriggerType,
-				GitLabWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitLabWebHookBuildTriggerType,
+				GitLabWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret100",
 				},
 			},
 			{
-				Type: api.GitLabWebHookBuildTriggerType,
-				GitLabWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitLabWebHookBuildTriggerType,
+				GitLabWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret102",
 				},
 			},
 		},
-		CommonSpec: api.CommonSpec{
-			Source: api.BuildSource{
-				Git: &api.GitBuildSource{
+		CommonSpec: buildapi.CommonSpec{
+			Source: buildapi.BuildSource{
+				Git: &buildapi.GitBuildSource{
 					URI: "git://github.com/my/repo.git",
 				},
 			},
@@ -47,8 +47,8 @@ var testBuildConfig = &api.BuildConfig{
 	},
 }
 
-var mockBuildStrategy = api.BuildStrategy{
-	SourceStrategy: &api.SourceBuildStrategy{
+var mockBuildStrategy = buildapi.BuildStrategy{
+	SourceStrategy: &buildapi.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Kind: "DockerImage",
 			Name: "repository/image",
@@ -58,8 +58,8 @@ var mockBuildStrategy = api.BuildStrategy{
 
 type okBuildConfigInstantiator struct{}
 
-func (*okBuildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
-	return &api.Build{}, nil
+func (*okBuildConfigInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
+	return &buildapi.Build{}, nil
 }
 
 type fakeResponder struct {
@@ -86,19 +86,19 @@ func (r *fakeResponder) Error(err error) {
 	r.err = err
 }
 
-var buildConfig = &api.BuildConfig{
-	Spec: api.BuildConfigSpec{
-		Triggers: []api.BuildTriggerPolicy{
+var buildConfig = &buildapi.BuildConfig{
+	Spec: buildapi.BuildConfigSpec{
+		Triggers: []buildapi.BuildTriggerPolicy{
 			{
-				Type: api.GitLabWebHookBuildTriggerType,
-				GitLabWebHook: &api.WebHookTrigger{
+				Type: buildapi.GitLabWebHookBuildTriggerType,
+				GitLabWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret100",
 				},
 			},
 		},
-		CommonSpec: api.CommonSpec{
-			Source: api.BuildSource{
-				Git: &api.GitBuildSource{},
+		CommonSpec: buildapi.CommonSpec{
+			Source: buildapi.BuildSource{
+				Git: &buildapi.GitBuildSource{},
 			},
 		},
 	},
@@ -249,7 +249,7 @@ func postWithCharset(eventHeader, eventName string, data []byte, url, charset st
 
 type testContext struct {
 	plugin   WebHook
-	buildCfg *api.BuildConfig
+	buildCfg *buildapi.BuildConfig
 	req      *http.Request
 	path     string
 }
@@ -257,31 +257,31 @@ type testContext struct {
 func setup(t *testing.T, filename, eventType, ref string) *testContext {
 	context := testContext{
 		plugin: WebHook{},
-		buildCfg: &api.BuildConfig{
-			Spec: api.BuildConfigSpec{
-				Triggers: []api.BuildTriggerPolicy{
+		buildCfg: &buildapi.BuildConfig{
+			Spec: buildapi.BuildConfigSpec{
+				Triggers: []buildapi.BuildTriggerPolicy{
 					{
-						Type: api.GitLabWebHookBuildTriggerType,
-						GitLabWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitLabWebHookBuildTriggerType,
+						GitLabWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret101",
 						},
 					},
 					{
-						Type: api.GitLabWebHookBuildTriggerType,
-						GitLabWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitLabWebHookBuildTriggerType,
+						GitLabWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret100",
 						},
 					},
 					{
-						Type: api.GitLabWebHookBuildTriggerType,
-						GitLabWebHook: &api.WebHookTrigger{
+						Type: buildapi.GitLabWebHookBuildTriggerType,
+						GitLabWebHook: &buildapi.WebHookTrigger{
 							Secret: "secret102",
 						},
 					},
 				},
-				CommonSpec: api.CommonSpec{
-					Source: api.BuildSource{
-						Git: &api.GitBuildSource{
+				CommonSpec: buildapi.CommonSpec{
+					Source: buildapi.BuildSource{
+						Git: &buildapi.GitBuildSource{
 							URI: "git://github.com/my/repo.git",
 							Ref: ref,
 						},

--- a/pkg/build/webhook/webhook_test.go
+++ b/pkg/build/webhook/webhook_test.go
@@ -3,91 +3,91 @@ package webhook
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
-func newBuildSource(ref string) *api.BuildSource {
-	return &api.BuildSource{
-		Git: &api.GitBuildSource{
+func newBuildSource(ref string) *buildapi.BuildSource {
+	return &buildapi.BuildSource{
+		Git: &buildapi.GitBuildSource{
 			Ref: ref,
 		},
 	}
 }
 
-func newBuildConfig() *api.BuildConfig {
-	return &api.BuildConfig{
-		Spec: api.BuildConfigSpec{
-			Triggers: []api.BuildTriggerPolicy{
+func newBuildConfig() *buildapi.BuildConfig {
+	return &buildapi.BuildConfig{
+		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret101",
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret:   "secret100",
 						AllowEnv: true,
 					},
 				},
 				{
-					Type: api.GenericWebHookBuildTriggerType,
-					GenericWebHook: &api.WebHookTrigger{
+					Type: buildapi.GenericWebHookBuildTriggerType,
+					GenericWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret102",
 					},
 				},
 				{
-					Type: api.GitHubWebHookBuildTriggerType,
-					GitHubWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitHubWebHookBuildTriggerType,
+					GitHubWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret201",
 					},
 				},
 				{
-					Type: api.GitHubWebHookBuildTriggerType,
-					GitHubWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitHubWebHookBuildTriggerType,
+					GitHubWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret200",
 					},
 				},
 				{
-					Type: api.GitHubWebHookBuildTriggerType,
-					GitHubWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitHubWebHookBuildTriggerType,
+					GitHubWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret202",
 					},
 				},
 				{
-					Type: api.GitLabWebHookBuildTriggerType,
-					GitLabWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitLabWebHookBuildTriggerType,
+					GitLabWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret301",
 					},
 				},
 				{
-					Type: api.GitLabWebHookBuildTriggerType,
-					GitLabWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitLabWebHookBuildTriggerType,
+					GitLabWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret300",
 					},
 				},
 				{
-					Type: api.GitLabWebHookBuildTriggerType,
-					GitLabWebHook: &api.WebHookTrigger{
+					Type: buildapi.GitLabWebHookBuildTriggerType,
+					GitLabWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret302",
 					},
 				},
 				{
-					Type: api.BitbucketWebHookBuildTriggerType,
-					BitbucketWebHook: &api.WebHookTrigger{
+					Type: buildapi.BitbucketWebHookBuildTriggerType,
+					BitbucketWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret401",
 					},
 				},
 				{
-					Type: api.BitbucketWebHookBuildTriggerType,
-					BitbucketWebHook: &api.WebHookTrigger{
+					Type: buildapi.BitbucketWebHookBuildTriggerType,
+					BitbucketWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret400",
 					},
 				},
 				{
-					Type: api.BitbucketWebHookBuildTriggerType,
-					BitbucketWebHook: &api.WebHookTrigger{
+					Type: buildapi.BitbucketWebHookBuildTriggerType,
+					BitbucketWebHook: &buildapi.WebHookTrigger{
 						Secret: "secret402",
 					},
 				},
@@ -122,7 +122,7 @@ func TestWebHookEventNoRef(t *testing.T) {
 
 func TestFindTriggerPolicyWebHookError(t *testing.T) {
 	buildConfig := newBuildConfig()
-	_, err := FindTriggerPolicy(api.ImageChangeBuildTriggerType, buildConfig)
+	_, err := FindTriggerPolicy(buildapi.ImageChangeBuildTriggerType, buildConfig)
 	if err != ErrHookNotEnabled {
 		t.Errorf("Expected error %s got %s", ErrHookNotEnabled, err)
 	}
@@ -130,7 +130,7 @@ func TestFindTriggerPolicyWebHookError(t *testing.T) {
 
 func TestFindTriggerPolicyMatchedGenericWebHook(t *testing.T) {
 	buildConfig := newBuildConfig()
-	triggers, err := FindTriggerPolicy(api.GenericWebHookBuildTriggerType, buildConfig)
+	triggers, err := FindTriggerPolicy(buildapi.GenericWebHookBuildTriggerType, buildConfig)
 
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %s", err)
@@ -147,7 +147,7 @@ func TestFindTriggerPolicyMatchedGenericWebHook(t *testing.T) {
 
 func TestFindTriggerPolicyMatchedGithubWebHook(t *testing.T) {
 	buildConfig := newBuildConfig()
-	triggers, err := FindTriggerPolicy(api.GitHubWebHookBuildTriggerType, buildConfig)
+	triggers, err := FindTriggerPolicy(buildapi.GitHubWebHookBuildTriggerType, buildConfig)
 
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %s", err)
@@ -164,7 +164,7 @@ func TestFindTriggerPolicyMatchedGithubWebHook(t *testing.T) {
 
 func TestFindTriggerPolicyMatchedGitLabWebHook(t *testing.T) {
 	buildConfig := newBuildConfig()
-	triggers, err := FindTriggerPolicy(api.GitLabWebHookBuildTriggerType, buildConfig)
+	triggers, err := FindTriggerPolicy(buildapi.GitLabWebHookBuildTriggerType, buildConfig)
 
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %s", err)
@@ -181,7 +181,7 @@ func TestFindTriggerPolicyMatchedGitLabWebHook(t *testing.T) {
 
 func TestFindTriggerPolicyMatchedBitbucketWebHook(t *testing.T) {
 	buildConfig := newBuildConfig()
-	triggers, err := FindTriggerPolicy(api.BitbucketWebHookBuildTriggerType, buildConfig)
+	triggers, err := FindTriggerPolicy(buildapi.BitbucketWebHookBuildTriggerType, buildConfig)
 
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %s", err)

--- a/pkg/client/deploymentlogs.go
+++ b/pkg/client/deploymentlogs.go
@@ -4,7 +4,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // DeploymentLogsNamespacer has methods to work with DeploymentLogs resources in a namespace
@@ -14,7 +14,7 @@ type DeploymentLogsNamespacer interface {
 
 // DeploymentLogInterface exposes methods on DeploymentLogs resources.
 type DeploymentLogInterface interface {
-	Get(name string, opts api.DeploymentLogOptions) *restclient.Request
+	Get(name string, opts deployapi.DeploymentLogOptions) *restclient.Request
 }
 
 // deploymentLogs implements DeploymentLogsNamespacer interface
@@ -32,6 +32,6 @@ func newDeploymentLogs(c *Client, namespace string) *deploymentLogs {
 }
 
 // Get gets the deploymentlogs and return a deploymentLog request
-func (c *deploymentLogs) Get(name string, opts api.DeploymentLogOptions) *restclient.Request {
+func (c *deploymentLogs) Get(name string, opts deployapi.DeploymentLogOptions) *restclient.Request {
 	return c.r.Get().Namespace(c.ns).Resource("deploymentConfigs").Name(name).SubResource("log").VersionedParams(&opts, kapi.ParameterCodec)
 }

--- a/pkg/client/imagestreamimages.go
+++ b/pkg/client/imagestreamimages.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // ImageStreamImagesNamespacer has methods to work with ImageStreamImage resources in a namespace
@@ -11,7 +11,7 @@ type ImageStreamImagesNamespacer interface {
 
 // ImageStreamImageInterface exposes methods on ImageStreamImage resources.
 type ImageStreamImageInterface interface {
-	Get(name, id string) (*api.ImageStreamImage, error)
+	Get(name, id string) (*imageapi.ImageStreamImage, error)
 }
 
 // imageStreamImages implements ImageStreamImagesNamespacer interface
@@ -29,8 +29,8 @@ func newImageStreamImages(c *Client, namespace string) *imageStreamImages {
 }
 
 // Get finds the specified image by name of an image repository and id.
-func (c *imageStreamImages) Get(name, id string) (result *api.ImageStreamImage, err error) {
-	result = &api.ImageStreamImage{}
-	err = c.r.Get().Namespace(c.ns).Resource("imageStreamImages").Name(api.MakeImageStreamImageName(name, id)).Do().Into(result)
+func (c *imageStreamImages) Get(name, id string) (result *imageapi.ImageStreamImage, err error) {
+	result = &imageapi.ImageStreamImage{}
+	err = c.r.Get().Namespace(c.ns).Resource("imageStreamImages").Name(imageapi.MakeImageStreamImageName(name, id)).Do().Into(result)
 	return
 }

--- a/pkg/client/imagestreams_test.go
+++ b/pkg/client/imagestreams_test.go
@@ -13,7 +13,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	_ "k8s.io/kubernetes/pkg/api/install"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	_ "github.com/openshift/origin/pkg/image/api/install"
 )
 
@@ -29,33 +29,33 @@ func TestImageStreamImportUnsupported(t *testing.T) {
 		errFn  func(err error) bool
 	}{
 		{
-			status: errors.NewNotFound(api.Resource(""), "").ErrStatus,
+			status: errors.NewNotFound(imageapi.Resource(""), "").ErrStatus,
 			errFn:  func(err error) bool { return err == ErrImageStreamImportUnsupported },
 		},
 		{
-			status: errors.NewNotFound(api.Resource("ImageStreamImport"), "").ErrStatus,
+			status: errors.NewNotFound(imageapi.Resource("ImageStreamImport"), "").ErrStatus,
 			errFn:  func(err error) bool { return err != ErrImageStreamImportUnsupported && errors.IsNotFound(err) },
 		},
 		{
-			status: errors.NewConflict(api.Resource("ImageStreamImport"), "", nil).ErrStatus,
+			status: errors.NewConflict(imageapi.Resource("ImageStreamImport"), "", nil).ErrStatus,
 			errFn:  func(err error) bool { return err != ErrImageStreamImportUnsupported && errors.IsConflict(err) },
 		},
 		{
-			status: errors.NewForbidden(api.Resource("ImageStreamImport"), "", nil).ErrStatus,
+			status: errors.NewForbidden(imageapi.Resource("ImageStreamImport"), "", nil).ErrStatus,
 			errFn:  func(err error) bool { return err == ErrImageStreamImportUnsupported },
 		},
 	}
 	for i, test := range testCases {
 		c, err := New(&restclient.Config{
 			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				buf := bytes.NewBuffer([]byte(runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(api.SchemeGroupVersion), &test.status)))
+				buf := bytes.NewBuffer([]byte(runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(imageapi.SchemeGroupVersion), &test.status)))
 				return &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(buf)}, nil
 			}),
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.ImageStreams("test").Import(&api.ImageStreamImport{}); !test.errFn(err) {
+		if _, err := c.ImageStreams("test").Import(&imageapi.ImageStreamImport{}); !test.errFn(err) {
 			t.Errorf("%d: error: %v", i, err)
 		}
 	}

--- a/pkg/client/imagestreamtags.go
+++ b/pkg/client/imagestreamtags.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // ImageStreamTagsNamespacer has methods to work with ImageStreamTag resources in a namespace
@@ -11,9 +11,9 @@ type ImageStreamTagsNamespacer interface {
 
 // ImageStreamTagInterface exposes methods on ImageStreamTag resources.
 type ImageStreamTagInterface interface {
-	Get(name, tag string) (*api.ImageStreamTag, error)
-	Create(tag *api.ImageStreamTag) (*api.ImageStreamTag, error)
-	Update(tag *api.ImageStreamTag) (*api.ImageStreamTag, error)
+	Get(name, tag string) (*imageapi.ImageStreamTag, error)
+	Create(tag *imageapi.ImageStreamTag) (*imageapi.ImageStreamTag, error)
+	Update(tag *imageapi.ImageStreamTag) (*imageapi.ImageStreamTag, error)
 	Delete(name, tag string) error
 }
 
@@ -32,26 +32,26 @@ func newImageStreamTags(c *Client, namespace string) *imageStreamTags {
 }
 
 // Get finds the specified image by name of an image stream and tag.
-func (c *imageStreamTags) Get(name, tag string) (result *api.ImageStreamTag, err error) {
-	result = &api.ImageStreamTag{}
-	err = c.r.Get().Namespace(c.ns).Resource("imageStreamTags").Name(api.JoinImageStreamTag(name, tag)).Do().Into(result)
+func (c *imageStreamTags) Get(name, tag string) (result *imageapi.ImageStreamTag, err error) {
+	result = &imageapi.ImageStreamTag{}
+	err = c.r.Get().Namespace(c.ns).Resource("imageStreamTags").Name(imageapi.JoinImageStreamTag(name, tag)).Do().Into(result)
 	return
 }
 
 // Update updates an image stream tag (creating it if it does not exist).
-func (c *imageStreamTags) Update(tag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
-	result = &api.ImageStreamTag{}
+func (c *imageStreamTags) Update(tag *imageapi.ImageStreamTag) (result *imageapi.ImageStreamTag, err error) {
+	result = &imageapi.ImageStreamTag{}
 	err = c.r.Put().Namespace(c.ns).Resource("imageStreamTags").Name(tag.Name).Body(tag).Do().Into(result)
 	return
 }
 
-func (c *imageStreamTags) Create(tag *api.ImageStreamTag) (result *api.ImageStreamTag, err error) {
-	result = &api.ImageStreamTag{}
+func (c *imageStreamTags) Create(tag *imageapi.ImageStreamTag) (result *imageapi.ImageStreamTag, err error) {
+	result = &imageapi.ImageStreamTag{}
 	err = c.r.Post().Namespace(c.ns).Resource("imageStreamTags").Body(tag).Do().Into(result)
 	return
 }
 
 // Delete deletes the specified tag from the image stream.
 func (c *imageStreamTags) Delete(name, tag string) error {
-	return c.r.Delete().Namespace(c.ns).Resource("imageStreamTags").Name(api.JoinImageStreamTag(name, tag)).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("imageStreamTags").Name(imageapi.JoinImageStreamTag(name, tag)).Do().Error()
 }

--- a/pkg/client/testclient/fake_deploymentlogs.go
+++ b/pkg/client/testclient/fake_deploymentlogs.go
@@ -4,7 +4,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientgotesting "k8s.io/client-go/testing"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // FakeDeploymentLogs implements DeploymentLogsInterface. Meant to be embedded into a struct to get a default
@@ -15,7 +15,7 @@ type FakeDeploymentLogs struct {
 }
 
 // Get builds and returns a buildLog request
-func (c *FakeDeploymentLogs) Get(name string, opt api.DeploymentLogOptions) *restclient.Request {
+func (c *FakeDeploymentLogs) Get(name string, opt deployapi.DeploymentLogOptions) *restclient.Request {
 	action := clientgotesting.GenericActionImpl{}
 	action.Verb = "get"
 	action.Namespace = c.Namespace
@@ -23,6 +23,6 @@ func (c *FakeDeploymentLogs) Get(name string, opt api.DeploymentLogOptions) *res
 	action.Subresource = "log"
 	action.Value = opt
 
-	_, _ = c.Fake.Invokes(action, &api.DeploymentConfig{})
+	_, _ = c.Fake.Invokes(action, &deployapi.DeploymentConfig{})
 	return &restclient.Request{}
 }

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -24,7 +24,7 @@ import (
 
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
@@ -100,7 +100,7 @@ func (p *ProjectOptions) Validate() error {
 	return kerrors.NewAggregate(errList)
 }
 
-func (p *ProjectOptions) GetProjects() ([]*api.Project, error) {
+func (p *ProjectOptions) GetProjects() ([]*projectapi.Project, error) {
 	nameArgs := []string{"projects"}
 	if len(p.ProjectNames) != 0 {
 		nameArgs = append(nameArgs, p.ProjectNames...)
@@ -118,12 +118,12 @@ func (p *ProjectOptions) GetProjects() ([]*api.Project, error) {
 	}
 
 	errList := []error{}
-	projectList := []*api.Project{}
+	projectList := []*projectapi.Project{}
 	_ = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
 		}
-		project, ok := info.Object.(*api.Project)
+		project, ok := info.Object.(*projectapi.Project)
 		if !ok {
 			err := fmt.Errorf("cannot convert input to Project: %v", reflect.TypeOf(info.Object))
 			errList = append(errList, err)

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -33,7 +33,7 @@ var (
 
 // NewCmdBuildLogs implements the OpenShift cli build-logs command
 func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	opts := api.BuildLogOptions{}
+	opts := buildapi.BuildLogOptions{}
 	cmd := &cobra.Command{
 		Use:        "build-logs BUILD",
 		Short:      "Show logs from a build",
@@ -67,7 +67,7 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 }
 
 // RunBuildLogs contains all the necessary functionality for the OpenShift cli build-logs command
-func RunBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, opts api.BuildLogOptions, args []string) error {
+func RunBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, opts buildapi.BuildLogOptions, args []string) error {
 	if len(args) != 1 {
 		cmdNamespace := kcmdutil.GetFlagString(cmd, "namespace")
 		var namespace string

--- a/pkg/cmd/cli/cmd/create/route.go
+++ b/pkg/cmd/cli/cmd/create/route.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	fileutil "github.com/openshift/origin/pkg/util/file"
 )
 
@@ -116,14 +116,14 @@ func CreateEdgeRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, ar
 
 	wildcardpolicy := kcmdutil.GetFlagString(cmd, "wildcard-policy")
 	if len(wildcardpolicy) > 0 {
-		route.Spec.WildcardPolicy = api.WildcardPolicyType(wildcardpolicy)
+		route.Spec.WildcardPolicy = routeapi.WildcardPolicyType(wildcardpolicy)
 	}
 
 	route.Spec.Host = kcmdutil.GetFlagString(cmd, "hostname")
 	route.Spec.Path = kcmdutil.GetFlagString(cmd, "path")
 
-	route.Spec.TLS = new(api.TLSConfig)
-	route.Spec.TLS.Termination = api.TLSTerminationEdge
+	route.Spec.TLS = new(routeapi.TLSConfig)
+	route.Spec.TLS.Termination = routeapi.TLSTerminationEdge
 	cert, err := fileutil.LoadData(kcmdutil.GetFlagString(cmd, "cert"))
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func CreateEdgeRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, ar
 
 	insecurePolicy := kcmdutil.GetFlagString(cmd, "insecure-policy")
 	if len(insecurePolicy) > 0 {
-		route.Spec.TLS.InsecureEdgeTerminationPolicy = api.InsecureEdgeTerminationPolicyType(insecurePolicy)
+		route.Spec.TLS.InsecureEdgeTerminationPolicy = routeapi.InsecureEdgeTerminationPolicyType(insecurePolicy)
 	}
 
 	dryRun := kcmdutil.GetFlagBool(cmd, "dry-run")
@@ -238,17 +238,17 @@ func CreatePassthroughRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comm
 
 	wildcardpolicy := kcmdutil.GetFlagString(cmd, "wildcard-policy")
 	if len(wildcardpolicy) > 0 {
-		route.Spec.WildcardPolicy = api.WildcardPolicyType(wildcardpolicy)
+		route.Spec.WildcardPolicy = routeapi.WildcardPolicyType(wildcardpolicy)
 	}
 
 	route.Spec.Host = kcmdutil.GetFlagString(cmd, "hostname")
 
-	route.Spec.TLS = new(api.TLSConfig)
-	route.Spec.TLS.Termination = api.TLSTerminationPassthrough
+	route.Spec.TLS = new(routeapi.TLSConfig)
+	route.Spec.TLS.Termination = routeapi.TLSTerminationPassthrough
 
 	insecurePolicy := kcmdutil.GetFlagString(cmd, "insecure-policy")
 	if len(insecurePolicy) > 0 {
-		route.Spec.TLS.InsecureEdgeTerminationPolicy = api.InsecureEdgeTerminationPolicyType(insecurePolicy)
+		route.Spec.TLS.InsecureEdgeTerminationPolicy = routeapi.InsecureEdgeTerminationPolicyType(insecurePolicy)
 	}
 
 	dryRun := kcmdutil.GetFlagBool(cmd, "dry-run")
@@ -355,14 +355,14 @@ func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comman
 
 	wildcardpolicy := kcmdutil.GetFlagString(cmd, "wildcard-policy")
 	if len(wildcardpolicy) > 0 {
-		route.Spec.WildcardPolicy = api.WildcardPolicyType(wildcardpolicy)
+		route.Spec.WildcardPolicy = routeapi.WildcardPolicyType(wildcardpolicy)
 	}
 
 	route.Spec.Host = kcmdutil.GetFlagString(cmd, "hostname")
 	route.Spec.Path = kcmdutil.GetFlagString(cmd, "path")
 
-	route.Spec.TLS = new(api.TLSConfig)
-	route.Spec.TLS.Termination = api.TLSTerminationReencrypt
+	route.Spec.TLS = new(routeapi.TLSConfig)
+	route.Spec.TLS.Termination = routeapi.TLSTerminationReencrypt
 
 	cert, err := fileutil.LoadData(kcmdutil.GetFlagString(cmd, "cert"))
 	if err != nil {
@@ -387,7 +387,7 @@ func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comman
 
 	insecurePolicy := kcmdutil.GetFlagString(cmd, "insecure-policy")
 	if len(insecurePolicy) > 0 {
-		route.Spec.TLS.InsecureEdgeTerminationPolicy = api.InsecureEdgeTerminationPolicyType(insecurePolicy)
+		route.Spec.TLS.InsecureEdgeTerminationPolicy = routeapi.InsecureEdgeTerminationPolicyType(insecurePolicy)
 	}
 
 	dryRun := kcmdutil.GetFlagBool(cmd, "dry-run")

--- a/pkg/cmd/cli/cmd/login/helpers.go
+++ b/pkg/cmd/cli/cmd/login/helpers.go
@@ -11,7 +11,7 @@ import (
 	"os"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/openshift/origin/pkg/cmd/util/term"
@@ -124,7 +124,7 @@ func getHostPort(hostURL string) (string, string, *url.URL, error) {
 	return host, port, parsedURL, err
 }
 
-func whoAmI(clientConfig *restclient.Config) (*api.User, error) {
+func whoAmI(clientConfig *restclient.Config) (*userapi.User, error) {
 	client, err := client.New(clientConfig)
 
 	me, err := client.Users().Get("~", metav1.GetOptions{})
@@ -135,10 +135,10 @@ func whoAmI(clientConfig *restclient.Config) (*api.User, error) {
 		case len(clientConfig.BearerToken) > 0:
 			// the user has already been willing to provide the token on the CLI, so they probably
 			// don't mind using it again if they switch to and from this user
-			return &api.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.BearerToken}}, nil
+			return &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.BearerToken}}, nil
 
 		case len(clientConfig.Username) > 0:
-			return &api.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.Username}}, nil
+			return &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: clientConfig.Username}}, nil
 
 		}
 	}

--- a/pkg/cmd/cli/cmd/login/loginoptions.go
+++ b/pkg/cmd/cli/cmd/login/loginoptions.go
@@ -30,7 +30,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/term"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 const defaultClusterURL = "https://localhost:8443"
@@ -399,7 +399,7 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 	return created, nil
 }
 
-func (o LoginOptions) whoAmI() (*api.User, error) {
+func (o LoginOptions) whoAmI() (*userapi.User, error) {
 	return whoAmI(o.Config)
 }
 

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -19,7 +19,7 @@ import (
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectapihelpers "github.com/openshift/origin/pkg/project/api/helpers"
 	projectutil "github.com/openshift/origin/pkg/project/util"
 
@@ -328,7 +328,7 @@ func confirmProjectAccess(currentProject string, oClient *client.Client, kClient
 	return projectErr
 }
 
-func getProjects(oClient *client.Client, kClient kclientset.Interface) ([]api.Project, error) {
+func getProjects(oClient *client.Client, kClient kclientset.Interface) ([]projectapi.Project, error) {
 	projects, err := oClient.Projects().List(metav1.ListOptions{})
 	if err == nil {
 		return projects.Items, nil

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -16,7 +16,7 @@ import (
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectapihelpers "github.com/openshift/origin/pkg/project/api/helpers"
 
 	"github.com/spf13/cobra"
@@ -37,7 +37,7 @@ type ProjectsOptions struct {
 }
 
 // SortByProjectName is sort
-type SortByProjectName []api.Project
+type SortByProjectName []projectapi.Project
 
 func (p SortByProjectName) Len() int {
 	return len(p)

--- a/pkg/cmd/server/admin/create_bootstrappolicy_file.go
+++ b/pkg/cmd/server/admin/create_bootstrappolicy_file.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 const (
@@ -78,7 +78,7 @@ func (o CreateBootstrapPolicyFileOptions) CreateBootstrapPolicyFile() error {
 		return err
 	}
 
-	policyTemplate := &api.Template{}
+	policyTemplate := &templateapi.Template{}
 
 	clusterRoles := bootstrappolicy.GetBootstrapClusterRoles()
 	for i := range clusterRoles {

--- a/pkg/cmd/util/route.go
+++ b/pkg/cmd/util/route.go
@@ -9,7 +9,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 // UnsecuredRoute will return a route with enough info so that it can direct traffic to
@@ -18,7 +18,7 @@ import (
 // forcePort always sets a port, even when there is only one and it has no name.
 // The kubernetes generator, when no port is present incorrectly selects the service Port
 // instead of the service TargetPort for the route TargetPort.
-func UnsecuredRoute(kc kclientset.Interface, namespace, routeName, serviceName, portString string, forcePort bool) (*api.Route, error) {
+func UnsecuredRoute(kc kclientset.Interface, namespace, routeName, serviceName, portString string, forcePort bool) (*routeapi.Route, error) {
 	if len(routeName) == 0 {
 		routeName = serviceName
 	}
@@ -28,12 +28,12 @@ func UnsecuredRoute(kc kclientset.Interface, namespace, routeName, serviceName, 
 		if len(portString) == 0 {
 			return nil, fmt.Errorf("you need to provide a route port via --port when exposing a non-existent service")
 		}
-		return &api.Route{
+		return &routeapi.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: routeName,
 			},
-			Spec: api.RouteSpec{
-				To: api.RouteTargetReference{
+			Spec: routeapi.RouteSpec{
+				To: routeapi.RouteTargetReference{
 					Name: serviceName,
 				},
 				Port: resolveRoutePort(portString),
@@ -46,13 +46,13 @@ func UnsecuredRoute(kc kclientset.Interface, namespace, routeName, serviceName, 
 		return nil, fmt.Errorf("service %q doesn't support TCP", svc.Name)
 	}
 
-	route := &api.Route{
+	route := &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   routeName,
 			Labels: svc.Labels,
 		},
-		Spec: api.RouteSpec{
-			To: api.RouteTargetReference{
+		Spec: routeapi.RouteSpec{
+			To: routeapi.RouteTargetReference{
 				Name: serviceName,
 			},
 		},
@@ -77,7 +77,7 @@ func UnsecuredRoute(kc kclientset.Interface, namespace, routeName, serviceName, 
 	return route, nil
 }
 
-func resolveRoutePort(portString string) *api.RoutePort {
+func resolveRoutePort(portString string) *routeapi.RoutePort {
 	if len(portString) == 0 {
 		return nil
 	}
@@ -88,7 +88,7 @@ func resolveRoutePort(portString string) *api.RoutePort {
 	} else {
 		routePort = intstr.FromInt(integer)
 	}
-	return &api.RoutePort{
+	return &routeapi.RoutePort{
 		TargetPort: routePort,
 	}
 }

--- a/pkg/deploy/api/install/apigroup.go
+++ b/pkg/deploy/api/install/apigroup.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
-	"github.com/openshift/origin/pkg/deploy/api/v1"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapiv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 )
 
 func installApiGroup() {
@@ -18,13 +18,13 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  deployapi.GroupName,
+			VersionPreferenceOrder:     []string{deployapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: deployapi.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			deployapiv1.SchemeGroupVersion.Version: deployapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/deploy/api/install/install.go
+++ b/pkg/deploy/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
-	"github.com/openshift/origin/pkg/deploy/api/v1"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapiv1 "github.com/openshift/origin/pkg/deploy/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/deploy/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/deploy/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{deployapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", deployapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	deployapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case deployapiv1.LegacySchemeGroupVersion:
+			deployapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case deployapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(deployapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -8,28 +8,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/api/test"
 )
 
 // Convenience methods
 
-func manualTrigger() []api.DeploymentTriggerPolicy {
-	return []api.DeploymentTriggerPolicy{
+func manualTrigger() []deployapi.DeploymentTriggerPolicy {
+	return []deployapi.DeploymentTriggerPolicy{
 		{
-			Type: api.DeploymentTriggerManual,
+			Type: deployapi.DeploymentTriggerManual,
 		},
 	}
 }
 
-func rollingConfig(interval, updatePeriod, timeout int) api.DeploymentConfig {
-	return api.DeploymentConfig{
+func rollingConfig(interval, updatePeriod, timeout int) deployapi.DeploymentConfig {
+	return deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Triggers: manualTrigger(),
-			Strategy: api.DeploymentStrategy{
-				Type: api.DeploymentStrategyTypeRolling,
-				RollingParams: &api.RollingDeploymentStrategyParams{
+			Strategy: deployapi.DeploymentStrategy{
+				Type: deployapi.DeploymentStrategyTypeRolling,
+				RollingParams: &deployapi.RollingDeploymentStrategyParams{
 					IntervalSeconds:     mkint64p(interval),
 					UpdatePeriodSeconds: mkint64p(updatePeriod),
 					TimeoutSeconds:      mkint64p(timeout),
@@ -43,14 +43,14 @@ func rollingConfig(interval, updatePeriod, timeout int) api.DeploymentConfig {
 	}
 }
 
-func rollingConfigMax(maxSurge, maxUnavailable intstr.IntOrString) api.DeploymentConfig {
-	return api.DeploymentConfig{
+func rollingConfigMax(maxSurge, maxUnavailable intstr.IntOrString) deployapi.DeploymentConfig {
+	return deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Triggers: manualTrigger(),
-			Strategy: api.DeploymentStrategy{
-				Type: api.DeploymentStrategyTypeRolling,
-				RollingParams: &api.RollingDeploymentStrategyParams{
+			Strategy: deployapi.DeploymentStrategy{
+				Type: deployapi.DeploymentStrategyTypeRolling,
+				RollingParams: &deployapi.RollingDeploymentStrategyParams{
 					IntervalSeconds:     mkint64p(1),
 					UpdatePeriodSeconds: mkint64p(1),
 					TimeoutSeconds:      mkint64p(1),
@@ -66,9 +66,9 @@ func rollingConfigMax(maxSurge, maxUnavailable intstr.IntOrString) api.Deploymen
 }
 
 func TestValidateDeploymentConfigOK(t *testing.T) {
-	errs := ValidateDeploymentConfig(&api.DeploymentConfig{
+	errs := ValidateDeploymentConfig(&deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: 1,
 			Triggers: manualTrigger(),
 			Selector: test.OkSelector(),
@@ -83,11 +83,11 @@ func TestValidateDeploymentConfigOK(t *testing.T) {
 }
 
 func TestValidateDeploymentConfigICTMissingImage(t *testing.T) {
-	dc := &api.DeploymentConfig{
+	dc := &deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: 1,
-			Triggers: []api.DeploymentTriggerPolicy{test.OkImageChangeTrigger()},
+			Triggers: []deployapi.DeploymentTriggerPolicy{test.OkImageChangeTrigger()},
 			Selector: test.OkSelector(),
 			Strategy: test.OkStrategy(),
 			Template: test.OkPodTemplateMissingImage("container1"),
@@ -108,16 +108,16 @@ func TestValidateDeploymentConfigICTMissingImage(t *testing.T) {
 
 func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 	errorCases := map[string]struct {
-		DeploymentConfig api.DeploymentConfig
+		DeploymentConfig deployapi.DeploymentConfig
 		ErrorType        field.ErrorType
 		Field            string
 	}{
 		"empty container field": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Triggers: []api.DeploymentTriggerPolicy{test.OkConfigChangeTrigger()},
+					Triggers: []deployapi.DeploymentTriggerPolicy{test.OkConfigChangeTrigger()},
 					Selector: test.OkSelector(),
 					Strategy: test.OkStrategy(),
 					Template: test.OkPodTemplateMissingImage("container1"),
@@ -127,7 +127,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.template.spec.containers[0].image",
 		},
 		"missing name": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "bar"},
 				Spec:       test.OkDeploymentConfigSpec(),
 			},
@@ -135,7 +135,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"metadata.name",
 		},
 		"missing namespace": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ""},
 				Spec:       test.OkDeploymentConfigSpec(),
 			},
@@ -143,7 +143,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"metadata.namespace",
 		},
 		"invalid name": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "-foo", Namespace: "bar"},
 				Spec:       test.OkDeploymentConfigSpec(),
 			},
@@ -151,7 +151,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"metadata.name",
 		},
 		"invalid namespace": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "-bar"},
 				Spec:       test.OkDeploymentConfigSpec(),
 			},
@@ -160,13 +160,13 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 		},
 
 		"missing trigger.type": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Triggers: []api.DeploymentTriggerPolicy{
+					Triggers: []deployapi.DeploymentTriggerPolicy{
 						{
-							ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
+							ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 								ContainerNames: []string{"foo"},
 							},
 						},
@@ -180,14 +180,14 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.triggers[0].type",
 		},
 		"missing Trigger imageChangeParams.from": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Triggers: []api.DeploymentTriggerPolicy{
+					Triggers: []deployapi.DeploymentTriggerPolicy{
 						{
-							Type: api.DeploymentTriggerOnImageChange,
-							ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
+							Type: deployapi.DeploymentTriggerOnImageChange,
+							ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 								ContainerNames: []string{"foo"},
 							},
 						},
@@ -201,14 +201,14 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.triggers[0].imageChangeParams.from",
 		},
 		"invalid Trigger imageChangeParams.from.kind": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Triggers: []api.DeploymentTriggerPolicy{
+					Triggers: []deployapi.DeploymentTriggerPolicy{
 						{
-							Type: api.DeploymentTriggerOnImageChange,
-							ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
+							Type: deployapi.DeploymentTriggerOnImageChange,
+							ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 								From: kapi.ObjectReference{
 									Kind: "Invalid",
 									Name: "name:tag",
@@ -226,14 +226,14 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.triggers[0].imageChangeParams.from.kind",
 		},
 		"missing Trigger imageChangeParams.containerNames": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Triggers: []api.DeploymentTriggerPolicy{
+					Triggers: []deployapi.DeploymentTriggerPolicy{
 						{
-							Type: api.DeploymentTriggerOnImageChange,
-							ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
+							Type: deployapi.DeploymentTriggerOnImageChange,
+							ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 								From: kapi.ObjectReference{
 									Kind: "ImageStreamTag",
 									Name: "foo:v1",
@@ -250,13 +250,13 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.triggers[0].imageChangeParams.containerNames",
 		},
 		"missing strategy.type": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
 					Triggers: manualTrigger(),
 					Selector: test.OkSelector(),
-					Strategy: api.DeploymentStrategy{
+					Strategy: deployapi.DeploymentStrategy{
 						CustomParams:          test.OkCustomParams(),
 						ActiveDeadlineSeconds: mkint64p(3600),
 					},
@@ -267,14 +267,14 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.type",
 		},
 		"missing strategy.customParams": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
 					Triggers: manualTrigger(),
 					Selector: test.OkSelector(),
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeCustom,
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeCustom,
 						ActiveDeadlineSeconds: mkint64p(3600),
 					},
 					Template: test.OkPodTemplate(),
@@ -284,15 +284,15 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.customParams",
 		},
 		"invalid spec.strategy.customParams.environment": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
 					Triggers: manualTrigger(),
 					Selector: test.OkSelector(),
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeCustom,
-						CustomParams: &api.CustomDeploymentStrategyParams{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeCustom,
+						CustomParams: &deployapi.CustomDeploymentStrategyParams{
 							Environment: []kapi.EnvVar{
 								{Name: "A=B"},
 							},
@@ -306,15 +306,15 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.customParams.environment[0].name",
 		},
 		"missing spec.strategy.recreateParams.pre.failurePolicy": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Pre: &api.LifecycleHook{
-								ExecNewPod: &api.ExecNewPodHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Pre: &deployapi.LifecycleHook{
+								ExecNewPod: &deployapi.ExecNewPodHook{
 									Command:       []string{"cmd"},
 									ContainerName: "container",
 								},
@@ -330,15 +330,15 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.pre.failurePolicy",
 		},
 		"missing spec.strategy.recreateParams.pre.execNewPod": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Pre: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Pre: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
 							},
 						},
 						ActiveDeadlineSeconds: mkint64p(3600),
@@ -351,16 +351,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.pre",
 		},
 		"missing spec.strategy.recreateParams.pre.execNewPod.command": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Pre: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								ExecNewPod: &api.ExecNewPodHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Pre: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &deployapi.ExecNewPodHook{
 									ContainerName: "container",
 								},
 							},
@@ -375,16 +375,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.pre.execNewPod.command",
 		},
 		"missing spec.strategy.recreateParams.pre.execNewPod.containerName": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Pre: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								ExecNewPod: &api.ExecNewPodHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Pre: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &deployapi.ExecNewPodHook{
 									Command: []string{"cmd"},
 								},
 							},
@@ -399,16 +399,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.pre.execNewPod.containerName",
 		},
 		"invalid spec.strategy.recreateParams.pre.execNewPod.volumes": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Pre: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								ExecNewPod: &api.ExecNewPodHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Pre: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &deployapi.ExecNewPodHook{
 									ContainerName: "container",
 									Command:       []string{"cmd"},
 									Volumes:       []string{"good", ""},
@@ -425,15 +425,15 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.pre.execNewPod.volumes[1]",
 		},
 		"missing spec.strategy.recreateParams.mid.execNewPod": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Mid: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Mid: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
 							},
 						},
 						ActiveDeadlineSeconds: mkint64p(3600),
@@ -446,15 +446,15 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.mid",
 		},
 		"missing spec.strategy.recreateParams.post.execNewPod": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Post: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Post: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
 							},
 						},
 						ActiveDeadlineSeconds: mkint64p(3600),
@@ -467,16 +467,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.post",
 		},
 		"missing spec.strategy.after.tagImages": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Post: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								TagImages: []api.TagImageHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Post: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								TagImages: []deployapi.TagImageHook{
 									{
 										ContainerName: "missing",
 										To:            kapi.ObjectReference{Kind: "ImageStreamTag", Name: "stream:tag"},
@@ -494,16 +494,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.post.tagImages[0].containerName",
 		},
 		"missing spec.strategy.after.tagImages.to.kind": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Post: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								TagImages: []api.TagImageHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Post: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								TagImages: []deployapi.TagImageHook{
 									{
 										ContainerName: "container1",
 										To:            kapi.ObjectReference{Name: "stream:tag"},
@@ -521,16 +521,16 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.post.tagImages[0].to.kind",
 		},
 		"missing spec.strategy.after.tagImages.to.name": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Post: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								TagImages: []api.TagImageHook{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Post: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								TagImages: []deployapi.TagImageHook{
 									{
 										ContainerName: "container1",
 										To:            kapi.ObjectReference{Kind: "ImageStreamTag"},
@@ -548,17 +548,17 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.recreateParams.post.tagImages[0].to.name",
 		},
 		"can't have both tag and execNewPod": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRecreate,
-						RecreateParams: &api.RecreateDeploymentStrategyParams{
-							Post: &api.LifecycleHook{
-								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
-								ExecNewPod:    &api.ExecNewPodHook{},
-								TagImages:     []api.TagImageHook{{}},
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRecreate,
+						RecreateParams: &deployapi.RecreateDeploymentStrategyParams{
+							Post: &deployapi.LifecycleHook{
+								FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+								ExecNewPod:    &deployapi.ExecNewPodHook{},
+								TagImages:     []deployapi.TagImageHook{{}},
 							},
 						},
 						ActiveDeadlineSeconds: mkint64p(3600),
@@ -586,19 +586,19 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			"spec.strategy.rollingParams.timeoutSeconds",
 		},
 		"missing spec.strategy.rollingParams.pre.failurePolicy": {
-			api.DeploymentConfig{
+			deployapi.DeploymentConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-				Spec: api.DeploymentConfigSpec{
+				Spec: deployapi.DeploymentConfigSpec{
 					Replicas: 1,
-					Strategy: api.DeploymentStrategy{
-						Type: api.DeploymentStrategyTypeRolling,
-						RollingParams: &api.RollingDeploymentStrategyParams{
+					Strategy: deployapi.DeploymentStrategy{
+						Type: deployapi.DeploymentStrategyTypeRolling,
+						RollingParams: &deployapi.RollingDeploymentStrategyParams{
 							IntervalSeconds:     mkint64p(1),
 							UpdatePeriodSeconds: mkint64p(1),
 							TimeoutSeconds:      mkint64p(20),
 							MaxSurge:            intstr.FromInt(1),
-							Pre: &api.LifecycleHook{
-								ExecNewPod: &api.ExecNewPodHook{
+							Pre: &deployapi.LifecycleHook{
+								ExecNewPod: &deployapi.ExecNewPodHook{
 									Command:       []string{"cmd"},
 									ContainerName: "container",
 								},
@@ -681,29 +681,29 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 }
 
 func TestValidateDeploymentConfigUpdate(t *testing.T) {
-	oldConfig := &api.DeploymentConfig{
+	oldConfig := &deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar", ResourceVersion: "1"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: 1,
 			Triggers: manualTrigger(),
 			Selector: test.OkSelector(),
 			Strategy: test.OkStrategy(),
 			Template: test.OkPodTemplate(),
 		},
-		Status: api.DeploymentConfigStatus{
+		Status: deployapi.DeploymentConfigStatus{
 			LatestVersion: 5,
 		},
 	}
-	newConfig := &api.DeploymentConfig{
+	newConfig := &deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar", ResourceVersion: "1"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: 1,
 			Triggers: manualTrigger(),
 			Selector: test.OkSelector(),
 			Strategy: test.OkStrategy(),
 			Template: test.OkPodTemplate(),
 		},
-		Status: api.DeploymentConfigStatus{
+		Status: deployapi.DeploymentConfigStatus{
 			LatestVersion: 3,
 		},
 	}
@@ -744,9 +744,9 @@ func TestValidateDeploymentConfigUpdate(t *testing.T) {
 }
 
 func TestValidateDeploymentConfigRollbackOK(t *testing.T) {
-	rollback := &api.DeploymentConfigRollback{
+	rollback := &deployapi.DeploymentConfigRollback{
 		Name: "config",
-		Spec: api.DeploymentConfigRollbackSpec{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
 			Revision: 2,
 		},
 	}
@@ -758,8 +758,8 @@ func TestValidateDeploymentConfigRollbackOK(t *testing.T) {
 }
 
 func TestValidateDeploymentConfigRollbackDeprecatedOK(t *testing.T) {
-	rollback := &api.DeploymentConfigRollback{
-		Spec: api.DeploymentConfigRollbackSpec{
+	rollback := &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
 			From: kapi.ObjectReference{
 				Name: "deployment",
 			},
@@ -778,13 +778,13 @@ func TestValidateDeploymentConfigRollbackDeprecatedOK(t *testing.T) {
 
 func TestValidateDeploymentConfigRollbackInvalidFields(t *testing.T) {
 	errorCases := map[string]struct {
-		D api.DeploymentConfigRollback
+		D deployapi.DeploymentConfigRollback
 		T field.ErrorType
 		F string
 	}{
 		"missing name": {
-			api.DeploymentConfigRollback{
-				Spec: api.DeploymentConfigRollbackSpec{
+			deployapi.DeploymentConfigRollback{
+				Spec: deployapi.DeploymentConfigRollbackSpec{
 					Revision: 2,
 				},
 			},
@@ -792,9 +792,9 @@ func TestValidateDeploymentConfigRollbackInvalidFields(t *testing.T) {
 			"name",
 		},
 		"invalid name": {
-			api.DeploymentConfigRollback{
+			deployapi.DeploymentConfigRollback{
 				Name: "*_*myconfig",
-				Spec: api.DeploymentConfigRollbackSpec{
+				Spec: deployapi.DeploymentConfigRollbackSpec{
 					Revision: 2,
 				},
 			},
@@ -802,9 +802,9 @@ func TestValidateDeploymentConfigRollbackInvalidFields(t *testing.T) {
 			"name",
 		},
 		"invalid revision": {
-			api.DeploymentConfigRollback{
+			deployapi.DeploymentConfigRollback{
 				Name: "config",
-				Spec: api.DeploymentConfigRollbackSpec{
+				Spec: deployapi.DeploymentConfigRollbackSpec{
 					Revision: -1,
 				},
 			},
@@ -831,13 +831,13 @@ func TestValidateDeploymentConfigRollbackInvalidFields(t *testing.T) {
 
 func TestValidateDeploymentConfigRollbackDeprecatedInvalidFields(t *testing.T) {
 	errorCases := map[string]struct {
-		D api.DeploymentConfigRollback
+		D deployapi.DeploymentConfigRollback
 		T field.ErrorType
 		F string
 	}{
 		"missing spec.from.name": {
-			api.DeploymentConfigRollback{
-				Spec: api.DeploymentConfigRollbackSpec{
+			deployapi.DeploymentConfigRollback{
+				Spec: deployapi.DeploymentConfigRollbackSpec{
 					From: kapi.ObjectReference{},
 				},
 			},
@@ -845,8 +845,8 @@ func TestValidateDeploymentConfigRollbackDeprecatedInvalidFields(t *testing.T) {
 			"spec.from.name",
 		},
 		"wrong spec.from.kind": {
-			api.DeploymentConfigRollback{
-				Spec: api.DeploymentConfigRollbackSpec{
+			deployapi.DeploymentConfigRollback{
+				Spec: deployapi.DeploymentConfigRollbackSpec{
 					From: kapi.ObjectReference{
 						Kind: "unknown",
 						Name: "deployment",
@@ -875,14 +875,14 @@ func TestValidateDeploymentConfigRollbackDeprecatedInvalidFields(t *testing.T) {
 }
 
 func TestValidateDeploymentConfigDefaultImageStreamKind(t *testing.T) {
-	config := &api.DeploymentConfig{
+	config := &deployapi.DeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.DeploymentConfigSpec{
+		Spec: deployapi.DeploymentConfigSpec{
 			Replicas: 1,
-			Triggers: []api.DeploymentTriggerPolicy{
+			Triggers: []deployapi.DeploymentTriggerPolicy{
 				{
-					Type: api.DeploymentTriggerOnImageChange,
-					ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
+					Type: deployapi.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
 						From: kapi.ObjectReference{
 							Kind: "ImageStreamTag",
 							Name: "name:v1",
@@ -913,20 +913,20 @@ func mkintp(i int) *int {
 
 func TestValidateSelectorMatchesPodTemplateLabels(t *testing.T) {
 	tests := map[string]struct {
-		spec        api.DeploymentConfigSpec
+		spec        deployapi.DeploymentConfigSpec
 		expectedErr bool
 		errorType   field.ErrorType
 		field       string
 	}{
 		"valid template labels": {
-			spec: api.DeploymentConfigSpec{
+			spec: deployapi.DeploymentConfigSpec{
 				Selector: test.OkSelector(),
 				Strategy: test.OkStrategy(),
 				Template: test.OkPodTemplate(),
 			},
 		},
 		"invalid template labels": {
-			spec: api.DeploymentConfigSpec{
+			spec: deployapi.DeploymentConfigSpec{
 				Selector: test.OkSelector(),
 				Strategy: test.OkStrategy(),
 				Template: test.OkPodTemplate(),

--- a/pkg/deploy/controller/test/fake_deployment_config_store.go
+++ b/pkg/deploy/controller/test/fake_deployment_config_store.go
@@ -3,15 +3,15 @@ package test
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 type FakeDeploymentConfigStore struct {
-	DeploymentConfig *api.DeploymentConfig
+	DeploymentConfig *deployapi.DeploymentConfig
 	Err              error
 }
 
-func NewFakeDeploymentConfigStore(deployment *api.DeploymentConfig) FakeDeploymentConfigStore {
+func NewFakeDeploymentConfigStore(deployment *deployapi.DeploymentConfig) FakeDeploymentConfigStore {
 	return FakeDeploymentConfigStore{DeploymentConfig: deployment}
 }
 

--- a/pkg/deploy/graph/edge_test.go
+++ b/pkg/deploy/graph/edge_test.go
@@ -12,7 +12,7 @@ import (
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	nodes "github.com/openshift/origin/pkg/deploy/graph/nodes"
 )
 
@@ -24,7 +24,7 @@ func TestNamespaceEdgeMatching(t *testing.T) {
 	g := osgraph.New()
 
 	fn := func(namespace string, g osgraph.Interface) {
-		dc := &api.DeploymentConfig{}
+		dc := &deployapi.DeploymentConfig{}
 		dc.Namespace = namespace
 		dc.Name = "the-dc"
 		dc.Spec.Selector = map[string]string{"a": "1"}
@@ -33,7 +33,7 @@ func TestNamespaceEdgeMatching(t *testing.T) {
 		rc := &kapi.ReplicationController{}
 		rc.Namespace = namespace
 		rc.Name = "the-rc"
-		rc.Annotations = map[string]string{api.DeploymentConfigAnnotation: "the-dc"}
+		rc.Annotations = map[string]string{deployapi.DeploymentConfigAnnotation: "the-dc"}
 		kubegraph.EnsureReplicationControllerNode(g, rc)
 	}
 

--- a/pkg/deploy/registry/deployconfig/etcd/etcd.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/registry/deployconfig"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -30,10 +30,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, *ScaleREST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.DeploymentConfig{} },
-		NewListFunc:       func() runtime.Object { return &api.DeploymentConfigList{} },
+		NewFunc:           func() runtime.Object { return &deployapi.DeploymentConfig{} },
+		NewListFunc:       func() runtime.Object { return &deployapi.DeploymentConfigList{} },
 		PredicateFunc:     deployconfig.Matcher,
-		QualifiedResource: api.Resource("deploymentconfigs"),
+		QualifiedResource: deployapi.Resource("deploymentconfigs"),
 
 		CreateStrategy: deployconfig.Strategy,
 		UpdateStrategy: deployconfig.Strategy,
@@ -76,7 +76,7 @@ func (r *ScaleREST) Get(ctx apirequest.Context, name string, options *metav1.Get
 		return nil, err
 	}
 
-	return api.ScaleFromConfig(deploymentConfig), nil
+	return deployapi.ScaleFromConfig(deploymentConfig), nil
 }
 
 // Update scales the DeploymentConfig for the given Scale subresource, returning the updated Scale.
@@ -86,7 +86,7 @@ func (r *ScaleREST) Update(ctx apirequest.Context, name string, objInfo rest.Upd
 		return nil, false, errors.NewNotFound(extensions.Resource("scale"), name)
 	}
 
-	old := api.ScaleFromConfig(deploymentConfig)
+	old := deployapi.ScaleFromConfig(deploymentConfig)
 	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
@@ -118,7 +118,7 @@ type StatusREST struct {
 var _ = rest.Patcher(&StatusREST{})
 
 func (r *StatusREST) New() runtime.Object {
-	return &api.DeploymentConfig{}
+	return &deployapi.DeploymentConfig{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/deploy/registry/deployconfig/etcd/etcd_test.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd_test.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	_ "github.com/openshift/origin/pkg/deploy/api/install"
 	"github.com/openshift/origin/pkg/deploy/api/test"
 	"github.com/openshift/origin/pkg/deploy/registry/deployconfig"
@@ -32,7 +32,7 @@ func TestStorage(t *testing.T) {
 	deployconfig.NewRegistry(storage)
 }
 
-func validDeploymentConfig() *api.DeploymentConfig {
+func validDeploymentConfig() *deployapi.DeploymentConfig {
 	return test.OkDeploymentConfig(1)
 }
 
@@ -46,7 +46,7 @@ func TestCreate(t *testing.T) {
 	test.TestCreate(
 		valid,
 		// invalid
-		&api.DeploymentConfig{},
+		&deployapi.DeploymentConfig{},
 	)
 }
 
@@ -59,18 +59,18 @@ func TestUpdate(t *testing.T) {
 		validDeploymentConfig(),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.DeploymentConfig)
+			object := obj.(*deployapi.DeploymentConfig)
 			object.Spec.Replicas = 2
 			return object
 		},
 		// invalid updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.DeploymentConfig)
+			object := obj.(*deployapi.DeploymentConfig)
 			object.Spec.Template = &kapi.PodTemplateSpec{}
 			return object
 		},
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.DeploymentConfig)
+			object := obj.(*deployapi.DeploymentConfig)
 			object.Spec.Replicas = -1
 			return object
 		},

--- a/pkg/deploy/registry/deployconfig/strategy.go
+++ b/pkg/deploy/registry/deployconfig/strategy.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/api/validation"
 )
 
@@ -48,9 +48,9 @@ func (s strategy) Export(ctx apirequest.Context, obj runtime.Object, exact bool)
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	dc := obj.(*api.DeploymentConfig)
+	dc := obj.(*deployapi.DeploymentConfig)
 	dc.Generation = 1
-	dc.Status = api.DeploymentConfigStatus{}
+	dc.Status = deployapi.DeploymentConfigStatus{}
 
 	for i := range dc.Spec.Triggers {
 		if params := dc.Spec.Triggers[i].ImageChangeParams; params != nil {
@@ -61,8 +61,8 @@ func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newDc := obj.(*api.DeploymentConfig)
-	oldDc := old.(*api.DeploymentConfig)
+	newDc := obj.(*deployapi.DeploymentConfig)
+	oldDc := old.(*deployapi.DeploymentConfig)
 
 	newVersion := newDc.Status.LatestVersion
 	oldVersion := oldDc.Status.LatestVersion
@@ -92,12 +92,12 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new policy.
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateDeploymentConfig(obj.(*api.DeploymentConfig))
+	return validation.ValidateDeploymentConfig(obj.(*deployapi.DeploymentConfig))
 }
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateDeploymentConfigUpdate(obj.(*api.DeploymentConfig), old.(*api.DeploymentConfig))
+	return validation.ValidateDeploymentConfigUpdate(obj.(*deployapi.DeploymentConfig), old.(*deployapi.DeploymentConfig))
 }
 
 // CheckGracefulDelete allows a deployment config to be gracefully deleted.
@@ -114,24 +114,24 @@ var StatusStrategy = statusStrategy{Strategy}
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update of status.
 func (statusStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newDc := obj.(*api.DeploymentConfig)
-	oldDc := old.(*api.DeploymentConfig)
+	newDc := obj.(*deployapi.DeploymentConfig)
+	oldDc := old.(*deployapi.DeploymentConfig)
 	newDc.Spec = oldDc.Spec
 	newDc.Labels = oldDc.Labels
 }
 
 // ValidateUpdate is the default update validation for an end user updating status.
 func (statusStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateDeploymentConfigStatusUpdate(obj.(*api.DeploymentConfig), old.(*api.DeploymentConfig))
+	return validation.ValidateDeploymentConfigStatusUpdate(obj.(*deployapi.DeploymentConfig), old.(*deployapi.DeploymentConfig))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	deploymentConfig, ok := obj.(*api.DeploymentConfig)
+	deploymentConfig, ok := obj.(*deployapi.DeploymentConfig)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a DeploymentConfig")
 	}
-	return labels.Set(deploymentConfig.ObjectMeta.Labels), api.DeploymentConfigToSelectableFields(deploymentConfig), nil
+	return labels.Set(deploymentConfig.ObjectMeta.Labels), deployapi.DeploymentConfigToSelectableFields(deploymentConfig), nil
 }
 
 // Matcher returns a generic matcher for a given label and field selector.

--- a/pkg/deploy/registry/deploylog/rest_test.go
+++ b/pkg/deploy/registry/deploylog/rest_test.go
@@ -19,7 +19,7 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
 	"github.com/openshift/origin/pkg/client/testclient"
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 
@@ -30,7 +30,7 @@ import (
 var testSelector = map[string]string{"test": "rest"}
 
 func makeDeployment(version int64) kapi.ReplicationController {
-	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(version), kapi.Codecs.LegacyCodec(api.SchemeGroupVersion))
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(version), kapi.Codecs.LegacyCodec(deployapi.SchemeGroupVersion))
 	deployment.Namespace = metav1.NamespaceDefault
 	deployment.Spec.Selector = testSelector
 	return *deployment
@@ -94,7 +94,7 @@ func (*fakeConnectionInfoGetter) GetConnectionInfo(nodeName types.NodeName) (*ku
 }
 
 // mockREST mocks a DeploymentLog REST
-func mockREST(version, desired int64, status api.DeploymentStatus) *REST {
+func mockREST(version, desired int64, status deployapi.DeploymentStatus) *REST {
 	// Fake deploymentConfig
 	config := deploytest.OkDeploymentConfig(version)
 	fakeDn := testclient.NewSimpleFake(config)
@@ -122,11 +122,11 @@ func mockREST(version, desired int64, status api.DeploymentStatus) *REST {
 	fakeWatch := watch.NewFake()
 	fakeRn.PrependWatchReactor("replicationcontrollers", clientgotesting.DefaultWatchReactor(fakeWatch, nil))
 	obj := &fakeDeployments.Items[desired-1]
-	obj.Annotations[api.DeploymentStatusAnnotation] = string(status)
+	obj.Annotations[deployapi.DeploymentStatusAnnotation] = string(status)
 	go fakeWatch.Add(obj)
 
 	fakePn := fake.NewSimpleClientset()
-	if status == api.DeploymentStatusComplete {
+	if status == deployapi.DeploymentStatusComplete {
 		// If the deployment is complete, we will try to get the logs from the oldest
 		// application pod...
 		fakePn.PrependReactor("list", "pods", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -181,9 +181,9 @@ func TestRESTGet(t *testing.T) {
 	}{
 		{
 			testName: "running deployment",
-			rest:     mockREST(1, 1, api.DeploymentStatusRunning),
+			rest:     mockREST(1, 1, deployapi.DeploymentStatusRunning),
 			name:     "config",
-			opts:     &api.DeploymentLogOptions{Follow: true, Version: intp(1)},
+			opts:     &deployapi.DeploymentLogOptions{Follow: true, Version: intp(1)},
 			expected: &genericrest.LocationStreamer{
 				Location: &url.URL{
 					Scheme:   "https",
@@ -200,9 +200,9 @@ func TestRESTGet(t *testing.T) {
 		},
 		{
 			testName: "complete deployment",
-			rest:     mockREST(5, 5, api.DeploymentStatusComplete),
+			rest:     mockREST(5, 5, deployapi.DeploymentStatusComplete),
 			name:     "config",
-			opts:     &api.DeploymentLogOptions{Follow: true, Version: intp(5)},
+			opts:     &deployapi.DeploymentLogOptions{Follow: true, Version: intp(5)},
 			expected: &genericrest.LocationStreamer{
 				Location: &url.URL{
 					Scheme:   "https",
@@ -219,9 +219,9 @@ func TestRESTGet(t *testing.T) {
 		},
 		{
 			testName: "previous failed deployment",
-			rest:     mockREST(3, 2, api.DeploymentStatusFailed),
+			rest:     mockREST(3, 2, deployapi.DeploymentStatusFailed),
 			name:     "config",
-			opts:     &api.DeploymentLogOptions{Follow: false, Version: intp(2)},
+			opts:     &deployapi.DeploymentLogOptions{Follow: false, Version: intp(2)},
 			expected: &genericrest.LocationStreamer{
 				Location: &url.URL{
 					Scheme: "https",
@@ -237,9 +237,9 @@ func TestRESTGet(t *testing.T) {
 		},
 		{
 			testName: "previous deployment",
-			rest:     mockREST(3, 2, api.DeploymentStatusFailed),
+			rest:     mockREST(3, 2, deployapi.DeploymentStatusFailed),
 			name:     "config",
-			opts:     &api.DeploymentLogOptions{Follow: false, Previous: true},
+			opts:     &deployapi.DeploymentLogOptions{Follow: false, Previous: true},
 			expected: &genericrest.LocationStreamer{
 				Location: &url.URL{
 					Scheme: "https",
@@ -257,7 +257,7 @@ func TestRESTGet(t *testing.T) {
 			testName:    "non-existent previous deployment",
 			rest:        mockREST(1 /* won't be used */, 101, ""),
 			name:        "config",
-			opts:        &api.DeploymentLogOptions{Follow: false, Previous: true},
+			opts:        &deployapi.DeploymentLogOptions{Follow: false, Previous: true},
 			expected:    nil,
 			expectedErr: errors.NewBadRequest("no previous deployment exists for deploymentConfig \"config\""),
 		},

--- a/pkg/deploy/registry/instantiate/strategy.go
+++ b/pkg/deploy/registry/instantiate/strategy.go
@@ -9,7 +9,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/api/validation"
 )
 
@@ -41,8 +41,8 @@ func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 
 // PrepareForUpdate clears fields that are not allowed to be set by the instantiate endpoint.
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newDc := obj.(*api.DeploymentConfig)
-	oldDc := old.(*api.DeploymentConfig)
+	newDc := obj.(*deployapi.DeploymentConfig)
+	oldDc := old.(*deployapi.DeploymentConfig)
 
 	// Allow the status fields that need to be updated in every instantiation.
 	oldStatus := oldDc.Status
@@ -66,10 +66,10 @@ func (strategy) CheckGracefulDelete(obj runtime.Object, options *metav1.DeleteOp
 
 // Validate is a no-op for the instantiate endpoint.
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateDeploymentConfig(obj.(*api.DeploymentConfig))
+	return validation.ValidateDeploymentConfig(obj.(*deployapi.DeploymentConfig))
 }
 
 // ValidateUpdate is the default update validation for the instantiate endpoint.
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateDeploymentConfigUpdate(obj.(*api.DeploymentConfig), old.(*api.DeploymentConfig))
+	return validation.ValidateDeploymentConfigUpdate(obj.(*deployapi.DeploymentConfig), old.(*deployapi.DeploymentConfig))
 }

--- a/pkg/deploy/registry/rest.go
+++ b/pkg/deploy/registry/rest.go
@@ -12,7 +12,7 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -53,9 +53,9 @@ func WaitForRunningDeployment(rn kcoreclient.ReplicationControllersGetter, obser
 		}
 		observed = obj
 		switch deployutil.DeploymentStatusFor(observed) {
-		case api.DeploymentStatusRunning, api.DeploymentStatusFailed, api.DeploymentStatusComplete:
+		case deployapi.DeploymentStatusRunning, deployapi.DeploymentStatusFailed, deployapi.DeploymentStatusComplete:
 			return true, nil
-		case api.DeploymentStatusNew, api.DeploymentStatusPending:
+		case deployapi.DeploymentStatusNew, deployapi.DeploymentStatusPending:
 			return false, nil
 		default:
 			return false, ErrUnknownDeploymentPhase

--- a/pkg/deploy/registry/test/deployconfig.go
+++ b/pkg/deploy/registry/test/deployconfig.go
@@ -3,7 +3,7 @@ package test
 import (
 	"sync"
 
-	"github.com/openshift/origin/pkg/deploy/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -13,8 +13,8 @@ import (
 
 type DeploymentConfigRegistry struct {
 	Err               error
-	DeploymentConfig  *api.DeploymentConfig
-	DeploymentConfigs *api.DeploymentConfigList
+	DeploymentConfig  *deployapi.DeploymentConfig
+	DeploymentConfigs *deployapi.DeploymentConfigList
 	sync.Mutex
 }
 
@@ -22,21 +22,21 @@ func NewDeploymentConfigRegistry() *DeploymentConfigRegistry {
 	return &DeploymentConfigRegistry{}
 }
 
-func (r *DeploymentConfigRegistry) ListDeploymentConfigs(ctx apirequest.Context, label labels.Selector, field fields.Selector) (*api.DeploymentConfigList, error) {
+func (r *DeploymentConfigRegistry) ListDeploymentConfigs(ctx apirequest.Context, label labels.Selector, field fields.Selector) (*deployapi.DeploymentConfigList, error) {
 	r.Lock()
 	defer r.Unlock()
 
 	return r.DeploymentConfigs, r.Err
 }
 
-func (r *DeploymentConfigRegistry) GetDeploymentConfig(ctx apirequest.Context, id string) (*api.DeploymentConfig, error) {
+func (r *DeploymentConfigRegistry) GetDeploymentConfig(ctx apirequest.Context, id string) (*deployapi.DeploymentConfig, error) {
 	r.Lock()
 	defer r.Unlock()
 
 	return r.DeploymentConfig, r.Err
 }
 
-func (r *DeploymentConfigRegistry) CreateDeploymentConfig(ctx apirequest.Context, image *api.DeploymentConfig) error {
+func (r *DeploymentConfigRegistry) CreateDeploymentConfig(ctx apirequest.Context, image *deployapi.DeploymentConfig) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -44,7 +44,7 @@ func (r *DeploymentConfigRegistry) CreateDeploymentConfig(ctx apirequest.Context
 	return r.Err
 }
 
-func (r *DeploymentConfigRegistry) UpdateDeploymentConfig(ctx apirequest.Context, image *api.DeploymentConfig) error {
+func (r *DeploymentConfigRegistry) UpdateDeploymentConfig(ctx apirequest.Context, image *deployapi.DeploymentConfig) error {
 	r.Lock()
 	defer r.Unlock()
 

--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -14,7 +14,6 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
-	"github.com/openshift/origin/pkg/sdn/api"
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/util/netutils"
 )
@@ -43,7 +42,7 @@ var (
 )
 
 func GetOpenShiftNetworkPlugin(osClient *osclient.Client) (string, bool, error) {
-	cn, err := osClient.ClusterNetwork().Get(api.ClusterNetworkDefault, metav1.GetOptions{})
+	cn, err := osClient.ClusterNetwork().Get(sdnapi.ClusterNetworkDefault, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return "", false, nil
@@ -155,7 +154,7 @@ func GetGlobalAndNonGlobalPods(pods []kapi.Pod, vnidMap map[string]uint32) ([]ka
 	globalPods := []kapi.Pod{}
 	nonGlobalPods := []kapi.Pod{}
 	for _, pod := range pods {
-		if vnidMap[pod.Namespace] == api.GlobalVNID {
+		if vnidMap[pod.Namespace] == sdnapi.GlobalVNID {
 			globalPods = append(globalPods, pod)
 		} else {
 			nonGlobalPods = append(nonGlobalPods, pod)
@@ -173,7 +172,7 @@ func ExpectedConnectionStatus(ns1, ns2 string, vnidMap map[string]uint32) bool {
 	} // else multitenant
 
 	// Check if one of the pods belongs to global network
-	if vnidMap[ns1] == api.GlobalVNID || vnidMap[ns2] == api.GlobalVNID {
+	if vnidMap[ns1] == sdnapi.GlobalVNID || vnidMap[ns2] == sdnapi.GlobalVNID {
 		return true
 	}
 

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/docker/distribution/context"
 	"github.com/openshift/origin/pkg/api/latest"
-	"github.com/openshift/origin/pkg/authorization/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 
 	// install all APIs
@@ -45,7 +45,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 			// Test valid openshift bearer token but token *not* scoped for create operation
 			openshiftResponse: response{
 				200,
-				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{
+				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{
 					Namespace: "foo",
 					Allowed:   false,
 					Reason:    "not authorized!",
@@ -57,7 +57,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 			// Test valid openshift bearer token and token scoped for create operation
 			openshiftResponse: response{
 				200,
-				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{
+				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{
 					Namespace: "foo",
 					Allowed:   true,
 					Reason:    "authorized!",
@@ -240,7 +240,7 @@ func TestAccessController(t *testing.T) {
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
 				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "foo", Allowed: false, Reason: "unauthorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: false, Reason: "unauthorized!"})},
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
@@ -261,10 +261,10 @@ func TestAccessController(t *testing.T) {
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
 				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "bar", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "baz", Allowed: false, Reason: "no!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "bar", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "baz", Allowed: false, Reason: "no!"})},
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
@@ -289,9 +289,9 @@ func TestAccessController(t *testing.T) {
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
 				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "fromrepo", Allowed: false, Reason: "no!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "fromrepo", Allowed: false, Reason: "no!"})},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
@@ -314,7 +314,7 @@ func TestAccessController(t *testing.T) {
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
 				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
@@ -333,7 +333,7 @@ func TestAccessController(t *testing.T) {
 			}},
 			bearerToken: "anonymous",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
@@ -358,7 +358,7 @@ func TestAccessController(t *testing.T) {
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
 				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &api.SubjectAccessReviewResponse{Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Allowed: true, Reason: "authorized!"})},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,

--- a/pkg/dockerregistry/testutil/fakeopenshift.go
+++ b/pkg/dockerregistry/testutil/fakeopenshift.go
@@ -12,7 +12,6 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 
 	"github.com/openshift/origin/pkg/client/testclient"
-	"github.com/openshift/origin/pkg/image/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
@@ -51,7 +50,7 @@ func (fos *FakeOpenShift) CreateImage(image *imageapi.Image) (*imageapi.Image, e
 
 	_, ok := fos.images[image.Name]
 	if ok {
-		return nil, errors.NewAlreadyExists(api.Resource("images"), image.Name)
+		return nil, errors.NewAlreadyExists(imageapi.Resource("images"), image.Name)
 	}
 
 	fos.images[image.Name] = *image
@@ -66,7 +65,7 @@ func (fos *FakeOpenShift) GetImage(name string) (*imageapi.Image, error) {
 
 	image, ok := fos.images[name]
 	if !ok {
-		return nil, errors.NewNotFound(api.Resource("images"), name)
+		return nil, errors.NewNotFound(imageapi.Resource("images"), name)
 	}
 
 	return &image, nil
@@ -78,7 +77,7 @@ func (fos *FakeOpenShift) UpdateImage(image *imageapi.Image) (*imageapi.Image, e
 
 	_, ok := fos.images[image.Name]
 	if !ok {
-		return nil, errors.NewNotFound(api.Resource("images"), image.Name)
+		return nil, errors.NewNotFound(imageapi.Resource("images"), image.Name)
 	}
 
 	fos.images[image.Name] = *image
@@ -95,7 +94,7 @@ func (fos *FakeOpenShift) CreateImageStream(namespace string, is *imageapi.Image
 
 	_, ok := fos.imageStreams[ref]
 	if ok {
-		return nil, errors.NewAlreadyExists(api.Resource("imagestreams"), is.Name)
+		return nil, errors.NewAlreadyExists(imageapi.Resource("imagestreams"), is.Name)
 	}
 
 	is.Namespace = namespace
@@ -115,7 +114,7 @@ func (fos *FakeOpenShift) UpdateImageStream(namespace string, is *imageapi.Image
 
 	oldis, ok := fos.imageStreams[ref]
 	if !ok {
-		return nil, errors.NewNotFound(api.Resource("imagestreams"), is.Name)
+		return nil, errors.NewNotFound(imageapi.Resource("imagestreams"), is.Name)
 	}
 
 	is.Namespace = namespace
@@ -135,7 +134,7 @@ func (fos *FakeOpenShift) GetImageStream(namespace, repo string) (*imageapi.Imag
 
 	is, ok := fos.imageStreams[ref]
 	if !ok {
-		return nil, errors.NewNotFound(api.Resource("imagestreams"), repo)
+		return nil, errors.NewNotFound(imageapi.Resource("imagestreams"), repo)
 	}
 	return &is, nil
 }
@@ -197,7 +196,7 @@ func (fos *FakeOpenShift) CreateImageStreamTag(namespace string, istag *imageapi
 	// The user wants to symlink a tag.
 	_, exists := is.Spec.Tags[imageTag]
 	if exists {
-		return nil, errors.NewAlreadyExists(api.Resource("imagestreamtag"), istag.Name)
+		return nil, errors.NewAlreadyExists(imageapi.Resource("imagestreamtag"), istag.Name)
 	}
 	is.Spec.Tags[imageTag] = *istag.Tag
 
@@ -232,7 +231,7 @@ func (fos *FakeOpenShift) CreateImageStreamTag(namespace string, istag *imageapi
 }
 
 func (fos *FakeOpenShift) GetImageStreamImage(namespace string, id string) (*imageapi.ImageStreamImage, error) {
-	name, imageID, err := api.ParseImageStreamImageName(id)
+	name, imageID, err := imageapi.ParseImageStreamImageName(id)
 	if err != nil {
 		return nil, errors.NewBadRequest("ImageStreamImages must be retrieved with <name>@<id>")
 	}
@@ -243,10 +242,10 @@ func (fos *FakeOpenShift) GetImageStreamImage(namespace string, id string) (*ima
 	}
 
 	if repo.Status.Tags == nil {
-		return nil, errors.NewNotFound(api.Resource("imagestreamimage"), id)
+		return nil, errors.NewNotFound(imageapi.Resource("imagestreamimage"), id)
 	}
 
-	event, err := api.ResolveImageID(repo, imageID)
+	event, err := imageapi.ResolveImageID(repo, imageID)
 	if err != nil {
 		return nil, err
 	}
@@ -256,16 +255,16 @@ func (fos *FakeOpenShift) GetImageStreamImage(namespace string, id string) (*ima
 	if err != nil {
 		return nil, err
 	}
-	if err := api.ImageWithMetadata(image); err != nil {
+	if err := imageapi.ImageWithMetadata(image); err != nil {
 		return nil, err
 	}
 	image.DockerImageManifest = ""
 	image.DockerImageConfig = ""
 
-	isi := api.ImageStreamImage{
+	isi := imageapi.ImageStreamImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:         namespace,
-			Name:              api.MakeImageStreamImageName(name, imageID),
+			Name:              imageapi.MakeImageStreamImageName(name, imageID),
 			CreationTimestamp: image.ObjectMeta.CreationTimestamp,
 			Annotations:       repo.Annotations,
 		},

--- a/pkg/image/api/install/apigroup.go
+++ b/pkg/image/api/install/apigroup.go
@@ -7,10 +7,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/docker10"
 	"github.com/openshift/origin/pkg/image/api/dockerpre012"
-	"github.com/openshift/origin/pkg/image/api/v1"
+	imageapiv1 "github.com/openshift/origin/pkg/image/api/v1"
 )
 
 func installApiGroup() {
@@ -21,8 +21,8 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:              api.GroupName,
-			VersionPreferenceOrder: []string{v1.SchemeGroupVersion.Version},
+			GroupName:              imageapi.GroupName,
+			VersionPreferenceOrder: []string{imageapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:           importPrefix,
 			AddInternalObjectsToScheme: func(scheme *runtime.Scheme) error {
 				if err := docker10.AddToScheme(scheme); err != nil {
@@ -31,11 +31,11 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 				if err := dockerpre012.AddToScheme(scheme); err != nil {
 					return err
 				}
-				return api.AddToScheme(scheme)
+				return imageapi.AddToScheme(scheme)
 			},
 			RootScopedKinds: sets.NewString("Image", "ImageSignature"),
 		},
-		announced.VersionToSchemeFunc{v1.SchemeGroupVersion.Version: v1.AddToScheme},
+		announced.VersionToSchemeFunc{imageapiv1.SchemeGroupVersion.Version: imageapiv1.AddToScheme},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}

--- a/pkg/image/api/install/install.go
+++ b/pkg/image/api/install/install.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/docker10"
 	"github.com/openshift/origin/pkg/image/api/dockerpre012"
-	"github.com/openshift/origin/pkg/image/api/v1"
+	imageapiv1 "github.com/openshift/origin/pkg/image/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/image/api"
@@ -24,7 +24,7 @@ var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
 var availableVersions = []schema.GroupVersion{
-	v1.LegacySchemeGroupVersion,
+	imageapiv1.LegacySchemeGroupVersion,
 }
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", imageapi.LegacyGroupName)
 		return
 	}
 
@@ -74,7 +74,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	imageapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -82,8 +82,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case imageapiv1.LegacySchemeGroupVersion:
+			imageapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 			docker10.AddToSchemeInCoreGroup(kapi.Scheme)
 			dockerpre012.AddToSchemeInCoreGroup(kapi.Scheme)
 
@@ -102,14 +102,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case imageapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(imageapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/image/api/v1/conversion_test.go
+++ b/pkg/image/api/v1/conversion_test.go
@@ -10,7 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	newer "github.com/openshift/origin/pkg/image/api"
-	"github.com/openshift/origin/pkg/image/api/v1"
+	imageapiv1 "github.com/openshift/origin/pkg/image/api/v1"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -23,14 +23,14 @@ func TestRoundTripVersionedObject(t *testing.T) {
 		},
 	}
 	i := &newer.Image{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		ObjectMeta: metaimageapiv1.ObjectMeta{Name: "foo"},
 
 		DockerImageLayers:    []newer.ImageLayer{{Name: "foo", LayerSize: 10}},
 		DockerImageMetadata:  *d,
 		DockerImageReference: "foo/bar/baz",
 	}
 
-	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), i)
+	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(imageapiv1.SchemeGroupVersion), i)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestImageImportSpecDefaulting(t *testing.T) {
 			},
 		},
 	}
-	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), i)
+	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(imageapiv1.SchemeGroupVersion), i)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/image/api/v1/conversion_test.go
+++ b/pkg/image/api/v1/conversion_test.go
@@ -23,7 +23,7 @@ func TestRoundTripVersionedObject(t *testing.T) {
 		},
 	}
 	i := &newer.Image{
-		ObjectMeta: metaimageapiv1.ObjectMeta{Name: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 
 		DockerImageLayers:    []newer.ImageLayer{{Name: "foo", LayerSize: 10}},
 		DockerImageMetadata:  *d,

--- a/pkg/image/controller/imagestream_controller.go
+++ b/pkg/image/controller/imagestream_controller.go
@@ -17,7 +17,7 @@ import (
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	imageinternalversion "github.com/openshift/origin/pkg/image/generated/listers/image/internalversion"
 )
 
@@ -34,7 +34,7 @@ type imageStreamLister interface {
 // Notifier provides information about when the controller makes a decision
 type Notifier interface {
 	// Importing is invoked when the controller is going to import an image stream
-	Importing(stream *api.ImageStream)
+	Importing(stream *imageapi.ImageStream)
 }
 
 type ImageStreamController struct {
@@ -79,17 +79,17 @@ func (c *ImageStreamController) Run(workers int, stopCh <-chan struct{}) {
 }
 
 func (c *ImageStreamController) addImageStream(obj interface{}) {
-	if stream, ok := obj.(*api.ImageStream); ok {
+	if stream, ok := obj.(*imageapi.ImageStream); ok {
 		c.enqueueImageStream(stream)
 	}
 }
 
 func (c *ImageStreamController) updateImageStream(old, cur interface{}) {
-	curStream, ok := cur.(*api.ImageStream)
+	curStream, ok := cur.(*imageapi.ImageStream)
 	if !ok {
 		return
 	}
-	oldStream, ok := old.(*api.ImageStream)
+	oldStream, ok := old.(*imageapi.ImageStream)
 	if !ok {
 		return
 	}
@@ -103,7 +103,7 @@ func (c *ImageStreamController) updateImageStream(old, cur interface{}) {
 	c.enqueueImageStream(curStream)
 }
 
-func (c *ImageStreamController) enqueueImageStream(stream *api.ImageStream) {
+func (c *ImageStreamController) enqueueImageStream(stream *imageapi.ImageStream) {
 	key, err := kcontroller.KeyFunc(stream)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for image stream %#v: %v", stream, err))
@@ -139,7 +139,7 @@ func (c *ImageStreamController) processNextWorkItem() bool {
 	return true
 }
 
-func (c *ImageStreamController) getByKey(key string) (*api.ImageStream, error) {
+func (c *ImageStreamController) getByKey(key string) (*imageapi.ImageStream, error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return nil, err
@@ -157,27 +157,27 @@ func (c *ImageStreamController) getByKey(key string) (*api.ImageStream, error) {
 }
 
 // tagImportable is true if the given TagReference is importable by this controller
-func tagImportable(tagRef api.TagReference) bool {
+func tagImportable(tagRef imageapi.TagReference) bool {
 	return !(tagRef.From == nil || tagRef.From.Kind != "DockerImage" || tagRef.Reference)
 }
 
 // tagNeedsImport is true if the observed tag generation for this tag is older than the
 // specified tag generation (if no tag generation is specified, the controller does not
 // need to import this tag).
-func tagNeedsImport(stream *api.ImageStream, tag string, tagRef api.TagReference, importWhenGenerationNil bool) bool {
+func tagNeedsImport(stream *imageapi.ImageStream, tag string, tagRef imageapi.TagReference, importWhenGenerationNil bool) bool {
 	if !tagImportable(tagRef) {
 		return false
 	}
 	if tagRef.Generation == nil {
 		return importWhenGenerationNil
 	}
-	return *tagRef.Generation > api.LatestObservedTagGeneration(stream, tag)
+	return *tagRef.Generation > imageapi.LatestObservedTagGeneration(stream, tag)
 }
 
 // needsImport returns true if the provided image stream should have tags imported. Partial is returned
 // as true if the spec.dockerImageRepository does not need to be refreshed (if only tags have to be imported).
-func needsImport(stream *api.ImageStream) (ok bool, partial bool) {
-	if stream.Annotations == nil || len(stream.Annotations[api.DockerImageRepositoryCheckAnnotation]) == 0 {
+func needsImport(stream *imageapi.ImageStream) (ok bool, partial bool) {
+	if stream.Annotations == nil || len(stream.Annotations[imageapi.DockerImageRepositoryCheckAnnotation]) == 0 {
 		if len(stream.Spec.DockerImageRepository) > 0 {
 			return true, false
 		}
@@ -218,7 +218,7 @@ func needsImport(stream *api.ImageStream) (ok bool, partial bool) {
 // 3. spec.DockerImageRepository not defined - import tags per each definition.
 //
 // Notifier, if passed, will be invoked if the stream is going to be imported.
-func handleImageStream(stream *api.ImageStream, isNamespacer client.ImageStreamsNamespacer, notifier Notifier) error {
+func handleImageStream(stream *imageapi.ImageStream, isNamespacer client.ImageStreamsNamespacer, notifier Notifier) error {
 	ok, partial := needsImport(stream)
 	if !ok {
 		return nil
@@ -229,20 +229,20 @@ func handleImageStream(stream *api.ImageStream, isNamespacer client.ImageStreams
 		notifier.Importing(stream)
 	}
 
-	isi := &api.ImageStreamImport{
+	isi := &imageapi.ImageStreamImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            stream.Name,
 			Namespace:       stream.Namespace,
 			ResourceVersion: stream.ResourceVersion,
 			UID:             stream.UID,
 		},
-		Spec: api.ImageStreamImportSpec{Import: true},
+		Spec: imageapi.ImageStreamImportSpec{Import: true},
 	}
 	for tag, tagRef := range stream.Spec.Tags {
 		if !(partial && tagImportable(tagRef)) && !tagNeedsImport(stream, tag, tagRef, true) {
 			continue
 		}
-		isi.Spec.Images = append(isi.Spec.Images, api.ImageImportSpec{
+		isi.Spec.Images = append(isi.Spec.Images, imageapi.ImageImportSpec{
 			From:            kapi.ObjectReference{Kind: "DockerImage", Name: tagRef.From.Name},
 			To:              &kapi.LocalObjectReference{Name: tag},
 			ImportPolicy:    tagRef.ImportPolicy,
@@ -250,10 +250,10 @@ func handleImageStream(stream *api.ImageStream, isNamespacer client.ImageStreams
 		})
 	}
 	if repo := stream.Spec.DockerImageRepository; !partial && len(repo) > 0 {
-		insecure := stream.Annotations[api.InsecureRepositoryAnnotation] == "true"
-		isi.Spec.Repository = &api.RepositoryImportSpec{
+		insecure := stream.Annotations[imageapi.InsecureRepositoryAnnotation] == "true"
+		isi.Spec.Repository = &imageapi.RepositoryImportSpec{
 			From:         kapi.ObjectReference{Kind: "DockerImage", Name: repo},
-			ImportPolicy: api.TagImportPolicy{Insecure: insecure},
+			ImportPolicy: imageapi.TagImportPolicy{Insecure: insecure},
 		}
 	}
 	result, err := isNamespacer.ImageStreams(stream.Namespace).Import(isi)

--- a/pkg/image/controller/imagestream_controller_test.go
+++ b/pkg/image/controller/imagestream_controller_test.go
@@ -9,7 +9,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	client "github.com/openshift/origin/pkg/client/testclient"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 )
@@ -17,38 +17,38 @@ import (
 func TestHandleImageStream(t *testing.T) {
 	two := int64(2)
 	testCases := []struct {
-		stream *api.ImageStream
+		stream *imageapi.ImageStream
 		run    bool
 	}{
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
 					Name:        "test",
 					Namespace:   "other",
 				},
 			},
 		},
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
 					Name:        "test",
 					Namespace:   "other",
 				},
-				Spec: api.ImageStreamSpec{
+				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "test/other",
 				},
 			},
 		},
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: "a random error"},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: "a random error"},
 					Name:        "test",
 					Namespace:   "other",
 				},
-				Spec: api.ImageStreamSpec{
+				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "test/other",
 				},
 			},
@@ -56,10 +56,10 @@ func TestHandleImageStream(t *testing.T) {
 
 		// references are ignored
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "other"},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:      &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Reference: true,
@@ -69,10 +69,10 @@ func TestHandleImageStream(t *testing.T) {
 			},
 		},
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "other"},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:      &kapi.ObjectReference{Kind: "AnotherImage", Name: "test/other:latest"},
 							Reference: true,
@@ -85,10 +85,10 @@ func TestHandleImageStream(t *testing.T) {
 		// spec tag will be imported
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "other"},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From: &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 						},
@@ -99,10 +99,10 @@ func TestHandleImageStream(t *testing.T) {
 		// spec tag with generation with no pending status will be imported
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "other"},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:       &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Generation: &two,
@@ -114,41 +114,41 @@ func TestHandleImageStream(t *testing.T) {
 		// spec tag with generation with older status generation will be imported
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "other"},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:       &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Generation: &two,
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{"latest": {Items: []api.TagEvent{{Generation: 1}}}},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{"latest": {Items: []imageapi.TagEvent{{Generation: 1}}}},
 				},
 			},
 		},
 		// spec tag with generation with status condition error and equal generation will not be imported
 		{
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
 					Name:        "test",
 					Namespace:   "other",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:       &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Generation: &two,
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{"latest": {Conditions: []api.TagEventCondition{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{"latest": {Conditions: []imageapi.TagEventCondition{
 						{
-							Type:       api.ImportSuccess,
+							Type:       imageapi.ImportSuccess,
 							Status:     kapi.ConditionFalse,
 							Generation: 2,
 						},
@@ -159,24 +159,24 @@ func TestHandleImageStream(t *testing.T) {
 		// spec tag with generation with status condition error and older generation will be imported
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
 					Name:        "test",
 					Namespace:   "other",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:       &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Generation: &two,
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{"latest": {Conditions: []api.TagEventCondition{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{"latest": {Conditions: []imageapi.TagEventCondition{
 						{
-							Type:       api.ImportSuccess,
+							Type:       imageapi.ImportSuccess,
 							Status:     kapi.ConditionFalse,
 							Generation: 1,
 						},
@@ -187,35 +187,35 @@ func TestHandleImageStream(t *testing.T) {
 		// spec tag with generation with older status generation will be imported
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
+					Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: metav1.Now().UTC().Format(time.RFC3339)},
 					Name:        "test",
 					Namespace:   "other",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							From:       &kapi.ObjectReference{Kind: "DockerImage", Name: "test/other:latest"},
 							Generation: &two,
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{"latest": {Items: []api.TagEvent{{Generation: 1}}}},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{"latest": {Items: []imageapi.TagEvent{{Generation: 1}}}},
 				},
 			},
 		},
 		// test external repo
 		{
 			run: true,
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "other",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"1.1": {
 							From: &kapi.ObjectReference{
 								Kind: "DockerImage",

--- a/pkg/image/controller/scheduled_image_controller.go
+++ b/pkg/image/controller/scheduled_image_controller.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/controller"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type uniqueItem struct {
@@ -42,7 +42,7 @@ type ScheduledImageStreamController struct {
 
 // Importing is invoked when the controller decides to import a stream in order to push back
 // the next schedule time.
-func (s *ScheduledImageStreamController) Importing(stream *api.ImageStream) {
+func (s *ScheduledImageStreamController) Importing(stream *imageapi.ImageStream) {
 	if !s.enabled {
 		return
 	}
@@ -71,16 +71,16 @@ func (s *ScheduledImageStreamController) Run(stopCh <-chan struct{}) {
 }
 
 func (s *ScheduledImageStreamController) addImageStream(obj interface{}) {
-	stream := obj.(*api.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
 	s.enqueueImageStream(stream)
 }
 
 func (s *ScheduledImageStreamController) updateImageStream(old, cur interface{}) {
-	curStream, ok := cur.(*api.ImageStream)
+	curStream, ok := cur.(*imageapi.ImageStream)
 	if !ok {
 		return
 	}
-	oldStream, ok := old.(*api.ImageStream)
+	oldStream, ok := old.(*imageapi.ImageStream)
 	if !ok {
 		return
 	}
@@ -93,13 +93,13 @@ func (s *ScheduledImageStreamController) updateImageStream(old, cur interface{})
 }
 
 func (s *ScheduledImageStreamController) deleteImageStream(obj interface{}) {
-	stream, isStream := obj.(*api.ImageStream)
+	stream, isStream := obj.(*imageapi.ImageStream)
 	if !isStream {
 		tombstone, objIsTombstone := obj.(cache.DeletedFinalStateUnknown)
 		if !objIsTombstone {
 			return
 		}
-		stream, isStream = tombstone.Obj.(*api.ImageStream)
+		stream, isStream = tombstone.Obj.(*imageapi.ImageStream)
 	}
 	key, err := cache.MetaNamespaceKeyFunc(stream)
 	if err != nil {
@@ -110,7 +110,7 @@ func (s *ScheduledImageStreamController) deleteImageStream(obj interface{}) {
 }
 
 // enqueueImageStream ensures an image stream is checked for scheduling
-func (s *ScheduledImageStreamController) enqueueImageStream(stream *api.ImageStream) {
+func (s *ScheduledImageStreamController) enqueueImageStream(stream *imageapi.ImageStream) {
 	if !s.enabled {
 		return
 	}
@@ -168,7 +168,7 @@ func (s *ScheduledImageStreamController) syncTimedByName(namespace, name string)
 	if err != nil {
 		return err
 	}
-	stream := copy.(*api.ImageStream)
+	stream := copy.(*imageapi.ImageStream)
 	resetScheduledTags(stream)
 
 	glog.V(3).Infof("Scheduled import of stream %s/%s...", stream.Namespace, stream.Name)
@@ -176,7 +176,7 @@ func (s *ScheduledImageStreamController) syncTimedByName(namespace, name string)
 }
 
 // resetScheduledTags artificially increments the generation on the tags that should be imported.
-func resetScheduledTags(stream *api.ImageStream) {
+func resetScheduledTags(stream *imageapi.ImageStream) {
 	next := stream.Generation + 1
 	for tag, tagRef := range stream.Spec.Tags {
 		if tagImportable(tagRef) && tagRef.ImportPolicy.Scheduled {
@@ -187,7 +187,7 @@ func resetScheduledTags(stream *api.ImageStream) {
 }
 
 // needsScheduling returns true if this image stream has any scheduled tags
-func needsScheduling(stream *api.ImageStream) bool {
+func needsScheduling(stream *imageapi.ImageStream) bool {
 	for _, tagRef := range stream.Spec.Tags {
 		if tagImportable(tagRef) && tagRef.ImportPolicy.Scheduled {
 			return true

--- a/pkg/image/controller/scheduled_image_controller_test.go
+++ b/pkg/image/controller/scheduled_image_controller_test.go
@@ -8,7 +8,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/client/testclient"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	imageinformer "github.com/openshift/origin/pkg/image/generated/informers/internalversion"
 	imageinternal "github.com/openshift/origin/pkg/image/generated/internalclientset/fake"
 
@@ -17,24 +17,24 @@ import (
 
 func TestScheduledImport(t *testing.T) {
 	one := int64(1)
-	stream := &api.ImageStream{
+	stream := &imageapi.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test", Namespace: "other", UID: "1", ResourceVersion: "1",
-			Annotations: map[string]string{api.DockerImageRepositoryCheckAnnotation: "done"},
+			Annotations: map[string]string{imageapi.DockerImageRepositoryCheckAnnotation: "done"},
 			Generation:  1,
 		},
-		Spec: api.ImageStreamSpec{
-			Tags: map[string]api.TagReference{
+		Spec: imageapi.ImageStreamSpec{
+			Tags: map[string]imageapi.TagReference{
 				"default": {
 					From:         &kapi.ObjectReference{Kind: "DockerImage", Name: "mysql:latest"},
 					Generation:   &one,
-					ImportPolicy: api.TagImportPolicy{Scheduled: true},
+					ImportPolicy: imageapi.TagImportPolicy{Scheduled: true},
 				},
 			},
 		},
-		Status: api.ImageStreamStatus{
-			Tags: map[string]api.TagEventList{
-				"default": {Items: []api.TagEvent{{Generation: 1}}},
+		Status: imageapi.ImageStreamStatus{
+			Tags: map[string]imageapi.TagEventList{
+				"default": {Items: []imageapi.TagEvent{{Generation: 1}}},
 			},
 		},
 	}

--- a/pkg/image/importer/client.go
+++ b/pkg/image/importer/client.go
@@ -27,7 +27,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/dockerregistry"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/dockerpre012"
 )
 
@@ -159,7 +159,7 @@ func (r *repositoryRetriever) ping(registry url.URL, insecure bool, transport ht
 	return nil, nil
 }
 
-func schema1ToImage(manifest *schema1.SignedManifest, d digest.Digest) (*api.Image, error) {
+func schema1ToImage(manifest *schema1.SignedManifest, d digest.Digest) (*imageapi.Image, error) {
 	if len(manifest.History) == 0 {
 		return nil, fmt.Errorf("image has no v1Compatibility history and cannot be used")
 	}
@@ -177,7 +177,7 @@ func schema1ToImage(manifest *schema1.SignedManifest, d digest.Digest) (*api.Ima
 	} else {
 		dockerImage.ID = digest.FromBytes(manifest.Canonical).String()
 	}
-	image := &api.Image{
+	image := &imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dockerImage.ID,
 		},
@@ -190,7 +190,7 @@ func schema1ToImage(manifest *schema1.SignedManifest, d digest.Digest) (*api.Ima
 	return image, nil
 }
 
-func schema2ToImage(manifest *schema2.DeserializedManifest, imageConfig []byte, d digest.Digest) (*api.Image, error) {
+func schema2ToImage(manifest *schema2.DeserializedManifest, imageConfig []byte, d digest.Digest) (*imageapi.Image, error) {
 	mediatype, payload, err := manifest.Payload()
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ func schema2ToImage(manifest *schema2.DeserializedManifest, imageConfig []byte, 
 		dockerImage.ID = digest.FromBytes(payload).String()
 	}
 
-	image := &api.Image{
+	image := &imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dockerImage.ID,
 		},
@@ -220,13 +220,13 @@ func schema2ToImage(manifest *schema2.DeserializedManifest, imageConfig []byte, 
 	return image, nil
 }
 
-func schema0ToImage(dockerImage *dockerregistry.Image) (*api.Image, error) {
-	var baseImage api.DockerImage
+func schema0ToImage(dockerImage *dockerregistry.Image) (*imageapi.Image, error) {
+	var baseImage imageapi.DockerImage
 	if err := kapi.Scheme.Convert(&dockerImage.Image, &baseImage, nil); err != nil {
 		return nil, fmt.Errorf("could not convert image: %#v", err)
 	}
 
-	image := &api.Image{
+	image := &imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dockerImage.ID,
 		},
@@ -237,12 +237,12 @@ func schema0ToImage(dockerImage *dockerregistry.Image) (*api.Image, error) {
 	return image, nil
 }
 
-func unmarshalDockerImage(body []byte) (*api.DockerImage, error) {
+func unmarshalDockerImage(body []byte) (*imageapi.DockerImage, error) {
 	var image dockerpre012.DockerImage
 	if err := json.Unmarshal(body, &image); err != nil {
 		return nil, err
 	}
-	dockerImage := &api.DockerImage{}
+	dockerImage := &imageapi.DockerImage{}
 	if err := kapi.Scheme.Convert(&image, dockerImage, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/image/importer/client_test.go
+++ b/pkg/image/importer/client_test.go
@@ -22,7 +22,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/dockerregistry"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type mockRetriever struct {
@@ -189,11 +189,11 @@ func TestDockerV1Fallback(t *testing.T) {
 	ctx := gocontext.WithValue(gocontext.Background(), ContextKeyV1RegistryClient, client)
 
 	uri, _ = url.Parse(server.URL)
-	isi := &api.ImageStreamImport{
-		Spec: api.ImageStreamImportSpec{
-			Repository: &api.RepositoryImportSpec{
+	isi := &imageapi.ImageStreamImport{
+		Spec: imageapi.ImageStreamImportSpec{
+			Repository: &imageapi.RepositoryImportSpec{
 				From:         kapi.ObjectReference{Kind: "DockerImage", Name: uri.Host + "/test:test"},
-				ImportPolicy: api.TagImportPolicy{Insecure: true},
+				ImportPolicy: imageapi.TagImportPolicy{Insecure: true},
 			},
 		},
 	}

--- a/pkg/image/importer/importer_test.go
+++ b/pkg/image/importer/importer_test.go
@@ -15,12 +15,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 func TestImportNothing(t *testing.T) {
 	ctx := NewContext(http.DefaultTransport, http.DefaultTransport).WithCredentials(NoCredentials)
-	isi := &api.ImageStreamImport{}
+	isi := &imageapi.ImageStreamImport{}
 	i := NewImageStreamImporter(ctx, 5, nil, nil)
 	if err := i.Import(nil, isi); err != nil {
 		t.Fatal(err)
@@ -61,19 +61,19 @@ func TestImport(t *testing.T) {
 	}
 	testCases := []struct {
 		retriever RepositoryRetriever
-		isi       api.ImageStreamImport
-		expect    func(*api.ImageStreamImport, *testing.T)
+		isi       imageapi.ImageStreamImport
+		expect    func(*imageapi.ImageStreamImport, *testing.T)
 	}{
 		{
 			retriever: insecureRetriever,
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Images: []api.ImageImportSpec{
-						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"}, ImportPolicy: api.TagImportPolicy{Insecure: true}},
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Images: []imageapi.ImageImportSpec{
+						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"}, ImportPolicy: imageapi.TagImportPolicy{Insecure: true}},
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if !insecureRetriever.insecure {
 					t.Errorf("expected retriever to beset insecure: %#v", insecureRetriever)
 				}
@@ -87,9 +87,9 @@ func TestImport(t *testing.T) {
 					getErr:      fmt.Errorf("no such digest"),
 				},
 			},
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Images: []api.ImageImportSpec{
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Images: []imageapi.ImageImportSpec{
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"}},
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}},
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test///un/parse/able/image"}},
@@ -97,7 +97,7 @@ func TestImport(t *testing.T) {
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if !expectStatusError(isi.Status.Images[0].Status, "Internal error occurred: no such manifest tag") {
 					t.Errorf("unexpected status: %#v", isi.Status.Images[0].Status)
 				}
@@ -121,14 +121,14 @@ func TestImport(t *testing.T) {
 		},
 		{
 			retriever: &mockRetriever{err: fmt.Errorf("error")},
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Repository: &api.RepositoryImportSpec{
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Repository: &imageapi.RepositoryImportSpec{
 						From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"},
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if !reflect.DeepEqual(isi.Status.Repository.AdditionalTags, []string(nil)) {
 					t.Errorf("unexpected additional tags: %#v", isi.Status.Repository)
 				}
@@ -142,15 +142,15 @@ func TestImport(t *testing.T) {
 		},
 		{
 			retriever: &mockRetriever{repo: &mockRepository{manifest: etcdManifestSchema1}},
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Images: []api.ImageImportSpec{
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Images: []imageapi.ImageImportSpec{
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test@sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238"}},
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test:tag"}},
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if len(isi.Status.Images) != 2 {
 					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
 				}
@@ -184,14 +184,14 @@ func TestImport(t *testing.T) {
 					manifest: busyboxManifestSchema2,
 				},
 			},
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Images: []api.ImageImportSpec{
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Images: []imageapi.ImageImportSpec{
 						{From: kapi.ObjectReference{Kind: "DockerImage", Name: "test:busybox"}},
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if len(isi.Status.Images) != 1 {
 					t.Errorf("unexpected number of images: %#v", isi.Status.Repository.Images)
 				}
@@ -231,14 +231,14 @@ func TestImport(t *testing.T) {
 					getByTagErr: fmt.Errorf("no such manifest tag"),
 				},
 			},
-			isi: api.ImageStreamImport{
-				Spec: api.ImageStreamImportSpec{
-					Repository: &api.RepositoryImportSpec{
+			isi: imageapi.ImageStreamImport{
+				Spec: imageapi.ImageStreamImportSpec{
+					Repository: &imageapi.RepositoryImportSpec{
 						From: kapi.ObjectReference{Kind: "DockerImage", Name: "test"},
 					},
 				},
 			},
-			expect: func(isi *api.ImageStreamImport, t *testing.T) {
+			expect: func(isi *imageapi.ImageStreamImport, t *testing.T) {
 				if !reflect.DeepEqual(isi.Status.Repository.AdditionalTags, []string{"v2"}) {
 					t.Errorf("unexpected additional tags: %#v", isi.Status.Repository)
 				}

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Image{} },
-		NewListFunc:       func() runtime.Object { return &api.ImageList{} },
+		NewFunc:           func() runtime.Object { return &imageapi.Image{} },
+		NewListFunc:       func() runtime.Object { return &imageapi.ImageList{} },
 		PredicateFunc:     image.Matcher,
-		QualifiedResource: api.Resource("images"),
+		QualifiedResource: imageapi.Resource("images"),
 
 		CreateStrategy: image.Strategy,
 		UpdateStrategy: image.Strategy,

--- a/pkg/image/registry/image/etcd/etcd_test.go
+++ b/pkg/image/registry/image/etcd/etcd_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
 	"github.com/openshift/origin/pkg/api/latest"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/util/restoptions"
 
@@ -36,8 +36,8 @@ func TestStorage(t *testing.T) {
 	image.NewRegistry(storage)
 }
 
-func validImage() *api.Image {
-	return &api.Image{
+func validImage() *imageapi.Image {
+	return &imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:         "foo",
 			GenerateName: "foo",
@@ -57,7 +57,7 @@ func TestCreate(t *testing.T) {
 	test.TestCreate(
 		valid,
 		// invalid
-		&api.Image{},
+		&imageapi.Image{},
 	)
 }
 
@@ -70,13 +70,13 @@ func TestUpdate(t *testing.T) {
 		validImage(),
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.Image)
+			object := obj.(*imageapi.Image)
 			object.DockerImageReference = "openshift/origin"
 			return object
 		},
 		// invalid updateFunc
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.Image)
+			object := obj.(*imageapi.Image)
 			object.DockerImageReference = "\\"
 			return object
 		},
@@ -228,17 +228,17 @@ const etcdManifestNoSignature = `{
 
 func TestCreateSetsMetadata(t *testing.T) {
 	testCases := []struct {
-		image  *api.Image
-		expect func(*api.Image) bool
+		image  *imageapi.Image
+		expect func(*imageapi.Image) bool
 	}{
 		{
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo"},
 				DockerImageReference: "openshift/ruby-19-centos",
 			},
 		},
 		{
-			expect: func(image *api.Image) bool {
+			expect: func(image *imageapi.Image) bool {
 				if image.DockerImageMetadata.Size != 28643712 {
 					t.Errorf("image had size %d", image.DockerImageMetadata.Size)
 					return false
@@ -249,7 +249,7 @@ func TestCreateSetsMetadata(t *testing.T) {
 				}
 				return true
 			},
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo"},
 				DockerImageReference: "openshift/ruby-19-centos",
 				DockerImageManifest:  etcdManifest,
@@ -271,7 +271,7 @@ func TestCreateSetsMetadata(t *testing.T) {
 			t.Errorf("%d: Unexpected non-nil error: %#v", i, err)
 			continue
 		}
-		image, ok := obj.(*api.Image)
+		image, ok := obj.(*imageapi.Image)
 		if !ok {
 			t.Errorf("%d: Expected image type, got: %#v", i, obj)
 			continue
@@ -284,13 +284,13 @@ func TestCreateSetsMetadata(t *testing.T) {
 
 func TestUpdateResetsMetadata(t *testing.T) {
 	testCases := []struct {
-		image    *api.Image
-		existing *api.Image
-		expect   func(*api.Image) bool
+		image    *imageapi.Image
+		existing *imageapi.Image
+		expect   func(*imageapi.Image) bool
 	}{
 		// manifest changes are ignored
 		{
-			expect: func(image *api.Image) bool {
+			expect: func(image *imageapi.Image) bool {
 				if image.Labels["a"] != "b" {
 					t.Errorf("unexpected labels: %s", image.Labels)
 					return false
@@ -317,13 +317,13 @@ func TestUpdateResetsMetadata(t *testing.T) {
 				}
 				return true
 			},
-			existing: &api.Image{
+			existing: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 				DockerImageReference: "openshift/ruby-19-centos-2",
-				DockerImageLayers:    []api.ImageLayer{{Name: "test", LayerSize: 10}},
-				DockerImageMetadata:  api.DockerImage{ID: "foo"},
+				DockerImageLayers:    []imageapi.ImageLayer{{Name: "test", LayerSize: 10}},
+				DockerImageMetadata:  imageapi.DockerImage{ID: "foo"},
 			},
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", Labels: map[string]string{"a": "b"}},
 				DockerImageReference: "openshift/ruby-19-centos",
 				DockerImageManifest:  etcdManifest,
@@ -331,7 +331,7 @@ func TestUpdateResetsMetadata(t *testing.T) {
 		},
 		// existing manifest is preserved, and unpacked
 		{
-			expect: func(image *api.Image) bool {
+			expect: func(image *imageapi.Image) bool {
 				if len(image.DockerImageManifest) != 0 {
 					t.Errorf("unexpected not empty manifest")
 					return false
@@ -354,21 +354,21 @@ func TestUpdateResetsMetadata(t *testing.T) {
 				}
 				return true
 			},
-			existing: &api.Image{
+			existing: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 				DockerImageReference: "openshift/ruby-19-centos-2",
-				DockerImageLayers:    []api.ImageLayer{},
+				DockerImageLayers:    []imageapi.ImageLayer{},
 				DockerImageManifest:  etcdManifest,
 			},
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 				DockerImageReference: "openshift/ruby-19-centos",
-				DockerImageMetadata:  api.DockerImage{ID: "foo"},
+				DockerImageMetadata:  imageapi.DockerImage{ID: "foo"},
 			},
 		},
 		// old manifest is replaced because the new manifest matches the digest
 		{
-			expect: func(image *api.Image) bool {
+			expect: func(image *imageapi.Image) bool {
 				if image.DockerImageManifest != etcdManifest {
 					t.Errorf("unexpected manifest: %s", image.DockerImageManifest)
 					return false
@@ -391,16 +391,16 @@ func TestUpdateResetsMetadata(t *testing.T) {
 				}
 				return true
 			},
-			existing: &api.Image{
+			existing: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238", ResourceVersion: "1"},
 				DockerImageReference: "openshift/ruby-19-centos-2",
-				DockerImageLayers:    []api.ImageLayer{},
+				DockerImageLayers:    []imageapi.ImageLayer{},
 				DockerImageManifest:  etcdManifestNoSignature,
 			},
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta:           metav1.ObjectMeta{Name: "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238", ResourceVersion: "1"},
 				DockerImageReference: "openshift/ruby-19-centos",
-				DockerImageMetadata:  api.DockerImage{ID: "foo"},
+				DockerImageMetadata:  imageapi.DockerImage{ID: "foo"},
 				DockerImageManifest:  etcdManifest,
 			},
 		}}
@@ -419,7 +419,7 @@ func TestUpdateResetsMetadata(t *testing.T) {
 		}
 
 		// Copy the resource version into our update object
-		test.image.ResourceVersion = created.(*api.Image).ResourceVersion
+		test.image.ResourceVersion = created.(*imageapi.Image).ResourceVersion
 		obj, _, err := storage.Update(apirequest.NewDefaultContext(), test.image.Name, rest.DefaultUpdatedObjectInfo(test.image, kapi.Scheme))
 		if err != nil {
 			t.Errorf("%d: Unexpected non-nil error: %#v", i, err)
@@ -429,7 +429,7 @@ func TestUpdateResetsMetadata(t *testing.T) {
 			t.Errorf("%d: Expected nil obj, got %v", i, obj)
 			continue
 		}
-		image, ok := obj.(*api.Image)
+		image, ok := obj.(*imageapi.Image)
 		if !ok {
 			t.Errorf("%d: Expected image type, got: %#v", i, obj)
 			continue

--- a/pkg/image/registry/image/registry.go
+++ b/pkg/image/registry/image/registry.go
@@ -9,23 +9,23 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // Registry is an interface for things that know how to store Image objects.
 type Registry interface {
 	// ListImages obtains a list of images that match a selector.
-	ListImages(ctx apirequest.Context, options *metainternal.ListOptions) (*api.ImageList, error)
+	ListImages(ctx apirequest.Context, options *metainternal.ListOptions) (*imageapi.ImageList, error)
 	// GetImage retrieves a specific image.
-	GetImage(ctx apirequest.Context, id string, options *metav1.GetOptions) (*api.Image, error)
+	GetImage(ctx apirequest.Context, id string, options *metav1.GetOptions) (*imageapi.Image, error)
 	// CreateImage creates a new image.
-	CreateImage(ctx apirequest.Context, image *api.Image) error
+	CreateImage(ctx apirequest.Context, image *imageapi.Image) error
 	// DeleteImage deletes an image.
 	DeleteImage(ctx apirequest.Context, id string) error
 	// WatchImages watches for new or deleted images.
 	WatchImages(ctx apirequest.Context, options *metainternal.ListOptions) (watch.Interface, error)
 	// UpdateImage updates given image.
-	UpdateImage(ctx apirequest.Context, image *api.Image) (*api.Image, error)
+	UpdateImage(ctx apirequest.Context, image *imageapi.Image) (*imageapi.Image, error)
 }
 
 // Storage is an interface for a standard REST Storage backend
@@ -50,33 +50,33 @@ func NewRegistry(s Storage) Registry {
 	return &storage{Storage: s}
 }
 
-func (s *storage) ListImages(ctx apirequest.Context, options *metainternal.ListOptions) (*api.ImageList, error) {
+func (s *storage) ListImages(ctx apirequest.Context, options *metainternal.ListOptions) (*imageapi.ImageList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageList), nil
+	return obj.(*imageapi.ImageList), nil
 }
 
-func (s *storage) GetImage(ctx apirequest.Context, imageID string, options *metav1.GetOptions) (*api.Image, error) {
+func (s *storage) GetImage(ctx apirequest.Context, imageID string, options *metav1.GetOptions) (*imageapi.Image, error) {
 	obj, err := s.Get(ctx, imageID, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Image), nil
+	return obj.(*imageapi.Image), nil
 }
 
-func (s *storage) CreateImage(ctx apirequest.Context, image *api.Image) error {
+func (s *storage) CreateImage(ctx apirequest.Context, image *imageapi.Image) error {
 	_, err := s.Create(ctx, image)
 	return err
 }
 
-func (s *storage) UpdateImage(ctx apirequest.Context, image *api.Image) (*api.Image, error) {
+func (s *storage) UpdateImage(ctx apirequest.Context, image *imageapi.Image) (*imageapi.Image, error) {
 	obj, _, err := s.Update(ctx, image.Name, rest.DefaultUpdatedObjectInfo(image, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Image), nil
+	return obj.(*imageapi.Image), nil
 }
 
 func (s *storage) DeleteImage(ctx apirequest.Context, imageID string) error {

--- a/pkg/image/registry/image/strategy_test.go
+++ b/pkg/image/registry/image/strategy_test.go
@@ -14,21 +14,21 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func fuzzImage(t *testing.T, image *api.Image, seed int64) *api.Image {
+func fuzzImage(t *testing.T, image *imageapi.Image, seed int64) *imageapi.Image {
 	f := apitesting.FuzzerFor(apitesting.GenericFuzzerFuncs(t, kapi.Codecs), rand.NewSource(seed))
 	f.Funcs(
-		func(j *api.Image, c fuzz.Continue) {
+		func(j *imageapi.Image, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
 			j.Annotations = make(map[string]string)
 			j.Labels = make(map[string]string)
-			j.Signatures = make([]api.ImageSignature, c.Rand.Intn(3)+2)
+			j.Signatures = make([]imageapi.ImageSignature, c.Rand.Intn(3)+2)
 			for i := range j.Signatures {
 				sign := &j.Signatures[i]
 				c.Fuzz(sign)
-				sign.Conditions = make([]api.SignatureCondition, c.Rand.Intn(3)+2)
+				sign.Conditions = make([]imageapi.SignatureCondition, c.Rand.Intn(3)+2)
 				for ci := range sign.Conditions {
 					cond := &sign.Conditions[ci]
 					c.Fuzz(cond)
@@ -41,7 +41,7 @@ func fuzzImage(t *testing.T, image *api.Image, seed int64) *api.Image {
 		},
 	)
 
-	updated := api.Image{}
+	updated := imageapi.Image{}
 	f.Fuzz(&updated)
 	updated.Namespace = image.Namespace
 	updated.Name = image.Name
@@ -59,7 +59,7 @@ func fuzzImage(t *testing.T, image *api.Image, seed int64) *api.Image {
 func TestStrategyPrepareForCreate(t *testing.T) {
 	ctx := apirequest.NewDefaultContext()
 
-	original := api.Image{
+	original := imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "image",
 		},
@@ -71,7 +71,7 @@ func TestStrategyPrepareForCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("faild to deep copy fuzzed image: %v", err)
 	}
-	image := obj.(*api.Image)
+	image := obj.(*imageapi.Image)
 
 	if len(image.Signatures) == 0 {
 		t.Fatalf("fuzzifier failed to generate signatures")

--- a/pkg/image/registry/imagesecret/rest.go
+++ b/pkg/image/registry/imagesecret/rest.go
@@ -9,7 +9,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // REST implements the RESTStorage interface for ImageStreamImport
@@ -51,7 +51,7 @@ func (r *REST) Get(ctx apirequest.Context, _ string, options runtime.Object) (ru
 	}
 	filtered := make([]kapi.Secret, 0, len(secrets.Items))
 	for i := range secrets.Items {
-		if secrets.Items[i].Annotations[api.ExcludeImageSecretAnnotation] == "true" {
+		if secrets.Items[i].Annotations[imageapi.ExcludeImageSecretAnnotation] == "true" {
 			continue
 		}
 		switch secrets.Items[i].Type {

--- a/pkg/image/registry/imagesecret/rest_test.go
+++ b/pkg/image/registry/imagesecret/rest_test.go
@@ -8,7 +8,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 func TestGetSecrets(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGetSecrets(t *testing.T) {
 				Type:       kapi.SecretTypeDockercfg,
 			},
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "secret-2", Annotations: map[string]string{api.ExcludeImageSecretAnnotation: "true"}, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "secret-2", Annotations: map[string]string{imageapi.ExcludeImageSecretAnnotation: "true"}, Namespace: "default"},
 				Type:       kapi.SecretTypeDockercfg,
 			},
 			{

--- a/pkg/image/registry/imagesignature/strategy_test.go
+++ b/pkg/image/registry/imagesignature/strategy_test.go
@@ -13,17 +13,17 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func fuzzImageSignature(t *testing.T, signature *api.ImageSignature, seed int64) *api.ImageSignature {
+func fuzzImageSignature(t *testing.T, signature *imageapi.ImageSignature, seed int64) *imageapi.ImageSignature {
 	f := apitesting.FuzzerFor(apitesting.GenericFuzzerFuncs(t, kapi.Codecs), rand.NewSource(seed))
 	f.Funcs(
-		func(j *api.ImageSignature, c fuzz.Continue) {
+		func(j *imageapi.ImageSignature, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
 			j.Annotations = make(map[string]string)
 			j.Labels = make(map[string]string)
-			j.Conditions = []api.SignatureCondition{}
+			j.Conditions = []imageapi.SignatureCondition{}
 			j.SignedClaims = make(map[string]string)
 
 			j.Content = []byte(c.RandString())
@@ -33,14 +33,14 @@ func fuzzImageSignature(t *testing.T, signature *api.ImageSignature, seed int64)
 				j.SignedClaims[c.RandString()] = c.RandString()
 			}
 			for i := 0; i < c.Rand.Intn(3)+2; i++ {
-				cond := api.SignatureCondition{}
+				cond := imageapi.SignatureCondition{}
 				c.Fuzz(&cond)
 				j.Conditions = append(j.Conditions, cond)
 			}
 		},
 	)
 
-	updated := api.ImageSignature{}
+	updated := imageapi.ImageSignature{}
 	f.Fuzz(&updated)
 	updated.Namespace = signature.Namespace
 	updated.Name = signature.Name
@@ -57,7 +57,7 @@ func fuzzImageSignature(t *testing.T, signature *api.ImageSignature, seed int64)
 
 func TestStrategyPrepareForCreate(t *testing.T) {
 	ctx := apirequest.NewDefaultContext()
-	signature := &api.ImageSignature{
+	signature := &imageapi.ImageSignature{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "image",
 		},

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -23,13 +23,13 @@ type REST struct {
 }
 
 // NewREST returns a new REST.
-func NewREST(optsGetter restoptions.Getter, defaultRegistry api.DefaultRegistry, subjectAccessReviewRegistry subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier) (*REST, *StatusREST, *InternalREST, error) {
+func NewREST(optsGetter restoptions.Getter, defaultRegistry imageapi.DefaultRegistry, subjectAccessReviewRegistry subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier) (*REST, *StatusREST, *InternalREST, error) {
 	store := registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ImageStream{} },
-		NewListFunc:       func() runtime.Object { return &api.ImageStreamList{} },
+		NewFunc:           func() runtime.Object { return &imageapi.ImageStream{} },
+		NewListFunc:       func() runtime.Object { return &imageapi.ImageStreamList{} },
 		PredicateFunc:     imagestream.Matcher,
-		QualifiedResource: api.Resource("imagestreams"),
+		QualifiedResource: imageapi.Resource("imagestreams"),
 	}
 
 	rest := &REST{
@@ -75,7 +75,7 @@ type StatusREST struct {
 var _ = rest.Patcher(&StatusREST{})
 
 func (r *StatusREST) New() runtime.Object {
-	return &api.ImageStream{}
+	return &imageapi.ImageStream{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.
@@ -94,7 +94,7 @@ type InternalREST struct {
 }
 
 func (r *InternalREST) New() runtime.Object {
-	return &api.ImageStream{}
+	return &imageapi.ImageStream{}
 }
 
 // Create alters both the spec and status of the object.

--- a/pkg/image/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/registry/imagestream/etcd/etcd_test.go
@@ -15,7 +15,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/image/admission/testutil"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/util/restoptions"
 
 	// install all APIs
@@ -27,8 +27,8 @@ const (
 )
 
 var (
-	testDefaultRegistry = api.DefaultRegistryFunc(func() (string, bool) { return "test", true })
-	noDefaultRegistry   = api.DefaultRegistryFunc(func() (string, bool) { return "", false })
+	testDefaultRegistry = imageapi.DefaultRegistryFunc(func() (string, bool) { return "test", true })
+	noDefaultRegistry   = imageapi.DefaultRegistryFunc(func() (string, bool) { return "", false })
 )
 
 type fakeSubjectAccessReviewRegistry struct {
@@ -55,21 +55,21 @@ func newStorage(t *testing.T) (*REST, *StatusREST, *InternalREST, *etcdtesting.E
 	return imageStorage, statusStorage, internalStorage, server
 }
 
-func validImageStream() *api.ImageStream {
-	return &api.ImageStream{
+func validImageStream() *imageapi.ImageStream {
+	return &imageapi.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 }
 
-func create(t *testing.T, storage *REST, obj *api.ImageStream) *api.ImageStream {
+func create(t *testing.T, storage *REST, obj *imageapi.ImageStream) *imageapi.ImageStream {
 	ctx := apirequest.WithUser(apirequest.NewDefaultContext(), &fakeUser{})
 	newObj, err := storage.Create(ctx, obj)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	return newObj.(*api.ImageStream)
+	return newObj.(*imageapi.ImageStream)
 }
 
 func TestCreate(t *testing.T) {
@@ -120,7 +120,7 @@ func TestGetImageStreamOK(t *testing.T) {
 	if obj == nil {
 		t.Fatalf("Unexpected nil stream")
 	}
-	got := obj.(*api.ImageStream)
+	got := obj.(*imageapi.ImageStream)
 	got.ResourceVersion = image.ResourceVersion
 	if !kapi.Semantic.DeepEqual(image, got) {
 		t.Errorf("Expected %#v, got %#v", image, got)

--- a/pkg/image/registry/imagestream/registry.go
+++ b/pkg/image/registry/imagestream/registry.go
@@ -9,23 +9,23 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // Registry is an interface for things that know how to store ImageStream objects.
 type Registry interface {
 	// ListImageStreams obtains a list of image streams that match a selector.
-	ListImageStreams(ctx apirequest.Context, options *metainternal.ListOptions) (*api.ImageStreamList, error)
+	ListImageStreams(ctx apirequest.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error)
 	// GetImageStream retrieves a specific image stream.
-	GetImageStream(ctx apirequest.Context, id string, options *metav1.GetOptions) (*api.ImageStream, error)
+	GetImageStream(ctx apirequest.Context, id string, options *metav1.GetOptions) (*imageapi.ImageStream, error)
 	// CreateImageStream creates a new image stream.
-	CreateImageStream(ctx apirequest.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	CreateImageStream(ctx apirequest.Context, repo *imageapi.ImageStream) (*imageapi.ImageStream, error)
 	// UpdateImageStream updates an image stream.
-	UpdateImageStream(ctx apirequest.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	UpdateImageStream(ctx apirequest.Context, repo *imageapi.ImageStream) (*imageapi.ImageStream, error)
 	// UpdateImageStreamSpec updates an image stream's spec.
-	UpdateImageStreamSpec(ctx apirequest.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	UpdateImageStreamSpec(ctx apirequest.Context, repo *imageapi.ImageStream) (*imageapi.ImageStream, error)
 	// UpdateImageStreamStatus updates an image stream's status.
-	UpdateImageStreamStatus(ctx apirequest.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	UpdateImageStreamStatus(ctx apirequest.Context, repo *imageapi.ImageStream) (*imageapi.ImageStream, error)
 	// DeleteImageStream deletes an image stream.
 	DeleteImageStream(ctx apirequest.Context, id string) (*metav1.Status, error)
 	// WatchImageStreams watches for new/changed/deleted image streams.
@@ -56,52 +56,52 @@ func NewRegistry(s Storage, status, internal rest.Updater) Registry {
 	return &storage{Storage: s, status: status, internal: internal}
 }
 
-func (s *storage) ListImageStreams(ctx apirequest.Context, options *metainternal.ListOptions) (*api.ImageStreamList, error) {
+func (s *storage) ListImageStreams(ctx apirequest.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStreamList), nil
+	return obj.(*imageapi.ImageStreamList), nil
 }
 
-func (s *storage) GetImageStream(ctx apirequest.Context, imageStreamID string, options *metav1.GetOptions) (*api.ImageStream, error) {
+func (s *storage) GetImageStream(ctx apirequest.Context, imageStreamID string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
 	obj, err := s.Get(ctx, imageStreamID, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStream), nil
+	return obj.(*imageapi.ImageStream), nil
 }
 
-func (s *storage) CreateImageStream(ctx apirequest.Context, imageStream *api.ImageStream) (*api.ImageStream, error) {
+func (s *storage) CreateImageStream(ctx apirequest.Context, imageStream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
 	obj, err := s.Create(ctx, imageStream)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStream), nil
+	return obj.(*imageapi.ImageStream), nil
 }
 
-func (s *storage) UpdateImageStream(ctx apirequest.Context, imageStream *api.ImageStream) (*api.ImageStream, error) {
+func (s *storage) UpdateImageStream(ctx apirequest.Context, imageStream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
 	obj, _, err := s.internal.Update(ctx, imageStream.Name, rest.DefaultUpdatedObjectInfo(imageStream, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStream), nil
+	return obj.(*imageapi.ImageStream), nil
 }
 
-func (s *storage) UpdateImageStreamSpec(ctx apirequest.Context, imageStream *api.ImageStream) (*api.ImageStream, error) {
+func (s *storage) UpdateImageStreamSpec(ctx apirequest.Context, imageStream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
 	obj, _, err := s.Update(ctx, imageStream.Name, rest.DefaultUpdatedObjectInfo(imageStream, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStream), nil
+	return obj.(*imageapi.ImageStream), nil
 }
 
-func (s *storage) UpdateImageStreamStatus(ctx apirequest.Context, imageStream *api.ImageStream) (*api.ImageStream, error) {
+func (s *storage) UpdateImageStreamStatus(ctx apirequest.Context, imageStream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
 	obj, _, err := s.status.Update(ctx, imageStream.Name, rest.DefaultUpdatedObjectInfo(imageStream, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStream), nil
+	return obj.(*imageapi.ImageStream), nil
 }
 
 func (s *storage) DeleteImageStream(ctx apirequest.Context, imageStreamID string) (*metav1.Status, error) {

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -21,7 +21,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
 )
 
@@ -33,7 +33,7 @@ type ResourceGetter interface {
 type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
-	defaultRegistry   api.DefaultRegistry
+	defaultRegistry   imageapi.DefaultRegistry
 	tagVerifier       *TagVerifier
 	limitVerifier     imageadmission.LimitVerifier
 	imageStreamGetter ResourceGetter
@@ -41,7 +41,7 @@ type Strategy struct {
 
 // NewStrategy is the default logic that applies when creating and updating
 // ImageStream objects via the REST API.
-func NewStrategy(defaultRegistry api.DefaultRegistry, subjectAccessReviewClient subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier, imageStreamGetter ResourceGetter) Strategy {
+func NewStrategy(defaultRegistry imageapi.DefaultRegistry, subjectAccessReviewClient subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier, imageStreamGetter ResourceGetter) Strategy {
 	return Strategy{
 		ObjectTyper:       kapi.Scheme,
 		NameGenerator:     names.SimpleNameGenerator,
@@ -59,10 +59,10 @@ func (s Strategy) NamespaceScoped() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (s Strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	stream := obj.(*api.ImageStream)
-	stream.Status = api.ImageStreamStatus{
+	stream := obj.(*imageapi.ImageStream)
+	stream.Status = imageapi.ImageStreamStatus{
 		DockerImageRepository: s.dockerImageRepository(stream),
-		Tags: make(map[string]api.TagEventList),
+		Tags: make(map[string]imageapi.TagEventList),
 	}
 	stream.Generation = 1
 	for tag, ref := range stream.Spec.Tags {
@@ -74,7 +74,7 @@ func (s Strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 // Validate validates a new image stream and verifies the current user is
 // authorized to access any image streams newly referenced in spec.tags.
 func (s Strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	stream := obj.(*api.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
 	var errs field.ErrorList
 	if err := s.validateTagsAndLimits(ctx, nil, stream); err != nil {
 		errs = append(errs, field.InternalError(field.NewPath(""), err))
@@ -83,7 +83,7 @@ func (s Strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.Err
 	return errs
 }
 
-func (s Strategy) validateTagsAndLimits(ctx apirequest.Context, oldStream, newStream *api.ImageStream) error {
+func (s Strategy) validateTagsAndLimits(ctx apirequest.Context, oldStream, newStream *imageapi.ImageStream) error {
 	user, ok := apirequest.UserFrom(ctx)
 	if !ok {
 		return kerrors.NewForbidden(schema.GroupResource{Resource: "imagestreams"}, newStream.Name, fmt.Errorf("no user context available"))
@@ -115,7 +115,7 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 // If stream.DockerImageRepository is set, that value is returned. Otherwise,
 // if a default registry exists, the value returned is of the form
 // <default registry>/<namespace>/<stream name>.
-func (s Strategy) dockerImageRepository(stream *api.ImageStream) string {
+func (s Strategy) dockerImageRepository(stream *imageapi.ImageStream) string {
 	registry, ok := s.defaultRegistry.DefaultRegistry()
 	if !ok {
 		return stream.Spec.DockerImageRepository
@@ -124,7 +124,7 @@ func (s Strategy) dockerImageRepository(stream *api.ImageStream) string {
 	if len(stream.Namespace) == 0 {
 		stream.Namespace = metav1.NamespaceDefault
 	}
-	ref := api.DockerImageReference{
+	ref := imageapi.DockerImageReference{
 		Registry:  registry,
 		Namespace: stream.Namespace,
 		Name:      stream.Name,
@@ -132,7 +132,7 @@ func (s Strategy) dockerImageRepository(stream *api.ImageStream) string {
 	return ref.String()
 }
 
-func parseFromReference(stream *api.ImageStream, from *kapi.ObjectReference) (string, string, error) {
+func parseFromReference(stream *imageapi.ImageStream, from *kapi.ObjectReference) (string, string, error) {
 	splitChar := ""
 	refType := ""
 
@@ -162,12 +162,12 @@ func parseFromReference(stream *api.ImageStream, from *kapi.ObjectReference) (st
 
 // tagsChanged updates stream.Status.Tags based on the old and new image stream.
 // if the old stream is nil, all tags are considered additions.
-func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
+func (s Strategy) tagsChanged(old, stream *imageapi.ImageStream) field.ErrorList {
 	internalRegistry, hasInternalRegistry := s.defaultRegistry.DefaultRegistry()
 
 	var errs field.ErrorList
 
-	oldTags := map[string]api.TagReference{}
+	oldTags := map[string]imageapi.TagReference{}
 	if old != nil && old.Spec.Tags != nil {
 		oldTags = old.Spec.Tags
 	}
@@ -195,7 +195,7 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
 					continue
 				}
 				stream.Spec.Tags[tag] = tagRef
-				api.AddTagEventToImageStream(stream, tag, *event)
+				imageapi.AddTagEventToImageStream(stream, tag, *event)
 			}
 			continue
 		}
@@ -222,7 +222,7 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
 				continue
 			}
 
-			streamRef = obj.(*api.ImageStream)
+			streamRef = obj.(*imageapi.ImageStream)
 		}
 
 		event, err := tagReferenceToTagEvent(streamRef, tagRef, tagOrID)
@@ -238,7 +238,7 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
 		// if this is not a reference tag, and the tag points to the internal registry for the other namespace, alter it to
 		// point to this stream so that pulls happen from this stream in the future.
 		if !tagRef.Reference {
-			if ref, err := api.ParseDockerImageReference(event.DockerImageReference); err == nil {
+			if ref, err := imageapi.ParseDockerImageReference(event.DockerImageReference); err == nil {
 				if hasInternalRegistry && ref.Registry == internalRegistry && ref.Namespace == streamRef.Namespace && ref.Name == streamRef.Name {
 					ref.Namespace = stream.Namespace
 					ref.Name = stream.Name
@@ -248,10 +248,10 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
 		}
 
 		stream.Spec.Tags[tag] = tagRef
-		api.AddTagEventToImageStream(stream, tag, *event)
+		imageapi.AddTagEventToImageStream(stream, tag, *event)
 	}
 
-	api.UpdateChangedTrackingTags(stream, old)
+	imageapi.UpdateChangedTrackingTags(stream, old)
 
 	// use a consistent timestamp on creation
 	if old == nil && !stream.CreationTimestamp.IsZero() {
@@ -266,22 +266,22 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) field.ErrorList {
 	return errs
 }
 
-func tagReferenceToTagEvent(stream *api.ImageStream, tagRef api.TagReference, tagOrID string) (*api.TagEvent, error) {
+func tagReferenceToTagEvent(stream *imageapi.ImageStream, tagRef imageapi.TagReference, tagOrID string) (*imageapi.TagEvent, error) {
 	var (
-		event *api.TagEvent
+		event *imageapi.TagEvent
 		err   error
 	)
 	switch tagRef.From.Kind {
 	case "DockerImage":
-		event = &api.TagEvent{
+		event = &imageapi.TagEvent{
 			Created:              metav1.Now(),
 			DockerImageReference: tagRef.From.Name,
 		}
 
 	case "ImageStreamImage":
-		event, err = api.ResolveImageID(stream, tagOrID)
+		event, err = imageapi.ResolveImageID(stream, tagOrID)
 	case "ImageStreamTag":
-		event, err = api.LatestTaggedImage(stream, tagOrID), nil
+		event, err = imageapi.LatestTaggedImage(stream, tagOrID), nil
 	default:
 		err = fmt.Errorf("invalid from.kind %q: it must be DockerImage, ImageStreamImage or ImageStreamTag", tagRef.From.Kind)
 	}
@@ -295,7 +295,7 @@ func tagReferenceToTagEvent(stream *api.ImageStream, tagRef api.TagReference, ta
 }
 
 // tagRefChanged returns true if the tag ref changed between two spec updates.
-func tagRefChanged(old, next api.TagReference, streamNamespace string) bool {
+func tagRefChanged(old, next imageapi.TagReference, streamNamespace string) bool {
 	if next.From == nil {
 		// both fields in next are empty
 		return false
@@ -327,7 +327,7 @@ func tagRefChanged(old, next api.TagReference, streamNamespace string) bool {
 
 // tagRefGenerationChanged returns true if and only the values were set and the new generation
 // is at zero.
-func tagRefGenerationChanged(old, next api.TagReference) bool {
+func tagRefGenerationChanged(old, next imageapi.TagReference) bool {
 	switch {
 	case old.Generation != nil && next.Generation != nil:
 		if *old.Generation == *next.Generation {
@@ -342,13 +342,13 @@ func tagRefGenerationChanged(old, next api.TagReference) bool {
 	}
 }
 
-func tagEventChanged(old, next api.TagEvent) bool {
+func tagEventChanged(old, next imageapi.TagEvent) bool {
 	return old.Image != next.Image || old.DockerImageReference != next.DockerImageReference || old.Generation > next.Generation
 }
 
 // updateSpecTagGenerationsForUpdate ensures that new spec updates always have a generation set, and that the value
 // cannot be updated by an end user (except by setting generation 0).
-func updateSpecTagGenerationsForUpdate(stream, oldStream *api.ImageStream) {
+func updateSpecTagGenerationsForUpdate(stream, oldStream *imageapi.ImageStream) {
 	for tag, ref := range stream.Spec.Tags {
 		if ref.Generation != nil && *ref.Generation == 0 {
 			continue
@@ -362,8 +362,8 @@ func updateSpecTagGenerationsForUpdate(stream, oldStream *api.ImageStream) {
 
 // ensureSpecTagGenerationsAreSet ensures that all spec tags have a generation set to either 0 or the
 // current stream value.
-func ensureSpecTagGenerationsAreSet(stream, oldStream *api.ImageStream) {
-	oldTags := map[string]api.TagReference{}
+func ensureSpecTagGenerationsAreSet(stream, oldStream *imageapi.ImageStream) {
+	oldTags := map[string]imageapi.TagReference{}
 	if oldStream != nil && oldStream.Spec.Tags != nil {
 		oldTags = oldStream.Spec.Tags
 	}
@@ -383,7 +383,7 @@ func ensureSpecTagGenerationsAreSet(stream, oldStream *api.ImageStream) {
 }
 
 // updateObservedGenerationForStatusUpdate ensures every status item has a generation set.
-func updateObservedGenerationForStatusUpdate(stream, oldStream *api.ImageStream) {
+func updateObservedGenerationForStatusUpdate(stream, oldStream *imageapi.ImageStream) {
 	for tag, newer := range stream.Status.Tags {
 		if len(newer.Items) == 0 || newer.Items[0].Generation != 0 {
 			// generation is set, continue
@@ -416,9 +416,9 @@ type TagVerifier struct {
 	subjectAccessReviewClient subjectaccessreview.Registry
 }
 
-func (v *TagVerifier) Verify(old, stream *api.ImageStream, user user.Info) field.ErrorList {
+func (v *TagVerifier) Verify(old, stream *imageapi.ImageStream, user user.Info) field.ErrorList {
 	var errors field.ErrorList
-	oldTags := map[string]api.TagReference{}
+	oldTags := map[string]imageapi.TagReference{}
 	if old != nil && old.Spec.Tags != nil {
 		oldTags = old.Spec.Tags
 	}
@@ -447,7 +447,7 @@ func (v *TagVerifier) Verify(old, stream *api.ImageStream, user user.Info) field
 		subjectAccessReview := authorizationapi.AddUserToSAR(user, &authorizationapi.SubjectAccessReview{
 			Action: authorizationapi.Action{
 				Verb:         "get",
-				Group:        api.LegacyGroupName,
+				Group:        imageapi.LegacyGroupName,
 				Resource:     "imagestreams/layers",
 				ResourceName: streamName,
 			},
@@ -475,8 +475,8 @@ func (Strategy) Canonicalize(obj runtime.Object) {
 }
 
 func (s Strategy) prepareForUpdate(obj, old runtime.Object, resetStatus bool) {
-	oldStream := old.(*api.ImageStream)
-	stream := obj.(*api.ImageStream)
+	oldStream := old.(*imageapi.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
 
 	stream.Generation = oldStream.Generation
 	if resetStatus {
@@ -505,8 +505,8 @@ func (s Strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Obje
 
 // ValidateUpdate is the default update validation for an end user.
 func (s Strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	stream := obj.(*api.ImageStream)
-	oldStream := old.(*api.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
+	oldStream := old.(*imageapi.ImageStream)
 	var errs field.ErrorList
 	if err := s.validateTagsAndLimits(ctx, oldStream, stream); err != nil {
 		errs = append(errs, field.InternalError(field.NewPath(""), err))
@@ -519,9 +519,9 @@ func (s Strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object
 // dockerImageRepository().
 func (s Strategy) Decorate(obj runtime.Object) error {
 	switch t := obj.(type) {
-	case *api.ImageStream:
+	case *imageapi.ImageStream:
 		t.Status.DockerImageRepository = s.dockerImageRepository(t)
-	case *api.ImageStreamList:
+	case *imageapi.ImageStreamList:
 		for i := range t.Items {
 			is := &t.Items[i]
 			is.Status.DockerImageRepository = s.dockerImageRepository(is)
@@ -547,8 +547,8 @@ func (StatusStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (StatusStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	oldStream := old.(*api.ImageStream)
-	stream := obj.(*api.ImageStream)
+	oldStream := old.(*imageapi.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
 
 	stream.Spec.Tags = oldStream.Spec.Tags
 	stream.Spec.DockerImageRepository = oldStream.Spec.DockerImageRepository
@@ -557,7 +557,7 @@ func (StatusStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.
 }
 
 func (s StatusStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	newIS := obj.(*api.ImageStream)
+	newIS := obj.(*imageapi.ImageStream)
 	errs := field.ErrorList{}
 
 	ns, ok := apirequest.NamespaceFrom(ctx)
@@ -570,13 +570,13 @@ func (s StatusStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.
 	}
 
 	// TODO: merge valid fields after update
-	errs = append(errs, validation.ValidateImageStreamStatusUpdate(newIS, old.(*api.ImageStream))...)
+	errs = append(errs, validation.ValidateImageStreamStatusUpdate(newIS, old.(*imageapi.ImageStream))...)
 	return errs
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.ImageStream)
+	obj, ok := o.(*imageapi.ImageStream)
 	if !ok {
 		return nil, nil, fmt.Errorf("not an ImageStream")
 	}
@@ -593,8 +593,8 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.ImageStream) fields.Set {
-	return api.ImageStreamToSelectableFields(obj)
+func SelectableFields(obj *imageapi.ImageStream) fields.Set {
+	return imageapi.ImageStreamToSelectableFields(obj)
 }
 
 // InternalStrategy implements behavior for updating both the spec and status
@@ -614,7 +614,7 @@ func (InternalStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (s InternalStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	stream := obj.(*api.ImageStream)
+	stream := obj.(*imageapi.ImageStream)
 
 	stream.Status.DockerImageRepository = s.dockerImageRepository(stream)
 	stream.Generation = 1

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/image/admission"
 	"github.com/openshift/origin/pkg/image/admission/testutil"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type fakeUser struct {
@@ -75,28 +75,28 @@ func (f *fakeSubjectAccessReviewRegistry) CreateSubjectAccessReview(ctx apireque
 
 func TestDockerImageRepository(t *testing.T) {
 	tests := map[string]struct {
-		stream          *api.ImageStream
+		stream          *imageapi.ImageStream
 		expected        string
 		defaultRegistry string
 	}{
 		"DockerImageRepository set on stream": {
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somerepo",
 				},
-				Spec: api.ImageStreamSpec{
+				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "a/b",
 				},
 			},
 			expected: "a/b",
 		},
 		"DockerImageRepository set on stream with default registry": {
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "somerepo",
 				},
-				Spec: api.ImageStreamSpec{
+				Spec: imageapi.ImageStreamSpec{
 					DockerImageRepository: "a/b",
 				},
 			},
@@ -104,7 +104,7 @@ func TestDockerImageRepository(t *testing.T) {
 			expected:        "registry:5000/foo/somerepo",
 		},
 		"default namespace": {
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somerepo",
 				},
@@ -113,7 +113,7 @@ func TestDockerImageRepository(t *testing.T) {
 			expected:        "registry:5000/default/somerepo",
 		},
 		"nondefault namespace": {
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "somerepo",
 					Namespace: "somens",
@@ -123,7 +123,7 @@ func TestDockerImageRepository(t *testing.T) {
 			expected:        "registry:5000/somens/somerepo",
 		},
 		"missing default registry": {
-			stream: &api.ImageStream{
+			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "somerepo",
 					Namespace: "somens",
@@ -145,8 +145,8 @@ func TestDockerImageRepository(t *testing.T) {
 
 func TestTagVerifier(t *testing.T) {
 	tests := map[string]struct {
-		oldTags    map[string]api.TagReference
-		newTags    map[string]api.TagReference
+		oldTags    map[string]imageapi.TagReference
+		newTags    map[string]imageapi.TagReference
 		sarError   error
 		sarAllowed bool
 		expectSar  bool
@@ -154,8 +154,8 @@ func TestTagVerifier(t *testing.T) {
 	}{
 		"old nil, no tags": {},
 		"old nil, all tags are new": {
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -167,8 +167,8 @@ func TestTagVerifier(t *testing.T) {
 			sarAllowed: true,
 		},
 		"nil from": {
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "registry/old/stream:latest",
@@ -178,7 +178,7 @@ func TestTagVerifier(t *testing.T) {
 			expectSar: false,
 		},
 		"same namespace": {
-			newTags: map[string]api.TagReference{
+			newTags: map[string]imageapi.TagReference{
 				"other": {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
@@ -189,8 +189,8 @@ func TestTagVerifier(t *testing.T) {
 			},
 		},
 		"ref unchanged": {
-			oldTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			oldTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -198,8 +198,8 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -210,8 +210,8 @@ func TestTagVerifier(t *testing.T) {
 			expectSar: false,
 		},
 		"invalid from name": {
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -224,8 +224,8 @@ func TestTagVerifier(t *testing.T) {
 			},
 		},
 		"sar error": {
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -240,8 +240,8 @@ func TestTagVerifier(t *testing.T) {
 			},
 		},
 		"sar denied": {
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -256,8 +256,8 @@ func TestTagVerifier(t *testing.T) {
 			},
 		},
 		"ref changed": {
-			oldTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			oldTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -265,8 +265,8 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			newTags: map[string]api.TagReference{
-				api.DefaultImageTag: {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
@@ -285,18 +285,18 @@ func TestTagVerifier(t *testing.T) {
 			allow: test.sarAllowed,
 		}
 
-		old := &api.ImageStream{
-			Spec: api.ImageStreamSpec{
+		old := &imageapi.ImageStream{
+			Spec: imageapi.ImageStreamSpec{
 				Tags: test.oldTags,
 			},
 		}
 
-		stream := &api.ImageStream{
+		stream := &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "namespace",
 				Name:      "stream",
 			},
-			Spec: api.ImageStreamSpec{
+			Spec: imageapi.ImageStreamSpec{
 				Tags: test.newTags,
 			},
 		}
@@ -348,14 +348,14 @@ func TestLimitVerifier(t *testing.T) {
 
 		err := fmt.Errorf("exceeded %s", strings.Join(exceededStrings, ","))
 
-		return kapierrors.NewForbidden(api.Resource("ImageStream"), isName, err)
+		return kapierrors.NewForbidden(imageapi.Resource("ImageStream"), isName, err)
 	}
 
-	makeISEvaluator := func(maxImages, maxImageTags int64) func(string, *api.ImageStream) error {
-		return func(ns string, is *api.ImageStream) error {
+	makeISEvaluator := func(maxImages, maxImageTags int64) func(string, *imageapi.ImageStream) error {
+		return func(ns string, is *imageapi.ImageStream) error {
 			limit := kapi.ResourceList{
-				api.ResourceImageStreamImages: *resource.NewQuantity(maxImages, resource.DecimalSI),
-				api.ResourceImageStreamTags:   *resource.NewQuantity(maxImageTags, resource.DecimalSI),
+				imageapi.ResourceImageStreamImages: *resource.NewQuantity(maxImages, resource.DecimalSI),
+				imageapi.ResourceImageStreamTags:   *resource.NewQuantity(maxImageTags, resource.DecimalSI),
 			}
 			usage := admission.GetImageStreamUsage(is)
 			if less, exceeded := kquota.LessThanOrEqual(usage, limit); !less {
@@ -367,21 +367,21 @@ func TestLimitVerifier(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		isEvaluator func(string, *api.ImageStream) error
-		is          api.ImageStream
+		isEvaluator func(string, *imageapi.ImageStream) error
+		is          imageapi.ImageStream
 		expected    field.ErrorList
 	}{
 		{
 			name: "no limit",
-			is: api.ImageStream{
+			is: imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "is",
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: testutil.MakeDockerImageReference("test", "is", testutil.BaseImageWith1LayerDigest),
 									Image:                testutil.BaseImageWith1LayerDigest,
@@ -395,15 +395,15 @@ func TestLimitVerifier(t *testing.T) {
 
 		{
 			name: "below limit",
-			is: api.ImageStream{
+			is: imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "is",
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: testutil.MakeDockerImageReference("test", "is", testutil.BaseImageWith1LayerDigest),
 									Image:                testutil.BaseImageWith1LayerDigest,
@@ -418,15 +418,15 @@ func TestLimitVerifier(t *testing.T) {
 
 		{
 			name: "exceed images",
-			is: api.ImageStream{
+			is: imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "is",
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: testutil.MakeDockerImageReference("test", "is", testutil.BaseImageWith1LayerDigest),
 									Image:                testutil.BaseImageWith1LayerDigest,
@@ -434,7 +434,7 @@ func TestLimitVerifier(t *testing.T) {
 							},
 						},
 						"oldest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: testutil.MakeDockerImageReference("test", "is", testutil.BaseImageWith2LayersDigest),
 									Image:                testutil.BaseImageWith2LayersDigest,
@@ -445,60 +445,60 @@ func TestLimitVerifier(t *testing.T) {
 				},
 			},
 			isEvaluator: makeISEvaluator(1, 0),
-			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{api.ResourceImageStreamImages}))},
+			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{imageapi.ResourceImageStreamImages}))},
 		},
 
 		{
 			name: "exceed tags",
-			is: api.ImageStream{
+			is: imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "is",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"new": {
 							Name: "new",
 							From: &kapi.ObjectReference{
 								Kind: "DockerImage",
 								Name: testutil.MakeDockerImageReference("test", "is", testutil.ChildImageWith2LayersDigest),
 							},
-							ReferencePolicy: api.TagReferencePolicy{
-								Type: api.SourceTagReferencePolicy,
+							ReferencePolicy: imageapi.TagReferencePolicy{
+								Type: imageapi.SourceTagReferencePolicy,
 							},
 						},
 					},
 				},
 			},
 			isEvaluator: makeISEvaluator(0, 0),
-			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{api.ResourceImageStreamTags}))},
+			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{imageapi.ResourceImageStreamTags}))},
 		},
 
 		{
 			name: "exceed images and tags",
-			is: api.ImageStream{
+			is: imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "is",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"new": {
 							Name: "new",
 							From: &kapi.ObjectReference{
 								Kind: "DockerImage",
 								Name: testutil.MakeDockerImageReference("test", "other", testutil.BaseImageWith1LayerDigest),
 							},
-							ReferencePolicy: api.TagReferencePolicy{
-								Type: api.SourceTagReferencePolicy,
+							ReferencePolicy: imageapi.TagReferencePolicy{
+								Type: imageapi.SourceTagReferencePolicy,
 							},
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: testutil.MakeDockerImageReference("test", "other", testutil.BaseImageWith1LayerDigest),
 									Image:                testutil.BaseImageWith1LayerDigest,
@@ -509,7 +509,7 @@ func TestLimitVerifier(t *testing.T) {
 				},
 			},
 			isEvaluator: makeISEvaluator(0, 0),
-			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{api.ResourceImageStreamImages, api.ResourceImageStreamTags}))},
+			expected:    field.ErrorList{field.InternalError(field.NewPath(""), makeISForbiddenError("is", []kapi.ResourceName{imageapi.ResourceImageStreamImages, imageapi.ResourceImageStreamTags}))},
 		},
 	}
 
@@ -535,7 +535,7 @@ func TestLimitVerifier(t *testing.T) {
 
 		// Update must fail the exact same way
 		tc.is.ResourceVersion = "1"
-		old := &api.ImageStream{
+		old := &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:       "test",
 				Name:            "is",
@@ -550,7 +550,7 @@ func TestLimitVerifier(t *testing.T) {
 }
 
 type fakeImageStreamGetter struct {
-	stream *api.ImageStream
+	stream *imageapi.ImageStream
 }
 
 func (f *fakeImageStreamGetter) Get(ctx apirequest.Context, name string, opts *metav1.GetOptions) (runtime.Object, error) {
@@ -559,23 +559,23 @@ func (f *fakeImageStreamGetter) Get(ctx apirequest.Context, name string, opts *m
 
 func TestTagsChanged(t *testing.T) {
 	tests := map[string]struct {
-		tags               map[string]api.TagReference
-		previous           map[string]api.TagReference
-		existingTagHistory map[string]api.TagEventList
-		expectedTagHistory map[string]api.TagEventList
+		tags               map[string]imageapi.TagReference
+		previous           map[string]imageapi.TagReference
+		existingTagHistory map[string]imageapi.TagEventList
+		expectedTagHistory map[string]imageapi.TagEventList
 		stream             string
-		otherStream        *api.ImageStream
+		otherStream        *imageapi.ImageStream
 	}{
 		"no tags, no history": {
 			stream:             "registry:5000/ns/stream",
-			tags:               make(map[string]api.TagReference),
-			existingTagHistory: make(map[string]api.TagEventList),
-			expectedTagHistory: make(map[string]api.TagEventList),
+			tags:               make(map[string]imageapi.TagReference),
+			existingTagHistory: make(map[string]imageapi.TagEventList),
+			expectedTagHistory: make(map[string]imageapi.TagEventList),
 		},
 		"single tag update, preserves history": {
 			stream:   "registry:5000/ns/stream",
-			previous: map[string]api.TagReference{},
-			tags: map[string]api.TagReference{
+			previous: map[string]imageapi.TagReference{},
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -584,22 +584,22 @@ func TestTagsChanged(t *testing.T) {
 					Reference: true,
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
-				"t2": {Items: []api.TagEvent{
+			existingTagHistory: map[string]imageapi.TagEventList{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 				}},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			expectedTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:t1",
 						Image:                "",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -609,13 +609,13 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"empty tag ignored on create": {
 			stream:             "registry:5000/ns/stream",
-			tags:               map[string]api.TagReference{"t1": {}},
-			existingTagHistory: make(map[string]api.TagEventList),
-			expectedTagHistory: map[string]api.TagEventList{},
+			tags:               map[string]imageapi.TagReference{"t1": {}},
+			existingTagHistory: make(map[string]imageapi.TagEventList),
+			expectedTagHistory: map[string]imageapi.TagEventList{},
 		},
 		"tag to missing ignored on create": {
 			stream: "registry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -623,12 +623,12 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: make(map[string]api.TagEventList),
-			expectedTagHistory: map[string]api.TagEventList{},
+			existingTagHistory: make(map[string]imageapi.TagEventList),
+			expectedTagHistory: map[string]imageapi.TagEventList{},
 		},
 		"new tags, no history": {
 			stream: "registry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -644,15 +644,15 @@ func TestTagsChanged(t *testing.T) {
 					Reference: true,
 				},
 			},
-			existingTagHistory: make(map[string]api.TagEventList),
-			expectedTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			existingTagHistory: make(map[string]imageapi.TagEventList),
+			expectedTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:t1",
 						Image:                "",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
@@ -661,7 +661,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"no-op": {
 			stream: "registry:5000/ns/stream",
-			previous: map[string]api.TagReference{
+			previous: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -675,7 +675,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -689,28 +689,28 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			existingTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:v1image1",
 						Image:                "v1image1",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 				}},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			expectedTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:v1image1",
 						Image:                "v1image1",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -720,7 +720,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"new tag copies existing history": {
 			stream: "registry:5000/ns/stream",
-			previous: map[string]api.TagReference{
+			previous: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -734,7 +734,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
@@ -757,33 +757,33 @@ func TestTagsChanged(t *testing.T) {
 					Reference: true,
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			existingTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:v1image1",
 						Image:                "v1image1",
 					},
 				}},
-				"t3": {Items: []api.TagEvent{
+				"t3": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 				}},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
-				"t1": {Items: []api.TagEvent{
+			expectedTagHistory: map[string]imageapi.TagEventList{
+				"t1": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:v1image1",
 					},
 				}},
 				// tag copies existing history
-				"t2": {Items: []api.TagEvent{
+				"t2": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream:v1image1",
 					},
 				}},
-				"t3": {Items: []api.TagEvent{
+				"t3": {Items: []imageapi.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -793,7 +793,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"object reference to image stream tag in same stream": {
 			stream: "registry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamTag",
@@ -801,9 +801,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
+			existingTagHistory: map[string]imageapi.TagEventList{
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -811,9 +811,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
+			expectedTagHistory: map[string]imageapi.TagEventList{
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -821,7 +821,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -832,7 +832,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"tag changes and referenced tag should react": {
 			stream: "registry:5000/ns/stream",
-			previous: map[string]api.TagReference{
+			previous: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamTag",
@@ -846,7 +846,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamImage",
@@ -860,9 +860,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
+			existingTagHistory: map[string]imageapi.TagEventList{
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
 							Image:                "sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
@@ -874,7 +874,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
 							Image:                "sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
@@ -882,7 +882,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"t2": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
 							Image:                "sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
@@ -890,9 +890,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
+			expectedTagHistory: map[string]imageapi.TagEventList{
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
 							Image:                "sha256:293aa25bf219f3e47472281b7e68c09bb6f315c2adf7f86a7302b85bdaa63db3",
@@ -904,7 +904,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -916,7 +916,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"t2": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -931,7 +931,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"object reference to image stream image in same stream": {
 			stream: "internalregistry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamImage",
@@ -939,9 +939,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
+			existingTagHistory: map[string]imageapi.TagEventList{
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -949,9 +949,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
+			expectedTagHistory: map[string]imageapi.TagEventList{
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -959,7 +959,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -970,7 +970,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"object reference to image stream image in same stream (bad digest)": {
 			stream: "internalregistry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamImage",
@@ -978,9 +978,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{
+			existingTagHistory: map[string]imageapi.TagEventList{
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream:12345",
 							Image:                "12345",
@@ -988,9 +988,9 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			expectedTagHistory: map[string]api.TagEventList{
+			expectedTagHistory: map[string]imageapi.TagEventList{
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream:12345",
 							Image:                "12345",
@@ -998,7 +998,7 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 				"other": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream:12345",
 							Image:                "12345",
@@ -1009,7 +1009,7 @@ func TestTagsChanged(t *testing.T) {
 		},
 		"object reference to image stream tag in different stream": {
 			stream: "registry:5000/ns/stream",
-			tags: map[string]api.TagReference{
+			tags: map[string]imageapi.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
 						Kind: "ImageStreamTag",
@@ -1017,10 +1017,10 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			existingTagHistory: map[string]api.TagEventList{},
-			expectedTagHistory: map[string]api.TagEventList{
+			existingTagHistory: map[string]imageapi.TagEventList{},
+			expectedTagHistory: map[string]imageapi.TagEventList{
 				"t1": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -1028,11 +1028,11 @@ func TestTagsChanged(t *testing.T) {
 					},
 				},
 			},
-			otherStream: &api.ImageStream{
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+			otherStream: &imageapi.ImageStream{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"other": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 									Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -1046,14 +1046,14 @@ func TestTagsChanged(t *testing.T) {
 	}
 
 	for testName, test := range tests {
-		stream := &api.ImageStream{
+		stream := &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "stream",
 			},
-			Spec: api.ImageStreamSpec{
+			Spec: imageapi.ImageStreamSpec{
 				Tags: test.tags,
 			},
-			Status: api.ImageStreamStatus{
+			Status: imageapi.ImageStreamStatus{
 				DockerImageRepository: test.stream,
 				Tags: test.existingTagHistory,
 			},
@@ -1062,16 +1062,16 @@ func TestTagsChanged(t *testing.T) {
 		var previousTagHistory = test.existingTagHistory
 		if previousTagHistory != nil {
 			obj, _ := kapi.Scheme.DeepCopy(previousTagHistory)
-			previousTagHistory, _ = obj.(map[string]api.TagEventList)
+			previousTagHistory, _ = obj.(map[string]imageapi.TagEventList)
 		}
-		previousStream := &api.ImageStream{
+		previousStream := &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "stream",
 			},
-			Spec: api.ImageStreamSpec{
+			Spec: imageapi.ImageStreamSpec{
 				Tags: test.previous,
 			},
-			Status: api.ImageStreamStatus{
+			Status: imageapi.ImageStreamStatus{
 				DockerImageRepository: test.stream,
 				Tags: previousTagHistory,
 			},
@@ -1120,34 +1120,34 @@ func TestTagsChanged(t *testing.T) {
 
 func TestTagRefChanged(t *testing.T) {
 	tests := map[string]struct {
-		old, next api.TagReference
+		old, next imageapi.TagReference
 		expected  bool
 	}{
 		"no ref, no from": {
-			old:      api.TagReference{},
-			next:     api.TagReference{},
+			old:      imageapi.TagReference{},
+			next:     imageapi.TagReference{},
 			expected: false,
 		},
 		"same ref": {
-			old:      api.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
-			next:     api.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
+			old:      imageapi.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
+			next:     imageapi.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
 			expected: false,
 		},
 		"different ref": {
-			old:      api.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
-			next:     api.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "bar"}},
+			old:      imageapi.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "foo"}},
+			next:     imageapi.TagReference{From: &kapi.ObjectReference{Kind: "DockerImage", Name: "bar"}},
 			expected: true,
 		},
 		"no kind, no name": {
-			old: api.TagReference{},
-			next: api.TagReference{
+			old: imageapi.TagReference{},
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{},
 			},
 			expected: false,
 		},
 		"old from nil": {
-			old: api.TagReference{},
-			next: api.TagReference{
+			old: imageapi.TagReference{},
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "another",
 					Name:      "other:latest",
@@ -1156,12 +1156,12 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different namespace - old implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "another",
 					Name:      "other:latest",
@@ -1170,13 +1170,13 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different namespace - old explicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "something",
 					Name:      "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "another",
 					Name:      "other:latest",
@@ -1185,13 +1185,13 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different namespace - next implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "something",
 					Name:      "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},
@@ -1199,12 +1199,12 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different name - old namespace implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:other",
@@ -1213,13 +1213,13 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different name - old namespace explicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:other",
@@ -1228,13 +1228,13 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"different name - new namespace implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:other",
 				},
@@ -1242,12 +1242,12 @@ func TestTagRefChanged(t *testing.T) {
 			expected: true,
 		},
 		"same name - old namespace implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:latest",
@@ -1256,13 +1256,13 @@ func TestTagRefChanged(t *testing.T) {
 			expected: false,
 		},
 		"same name - old namespace explicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Namespace: "streamnamespace",
 					Name:      "other:latest",
@@ -1271,12 +1271,12 @@ func TestTagRefChanged(t *testing.T) {
 			expected: false,
 		},
 		"same name - both namespaces implicit": {
-			old: api.TagReference{
+			old: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},
 			},
-			next: api.TagReference{
+			next: imageapi.TagReference{
 				From: &kapi.ObjectReference{
 					Name: "other:latest",
 				},

--- a/pkg/image/registry/imagestreamimage/registry.go
+++ b/pkg/image/registry/imagestreamimage/registry.go
@@ -1,7 +1,7 @@
 package imagestreamimage
 
 import (
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -9,7 +9,7 @@ import (
 
 // Registry is an interface for things that know how to store ImageStreamImage objects.
 type Registry interface {
-	GetImageStreamImage(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*api.ImageStreamImage, error)
+	GetImageStreamImage(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error)
 }
 
 // Storage is an interface for a standard REST Storage backend
@@ -28,10 +28,10 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) GetImageStreamImage(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.ImageStreamImage, error) {
+func (s *storage) GetImageStreamImage(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStreamImage), nil
+	return obj.(*imageapi.ImageStreamImage), nil
 }

--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 )
@@ -27,13 +27,13 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 
 // New is only implemented to make REST implement RESTStorage
 func (r *REST) New() runtime.Object {
-	return &api.ImageStreamImage{}
+	return &imageapi.ImageStreamImage{}
 }
 
 // parseNameAndID splits a string into its name component and ID component, and returns an error
 // if the string is not in the right form.
 func parseNameAndID(input string) (name string, id string, err error) {
-	name, id, err = api.ParseImageStreamImageName(input)
+	name, id, err = imageapi.ParseImageStreamImageName(input)
 	if err != nil {
 		err = errors.NewBadRequest("ImageStreamImages must be retrieved with <name>@<id>")
 	}
@@ -54,10 +54,10 @@ func (r *REST) Get(ctx apirequest.Context, id string, options *metav1.GetOptions
 	}
 
 	if repo.Status.Tags == nil {
-		return nil, errors.NewNotFound(api.Resource("imagestreamimage"), id)
+		return nil, errors.NewNotFound(imageapi.Resource("imagestreamimage"), id)
 	}
 
-	event, err := api.ResolveImageID(repo, imageID)
+	event, err := imageapi.ResolveImageID(repo, imageID)
 	if err != nil {
 		return nil, err
 	}
@@ -67,16 +67,16 @@ func (r *REST) Get(ctx apirequest.Context, id string, options *metav1.GetOptions
 	if err != nil {
 		return nil, err
 	}
-	if err := api.ImageWithMetadata(image); err != nil {
+	if err := imageapi.ImageWithMetadata(image); err != nil {
 		return nil, err
 	}
 	image.DockerImageManifest = ""
 	image.DockerImageConfig = ""
 
-	isi := api.ImageStreamImage{
+	isi := imageapi.ImageStreamImage{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:         apirequest.NamespaceValue(ctx),
-			Name:              api.MakeImageStreamImageName(name, imageID),
+			Name:              imageapi.MakeImageStreamImageName(name, imageID),
 			CreationTimestamp: image.ObjectMeta.CreationTimestamp,
 			Annotations:       repo.Annotations,
 		},

--- a/pkg/image/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/registry/imagestreamimage/rest_test.go
@@ -18,7 +18,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/image/admission/testutil"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
@@ -28,7 +28,7 @@ import (
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-var testDefaultRegistry = api.DefaultRegistryFunc(func() (string, bool) { return "defaultregistry:5000", true })
+var testDefaultRegistry = imageapi.DefaultRegistryFunc(func() (string, bool) { return "defaultregistry:5000", true })
 
 type fakeSubjectAccessReviewRegistry struct {
 }
@@ -63,8 +63,8 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 func TestGet(t *testing.T) {
 	tests := map[string]struct {
 		input       string
-		repo        *api.ImageStream
-		image       *api.Image
+		repo        *imageapi.ImageStream
+		image       *imageapi.Image
 		expectError bool
 	}{
 		"empty string": {
@@ -94,16 +94,16 @@ func TestGet(t *testing.T) {
 		},
 		"nil tags": {
 			input:       "repo@id",
-			repo:        &api.ImageStream{},
+			repo:        &imageapi.ImageStream{},
 			expectError: true,
 		},
 		"image not found": {
 			input: "repo@id",
-			repo: &api.ImageStream{
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+			repo: &imageapi.ImageStream{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{Image: "anotherid"},
 							},
 						},
@@ -114,15 +114,15 @@ func TestGet(t *testing.T) {
 		},
 		"happy path": {
 			input: "repo@id",
-			repo: &api.ImageStream{
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "repo",
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{Image: "anotherid"},
 								{Image: "anotherid2"},
 								{Image: "id"},
@@ -131,7 +131,7 @@ func TestGet(t *testing.T) {
 					},
 				},
 			},
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "id",
 				},
@@ -236,7 +236,7 @@ func TestGet(t *testing.T) {
 				return
 			}
 
-			imageStreamImage := obj.(*api.ImageStreamImage)
+			imageStreamImage := obj.(*imageapi.ImageStreamImage)
 			// validate a couple of the fields
 			if e, a := test.repo.Namespace, "ns"; e != a {
 				t.Errorf("%s: namespace: expected %q, got %q", name, e, a)

--- a/pkg/image/registry/imagestreamimport/rest_test.go
+++ b/pkg/image/registry/imagestreamimport/rest_test.go
@@ -8,7 +8,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type fakeImageCreater struct{}
@@ -26,20 +26,20 @@ func TestImportSuccessful(t *testing.T) {
 	two := int64(2)
 	now := metav1.Now()
 	tests := map[string]struct {
-		image    *api.Image
-		stream   *api.ImageStream
-		expected api.TagEvent
+		image    *imageapi.Image
+		stream   *imageapi.ImageStream
+		expected imageapi.TagEvent
 	}{
 		"reference differs": {
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "image",
 				},
 				DockerImageReference: "registry.com/namespace/image:mytag",
 			},
-			stream: &api.ImageStream{
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+			stream: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"mytag": {
 							Name: "mytag",
 							From: &kapi.ObjectReference{
@@ -50,10 +50,10 @@ func TestImportSuccessful(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"mytag": {
-							Items: []api.TagEvent{{
+							Items: []imageapi.TagEvent{{
 								DockerImageReference: "registry.com/namespace/image:othertag",
 								Image:                "image",
 								Generation:           one,
@@ -62,22 +62,22 @@ func TestImportSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expected: api.TagEvent{
+			expected: imageapi.TagEvent{
 				DockerImageReference: "registry.com/namespace/image:mytag",
 				Image:                "image",
 				Generation:           two,
 			},
 		},
 		"image differs": {
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "image",
 				},
 				DockerImageReference: "registry.com/namespace/image:mytag",
 			},
-			stream: &api.ImageStream{
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+			stream: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"mytag": {
 							Name: "mytag",
 							From: &kapi.ObjectReference{
@@ -88,10 +88,10 @@ func TestImportSuccessful(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"mytag": {
-							Items: []api.TagEvent{{
+							Items: []imageapi.TagEvent{{
 								DockerImageReference: "registry.com/namespace/image:othertag",
 								Image:                "non-image",
 								Generation:           one,
@@ -100,7 +100,7 @@ func TestImportSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expected: api.TagEvent{
+			expected: imageapi.TagEvent{
 				Created:              now,
 				DockerImageReference: "registry.com/namespace/image:mytag",
 				Image:                "image",
@@ -108,15 +108,15 @@ func TestImportSuccessful(t *testing.T) {
 			},
 		},
 		"empty status": {
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "image",
 				},
 				DockerImageReference: "registry.com/namespace/image:mytag",
 			},
-			stream: &api.ImageStream{
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+			stream: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"mytag": {
 							Name: "mytag",
 							From: &kapi.ObjectReference{
@@ -127,9 +127,9 @@ func TestImportSuccessful(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{},
+				Status: imageapi.ImageStreamStatus{},
 			},
-			expected: api.TagEvent{
+			expected: imageapi.TagEvent{
 				Created:              now,
 				DockerImageReference: "registry.com/namespace/image:mytag",
 				Image:                "image",
@@ -138,15 +138,15 @@ func TestImportSuccessful(t *testing.T) {
 		},
 		// https://github.com/openshift/origin/issues/10402:
 		"only generation differ": {
-			image: &api.Image{
+			image: &imageapi.Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "image",
 				},
 				DockerImageReference: "registry.com/namespace/image:mytag",
 			},
-			stream: &api.ImageStream{
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+			stream: &imageapi.ImageStream{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"mytag": {
 							Name: "mytag",
 							From: &kapi.ObjectReference{
@@ -157,10 +157,10 @@ func TestImportSuccessful(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"mytag": {
-							Items: []api.TagEvent{{
+							Items: []imageapi.TagEvent{{
 								DockerImageReference: "registry.com/namespace/image:mytag",
 								Image:                "image",
 								Generation:           one,
@@ -169,7 +169,7 @@ func TestImportSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expected: api.TagEvent{
+			expected: imageapi.TagEvent{
 				DockerImageReference: "registry.com/namespace/image:mytag",
 				Image:                "image",
 				Generation:           two,
@@ -178,16 +178,16 @@ func TestImportSuccessful(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		ref, err := api.ParseDockerImageReference(test.image.DockerImageReference)
+		ref, err := imageapi.ParseDockerImageReference(test.image.DockerImageReference)
 		if err != nil {
 			t.Errorf("%s: error parsing image ref: %v", name, err)
 			continue
 		}
 
-		importPolicy := api.TagImportPolicy{}
-		referencePolicy := api.TagReferencePolicy{Type: api.SourceTagReferencePolicy}
+		importPolicy := imageapi.TagImportPolicy{}
+		referencePolicy := imageapi.TagReferencePolicy{Type: imageapi.SourceTagReferencePolicy}
 		importedImages := make(map[string]error)
-		updatedImages := make(map[string]*api.Image)
+		updatedImages := make(map[string]*imageapi.Image)
 		storage := REST{images: fakeImageCreater{}}
 		_, ok := storage.importSuccessful(apirequest.NewDefaultContext(), test.image, test.stream,
 			ref.Tag, ref.Exact(), two, now, importPolicy, referencePolicy, importedImages, updatedImages)

--- a/pkg/image/registry/imagestreamimport/strategy.go
+++ b/pkg/image/registry/imagestreamimport/strategy.go
@@ -8,7 +8,7 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
 )
 
@@ -16,10 +16,10 @@ import (
 type strategy struct {
 	runtime.ObjectTyper
 	allowedRegistries *serverapi.AllowedRegistries
-	registryFn        api.DefaultRegistryFunc
+	registryFn        imageapi.DefaultRegistryFunc
 }
 
-func NewStrategy(registries *serverapi.AllowedRegistries, registryFn api.DefaultRegistryFunc) *strategy {
+func NewStrategy(registries *serverapi.AllowedRegistries, registryFn imageapi.DefaultRegistryFunc) *strategy {
 	return &strategy{
 		ObjectTyper:       kapi.Scheme,
 		allowedRegistries: registries,
@@ -38,7 +38,7 @@ func (s *strategy) GenerateName(string) string {
 func (s *strategy) Canonicalize(runtime.Object) {
 }
 
-func (s *strategy) ValidateAllowedRegistries(isi *api.ImageStreamImport) field.ErrorList {
+func (s *strategy) ValidateAllowedRegistries(isi *imageapi.ImageStreamImport) field.ErrorList {
 	errs := field.ErrorList{}
 	if s.allowedRegistries == nil {
 		return errs
@@ -50,7 +50,7 @@ func (s *strategy) ValidateAllowedRegistries(isi *api.ImageStreamImport) field.E
 		allowedRegistries = append([]configapi.RegistryLocation{{DomainName: localRegistry}}, allowedRegistries...)
 	}
 	validate := func(path *field.Path, name string, insecure bool) field.ErrorList {
-		ref, _ := api.ParseDockerImageReference(name)
+		ref, _ := imageapi.ParseDockerImageReference(name)
 		registryHost, registryPort := ref.RegistryHostPort(insecure)
 		return validation.ValidateRegistryAllowedForImport(path.Child("from", "name"), ref.Name, registryHost, registryPort, &allowedRegistries)
 	}
@@ -66,12 +66,12 @@ func (s *strategy) ValidateAllowedRegistries(isi *api.ImageStreamImport) field.E
 }
 
 func (s *strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	newIST := obj.(*api.ImageStreamImport)
-	newIST.Status = api.ImageStreamImportStatus{}
+	newIST := obj.(*imageapi.ImageStreamImport)
+	newIST.Status = imageapi.ImageStreamImportStatus{}
 }
 
 func (s *strategy) PrepareImageForCreate(obj runtime.Object) {
-	image := obj.(*api.Image)
+	image := obj.(*imageapi.Image)
 
 	// signatures can be added using "images" or "imagesignatures" resources
 	image.Signatures = nil
@@ -82,6 +82,6 @@ func (s *strategy) PrepareImageForCreate(obj runtime.Object) {
 }
 
 func (s *strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	isi := obj.(*api.ImageStreamImport)
+	isi := obj.(*imageapi.ImageStreamImport)
 	return validation.ValidateImageStreamImport(isi)
 }

--- a/pkg/image/registry/imagestreammapping/registry.go
+++ b/pkg/image/registry/imagestreammapping/registry.go
@@ -5,13 +5,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // Registry is an interface for things that know how to store ImageStreamMapping objects.
 type Registry interface {
 	// CreateImageStreamMapping creates a new image stream mapping.
-	CreateImageStreamMapping(ctx apirequest.Context, mapping *api.ImageStreamMapping) (*metav1.Status, error)
+	CreateImageStreamMapping(ctx apirequest.Context, mapping *imageapi.ImageStreamMapping) (*metav1.Status, error)
 }
 
 // Storage is an interface for a standard REST Storage backend
@@ -31,7 +31,7 @@ func NewRegistry(s Storage) Registry {
 }
 
 // CreateImageStreamMapping will create an image stream mapping.
-func (s *storage) CreateImageStreamMapping(ctx apirequest.Context, mapping *api.ImageStreamMapping) (*metav1.Status, error) {
+func (s *storage) CreateImageStreamMapping(ctx apirequest.Context, mapping *imageapi.ImageStreamMapping) (*metav1.Status, error) {
 	obj, err := s.Create(ctx, mapping)
 	if err != nil {
 		return nil, err

--- a/pkg/image/registry/imagestreammapping/rest.go
+++ b/pkg/image/registry/imagestreammapping/rest.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 )
@@ -32,7 +32,7 @@ type REST struct {
 }
 
 // NewREST returns a new REST.
-func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry, defaultRegistry api.DefaultRegistry) *REST {
+func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry, defaultRegistry imageapi.DefaultRegistry) *REST {
 	return &REST{
 		imageRegistry:       imageRegistry,
 		imageStreamRegistry: imageStreamRegistry,
@@ -42,7 +42,7 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 
 // New returns a new ImageStreamMapping for use with Create.
 func (r *REST) New() runtime.Object {
-	return &api.ImageStreamMapping{}
+	return &imageapi.ImageStreamMapping{}
 }
 
 // Create registers a new image (if it doesn't exist) and updates the
@@ -55,7 +55,7 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 		return nil, err
 	}
 
-	mapping := obj.(*api.ImageStreamMapping)
+	mapping := obj.(*imageapi.ImageStreamMapping)
 
 	stream, err := s.findStreamForMapping(ctx, mapping)
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 	image := mapping.Image
 	tag := mapping.Tag
 	if len(tag) == 0 {
-		tag = api.DefaultImageTag
+		tag = imageapi.DefaultImageTag
 	}
 
 	imageCreateErr := s.imageRegistry.CreateImage(ctx, &image)
@@ -75,10 +75,10 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 
 	// prefer dockerImageReference set on image for the tagEvent if the image is new
 	ref := image.DockerImageReference
-	if errors.IsAlreadyExists(imageCreateErr) && image.Annotations[api.ManagedByOpenShiftAnnotation] == "true" {
+	if errors.IsAlreadyExists(imageCreateErr) && image.Annotations[imageapi.ManagedByOpenShiftAnnotation] == "true" {
 		// the image is managed by us and, most probably, tagged in some other image stream
 		// let's make the reference local to this stream
-		if streamRef, err := api.DockerImageReferenceForStream(stream); err == nil {
+		if streamRef, err := imageapi.DockerImageReferenceForStream(stream); err == nil {
 			streamRef.ID = image.Name
 			ref = streamRef.Exact()
 		} else {
@@ -86,22 +86,22 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 		}
 	}
 
-	next := api.TagEvent{
+	next := imageapi.TagEvent{
 		Created:              metav1.Now(),
 		DockerImageReference: ref,
 		Image:                image.Name,
 	}
 
 	err = wait.ExponentialBackoff(wait.Backoff{Steps: maxRetriesOnConflict}, func() (bool, error) {
-		lastEvent := api.LatestTaggedImage(stream, tag)
+		lastEvent := imageapi.LatestTaggedImage(stream, tag)
 
 		next.Generation = stream.Generation
 
-		if !api.AddTagEventToImageStream(stream, tag, next) {
+		if !imageapi.AddTagEventToImageStream(stream, tag, next) {
 			// nothing actually changed
 			return true, nil
 		}
-		api.UpdateTrackingTags(stream, tag, next)
+		imageapi.UpdateTrackingTags(stream, tag, next)
 		_, err := s.imageStreamRegistry.UpdateImageStreamStatus(ctx, stream)
 		if err == nil {
 			return true, nil
@@ -124,7 +124,7 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 		}
 
 		// check for tag change
-		newerEvent := api.LatestTaggedImage(latestStream, tag)
+		newerEvent := imageapi.LatestTaggedImage(latestStream, tag)
 		// generation and creation time differences are ignored
 		lastEvent.Generation = newerEvent.Generation
 		lastEvent.Created = newerEvent.Created
@@ -144,7 +144,7 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 }
 
 // findStreamForMapping retrieves an ImageStream whose DockerImageRepository matches dockerRepo.
-func (s *REST) findStreamForMapping(ctx apirequest.Context, mapping *api.ImageStreamMapping) (*api.ImageStream, error) {
+func (s *REST) findStreamForMapping(ctx apirequest.Context, mapping *imageapi.ImageStreamMapping) (*imageapi.ImageStream, error) {
 	if len(mapping.Name) > 0 {
 		return s.imageStreamRegistry.GetImageStream(ctx, mapping.Name, &metav1.GetOptions{})
 	}
@@ -158,9 +158,9 @@ func (s *REST) findStreamForMapping(ctx apirequest.Context, mapping *api.ImageSt
 				return &list.Items[i], nil
 			}
 		}
-		return nil, errors.NewInvalid(api.Kind("ImageStreamMapping"), "", field.ErrorList{
+		return nil, errors.NewInvalid(imageapi.Kind("ImageStreamMapping"), "", field.ErrorList{
 			field.NotFound(field.NewPath("dockerImageStream"), mapping.DockerImageRepository),
 		})
 	}
-	return nil, errors.NewNotFound(api.Resource("imagestream"), "")
+	return nil, errors.NewNotFound(imageapi.Resource("imagestream"), "")
 }

--- a/pkg/image/registry/imagestreammapping/strategy.go
+++ b/pkg/image/registry/imagestreammapping/strategy.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
 )
 
@@ -16,12 +16,12 @@ type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 
-	defaultRegistry api.DefaultRegistry
+	defaultRegistry imageapi.DefaultRegistry
 }
 
 // Strategy is the default logic that applies when creating ImageStreamMapping
 // objects via the REST API.
-func NewStrategy(defaultRegistry api.DefaultRegistry) Strategy {
+func NewStrategy(defaultRegistry imageapi.DefaultRegistry) Strategy {
 	return Strategy{
 		kapi.Scheme,
 		names.SimpleNameGenerator,
@@ -36,11 +36,11 @@ func (s Strategy) NamespaceScoped() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (s Strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	ism := obj.(*api.ImageStreamMapping)
+	ism := obj.(*imageapi.ImageStreamMapping)
 	if len(ism.Image.DockerImageReference) == 0 {
 		internalRegistry, ok := s.defaultRegistry.DefaultRegistry()
 		if ok {
-			ism.Image.DockerImageReference = api.DockerImageReference{
+			ism.Image.DockerImageReference = imageapi.DockerImageReference{
 				Registry:  internalRegistry,
 				Namespace: ism.Namespace,
 				Name:      ism.Name,
@@ -59,6 +59,6 @@ func (s Strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new ImageStreamMapping.
 func (s Strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	mapping := obj.(*api.ImageStreamMapping)
+	mapping := obj.(*imageapi.ImageStreamMapping)
 	return validation.ValidateImageStreamMapping(mapping)
 }

--- a/pkg/image/registry/imagestreamtag/registry.go
+++ b/pkg/image/registry/imagestreamtag/registry.go
@@ -5,12 +5,12 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // Registry is an interface for things that know how to store ImageStreamTag objects.
 type Registry interface {
-	GetImageStreamTag(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*api.ImageStreamTag, error)
+	GetImageStreamTag(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error)
 	DeleteImageStreamTag(ctx apirequest.Context, nameAndTag string) (*metav1.Status, error)
 }
 
@@ -31,12 +31,12 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) GetImageStreamTag(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*api.ImageStreamTag, error) {
+func (s *storage) GetImageStreamTag(ctx apirequest.Context, nameAndTag string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
 	obj, err := s.Get(ctx, nameAndTag, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.ImageStreamTag), nil
+	return obj.(*imageapi.ImageStreamTag), nil
 }
 
 func (s *storage) DeleteImageStreamTag(ctx apirequest.Context, nameAndTag string) (*metav1.Status, error) {

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -22,7 +22,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/image/admission/testutil"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
@@ -32,7 +32,7 @@ import (
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-var testDefaultRegistry = api.DefaultRegistryFunc(func() (string, bool) { return "defaultregistry:5000", true })
+var testDefaultRegistry = imageapi.DefaultRegistryFunc(func() (string, bool) { return "defaultregistry:5000", true })
 
 type fakeSubjectAccessReviewRegistry struct {
 }
@@ -91,21 +91,21 @@ type statusError interface {
 
 func TestGetImageStreamTag(t *testing.T) {
 	tests := map[string]struct {
-		image           *api.Image
-		repo            *api.ImageStream
+		image           *imageapi.Image
+		repo            *imageapi.ImageStream
 		expectError     bool
 		errorTargetKind string
 		errorTargetID   string
 	}{
 		"happy path": {
-			image: &api.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz"},
-			repo: &api.ImageStream{
+			image: &imageapi.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz"},
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "test",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"latest": {
 							Annotations: map[string]string{
 								"color": "blue",
@@ -114,10 +114,10 @@ func TestGetImageStreamTag(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									Created:              metav1.Date(2015, 3, 24, 9, 38, 0, 0, time.UTC),
 									DockerImageReference: "test",
@@ -130,11 +130,11 @@ func TestGetImageStreamTag(t *testing.T) {
 			},
 		},
 		"image = ''": {
-			repo: &api.ImageStream{
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
-						"latest": {Items: []api.TagEvent{{DockerImageReference: "test", Image: ""}}},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"latest": {Items: []imageapi.TagEvent{{DockerImageReference: "test", Image: ""}}},
 					},
 				}},
 			expectError:     true,
@@ -142,9 +142,9 @@ func TestGetImageStreamTag(t *testing.T) {
 			errorTargetID:   "test:latest",
 		},
 		"missing image": {
-			repo: &api.ImageStream{Status: api.ImageStreamStatus{
-				Tags: map[string]api.TagEventList{
-					"latest": {Items: []api.TagEvent{{DockerImageReference: "test", Image: "10"}}},
+			repo: &imageapi.ImageStream{Status: imageapi.ImageStreamStatus{
+				Tags: map[string]imageapi.TagEventList{
+					"latest": {Items: []imageapi.TagEvent{{DockerImageReference: "test", Image: "10"}}},
 				},
 			}},
 			expectError:     true,
@@ -157,12 +157,12 @@ func TestGetImageStreamTag(t *testing.T) {
 			errorTargetID:   "test",
 		},
 		"missing tag": {
-			image: &api.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz"},
-			repo: &api.ImageStream{
+			image: &imageapi.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz"},
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
-				Status: api.ImageStreamStatus{
-					Tags: map[string]api.TagEventList{
-						"other": {Items: []api.TagEvent{{DockerImageReference: "test", Image: "10"}}},
+				Status: imageapi.ImageStreamStatus{
+					Tags: map[string]imageapi.TagEventList{
+						"other": {Items: []imageapi.TagEvent{{DockerImageReference: "test", Image: "10"}}},
 					},
 				}},
 			expectError:     true,
@@ -208,7 +208,7 @@ func TestGetImageStreamTag(t *testing.T) {
 					return
 				}
 			} else {
-				actual := obj.(*api.ImageStreamTag)
+				actual := obj.(*imageapi.ImageStreamTag)
 				if e, a := "default", actual.Namespace; e != a {
 					t.Errorf("%s: namespace: expected %v, got %v", name, e, a)
 				}
@@ -228,16 +228,16 @@ func TestGetImageStreamTag(t *testing.T) {
 
 func TestGetImageStreamTagDIR(t *testing.T) {
 	expDockerImageReference := "foo/bar/baz:latest"
-	image := &api.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz:different"}
-	repo := &api.ImageStream{
+	image := &imageapi.Image{ObjectMeta: metav1.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz:different"}
+	repo := &imageapi.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "test",
 		},
-		Status: api.ImageStreamStatus{
-			Tags: map[string]api.TagEventList{
+		Status: imageapi.ImageStreamStatus{
+			Tags: map[string]imageapi.TagEventList{
 				"latest": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							Created:              metav1.Date(2015, 3, 24, 9, 38, 0, 0, time.UTC),
 							DockerImageReference: expDockerImageReference,
@@ -265,7 +265,7 @@ func TestGetImageStreamTagDIR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	actual := obj.(*api.ImageStreamTag)
+	actual := obj.(*imageapi.ImageStreamTag)
 	if actual.Image.DockerImageReference != expDockerImageReference {
 		t.Errorf("Different DockerImageReference: expected %s, got %s", expDockerImageReference, actual.Image.DockerImageReference)
 	}
@@ -273,14 +273,14 @@ func TestGetImageStreamTagDIR(t *testing.T) {
 
 func TestDeleteImageStreamTag(t *testing.T) {
 	tests := map[string]struct {
-		repo        *api.ImageStream
+		repo        *imageapi.ImageStream
 		expectError bool
 	}{
 		"repo not found": {
 			expectError: true,
 		},
 		"nil tag map": {
-			repo: &api.ImageStream{
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "test",
@@ -289,13 +289,13 @@ func TestDeleteImageStreamTag(t *testing.T) {
 			expectError: true,
 		},
 		"missing tag": {
-			repo: &api.ImageStream{
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "test",
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"other": {
 							From: &kapi.ObjectReference{
 								Kind: "ImageStreamTag",
@@ -308,14 +308,14 @@ func TestDeleteImageStreamTag(t *testing.T) {
 			expectError: true,
 		},
 		"happy path": {
-			repo: &api.ImageStream{
+			repo: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:  "default",
 					Name:       "test",
 					Generation: 2,
 				},
-				Spec: api.ImageStreamSpec{
-					Tags: map[string]api.TagReference{
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
 						"another": {
 							From: &kapi.ObjectReference{
 								Kind: "ImageStreamTag",
@@ -330,11 +330,11 @@ func TestDeleteImageStreamTag(t *testing.T) {
 						},
 					},
 				},
-				Status: api.ImageStreamStatus{
+				Status: imageapi.ImageStreamStatus{
 					DockerImageRepository: "registry.default.local/default/test",
-					Tags: map[string]api.TagEventList{
+					Tags: map[string]imageapi.TagEventList{
 						"another": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 									Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -343,7 +343,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 							},
 						},
 						"foo": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 									Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -352,7 +352,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 							},
 						},
 						"latest": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 									Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -361,7 +361,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 							},
 						},
 						"bar": {
-							Items: []api.TagEvent{
+							Items: []imageapi.TagEvent{
 								{
 									DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 									Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -411,7 +411,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 				t.Fatalf("%s: error retrieving updated repo: %s", name, err)
 			}
 			three := int64(3)
-			expectedStreamSpec := map[string]api.TagReference{
+			expectedStreamSpec := map[string]imageapi.TagReference{
 				"another": {
 					Name: "another",
 					From: &kapi.ObjectReference{
@@ -419,14 +419,14 @@ func TestDeleteImageStreamTag(t *testing.T) {
 						Name: "test:foo",
 					},
 					Generation: &three,
-					ReferencePolicy: api.TagReferencePolicy{
-						Type: api.SourceTagReferencePolicy,
+					ReferencePolicy: imageapi.TagReferencePolicy{
+						Type: imageapi.SourceTagReferencePolicy,
 					},
 				},
 			}
-			expectedStreamStatus := map[string]api.TagEventList{
+			expectedStreamStatus := map[string]imageapi.TagEventList{
 				"another": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 							Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -435,7 +435,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 					},
 				},
 				"foo": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 							Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
@@ -444,7 +444,7 @@ func TestDeleteImageStreamTag(t *testing.T) {
 					},
 				},
 				"bar": {
-					Items: []api.TagEvent{
+					Items: []imageapi.TagEvent{
 						{
 							DockerImageReference: "registry.default.local/default/test@sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",
 							Image:                "sha256:381151ac5b7f775e8371e489f3479b84a4c004c90ceddb2ad80b6877215a892f",

--- a/pkg/image/registry/imagestreamtag/strategy.go
+++ b/pkg/image/registry/imagestreamtag/strategy.go
@@ -12,7 +12,7 @@ import (
 	kstorage "k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
 )
 
@@ -30,10 +30,10 @@ func (s *strategy) NamespaceScoped() bool {
 }
 
 func (s *strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	newIST := obj.(*api.ImageStreamTag)
+	newIST := obj.(*imageapi.ImageStreamTag)
 
 	newIST.Conditions = nil
-	newIST.Image = api.Image{}
+	newIST.Image = imageapi.Image{}
 }
 
 func (s *strategy) GenerateName(base string) string {
@@ -41,7 +41,7 @@ func (s *strategy) GenerateName(base string) string {
 }
 
 func (s *strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	istag := obj.(*api.ImageStreamTag)
+	istag := obj.(*imageapi.ImageStreamTag)
 
 	return validation.ValidateImageStreamTag(istag)
 }
@@ -59,8 +59,8 @@ func (strategy) Canonicalize(obj runtime.Object) {
 }
 
 func (s *strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newIST := obj.(*api.ImageStreamTag)
-	oldIST := old.(*api.ImageStreamTag)
+	newIST := obj.(*imageapi.ImageStreamTag)
+	oldIST := old.(*imageapi.ImageStreamTag)
 
 	// for backwards compatibility, callers can't be required to set both annotation locations when
 	// doing a GET and then update.
@@ -73,8 +73,8 @@ func (s *strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Obj
 }
 
 func (s *strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	newIST := obj.(*api.ImageStreamTag)
-	oldIST := old.(*api.ImageStreamTag)
+	newIST := obj.(*imageapi.ImageStreamTag)
+	oldIST := old.(*imageapi.ImageStreamTag)
 
 	return validation.ValidateImageStreamTagUpdate(newIST, oldIST)
 }
@@ -85,7 +85,7 @@ func MatchImageStreamTag(label labels.Selector, field fields.Selector) kstorage.
 		Label: label,
 		Field: field,
 		GetAttrs: func(o runtime.Object) (labels.Set, fields.Set, error) {
-			obj, ok := o.(*api.ImageStreamTag)
+			obj, ok := o.(*imageapi.ImageStreamTag)
 			if !ok {
 				return nil, nil, fmt.Errorf("not an ImageStreamTag")
 			}
@@ -95,6 +95,6 @@ func MatchImageStreamTag(label labels.Selector, field fields.Selector) kstorage.
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.ImageStreamTag) fields.Set {
+func SelectableFields(obj *imageapi.ImageStreamTag) fields.Set {
 	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
 }

--- a/pkg/oauth/api/install/apigroup.go
+++ b/pkg/oauth/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
-	"github.com/openshift/origin/pkg/oauth/api/v1"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	oauthapiv1 "github.com/openshift/origin/pkg/oauth/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  oauthapi.GroupName,
+			VersionPreferenceOrder:     []string{oauthapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: oauthapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("OAuthAccessToken", "OAuthAuthorizeToken", "OAuthClient", "OAuthClientAuthorization"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			oauthapiv1.SchemeGroupVersion.Version: oauthapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/oauth/api/install/install.go
+++ b/pkg/oauth/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
-	"github.com/openshift/origin/pkg/oauth/api/v1"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	oauthapiv1 "github.com/openshift/origin/pkg/oauth/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/oauth/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/oauth/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{oauthapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", oauthapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	oauthapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case oauthapiv1.LegacySchemeGroupVersion:
+			oauthapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case oauthapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(oauthapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/oauth/api/v1/conversion.go
+++ b/pkg/oauth/api/v1/conversion.go
@@ -4,30 +4,30 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthAccessToken",
-		oapi.GetFieldLabelConversionFunc(api.OAuthAccessTokenToSelectableFields(&api.OAuthAccessToken{}), nil),
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthAccessTokenToSelectableFields(&oauthapi.OAuthAccessToken{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthAuthorizeToken",
-		oapi.GetFieldLabelConversionFunc(api.OAuthAuthorizeTokenToSelectableFields(&api.OAuthAuthorizeToken{}), nil),
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthAuthorizeTokenToSelectableFields(&oauthapi.OAuthAuthorizeToken{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthClient",
-		oapi.GetFieldLabelConversionFunc(api.OAuthClientToSelectableFields(&api.OAuthClient{}), nil),
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthClientToSelectableFields(&oauthapi.OAuthClient{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthClientAuthorization",
-		oapi.GetFieldLabelConversionFunc(api.OAuthClientAuthorizationToSelectableFields(&api.OAuthClientAuthorization{}), nil),
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthClientAuthorizationToSelectableFields(&oauthapi.OAuthClientAuthorization{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/oauth/api/v1/conversion_test.go
+++ b/pkg/oauth/api/v1/conversion_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	// install all APIs
@@ -13,26 +13,26 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAccessToken",
 		// Ensure all currently returned labels are supported
-		api.OAuthAccessTokenToSelectableFields(&api.OAuthAccessToken{}),
+		oauthapi.OAuthAccessTokenToSelectableFields(&oauthapi.OAuthAccessToken{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"clientName", "userName", "userUID", "authorizeToken",
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "OAuthAuthorizeToken",
 		// Ensure all currently returned labels are supported
-		api.OAuthAuthorizeTokenToSelectableFields(&api.OAuthAuthorizeToken{}),
+		oauthapi.OAuthAuthorizeTokenToSelectableFields(&oauthapi.OAuthAuthorizeToken{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"clientName", "userName", "userUID",
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClient",
 		// Ensure all currently returned labels are supported
-		api.OAuthClientToSelectableFields(&api.OAuthClient{}),
+		oauthapi.OAuthClientToSelectableFields(&oauthapi.OAuthClient{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "OAuthClientAuthorization",
 		// Ensure all currently returned labels are supported
-		api.OAuthClientAuthorizationToSelectableFields(&api.OAuthClientAuthorization{}),
+		oauthapi.OAuthClientAuthorizationToSelectableFields(&oauthapi.OAuthClientAuthorization{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"clientName", "userName", "userUID",
 	)

--- a/pkg/oauth/api/validation/validation.go
+++ b/pkg/oauth/api/validation/validation.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 
 	authorizerscopes "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
@@ -61,7 +61,7 @@ func ValidateRedirectURI(redirect string) (bool, string) {
 	return true, ""
 }
 
-func ValidateAccessToken(accessToken *api.OAuthAccessToken) field.ErrorList {
+func ValidateAccessToken(accessToken *oauthapi.OAuthAccessToken) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&accessToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(accessToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(accessToken.UserName, field.NewPath("userName"))...)
@@ -77,7 +77,7 @@ func ValidateAccessToken(accessToken *api.OAuthAccessToken) field.ErrorList {
 	return allErrs
 }
 
-func ValidateAccessTokenUpdate(newToken, oldToken *api.OAuthAccessToken) field.ErrorList {
+func ValidateAccessTokenUpdate(newToken, oldToken *oauthapi.OAuthAccessToken) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&newToken.ObjectMeta, &oldToken.ObjectMeta, field.NewPath("metadata"))
 	copied := *oldToken
 	copied.ObjectMeta = newToken.ObjectMeta
@@ -86,7 +86,7 @@ func ValidateAccessTokenUpdate(newToken, oldToken *api.OAuthAccessToken) field.E
 
 var codeChallengeRegex = regexp.MustCompile("^[a-zA-Z0-9._~-]{43,128}$")
 
-func ValidateAuthorizeToken(authorizeToken *api.OAuthAuthorizeToken) field.ErrorList {
+func ValidateAuthorizeToken(authorizeToken *oauthapi.OAuthAuthorizeToken) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&authorizeToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(authorizeToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(authorizeToken.UserName, field.NewPath("userName"))...)
@@ -120,14 +120,14 @@ func ValidateAuthorizeToken(authorizeToken *api.OAuthAuthorizeToken) field.Error
 	return allErrs
 }
 
-func ValidateAuthorizeTokenUpdate(newToken, oldToken *api.OAuthAuthorizeToken) field.ErrorList {
+func ValidateAuthorizeTokenUpdate(newToken, oldToken *oauthapi.OAuthAuthorizeToken) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&newToken.ObjectMeta, &oldToken.ObjectMeta, field.NewPath("metadata"))
 	copied := *oldToken
 	copied.ObjectMeta = newToken.ObjectMeta
 	return append(allErrs, validation.ValidateImmutableField(newToken, &copied, field.NewPath(""))...)
 }
 
-func ValidateClient(client *api.OAuthClient) field.ErrorList {
+func ValidateClient(client *oauthapi.OAuthClient) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&client.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	for i, redirect := range client.RedirectURIs {
 		if ok, msg := ValidateRedirectURI(redirect); !ok {
@@ -142,7 +142,7 @@ func ValidateClient(client *api.OAuthClient) field.ErrorList {
 	return allErrs
 }
 
-func ValidateScopeRestriction(restriction api.ScopeRestriction, fldPath *field.Path) field.ErrorList {
+func ValidateScopeRestriction(restriction oauthapi.ScopeRestriction, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	specifiers := 0
@@ -177,7 +177,7 @@ func ValidateScopeRestriction(restriction api.ScopeRestriction, fldPath *field.P
 	return allErrs
 }
 
-func ValidateClientUpdate(client *api.OAuthClient, oldClient *api.OAuthClient) field.ErrorList {
+func ValidateClientUpdate(client *oauthapi.OAuthClient, oldClient *oauthapi.OAuthClient) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateClient(client)...)
@@ -199,7 +199,7 @@ func ValidateClientAuthorizationName(name string, prefix bool) []string {
 	return nil
 }
 
-func ValidateClientAuthorization(clientAuthorization *api.OAuthClientAuthorization) field.ErrorList {
+func ValidateClientAuthorization(clientAuthorization *oauthapi.OAuthClientAuthorization) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	expectedName := fmt.Sprintf("%s:%s", clientAuthorization.UserName, clientAuthorization.ClientName)
@@ -222,7 +222,7 @@ func ValidateClientAuthorization(clientAuthorization *api.OAuthClientAuthorizati
 	return allErrs
 }
 
-func ValidateClientAuthorizationUpdate(newAuth *api.OAuthClientAuthorization, oldAuth *api.OAuthClientAuthorization) field.ErrorList {
+func ValidateClientAuthorizationUpdate(newAuth *oauthapi.OAuthClientAuthorization, oldAuth *oauthapi.OAuthClientAuthorization) field.ErrorList {
 	allErrs := ValidateClientAuthorization(newAuth)
 
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&newAuth.ObjectMeta, &oldAuth.ObjectMeta, field.NewPath("metadata"))...)
@@ -304,12 +304,12 @@ func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func ValidateOAuthRedirectReference(sref *api.OAuthRedirectReference) field.ErrorList {
+func ValidateOAuthRedirectReference(sref *oauthapi.OAuthRedirectReference) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&sref.ObjectMeta, true, path.ValidatePathSegmentName, field.NewPath("metadata"))
 	return append(allErrs, validateRedirectReference(&sref.Reference)...)
 }
 
-func validateRedirectReference(ref *api.RedirectReference) field.ErrorList {
+func validateRedirectReference(ref *oauthapi.RedirectReference) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(ref.Name) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("name"), "may not be empty"))

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/util/observe"
@@ -27,13 +27,13 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter, bac
 	strategy := oauthaccesstoken.NewStrategy(clientGetter)
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.OAuthAccessToken{} },
-		NewListFunc:       func() runtime.Object { return &api.OAuthAccessTokenList{} },
+		NewFunc:           func() runtime.Object { return &oauthapi.OAuthAccessToken{} },
+		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthAccessTokenList{} },
 		PredicateFunc:     oauthaccesstoken.Matcher,
-		QualifiedResource: api.Resource("oauthaccesstokens"),
+		QualifiedResource: oauthapi.Resource("oauthaccesstokens"),
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
-			token := obj.(*api.OAuthAccessToken)
+			token := obj.(*oauthapi.OAuthAccessToken)
 			expires := uint64(token.ExpiresIn)
 			return expires, nil
 		},
@@ -60,7 +60,7 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter, bac
 		observer := observe.NewClusterObserver(store.Storage.Versioner(), watchers, 1)
 		// After creation, wait for the new token to propagate
 		store.AfterCreate = func(obj runtime.Object) error {
-			return observer.ObserveResourceVersion(obj.(*api.OAuthAccessToken).ResourceVersion, 5*time.Second)
+			return observer.ObserveResourceVersion(obj.(*oauthapi.OAuthAccessToken).ResourceVersion, 5*time.Second)
 		}
 	}
 

--- a/pkg/oauth/registry/oauthaccesstoken/registry.go
+++ b/pkg/oauth/registry/oauthaccesstoken/registry.go
@@ -6,17 +6,17 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 // Registry is an interface for things that know how to store AccessToken objects.
 type Registry interface {
 	// ListAccessTokens obtains a list of access tokens that match a selector.
-	ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAccessTokenList, error)
+	ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAccessTokenList, error)
 	// GetAccessToken retrieves a specific access token.
-	GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAccessToken, error)
+	GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAccessToken, error)
 	// CreateAccessToken creates a new access token.
-	CreateAccessToken(ctx apirequest.Context, token *api.OAuthAccessToken) (*api.OAuthAccessToken, error)
+	CreateAccessToken(ctx apirequest.Context, token *oauthapi.OAuthAccessToken) (*oauthapi.OAuthAccessToken, error)
 	// DeleteAccessToken deletes an access token.
 	DeleteAccessToken(ctx apirequest.Context, name string) error
 }
@@ -40,28 +40,28 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAccessTokenList, error) {
+func (s *storage) ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAccessTokenList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAccessTokenList), nil
+	return obj.(*oauthapi.OAuthAccessTokenList), nil
 }
 
-func (s *storage) GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAccessToken, error) {
+func (s *storage) GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAccessToken, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAccessToken), nil
+	return obj.(*oauthapi.OAuthAccessToken), nil
 }
 
-func (s *storage) CreateAccessToken(ctx apirequest.Context, token *api.OAuthAccessToken) (*api.OAuthAccessToken, error) {
+func (s *storage) CreateAccessToken(ctx apirequest.Context, token *oauthapi.OAuthAccessToken) (*oauthapi.OAuthAccessToken, error) {
 	obj, err := s.Create(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAccessToken), nil
+	return obj.(*oauthapi.OAuthAccessToken), nil
 }
 
 func (s *storage) DeleteAccessToken(ctx apirequest.Context, name string) error {

--- a/pkg/oauth/registry/oauthaccesstoken/strategy.go
+++ b/pkg/oauth/registry/oauthaccesstoken/strategy.go
@@ -14,7 +14,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 )
@@ -49,7 +49,7 @@ func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 
 // Validate validates a new token
 func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	token := obj.(*api.OAuthAccessToken)
+	token := obj.(*oauthapi.OAuthAccessToken)
 	validationErrors := validation.ValidateAccessToken(token)
 
 	client, err := s.clientGetter.GetClient(ctx, token.ClientName, &metav1.GetOptions{})
@@ -65,8 +65,8 @@ func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.Err
 
 // ValidateUpdate validates an update
 func (s strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	oldToken := old.(*api.OAuthAccessToken)
-	newToken := obj.(*api.OAuthAccessToken)
+	oldToken := old.(*oauthapi.OAuthAccessToken)
+	newToken := obj.(*oauthapi.OAuthAccessToken)
 	return validation.ValidateAccessTokenUpdate(newToken, oldToken)
 }
 
@@ -85,7 +85,7 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.OAuthAccessToken)
+	obj, ok := o.(*oauthapi.OAuthAccessToken)
 	if !ok {
 		return nil, nil, fmt.Errorf("not an OAuthAccessToken")
 	}
@@ -102,6 +102,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.OAuthAccessToken) fields.Set {
-	return api.OAuthAccessTokenToSelectableFields(obj)
+func SelectableFields(obj *oauthapi.OAuthAccessToken) fields.Set {
+	return oauthapi.OAuthAccessTokenToSelectableFields(obj)
 }

--- a/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -22,13 +22,13 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 	strategy := oauthauthorizetoken.NewStrategy(clientGetter)
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.OAuthAuthorizeToken{} },
-		NewListFunc:       func() runtime.Object { return &api.OAuthAuthorizeTokenList{} },
+		NewFunc:           func() runtime.Object { return &oauthapi.OAuthAuthorizeToken{} },
+		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthAuthorizeTokenList{} },
 		PredicateFunc:     oauthauthorizetoken.Matcher,
-		QualifiedResource: api.Resource("oauthauthorizetokens"),
+		QualifiedResource: oauthapi.Resource("oauthauthorizetokens"),
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
-			token := obj.(*api.OAuthAuthorizeToken)
+			token := obj.(*oauthapi.OAuthAuthorizeToken)
 			expires := uint64(token.ExpiresIn)
 			return expires, nil
 		},

--- a/pkg/oauth/registry/oauthauthorizetoken/registry.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/registry.go
@@ -6,17 +6,17 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 // Registry is an interface for things that know how to store AuthorizeToken objects.
 type Registry interface {
 	// ListAuthorizeTokens obtains a list of authorize tokens that match a selector.
-	ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAuthorizeTokenList, error)
+	ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAuthorizeTokenList, error)
 	// GetAuthorizeToken retrieves a specific authorize token.
-	GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAuthorizeToken, error)
+	GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAuthorizeToken, error)
 	// CreateAuthorizeToken creates a new authorize token.
-	CreateAuthorizeToken(ctx apirequest.Context, token *api.OAuthAuthorizeToken) (*api.OAuthAuthorizeToken, error)
+	CreateAuthorizeToken(ctx apirequest.Context, token *oauthapi.OAuthAuthorizeToken) (*oauthapi.OAuthAuthorizeToken, error)
 	// DeleteAuthorizeToken deletes an authorize token.
 	DeleteAuthorizeToken(ctx apirequest.Context, name string) error
 }
@@ -40,28 +40,28 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAuthorizeTokenList, error) {
+func (s *storage) ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAuthorizeTokenList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAuthorizeTokenList), nil
+	return obj.(*oauthapi.OAuthAuthorizeTokenList), nil
 }
 
-func (s *storage) GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAuthorizeToken, error) {
+func (s *storage) GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAuthorizeToken, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAuthorizeToken), nil
+	return obj.(*oauthapi.OAuthAuthorizeToken), nil
 }
 
-func (s *storage) CreateAuthorizeToken(ctx apirequest.Context, token *api.OAuthAuthorizeToken) (*api.OAuthAuthorizeToken, error) {
+func (s *storage) CreateAuthorizeToken(ctx apirequest.Context, token *oauthapi.OAuthAuthorizeToken) (*oauthapi.OAuthAuthorizeToken, error) {
 	obj, err := s.Create(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthAuthorizeToken), nil
+	return obj.(*oauthapi.OAuthAuthorizeToken), nil
 }
 
 func (s *storage) DeleteAuthorizeToken(ctx apirequest.Context, name string) error {

--- a/pkg/oauth/registry/oauthauthorizetoken/strategy.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/strategy.go
@@ -14,7 +14,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 )
@@ -53,7 +53,7 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new token
 func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	token := obj.(*api.OAuthAuthorizeToken)
+	token := obj.(*oauthapi.OAuthAuthorizeToken)
 	validationErrors := validation.ValidateAuthorizeToken(token)
 
 	client, err := s.clientGetter.GetClient(ctx, token.ClientName, &metav1.GetOptions{})
@@ -69,8 +69,8 @@ func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.Err
 
 // ValidateUpdate validates an update
 func (s strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	oldToken := old.(*api.OAuthAuthorizeToken)
-	newToken := obj.(*api.OAuthAuthorizeToken)
+	oldToken := old.(*oauthapi.OAuthAuthorizeToken)
+	newToken := obj.(*oauthapi.OAuthAuthorizeToken)
 	return validation.ValidateAuthorizeTokenUpdate(newToken, oldToken)
 }
 
@@ -85,7 +85,7 @@ func (strategy) AllowUnconditionalUpdate() bool {
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.OAuthAuthorizeToken)
+	obj, ok := o.(*oauthapi.OAuthAuthorizeToken)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a OAuthAuthorizeToken")
 	}
@@ -102,6 +102,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.OAuthAuthorizeToken) fields.Set {
-	return api.OAuthAuthorizeTokenToSelectableFields(obj)
+func SelectableFields(obj *oauthapi.OAuthAuthorizeToken) fields.Set {
+	return oauthapi.OAuthAuthorizeTokenToSelectableFields(obj)
 }

--- a/pkg/oauth/registry/oauthclient/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclient/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.OAuthClient{} },
-		NewListFunc:       func() runtime.Object { return &api.OAuthClientList{} },
+		NewFunc:           func() runtime.Object { return &oauthapi.OAuthClient{} },
+		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthClientList{} },
 		PredicateFunc:     oauthclient.Matcher,
-		QualifiedResource: api.Resource("oauthclients"),
+		QualifiedResource: oauthapi.Resource("oauthclients"),
 
 		CreateStrategy: oauthclient.Strategy,
 		UpdateStrategy: oauthclient.Strategy,

--- a/pkg/oauth/registry/oauthclient/registry.go
+++ b/pkg/oauth/registry/oauthclient/registry.go
@@ -7,19 +7,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 // Registry is an interface for things that know how to store OAuthClient objects.
 type Registry interface {
 	// ListClients obtains a list of clients that match a selector.
-	ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientList, error)
+	ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientList, error)
 	// GetClient retrieves a specific client.
-	GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClient, error)
+	GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClient, error)
 	// CreateClient creates a new client.
-	CreateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error)
+	CreateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error)
 	// UpdateClient updates a client.
-	UpdateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error)
+	UpdateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error)
 	// DeleteClient deletes a client.
 	DeleteClient(ctx apirequest.Context, name string) error
 }
@@ -27,7 +27,7 @@ type Registry interface {
 // Getter exposes a way to get a specific client.  This is useful for other registries to get scope limitations
 // on particular clients.   This interface will make its easier to write a future cache on it
 type Getter interface {
-	GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClient, error)
+	GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClient, error)
 }
 
 // storage puts strong typing around storage calls
@@ -41,36 +41,36 @@ func NewRegistry(s rest.StandardStorage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientList, error) {
+func (s *storage) ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClientList), nil
+	return obj.(*oauthapi.OAuthClientList), nil
 }
 
-func (s *storage) GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClient, error) {
+func (s *storage) GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClient, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClient), nil
+	return obj.(*oauthapi.OAuthClient), nil
 }
 
-func (s *storage) CreateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error) {
+func (s *storage) CreateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error) {
 	obj, err := s.Create(ctx, client)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClient), nil
+	return obj.(*oauthapi.OAuthClient), nil
 }
 
-func (s *storage) UpdateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error) {
+func (s *storage) UpdateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error) {
 	obj, _, err := s.Update(ctx, client.Name, rest.DefaultUpdatedObjectInfo(client, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClient), nil
+	return obj.(*oauthapi.OAuthClient), nil
 }
 
 func (s *storage) DeleteClient(ctx apirequest.Context, name string) error {

--- a/pkg/oauth/registry/oauthclient/strategy.go
+++ b/pkg/oauth/registry/oauthclient/strategy.go
@@ -3,7 +3,7 @@ package oauthclient
 import (
 	"fmt"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,14 +43,14 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new client
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	token := obj.(*api.OAuthClient)
+	token := obj.(*oauthapi.OAuthClient)
 	return validation.ValidateClient(token)
 }
 
 // ValidateUpdate validates a client update
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj runtime.Object, old runtime.Object) field.ErrorList {
-	client := obj.(*api.OAuthClient)
-	oldClient := old.(*api.OAuthClient)
+	client := obj.(*oauthapi.OAuthClient)
+	oldClient := old.(*oauthapi.OAuthClient)
 	return validation.ValidateClientUpdate(client, oldClient)
 }
 
@@ -65,7 +65,7 @@ func (strategy) AllowUnconditionalUpdate() bool {
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.OAuthClient)
+	obj, ok := o.(*oauthapi.OAuthClient)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a OAuthClient")
 	}
@@ -82,6 +82,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.OAuthClient) fields.Set {
-	return api.OAuthClientToSelectableFields(obj)
+func SelectableFields(obj *oauthapi.OAuthClient) fields.Set {
+	return oauthapi.OAuthClientToSelectableFields(obj)
 }

--- a/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -23,10 +23,10 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.OAuthClientAuthorization{} },
-		NewListFunc:       func() runtime.Object { return &api.OAuthClientAuthorizationList{} },
+		NewFunc:           func() runtime.Object { return &oauthapi.OAuthClientAuthorization{} },
+		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthClientAuthorizationList{} },
 		PredicateFunc:     oauthclientauthorization.Matcher,
-		QualifiedResource: api.Resource("oauthclientauthorizations"),
+		QualifiedResource: oauthapi.Resource("oauthclientauthorizations"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/oauth/registry/oauthclientauthorization/registry.go
+++ b/pkg/oauth/registry/oauthclientauthorization/registry.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 // Registry is an interface for things that know how to store OAuthClientAuthorization objects.
@@ -15,13 +15,13 @@ type Registry interface {
 	// ClientAuthorizationName returns the name of the OAuthClientAuthorization for the given user name and client name
 	ClientAuthorizationName(userName, clientName string) string
 	// ListClientAuthorizations obtains a list of client auths that match a selector.
-	ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientAuthorizationList, error)
+	ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientAuthorizationList, error)
 	// GetClientAuthorization retrieves a specific client auth.
-	GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClientAuthorization, error)
+	GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClientAuthorization, error)
 	// CreateClientAuthorization creates a new client auth.
-	CreateClientAuthorization(ctx apirequest.Context, client *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error)
+	CreateClientAuthorization(ctx apirequest.Context, client *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error)
 	// UpdateClientAuthorization updates a client auth.
-	UpdateClientAuthorization(ctx apirequest.Context, client *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error)
+	UpdateClientAuthorization(ctx apirequest.Context, client *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error)
 	// DeleteClientAuthorization deletes a client auth.
 	DeleteClientAuthorization(ctx apirequest.Context, name string) error
 }
@@ -41,36 +41,36 @@ func (s *storage) ClientAuthorizationName(userName, clientName string) string {
 	return userName + ":" + clientName
 }
 
-func (s *storage) ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientAuthorizationList, error) {
+func (s *storage) ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientAuthorizationList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClientAuthorizationList), nil
+	return obj.(*oauthapi.OAuthClientAuthorizationList), nil
 }
 
-func (s *storage) GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClientAuthorization, error) {
+func (s *storage) GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClientAuthorization, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClientAuthorization), nil
+	return obj.(*oauthapi.OAuthClientAuthorization), nil
 }
 
-func (s *storage) CreateClientAuthorization(ctx apirequest.Context, client *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
+func (s *storage) CreateClientAuthorization(ctx apirequest.Context, client *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error) {
 	obj, err := s.Create(ctx, client)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClientAuthorization), nil
+	return obj.(*oauthapi.OAuthClientAuthorization), nil
 }
 
-func (s *storage) UpdateClientAuthorization(ctx apirequest.Context, client *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
+func (s *storage) UpdateClientAuthorization(ctx apirequest.Context, client *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error) {
 	obj, _, err := s.Update(ctx, client.Name, rest.DefaultUpdatedObjectInfo(client, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.OAuthClientAuthorization), nil
+	return obj.(*oauthapi.OAuthClientAuthorization), nil
 }
 
 func (s *storage) DeleteClientAuthorization(ctx apirequest.Context, name string) error {

--- a/pkg/oauth/registry/oauthclientauthorization/strategy.go
+++ b/pkg/oauth/registry/oauthclientauthorization/strategy.go
@@ -3,7 +3,7 @@ package oauthclientauthorization
 import (
 	"fmt"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -30,7 +30,7 @@ func NewStrategy(clientGetter oauthclient.Getter) strategy {
 }
 
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	auth := obj.(*api.OAuthClientAuthorization)
+	auth := obj.(*oauthapi.OAuthClientAuthorization)
 	auth.Name = fmt.Sprintf("%s:%s", auth.UserName, auth.ClientName)
 }
 
@@ -44,7 +44,7 @@ func (strategy) GenerateName(base string) string {
 }
 
 func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	auth := obj.(*api.OAuthClientAuthorization)
+	auth := obj.(*oauthapi.OAuthClientAuthorization)
 	auth.Name = fmt.Sprintf("%s:%s", auth.UserName, auth.ClientName)
 }
 
@@ -54,7 +54,7 @@ func (strategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new client
 func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	auth := obj.(*api.OAuthClientAuthorization)
+	auth := obj.(*oauthapi.OAuthClientAuthorization)
 	validationErrors := validation.ValidateClientAuthorization(auth)
 
 	client, err := s.clientGetter.GetClient(ctx, auth.ClientName, &metav1.GetOptions{})
@@ -70,8 +70,8 @@ func (s strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.Err
 
 // ValidateUpdate validates a client auth update
 func (s strategy) ValidateUpdate(ctx apirequest.Context, obj runtime.Object, old runtime.Object) field.ErrorList {
-	clientAuth := obj.(*api.OAuthClientAuthorization)
-	oldClientAuth := old.(*api.OAuthClientAuthorization)
+	clientAuth := obj.(*oauthapi.OAuthClientAuthorization)
+	oldClientAuth := old.(*oauthapi.OAuthClientAuthorization)
 	validationErrors := validation.ValidateClientAuthorizationUpdate(clientAuth, oldClientAuth)
 
 	client, err := s.clientGetter.GetClient(ctx, clientAuth.ClientName, &metav1.GetOptions{})
@@ -95,7 +95,7 @@ func (strategy) AllowUnconditionalUpdate() bool {
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.OAuthClientAuthorization)
+	obj, ok := o.(*oauthapi.OAuthClientAuthorization)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a OAuthClientAuthorization")
 	}
@@ -112,6 +112,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.OAuthClientAuthorization) fields.Set {
-	return api.OAuthClientAuthorizationToSelectableFields(obj)
+func SelectableFields(obj *oauthapi.OAuthClientAuthorization) fields.Set {
+	return oauthapi.OAuthClientAuthorizationToSelectableFields(obj)
 }

--- a/pkg/oauth/registry/test/accesstoken.go
+++ b/pkg/oauth/registry/test/accesstoken.go
@@ -5,25 +5,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 type AccessTokenRegistry struct {
 	Err                    error
-	AccessTokens           *api.OAuthAccessTokenList
-	AccessToken            *api.OAuthAccessToken
+	AccessTokens           *oauthapi.OAuthAccessTokenList
+	AccessToken            *oauthapi.OAuthAccessToken
 	DeletedAccessTokenName string
 }
 
-func (r *AccessTokenRegistry) ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAccessTokenList, error) {
+func (r *AccessTokenRegistry) ListAccessTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAccessTokenList, error) {
 	return r.AccessTokens, r.Err
 }
 
-func (r *AccessTokenRegistry) GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAccessToken, error) {
+func (r *AccessTokenRegistry) GetAccessToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAccessToken, error) {
 	return r.AccessToken, r.Err
 }
 
-func (r *AccessTokenRegistry) CreateAccessToken(ctx apirequest.Context, token *api.OAuthAccessToken) (*api.OAuthAccessToken, error) {
+func (r *AccessTokenRegistry) CreateAccessToken(ctx apirequest.Context, token *oauthapi.OAuthAccessToken) (*oauthapi.OAuthAccessToken, error) {
 	return r.AccessToken, r.Err
 }
 

--- a/pkg/oauth/registry/test/authorizetoken.go
+++ b/pkg/oauth/registry/test/authorizetoken.go
@@ -5,25 +5,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 type AuthorizeTokenRegistry struct {
 	Err                       error
-	AuthorizeTokens           *api.OAuthAuthorizeTokenList
-	AuthorizeToken            *api.OAuthAuthorizeToken
+	AuthorizeTokens           *oauthapi.OAuthAuthorizeTokenList
+	AuthorizeToken            *oauthapi.OAuthAuthorizeToken
 	DeletedAuthorizeTokenName string
 }
 
-func (r *AuthorizeTokenRegistry) ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthAuthorizeTokenList, error) {
+func (r *AuthorizeTokenRegistry) ListAuthorizeTokens(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthAuthorizeTokenList, error) {
 	return r.AuthorizeTokens, r.Err
 }
 
-func (r *AuthorizeTokenRegistry) GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthAuthorizeToken, error) {
+func (r *AuthorizeTokenRegistry) GetAuthorizeToken(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthAuthorizeToken, error) {
 	return r.AuthorizeToken, r.Err
 }
 
-func (r *AuthorizeTokenRegistry) CreateAuthorizeToken(ctx apirequest.Context, token *api.OAuthAuthorizeToken) (*api.OAuthAuthorizeToken, error) {
+func (r *AuthorizeTokenRegistry) CreateAuthorizeToken(ctx apirequest.Context, token *oauthapi.OAuthAuthorizeToken) (*oauthapi.OAuthAuthorizeToken, error) {
 	return r.AuthorizeToken, r.Err
 }
 

--- a/pkg/oauth/registry/test/client.go
+++ b/pkg/oauth/registry/test/client.go
@@ -5,29 +5,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 type ClientRegistry struct {
 	Err               error
-	Clients           *api.OAuthClientList
-	Client            *api.OAuthClient
+	Clients           *oauthapi.OAuthClientList
+	Client            *oauthapi.OAuthClient
 	DeletedClientName string
 }
 
-func (r *ClientRegistry) ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientList, error) {
+func (r *ClientRegistry) ListClients(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientList, error) {
 	return r.Clients, r.Err
 }
 
-func (r *ClientRegistry) GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClient, error) {
+func (r *ClientRegistry) GetClient(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClient, error) {
 	return r.Client, r.Err
 }
 
-func (r *ClientRegistry) CreateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error) {
+func (r *ClientRegistry) CreateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error) {
 	return r.Client, r.Err
 }
 
-func (r *ClientRegistry) UpdateClient(ctx apirequest.Context, client *api.OAuthClient) (*api.OAuthClient, error) {
+func (r *ClientRegistry) UpdateClient(ctx apirequest.Context, client *oauthapi.OAuthClient) (*oauthapi.OAuthClient, error) {
 	return r.Client, r.Err
 }
 

--- a/pkg/oauth/registry/test/clientauthorization.go
+++ b/pkg/oauth/registry/test/clientauthorization.go
@@ -7,19 +7,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 )
 
 type ClientAuthorizationRegistry struct {
 	GetErr               error
-	ClientAuthorizations *api.OAuthClientAuthorizationList
-	ClientAuthorization  *api.OAuthClientAuthorization
+	ClientAuthorizations *oauthapi.OAuthClientAuthorizationList
+	ClientAuthorization  *oauthapi.OAuthClientAuthorization
 
 	CreateErr            error
-	CreatedAuthorization *api.OAuthClientAuthorization
+	CreatedAuthorization *oauthapi.OAuthClientAuthorization
 
 	UpdateErr            error
-	UpdatedAuthorization *api.OAuthClientAuthorization
+	UpdatedAuthorization *oauthapi.OAuthClientAuthorization
 
 	DeleteErr                      error
 	DeletedClientAuthorizationName string
@@ -29,20 +29,20 @@ func (r *ClientAuthorizationRegistry) ClientAuthorizationName(userName, clientNa
 	return fmt.Sprintf("%s:%s", userName, clientName)
 }
 
-func (r *ClientAuthorizationRegistry) ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*api.OAuthClientAuthorizationList, error) {
+func (r *ClientAuthorizationRegistry) ListClientAuthorizations(ctx apirequest.Context, options *metainternal.ListOptions) (*oauthapi.OAuthClientAuthorizationList, error) {
 	return r.ClientAuthorizations, r.GetErr
 }
 
-func (r *ClientAuthorizationRegistry) GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.OAuthClientAuthorization, error) {
+func (r *ClientAuthorizationRegistry) GetClientAuthorization(ctx apirequest.Context, name string, options *metav1.GetOptions) (*oauthapi.OAuthClientAuthorization, error) {
 	return r.ClientAuthorization, r.GetErr
 }
 
-func (r *ClientAuthorizationRegistry) CreateClientAuthorization(ctx apirequest.Context, grant *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
+func (r *ClientAuthorizationRegistry) CreateClientAuthorization(ctx apirequest.Context, grant *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error) {
 	r.CreatedAuthorization = grant
 	return r.ClientAuthorization, r.CreateErr
 }
 
-func (r *ClientAuthorizationRegistry) UpdateClientAuthorization(ctx apirequest.Context, grant *api.OAuthClientAuthorization) (*api.OAuthClientAuthorization, error) {
+func (r *ClientAuthorizationRegistry) UpdateClientAuthorization(ctx apirequest.Context, grant *oauthapi.OAuthClientAuthorization) (*oauthapi.OAuthClientAuthorization, error) {
 	r.UpdatedAuthorization = grant
 	return r.ClientAuthorization, r.UpdateErr
 }

--- a/pkg/oauth/server/osinserver/registrystorage/storage.go
+++ b/pkg/oauth/server/osinserver/registrystorage/storage.go
@@ -11,7 +11,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
@@ -19,10 +19,10 @@ import (
 )
 
 type UserConversion interface {
-	ConvertToAuthorizeToken(interface{}, *api.OAuthAuthorizeToken) error
-	ConvertToAccessToken(interface{}, *api.OAuthAccessToken) error
-	ConvertFromAuthorizeToken(*api.OAuthAuthorizeToken) (interface{}, error)
-	ConvertFromAccessToken(*api.OAuthAccessToken) (interface{}, error)
+	ConvertToAuthorizeToken(interface{}, *oauthapi.OAuthAuthorizeToken) error
+	ConvertToAccessToken(interface{}, *oauthapi.OAuthAccessToken) error
+	ConvertFromAuthorizeToken(*oauthapi.OAuthAuthorizeToken) (interface{}, error)
+	ConvertFromAccessToken(*oauthapi.OAuthAccessToken) (interface{}, error)
 }
 
 type storage struct {
@@ -43,7 +43,7 @@ func New(access oauthaccesstoken.Registry, authorize oauthauthorizetoken.Registr
 
 type clientWrapper struct {
 	id     string
-	client *api.OAuthClient
+	client *oauthapi.OAuthClient
 }
 
 // Ensure we implement the secret matcher method that allows us to validate multiple secrets
@@ -179,8 +179,8 @@ func (s *storage) RemoveRefresh(token string) error {
 	return errors.New("not implemented")
 }
 
-func (s *storage) convertToAuthorizeToken(data *osin.AuthorizeData) (*api.OAuthAuthorizeToken, error) {
-	token := &api.OAuthAuthorizeToken{
+func (s *storage) convertToAuthorizeToken(data *osin.AuthorizeData) (*oauthapi.OAuthAuthorizeToken, error) {
+	token := &oauthapi.OAuthAuthorizeToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              data.Code,
 			CreationTimestamp: metav1.Time{Time: data.CreatedAt},
@@ -199,7 +199,7 @@ func (s *storage) convertToAuthorizeToken(data *osin.AuthorizeData) (*api.OAuthA
 	return token, nil
 }
 
-func (s *storage) convertFromAuthorizeToken(authorize *api.OAuthAuthorizeToken) (*osin.AuthorizeData, error) {
+func (s *storage) convertFromAuthorizeToken(authorize *oauthapi.OAuthAuthorizeToken) (*osin.AuthorizeData, error) {
 	user, err := s.user.ConvertFromAuthorizeToken(authorize)
 	if err != nil {
 		return nil, err
@@ -226,8 +226,8 @@ func (s *storage) convertFromAuthorizeToken(authorize *api.OAuthAuthorizeToken) 
 	}, nil
 }
 
-func (s *storage) convertToAccessToken(data *osin.AccessData) (*api.OAuthAccessToken, error) {
-	token := &api.OAuthAccessToken{
+func (s *storage) convertToAccessToken(data *osin.AccessData) (*oauthapi.OAuthAccessToken, error) {
+	token := &oauthapi.OAuthAccessToken{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              data.AccessToken,
 			CreationTimestamp: metav1.Time{Time: data.CreatedAt},
@@ -247,7 +247,7 @@ func (s *storage) convertToAccessToken(data *osin.AccessData) (*api.OAuthAccessT
 	return token, nil
 }
 
-func (s *storage) convertFromAccessToken(access *api.OAuthAccessToken) (*osin.AccessData, error) {
+func (s *storage) convertFromAccessToken(access *oauthapi.OAuthAccessToken) (*osin.AccessData, error) {
 	user, err := s.user.ConvertFromAccessToken(access)
 	if err != nil {
 		return nil, err

--- a/pkg/project/api/helpers/helpers.go
+++ b/pkg/project/api/helpers/helpers.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 const displayNameOldAnnotation = "displayName"
 
 // DisplayNameAndNameForProject returns a formatted string containing the name
 // of the project and includes the display name if it differs.
-func DisplayNameAndNameForProject(project *api.Project) string {
+func DisplayNameAndNameForProject(project *projectapi.Project) string {
 	displayName := project.Annotations[oapi.OpenShiftDisplayName]
 	if len(displayName) == 0 {
 		displayName = project.Annotations[displayNameOldAnnotation]

--- a/pkg/project/api/install/apigroup.go
+++ b/pkg/project/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/project/api"
-	"github.com/openshift/origin/pkg/project/api/v1"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectapiv1 "github.com/openshift/origin/pkg/project/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  projectapi.GroupName,
+			VersionPreferenceOrder:     []string{projectapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: projectapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("Project", "ProjectRequest"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			projectapiv1.SchemeGroupVersion.Version: projectapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/project/api/install/install.go
+++ b/pkg/project/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/project/api"
-	"github.com/openshift/origin/pkg/project/api/v1"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectapiv1 "github.com/openshift/origin/pkg/project/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/project/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/project/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{projectapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %q", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %q", projectapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	projectapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case projectapiv1.LegacySchemeGroupVersion:
+			projectapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case projectapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(projectapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/project/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
@@ -33,7 +32,7 @@ func ValidateProjectName(name string, prefix bool) []string {
 // ValidateProject tests required fields for a Project.
 // This should only be called when creating a project (not on update),
 // since its name validation is more restrictive than default namespace name validation
-func ValidateProject(project *api.Project) field.ErrorList {
+func ValidateProject(project *projectapi.Project) field.ErrorList {
 	result := validation.ValidateObjectMeta(&project.ObjectMeta, false, ValidateProjectName, field.NewPath("metadata"))
 
 	if !validateNoNewLineOrTab(project.Annotations[oapi.OpenShiftDisplayName]) {
@@ -50,7 +49,7 @@ func validateNoNewLineOrTab(s string) bool {
 }
 
 // ValidateProjectUpdate tests to make sure a project update can be applied.  Modifies newProject with immutable fields.
-func ValidateProjectUpdate(newProject *api.Project, oldProject *api.Project) field.ErrorList {
+func ValidateProjectUpdate(newProject *projectapi.Project, oldProject *projectapi.Project) field.ErrorList {
 	allErrs := validation.ValidateObjectMetaUpdate(&newProject.ObjectMeta, &oldProject.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateProject(newProject)...)
 
@@ -95,14 +94,14 @@ func ValidateProjectUpdate(newProject *api.Project, oldProject *api.Project) fie
 	return allErrs
 }
 
-func ValidateProjectRequest(request *api.ProjectRequest) field.ErrorList {
-	project := &api.Project{}
+func ValidateProjectRequest(request *projectapi.ProjectRequest) field.ErrorList {
+	project := &projectapi.Project{}
 	project.ObjectMeta = request.ObjectMeta
 
 	return ValidateProject(project)
 }
 
-func validateNodeSelector(p *api.Project) field.ErrorList {
+func validateNodeSelector(p *projectapi.Project) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(p.Annotations) > 0 {

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -7,18 +7,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 func TestValidateProject(t *testing.T) {
 	testCases := []struct {
 		name    string
-		project api.Project
+		project projectapi.Project
 		numErrs int
 	}{
 		{
 			name: "missing id",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						oapi.OpenShiftDescription: "This is a description",
@@ -31,7 +31,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid id",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "141-.124.$",
 					Annotations: map[string]string{
@@ -45,7 +45,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid id uppercase",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "AA",
 				},
@@ -54,7 +54,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "valid id leading number",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "11",
 				},
@@ -63,7 +63,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid id for create (< 2 characters)",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "h",
 				},
@@ -72,7 +72,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "valid id for create (2+ characters)",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "hi",
 				},
@@ -81,7 +81,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid id internal dots",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "1.a.1",
 				},
@@ -90,7 +90,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "has namespace",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "foo",
@@ -105,7 +105,7 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid display name",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "",
@@ -120,12 +120,12 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "valid node selector",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						api.ProjectNodeSelector: "infra=true, env = test",
+						projectapi.ProjectNodeSelector: "infra=true, env = test",
 					},
 				},
 			},
@@ -133,12 +133,12 @@ func TestValidateProject(t *testing.T) {
 		},
 		{
 			name: "invalid node selector",
-			project: api.Project{
+			project: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						api.ProjectNodeSelector: "infra, env = $test",
+						projectapi.ProjectNodeSelector: "infra, env = $test",
 					},
 				},
 			},
@@ -154,7 +154,7 @@ func TestValidateProject(t *testing.T) {
 		}
 	}
 
-	project := api.Project{
+	project := projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
@@ -172,26 +172,26 @@ func TestValidateProject(t *testing.T) {
 func TestValidateProjectUpdate(t *testing.T) {
 	// Ensure we can update projects with short names, to make sure we can
 	// proxy updates to namespaces created outside project validation
-	project := &api.Project{
+	project := &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "project-name",
 			ResourceVersion: "1",
 			Annotations: map[string]string{
-				oapi.OpenShiftDescription: "This is a description",
-				oapi.OpenShiftDisplayName: "display name",
-				api.ProjectNodeSelector:   "infra=true, env = test",
+				oapi.OpenShiftDescription:      "This is a description",
+				oapi.OpenShiftDisplayName:      "display name",
+				projectapi.ProjectNodeSelector: "infra=true, env = test",
 			},
 			Labels: map[string]string{"label-name": "value"},
 		},
 	}
-	updateDisplayname := &api.Project{
+	updateDisplayname := &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "project-name",
 			ResourceVersion: "1",
 			Annotations: map[string]string{
-				oapi.OpenShiftDescription: "This is a description",
-				oapi.OpenShiftDisplayName: "display name change",
-				api.ProjectNodeSelector:   "infra=true, env = test",
+				oapi.OpenShiftDescription:      "This is a description",
+				oapi.OpenShiftDisplayName:      "display name change",
+				projectapi.ProjectNodeSelector: "infra=true, env = test",
 			},
 			Labels: map[string]string{"label-name": "value"},
 		},
@@ -203,12 +203,12 @@ func TestValidateProjectUpdate(t *testing.T) {
 	}
 
 	errorCases := map[string]struct {
-		A api.Project
+		A projectapi.Project
 		T field.ErrorType
 		F string
 	}{
 		"change name": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "different",
 					ResourceVersion: "1",
@@ -220,14 +220,14 @@ func TestValidateProjectUpdate(t *testing.T) {
 			F: "metadata.name",
 		},
 		"invalid displayname": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
 					ResourceVersion: "1",
 					Annotations: map[string]string{
-						oapi.OpenShiftDescription: "This is a description",
-						oapi.OpenShiftDisplayName: "display name\n",
-						api.ProjectNodeSelector:   "infra=true, env = test",
+						oapi.OpenShiftDescription:      "This is a description",
+						oapi.OpenShiftDisplayName:      "display name\n",
+						projectapi.ProjectNodeSelector: "infra=true, env = test",
 					},
 					Labels: project.Labels,
 				},
@@ -236,14 +236,14 @@ func TestValidateProjectUpdate(t *testing.T) {
 			F: "metadata.annotations[" + oapi.OpenShiftDisplayName + "]",
 		},
 		"updating disallowed annotation": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
 					ResourceVersion: "1",
 					Annotations: map[string]string{
-						oapi.OpenShiftDescription: "This is a description",
-						oapi.OpenShiftDisplayName: "display name",
-						api.ProjectNodeSelector:   "infra=true, env = test2",
+						oapi.OpenShiftDescription:      "This is a description",
+						oapi.OpenShiftDisplayName:      "display name",
+						projectapi.ProjectNodeSelector: "infra=true, env = test2",
 					},
 					Labels: project.Labels,
 				},
@@ -252,7 +252,7 @@ func TestValidateProjectUpdate(t *testing.T) {
 			F: "metadata.annotations[openshift.io/node-selector]",
 		},
 		"delete annotation": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
 					ResourceVersion: "1",
@@ -267,7 +267,7 @@ func TestValidateProjectUpdate(t *testing.T) {
 			F: "metadata.annotations[openshift.io/node-selector]",
 		},
 		"updating label": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
 					ResourceVersion: "1",
@@ -279,7 +279,7 @@ func TestValidateProjectUpdate(t *testing.T) {
 			F: "metadata.labels[label-name]",
 		},
 		"deleting label": {
-			A: api.Project{
+			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
 					ResourceVersion: "1",

--- a/pkg/project/controller/project_finalizer_controller_test.go
+++ b/pkg/project/controller/project_finalizer_controller_test.go
@@ -8,7 +8,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 )
 
@@ -25,7 +25,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 			DeletionTimestamp: &now,
 		},
 		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
+			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, projectapi.FinalizerOrigin},
 		},
 		Status: kapi.NamespaceStatus{
 			Phase: kapi.NamespaceTerminating,
@@ -61,7 +61,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
+			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, projectapi.FinalizerOrigin},
 		},
 		Status: kapi.NamespaceStatus{
 			Phase: kapi.NamespaceActive,

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -19,7 +19,6 @@ import (
 	oapi "github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/project/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
@@ -56,12 +55,12 @@ func NewREST(client kcoreclient.NamespaceInterface, lister projectauth.Lister, a
 
 // New returns a new Project
 func (s *REST) New() runtime.Object {
-	return &api.Project{}
+	return &projectapi.Project{}
 }
 
 // NewList returns a new ProjectList
 func (*REST) NewList() runtime.Object {
-	return &api.ProjectList{}
+	return &projectapi.ProjectList{}
 }
 
 var _ = rest.Lister(&REST{})
@@ -127,7 +126,7 @@ var _ = rest.Creater(&REST{})
 
 // Create registers the given Project.
 func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Object, error) {
-	project, ok := obj.(*api.Project)
+	project, ok := obj.(*projectapi.Project)
 	if !ok {
 		return nil, fmt.Errorf("not a project: %#v", obj)
 	}
@@ -156,7 +155,7 @@ func (s *REST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedO
 		return nil, false, err
 	}
 
-	project, ok := obj.(*api.Project)
+	project, ok := obj.(*projectapi.Project)
 	if !ok {
 		return nil, false, fmt.Errorf("not a project: %#v", obj)
 	}

--- a/pkg/project/registry/project/proxy/proxy_test.go
+++ b/pkg/project/registry/project/proxy/proxy_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 // mockLister returns the namespaces in the list
@@ -47,7 +47,7 @@ func TestListProjects(t *testing.T) {
 	if err != nil {
 		t.Errorf("%#v should be nil.", err)
 	}
-	projects := response.(*api.ProjectList)
+	projects := response.(*projectapi.ProjectList)
 	if len(projects.Items) != 1 {
 		t.Errorf("%#v projects.Items should have len 1.", projects.Items)
 	}
@@ -60,7 +60,7 @@ func TestListProjects(t *testing.T) {
 func TestCreateProjectBadObject(t *testing.T) {
 	storage := REST{}
 
-	obj, err := storage.Create(apirequest.NewContext(), &api.ProjectList{})
+	obj, err := storage.Create(apirequest.NewContext(), &projectapi.ProjectList{})
 	if obj != nil {
 		t.Errorf("Expected nil, got %v", obj)
 	}
@@ -72,7 +72,7 @@ func TestCreateProjectBadObject(t *testing.T) {
 func TestCreateInvalidProject(t *testing.T) {
 	mockClient := &fake.Clientset{}
 	storage := NewREST(mockClient.Core().Namespaces(), &mockLister{}, nil, nil)
-	_, err := storage.Create(apirequest.NewContext(), &api.Project{
+	_, err := storage.Create(apirequest.NewContext(), &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{oapi.OpenShiftDisplayName: "h\t\ni"},
 		},
@@ -85,7 +85,7 @@ func TestCreateInvalidProject(t *testing.T) {
 func TestCreateProjectOK(t *testing.T) {
 	mockClient := &fake.Clientset{}
 	storage := NewREST(mockClient.Core().Namespaces(), &mockLister{}, nil, nil)
-	_, err := storage.Create(apirequest.NewContext(), &api.Project{
+	_, err := storage.Create(apirequest.NewContext(), &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 	})
 	if err != nil {
@@ -109,7 +109,7 @@ func TestGetProjectOK(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected non-nil error: %v", err)
 	}
-	if project.(*api.Project).Name != "foo" {
+	if project.(*projectapi.Project).Name != "foo" {
 		t.Errorf("Unexpected project: %#v", project)
 	}
 }

--- a/pkg/project/registry/project/rest_test.go
+++ b/pkg/project/registry/project/rest_test.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 func TestProjectStrategy(t *testing.T) {
@@ -17,23 +17,23 @@ func TestProjectStrategy(t *testing.T) {
 	if Strategy.AllowCreateOnUpdate() {
 		t.Errorf("Projects should not allow create on update")
 	}
-	project := &api.Project{
+	project := &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "10"},
 	}
 	Strategy.PrepareForCreate(ctx, project)
-	if len(project.Spec.Finalizers) != 1 || project.Spec.Finalizers[0] != api.FinalizerOrigin {
+	if len(project.Spec.Finalizers) != 1 || project.Spec.Finalizers[0] != projectapi.FinalizerOrigin {
 		t.Errorf("Prepare For Create should have added project finalizer")
 	}
 	errs := Strategy.Validate(ctx, project)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
-	invalidProject := &api.Project{
+	invalidProject := &projectapi.Project{
 		ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "4"},
 	}
 	// ensure we copy spec.finalizers from old to new
 	Strategy.PrepareForUpdate(ctx, invalidProject, project)
-	if len(invalidProject.Spec.Finalizers) != 1 || invalidProject.Spec.Finalizers[0] != api.FinalizerOrigin {
+	if len(invalidProject.Spec.Finalizers) != 1 || invalidProject.Spec.Finalizers[0] != projectapi.FinalizerOrigin {
 		t.Errorf("PrepareForUpdate should have preserved old.spec.finalizers")
 	}
 	errs = Strategy.ValidateUpdate(ctx, invalidProject, project)

--- a/pkg/project/registry/project/strategy.go
+++ b/pkg/project/registry/project/strategy.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	"github.com/openshift/origin/pkg/project/api/validation"
 )
 
@@ -28,34 +28,34 @@ func (projectStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (projectStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	project := obj.(*api.Project)
+	project := obj.(*projectapi.Project)
 	hasProjectFinalizer := false
 	for i := range project.Spec.Finalizers {
-		if project.Spec.Finalizers[i] == api.FinalizerOrigin {
+		if project.Spec.Finalizers[i] == projectapi.FinalizerOrigin {
 			hasProjectFinalizer = true
 			break
 		}
 	}
 	if !hasProjectFinalizer {
 		if len(project.Spec.Finalizers) == 0 {
-			project.Spec.Finalizers = []kapi.FinalizerName{api.FinalizerOrigin}
+			project.Spec.Finalizers = []kapi.FinalizerName{projectapi.FinalizerOrigin}
 		} else {
-			project.Spec.Finalizers = append(project.Spec.Finalizers, api.FinalizerOrigin)
+			project.Spec.Finalizers = append(project.Spec.Finalizers, projectapi.FinalizerOrigin)
 		}
 	}
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (projectStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	newProject := obj.(*api.Project)
-	oldProject := old.(*api.Project)
+	newProject := obj.(*projectapi.Project)
+	oldProject := old.(*projectapi.Project)
 	newProject.Spec.Finalizers = oldProject.Spec.Finalizers
 	newProject.Status = oldProject.Status
 }
 
 // Validate validates a new project.
 func (projectStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateProject(obj.(*api.Project))
+	return validation.ValidateProject(obj.(*projectapi.Project))
 }
 
 // AllowCreateOnUpdate is false for project.
@@ -73,5 +73,5 @@ func (projectStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (projectStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateProjectUpdate(obj.(*api.Project), old.(*api.Project))
+	return validation.ValidateProjectUpdate(obj.(*projectapi.Project), old.(*projectapi.Project))
 }

--- a/pkg/project/util/util.go
+++ b/pkg/project/util/util.go
@@ -8,13 +8,13 @@ import (
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 // Associated returns true if the spec.finalizers contains the origin finalizer
 func Associated(namespace *kapi.Namespace) bool {
 	for i := range namespace.Spec.Finalizers {
-		if api.FinalizerOrigin == namespace.Spec.Finalizers[i] {
+		if projectapi.FinalizerOrigin == namespace.Spec.Finalizers[i] {
 			return true
 		}
 	}
@@ -32,7 +32,7 @@ func Associate(kubeClient clientset.Interface, namespace *kapi.Namespace) (*kapi
 // Finalized returns true if the spec.finalizers does not contain the origin finalizer
 func Finalized(namespace *kapi.Namespace) bool {
 	for i := range namespace.Spec.Finalizers {
-		if api.FinalizerOrigin == namespace.Spec.Finalizers[i] {
+		if projectapi.FinalizerOrigin == namespace.Spec.Finalizers[i] {
 			return false
 		}
 	}
@@ -77,9 +77,9 @@ func finalizeInternal(kubeClient clientset.Interface, namespace *kapi.Namespace,
 	}
 
 	if withOrigin {
-		finalizerSet.Insert(string(api.FinalizerOrigin))
+		finalizerSet.Insert(string(projectapi.FinalizerOrigin))
 	} else {
-		finalizerSet.Delete(string(api.FinalizerOrigin))
+		finalizerSet.Delete(string(projectapi.FinalizerOrigin))
 	}
 
 	namespaceFinalize.Spec.Finalizers = make([]kapi.FinalizerName, 0, len(finalizerSet))
@@ -90,20 +90,20 @@ func finalizeInternal(kubeClient clientset.Interface, namespace *kapi.Namespace,
 }
 
 // ConvertNamespace transforms a Namespace into a Project
-func ConvertNamespace(namespace *kapi.Namespace) *api.Project {
-	return &api.Project{
+func ConvertNamespace(namespace *kapi.Namespace) *projectapi.Project {
+	return &projectapi.Project{
 		ObjectMeta: namespace.ObjectMeta,
-		Spec: api.ProjectSpec{
+		Spec: projectapi.ProjectSpec{
 			Finalizers: namespace.Spec.Finalizers,
 		},
-		Status: api.ProjectStatus{
+		Status: projectapi.ProjectStatus{
 			Phase: namespace.Status.Phase,
 		},
 	}
 }
 
 // convertProject transforms a Project into a Namespace
-func ConvertProject(project *api.Project) *kapi.Namespace {
+func ConvertProject(project *projectapi.Project) *kapi.Namespace {
 	namespace := &kapi.Namespace{
 		ObjectMeta: project.ObjectMeta,
 		Spec: kapi.NamespaceSpec{
@@ -121,8 +121,8 @@ func ConvertProject(project *api.Project) *kapi.Namespace {
 }
 
 // ConvertNamespaceList transforms a NamespaceList into a ProjectList
-func ConvertNamespaceList(namespaceList *kapi.NamespaceList) *api.ProjectList {
-	projects := &api.ProjectList{}
+func ConvertNamespaceList(namespaceList *kapi.NamespaceList) *projectapi.ProjectList {
+	projects := &projectapi.ProjectList{}
 	for _, n := range namespaceList.Items {
 		projects.Items = append(projects.Items, *ConvertNamespace(&n))
 	}

--- a/pkg/project/util/util_test.go
+++ b/pkg/project/util/util_test.go
@@ -9,13 +9,13 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/google/gofuzz"
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 // TestProjectFidelity makes sure that the project to namespace round trip does not lose any data
 func TestProjectFidelity(t *testing.T) {
 	f := fuzz.New().NilChance(0)
-	p := &api.Project{}
+	p := &projectapi.Project{}
 	for i := 0; i < 100; i++ {
 		f.Fuzz(p)
 		p.TypeMeta = metav1.TypeMeta{} // Ignore TypeMeta

--- a/pkg/quota/api/deep_copy_test.go
+++ b/pkg/quota/api/deep_copy_test.go
@@ -7,15 +7,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/quota/api"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
 	_ "github.com/openshift/origin/pkg/quota/api/install"
 )
 
 func TestDeepCopy(t *testing.T) {
-	make := func() *api.ClusterResourceQuota {
+	make := func() *quotaapi.ClusterResourceQuota {
 		q := resource.Quantity{}
 		q.Set(100)
-		crq := &api.ClusterResourceQuota{}
+		crq := &quotaapi.ClusterResourceQuota{}
 		crq.Status.Namespaces.Insert("ns1", kapi.ResourceQuotaStatus{Hard: kapi.ResourceList{"a": q.DeepCopy()}, Used: kapi.ResourceList{"a": q.DeepCopy()}})
 		crq.Status.Namespaces.Insert("ns2", kapi.ResourceQuotaStatus{Hard: kapi.ResourceList{"b": q.DeepCopy()}, Used: kapi.ResourceList{"b": q.DeepCopy()}})
 		return crq
@@ -35,7 +35,7 @@ func TestDeepCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	copied := copiedObj.(*api.ClusterResourceQuota)
+	copied := copiedObj.(*quotaapi.ClusterResourceQuota)
 	if !reflect.DeepEqual(copied, original) {
 		t.Error("before mutation of copy, copied and original should be identical but are not, likely failure in deepequal")
 	}

--- a/pkg/quota/api/install/apigroup.go
+++ b/pkg/quota/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/quota/api"
-	"github.com/openshift/origin/pkg/quota/api/v1"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
+	quotaapiv1 "github.com/openshift/origin/pkg/quota/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  quotaapi.GroupName,
+			VersionPreferenceOrder:     []string{quotaapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: quotaapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("ClusterResourceQuota"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			quotaapiv1.SchemeGroupVersion.Version: quotaapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/quota/api"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
 	"github.com/openshift/origin/pkg/quota/registry/clusterresourcequota"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -22,10 +22,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ClusterResourceQuota{} },
-		NewListFunc:       func() runtime.Object { return &api.ClusterResourceQuotaList{} },
+		NewFunc:           func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
+		NewListFunc:       func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
 		PredicateFunc:     clusterresourcequota.Matcher,
-		QualifiedResource: api.Resource("clusterresourcequotas"),
+		QualifiedResource: quotaapi.Resource("clusterresourcequotas"),
 
 		CreateStrategy: clusterresourcequota.Strategy,
 		UpdateStrategy: clusterresourcequota.Strategy,
@@ -54,7 +54,7 @@ type StatusREST struct {
 var _ = rest.Patcher(&StatusREST{})
 
 func (r *StatusREST) New() runtime.Object {
-	return &api.ClusterResourceQuota{}
+	return &quotaapi.ClusterResourceQuota{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/quota/registry/clusterresourcequota/strategy.go
+++ b/pkg/quota/registry/clusterresourcequota/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/quota/api"
+	quotaapi "github.com/openshift/origin/pkg/quota/api"
 	"github.com/openshift/origin/pkg/quota/api/validation"
 )
 
@@ -38,14 +38,14 @@ func (strategy) GenerateName(base string) string {
 }
 
 func (strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	quota := obj.(*api.ClusterResourceQuota)
-	quota.Status = api.ClusterResourceQuotaStatus{}
+	quota := obj.(*quotaapi.ClusterResourceQuota)
+	quota.Status = quotaapi.ClusterResourceQuotaStatus{}
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	curr := obj.(*api.ClusterResourceQuota)
-	prev := old.(*api.ClusterResourceQuota)
+	curr := obj.(*quotaapi.ClusterResourceQuota)
+	prev := old.(*quotaapi.ClusterResourceQuota)
 
 	curr.Status = prev.Status
 }
@@ -55,20 +55,20 @@ func (strategy) Canonicalize(obj runtime.Object) {
 }
 
 func (strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateClusterResourceQuota(obj.(*api.ClusterResourceQuota))
+	return validation.ValidateClusterResourceQuota(obj.(*quotaapi.ClusterResourceQuota))
 }
 
 func (strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateClusterResourceQuotaUpdate(obj.(*api.ClusterResourceQuota), old.(*api.ClusterResourceQuota))
+	return validation.ValidateClusterResourceQuotaUpdate(obj.(*quotaapi.ClusterResourceQuota), old.(*quotaapi.ClusterResourceQuota))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	quota, ok := obj.(*api.ClusterResourceQuota)
+	quota, ok := obj.(*quotaapi.ClusterResourceQuota)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a ClusterResourceQuota")
 	}
-	return labels.Set(quota.ObjectMeta.Labels), api.ClusterResourceQuotaToSelectableFields(quota), nil
+	return labels.Set(quota.ObjectMeta.Labels), quotaapi.ClusterResourceQuotaToSelectableFields(quota), nil
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
@@ -106,8 +106,8 @@ func (statusStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Objec
 }
 
 func (statusStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	curr := obj.(*api.ClusterResourceQuota)
-	prev := old.(*api.ClusterResourceQuota)
+	curr := obj.(*quotaapi.ClusterResourceQuota)
+	prev := old.(*quotaapi.ClusterResourceQuota)
 
 	curr.Spec = prev.Spec
 }
@@ -116,9 +116,9 @@ func (statusStrategy) Canonicalize(obj runtime.Object) {
 }
 
 func (statusStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateClusterResourceQuota(obj.(*api.ClusterResourceQuota))
+	return validation.ValidateClusterResourceQuota(obj.(*quotaapi.ClusterResourceQuota))
 }
 
 func (statusStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateClusterResourceQuotaUpdate(obj.(*api.ClusterResourceQuota), old.(*api.ClusterResourceQuota))
+	return validation.ValidateClusterResourceQuotaUpdate(obj.(*quotaapi.ClusterResourceQuota), old.(*quotaapi.ClusterResourceQuota))
 }

--- a/pkg/route/allocation/simple/plugin_test.go
+++ b/pkg/route/allocation/simple/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	rac "github.com/openshift/origin/pkg/route/controller/allocation"
 )
 
@@ -63,17 +63,17 @@ func TestNewSimpleAllocationPlugin(t *testing.T) {
 func TestSimpleAllocationPlugin(t *testing.T) {
 	tests := []struct {
 		name  string
-		route *api.Route
+		route *routeapi.Route
 		empty bool
 	}{
 		{
 			name: "No Name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "namespace",
 				},
-				Spec: api.RouteSpec{
-					To: api.RouteTargetReference{
+				Spec: routeapi.RouteSpec{
+					To: routeapi.RouteTargetReference{
 						Name: "service",
 					},
 				},
@@ -82,12 +82,12 @@ func TestSimpleAllocationPlugin(t *testing.T) {
 		},
 		{
 			name: "No namespace",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
 				},
-				Spec: api.RouteSpec{
-					To: api.RouteTargetReference{
+				Spec: routeapi.RouteSpec{
+					To: routeapi.RouteTargetReference{
 						Name: "nonamespace",
 					},
 				},
@@ -96,7 +96,7 @@ func TestSimpleAllocationPlugin(t *testing.T) {
 		},
 		{
 			name: "No service name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
@@ -105,14 +105,14 @@ func TestSimpleAllocationPlugin(t *testing.T) {
 		},
 		{
 			name: "Valid route",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "myservice",
 					},
 				},
@@ -120,14 +120,14 @@ func TestSimpleAllocationPlugin(t *testing.T) {
 		},
 		{
 			name: "No host",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "myservice",
 					},
 				},
@@ -159,17 +159,17 @@ func TestSimpleAllocationPlugin(t *testing.T) {
 func TestSimpleAllocationPluginViaController(t *testing.T) {
 	tests := []struct {
 		name  string
-		route *api.Route
+		route *routeapi.Route
 		empty bool
 	}{
 		{
 			name: "No Name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "namespace",
 				},
-				Spec: api.RouteSpec{
-					To: api.RouteTargetReference{
+				Spec: routeapi.RouteSpec{
+					To: routeapi.RouteTargetReference{
 						Name: "service",
 					},
 				},
@@ -178,11 +178,11 @@ func TestSimpleAllocationPluginViaController(t *testing.T) {
 		},
 		{
 			name: "Host but no name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "namespace",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "foo.com",
 				},
 			},
@@ -190,12 +190,12 @@ func TestSimpleAllocationPluginViaController(t *testing.T) {
 		},
 		{
 			name: "No namespace",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
 				},
-				Spec: api.RouteSpec{
-					To: api.RouteTargetReference{
+				Spec: routeapi.RouteSpec{
+					To: routeapi.RouteTargetReference{
 						Name: "nonamespace",
 					},
 				},
@@ -204,7 +204,7 @@ func TestSimpleAllocationPluginViaController(t *testing.T) {
 		},
 		{
 			name: "No service name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
@@ -213,14 +213,14 @@ func TestSimpleAllocationPluginViaController(t *testing.T) {
 		},
 		{
 			name: "Valid route",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "s3",
 					},
 				},

--- a/pkg/route/api/install/apigroup.go
+++ b/pkg/route/api/install/apigroup.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/route/api"
-	"github.com/openshift/origin/pkg/route/api/v1"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	routeapiv1 "github.com/openshift/origin/pkg/route/api/v1"
 )
 
 func installApiGroup() {
@@ -18,13 +18,13 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  routeapi.GroupName,
+			VersionPreferenceOrder:     []string{routeapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: routeapi.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			routeapiv1.SchemeGroupVersion.Version: routeapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/route/api/install/install.go
+++ b/pkg/route/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/route/api"
-	"github.com/openshift/origin/pkg/route/api/v1"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	routeapiv1 "github.com/openshift/origin/pkg/route/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/route/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/route/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{routeapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", routeapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	routeapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case routeapiv1.LegacySchemeGroupVersion:
+			routeapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case routeapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(routeapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/route/api/v1/conversion_test.go
+++ b/pkg/route/api/v1/conversion_test.go
@@ -5,8 +5,8 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/route/api"
-	"github.com/openshift/origin/pkg/route/api/v1"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	routeapiv1 "github.com/openshift/origin/pkg/route/api/v1"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	// install all APIs
@@ -16,20 +16,20 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "Route",
 		// Ensure all currently returned labels are supported
-		api.RouteToSelectableFields(&api.Route{}),
+		routeapi.RouteToSelectableFields(&routeapi.Route{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"spec.host", "spec.path", "spec.to.name",
 	)
 }
 
 func TestSupportingCamelConstants(t *testing.T) {
-	for k, v := range map[v1.TLSTerminationType]api.TLSTerminationType{
-		"Reencrypt":   api.TLSTerminationReencrypt,
-		"Edge":        api.TLSTerminationEdge,
-		"Passthrough": api.TLSTerminationPassthrough,
+	for k, v := range map[routeapiv1.TLSTerminationType]routeapi.TLSTerminationType{
+		"Reencrypt":   routeapi.TLSTerminationReencrypt,
+		"Edge":        routeapi.TLSTerminationEdge,
+		"Passthrough": routeapi.TLSTerminationPassthrough,
 	} {
-		obj := &v1.TLSConfig{Termination: k}
-		out := &api.TLSConfig{}
+		obj := &routeapiv1.TLSConfig{Termination: k}
+		out := &routeapi.TLSConfig{}
 		if err := kapi.Scheme.Convert(obj, out, nil); err != nil {
 			t.Errorf("%s: did not convert: %v", k, err)
 			continue

--- a/pkg/route/api/v1/defaults_test.go
+++ b/pkg/route/api/v1/defaults_test.go
@@ -7,46 +7,46 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/route/api/v1"
+	routeapiv1 "github.com/openshift/origin/pkg/route/api/v1"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 func TestDefaults(t *testing.T) {
-	obj := &v1.Route{
-		Spec: v1.RouteSpec{
-			To:  v1.RouteTargetReference{Name: "other"},
-			TLS: &v1.TLSConfig{},
+	obj := &routeapiv1.Route{
+		Spec: routeapiv1.RouteSpec{
+			To:  routeapiv1.RouteTargetReference{Name: "other"},
+			TLS: &routeapiv1.TLSConfig{},
 		},
-		Status: v1.RouteStatus{
-			Ingress: []v1.RouteIngress{{}},
+		Status: routeapiv1.RouteStatus{
+			Ingress: []routeapiv1.RouteIngress{{}},
 		},
 	}
 
 	obj2 := roundTrip(t, obj)
-	out, ok := obj2.(*v1.Route)
+	out, ok := obj2.(*routeapiv1.Route)
 	if !ok {
 		t.Errorf("Unexpected object: %v", obj2)
 		t.FailNow()
 	}
 
-	if out.Spec.TLS.Termination != v1.TLSTerminationEdge {
+	if out.Spec.TLS.Termination != routeapiv1.TLSTerminationEdge {
 		t.Errorf("did not default termination: %#v", out)
 	}
-	if out.Spec.WildcardPolicy != v1.WildcardPolicyNone {
+	if out.Spec.WildcardPolicy != routeapiv1.WildcardPolicyNone {
 		t.Errorf("did not default wildcard policy: %#v", out)
 	}
 	if out.Spec.To.Kind != "Service" {
 		t.Errorf("did not default object reference kind: %#v", out)
 	}
-	if out.Status.Ingress[0].WildcardPolicy != v1.WildcardPolicyNone {
+	if out.Status.Ingress[0].WildcardPolicy != routeapiv1.WildcardPolicyNone {
 		t.Errorf("did not default status ingress wildcard policy: %#v", out)
 	}
 }
 
 func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
-	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), obj)
+	data, err := runtime.Encode(kapi.Codecs.LegacyCodec(routeapiv1.SchemeGroupVersion), obj)
 	if err != nil {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 const (
@@ -737,8 +737,8 @@ The+rest+of+the+certificate+info+is+invalid+and+badly+malformed/
 -----END CERTIFICATE-----`
 )
 
-func createRouteSpecTo(name string, kind string) api.RouteTargetReference {
-	svc := api.RouteTargetReference{
+func createRouteSpecTo(name string, kind string) routeapi.RouteTargetReference {
+	svc := routeapi.RouteTargetReference{
 		Name: name,
 		Kind: kind,
 	}
@@ -750,16 +750,16 @@ func createRouteSpecTo(name string, kind string) api.RouteTargetReference {
 func TestValidateRoute(t *testing.T) {
 	tests := []struct {
 		name           string
-		route          *api.Route
+		route          *routeapi.Route
 		expectedErrors int
 	}{
 		{
 			name: "No Name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
 					To:   createRouteSpecTo("serviceName", "Service"),
 				},
@@ -768,11 +768,11 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "No namespace",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "name",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
 					To:   createRouteSpecTo("serviceName", "Service"),
 				},
@@ -781,12 +781,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "No host",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					To: createRouteSpecTo("serviceName", "Service"),
 				},
 			},
@@ -794,12 +794,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Invalid DNS 952 host",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "**",
 					To:   createRouteSpecTo("serviceName", "Service"),
 				},
@@ -808,12 +808,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "No service name",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
 					To:   createRouteSpecTo("", "Service"),
 				},
@@ -822,12 +822,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "No service kind",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
 					To:   createRouteSpecTo("serviceName", ""),
 				},
@@ -836,15 +836,15 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Zero port",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					To:   createRouteSpecTo("serviceName", "Service"),
-					Port: &api.RoutePort{
+					Port: &routeapi.RoutePort{
 						TargetPort: intstr.FromInt(0),
 					},
 				},
@@ -853,15 +853,15 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Empty string port",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					To:   createRouteSpecTo("serviceName", "Service"),
-					Port: &api.RoutePort{
+					Port: &routeapi.RoutePort{
 						TargetPort: intstr.FromString(""),
 					},
 				},
@@ -870,12 +870,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Valid route",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					To:   createRouteSpecTo("serviceName", "Service"),
 				},
@@ -884,12 +884,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Valid route with path",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					To:   createRouteSpecTo("serviceName", "Service"),
 					Path: "/test",
@@ -899,12 +899,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Invalid route with path",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					To:   createRouteSpecTo("serviceName", "Service"),
 					Path: "test",
@@ -914,17 +914,17 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Passthrough route with path",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 					Path: "/test",
 					To:   createRouteSpecTo("serviceName", "Service"),
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationPassthrough,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationPassthrough,
 					},
 				},
 			},
@@ -932,12 +932,12 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "No wildcard policy",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "nowildcard",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "no.wildcard.test",
 					To:   createRouteSpecTo("serviceName", "Service"),
 				},
@@ -946,42 +946,42 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "wildcard policy none",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "nowildcard2",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host:           "none.wildcard.test",
 					To:             createRouteSpecTo("serviceName", "Service"),
-					WildcardPolicy: api.WildcardPolicyNone,
+					WildcardPolicy: routeapi.WildcardPolicyNone,
 				},
 			},
 			expectedErrors: 0,
 		},
 		{
 			name: "wildcard policy subdomain",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wildcardpolicy",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host:           "subdomain.wildcard.test",
 					To:             createRouteSpecTo("serviceName", "Service"),
-					WildcardPolicy: api.WildcardPolicySubdomain,
+					WildcardPolicy: routeapi.WildcardPolicySubdomain,
 				},
 			},
 			expectedErrors: 0,
 		},
 		{
 			name: "Invalid wildcard policy",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "badwildcard",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host:           "bad.wildcard.test",
 					To:             createRouteSpecTo("serviceName", "Service"),
 					WildcardPolicy: "bad-wolf",
@@ -991,29 +991,29 @@ func TestValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Invalid host for wildcard policy",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "badhost",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					To:             createRouteSpecTo("serviceName", "Service"),
-					WildcardPolicy: api.WildcardPolicySubdomain,
+					WildcardPolicy: routeapi.WildcardPolicySubdomain,
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Empty host for wildcard policy",
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "emptyhost",
 					Namespace: "foo",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host:           "",
 					To:             createRouteSpecTo("serviceName", "Service"),
-					WildcardPolicy: api.WildcardPolicySubdomain,
+					WildcardPolicy: routeapi.WildcardPolicySubdomain,
 				},
 			},
 			expectedErrors: 1,
@@ -1032,14 +1032,14 @@ func TestValidateRoute(t *testing.T) {
 func TestValidateTLS(t *testing.T) {
 	tests := []struct {
 		name           string
-		route          *api.Route
+		route          *routeapi.Route
 		expectedErrors int
 	}{
 		{
 			name: "No TLS Termination",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
 						Termination: "",
 					},
 				},
@@ -1048,10 +1048,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Passthrough termination OK",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationPassthrough,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationPassthrough,
 					},
 				},
 			},
@@ -1059,10 +1059,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination OK with certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              "def",
 						Key:                      "ghi",
 						CACertificate:            "jkl",
@@ -1074,10 +1074,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination OK without certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: "abc",
 					},
 				},
@@ -1086,10 +1086,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination no dest cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationReencrypt,
 						Certificate:   "def",
 						Key:           "ghi",
 						CACertificate: "jkl",
@@ -1100,10 +1100,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Edge termination OK with certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   "abc",
 						Key:           "abc",
 						CACertificate: "abc",
@@ -1114,10 +1114,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Edge termination OK without certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 					},
 				},
 			},
@@ -1125,10 +1125,10 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Edge termination, dest cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationEdge,
 						DestinationCACertificate: "abc",
 					},
 				},
@@ -1137,45 +1137,45 @@ func TestValidateTLS(t *testing.T) {
 		},
 		{
 			name: "Passthrough termination, cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, Certificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, Certificate: "test"},
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Passthrough termination, key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, Key: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, Key: "test"},
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Passthrough termination, ca cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, CACertificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, CACertificate: "test"},
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Passthrough termination, dest ca cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, DestinationCACertificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, DestinationCACertificate: "test"},
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Invalid termination type",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
 						Termination: "invalid",
 					},
 				},
@@ -1195,20 +1195,20 @@ func TestValidateTLS(t *testing.T) {
 
 func TestValidatePassthroughInsecureEdgeTerminationPolicy(t *testing.T) {
 
-	insecureTypes := map[api.InsecureEdgeTerminationPolicyType]bool{
+	insecureTypes := map[routeapi.InsecureEdgeTerminationPolicyType]bool{
 		"": false,
-		api.InsecureEdgeTerminationPolicyNone:     false,
-		api.InsecureEdgeTerminationPolicyAllow:    true,
-		api.InsecureEdgeTerminationPolicyRedirect: false,
-		"support HTTPsec":                         true,
-		"or maybe HSTS":                           true,
+		routeapi.InsecureEdgeTerminationPolicyNone:     false,
+		routeapi.InsecureEdgeTerminationPolicyAllow:    true,
+		routeapi.InsecureEdgeTerminationPolicyRedirect: false,
+		"support HTTPsec":                              true,
+		"or maybe HSTS":                                true,
 	}
 
 	for key, expected := range insecureTypes {
-		route := &api.Route{
-			Spec: api.RouteSpec{
-				TLS: &api.TLSConfig{
-					Termination:                   api.TLSTerminationPassthrough,
+		route := &routeapi.Route{
+			Spec: routeapi.RouteSpec{
+				TLS: &routeapi.TLSConfig{
+					Termination:                   routeapi.TLSTerminationPassthrough,
 					InsecureEdgeTerminationPolicy: key,
 				},
 			},
@@ -1230,62 +1230,62 @@ func TestValidatePassthroughInsecureEdgeTerminationPolicy(t *testing.T) {
 func TestValidateRouteUpdate(t *testing.T) {
 	tests := []struct {
 		name           string
-		route          *api.Route
-		change         func(route *api.Route)
+		route          *routeapi.Route
+		change         func(route *routeapi.Route)
 		expectedErrors int
 	}{
 		{
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "bar",
 					Namespace:       "foo",
 					ResourceVersion: "1",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "serviceName",
 						Kind: "Service",
 					},
 				},
 			},
-			change:         func(route *api.Route) { route.Spec.Host = "" },
+			change:         func(route *routeapi.Route) { route.Spec.Host = "" },
 			expectedErrors: 0, // now controlled by rbac
 		},
 		{
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "bar",
 					Namespace:       "foo",
 					ResourceVersion: "1",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "serviceName",
 						Kind: "Service",
 					},
 				},
 			},
-			change:         func(route *api.Route) { route.Spec.Host = "other" },
+			change:         func(route *routeapi.Route) { route.Spec.Host = "other" },
 			expectedErrors: 0, // now controlled by rbac
 		},
 		{
-			route: &api.Route{
+			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "bar",
 					Namespace:       "foo",
 					ResourceVersion: "1",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host: "host",
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "serviceName",
 						Kind: "Service",
 					},
 				},
 			},
-			change:         func(route *api.Route) { route.Name = "baz" },
+			change:         func(route *routeapi.Route) { route.Name = "baz" },
 			expectedErrors: 1,
 		},
 	}
@@ -1295,7 +1295,7 @@ func TestValidateRouteUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		newRoute := copied.(*api.Route)
+		newRoute := copied.(*routeapi.Route)
 		tc.change(newRoute)
 		errs := ValidateRouteUpdate(newRoute, tc.route)
 		if len(errs) != tc.expectedErrors {
@@ -1307,7 +1307,7 @@ func TestValidateRouteUpdate(t *testing.T) {
 func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
 	tests := []struct {
 		name           string
-		insecure       api.InsecureEdgeTerminationPolicyType
+		insecure       routeapi.InsecureEdgeTerminationPolicyType
 		expectedErrors int
 	}{
 		{
@@ -1322,17 +1322,17 @@ func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
 		},
 		{
 			name:           "insecure option none",
-			insecure:       api.InsecureEdgeTerminationPolicyNone,
+			insecure:       routeapi.InsecureEdgeTerminationPolicyNone,
 			expectedErrors: 0,
 		},
 		{
 			name:           "insecure option allow",
-			insecure:       api.InsecureEdgeTerminationPolicyAllow,
+			insecure:       routeapi.InsecureEdgeTerminationPolicyAllow,
 			expectedErrors: 0,
 		},
 		{
 			name:           "insecure option redirect",
-			insecure:       api.InsecureEdgeTerminationPolicyRedirect,
+			insecure:       routeapi.InsecureEdgeTerminationPolicyRedirect,
 			expectedErrors: 0,
 		},
 		{
@@ -1343,10 +1343,10 @@ func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		route := &api.Route{
-			Spec: api.RouteSpec{
-				TLS: &api.TLSConfig{
-					Termination:                   api.TLSTerminationEdge,
+		route := &routeapi.Route{
+			Spec: routeapi.RouteSpec{
+				TLS: &routeapi.TLSConfig{
+					Termination:                   routeapi.TLSTerminationEdge,
 					InsecureEdgeTerminationPolicy: tc.insecure,
 				},
 			},
@@ -1362,14 +1362,14 @@ func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
 func TestValidateEdgeReencryptInsecureEdgeTerminationPolicy(t *testing.T) {
 	tests := []struct {
 		name  string
-		route *api.Route
+		route *routeapi.Route
 	}{
 		{
 			name: "Reencrypt termination",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: "dca",
 					},
 				},
@@ -1377,10 +1377,10 @@ func TestValidateEdgeReencryptInsecureEdgeTerminationPolicy(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination DestCACert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testDestinationCACertificate,
 					},
 				},
@@ -1388,22 +1388,22 @@ func TestValidateEdgeReencryptInsecureEdgeTerminationPolicy(t *testing.T) {
 		},
 		{
 			name: "Edge termination",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 					},
 				},
 			},
 		},
 	}
 
-	insecureTypes := map[api.InsecureEdgeTerminationPolicyType]bool{
-		api.InsecureEdgeTerminationPolicyNone:     false,
-		api.InsecureEdgeTerminationPolicyAllow:    false,
-		api.InsecureEdgeTerminationPolicyRedirect: false,
-		"support HTTPsec":                         true,
-		"or maybe HSTS":                           true,
+	insecureTypes := map[routeapi.InsecureEdgeTerminationPolicyType]bool{
+		routeapi.InsecureEdgeTerminationPolicyNone:     false,
+		routeapi.InsecureEdgeTerminationPolicyAllow:    false,
+		routeapi.InsecureEdgeTerminationPolicyRedirect: false,
+		"support HTTPsec":                              true,
+		"or maybe HSTS":                                true,
 	}
 
 	for _, tc := range tests {
@@ -1426,15 +1426,15 @@ func TestValidateEdgeReencryptInsecureEdgeTerminationPolicy(t *testing.T) {
 func TestExtendedValidateRoute(t *testing.T) {
 	tests := []struct {
 		name           string
-		route          *api.Route
-		expectRoute    *api.Route
+		route          *routeapi.Route
+		expectRoute    *routeapi.Route
 		expectedErrors int
 	}{
 		{
 			name: "No TLS Termination",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
 						Termination: "",
 					},
 				},
@@ -1443,10 +1443,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Passthrough termination OK",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationPassthrough,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationPassthrough,
 					},
 				},
 			},
@@ -1454,12 +1454,12 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination OK with certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
 
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              testCertificate,
 						Key:                      testPrivateKey,
 						CACertificate:            testCACertificate,
@@ -1471,10 +1471,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination OK with bad config",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              "def",
 						Key:                      "ghi",
 						CACertificate:            "jkl",
@@ -1486,10 +1486,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination OK without certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testDestinationCACertificate,
 					},
 				},
@@ -1498,10 +1498,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination bad config without certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: "abc",
 					},
 				},
@@ -1510,11 +1510,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Reencrypt termination no dest cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationReencrypt,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1525,10 +1525,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination OK with certs without host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1539,11 +1539,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination OK with certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1554,11 +1554,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination bad config with certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   "abc",
 						Key:           "abc",
 						CACertificate: "abc",
@@ -1569,11 +1569,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination mismatched key and cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testExpiredCertPrivateKey,
 						CACertificate: testCACertificate,
@@ -1584,11 +1584,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination expired cert unknown CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testExpiredCAUnknownCertificate,
 						Key:         testExpiredCertPrivateKey,
 					},
@@ -1598,11 +1598,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination expired cert mismatched CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testExpiredCAUnknownCertificate,
 						Key:           testExpiredCertPrivateKey,
 						CACertificate: testCACertificate,
@@ -1613,11 +1613,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination expired cert key mismatch",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testExpiredCAUnknownCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1628,10 +1628,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination OK without certs",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 					},
 				},
 			},
@@ -1639,10 +1639,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Edge termination, dest cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationEdge,
 						DestinationCACertificate: "abc",
 					},
 				},
@@ -1651,45 +1651,45 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Passthrough termination, cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, Certificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, Certificate: "test"},
 				},
 			},
 			expectedErrors: 3,
 		},
 		{
 			name: "Passthrough termination, key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, Key: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, Key: "test"},
 				},
 			},
 			expectedErrors: 1,
 		},
 		{
 			name: "Passthrough termination, ca cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, CACertificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, CACertificate: "test"},
 				},
 			},
 			expectedErrors: 2,
 		},
 		{
 			name: "Passthrough termination, dest ca cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{Termination: api.TLSTerminationPassthrough, DestinationCACertificate: "test"},
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{Termination: routeapi.TLSTerminationPassthrough, DestinationCACertificate: "test"},
 				},
 			},
 			expectedErrors: 2,
 		},
 		{
 			name: "Invalid termination type",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
 						Termination: "invalid",
 					},
 				},
@@ -1698,10 +1698,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Double escaped newlines",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              "d\\nef",
 						Key:                      "g\\nhi",
 						CACertificate:            "j\\nkl",
@@ -1713,11 +1713,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "example cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1728,11 +1728,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1743,11 +1743,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert reencrypt",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              testCertificate,
 						Key:                      testPrivateKey,
 						CACertificate:            testCACertificate,
@@ -1759,11 +1759,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert invalid key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testExpiredCertNoKey,
 					},
 				},
@@ -1772,11 +1772,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert mismatched key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testExpiredCertNoKey,
 						Key:         testPrivateKey,
 					},
@@ -1786,11 +1786,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert invalid key reencrypt",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.com",
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						Certificate:              testExpiredCertNoKey,
 						DestinationCACertificate: testExpiredCertNoKey,
 					},
@@ -1800,11 +1800,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "Expired cert with a different route host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "think.different.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testCACertificate,
@@ -1815,11 +1815,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "self-signed cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "self.signer.test",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationReencrypt,
 						Certificate: testSelfSignedCert,
 						Key:         testSelfSignedKey,
 
@@ -1831,11 +1831,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "self-signed cert with different host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "different.co.us",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testSelfSignedCert,
 						Key:         testSelfSignedKey,
 					},
@@ -1845,11 +1845,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "future validity date 2038 cert",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "self.signer.test",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testValidInFutureCert,
 						Key:         testValidInFutureKey,
 					},
@@ -1859,11 +1859,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "future validity date 2038 cert with whitespace",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "self.signer.test",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testValidInFutureCertWithWhitespace,
 						Key:         testValidInFutureKeyWithWhitespace,
 					},
@@ -1873,11 +1873,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "future validity date 2038 cert with different host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.in.the.future.test",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationEdge,
 						Certificate: testValidInFutureCert,
 						Key:         testValidInFutureKey,
 					},
@@ -1887,11 +1887,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "cert with intermediate CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificateWithIntCA,
 						Key:           testPrivateKeyWithIntCA,
 						CACertificate: testIntCACertificateChain,
@@ -1902,11 +1902,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "cert with intermediate CA and diff host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "different.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificateWithIntCA,
 						Key:           testPrivateKeyWithIntCA,
 						CACertificate: testIntCACertificateChain,
@@ -1917,11 +1917,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "expired cert with intermediate CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "expired.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testExpiredCertificateWithIntCA,
 						Key:           testExpiredCertificateKey,
 						CACertificate: testIntCACertificateChain,
@@ -1932,11 +1932,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "expired cert with intermediate CA and diff host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "still.expired.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testExpiredCertificateWithIntCA,
 						Key:           testExpiredCertificateKey,
 						CACertificate: testIntCACertificateChain,
@@ -1947,11 +1947,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "future valid cert with intermediate CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "valid.in.the.future.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testFutureValidCertificateWithIntCA,
 						Key:           testFutureValidCertificateKey,
 						CACertificate: testIntCACertificateChain,
@@ -1962,11 +1962,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "future valid cert with intermediate CA and diff host",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "future.valid.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testFutureValidCertificateWithIntCA,
 						Key:           testFutureValidCertificateKey,
 						CACertificate: testIntCACertificateChain,
@@ -1977,11 +1977,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid CA with csr",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "invalid.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testInvalidCANoCert1,
@@ -1992,11 +1992,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "another invalid CA with private key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "another.invalid.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testInvalidCANoCert2,
@@ -2007,11 +2007,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid CA malformed certificate",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "malformed.ca.test",
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						Certificate:   testCertificate,
 						Key:           testPrivateKey,
 						CACertificate: testInvalidCAMalformedCert,
@@ -2022,11 +2022,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid destination CA with csr",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "csr.destination.ca",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationReencrypt,
 						Certificate: testSelfSignedCert,
 						Key:         testSelfSignedKey,
 
@@ -2038,11 +2038,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid destination CA with private key",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "key.destination.ca",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationReencrypt,
 						Certificate: testSelfSignedCert,
 						Key:         testSelfSignedKey,
 
@@ -2054,11 +2054,11 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "malformed destination CA",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "malformed.destination.ca",
-					TLS: &api.TLSConfig{
-						Termination: api.TLSTerminationReencrypt,
+					TLS: &routeapi.TLSConfig{
+						Termination: routeapi.TLSTerminationReencrypt,
 						Certificate: testSelfSignedCert,
 						Key:         testSelfSignedKey,
 
@@ -2070,10 +2070,10 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "valid destination CA with whitespace",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChain,
 					},
 				},
@@ -2082,19 +2082,19 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "unexpected key type",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChain,
 						Key: "-----BEGIN UNRECOGNIZED-----\n-----END UNRECOGNIZED-----\n",
 					},
 				},
 			},
-			expectRoute: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			expectRoute: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChainCanonical,
 						Key: "",
 					},
@@ -2104,19 +2104,19 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid PEM data silently dropped (bad trailer)",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChain,
 						Key: "-----BEGIN UNRECOGNIZED-----\n----END UNRECOGNIZED-----\n",
 					},
 				},
 			},
-			expectRoute: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			expectRoute: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChainCanonical,
 						Key: "",
 					},
@@ -2126,19 +2126,19 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "EC PARAMETERS silently dropped",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChain,
 						Key: "-----BEGIN EC PARAMETERS-----\n-----END EC PARAMETERS-----\n",
 					},
 				},
 			},
-			expectRoute: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:              api.TLSTerminationReencrypt,
+			expectRoute: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:              routeapi.TLSTerminationReencrypt,
 						DestinationCACertificate: testIntCACertificateChainCanonical,
 						Key: "",
 					},
@@ -2148,19 +2148,19 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "EC PARAMETERS silently dropped and CA rewritten",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						CACertificate: testIntCACertificateChain,
 						Key:           "-----BEGIN EC PARAMETERS-----\n-----END EC PARAMETERS-----\n",
 					},
 				},
 			},
-			expectRoute: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			expectRoute: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						CACertificate: testIntCACertificateChainCanonical,
 						Key:           "",
 					},
@@ -2170,19 +2170,19 @@ func TestExtendedValidateRoute(t *testing.T) {
 		},
 		{
 			name: "invalid key returns error",
-			route: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						CACertificate: testIntCACertificateChain,
 						Key:           "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
 					},
 				},
 			},
-			expectRoute: &api.Route{
-				Spec: api.RouteSpec{
-					TLS: &api.TLSConfig{
-						Termination:   api.TLSTerminationEdge,
+			expectRoute: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					TLS: &routeapi.TLSConfig{
+						Termination:   routeapi.TLSTerminationEdge,
 						CACertificate: testIntCACertificateChainCanonical,
 						Key:           "",
 					},
@@ -2243,13 +2243,13 @@ func TestExtendedValidateRoute(t *testing.T) {
 func TestValidateHostName(t *testing.T) {
 	tests := []struct {
 		name           string
-		route          *api.Route
+		route          *routeapi.Route
 		expectedErrors bool
 	}{
 		{
 			name: "valid-host-name",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "www.example.test",
 				},
 			},
@@ -2257,8 +2257,8 @@ func TestValidateHostName(t *testing.T) {
 		},
 		{
 			name: "invalid-host-name",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890-1234567890.example.test",
 				},
 			},
@@ -2266,8 +2266,8 @@ func TestValidateHostName(t *testing.T) {
 		},
 		{
 			name: "valid-host-63-chars-label",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-1234.example.test",
 				},
 			},
@@ -2275,8 +2275,8 @@ func TestValidateHostName(t *testing.T) {
 		},
 		{
 			name: "invalid-host-64-chars-label",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "name-namespace-1234567890-1234567890-1234567890-1234567890-12345.example.test",
 				},
 			},
@@ -2284,8 +2284,8 @@ func TestValidateHostName(t *testing.T) {
 		},
 		{
 			name: "valid-name-253-chars",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s12345678.example.test",
 				},
 			},
@@ -2293,8 +2293,8 @@ func TestValidateHostName(t *testing.T) {
 		},
 		{
 			name: "invalid-name-279-chars",
-			route: &api.Route{
-				Spec: api.RouteSpec{
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
 					Host: "name-namespace.a1234567890.b1234567890.c1234567890.d1234567890.e1234567890.f1234567890.g1234567890.h1234567890.i1234567890.j1234567890.k1234567890.l1234567890.m1234567890.n1234567890.o1234567890.p1234567890.q1234567890.r1234567890.s1234567890.t1234567890.u1234567890.example.test",
 				},
 			},

--- a/pkg/route/generator/generate.go
+++ b/pkg/route/generator/generate.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/kubectl"
 
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 // RouteGenerator generates routes from a given set of parameters
@@ -63,16 +63,16 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 		}
 	}
 
-	route := &api.Route{
+	route := &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
-		Spec: api.RouteSpec{
+		Spec: routeapi.RouteSpec{
 			Host:           params["hostname"],
-			WildcardPolicy: api.WildcardPolicyType(params["wildcard-policy"]),
+			WildcardPolicy: routeapi.WildcardPolicyType(params["wildcard-policy"]),
 			Path:           params["path"],
-			To: api.RouteTargetReference{
+			To: routeapi.RouteTargetReference{
 				Name: params["default-name"],
 			},
 		},
@@ -86,7 +86,7 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 		} else {
 			targetPort = intstr.FromString(portString)
 		}
-		route.Spec.Port = &api.RoutePort{
+		route.Spec.Port = &routeapi.RoutePort{
 			TargetPort: targetPort,
 		}
 	}

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -10,7 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/route"
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	rest "github.com/openshift/origin/pkg/route/registry/route"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -25,10 +25,10 @@ func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarC
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Route{} },
-		NewListFunc:       func() runtime.Object { return &api.RouteList{} },
+		NewFunc:           func() runtime.Object { return &routeapi.Route{} },
+		NewListFunc:       func() runtime.Object { return &routeapi.RouteList{} },
 		PredicateFunc:     rest.Matcher,
-		QualifiedResource: api.Resource("routes"),
+		QualifiedResource: routeapi.Resource("routes"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
@@ -56,7 +56,7 @@ var _ = kapirest.Patcher(&StatusREST{})
 
 // New creates a new route resource
 func (r *StatusREST) New() runtime.Object {
-	return &api.Route{}
+	return &routeapi.Route{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/route/registry/route/etcd/etcd_test.go
+++ b/pkg/route/registry/route/etcd/etcd_test.go
@@ -13,7 +13,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	routetypes "github.com/openshift/origin/pkg/route"
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	_ "github.com/openshift/origin/pkg/route/api/install"
 	"github.com/openshift/origin/pkg/route/registry/route"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -26,11 +26,11 @@ type testAllocator struct {
 	Generate bool
 }
 
-func (a *testAllocator) AllocateRouterShard(*api.Route) (*api.RouterShard, error) {
+func (a *testAllocator) AllocateRouterShard(*routeapi.Route) (*routeapi.RouterShard, error) {
 	a.Allocate = true
 	return nil, a.Err
 }
-func (a *testAllocator) GenerateHostname(*api.Route, *api.RouterShard) string {
+func (a *testAllocator) GenerateHostname(*routeapi.Route, *routeapi.RouterShard) string {
 	a.Generate = true
 	return a.Hostname
 }
@@ -55,13 +55,13 @@ func newStorage(t *testing.T, allocator routetypes.RouteAllocator) (*REST, *etcd
 	return storage, server
 }
 
-func validRoute() *api.Route {
-	return &api.Route{
+func validRoute() *routeapi.Route {
+	return &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
-		Spec: api.RouteSpec{
-			To: api.RouteTargetReference{
+		Spec: routeapi.RouteSpec{
+			To: routeapi.RouteTargetReference{
 				Name: "test",
 				Kind: "Service",
 			},
@@ -78,7 +78,7 @@ func TestCreate(t *testing.T) {
 		// valid
 		validRoute(),
 		// invalid
-		&api.Route{
+		&routeapi.Route{
 			ObjectMeta: metav1.ObjectMeta{Name: "_-a123-a_"},
 		},
 	)
@@ -94,7 +94,7 @@ func TestCreateWithAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create object: %v", err)
 	}
-	result := obj.(*api.Route)
+	result := obj.(*routeapi.Route)
 	if result.Spec.Host != "bar" {
 		t.Fatalf("unexpected route: %#v", result)
 	}
@@ -116,7 +116,7 @@ func TestUpdate(t *testing.T) {
 		validRoute(),
 		// valid update
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.Route)
+			object := obj.(*routeapi.Route)
 			if object.Annotations == nil {
 				object.Annotations = map[string]string{}
 			}
@@ -125,7 +125,7 @@ func TestUpdate(t *testing.T) {
 		},
 		// invalid update
 		func(obj runtime.Object) runtime.Object {
-			object := obj.(*api.Route)
+			object := obj.(*routeapi.Route)
 			object.Spec.Path = "invalid/path"
 			return object
 		},

--- a/pkg/route/registry/route/registry.go
+++ b/pkg/route/registry/route/registry.go
@@ -6,19 +6,19 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 // Registry is an interface for things that know how to store Routes.
 type Registry interface {
 	// ListRoutes obtains list of routes that match a selector.
-	ListRoutes(ctx apirequest.Context, options *metainternal.ListOptions) (*api.RouteList, error)
+	ListRoutes(ctx apirequest.Context, options *metainternal.ListOptions) (*routeapi.RouteList, error)
 	// GetRoute retrieves a specific route.
-	GetRoute(ctx apirequest.Context, routeID string, options *metav1.GetOptions) (*api.Route, error)
+	GetRoute(ctx apirequest.Context, routeID string, options *metav1.GetOptions) (*routeapi.Route, error)
 	// CreateRoute creates a new route.
-	CreateRoute(ctx apirequest.Context, route *api.Route) error
+	CreateRoute(ctx apirequest.Context, route *routeapi.Route) error
 	// UpdateRoute updates a route.
-	UpdateRoute(ctx apirequest.Context, route *api.Route) error
+	UpdateRoute(ctx apirequest.Context, route *routeapi.Route) error
 	// DeleteRoute deletes a route.
 	DeleteRoute(ctx apirequest.Context, routeID string) error
 	// WatchRoutes watches for new/modified/deleted routes.

--- a/pkg/route/registry/route/strategy_test.go
+++ b/pkg/route/registry/route/strategy_test.go
@@ -11,16 +11,16 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
-	"github.com/openshift/origin/pkg/route/api"
+	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
 type testAllocator struct {
 }
 
-func (t testAllocator) AllocateRouterShard(*api.Route) (*api.RouterShard, error) {
-	return &api.RouterShard{}, nil
+func (t testAllocator) AllocateRouterShard(*routeapi.Route) (*routeapi.RouterShard, error) {
+	return &routeapi.RouterShard{}, nil
 }
-func (t testAllocator) GenerateHostname(*api.Route, *api.RouterShard) string {
+func (t testAllocator) GenerateHostname(*routeapi.Route, *routeapi.RouterShard) string {
 	return "mygeneratedhost.com"
 }
 
@@ -39,25 +39,25 @@ func TestEmptyHostDefaulting(t *testing.T) {
 	ctx := apirequest.NewContext()
 	strategy := NewStrategy(testAllocator{}, &testSAR{allow: true})
 
-	hostlessCreatedRoute := &api.Route{}
+	hostlessCreatedRoute := &routeapi.Route{}
 	strategy.Validate(ctx, hostlessCreatedRoute)
 	if hostlessCreatedRoute.Spec.Host != "mygeneratedhost.com" {
 		t.Fatalf("Expected host to be allocated, got %s", hostlessCreatedRoute.Spec.Host)
 	}
 
-	persistedRoute := &api.Route{
+	persistedRoute := &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       "foo",
 			Name:            "myroute",
 			UID:             types.UID("abc"),
 			ResourceVersion: "1",
 		},
-		Spec: api.RouteSpec{
+		Spec: routeapi.RouteSpec{
 			Host: "myhost.com",
 		},
 	}
 	obj, _ := kapi.Scheme.DeepCopy(persistedRoute)
-	hostlessUpdatedRoute := obj.(*api.Route)
+	hostlessUpdatedRoute := obj.(*routeapi.Route)
 	hostlessUpdatedRoute.Spec.Host = ""
 	strategy.PrepareForUpdate(ctx, hostlessUpdatedRoute, persistedRoute)
 	if hostlessUpdatedRoute.Spec.Host != "myhost.com" {
@@ -72,8 +72,8 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 	tests := []struct {
 		name           string
 		host, oldHost  string
-		wildcardPolicy api.WildcardPolicyType
-		tls, oldTLS    *api.TLSConfig
+		wildcardPolicy routeapi.WildcardPolicyType
+		tls, oldTLS    *routeapi.TLSConfig
 		expected       string
 		errs           int
 		allow          bool
@@ -85,13 +85,13 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 		},
 		{
 			name:           "no-host-nopolicy",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			expected:       "mygeneratedhost.com",
 			allow:          true,
 		},
 		{
 			name:           "no-host-wildcard-subdomain",
-			wildcardPolicy: api.WildcardPolicySubdomain,
+			wildcardPolicy: routeapi.WildcardPolicySubdomain,
 			expected:       "",
 			allow:          true,
 			errs:           1,
@@ -105,14 +105,14 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 		{
 			name:           "host-no-policy",
 			host:           "no.policy.test",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			expected:       "no.policy.test",
 			allow:          true,
 		},
 		{
 			name:           "host-wildcard-subdomain",
 			host:           "wildcard.policy.test",
-			wildcardPolicy: api.WildcardPolicySubdomain,
+			wildcardPolicy: routeapi.WildcardPolicySubdomain,
 			expected:       "wildcard.policy.test",
 			allow:          true,
 		},
@@ -120,42 +120,42 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			name:           "custom-host-permission-denied",
 			host:           "another.test",
 			expected:       "another.test",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
 		{
 			name:           "tls-permission-denied-destination",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
 		{
 			name:           "tls-permission-denied-cert",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
 		{
 			name:           "tls-permission-denied-ca-cert",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
 		{
 			name:           "tls-permission-denied-key",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
 		{
 			name:           "no-host-but-allowed",
 			expected:       "mygeneratedhost.com",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 		},
 		{
@@ -163,7 +163,7 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "new.host",
 			expected:       "new.host",
 			oldHost:        "original.host",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -172,7 +172,7 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "new.host",
 			expected:       "new.host",
 			oldHost:        "original.host",
-			wildcardPolicy: api.WildcardPolicyNone,
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          true,
 			errs:           0,
 		},
@@ -181,9 +181,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           0,
 		},
@@ -192,9 +192,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "b"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -203,9 +203,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           0,
 		},
@@ -214,9 +214,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Certificate: "b"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Certificate: "b"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -225,9 +225,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           0,
 		},
@@ -236,9 +236,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, CACertificate: "b"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, CACertificate: "b"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -247,9 +247,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           0,
 		},
@@ -258,9 +258,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationEdge, Key: "b"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -269,9 +269,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           0,
 		},
@@ -280,9 +280,9 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			host:           "host",
 			expected:       "host",
 			oldHost:        "host",
-			tls:            &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "a"},
-			oldTLS:         &api.TLSConfig{Termination: api.TLSTerminationReencrypt, DestinationCACertificate: "b"},
-			wildcardPolicy: api.WildcardPolicyNone,
+			tls:            &routeapi.TLSConfig{Termination: routeapi.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routeapi.TLSConfig{Termination: routeapi.TLSTerminationReencrypt, DestinationCACertificate: "b"},
+			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          false,
 			errs:           1,
 		},
@@ -292,18 +292,18 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 		sar := &testSAR{allow: tc.allow}
 		strategy := NewStrategy(testAllocator{}, sar)
 
-		route := &api.Route{
+		route := &routeapi.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:       "wildcard",
 				Name:            tc.name,
 				UID:             types.UID("wild"),
 				ResourceVersion: "1",
 			},
-			Spec: api.RouteSpec{
+			Spec: routeapi.RouteSpec{
 				Host:           tc.host,
 				WildcardPolicy: tc.wildcardPolicy,
 				TLS:            tc.tls,
-				To: api.RouteTargetReference{
+				To: routeapi.RouteTargetReference{
 					Name: "test",
 					Kind: "Service",
 				},
@@ -312,18 +312,18 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 
 		var errs field.ErrorList
 		if len(tc.oldHost) > 0 {
-			oldRoute := &api.Route{
+			oldRoute := &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:       "wildcard",
 					Name:            tc.name,
 					UID:             types.UID("wild"),
 					ResourceVersion: "1",
 				},
-				Spec: api.RouteSpec{
+				Spec: routeapi.RouteSpec{
 					Host:           tc.oldHost,
 					WildcardPolicy: tc.wildcardPolicy,
 					TLS:            tc.oldTLS,
-					To: api.RouteTargetReference{
+					To: routeapi.RouteTargetReference{
 						Name: "test",
 						Kind: "Service",
 					},

--- a/pkg/sdn/api/install/apigroup.go
+++ b/pkg/sdn/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
-	"github.com/openshift/origin/pkg/sdn/api/v1"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+	sdnapiv1 "github.com/openshift/origin/pkg/sdn/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  sdnapi.GroupName,
+			VersionPreferenceOrder:     []string{sdnapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: sdnapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("ClusterNetwork", "HostSubnet", "NetNamespace"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			sdnapiv1.SchemeGroupVersion.Version: sdnapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/sdn/api/install/install.go
+++ b/pkg/sdn/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
-	"github.com/openshift/origin/pkg/sdn/api/v1"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+	sdnapiv1 "github.com/openshift/origin/pkg/sdn/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/sdn/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/sdn/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{sdnapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", sdnapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	sdnapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case sdnapiv1.LegacySchemeGroupVersion:
+			sdnapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case sdnapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(sdnapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/sdn/api/v1/conversion.go
+++ b/pkg/sdn/api/v1/conversion.go
@@ -4,30 +4,30 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc("network.openshift.io/v1", "ClusterNetwork",
-		oapi.GetFieldLabelConversionFunc(api.ClusterNetworkToSelectableFields(&api.ClusterNetwork{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.ClusterNetworkToSelectableFields(&sdnapi.ClusterNetwork{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("network.openshift.io/v1", "HostSubnet",
-		oapi.GetFieldLabelConversionFunc(api.HostSubnetToSelectableFields(&api.HostSubnet{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.HostSubnetToSelectableFields(&sdnapi.HostSubnet{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("network.openshift.io/v1", "NetNamespace",
-		oapi.GetFieldLabelConversionFunc(api.NetNamespaceToSelectableFields(&api.NetNamespace{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.NetNamespaceToSelectableFields(&sdnapi.NetNamespace{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("network.openshift.io/v1", "EgressNetworkPolicy",
-		oapi.GetFieldLabelConversionFunc(api.EgressNetworkPolicyToSelectableFields(&api.EgressNetworkPolicy{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.EgressNetworkPolicyToSelectableFields(&sdnapi.EgressNetworkPolicy{}), nil),
 	); err != nil {
 		return err
 	}
@@ -37,25 +37,25 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 
 func addLegacyConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc("v1", "ClusterNetwork",
-		oapi.GetFieldLabelConversionFunc(api.ClusterNetworkToSelectableFields(&api.ClusterNetwork{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.ClusterNetworkToSelectableFields(&sdnapi.ClusterNetwork{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "HostSubnet",
-		oapi.GetFieldLabelConversionFunc(api.HostSubnetToSelectableFields(&api.HostSubnet{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.HostSubnetToSelectableFields(&sdnapi.HostSubnet{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "NetNamespace",
-		oapi.GetFieldLabelConversionFunc(api.NetNamespaceToSelectableFields(&api.NetNamespace{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.NetNamespaceToSelectableFields(&sdnapi.NetNamespace{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "EgressNetworkPolicy",
-		oapi.GetFieldLabelConversionFunc(api.EgressNetworkPolicyToSelectableFields(&api.EgressNetworkPolicy{}), nil),
+		oapi.GetFieldLabelConversionFunc(sdnapi.EgressNetworkPolicyToSelectableFields(&sdnapi.EgressNetworkPolicy{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/sdn/api/v1/conversion_test.go
+++ b/pkg/sdn/api/v1/conversion_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	// install all APIs
@@ -13,43 +13,43 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "network.openshift.io/v1", "ClusterNetwork",
 		// Ensure all currently returned labels are supported
-		api.ClusterNetworkToSelectableFields(&api.ClusterNetwork{}),
+		sdnapi.ClusterNetworkToSelectableFields(&sdnapi.ClusterNetwork{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "network.openshift.io/v1", "HostSubnet",
 		// Ensure all currently returned labels are supported
-		api.HostSubnetToSelectableFields(&api.HostSubnet{}),
+		sdnapi.HostSubnetToSelectableFields(&sdnapi.HostSubnet{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "network.openshift.io/v1", "NetNamespace",
 		// Ensure all currently returned labels are supported
-		api.NetNamespaceToSelectableFields(&api.NetNamespace{}),
+		sdnapi.NetNamespaceToSelectableFields(&sdnapi.NetNamespace{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "network.openshift.io/v1", "EgressNetworkPolicy",
 		// Ensure all currently returned labels are supported
-		api.EgressNetworkPolicyToSelectableFields(&api.EgressNetworkPolicy{}),
+		sdnapi.EgressNetworkPolicyToSelectableFields(&sdnapi.EgressNetworkPolicy{}),
 	)
 }
 
 func TestLegacyFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "ClusterNetwork",
 		// Ensure all currently returned labels are supported
-		api.ClusterNetworkToSelectableFields(&api.ClusterNetwork{}),
+		sdnapi.ClusterNetworkToSelectableFields(&sdnapi.ClusterNetwork{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "HostSubnet",
 		// Ensure all currently returned labels are supported
-		api.HostSubnetToSelectableFields(&api.HostSubnet{}),
+		sdnapi.HostSubnetToSelectableFields(&sdnapi.HostSubnet{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "NetNamespace",
 		// Ensure all currently returned labels are supported
-		api.NetNamespaceToSelectableFields(&api.NetNamespace{}),
+		sdnapi.NetNamespaceToSelectableFields(&sdnapi.NetNamespace{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "EgressNetworkPolicy",
 		// Ensure all currently returned labels are supported
-		api.EgressNetworkPolicyToSelectableFields(&api.EgressNetworkPolicy{}),
+		sdnapi.EgressNetworkPolicyToSelectableFields(&sdnapi.EgressNetworkPolicy{}),
 	)
 }

--- a/pkg/sdn/api/validation/validation_test.go
+++ b/pkg/sdn/api/validation/validation_test.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
 // TestValidateClusterNetwork ensures not specifying a required field results in error and a fully specified
@@ -13,12 +13,12 @@ import (
 func TestValidateClusterNetwork(t *testing.T) {
 	tests := []struct {
 		name           string
-		cn             *api.ClusterNetwork
+		cn             *sdnapi.ClusterNetwork
 		expectedErrors int
 	}{
 		{
 			name: "Good one",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
@@ -28,7 +28,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Bad network",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0.0/16",
 				HostSubnetLength: 8,
@@ -38,7 +38,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Bad network CIDR",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.1/16",
 				HostSubnetLength: 8,
@@ -48,7 +48,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Subnet length too large for network",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.30.0/24",
 				HostSubnetLength: 16,
@@ -58,7 +58,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Subnet length too small",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.30.0/24",
 				HostSubnetLength: 1,
@@ -68,7 +68,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Bad service network",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
@@ -78,7 +78,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Bad service network CIDR",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
@@ -88,7 +88,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Service network overlaps with cluster network",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
@@ -98,7 +98,7 @@ func TestValidateClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Cluster network overlaps with service network",
-			cn: &api.ClusterNetwork{
+			cn: &sdnapi.ClusterNetwork{
 				ObjectMeta:       metav1.ObjectMeta{Name: "any"},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
@@ -118,8 +118,8 @@ func TestValidateClusterNetwork(t *testing.T) {
 }
 
 func TestSetDefaultClusterNetwork(t *testing.T) {
-	defaultClusterNetwork := api.ClusterNetwork{
-		ObjectMeta:       metav1.ObjectMeta{Name: api.ClusterNetworkDefault},
+	defaultClusterNetwork := sdnapi.ClusterNetwork{
+		ObjectMeta:       metav1.ObjectMeta{Name: sdnapi.ClusterNetworkDefault},
 		Network:          "10.20.0.0/16",
 		HostSubnetLength: 8,
 		ServiceNetwork:   "172.30.0.0/16",
@@ -129,7 +129,7 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		cn             *api.ClusterNetwork
+		cn             *sdnapi.ClusterNetwork
 		expectedErrors int
 	}{
 		{
@@ -139,8 +139,8 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Wrong Network",
-			cn: &api.ClusterNetwork{
-				ObjectMeta:       metav1.ObjectMeta{Name: api.ClusterNetworkDefault},
+			cn: &sdnapi.ClusterNetwork{
+				ObjectMeta:       metav1.ObjectMeta{Name: sdnapi.ClusterNetworkDefault},
 				Network:          "10.30.0.0/16",
 				HostSubnetLength: 8,
 				ServiceNetwork:   "172.30.0.0/16",
@@ -150,8 +150,8 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Wrong HostSubnetLength",
-			cn: &api.ClusterNetwork{
-				ObjectMeta:       metav1.ObjectMeta{Name: api.ClusterNetworkDefault},
+			cn: &sdnapi.ClusterNetwork{
+				ObjectMeta:       metav1.ObjectMeta{Name: sdnapi.ClusterNetworkDefault},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 9,
 				ServiceNetwork:   "172.30.0.0/16",
@@ -161,8 +161,8 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Wrong ServiceNetwork",
-			cn: &api.ClusterNetwork{
-				ObjectMeta:       metav1.ObjectMeta{Name: api.ClusterNetworkDefault},
+			cn: &sdnapi.ClusterNetwork{
+				ObjectMeta:       metav1.ObjectMeta{Name: sdnapi.ClusterNetworkDefault},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
 				ServiceNetwork:   "172.20.0.0/16",
@@ -172,8 +172,8 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 		},
 		{
 			name: "Wrong PluginName",
-			cn: &api.ClusterNetwork{
-				ObjectMeta:       metav1.ObjectMeta{Name: api.ClusterNetworkDefault},
+			cn: &sdnapi.ClusterNetwork{
+				ObjectMeta:       metav1.ObjectMeta{Name: sdnapi.ClusterNetworkDefault},
 				Network:          "10.20.0.0/16",
 				HostSubnetLength: 8,
 				ServiceNetwork:   "172.30.0.0/16",
@@ -195,12 +195,12 @@ func TestSetDefaultClusterNetwork(t *testing.T) {
 func TestValidateHostSubnet(t *testing.T) {
 	tests := []struct {
 		name           string
-		hs             *api.HostSubnet
+		hs             *sdnapi.HostSubnet
 		expectedErrors int
 	}{
 		{
 			name: "Good one",
-			hs: &api.HostSubnet{
+			hs: &sdnapi.HostSubnet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc.def.com",
 				},
@@ -212,7 +212,7 @@ func TestValidateHostSubnet(t *testing.T) {
 		},
 		{
 			name: "Malformed HostIP",
-			hs: &api.HostSubnet{
+			hs: &sdnapi.HostSubnet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc.def.com",
 				},
@@ -224,7 +224,7 @@ func TestValidateHostSubnet(t *testing.T) {
 		},
 		{
 			name: "Malformed subnet",
-			hs: &api.HostSubnet{
+			hs: &sdnapi.HostSubnet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc.def.com",
 				},
@@ -236,7 +236,7 @@ func TestValidateHostSubnet(t *testing.T) {
 		},
 		{
 			name: "Malformed subnet CIDR",
-			hs: &api.HostSubnet{
+			hs: &sdnapi.HostSubnet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "abc.def.com",
 				},
@@ -260,52 +260,52 @@ func TestValidateHostSubnet(t *testing.T) {
 func TestValidateEgressNetworkPolicy(t *testing.T) {
 	tests := []struct {
 		name           string
-		fw             *api.EgressNetworkPolicy
+		fw             *sdnapi.EgressNetworkPolicy
 		expectedErrors int
 	}{
 		{
 			name: "Empty",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{},
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{},
 				},
 			},
 			expectedErrors: 0,
 		},
 		{
 			name: "Good one",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.0/24",
 							},
 						},
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								DNSName: "www.example.com",
 							},
 						},
 						{
-							Type: api.EgressNetworkPolicyRuleDeny,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleDeny,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.4/32",
 							},
 						},
 						{
-							Type: api.EgressNetworkPolicyRuleDeny,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleDeny,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								DNSName: "www.foo.com",
 							},
 						},
@@ -316,22 +316,22 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Bad policy",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleType("Bob"),
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleType("Bob"),
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.0/24",
 							},
 						},
 						{
-							Type: api.EgressNetworkPolicyRuleDeny,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleDeny,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.4/32",
 							},
 						},
@@ -342,22 +342,22 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Bad destination",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.4",
 							},
 						},
 						{
-							Type: api.EgressNetworkPolicyRuleDeny,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleDeny,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "",
 							},
 						},
@@ -368,16 +368,16 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Policy rule with both CIDR and DNS",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								CIDRSelector: "1.2.3.4",
 								DNSName:      "www.example.com",
 							},
@@ -389,16 +389,16 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Policy rule without CIDR or DNS",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To:   api.EgressNetworkPolicyPeer{},
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To:   sdnapi.EgressNetworkPolicyPeer{},
 						},
 					},
 				},
@@ -407,16 +407,16 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Policy rule with invalid DNS",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								DNSName: "www.Example$.com",
 							},
 						},
@@ -427,16 +427,16 @@ func TestValidateEgressNetworkPolicy(t *testing.T) {
 		},
 		{
 			name: "Policy rule with wildcard DNS",
-			fw: &api.EgressNetworkPolicy{
+			fw: &sdnapi.EgressNetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "testing",
 				},
-				Spec: api.EgressNetworkPolicySpec{
-					Egress: []api.EgressNetworkPolicyRule{
+				Spec: sdnapi.EgressNetworkPolicySpec{
+					Egress: []sdnapi.EgressNetworkPolicyRule{
 						{
-							Type: api.EgressNetworkPolicyRuleAllow,
-							To: api.EgressNetworkPolicyPeer{
+							Type: sdnapi.EgressNetworkPolicyRuleAllow,
+							To: sdnapi.EgressNetworkPolicyPeer{
 								DNSName: "*.example.com",
 							},
 						},

--- a/pkg/sdn/plugin/netid/netid.go
+++ b/pkg/sdn/plugin/netid/netid.go
@@ -3,7 +3,7 @@ package netid
 import (
 	"fmt"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
 type NetIDRange struct {
@@ -28,14 +28,14 @@ func (r *NetIDRange) String() string {
 }
 
 func (r *NetIDRange) Set(base, size uint32) error {
-	if base < api.MinVNID {
-		return fmt.Errorf("invalid netid base, must be greater than %d", api.MinVNID)
+	if base < sdnapi.MinVNID {
+		return fmt.Errorf("invalid netid base, must be greater than %d", sdnapi.MinVNID)
 	}
 	if size == 0 {
 		return fmt.Errorf("invalid netid size, must be greater than zero")
 	}
-	if (base + size - 1) > api.MaxVNID {
-		return fmt.Errorf("netid range exceeded max value %d", api.MaxVNID)
+	if (base + size - 1) > sdnapi.MaxVNID {
+		return fmt.Errorf("netid range exceeded max value %d", sdnapi.MaxVNID)
 	}
 
 	r.Base = base

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/registry/clusternetwork"
 	"github.com/openshift/origin/pkg/user/registry/user"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -21,10 +21,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ClusterNetwork{} },
-		NewListFunc:       func() runtime.Object { return &api.ClusterNetworkList{} },
+		NewFunc:           func() runtime.Object { return &sdnapi.ClusterNetwork{} },
+		NewListFunc:       func() runtime.Object { return &sdnapi.ClusterNetworkList{} },
 		PredicateFunc:     clusternetwork.Matcher,
-		QualifiedResource: api.Resource("clusternetworks"),
+		QualifiedResource: sdnapi.Resource("clusternetworks"),
 
 		CreateStrategy: clusternetwork.Strategy,
 		UpdateStrategy: clusternetwork.Strategy,

--- a/pkg/sdn/registry/clusternetwork/strategy.go
+++ b/pkg/sdn/registry/clusternetwork/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/api/validation"
 )
 
@@ -44,7 +44,7 @@ func (sdnStrategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new sdn
 func (sdnStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateClusterNetwork(obj.(*api.ClusterNetwork))
+	return validation.ValidateClusterNetwork(obj.(*sdnapi.ClusterNetwork))
 }
 
 // AllowCreateOnUpdate is false for sdn
@@ -58,12 +58,12 @@ func (sdnStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for a ClusterNetwork
 func (sdnStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateClusterNetworkUpdate(obj.(*api.ClusterNetwork), old.(*api.ClusterNetwork))
+	return validation.ValidateClusterNetworkUpdate(obj.(*sdnapi.ClusterNetwork), old.(*sdnapi.ClusterNetwork))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.ClusterNetwork)
+	obj, ok := o.(*sdnapi.ClusterNetwork)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a ClusterNetwork")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.ClusterNetwork) fields.Set {
-	return api.ClusterNetworkToSelectableFields(obj)
+func SelectableFields(obj *sdnapi.ClusterNetwork) fields.Set {
+	return sdnapi.ClusterNetworkToSelectableFields(obj)
 }

--- a/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
+++ b/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/registry/egressnetworkpolicy"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.EgressNetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &api.EgressNetworkPolicyList{} },
+		NewFunc:           func() runtime.Object { return &sdnapi.EgressNetworkPolicy{} },
+		NewListFunc:       func() runtime.Object { return &sdnapi.EgressNetworkPolicyList{} },
 		PredicateFunc:     egressnetworkpolicy.Matcher,
-		QualifiedResource: api.Resource("egressnetworkpolicies"),
+		QualifiedResource: sdnapi.Resource("egressnetworkpolicies"),
 
 		CreateStrategy: egressnetworkpolicy.Strategy,
 		UpdateStrategy: egressnetworkpolicy.Strategy,

--- a/pkg/sdn/registry/egressnetworkpolicy/strategy.go
+++ b/pkg/sdn/registry/egressnetworkpolicy/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/api/validation"
 )
 
@@ -44,7 +44,7 @@ func (enpStrategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new egress network policy
 func (enpStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateEgressNetworkPolicy(obj.(*api.EgressNetworkPolicy))
+	return validation.ValidateEgressNetworkPolicy(obj.(*sdnapi.EgressNetworkPolicy))
 }
 
 // AllowCreateOnUpdate is false for egress network policies
@@ -58,12 +58,12 @@ func (enpStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for a EgressNetworkPolicy
 func (enpStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateEgressNetworkPolicyUpdate(obj.(*api.EgressNetworkPolicy), old.(*api.EgressNetworkPolicy))
+	return validation.ValidateEgressNetworkPolicyUpdate(obj.(*sdnapi.EgressNetworkPolicy), old.(*sdnapi.EgressNetworkPolicy))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.EgressNetworkPolicy)
+	obj, ok := o.(*sdnapi.EgressNetworkPolicy)
 	if !ok {
 		return nil, nil, fmt.Errorf("not an EgressNetworkPolicy")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.EgressNetworkPolicy) fields.Set {
-	return api.EgressNetworkPolicyToSelectableFields(obj)
+func SelectableFields(obj *sdnapi.EgressNetworkPolicy) fields.Set {
+	return sdnapi.EgressNetworkPolicyToSelectableFields(obj)
 }

--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/registry/hostsubnet"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.HostSubnet{} },
-		NewListFunc:       func() runtime.Object { return &api.HostSubnetList{} },
+		NewFunc:           func() runtime.Object { return &sdnapi.HostSubnet{} },
+		NewListFunc:       func() runtime.Object { return &sdnapi.HostSubnetList{} },
 		PredicateFunc:     hostsubnet.Matcher,
-		QualifiedResource: api.Resource("hostsubnets"),
+		QualifiedResource: sdnapi.Resource("hostsubnets"),
 
 		CreateStrategy: hostsubnet.Strategy,
 		UpdateStrategy: hostsubnet.Strategy,

--- a/pkg/sdn/registry/hostsubnet/strategy.go
+++ b/pkg/sdn/registry/hostsubnet/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/api/validation"
 )
 
@@ -44,7 +44,7 @@ func (sdnStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) 
 
 // Validate validates a new sdn
 func (sdnStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateHostSubnet(obj.(*api.HostSubnet))
+	return validation.ValidateHostSubnet(obj.(*sdnapi.HostSubnet))
 }
 
 // AllowCreateOnUpdate is false for sdns
@@ -58,12 +58,12 @@ func (sdnStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for a HostSubnet
 func (sdnStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateHostSubnetUpdate(obj.(*api.HostSubnet), old.(*api.HostSubnet))
+	return validation.ValidateHostSubnetUpdate(obj.(*sdnapi.HostSubnet), old.(*sdnapi.HostSubnet))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.HostSubnet)
+	obj, ok := o.(*sdnapi.HostSubnet)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a HostSubnet")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.HostSubnet) fields.Set {
-	return api.HostSubnetToSelectableFields(obj)
+func SelectableFields(obj *sdnapi.HostSubnet) fields.Set {
+	return sdnapi.HostSubnetToSelectableFields(obj)
 }

--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/registry/netnamespace"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.NetNamespace{} },
-		NewListFunc:       func() runtime.Object { return &api.NetNamespaceList{} },
+		NewFunc:           func() runtime.Object { return &sdnapi.NetNamespace{} },
+		NewListFunc:       func() runtime.Object { return &sdnapi.NetNamespaceList{} },
 		PredicateFunc:     netnamespace.Matcher,
-		QualifiedResource: api.Resource("netnamespaces"),
+		QualifiedResource: sdnapi.Resource("netnamespaces"),
 
 		CreateStrategy: netnamespace.Strategy,
 		UpdateStrategy: netnamespace.Strategy,

--- a/pkg/sdn/registry/netnamespace/strategy.go
+++ b/pkg/sdn/registry/netnamespace/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/sdn/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/api/validation"
 )
 
@@ -44,7 +44,7 @@ func (sdnStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) 
 
 // Validate validates a new NetNamespace
 func (sdnStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateNetNamespace(obj.(*api.NetNamespace))
+	return validation.ValidateNetNamespace(obj.(*sdnapi.NetNamespace))
 }
 
 // AllowCreateOnUpdate is false for NetNamespace
@@ -58,12 +58,12 @@ func (sdnStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for a NetNamespace
 func (sdnStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateNetNamespaceUpdate(obj.(*api.NetNamespace), old.(*api.NetNamespace))
+	return validation.ValidateNetNamespaceUpdate(obj.(*sdnapi.NetNamespace), old.(*sdnapi.NetNamespace))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.NetNamespace)
+	obj, ok := o.(*sdnapi.NetNamespace)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a NetNamespace")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.NetNamespace) fields.Set {
-	return api.NetNamespaceToSelectableFields(obj)
+func SelectableFields(obj *sdnapi.NetNamespace) fields.Set {
+	return sdnapi.NetNamespaceToSelectableFields(obj)
 }

--- a/pkg/security/api/install/apigroup.go
+++ b/pkg/security/api/install/apigroup.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/security/api"
-	"github.com/openshift/origin/pkg/security/api/v1"
+	securityapi "github.com/openshift/origin/pkg/security/api"
+	securityapiv1 "github.com/openshift/origin/pkg/security/api/v1"
 )
 
 func installApiGroup() {
@@ -18,13 +18,13 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  securityapi.GroupName,
+			VersionPreferenceOrder:     []string{securityapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: securityapi.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			securityapiv1.SchemeGroupVersion.Version: securityapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/security/api/install/install.go
+++ b/pkg/security/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/security/api"
-	"github.com/openshift/origin/pkg/security/api/v1"
+	securityapi "github.com/openshift/origin/pkg/security/api"
+	securityapiv1 "github.com/openshift/origin/pkg/security/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/security/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/security/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{securityapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", securityapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	securityapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case securityapiv1.LegacySchemeGroupVersion:
+			securityapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
 			continue
@@ -95,14 +95,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case securityapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(securityapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/template/api/install/apigroup.go
+++ b/pkg/template/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
-	"github.com/openshift/origin/pkg/template/api/v1"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	templateapiv1 "github.com/openshift/origin/pkg/template/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.LegacySchemeGroupVersion.Version},
+			GroupName:                  templateapi.GroupName,
+			VersionPreferenceOrder:     []string{templateapiv1.LegacySchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: templateapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("BrokerTemplateInstance"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.LegacySchemeGroupVersion.Version: v1.AddToScheme,
+			templateapiv1.LegacySchemeGroupVersion.Version: templateapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/template/api/install/install.go
+++ b/pkg/template/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
-	"github.com/openshift/origin/pkg/template/api/v1"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	templateapiv1 "github.com/openshift/origin/pkg/template/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/template/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/template/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{templateapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.LegacyGroupName)
+		glog.Infof("No version is registered for group %v", templateapi.LegacyGroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	templateapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case templateapiv1.LegacySchemeGroupVersion:
+			templateapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -100,14 +100,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case templateapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(templateapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/template/api/v1/conversion.go
+++ b/pkg/template/api/v1/conversion.go
@@ -6,24 +6,24 @@ import (
 
 	oapi "github.com/openshift/origin/pkg/api"
 	"github.com/openshift/origin/pkg/api/extension"
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Template",
-		oapi.GetFieldLabelConversionFunc(api.TemplateToSelectableFields(&api.Template{}), nil),
+		oapi.GetFieldLabelConversionFunc(templateapi.TemplateToSelectableFields(&templateapi.Template{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "TemplateInstance",
-		oapi.GetFieldLabelConversionFunc(api.TemplateInstanceToSelectableFields(&api.TemplateInstance{}), nil),
+		oapi.GetFieldLabelConversionFunc(templateapi.TemplateInstanceToSelectableFields(&templateapi.TemplateInstance{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "BrokerTemplateInstance",
-		oapi.GetFieldLabelConversionFunc(api.BrokerTemplateInstanceToSelectableFields(&api.BrokerTemplateInstance{}), nil),
+		oapi.GetFieldLabelConversionFunc(templateapi.BrokerTemplateInstanceToSelectableFields(&templateapi.BrokerTemplateInstance{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/template/api/v1/conversion_test.go
+++ b/pkg/template/api/v1/conversion_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	// install all APIs
@@ -13,6 +13,6 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "Template",
 		// Ensure all currently returned labels are supported
-		api.TemplateToSelectableFields(&api.Template{}),
+		templateapi.TemplateToSelectableFields(&templateapi.Template{}),
 	)
 }

--- a/pkg/template/api/validation/validation.go
+++ b/pkg/template/api/validation/validation.go
@@ -10,14 +10,14 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 var ParameterNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // ValidateParameter tests if required fields in the Parameter are set.
-func ValidateParameter(param *api.Parameter, fldPath *field.Path) (allErrs field.ErrorList) {
+func ValidateParameter(param *templateapi.Parameter, fldPath *field.Path) (allErrs field.ErrorList) {
 	if len(param.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 		return
@@ -29,24 +29,24 @@ func ValidateParameter(param *api.Parameter, fldPath *field.Path) (allErrs field
 }
 
 // ValidateProcessedTemplate tests if required fields in the Template are set for processing
-func ValidateProcessedTemplate(template *api.Template) field.ErrorList {
+func ValidateProcessedTemplate(template *templateapi.Template) field.ErrorList {
 	return validateTemplateBody(template)
 }
 
 // ValidateTemplate tests if required fields in the Template are set.
-func ValidateTemplate(template *api.Template) (allErrs field.ErrorList) {
+func ValidateTemplate(template *templateapi.Template) (allErrs field.ErrorList) {
 	allErrs = validation.ValidateObjectMeta(&template.ObjectMeta, true, oapi.GetNameValidationFunc(validation.ValidatePodName), field.NewPath("metadata"))
 	allErrs = append(allErrs, validateTemplateBody(template)...)
 	return
 }
 
 // ValidateTemplateUpdate tests if required fields in the template are set during an update
-func ValidateTemplateUpdate(template, oldTemplate *api.Template) field.ErrorList {
+func ValidateTemplateUpdate(template, oldTemplate *templateapi.Template) field.ErrorList {
 	return validation.ValidateObjectMetaUpdate(&template.ObjectMeta, &oldTemplate.ObjectMeta, field.NewPath("metadata"))
 }
 
 // validateTemplateBody checks the body of a template.
-func validateTemplateBody(template *api.Template) (allErrs field.ErrorList) {
+func validateTemplateBody(template *templateapi.Template) (allErrs field.ErrorList) {
 	for i := range template.Parameters {
 		allErrs = append(allErrs, ValidateParameter(&template.Parameters[i], field.NewPath("parameters").Index(i))...)
 	}
@@ -55,7 +55,7 @@ func validateTemplateBody(template *api.Template) (allErrs field.ErrorList) {
 }
 
 // ValidateTemplateInstance tests if required fields in the TemplateInstance are set.
-func ValidateTemplateInstance(templateInstance *api.TemplateInstance) (allErrs field.ErrorList) {
+func ValidateTemplateInstance(templateInstance *templateapi.TemplateInstance) (allErrs field.ErrorList) {
 	allErrs = validation.ValidateObjectMeta(&templateInstance.ObjectMeta, true, oapi.GetNameValidationFunc(validation.ValidatePodName), field.NewPath("metadata"))
 	for _, err := range ValidateTemplate(&templateInstance.Spec.Template) {
 		err.Field = "spec.template." + err.Field
@@ -79,7 +79,7 @@ func ValidateTemplateInstance(templateInstance *api.TemplateInstance) (allErrs f
 }
 
 // ValidateTemplateInstanceUpdate tests if required fields in the TemplateInstance are set during an update
-func ValidateTemplateInstanceUpdate(templateInstance, oldTemplateInstance *api.TemplateInstance) (allErrs field.ErrorList) {
+func ValidateTemplateInstanceUpdate(templateInstance, oldTemplateInstance *templateapi.TemplateInstance) (allErrs field.ErrorList) {
 	allErrs = validation.ValidateObjectMetaUpdate(&templateInstance.ObjectMeta, &oldTemplateInstance.ObjectMeta, field.NewPath("metadata"))
 
 	if !kapi.Semantic.DeepEqual(templateInstance.Spec, oldTemplateInstance.Spec) {
@@ -89,7 +89,7 @@ func ValidateTemplateInstanceUpdate(templateInstance, oldTemplateInstance *api.T
 }
 
 // ValidateBrokerTemplateInstance tests if required fields in the BrokerTemplateInstance are set.
-func ValidateBrokerTemplateInstance(brokerTemplateInstance *api.BrokerTemplateInstance) (allErrs field.ErrorList) {
+func ValidateBrokerTemplateInstance(brokerTemplateInstance *templateapi.BrokerTemplateInstance) (allErrs field.ErrorList) {
 	allErrs = validation.ValidateObjectMeta(&brokerTemplateInstance.ObjectMeta, false, oapi.GetNameValidationFunc(validation.ValidatePodName), field.NewPath("metadata"))
 	allErrs = append(allErrs, validateTemplateInstanceReference(&brokerTemplateInstance.Spec.TemplateInstance, field.NewPath("spec.templateInstance"), "TemplateInstance")...)
 	allErrs = append(allErrs, validateTemplateInstanceReference(&brokerTemplateInstance.Spec.Secret, field.NewPath("spec.secret"), "Secret")...)
@@ -102,7 +102,7 @@ func ValidateBrokerTemplateInstance(brokerTemplateInstance *api.BrokerTemplateIn
 }
 
 // ValidateBrokerTemplateInstanceUpdate tests if required fields in the BrokerTemplateInstance are set during an update
-func ValidateBrokerTemplateInstanceUpdate(brokerTemplateInstance, oldBrokerTemplateInstance *api.BrokerTemplateInstance) (allErrs field.ErrorList) {
+func ValidateBrokerTemplateInstanceUpdate(brokerTemplateInstance, oldBrokerTemplateInstance *templateapi.BrokerTemplateInstance) (allErrs field.ErrorList) {
 	allErrs = validation.ValidateObjectMetaUpdate(&brokerTemplateInstance.ObjectMeta, &oldBrokerTemplateInstance.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateTemplateInstanceReference(&brokerTemplateInstance.Spec.TemplateInstance, field.NewPath("spec.templateInstance"), "TemplateInstance")...)
 	allErrs = append(allErrs, validateTemplateInstanceReference(&brokerTemplateInstance.Spec.Secret, field.NewPath("spec.secret"), "Secret")...)

--- a/pkg/template/api/validation/validation_test.go
+++ b/pkg/template/api/validation/validation_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 const (
@@ -16,8 +16,8 @@ const (
 	validUUID2 = "7ee0204f-1ac5-40aa-a976-efcfca1b4b84"
 )
 
-func makeParameter(name, value string) *api.Parameter {
-	return &api.Parameter{
+func makeParameter(name, value string) *templateapi.Parameter {
+	return &templateapi.Parameter{
 		Name:  name,
 		Value: value,
 	}
@@ -52,41 +52,41 @@ func TestValidateParameter(t *testing.T) {
 
 func TestValidateProcessTemplate(t *testing.T) {
 	var tests = []struct {
-		template        *api.Template
+		template        *templateapi.Template
 		isValidExpected bool
 	}{
 		{ // Empty Template, should pass
-			&api.Template{},
+			&templateapi.Template{},
 			true,
 		},
 		{ // Template with name, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "templateId"},
 			},
 			true,
 		},
 		{ // Template with invalid Parameter, should fail on Parameter name
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "templateId"},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					*(makeParameter("", "1")),
 				},
 			},
 			false,
 		},
 		{ // Template with valid Parameter, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "templateId"},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					*(makeParameter("VALname_NAME", "1")),
 				},
 			},
 			true,
 		},
 		{ // Template with Item of unknown Kind, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "templateId"},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					*(makeParameter("VALname_NAME", "1")),
 				},
 				Objects: []runtime.Object{},
@@ -108,15 +108,15 @@ func TestValidateProcessTemplate(t *testing.T) {
 
 func TestValidateTemplate(t *testing.T) {
 	var tests = []struct {
-		template        *api.Template
+		template        *templateapi.Template
 		isValidExpected bool
 	}{
 		{ // Empty Template, should fail on empty name
-			&api.Template{},
+			&templateapi.Template{},
 			false,
 		},
 		{ // Template with name, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "template",
 					Namespace: metav1.NamespaceDefault,
@@ -125,7 +125,7 @@ func TestValidateTemplate(t *testing.T) {
 			true,
 		},
 		{ // Template without namespace, should fail
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "template",
 				},
@@ -133,7 +133,7 @@ func TestValidateTemplate(t *testing.T) {
 			false,
 		},
 		{ // Template with invalid name characters, should fail
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "templateId",
 					Namespace: metav1.NamespaceDefault,
@@ -142,35 +142,35 @@ func TestValidateTemplate(t *testing.T) {
 			false,
 		},
 		{ // Template with invalid Parameter, should fail on Parameter name
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: metav1.NamespaceDefault},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					*(makeParameter("", "1")),
 				},
 			},
 			false,
 		},
 		{ // Template with valid Parameter, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: metav1.NamespaceDefault},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					*(makeParameter("VALname_NAME", "1")),
 				},
 			},
 			true,
 		},
 		{ // Template with empty items, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: metav1.NamespaceDefault},
-				Parameters: []api.Parameter{},
+				Parameters: []templateapi.Parameter{},
 				Objects:    []runtime.Object{},
 			},
 			true,
 		},
 		{ // Template with an item that is invalid, should pass
-			&api.Template{
+			&templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: metav1.NamespaceDefault},
-				Parameters: []api.Parameter{},
+				Parameters: []templateapi.Parameter{},
 				Objects: []runtime.Object{
 					&kapi.Service{
 						ObjectMeta: metav1.ObjectMeta{
@@ -199,15 +199,15 @@ func TestValidateTemplate(t *testing.T) {
 
 func TestValidateTemplateInstance(t *testing.T) {
 	var tests = []struct {
-		templateInstance  api.TemplateInstance
+		templateInstance  templateapi.TemplateInstance
 		expectedErrorType field.ErrorType
 	}{
 		{
-			templateInstance:  api.TemplateInstance{},
+			templateInstance:  templateapi.TemplateInstance{},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
@@ -216,65 +216,65 @@ func TestValidateTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{},
+				Spec: templateapi.TemplateInstanceSpec{},
 			},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{
-					Template: api.Template{},
+				Spec: templateapi.TemplateInstanceSpec{
+					Template: templateapi.Template{},
 				},
 			},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{
-					Template: api.Template{
+				Spec: templateapi.TemplateInstanceSpec{
+					Template: templateapi.Template{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "test",
 						},
 					},
-					Requester: &api.TemplateInstanceRequester{
+					Requester: &templateapi.TemplateInstanceRequester{
 						Username: "test",
 					},
 				},
 			},
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{
-					Template: api.Template{
+				Spec: templateapi.TemplateInstanceSpec{
+					Template: templateapi.Template{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "test",
 						},
-						Parameters: []api.Parameter{
+						Parameters: []templateapi.Parameter{
 							{
 								Name: "b@d",
 							},
 						},
 					},
-					Requester: &api.TemplateInstanceRequester{
+					Requester: &templateapi.TemplateInstanceRequester{
 						Username: "test",
 					},
 				},
@@ -282,13 +282,13 @@ func TestValidateTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{
-					Template: api.Template{
+				Spec: templateapi.TemplateInstanceSpec{
+					Template: templateapi.Template{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "test",
@@ -297,7 +297,7 @@ func TestValidateTemplateInstance(t *testing.T) {
 					Secret: kapi.LocalObjectReference{
 						Name: "b@d",
 					},
-					Requester: &api.TemplateInstanceRequester{
+					Requester: &templateapi.TemplateInstanceRequester{
 						Username: "test",
 					},
 				},
@@ -305,13 +305,13 @@ func TestValidateTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			templateInstance: api.TemplateInstance{
+			templateInstance: templateapi.TemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Spec: api.TemplateInstanceSpec{
-					Template: api.Template{
+				Spec: templateapi.TemplateInstanceSpec{
+					Template: templateapi.Template{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test",
 							Namespace: "test",
@@ -320,7 +320,7 @@ func TestValidateTemplateInstance(t *testing.T) {
 					Secret: kapi.LocalObjectReference{
 						Name: "test",
 					},
-					Requester: &api.TemplateInstanceRequester{
+					Requester: &templateapi.TemplateInstanceRequester{
 						Username: "test",
 					},
 				},
@@ -349,19 +349,19 @@ func TestValidateTemplateInstance(t *testing.T) {
 }
 
 func TestValidateTemplateInstanceUpdate(t *testing.T) {
-	oldTemplateInstance := &api.TemplateInstance{
+	oldTemplateInstance := &templateapi.TemplateInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test",
 			Namespace:       "test",
 			ResourceVersion: "1",
 		},
-		Spec: api.TemplateInstanceSpec{
-			Template: api.Template{
+		Spec: templateapi.TemplateInstanceSpec{
+			Template: templateapi.Template{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "test",
 				},
-				Parameters: []api.Parameter{
+				Parameters: []templateapi.Parameter{
 					{
 						Name: "test",
 					},
@@ -370,100 +370,100 @@ func TestValidateTemplateInstanceUpdate(t *testing.T) {
 			Secret: kapi.LocalObjectReference{
 				Name: "test",
 			},
-			Requester: &api.TemplateInstanceRequester{
+			Requester: &templateapi.TemplateInstanceRequester{
 				Username: "test",
 			},
 		},
 	}
 
 	var tests = []struct {
-		modifyTemplateInstance func(*api.TemplateInstance)
+		modifyTemplateInstance func(*templateapi.TemplateInstance)
 		expectedErrorType      field.ErrorType
 	}{
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 			},
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Name = "new"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Namespace = "new"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Name = "new"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Name = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Namespace = "new"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Namespace = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Parameters[0].Name = "new"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Parameters[0].Name = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Template.Parameters = nil
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Secret.Name = "new"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Secret.Name = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Secret.Name = ""
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Requester.Username = "new"
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			modifyTemplateInstance: func(new *api.TemplateInstance) {
+			modifyTemplateInstance: func(new *templateapi.TemplateInstance) {
 				new.Spec.Requester.Username = ""
 			},
 			expectedErrorType: field.ErrorTypeForbidden,
@@ -475,8 +475,8 @@ func TestValidateTemplateInstanceUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		test.modifyTemplateInstance(newTemplateInstance.(*api.TemplateInstance))
-		errs := ValidateTemplateInstanceUpdate(newTemplateInstance.(*api.TemplateInstance), oldTemplateInstance)
+		test.modifyTemplateInstance(newTemplateInstance.(*templateapi.TemplateInstance))
+		errs := ValidateTemplateInstanceUpdate(newTemplateInstance.(*templateapi.TemplateInstance), oldTemplateInstance)
 		if test.expectedErrorType == "" {
 			if len(errs) != 0 {
 				t.Errorf("%d: Unexpected non-empty error list", i)
@@ -497,15 +497,15 @@ func TestValidateTemplateInstanceUpdate(t *testing.T) {
 
 func TestValidateBrokerTemplateInstance(t *testing.T) {
 	var tests = []struct {
-		brokerTemplateInstance api.BrokerTemplateInstance
+		brokerTemplateInstance templateapi.BrokerTemplateInstance
 		expectedErrorType      field.ErrorType
 	}{
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -523,11 +523,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			},
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -542,11 +542,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			},
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -565,12 +565,12 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      validUUID,
 					Namespace: "test",
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -586,11 +586,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeForbidden,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "b@d",
@@ -606,11 +606,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -626,11 +626,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "test",
 						Name:      "test",
@@ -646,11 +646,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -666,11 +666,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -686,11 +686,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -706,11 +706,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					TemplateInstance: kapi.ObjectReference{
 						Kind:      "TemplateInstance",
 						Name:      "test",
@@ -721,11 +721,11 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			brokerTemplateInstance: api.BrokerTemplateInstance{
+			brokerTemplateInstance: templateapi.BrokerTemplateInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: validUUID,
 				},
-				Spec: api.BrokerTemplateInstanceSpec{
+				Spec: templateapi.BrokerTemplateInstanceSpec{
 					Secret: kapi.ObjectReference{
 						Kind:      "Secret",
 						Name:      "test",
@@ -758,12 +758,12 @@ func TestValidateBrokerTemplateInstance(t *testing.T) {
 }
 
 func TestValidateBrokerTemplateInstanceUpdate(t *testing.T) {
-	oldBrokerTemplateInstance := &api.BrokerTemplateInstance{
+	oldBrokerTemplateInstance := &templateapi.BrokerTemplateInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            validUUID,
 			ResourceVersion: "1",
 		},
-		Spec: api.BrokerTemplateInstanceSpec{
+		Spec: templateapi.BrokerTemplateInstanceSpec{
 			TemplateInstance: kapi.ObjectReference{
 				Kind:      "TemplateInstance",
 				Name:      "test",
@@ -781,89 +781,89 @@ func TestValidateBrokerTemplateInstanceUpdate(t *testing.T) {
 	}
 
 	var tests = []struct {
-		modifyBrokerTemplateInstance func(*api.BrokerTemplateInstance)
+		modifyBrokerTemplateInstance func(*templateapi.BrokerTemplateInstance)
 		expectedErrorType            field.ErrorType
 	}{
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 			},
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Name = "new"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Namespace = "new"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Kind = "new"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Kind = ""
 			},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Kind = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Name = "new"
 			},
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Name = ""
 			},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Name = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Namespace = "new"
 			},
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Namespace = ""
 			},
 			expectedErrorType: field.ErrorTypeRequired,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.TemplateInstance.Namespace = "b@d"
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.BindingIDs = []string{validUUID2}
 			},
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.BindingIDs = nil
 			},
 		},
 		{
-			modifyBrokerTemplateInstance: func(new *api.BrokerTemplateInstance) {
+			modifyBrokerTemplateInstance: func(new *templateapi.BrokerTemplateInstance) {
 				new.Spec.BindingIDs = []string{"bad"}
 			},
 			expectedErrorType: field.ErrorTypeInvalid,
@@ -875,8 +875,8 @@ func TestValidateBrokerTemplateInstanceUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		test.modifyBrokerTemplateInstance(newBrokerTemplateInstance.(*api.BrokerTemplateInstance))
-		errs := ValidateBrokerTemplateInstanceUpdate(newBrokerTemplateInstance.(*api.BrokerTemplateInstance), oldBrokerTemplateInstance)
+		test.modifyBrokerTemplateInstance(newBrokerTemplateInstance.(*templateapi.BrokerTemplateInstance))
+		errs := ValidateBrokerTemplateInstanceUpdate(newBrokerTemplateInstance.(*templateapi.BrokerTemplateInstance), oldBrokerTemplateInstance)
 		if test.expectedErrorType == "" {
 			if len(errs) != 0 {
 				t.Errorf("%d: Unexpected non-empty error list", i)

--- a/pkg/template/generated/listers/template/internalversion/template_expansion.go
+++ b/pkg/template/generated/listers/template/internalversion/template_expansion.go
@@ -1,27 +1,27 @@
 package internalversion
 
 import (
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // TemplateListerExpansion allows custom methods to be added to
 // TemplateLister.
 type TemplateListerExpansion interface {
-	GetByUID(uid string) (*api.Template, error)
+	GetByUID(uid string) (*templateapi.Template, error)
 }
 
 // TemplateNamespaceListerExpansion allows custom methods to be added to
 // TemplateNamespaceLister.
 type TemplateNamespaceListerExpansion interface{}
 
-func (s templateLister) GetByUID(uid string) (*api.Template, error) {
-	templates, err := s.indexer.ByIndex(api.TemplateUIDIndex, uid)
+func (s templateLister) GetByUID(uid string) (*templateapi.Template, error) {
+	templates, err := s.indexer.ByIndex(templateapi.TemplateUIDIndex, uid)
 	if err != nil {
 		return nil, err
 	}
 	if len(templates) == 0 {
-		return nil, errors.NewNotFound(api.Resource("template"), uid)
+		return nil, errors.NewNotFound(templateapi.Resource("template"), uid)
 	}
-	return templates[0].(*api.Template), nil
+	return templates[0].(*templateapi.Template), nil
 }

--- a/pkg/template/generated/listers/template/v1/template_expansion.go
+++ b/pkg/template/generated/listers/template/v1/template_expansion.go
@@ -1,27 +1,27 @@
 package v1
 
 import (
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // TemplateListerExpansion allows custom methods to be added to
 // TemplateLister.
 type TemplateListerExpansion interface {
-	GetByUID(uid string) (*api.Template, error)
+	GetByUID(uid string) (*templateapi.Template, error)
 }
 
 // TemplateNamespaceListerExpansion allows custom methods to be added to
 // TemplateNamespaceLister.
 type TemplateNamespaceListerExpansion interface{}
 
-func (s templateLister) GetByUID(uid string) (*api.Template, error) {
-	templates, err := s.indexer.ByIndex(api.TemplateUIDIndex, uid)
+func (s templateLister) GetByUID(uid string) (*templateapi.Template, error) {
+	templates, err := s.indexer.ByIndex(templateapi.TemplateUIDIndex, uid)
 	if err != nil {
 		return nil, err
 	}
 	if len(templates) == 0 {
-		return nil, errors.NewNotFound(api.Resource("template"), uid)
+		return nil, errors.NewNotFound(templateapi.Resource("template"), uid)
 	}
-	return templates[0].(*api.Template), nil
+	return templates[0].(*templateapi.Template), nil
 }

--- a/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
+++ b/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	rest "github.com/openshift/origin/pkg/template/registry/brokertemplateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.BrokerTemplateInstance{} },
-		NewListFunc:       func() runtime.Object { return &api.BrokerTemplateInstanceList{} },
+		NewFunc:           func() runtime.Object { return &templateapi.BrokerTemplateInstance{} },
+		NewListFunc:       func() runtime.Object { return &templateapi.BrokerTemplateInstanceList{} },
 		PredicateFunc:     rest.Matcher,
-		QualifiedResource: api.Resource("brokertemplateinstances"),
+		QualifiedResource: templateapi.Resource("brokertemplateinstances"),
 
 		CreateStrategy: rest.Strategy,
 		UpdateStrategy: rest.Strategy,

--- a/pkg/template/registry/brokertemplateinstance/strategy.go
+++ b/pkg/template/registry/brokertemplateinstance/strategy.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	"github.com/openshift/origin/pkg/template/api/validation"
 )
 
@@ -45,7 +45,7 @@ func (brokerTemplateInstanceStrategy) PrepareForCreate(ctx apirequest.Context, o
 
 // Validate validates a new brokertemplateinstance.
 func (brokerTemplateInstanceStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateBrokerTemplateInstance(obj.(*api.BrokerTemplateInstance))
+	return validation.ValidateBrokerTemplateInstance(obj.(*templateapi.BrokerTemplateInstance))
 }
 
 // AllowCreateOnUpdate is false for brokertemplateinstances.
@@ -59,7 +59,7 @@ func (brokerTemplateInstanceStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (brokerTemplateInstanceStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateBrokerTemplateInstanceUpdate(obj.(*api.BrokerTemplateInstance), old.(*api.BrokerTemplateInstance))
+	return validation.ValidateBrokerTemplateInstanceUpdate(obj.(*templateapi.BrokerTemplateInstance), old.(*templateapi.BrokerTemplateInstance))
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
@@ -72,7 +72,7 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.BrokerTemplateInstance)
+	obj, ok := o.(*templateapi.BrokerTemplateInstance)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a BrokerTemplateInstance")
 	}
@@ -80,6 +80,6 @@ func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.BrokerTemplateInstance) fields.Set {
-	return api.BrokerTemplateInstanceToSelectableFields(obj)
+func SelectableFields(obj *templateapi.BrokerTemplateInstance) fields.Set {
+	return templateapi.BrokerTemplateInstanceToSelectableFields(obj)
 }

--- a/pkg/template/registry/template/etcd/etcd.go
+++ b/pkg/template/registry/template/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	rest "github.com/openshift/origin/pkg/template/registry/template"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Template{} },
-		NewListFunc:       func() runtime.Object { return &api.TemplateList{} },
+		NewFunc:           func() runtime.Object { return &templateapi.Template{} },
+		NewListFunc:       func() runtime.Object { return &templateapi.TemplateList{} },
 		PredicateFunc:     rest.Matcher,
-		QualifiedResource: api.Resource("templates"),
+		QualifiedResource: templateapi.Resource("templates"),
 
 		CreateStrategy: rest.Strategy,
 		UpdateStrategy: rest.Strategy,

--- a/pkg/template/registry/template/etcd/etcd_test.go
+++ b/pkg/template/registry/template/etcd/etcd_test.go
@@ -9,7 +9,7 @@ import (
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	_ "github.com/openshift/origin/pkg/template/api/install"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -23,8 +23,8 @@ func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
 	return storage, server
 }
 
-func validTemplate() *api.Template {
-	return &api.Template{
+func validTemplate() *templateapi.Template {
+	return &templateapi.Template{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",
 		},
@@ -42,7 +42,7 @@ func TestCreate(t *testing.T) {
 	test.TestCreate(
 		valid,
 		// invalid
-		&api.Template{},
+		&templateapi.Template{},
 	)
 }
 

--- a/pkg/template/registry/template/rest.go
+++ b/pkg/template/registry/template/rest.go
@@ -11,7 +11,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/openshift/origin/pkg/template"
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	templatevalidation "github.com/openshift/origin/pkg/template/api/validation"
 	"github.com/openshift/origin/pkg/template/generator"
 )
@@ -31,17 +31,17 @@ func NewREST() *REST {
 // a rest.Storage object to vary its output or input types (not sure whether New()
 // should be input or output... probably input).
 func (s *REST) New() runtime.Object {
-	return &api.Template{}
+	return &templateapi.Template{}
 }
 
 // Create processes a Template and creates a new list of objects
 func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Object, error) {
-	tpl, ok := obj.(*api.Template)
+	tpl, ok := obj.(*templateapi.Template)
 	if !ok {
 		return nil, errors.NewBadRequest("not a template")
 	}
 	if errs := templatevalidation.ValidateProcessedTemplate(tpl); len(errs) > 0 {
-		return nil, errors.NewInvalid(api.Kind("Template"), tpl.Name, errs)
+		return nil, errors.NewInvalid(templateapi.Kind("Template"), tpl.Name, errs)
 	}
 
 	generators := map[string]generator.Generator{
@@ -50,7 +50,7 @@ func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Objec
 	processor := template.NewProcessor(generators)
 	if errs := processor.Process(tpl); len(errs) > 0 {
 		glog.V(1).Infof(errs.ToAggregate().Error())
-		return nil, errors.NewInvalid(api.Kind("Template"), tpl.Name, errs)
+		return nil, errors.NewInvalid(templateapi.Kind("Template"), tpl.Name, errs)
 	}
 
 	// we know that we get back runtime.Unstructured objects from the Process call.  We need to encode those

--- a/pkg/template/registry/template/strategy.go
+++ b/pkg/template/registry/template/strategy.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	"github.com/openshift/origin/pkg/template/api/validation"
 )
 
@@ -44,7 +44,7 @@ func (templateStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Obj
 
 // Validate validates a new template.
 func (templateStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateTemplate(obj.(*api.Template))
+	return validation.ValidateTemplate(obj.(*templateapi.Template))
 }
 
 // AllowCreateOnUpdate is false for templates.
@@ -58,12 +58,12 @@ func (templateStrategy) AllowUnconditionalUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (templateStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateTemplateUpdate(obj.(*api.Template), old.(*api.Template))
+	return validation.ValidateTemplateUpdate(obj.(*templateapi.Template), old.(*templateapi.Template))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.Template)
+	obj, ok := o.(*templateapi.Template)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a Template")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPred
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.Template) fields.Set {
-	return api.TemplateToSelectableFields(obj)
+func SelectableFields(obj *templateapi.Template) fields.Set {
+	return templateapi.TemplateToSelectableFields(obj)
 }

--- a/pkg/template/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/registry/templateinstance/etcd/etcd.go
@@ -10,7 +10,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	"github.com/openshift/origin/pkg/template/api"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 	rest "github.com/openshift/origin/pkg/template/registry/templateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -26,10 +26,10 @@ func NewREST(optsGetter restoptions.Getter, kc kclientset.Interface) (*REST, *St
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.TemplateInstance{} },
-		NewListFunc:       func() runtime.Object { return &api.TemplateInstanceList{} },
+		NewFunc:           func() runtime.Object { return &templateapi.TemplateInstance{} },
+		NewListFunc:       func() runtime.Object { return &templateapi.TemplateInstanceList{} },
 		PredicateFunc:     rest.Matcher,
-		QualifiedResource: api.Resource("templateinstances"),
+		QualifiedResource: templateapi.Resource("templateinstances"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,
@@ -57,7 +57,7 @@ var _ = kapirest.Patcher(&StatusREST{})
 
 // New creates a new templateInstance resource
 func (r *StatusREST) New() runtime.Object {
-	return &api.TemplateInstance{}
+	return &templateapi.TemplateInstance{}
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -14,15 +14,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/template/api"
-	"github.com/openshift/origin/pkg/template/api/v1"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	templateapiv1 "github.com/openshift/origin/pkg/template/api/v1"
 	"github.com/openshift/origin/pkg/template/generator"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-func makeParameter(name, value, generate string, required bool) api.Parameter {
-	return api.Parameter{
+func makeParameter(name, value, generate string, required bool) templateapi.Parameter {
+	return templateapi.Parameter{
 		Name:     name,
 		Value:    value,
 		Generate: generate,
@@ -31,7 +31,7 @@ func makeParameter(name, value, generate string, required bool) api.Parameter {
 }
 
 func TestAddParameter(t *testing.T) {
-	var template api.Template
+	var template templateapi.Template
 
 	jsonData, _ := ioutil.ReadFile("../../test/templates/testdata/guestbook.json")
 	json.Unmarshal(jsonData, &template)
@@ -78,10 +78,10 @@ func (g EmptyGenerator) GenerateValue(expression string) (interface{}, error) {
 
 func TestParameterGenerators(t *testing.T) {
 	tests := []struct {
-		parameter  api.Parameter
+		parameter  templateapi.Parameter
 		generators map[string]generator.Generator
 		shouldPass bool
-		expected   api.Parameter
+		expected   templateapi.Parameter
 		errType    field.ErrorType
 		fieldPath  string
 	}{
@@ -153,7 +153,7 @@ func TestParameterGenerators(t *testing.T) {
 
 	for i, test := range tests {
 		processor := NewProcessor(test.generators)
-		template := api.Template{Parameters: []api.Parameter{test.parameter}}
+		template := templateapi.Template{Parameters: []templateapi.Parameter{test.parameter}}
 		err := processor.GenerateParameterValues(&template)
 		if err != nil && test.shouldPass {
 			t.Errorf("test[%v]: Unexpected error %v", i, err)
@@ -178,7 +178,7 @@ func TestParameterGenerators(t *testing.T) {
 }
 
 func TestProcessValue(t *testing.T) {
-	var template api.Template
+	var template templateapi.Template
 	if err := runtime.DecodeInto(kapi.Codecs.UniversalDecoder(), []byte(`{
 		"kind":"Template", "apiVersion":"v1",
 		"objects": [
@@ -228,7 +228,7 @@ func TestProcessValue(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("unexpected error: %v", errs)
 	}
-	result, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), &template)
+	result, err := runtime.Encode(kapi.Codecs.LegacyCodec(templateapiv1.SchemeGroupVersion), &template)
 	if err != nil {
 		t.Fatalf("unexpected error during encoding Config: %#v", err)
 	}
@@ -342,7 +342,7 @@ func TestEvaluateLabels(t *testing.T) {
 	}
 
 	for k, testCase := range testCases {
-		var template api.Template
+		var template templateapi.Template
 		if err := runtime.DecodeInto(kapi.Codecs.UniversalDecoder(), []byte(testCase.Input), &template); err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue
@@ -361,7 +361,7 @@ func TestEvaluateLabels(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", k, errs)
 			continue
 		}
-		result, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), &template)
+		result, err := runtime.Encode(kapi.Codecs.LegacyCodec(templateapiv1.SchemeGroupVersion), &template)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue
@@ -377,7 +377,7 @@ func TestEvaluateLabels(t *testing.T) {
 }
 
 func TestProcessTemplateParameters(t *testing.T) {
-	var template, expectedTemplate api.Template
+	var template, expectedTemplate templateapi.Template
 	jsonData, _ := ioutil.ReadFile("../../test/templates/testdata/guestbook.json")
 	if err := runtime.DecodeInto(kapi.Codecs.UniversalDecoder(), jsonData, &template); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -401,11 +401,11 @@ func TestProcessTemplateParameters(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("unexpected error: %v", errs)
 	}
-	result, err := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), &template)
+	result, err := runtime.Encode(kapi.Codecs.LegacyCodec(templateapiv1.SchemeGroupVersion), &template)
 	if err != nil {
 		t.Fatalf("unexpected error during encoding Config: %#v", err)
 	}
-	exp, _ := runtime.Encode(kapi.Codecs.LegacyCodec(v1.SchemeGroupVersion), &expectedTemplate)
+	exp, _ := runtime.Encode(kapi.Codecs.LegacyCodec(templateapiv1.SchemeGroupVersion), &expectedTemplate)
 
 	if string(result) != string(exp) {
 		t.Errorf("unexpected output: %s", diff.StringDiff(string(exp), string(result)))

--- a/pkg/user/api/install/apigroup.go
+++ b/pkg/user/api/install/apigroup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
-	"github.com/openshift/origin/pkg/user/api/v1"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	userapiv1 "github.com/openshift/origin/pkg/user/api/v1"
 )
 
 func installApiGroup() {
@@ -19,14 +19,14 @@ func installApiGroup() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:                  api.GroupName,
-			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
+			GroupName:                  userapi.GroupName,
+			VersionPreferenceOrder:     []string{userapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
-			AddInternalObjectsToScheme: api.AddToScheme,
+			AddInternalObjectsToScheme: userapi.AddToScheme,
 			RootScopedKinds:            sets.NewString("User", "Identity", "UserIdentityMapping", "Group"),
 		},
 		announced.VersionToSchemeFunc{
-			v1.SchemeGroupVersion.Version: v1.AddToScheme,
+			userapiv1.SchemeGroupVersion.Version: userapiv1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)

--- a/pkg/user/api/install/install.go
+++ b/pkg/user/api/install/install.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
-	"github.com/openshift/origin/pkg/user/api/v1"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	userapiv1 "github.com/openshift/origin/pkg/user/api/v1"
 )
 
 const importPrefix = "github.com/openshift/origin/pkg/user/api"
@@ -21,7 +21,7 @@ const importPrefix = "github.com/openshift/origin/pkg/user/api"
 var accessor = meta.NewAccessor()
 
 // availableVersions lists all known external versions for this group from most preferred to least preferred
-var availableVersions = []schema.GroupVersion{v1.LegacySchemeGroupVersion}
+var availableVersions = []schema.GroupVersion{userapiv1.LegacySchemeGroupVersion}
 
 func init() {
 	kapi.Registry.RegisterVersions(availableVersions)
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 	if len(externalVersions) == 0 {
-		glog.Infof("No version is registered for group %v", api.GroupName)
+		glog.Infof("No version is registered for group %v", userapi.GroupName)
 		return
 	}
 
@@ -70,7 +70,7 @@ func enableVersions(externalVersions []schema.GroupVersion) error {
 
 func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 	// add the internal version to Scheme
-	api.AddToSchemeInCoreGroup(kapi.Scheme)
+	userapi.AddToSchemeInCoreGroup(kapi.Scheme)
 	// add the enabled external versions to Scheme
 	for _, v := range externalVersions {
 		if !kapi.Registry.IsEnabledVersion(v) {
@@ -78,8 +78,8 @@ func addVersionsToScheme(externalVersions ...schema.GroupVersion) {
 			continue
 		}
 		switch v {
-		case v1.LegacySchemeGroupVersion:
-			v1.AddToSchemeInCoreGroup(kapi.Scheme)
+		case userapiv1.LegacySchemeGroupVersion:
+			userapiv1.AddToSchemeInCoreGroup(kapi.Scheme)
 
 		default:
 			glog.Errorf("Version %s is not known, so it will not be added to the Scheme.", v)
@@ -96,14 +96,14 @@ func newRESTMapper(externalVersions []schema.GroupVersion) meta.RESTMapper {
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 	switch version {
-	case v1.LegacySchemeGroupVersion:
+	case userapiv1.LegacySchemeGroupVersion:
 		return &meta.VersionInterfaces{
 			ObjectConvertor:  kapi.Scheme,
 			MetadataAccessor: accessor,
 		}, nil
 
 	default:
-		g, _ := kapi.Registry.Group(api.LegacyGroupName)
+		g, _ := kapi.Registry.Group(userapi.LegacyGroupName)
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, g.GroupVersions)
 	}
 }

--- a/pkg/user/api/v1/conversion.go
+++ b/pkg/user/api/v1/conversion.go
@@ -4,24 +4,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	oapi "github.com/openshift/origin/pkg/api"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Group",
-		oapi.GetFieldLabelConversionFunc(api.GroupToSelectableFields(&api.Group{}), nil),
+		oapi.GetFieldLabelConversionFunc(userapi.GroupToSelectableFields(&userapi.Group{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Identity",
-		oapi.GetFieldLabelConversionFunc(api.IdentityToSelectableFields(&api.Identity{}), nil),
+		oapi.GetFieldLabelConversionFunc(userapi.IdentityToSelectableFields(&userapi.Identity{}), nil),
 	); err != nil {
 		return err
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "User",
-		oapi.GetFieldLabelConversionFunc(api.UserToSelectableFields(&api.User{}), nil),
+		oapi.GetFieldLabelConversionFunc(userapi.UserToSelectableFields(&userapi.User{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/user/api/v1/conversion_test.go
+++ b/pkg/user/api/v1/conversion_test.go
@@ -3,7 +3,7 @@ package v1_test
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util/api"
 
 	// install all APIs
@@ -13,18 +13,18 @@ import (
 func TestFieldSelectorConversions(t *testing.T) {
 	testutil.CheckFieldLabelConversions(t, "v1", "Group",
 		// Ensure all currently returned labels are supported
-		api.GroupToSelectableFields(&api.Group{}),
+		userapi.GroupToSelectableFields(&userapi.Group{}),
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "Identity",
 		// Ensure all currently returned labels are supported
-		api.IdentityToSelectableFields(&api.Identity{}),
+		userapi.IdentityToSelectableFields(&userapi.Identity{}),
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"providerName", "providerUserName", "user.name", "user.uid",
 	)
 
 	testutil.CheckFieldLabelConversions(t, "v1", "User",
 		// Ensure all currently returned labels are supported
-		api.UserToSelectableFields(&api.User{}),
+		userapi.UserToSelectableFields(&userapi.User{}),
 	)
 }

--- a/pkg/user/api/validation/validation.go
+++ b/pkg/user/api/validation/validation.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kvalidation "k8s.io/kubernetes/pkg/api/validation"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 func ValidateUserName(name string, _ bool) []string {
@@ -73,7 +73,7 @@ func ValidateIdentityProviderUserName(name string) []string {
 	return ValidateUserName(name, false)
 }
 
-func ValidateGroup(group *api.Group) field.ErrorList {
+func ValidateGroup(group *userapi.Group) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMeta(&group.ObjectMeta, false, ValidateGroupName, field.NewPath("metadata"))
 
 	userPath := field.NewPath("user")
@@ -91,13 +91,13 @@ func ValidateGroup(group *api.Group) field.ErrorList {
 	return allErrs
 }
 
-func ValidateGroupUpdate(group *api.Group, old *api.Group) field.ErrorList {
+func ValidateGroupUpdate(group *userapi.Group, old *userapi.Group) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMetaUpdate(&group.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateGroup(group)...)
 	return allErrs
 }
 
-func ValidateUser(user *api.User) field.ErrorList {
+func ValidateUser(user *userapi.User) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMeta(&user.ObjectMeta, false, ValidateUserName, field.NewPath("metadata"))
 	identitiesPath := field.NewPath("identities")
 	for index, identity := range user.Identities {
@@ -122,13 +122,13 @@ func ValidateUser(user *api.User) field.ErrorList {
 	return allErrs
 }
 
-func ValidateUserUpdate(user *api.User, old *api.User) field.ErrorList {
+func ValidateUserUpdate(user *userapi.User, old *userapi.User) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMetaUpdate(&user.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateUser(user)...)
 	return allErrs
 }
 
-func ValidateIdentity(identity *api.Identity) field.ErrorList {
+func ValidateIdentity(identity *userapi.Identity) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMeta(&identity.ObjectMeta, false, ValidateIdentityName, field.NewPath("metadata"))
 
 	if len(identity.ProviderName) == 0 {
@@ -163,7 +163,7 @@ func ValidateIdentity(identity *api.Identity) field.ErrorList {
 	return allErrs
 }
 
-func ValidateIdentityUpdate(identity *api.Identity, old *api.Identity) field.ErrorList {
+func ValidateIdentityUpdate(identity *userapi.Identity, old *userapi.Identity) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMetaUpdate(&identity.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateIdentity(identity)...)
 
@@ -177,7 +177,7 @@ func ValidateIdentityUpdate(identity *api.Identity, old *api.Identity) field.Err
 	return allErrs
 }
 
-func ValidateUserIdentityMapping(mapping *api.UserIdentityMapping) field.ErrorList {
+func ValidateUserIdentityMapping(mapping *userapi.UserIdentityMapping) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMeta(&mapping.ObjectMeta, false, ValidateIdentityName, field.NewPath("metadata"))
 
 	identityPath := field.NewPath("identity")
@@ -193,7 +193,7 @@ func ValidateUserIdentityMapping(mapping *api.UserIdentityMapping) field.ErrorLi
 	return allErrs
 }
 
-func ValidateUserIdentityMappingUpdate(mapping *api.UserIdentityMapping, old *api.UserIdentityMapping) field.ErrorList {
+func ValidateUserIdentityMappingUpdate(mapping *userapi.UserIdentityMapping, old *userapi.UserIdentityMapping) field.ErrorList {
 	allErrs := kvalidation.ValidateObjectMetaUpdate(&mapping.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateUserIdentityMapping(mapping)...)
 	return allErrs

--- a/pkg/user/api/validation/validation_test.go
+++ b/pkg/user/api/validation/validation_test.go
@@ -3,14 +3,14 @@ package validation
 import (
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 func TestValidateGroup(t *testing.T) {
-	validObj := func() *api.Group {
-		return &api.Group{
+	validObj := func() *userapi.Group {
+		return &userapi.Group{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myname",
 			},
@@ -42,8 +42,8 @@ func TestValidateGroup(t *testing.T) {
 }
 
 func TestValidateGroupUpdate(t *testing.T) {
-	validObj := func() *api.Group {
-		return &api.Group{
+	validObj := func() *userapi.Group {
+		return &userapi.Group{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "myname",
 				ResourceVersion: "1",
@@ -78,8 +78,8 @@ func TestValidateGroupUpdate(t *testing.T) {
 }
 
 func TestValidateUser(t *testing.T) {
-	validObj := func() *api.User {
-		return &api.User{
+	validObj := func() *userapi.User {
+		return &userapi.User{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myname",
 			},
@@ -119,8 +119,8 @@ func TestValidateUser(t *testing.T) {
 
 func TestValidateUserUpdate(t *testing.T) {
 
-	validObj := func() *api.User {
-		return &api.User{
+	validObj := func() *userapi.User {
+		return &userapi.User{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "myname",
 				ResourceVersion: "1",
@@ -163,8 +163,8 @@ func TestValidateUserUpdate(t *testing.T) {
 }
 
 func TestValidateIdentity(t *testing.T) {
-	validObj := func() *api.Identity {
-		return &api.Identity{
+	validObj := func() *userapi.Identity {
+		return &userapi.Identity{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myprovider:myproviderusername",
 			},
@@ -216,8 +216,8 @@ func TestValidateIdentity(t *testing.T) {
 }
 
 func TestValidateIdentityUpdate(t *testing.T) {
-	validObj := func() *api.Identity {
-		return &api.Identity{
+	validObj := func() *userapi.Identity {
+		return &userapi.Identity{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "myprovider:myproviderusername",
 				ResourceVersion: "1",
@@ -272,8 +272,8 @@ func TestValidateIdentityUpdate(t *testing.T) {
 }
 
 func TestValidateUserIdentityMapping(t *testing.T) {
-	validObj := func() *api.UserIdentityMapping {
-		return &api.UserIdentityMapping{
+	validObj := func() *userapi.UserIdentityMapping {
+		return &userapi.UserIdentityMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myprovider:myproviderusername",
 			},
@@ -306,8 +306,8 @@ func TestValidateUserIdentityMapping(t *testing.T) {
 }
 
 func TestValidateUserIdentityMappingUpdate(t *testing.T) {
-	validObj := func() *api.UserIdentityMapping {
-		return &api.UserIdentityMapping{
+	validObj := func() *userapi.UserIdentityMapping {
+		return &userapi.UserIdentityMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "myprovider:myproviderusername",
 				ResourceVersion: "1",

--- a/pkg/user/initializer_test.go
+++ b/pkg/user/initializer_test.go
@@ -4,38 +4,38 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 func TestInitializerUser(t *testing.T) {
 	testcases := map[string]struct {
-		Identity     *api.Identity
-		User         *api.User
-		ExpectedUser *api.User
+		Identity     *userapi.Identity
+		User         *userapi.User
+		ExpectedUser *userapi.User
 	}{
 		"empty": {
-			Identity:     &api.Identity{},
-			User:         &api.User{},
-			ExpectedUser: &api.User{},
+			Identity:     &userapi.Identity{},
+			User:         &userapi.User{},
+			ExpectedUser: &userapi.User{},
 		},
 		"empty extra": {
-			Identity:     &api.Identity{Extra: map[string]string{}},
-			User:         &api.User{},
-			ExpectedUser: &api.User{},
+			Identity:     &userapi.Identity{Extra: map[string]string{}},
+			User:         &userapi.User{},
+			ExpectedUser: &userapi.User{},
 		},
 		"sets full name": {
-			Identity: &api.Identity{
+			Identity: &userapi.Identity{
 				Extra: map[string]string{"name": "Bob"},
 			},
-			User:         &api.User{},
-			ExpectedUser: &api.User{FullName: "Bob"},
+			User:         &userapi.User{},
+			ExpectedUser: &userapi.User{FullName: "Bob"},
 		},
 		"respects existing full name": {
-			Identity: &api.Identity{
+			Identity: &userapi.Identity{
 				Extra: map[string]string{"name": "Bob"},
 			},
-			User:         &api.User{FullName: "Harold"},
-			ExpectedUser: &api.User{FullName: "Harold"},
+			User:         &userapi.User{FullName: "Harold"},
+			ExpectedUser: &userapi.User{FullName: "Harold"},
 		},
 	}
 

--- a/pkg/user/interfaces.go
+++ b/pkg/user/interfaces.go
@@ -1,11 +1,11 @@
 package user
 
 import (
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 // Initializer is responsible for initializing fields in a User API object from its associated Identity
 type Initializer interface {
 	// InitializeUser is responsible for initializing fields in a User API object from its associated Identity
-	InitializeUser(identity *api.Identity, user *api.User) error
+	InitializeUser(identity *userapi.Identity, user *userapi.User) error
 }

--- a/pkg/user/registry/group/etcd/etcd.go
+++ b/pkg/user/registry/group/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/group"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Group{} },
-		NewListFunc:       func() runtime.Object { return &api.GroupList{} },
+		NewFunc:           func() runtime.Object { return &userapi.Group{} },
+		NewListFunc:       func() runtime.Object { return &userapi.GroupList{} },
 		PredicateFunc:     group.Matcher,
-		QualifiedResource: api.Resource("groups"),
+		QualifiedResource: userapi.Resource("groups"),
 
 		CreateStrategy: group.Strategy,
 		UpdateStrategy: group.Strategy,

--- a/pkg/user/registry/group/registry.go
+++ b/pkg/user/registry/group/registry.go
@@ -8,19 +8,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 // Registry is an interface implemented by things that know how to store Group objects.
 type Registry interface {
 	// ListGroups obtains a list of groups having labels which match selector.
-	ListGroups(ctx apirequest.Context, options *metainternal.ListOptions) (*api.GroupList, error)
+	ListGroups(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.GroupList, error)
 	// GetGroup returns a specific group
-	GetGroup(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.Group, error)
+	GetGroup(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.Group, error)
 	// CreateGroup creates a group
-	CreateGroup(ctx apirequest.Context, group *api.Group) (*api.Group, error)
+	CreateGroup(ctx apirequest.Context, group *userapi.Group) (*userapi.Group, error)
 	// UpdateGroup updates an existing group
-	UpdateGroup(ctx apirequest.Context, group *api.Group) (*api.Group, error)
+	UpdateGroup(ctx apirequest.Context, group *userapi.Group) (*userapi.Group, error)
 	// DeleteGroup deletes a name.
 	DeleteGroup(ctx apirequest.Context, name string) error
 	// WatchGroups watches groups.
@@ -43,36 +43,36 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListGroups(ctx apirequest.Context, options *metainternal.ListOptions) (*api.GroupList, error) {
+func (s *storage) ListGroups(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.GroupList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.GroupList), nil
+	return obj.(*userapi.GroupList), nil
 }
 
-func (s *storage) GetGroup(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.Group, error) {
+func (s *storage) GetGroup(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.Group, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Group), nil
+	return obj.(*userapi.Group), nil
 }
 
-func (s *storage) CreateGroup(ctx apirequest.Context, group *api.Group) (*api.Group, error) {
+func (s *storage) CreateGroup(ctx apirequest.Context, group *userapi.Group) (*userapi.Group, error) {
 	obj, err := s.Create(ctx, group)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Group), nil
+	return obj.(*userapi.Group), nil
 }
 
-func (s *storage) UpdateGroup(ctx apirequest.Context, group *api.Group) (*api.Group, error) {
+func (s *storage) UpdateGroup(ctx apirequest.Context, group *userapi.Group) (*userapi.Group, error) {
 	obj, _, err := s.Update(ctx, group.Name, rest.DefaultUpdatedObjectInfo(group, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Group), nil
+	return obj.(*userapi.Group), nil
 }
 
 func (s *storage) DeleteGroup(ctx apirequest.Context, name string) error {

--- a/pkg/user/registry/group/strategy.go
+++ b/pkg/user/registry/group/strategy.go
@@ -11,7 +11,7 @@ import (
 	kstorage "k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
 )
 
@@ -40,7 +40,7 @@ func (groupStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object
 
 // Validate validates a new group
 func (groupStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateGroup(obj.(*api.Group))
+	return validation.ValidateGroup(obj.(*userapi.Group))
 }
 
 // AllowCreateOnUpdate is false for groups
@@ -58,12 +58,12 @@ func (groupStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end group.
 func (groupStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateGroupUpdate(obj.(*api.Group), old.(*api.Group))
+	return validation.ValidateGroupUpdate(obj.(*userapi.Group), old.(*userapi.Group))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.Group)
+	obj, ok := o.(*userapi.Group)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a Group")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.Group) fields.Set {
-	return api.GroupToSelectableFields(obj)
+func SelectableFields(obj *userapi.Group) fields.Set {
+	return userapi.GroupToSelectableFields(obj)
 }

--- a/pkg/user/registry/identity/etcd/etcd.go
+++ b/pkg/user/registry/identity/etcd/etcd.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/identity"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -20,10 +20,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Identity{} },
-		NewListFunc:       func() runtime.Object { return &api.IdentityList{} },
+		NewFunc:           func() runtime.Object { return &userapi.Identity{} },
+		NewListFunc:       func() runtime.Object { return &userapi.IdentityList{} },
 		PredicateFunc:     identity.Matcher,
-		QualifiedResource: api.Resource("identities"),
+		QualifiedResource: userapi.Resource("identities"),
 
 		CreateStrategy: identity.Strategy,
 		UpdateStrategy: identity.Strategy,

--- a/pkg/user/registry/identity/registry.go
+++ b/pkg/user/registry/identity/registry.go
@@ -8,19 +8,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 // Registry is an interface implemented by things that know how to store Identity objects.
 type Registry interface {
 	// ListIdentities obtains a list of Identities having labels which match selector.
-	ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*api.IdentityList, error)
+	ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.IdentityList, error)
 	// GetIdentity returns a specific Identity
-	GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.Identity, error)
+	GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.Identity, error)
 	// CreateIdentity creates a Identity
-	CreateIdentity(ctx apirequest.Context, Identity *api.Identity) (*api.Identity, error)
+	CreateIdentity(ctx apirequest.Context, Identity *userapi.Identity) (*userapi.Identity, error)
 	// UpdateIdentity updates an existing Identity
-	UpdateIdentity(ctx apirequest.Context, Identity *api.Identity) (*api.Identity, error)
+	UpdateIdentity(ctx apirequest.Context, Identity *userapi.Identity) (*userapi.Identity, error)
 }
 
 func identityName(provider, identity string) string {
@@ -49,34 +49,34 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*api.IdentityList, error) {
+func (s *storage) ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.IdentityList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.IdentityList), nil
+	return obj.(*userapi.IdentityList), nil
 }
 
-func (s *storage) GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.Identity, error) {
+func (s *storage) GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.Identity, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Identity), nil
+	return obj.(*userapi.Identity), nil
 }
 
-func (s *storage) CreateIdentity(ctx apirequest.Context, identity *api.Identity) (*api.Identity, error) {
+func (s *storage) CreateIdentity(ctx apirequest.Context, identity *userapi.Identity) (*userapi.Identity, error) {
 	obj, err := s.Create(ctx, identity)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Identity), nil
+	return obj.(*userapi.Identity), nil
 }
 
-func (s *storage) UpdateIdentity(ctx apirequest.Context, identity *api.Identity) (*api.Identity, error) {
+func (s *storage) UpdateIdentity(ctx apirequest.Context, identity *userapi.Identity) (*userapi.Identity, error) {
 	obj, _, err := s.Update(ctx, identity.Name, rest.DefaultUpdatedObjectInfo(identity, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Identity), nil
+	return obj.(*userapi.Identity), nil
 }

--- a/pkg/user/registry/identity/strategy.go
+++ b/pkg/user/registry/identity/strategy.go
@@ -11,7 +11,7 @@ import (
 	kstorage "k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
 )
 
@@ -36,13 +36,13 @@ func (identityStrategy) GenerateName(base string) string {
 }
 
 func (identityStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	identity := obj.(*api.Identity)
+	identity := obj.(*userapi.Identity)
 	identity.Name = identityName(identity.ProviderName, identity.ProviderUserName)
 }
 
 // Validate validates a new user
 func (identityStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	identity := obj.(*api.Identity)
+	identity := obj.(*userapi.Identity)
 	return validation.ValidateIdentity(identity)
 }
 
@@ -61,12 +61,12 @@ func (identityStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an identity
 func (identityStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateIdentityUpdate(obj.(*api.Identity), old.(*api.Identity))
+	return validation.ValidateIdentityUpdate(obj.(*userapi.Identity), old.(*userapi.Identity))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.Identity)
+	obj, ok := o.(*userapi.Identity)
 	if !ok {
 		return nil, nil, fmt.Errorf("not an Identity")
 	}
@@ -83,6 +83,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.Identity) fields.Set {
-	return api.IdentityToSelectableFields(obj)
+func SelectableFields(obj *userapi.Identity) fields.Set {
+	return userapi.IdentityToSelectableFields(obj)
 }

--- a/pkg/user/registry/test/identity.go
+++ b/pkg/user/registry/test/identity.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 type Action struct {
@@ -16,16 +16,16 @@ type Action struct {
 
 type IdentityRegistry struct {
 	GetErr map[string]error
-	Get    map[string]*api.Identity
+	Get    map[string]*userapi.Identity
 
 	CreateErr error
-	Create    *api.Identity
+	Create    *userapi.Identity
 
 	UpdateErr error
-	Update    *api.Identity
+	Update    *userapi.Identity
 
 	ListErr error
-	List    *api.IdentityList
+	List    *userapi.IdentityList
 
 	Actions *[]Action
 }
@@ -33,12 +33,12 @@ type IdentityRegistry struct {
 func NewIdentityRegistry() *IdentityRegistry {
 	return &IdentityRegistry{
 		GetErr:  map[string]error{},
-		Get:     map[string]*api.Identity{},
+		Get:     map[string]*userapi.Identity{},
 		Actions: &[]Action{},
 	}
 }
 
-func (r *IdentityRegistry) GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.Identity, error) {
+func (r *IdentityRegistry) GetIdentity(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.Identity, error) {
 	*r.Actions = append(*r.Actions, Action{"GetIdentity", name})
 	if identity, ok := r.Get[name]; ok {
 		return identity, nil
@@ -46,10 +46,10 @@ func (r *IdentityRegistry) GetIdentity(ctx apirequest.Context, name string, opti
 	if err, ok := r.GetErr[name]; ok {
 		return nil, err
 	}
-	return nil, kerrs.NewNotFound(api.Resource("identity"), name)
+	return nil, kerrs.NewNotFound(userapi.Resource("identity"), name)
 }
 
-func (r *IdentityRegistry) CreateIdentity(ctx apirequest.Context, u *api.Identity) (*api.Identity, error) {
+func (r *IdentityRegistry) CreateIdentity(ctx apirequest.Context, u *userapi.Identity) (*userapi.Identity, error) {
 	*r.Actions = append(*r.Actions, Action{"CreateIdentity", u})
 	if r.Create == nil && r.CreateErr == nil {
 		return u, nil
@@ -57,7 +57,7 @@ func (r *IdentityRegistry) CreateIdentity(ctx apirequest.Context, u *api.Identit
 	return r.Create, r.CreateErr
 }
 
-func (r *IdentityRegistry) UpdateIdentity(ctx apirequest.Context, u *api.Identity) (*api.Identity, error) {
+func (r *IdentityRegistry) UpdateIdentity(ctx apirequest.Context, u *userapi.Identity) (*userapi.Identity, error) {
 	*r.Actions = append(*r.Actions, Action{"UpdateIdentity", u})
 	if r.Update == nil && r.UpdateErr == nil {
 		return u, nil
@@ -65,10 +65,10 @@ func (r *IdentityRegistry) UpdateIdentity(ctx apirequest.Context, u *api.Identit
 	return r.Update, r.UpdateErr
 }
 
-func (r *IdentityRegistry) ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*api.IdentityList, error) {
+func (r *IdentityRegistry) ListIdentities(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.IdentityList, error) {
 	*r.Actions = append(*r.Actions, Action{"ListIdentities", options})
 	if r.List == nil && r.ListErr == nil {
-		return &api.IdentityList{}, nil
+		return &userapi.IdentityList{}, nil
 	}
 	return r.List, r.ListErr
 }

--- a/pkg/user/registry/test/user.go
+++ b/pkg/user/registry/test/user.go
@@ -6,21 +6,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 type UserRegistry struct {
 	GetErr map[string]error
-	Get    map[string]*api.User
+	Get    map[string]*userapi.User
 
 	CreateErr error
-	Create    *api.User
+	Create    *userapi.User
 
 	UpdateErr map[string]error
-	Update    *api.User
+	Update    *userapi.User
 
 	ListErr error
-	List    *api.UserList
+	List    *userapi.UserList
 
 	Actions *[]Action
 }
@@ -28,13 +28,13 @@ type UserRegistry struct {
 func NewUserRegistry() *UserRegistry {
 	return &UserRegistry{
 		GetErr:    map[string]error{},
-		Get:       map[string]*api.User{},
+		Get:       map[string]*userapi.User{},
 		UpdateErr: map[string]error{},
 		Actions:   &[]Action{},
 	}
 }
 
-func (r *UserRegistry) GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.User, error) {
+func (r *UserRegistry) GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.User, error) {
 	*r.Actions = append(*r.Actions, Action{"GetUser", name})
 	if user, ok := r.Get[name]; ok {
 		return user, nil
@@ -42,10 +42,10 @@ func (r *UserRegistry) GetUser(ctx apirequest.Context, name string, options *met
 	if err, ok := r.GetErr[name]; ok {
 		return nil, err
 	}
-	return nil, kerrs.NewNotFound(api.Resource("user"), name)
+	return nil, kerrs.NewNotFound(userapi.Resource("user"), name)
 }
 
-func (r *UserRegistry) CreateUser(ctx apirequest.Context, u *api.User) (*api.User, error) {
+func (r *UserRegistry) CreateUser(ctx apirequest.Context, u *userapi.User) (*userapi.User, error) {
 	*r.Actions = append(*r.Actions, Action{"CreateUser", u})
 	if r.Create == nil && r.CreateErr == nil {
 		return u, nil
@@ -53,7 +53,7 @@ func (r *UserRegistry) CreateUser(ctx apirequest.Context, u *api.User) (*api.Use
 	return r.Create, r.CreateErr
 }
 
-func (r *UserRegistry) UpdateUser(ctx apirequest.Context, u *api.User) (*api.User, error) {
+func (r *UserRegistry) UpdateUser(ctx apirequest.Context, u *userapi.User) (*userapi.User, error) {
 	*r.Actions = append(*r.Actions, Action{"UpdateUser", u})
 	err, _ := r.UpdateErr[u.Name]
 	if r.Update == nil && err == nil {
@@ -62,10 +62,10 @@ func (r *UserRegistry) UpdateUser(ctx apirequest.Context, u *api.User) (*api.Use
 	return r.Update, err
 }
 
-func (r *UserRegistry) ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*api.UserList, error) {
+func (r *UserRegistry) ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.UserList, error) {
 	*r.Actions = append(*r.Actions, Action{"ListUsers", options})
 	if r.List == nil && r.ListErr == nil {
-		return &api.UserList{}, nil
+		return &userapi.UserList{}, nil
 	}
 	return r.List, r.ListErr
 }

--- a/pkg/user/registry/test/useridentitymappingregistry.go
+++ b/pkg/user/registry/test/useridentitymappingregistry.go
@@ -1,21 +1,21 @@
 package test
 
 import (
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 type UserIdentityMappingRegistry struct {
 	Err                        error
 	Created                    bool
-	UserIdentityMapping        *api.UserIdentityMapping
-	CreatedUserIdentityMapping *api.UserIdentityMapping
+	UserIdentityMapping        *userapi.UserIdentityMapping
+	CreatedUserIdentityMapping *userapi.UserIdentityMapping
 }
 
-func (r *UserIdentityMappingRegistry) GetUserIdentityMapping(name string) (*api.UserIdentityMapping, error) {
+func (r *UserIdentityMappingRegistry) GetUserIdentityMapping(name string) (*userapi.UserIdentityMapping, error) {
 	return r.UserIdentityMapping, r.Err
 }
 
-func (r *UserIdentityMappingRegistry) CreateOrUpdateUserIdentityMapping(mapping *api.UserIdentityMapping) (*api.UserIdentityMapping, bool, error) {
+func (r *UserIdentityMappingRegistry) CreateOrUpdateUserIdentityMapping(mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, bool, error) {
 	r.CreatedUserIdentityMapping = mapping
 	return r.CreatedUserIdentityMapping, r.Created, r.Err
 }

--- a/pkg/user/registry/user/etcd/etcd.go
+++ b/pkg/user/registry/user/etcd/etcd.go
@@ -15,7 +15,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
 	"github.com/openshift/origin/pkg/user/registry/user"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -30,10 +30,10 @@ type REST struct {
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &api.User{} },
-		NewListFunc:       func() runtime.Object { return &api.UserList{} },
+		NewFunc:           func() runtime.Object { return &userapi.User{} },
+		NewListFunc:       func() runtime.Object { return &userapi.UserList{} },
 		PredicateFunc:     user.Matcher,
-		QualifiedResource: api.Resource("users"),
+		QualifiedResource: userapi.Resource("users"),
 
 		CreateStrategy: user.Strategy,
 		UpdateStrategy: user.Strategy,
@@ -54,7 +54,7 @@ func (r *REST) Get(ctx apirequest.Context, name string, options *metav1.GetOptio
 	if name == "~" {
 		user, ok := apirequest.UserFrom(ctx)
 		if !ok || user.GetName() == "" {
-			return nil, kerrs.NewForbidden(api.Resource("user"), "~", errors.New("requests to ~ must be authenticated"))
+			return nil, kerrs.NewForbidden(userapi.Resource("user"), "~", errors.New("requests to ~ must be authenticated"))
 		}
 		name = user.GetName()
 
@@ -65,7 +65,7 @@ func (r *REST) Get(ctx apirequest.Context, name string, options *metav1.GetOptio
 		if reasons := validation.ValidateUserName(name, false); len(reasons) != 0 {
 			// The user the authentication layer has identified cannot be a valid persisted user
 			// Return an API representation of the virtual user
-			return &api.User{ObjectMeta: metav1.ObjectMeta{Name: name}, Groups: contextGroups.List()}, nil
+			return &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: name}, Groups: contextGroups.List()}, nil
 		}
 
 		obj, err := r.Store.Get(ctx, name, options)
@@ -77,7 +77,7 @@ func (r *REST) Get(ctx apirequest.Context, name string, options *metav1.GetOptio
 			return nil, err
 		}
 
-		return &api.User{ObjectMeta: metav1.ObjectMeta{Name: name}, Groups: contextGroups.List()}, nil
+		return &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: name}, Groups: contextGroups.List()}, nil
 	}
 
 	if reasons := validation.ValidateUserName(name, false); len(reasons) != 0 {

--- a/pkg/user/registry/user/registry.go
+++ b/pkg/user/registry/user/registry.go
@@ -8,19 +8,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 // Registry is an interface implemented by things that know how to store User objects.
 type Registry interface {
 	// ListUsers obtains a list of users having labels which match selector.
-	ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*api.UserList, error)
+	ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.UserList, error)
 	// GetUser returns a specific user
-	GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.User, error)
+	GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.User, error)
 	// CreateUser creates a user
-	CreateUser(ctx apirequest.Context, user *api.User) (*api.User, error)
+	CreateUser(ctx apirequest.Context, user *userapi.User) (*userapi.User, error)
 	// UpdateUser updates an existing user
-	UpdateUser(ctx apirequest.Context, user *api.User) (*api.User, error)
+	UpdateUser(ctx apirequest.Context, user *userapi.User) (*userapi.User, error)
 }
 
 // Storage is an interface for a standard REST Storage backend
@@ -44,34 +44,34 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*api.UserList, error) {
+func (s *storage) ListUsers(ctx apirequest.Context, options *metainternal.ListOptions) (*userapi.UserList, error) {
 	obj, err := s.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.UserList), nil
+	return obj.(*userapi.UserList), nil
 }
 
-func (s *storage) GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.User, error) {
+func (s *storage) GetUser(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.User, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.User), nil
+	return obj.(*userapi.User), nil
 }
 
-func (s *storage) CreateUser(ctx apirequest.Context, user *api.User) (*api.User, error) {
+func (s *storage) CreateUser(ctx apirequest.Context, user *userapi.User) (*userapi.User, error) {
 	obj, err := s.Create(ctx, user)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.User), nil
+	return obj.(*userapi.User), nil
 }
 
-func (s *storage) UpdateUser(ctx apirequest.Context, user *api.User) (*api.User, error) {
+func (s *storage) UpdateUser(ctx apirequest.Context, user *userapi.User) (*userapi.User, error) {
 	obj, _, err := s.Update(ctx, user.Name, rest.DefaultUpdatedObjectInfo(user, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.User), nil
+	return obj.(*userapi.User), nil
 }

--- a/pkg/user/registry/user/strategy.go
+++ b/pkg/user/registry/user/strategy.go
@@ -11,7 +11,7 @@ import (
 	kstorage "k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
 )
 
@@ -40,7 +40,7 @@ func (userStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object)
 
 // Validate validates a new user
 func (userStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateUser(obj.(*api.User))
+	return validation.ValidateUser(obj.(*userapi.User))
 }
 
 // AllowCreateOnUpdate is false for users
@@ -58,12 +58,12 @@ func (userStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (userStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateUserUpdate(obj.(*api.User), old.(*api.User))
+	return validation.ValidateUserUpdate(obj.(*userapi.User), old.(*userapi.User))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes
 func GetAttrs(o runtime.Object) (labels.Set, fields.Set, error) {
-	obj, ok := o.(*api.User)
+	obj, ok := o.(*userapi.User)
 	if !ok {
 		return nil, nil, fmt.Errorf("not a User")
 	}
@@ -80,6 +80,6 @@ func Matcher(label labels.Selector, field fields.Selector) kstorage.SelectionPre
 }
 
 // SelectableFields returns a field set that can be used for filter selection
-func SelectableFields(obj *api.User) fields.Set {
-	return api.UserToSelectableFields(obj)
+func SelectableFields(obj *userapi.User) fields.Set {
+	return userapi.UserToSelectableFields(obj)
 }

--- a/pkg/user/registry/useridentitymapping/registry.go
+++ b/pkg/user/registry/useridentitymapping/registry.go
@@ -7,17 +7,17 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
 // Registry is an interface implemented by things that know how to store UserIdentityMapping objects.
 type Registry interface {
 	// GetUserIdentityMapping returns a UserIdentityMapping for the named identity
-	GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.UserIdentityMapping, error)
+	GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.UserIdentityMapping, error)
 	// CreateUserIdentityMapping associates a user and an identity
-	CreateUserIdentityMapping(ctx apirequest.Context, mapping *api.UserIdentityMapping) (*api.UserIdentityMapping, error)
+	CreateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error)
 	// UpdateUserIdentityMapping updates an associated user and identity
-	UpdateUserIdentityMapping(ctx apirequest.Context, mapping *api.UserIdentityMapping) (*api.UserIdentityMapping, error)
+	UpdateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error)
 	// DeleteUserIdentityMapping removes the user association for the named identity
 	DeleteUserIdentityMapping(ctx apirequest.Context, name string) error
 }
@@ -43,28 +43,28 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*api.UserIdentityMapping, error) {
+func (s *storage) GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.UserIdentityMapping, error) {
 	obj, err := s.Get(ctx, name, options)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.UserIdentityMapping), nil
+	return obj.(*userapi.UserIdentityMapping), nil
 }
 
-func (s *storage) CreateUserIdentityMapping(ctx apirequest.Context, mapping *api.UserIdentityMapping) (*api.UserIdentityMapping, error) {
+func (s *storage) CreateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
 	obj, err := s.Create(ctx, mapping)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.UserIdentityMapping), nil
+	return obj.(*userapi.UserIdentityMapping), nil
 }
 
-func (s *storage) UpdateUserIdentityMapping(ctx apirequest.Context, mapping *api.UserIdentityMapping) (*api.UserIdentityMapping, error) {
+func (s *storage) UpdateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
 	obj, _, err := s.Update(ctx, mapping.Name, rest.DefaultUpdatedObjectInfo(mapping, kapi.Scheme))
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.UserIdentityMapping), nil
+	return obj.(*userapi.UserIdentityMapping), nil
 }
 
 //

--- a/pkg/user/registry/useridentitymapping/rest.go
+++ b/pkg/user/registry/useridentitymapping/rest.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/identity"
 	"github.com/openshift/origin/pkg/user/registry/user"
 )
@@ -33,7 +33,7 @@ func NewREST(userRegistry user.Registry, identityRegistry identity.Registry) *RE
 
 // New returns a new UserIdentityMapping for use with Create.
 func (r *REST) New() runtime.Object {
-	return &api.UserIdentityMapping{}
+	return &userapi.UserIdentityMapping{}
 }
 
 // Get returns the mapping for the named identity
@@ -44,7 +44,7 @@ func (s *REST) Get(ctx apirequest.Context, name string, options *metav1.GetOptio
 
 // Create associates a user and identity if they both exist, and the identity is not already mapped to a user
 func (s *REST) Create(ctx apirequest.Context, obj runtime.Object) (runtime.Object, error) {
-	mapping, ok := obj.(*api.UserIdentityMapping)
+	mapping, ok := obj.(*userapi.UserIdentityMapping)
 	if !ok {
 		return nil, kerrs.NewBadRequest("invalid type")
 	}
@@ -61,7 +61,7 @@ func (s *REST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedO
 	if err != nil {
 		return nil, false, err
 	}
-	mapping, ok := obj.(*api.UserIdentityMapping)
+	mapping, ok := obj.(*userapi.UserIdentityMapping)
 	if !ok {
 		return nil, false, kerrs.NewBadRequest("invalid type")
 	}
@@ -70,7 +70,7 @@ func (s *REST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedO
 }
 
 func (s *REST) createOrUpdate(ctx apirequest.Context, obj runtime.Object, forceCreate bool) (runtime.Object, bool, error) {
-	mapping := obj.(*api.UserIdentityMapping)
+	mapping := obj.(*userapi.UserIdentityMapping)
 	identity, identityErr, oldUser, oldUserErr, oldMapping, oldMappingErr := s.getRelatedObjects(ctx, mapping.Name, &metav1.GetOptions{})
 
 	// Ensure we didn't get any errors other than NotFound errors
@@ -86,7 +86,7 @@ func (s *REST) createOrUpdate(ctx apirequest.Context, obj runtime.Object, forceC
 
 	// If we expect to be creating, fail if the mapping already existed
 	if forceCreate && oldMappingErr == nil {
-		return nil, false, kerrs.NewAlreadyExists(api.Resource("useridentitymapping"), oldMapping.Name)
+		return nil, false, kerrs.NewAlreadyExists(userapi.Resource("useridentitymapping"), oldMapping.Name)
 	}
 
 	// Allow update to create if missing
@@ -99,7 +99,7 @@ func (s *REST) createOrUpdate(ctx apirequest.Context, obj runtime.Object, forceC
 
 		// Ensure resource version is not specified
 		if len(mapping.ResourceVersion) > 0 {
-			return nil, false, kerrs.NewNotFound(api.Resource("useridentitymapping"), mapping.Name)
+			return nil, false, kerrs.NewNotFound(userapi.Resource("useridentitymapping"), mapping.Name)
 		}
 	} else {
 		// Pre-update checks with access to oldMapping
@@ -109,7 +109,7 @@ func (s *REST) createOrUpdate(ctx apirequest.Context, obj runtime.Object, forceC
 
 		// Ensure resource versions match
 		if len(mapping.ResourceVersion) > 0 && mapping.ResourceVersion != oldMapping.ResourceVersion {
-			return nil, false, kerrs.NewConflict(api.Resource("useridentitymapping"), mapping.Name, fmt.Errorf("the resource was updated to %s", oldMapping.ResourceVersion))
+			return nil, false, kerrs.NewConflict(userapi.Resource("useridentitymapping"), mapping.Name, fmt.Errorf("the resource was updated to %s", oldMapping.ResourceVersion))
 		}
 
 		// If we're "updating" to the user we're already pointing to, we're already done
@@ -121,14 +121,14 @@ func (s *REST) createOrUpdate(ctx apirequest.Context, obj runtime.Object, forceC
 	// Validate identity
 	if kerrs.IsNotFound(identityErr) {
 		errs := field.ErrorList{field.Invalid(field.NewPath("identity", "name"), mapping.Identity.Name, "referenced identity does not exist")}
-		return nil, false, kerrs.NewInvalid(api.Kind("UserIdentityMapping"), mapping.Name, errs)
+		return nil, false, kerrs.NewInvalid(userapi.Kind("UserIdentityMapping"), mapping.Name, errs)
 	}
 
 	// Get new user
 	newUser, err := s.userRegistry.GetUser(ctx, mapping.User.Name, &metav1.GetOptions{})
 	if kerrs.IsNotFound(err) {
 		errs := field.ErrorList{field.Invalid(field.NewPath("user", "name"), mapping.User.Name, "referenced user does not exist")}
-		return nil, false, kerrs.NewInvalid(api.Kind("UserIdentityMapping"), mapping.Name, errs)
+		return nil, false, kerrs.NewInvalid(userapi.Kind("UserIdentityMapping"), mapping.Name, errs)
 	}
 	if err != nil {
 		return nil, false, err
@@ -196,14 +196,14 @@ func (s *REST) Delete(ctx apirequest.Context, name string) (runtime.Object, erro
 // getRelatedObjects returns the identity, user, and mapping for the named identity
 // a nil mappingErr means all objects were retrieved without errors, and correctly reference each other
 func (s *REST) getRelatedObjects(ctx apirequest.Context, name string, options *metav1.GetOptions) (
-	identity *api.Identity, identityErr error,
-	user *api.User, userErr error,
-	mapping *api.UserIdentityMapping, mappingErr error,
+	identity *userapi.Identity, identityErr error,
+	user *userapi.User, userErr error,
+	mapping *userapi.UserIdentityMapping, mappingErr error,
 ) {
 	// Initialize errors to NotFound
-	identityErr = kerrs.NewNotFound(api.Resource("identity"), name)
-	userErr = kerrs.NewNotFound(api.Resource("user"), "")
-	mappingErr = kerrs.NewNotFound(api.Resource("useridentitymapping"), name)
+	identityErr = kerrs.NewNotFound(userapi.Resource("identity"), name)
+	userErr = kerrs.NewNotFound(userapi.Resource("user"), "")
+	mappingErr = kerrs.NewNotFound(userapi.Resource("useridentitymapping"), name)
 
 	// Get identity
 	identity, identityErr = s.identityRegistry.GetIdentity(ctx, name, options)
@@ -234,23 +234,23 @@ func (s *REST) getRelatedObjects(ctx apirequest.Context, name string, options *m
 }
 
 // hasUserMapping returns true if the given identity references a user
-func hasUserMapping(identity *api.Identity) bool {
+func hasUserMapping(identity *userapi.Identity) bool {
 	return len(identity.User.Name) > 0
 }
 
 // identityReferencesUser returns true if the identity's user name and uid match the given user
-func identityReferencesUser(identity *api.Identity, user *api.User) bool {
+func identityReferencesUser(identity *userapi.Identity, user *userapi.User) bool {
 	return identity.User.Name == user.Name && identity.User.UID == user.UID
 }
 
 // userReferencesIdentity returns true if the user's identity list contains the given identity
-func userReferencesIdentity(user *api.User, identity *api.Identity) bool {
+func userReferencesIdentity(user *userapi.User, identity *userapi.Identity) bool {
 	return sets.NewString(user.Identities...).Has(identity.Name)
 }
 
 // addIdentityToUser adds the given identity to the user's list of identities
 // returns true if the user's identity list was modified
-func addIdentityToUser(identity *api.Identity, user *api.User) bool {
+func addIdentityToUser(identity *userapi.Identity, user *userapi.User) bool {
 	identities := sets.NewString(user.Identities...)
 	if identities.Has(identity.Name) {
 		return false
@@ -262,7 +262,7 @@ func addIdentityToUser(identity *api.Identity, user *api.User) bool {
 
 // removeIdentityFromUser removes the given identity from the user's list of identities
 // returns true if the user's identity list was modified
-func removeIdentityFromUser(identity *api.Identity, user *api.User) bool {
+func removeIdentityFromUser(identity *userapi.Identity, user *userapi.User) bool {
 	identities := sets.NewString(user.Identities...)
 	if !identities.Has(identity.Name) {
 		return false
@@ -274,7 +274,7 @@ func removeIdentityFromUser(identity *api.Identity, user *api.User) bool {
 
 // setIdentityUser sets the identity to reference the given user
 // returns true if the identity's user reference was modified
-func setIdentityUser(identity *api.Identity, user *api.User) bool {
+func setIdentityUser(identity *userapi.Identity, user *userapi.User) bool {
 	if identityReferencesUser(identity, user) {
 		return false
 	}
@@ -287,7 +287,7 @@ func setIdentityUser(identity *api.Identity, user *api.User) bool {
 
 // unsetIdentityUser clears the identity's user reference
 // returns true if the identity's user reference was modified
-func unsetIdentityUser(identity *api.Identity) bool {
+func unsetIdentityUser(identity *userapi.Identity) bool {
 	if !hasUserMapping(identity) {
 		return false
 	}
@@ -297,8 +297,8 @@ func unsetIdentityUser(identity *api.Identity) bool {
 
 // mappingFor returns a UserIdentityMapping for the given user and identity
 // The name and resource version of the identity mapping match the identity
-func mappingFor(user *api.User, identity *api.Identity) (*api.UserIdentityMapping, error) {
-	return &api.UserIdentityMapping{
+func mappingFor(user *userapi.User, identity *userapi.Identity) (*userapi.UserIdentityMapping, error) {
+	return &userapi.UserIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            identity.Name,
 			ResourceVersion: identity.ResourceVersion,

--- a/pkg/user/registry/useridentitymapping/strategy.go
+++ b/pkg/user/registry/useridentitymapping/strategy.go
@@ -6,7 +6,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
 )
 
@@ -38,7 +38,7 @@ func (userIdentityMappingStrategy) AllowUnconditionalUpdate() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (s userIdentityMappingStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
-	mapping := obj.(*api.UserIdentityMapping)
+	mapping := obj.(*userapi.UserIdentityMapping)
 
 	if len(mapping.Name) == 0 {
 		mapping.Name = mapping.Identity.Name
@@ -57,7 +57,7 @@ func (s userIdentityMappingStrategy) PrepareForCreate(ctx apirequest.Context, ob
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update
 func (s userIdentityMappingStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
-	mapping := obj.(*api.UserIdentityMapping)
+	mapping := obj.(*userapi.UserIdentityMapping)
 
 	if len(mapping.Name) == 0 {
 		mapping.Name = mapping.Identity.Name
@@ -79,10 +79,10 @@ func (s userIdentityMappingStrategy) Canonicalize(obj runtime.Object) {
 
 // Validate validates a new UserIdentityMapping.
 func (s userIdentityMappingStrategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateUserIdentityMapping(obj.(*api.UserIdentityMapping))
+	return validation.ValidateUserIdentityMapping(obj.(*userapi.UserIdentityMapping))
 }
 
 // Validate validates an updated UserIdentityMapping.
 func (s userIdentityMappingStrategy) ValidateUpdate(ctx apirequest.Context, obj runtime.Object, old runtime.Object) field.ErrorList {
-	return validation.ValidateUserIdentityMappingUpdate(obj.(*api.UserIdentityMapping), old.(*api.UserIdentityMapping))
+	return validation.ValidateUserIdentityMappingUpdate(obj.(*userapi.UserIdentityMapping), old.(*userapi.UserIdentityMapping))
 }

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -7,11 +7,11 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-func verifyStages(stages []api.StageInfo, expectedStages map[string][]string) {
+func verifyStages(stages []buildapi.StageInfo, expectedStages map[string][]string) {
 	for _, stage := range stages {
 		expectedDurations, ok := expectedStages[string(stage.Name)]
 		if !ok {

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -16,7 +16,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/jenkins"
 )
@@ -297,7 +297,7 @@ var _ = g.Describe("[builds][Slow] openshift pipeline build", func() {
 							errs <- fmt.Errorf("error getting build: %s", err)
 							return
 						}
-						jenkinsBuildURI = build.Annotations[api.BuildJenkinsBuildURIAnnotation]
+						jenkinsBuildURI = build.Annotations[buildapi.BuildJenkinsBuildURIAnnotation]
 						if jenkinsBuildURI != "" {
 							break
 						}

--- a/test/extended/images/helper.go
+++ b/test/extended/images/helper.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	exutil "github.com/openshift/origin/test/extended/util"
 	testutil "github.com/openshift/origin/test/util"
 )
@@ -53,7 +53,7 @@ var (
 // GetImageLabels retrieves Docker labels from image from image repository name and
 // image reference
 func GetImageLabels(c client.ImageStreamImageInterface, imageRepoName, imageRef string) (map[string]string, error) {
-	_, imageID, err := api.ParseImageStreamImageName(imageRef)
+	_, imageID, err := imageapi.ParseImageStreamImageName(imageRef)
 	image, err := c.Get(imageRepoName, imageID)
 
 	if err != nil {

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -139,7 +139,7 @@ func newLoginOptions(server string, username string, password string, insecure b
 	return loginOptions
 }
 
-func whoami(clientCfg *restclient.Config) (*api.User, error) {
+func whoami(clientCfg *restclient.Config) (*userapi.User, error) {
 	oClient, err := client.New(clientCfg)
 	if err != nil {
 		return nil, err

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -46,7 +46,7 @@ func TestNamespaceLifecycleAdmission(t *testing.T) {
 	}
 	found := false
 	for _, f := range ns.Spec.Finalizers {
-		if f == api.FinalizerOrigin {
+		if f == projectapi.FinalizerOrigin {
 			found = true
 			break
 		}
@@ -72,7 +72,7 @@ func TestNamespaceLifecycleAdmission(t *testing.T) {
 	}
 	found = false
 	for _, f := range ns.Spec.Finalizers {
-		if f == api.FinalizerOrigin {
+		if f == projectapi.FinalizerOrigin {
 			found = true
 			break
 		}

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -13,7 +13,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	originrest "github.com/openshift/origin/pkg/cmd/server/origin/rest"
-	"github.com/openshift/origin/pkg/oauth/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	accesstokenregistry "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
 	authorizetokenregistry "github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken"
@@ -32,23 +32,23 @@ type testUser struct {
 	Err      error
 }
 
-func (u *testUser) ConvertToAuthorizeToken(_ interface{}, token *api.OAuthAuthorizeToken) error {
+func (u *testUser) ConvertToAuthorizeToken(_ interface{}, token *oauthapi.OAuthAuthorizeToken) error {
 	token.UserName = u.UserName
 	token.UserUID = u.UserUID
 	return u.Err
 }
 
-func (u *testUser) ConvertToAccessToken(_ interface{}, token *api.OAuthAccessToken) error {
+func (u *testUser) ConvertToAccessToken(_ interface{}, token *oauthapi.OAuthAccessToken) error {
 	token.UserName = u.UserName
 	token.UserUID = u.UserUID
 	return u.Err
 }
 
-func (u *testUser) ConvertFromAuthorizeToken(*api.OAuthAuthorizeToken) (interface{}, error) {
+func (u *testUser) ConvertFromAuthorizeToken(*oauthapi.OAuthAuthorizeToken) (interface{}, error) {
 	return u.UserName, u.Err
 }
 
-func (u *testUser) ConvertFromAccessToken(*api.OAuthAccessToken) (interface{}, error) {
+func (u *testUser) ConvertFromAccessToken(*oauthapi.OAuthAccessToken) (interface{}, error) {
 	return u.UserName, u.Err
 }
 
@@ -124,7 +124,7 @@ func TestOAuthStorage(t *testing.T) {
 		ch <- token
 	}))
 
-	clientRegistry.CreateClient(apirequest.NewContext(), &api.OAuthClient{
+	clientRegistry.CreateClient(apirequest.NewContext(), &oauthapi.OAuthClient{
 		ObjectMeta:        metav1.ObjectMeta{Name: "test"},
 		Secret:            "secret",
 		AdditionalSecrets: []string{"secret1"},

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -31,7 +31,7 @@ import (
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
 
 	routeapi "github.com/openshift/origin/pkg/route/api"
-	"github.com/openshift/origin/pkg/route/api/v1"
+	routeapiv1 "github.com/openshift/origin/pkg/route/api/v1"
 	tr "github.com/openshift/origin/test/integration/router"
 	testutil "github.com/openshift/origin/test/util"
 )
@@ -317,7 +317,7 @@ func TestRouter(t *testing.T) {
 			Type: tc.endpointEventType,
 
 			Object: &kapi.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: metarouteapiv1.ObjectMeta{
 					Name:      tc.serviceName,
 					Namespace: ns,
 				},
@@ -328,7 +328,7 @@ func TestRouter(t *testing.T) {
 		routeEvent := &watch.Event{
 			Type: tc.routeEventType,
 			Object: &routeapi.Route{
-				ObjectMeta: metav1.ObjectMeta{
+				ObjectMeta: metarouteapiv1.ObjectMeta{
 					Name:      tc.serviceName,
 					Namespace: ns,
 				},
@@ -419,7 +419,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 
 	waitForRouterToBecomeAvailable("127.0.0.1", statsPort)
 
-	now := metav1.Now()
+	now := metarouteapiv1.Now()
 
 	protocols := []struct {
 		name string
@@ -447,7 +447,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				CreationTimestamp: now,
 				Name:              "myService",
 				Namespace:         "default",
@@ -458,7 +458,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "path",
 				Namespace: "default",
 			},
@@ -503,7 +503,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "altService",
 				Namespace: "alt",
 			},
@@ -513,8 +513,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Time{Time: now.Add(time.Hour)},
+			ObjectMeta: metarouteapiv1.ObjectMeta{
+				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(time.Hour)},
 				Name:              "path",
 				Namespace:         "alt",
 			},
@@ -551,7 +551,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				CreationTimestamp: now,
 				Name:              "host",
 				Namespace:         "default",
@@ -590,7 +590,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "path",
 				Namespace: "default",
 			},
@@ -634,8 +634,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Time{Time: now.Add(time.Hour)},
+			ObjectMeta: metarouteapiv1.ObjectMeta{
+				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(time.Hour)},
 				Name:              "host",
 				Namespace:         "alt",
 			},
@@ -672,8 +672,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)},
+			ObjectMeta: metarouteapiv1.ObjectMeta{
+				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(-time.Hour)},
 				Name:              "host",
 				Namespace:         "alt",
 			},
@@ -710,7 +710,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "host",
 				Namespace: "default",
 			},
@@ -733,7 +733,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent = &watch.Event{
 		Type: watch.Modified,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -777,7 +777,7 @@ func TestRouterDuplications(t *testing.T) {
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -787,7 +787,7 @@ func TestRouterDuplications(t *testing.T) {
 	exampleRouteEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "example",
 				Namespace: "default",
 			},
@@ -802,7 +802,7 @@ func TestRouterDuplications(t *testing.T) {
 	example2RouteEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "example2",
 				Namespace: "default",
 			},
@@ -833,7 +833,7 @@ func TestRouterDuplications(t *testing.T) {
 	example2RouteCleanupEvent := &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "example2",
 				Namespace: "default",
 			},
@@ -849,7 +849,7 @@ func TestRouterDuplications(t *testing.T) {
 	exampleRouteCleanupEvent := &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "example",
 				Namespace: "default",
 			},
@@ -865,7 +865,7 @@ func TestRouterDuplications(t *testing.T) {
 	endpointCleanupEvent := &watch.Event{
 		Type: watch.Modified,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -1228,7 +1228,7 @@ func sendTimeout(t *testing.T, ch chan string, s string, timeout time.Duration) 
 
 // eventString marshals the event into a string
 func eventString(e *watch.Event) string {
-	obj, _ := watchjson.Object(kapi.Codecs.LegacyCodec(v1.LegacySchemeGroupVersion), e)
+	obj, _ := watchjson.Object(kapi.Codecs.LegacyCodec(routeapiv1.LegacySchemeGroupVersion), e)
 	s, _ := json.Marshal(obj)
 	return string(s)
 }
@@ -1459,7 +1459,7 @@ func generateEndpointEvent(t *testing.T, fakeMasterAndPod *tr.TestHttpService, f
 		Type: watch.Added,
 
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: "event-brite",
 			},
@@ -1481,7 +1481,7 @@ func generateTestEvents(t *testing.T, fakeMasterAndPod *tr.TestHttpService, flag
 	routeEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      routeName,
 				Namespace: "event-brite",
 			},
@@ -1744,21 +1744,21 @@ func getNamespaceConfig(t *testing.T, namespaceNames *[]string) (namespaceLabels
 	namespaceLabels = fmt.Sprintf("%s=%s", key, value)
 
 	namespaceList := &kapi.NamespaceList{
-		ListMeta: metav1.ListMeta{
+		ListMeta: metarouteapiv1.ListMeta{
 			ResourceVersion: fmt.Sprintf("%d", len(*namespaceNames)),
 		},
 		Items: []kapi.Namespace{},
 	}
 	for _, name := range *namespaceNames {
 		namespaceList.Items = append(namespaceList.Items, kapi.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:   name,
 				Labels: map[string]string{key: value},
 			},
 		})
 	}
 
-	obj, err := runtime.Encode(kapi.Codecs.LegacyCodec(kv1.SchemeGroupVersion), namespaceList)
+	obj, err := runtime.Encode(kapi.Codecs.LegacyCodec(krouteapiv1.SchemeGroupVersion), namespaceList)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1791,7 +1791,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: defaultNamespace,
 			},
@@ -1809,7 +1809,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	secretEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Secret{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      secretName,
 				Namespace: defaultNamespace,
 			},
@@ -1824,7 +1824,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	ingressEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &extensions.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
+			ObjectMeta: metarouteapiv1.ObjectMeta{
 				Name:      "foo",
 				Namespace: defaultNamespace,
 			},

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kv1 "k8s.io/kubernetes/pkg/api/v1"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
@@ -317,7 +317,7 @@ func TestRouter(t *testing.T) {
 			Type: tc.endpointEventType,
 
 			Object: &kapi.Endpoints{
-				ObjectMeta: metarouteapiv1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      tc.serviceName,
 					Namespace: ns,
 				},
@@ -328,7 +328,7 @@ func TestRouter(t *testing.T) {
 		routeEvent := &watch.Event{
 			Type: tc.routeEventType,
 			Object: &routeapi.Route{
-				ObjectMeta: metarouteapiv1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      tc.serviceName,
 					Namespace: ns,
 				},
@@ -419,7 +419,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 
 	waitForRouterToBecomeAvailable("127.0.0.1", statsPort)
 
-	now := metarouteapiv1.Now()
+	now := metav1.Now()
 
 	protocols := []struct {
 		name string
@@ -447,7 +447,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: now,
 				Name:              "myService",
 				Namespace:         "default",
@@ -458,7 +458,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "path",
 				Namespace: "default",
 			},
@@ -503,7 +503,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "altService",
 				Namespace: "alt",
 			},
@@ -513,8 +513,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
-				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(time.Hour)},
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: now.Add(time.Hour)},
 				Name:              "path",
 				Namespace:         "alt",
 			},
@@ -551,7 +551,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: now,
 				Name:              "host",
 				Namespace:         "default",
@@ -590,7 +590,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "path",
 				Namespace: "default",
 			},
@@ -634,8 +634,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
-				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(time.Hour)},
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: now.Add(time.Hour)},
 				Name:              "host",
 				Namespace:         "alt",
 			},
@@ -672,8 +672,8 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
-				CreationTimestamp: metarouteapiv1.Time{Time: now.Add(-time.Hour)},
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)},
 				Name:              "host",
 				Namespace:         "alt",
 			},
@@ -710,7 +710,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	routeEvent = &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "host",
 				Namespace: "default",
 			},
@@ -733,7 +733,7 @@ func TestRouterPathSpecificity(t *testing.T) {
 	endpointEvent = &watch.Event{
 		Type: watch.Modified,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -777,7 +777,7 @@ func TestRouterDuplications(t *testing.T) {
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -787,7 +787,7 @@ func TestRouterDuplications(t *testing.T) {
 	exampleRouteEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example",
 				Namespace: "default",
 			},
@@ -802,7 +802,7 @@ func TestRouterDuplications(t *testing.T) {
 	example2RouteEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example2",
 				Namespace: "default",
 			},
@@ -833,7 +833,7 @@ func TestRouterDuplications(t *testing.T) {
 	example2RouteCleanupEvent := &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example2",
 				Namespace: "default",
 			},
@@ -849,7 +849,7 @@ func TestRouterDuplications(t *testing.T) {
 	exampleRouteCleanupEvent := &watch.Event{
 		Type: watch.Deleted,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example",
 				Namespace: "default",
 			},
@@ -865,7 +865,7 @@ func TestRouterDuplications(t *testing.T) {
 	endpointCleanupEvent := &watch.Event{
 		Type: watch.Modified,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "myService",
 				Namespace: "default",
 			},
@@ -1459,7 +1459,7 @@ func generateEndpointEvent(t *testing.T, fakeMasterAndPod *tr.TestHttpService, f
 		Type: watch.Added,
 
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: "event-brite",
 			},
@@ -1481,7 +1481,7 @@ func generateTestEvents(t *testing.T, fakeMasterAndPod *tr.TestHttpService, flag
 	routeEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &routeapi.Route{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      routeName,
 				Namespace: "event-brite",
 			},
@@ -1744,21 +1744,21 @@ func getNamespaceConfig(t *testing.T, namespaceNames *[]string) (namespaceLabels
 	namespaceLabels = fmt.Sprintf("%s=%s", key, value)
 
 	namespaceList := &kapi.NamespaceList{
-		ListMeta: metarouteapiv1.ListMeta{
+		ListMeta: metav1.ListMeta{
 			ResourceVersion: fmt.Sprintf("%d", len(*namespaceNames)),
 		},
 		Items: []kapi.Namespace{},
 	}
 	for _, name := range *namespaceNames {
 		namespaceList.Items = append(namespaceList.Items, kapi.Namespace{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:   name,
 				Labels: map[string]string{key: value},
 			},
 		})
 	}
 
-	obj, err := runtime.Encode(kapi.Codecs.LegacyCodec(krouteapiv1.SchemeGroupVersion), namespaceList)
+	obj, err := runtime.Encode(kapi.Codecs.LegacyCodec(kapiv1.SchemeGroupVersion), namespaceList)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1791,7 +1791,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	endpointEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Endpoints{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: defaultNamespace,
 			},
@@ -1809,7 +1809,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	secretEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &kapi.Secret{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: defaultNamespace,
 			},
@@ -1824,7 +1824,7 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 	ingressEvent := &watch.Event{
 		Type: watch.Added,
 		Object: &extensions.Ingress{
-			ObjectMeta: metarouteapiv1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: defaultNamespace,
 			},

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/userregistry/identitymapper"
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
 	originrest "github.com/openshift/origin/pkg/cmd/server/origin/rest"
-	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	identityregistry "github.com/openshift/origin/pkg/user/registry/identity"
 	identityetcd "github.com/openshift/origin/pkg/user/registry/identity/etcd"
 	userregistry "github.com/openshift/origin/pkg/user/registry/user"
@@ -36,16 +36,16 @@ func makeIdentityInfo(providerName, providerUserName string, extra map[string]st
 	return info
 }
 
-func makeUser(name string, identities ...string) *api.User {
-	return &api.User{
+func makeUser(name string, identities ...string) *userapi.User {
+	return &userapi.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Identities: identities,
 	}
 }
-func makeIdentity(providerName, providerUserName string) *api.Identity {
-	return &api.Identity{
+func makeIdentity(providerName, providerUserName string) *userapi.Identity {
+	return &userapi.Identity{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: providerName + ":" + providerUserName,
 		},
@@ -53,14 +53,14 @@ func makeIdentity(providerName, providerUserName string) *api.Identity {
 		ProviderUserName: providerUserName,
 	}
 }
-func makeIdentityWithUserReference(providerName, providerUserName string, userName string, userUID types.UID) *api.Identity {
+func makeIdentityWithUserReference(providerName, providerUserName string, userName string, userUID types.UID) *userapi.Identity {
 	identity := makeIdentity(providerName, providerUserName)
 	identity.User.Name = userName
 	identity.User.UID = userUID
 	return identity
 }
-func makeMapping(user, identity string) *api.UserIdentityMapping {
-	return &api.UserIdentityMapping{
+func makeMapping(user, identity string) *userapi.UserIdentityMapping {
+	return &userapi.UserIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{Name: identity},
 		User:       kapi.ObjectReference{Name: user},
 		Identity:   kapi.ObjectReference{Name: identity},
@@ -118,10 +118,10 @@ func TestUserInitialization(t *testing.T) {
 		Identity authapi.UserIdentityInfo
 		Mapper   authapi.UserIdentityMapper
 
-		CreateIdentity *api.Identity
-		CreateUser     *api.User
-		CreateMapping  *api.UserIdentityMapping
-		UpdateUser     *api.User
+		CreateIdentity *userapi.Identity
+		CreateUser     *userapi.User
+		CreateMapping  *userapi.UserIdentityMapping
+		UpdateUser     *userapi.User
 
 		ExpectedErr        error
 		ExpectedUserName   string
@@ -132,7 +132,7 @@ func TestUserInitialization(t *testing.T) {
 			Identity: makeIdentityInfo("idp", "bob", nil),
 			Mapper:   lookup,
 
-			ExpectedErr: identitymapper.NewLookupError(makeIdentityInfo("idp", "bob", nil), kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob")),
+			ExpectedErr: identitymapper.NewLookupError(makeIdentityInfo("idp", "bob", nil), kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob")),
 		},
 		"lookup existing identity": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -193,7 +193,7 @@ func TestUserInitialization(t *testing.T) {
 
 			CreateIdentity: makeIdentity("idp", "bob"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"generate with existing mapped identity with invalid user UID": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -202,7 +202,7 @@ func TestUserInitialization(t *testing.T) {
 			CreateUser:     makeUser("mappeduser"),
 			CreateIdentity: makeIdentityWithUserReference("idp", "bob", "mappeduser", "invalidUID"),
 
-			ExpectedErr:        kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr:        kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 			ExpectedIdentities: []string{"idp:bob"},
 		},
 		"generate with existing mapped identity without user backreference": {
@@ -215,7 +215,7 @@ func TestUserInitialization(t *testing.T) {
 			// Update user to a version which does not reference the identity
 			UpdateUser: makeUser("mappeduser"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"generate returns existing mapping": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -277,7 +277,7 @@ func TestUserInitialization(t *testing.T) {
 
 			CreateIdentity: makeIdentity("idp", "bob"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"add with existing mapped identity with invalid user UID": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -286,7 +286,7 @@ func TestUserInitialization(t *testing.T) {
 			CreateUser:     makeUser("mappeduser"),
 			CreateIdentity: makeIdentityWithUserReference("idp", "bob", "mappeduser", "invalidUID"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"add with existing mapped identity without user backreference": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -298,7 +298,7 @@ func TestUserInitialization(t *testing.T) {
 			// Update user to a version which does not reference the identity
 			UpdateUser: makeUser("mappeduser"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"add returns existing mapping": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -367,7 +367,7 @@ func TestUserInitialization(t *testing.T) {
 
 			CreateIdentity: makeIdentity("idp", "bob"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"claim with existing mapped identity with invalid user UID": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -376,7 +376,7 @@ func TestUserInitialization(t *testing.T) {
 			CreateUser:     makeUser("mappeduser"),
 			CreateIdentity: makeIdentityWithUserReference("idp", "bob", "mappeduser", "invalidUID"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"claim with existing mapped identity without user backreference": {
 			Identity: makeIdentityInfo("idp", "bob", nil),
@@ -388,7 +388,7 @@ func TestUserInitialization(t *testing.T) {
 			// Update user to a version which does not reference the identity
 			UpdateUser: makeUser("mappeduser"),
 
-			ExpectedErr: kerrs.NewNotFound(api.Resource("useridentitymapping"), "idp:bob"),
+			ExpectedErr: kerrs.NewNotFound(userapi.Resource("useridentitymapping"), "idp:bob"),
 		},
 		"claim returns existing mapping": {
 			Identity: makeIdentityInfo("idp", "bob", nil),


### PR DESCRIPTION
Makes sure that all api package imports which would change in a refactor to match kube have aliases set to make the next step run smoothly.

@liggitt @smarterclayton Mostly done by script, fixup in a separate commit, plan to tag for merge on green (but not force merge since non-conflicting conflicts are likely).

[test][testextended][extended:core(builds)]