### PR TITLE
Update Prometheus example to match latest image

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -126,8 +126,7 @@ objects:
 
         - name: prometheus
           args:
-          - -storage.local.retention=6h
-          - -storage.local.memory-chunks=500000
+          - -storage.tsdb.retention=6h
           - -config.file=/etc/prometheus/prometheus.yml
           - -web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}


### PR DESCRIPTION
Given the current default `PROMETHEUS_IMAGE` `registry.svc.ci.openshift.org/ci/prometheus:latest` the prometheus command line arguments must be updated.

Another option would be to change the default image to the previous version.

This actually boils down to decide whether we want prometheus 1 or 2 in this example.

cc @smarterclayton 