### PR TITLE
Remove ImageStreamReferenceIndex from BuildInformer

### DIFF
--- a/pkg/controller/shared/build_informers.go
+++ b/pkg/controller/shared/build_informers.go
@@ -45,7 +45,7 @@ func (f *buildInformer) Informer() cache.SharedIndexInformer {
 		},
 		informerObj,
 		f.defaultResync,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc, oscache.ImageStreamReferenceIndex: oscache.ImageStreamReferenceIndexFunc},
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
 	f.informers[informerType] = informer
 


### PR DESCRIPTION
The ImageStreamReferenceIndex doesn't apply to builds. Removes that index from the builds informer.