### PR TITLE
prometheus update storage arguments

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -126,8 +126,7 @@ objects:
 
         - name: prometheus
           args:
-          - -storage.local.retention=6h
-          - -storage.local.memory-chunks=500000
+          - -storage.tsdb.retention=6h
           - -config.file=/etc/prometheus/prometheus.yml
           - -web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}


### PR DESCRIPTION
new name for retention, removal of chunk 

@smarterclayton 

```
docker run --rm -it --entrypoint=sh registry.svc.ci.openshift.org/ci/prometheus:latest

/prometheus # prometheus -?
.. snip ...

== STORAGE ==
  
   -storage.local.engine "persisted"
      Local storage engine. Supported values are: 'persisted' (full local 
      storage with on-disk persistence) and 'none' (no local storage).
  
   -storage.local.path "data"
      Base path for metrics storage.
  
   -storage.tsdb.max-block-duration 0s
      Maximum duration compacted blocks may span. (Defaults to 10% of the 
      retention period)
  
   -storage.tsdb.min-block-duration 2h0m0s
      Minimum duration of a data block before being persisted.
  
   -storage.tsdb.no-lockfile false
      Disable lock file usage.
  
   -storage.tsdb.retention 360h0m0s
      How long to retain samples in the storage.
```