### PR TITLE
Allow setting volumes:["none"] to disallow all volume types in SCC

### DIFF
--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -81054,7 +81054,7 @@
       }
      },
      "volumes": {
-      "description": "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.",
+      "description": "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use \"*\". To allow no volumes, set to [\"none\"].",
       "type": "array",
       "items": {
        "type": "string"

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -18273,7 +18273,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 						},
 						"volumes": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.",
+								Description: "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use \"*\". To allow no volumes, set to [\"none\"].",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{

--- a/pkg/security/scc/byrestrictions.go
+++ b/pkg/security/scc/byrestrictions.go
@@ -67,7 +67,7 @@ func volumePointValue(scc *kapi.SecurityContextConstraints) int {
 		// default case to be non-trivial so we don't have to worry about adding
 		// volumes in the future unless they're trivial.
 		case kapi.FSTypeSecret, kapi.FSTypeConfigMap,
-			kapi.FSTypeEmptyDir, kapi.FSTypeDownwardAPI:
+			kapi.FSTypeEmptyDir, kapi.FSTypeDownwardAPI, kapi.FSTypeNone:
 			// do nothing
 		default:
 			hasNonTrivialVolume = true

--- a/vendor/k8s.io/kubernetes/pkg/api/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/types.go
@@ -3893,7 +3893,8 @@ type SecurityContextConstraints struct {
 	// To allow all capabilities you may use '*'.
 	AllowedCapabilities []Capability
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
-	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
+	// To allow no volumes, set to ["none"].
 	Volumes []FSType
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool
@@ -3961,6 +3962,7 @@ var (
 	FSPortworxVolume            FSType = "portworxVolume"
 	FSScaleIO                   FSType = "scaleIO"
 	FSTypeAll                   FSType = "*"
+	FSTypeNone                  FSType = "none"
 )
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
@@ -1047,7 +1047,7 @@ func TestDefaultSCCVolumes(t *testing.T) {
 				Volumes:                  []versioned.FSType{},
 				AllowHostDirVolumePlugin: false,
 			},
-			expectedVolumes: []versioned.FSType{},
+			expectedVolumes: []versioned.FSType{versioned.FSTypeNone},
 			expectedHostDir: false,
 		},
 	}

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -4460,7 +4460,8 @@ type SecurityContextConstraints struct {
 	// +k8s:conversion-gen=false
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" protobuf:"varint,7,opt,name=allowHostDirVolumePlugin"`
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
-	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
+	// To allow no volumes, set to ["none"].
 	Volumes []FSType `json:"volumes" protobuf:"bytes,8,rep,name=volumes,casttype=FSType"`
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool `json:"allowHostNetwork" protobuf:"varint,9,opt,name=allowHostNetwork"`
@@ -4522,6 +4523,7 @@ var (
 	FSTypeFC                    FSType = "fc"
 	FSTypeConfigMap             FSType = "configMap"
 	FSTypeAll                   FSType = "*"
+	FSTypeNone                  FSType = "none"
 )
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.

--- a/vendor/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -3976,6 +3976,20 @@ func ValidateSecurityContextConstraints(scc *api.SecurityContextConstraints) fie
 			"required capabilities must be empty when all capabilities are allowed by a wildcard"))
 	}
 
+	if len(scc.Volumes) > 1 {
+		hasNone := false
+		for _, fsType := range scc.Volumes {
+			if fsType == api.FSTypeNone {
+				hasNone = true
+				break
+			}
+		}
+		if hasNone {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("volumes"), scc.Volumes,
+				"if 'none' is specified, no other values are allowed"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/api/types.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/api/types.go
@@ -3883,7 +3883,8 @@ type SecurityContextConstraints struct {
 	// To allow all capabilities you may use '*'.
 	AllowedCapabilities []Capability
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
-	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
+	// To allow no volumes, set to ["none"].
 	Volumes []FSType
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool
@@ -3951,6 +3952,7 @@ var (
 	FSPortworxVolume            FSType = "portworxVolume"
 	FSScaleIO                   FSType = "scaleIO"
 	FSTypeAll                   FSType = "*"
+	FSTypeNone                  FSType = "none"
 )
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -4451,7 +4451,8 @@ type SecurityContextConstraints struct {
 	// +k8s:conversion-gen=false
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" protobuf:"varint,7,opt,name=allowHostDirVolumePlugin"`
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
-	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use '*'.
+	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
+	// To allow no volumes, set to ["none"].
 	Volumes []FSType `json:"volumes" protobuf:"bytes,8,rep,name=volumes,casttype=FSType"`
 	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
 	AllowHostNetwork bool `json:"allowHostNetwork" protobuf:"varint,9,opt,name=allowHostNetwork"`
@@ -4513,6 +4514,7 @@ var (
 	FSTypeFC                    FSType = "fc"
 	FSTypeConfigMap             FSType = "configMap"
 	FSTypeAll                   FSType = "*"
+	FSTypeNone                  FSType = "none"
 )
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.


### PR DESCRIPTION
xref https://github.com/openshift/origin/issues/13419

When reading old SCC objects, we default `volumes: null` to mean `volumes: [*]` for backwards compatibility.

If you wanted to disallow all volumes, previously you would specify `volumes: []`. Once we switch to storing in protobuf, `[]` will no longer be stored, which means we would default back to `[*]` the next time we read the object from etcd.

Given that an SCC that disallows all volumes is not usable (since all pods have a secret volume), my main concern is ensuring a previously useless SCC stored in etcd doesn't suddenly become a very permissive SCC.

This PR:
* defaults an SCC with `volumes: []` to `volumes: [none]` (so it can be persisted regardless of storage type and not escalate to allow all volumes on next read)
* validates that an SCC that specifies `volumes: [none]` doesn't allow any other volume types
