### PR TITLE
UPSTREAM: 45349:  Fix daemonsets to have correct tolerations for TaintNodeNotReady and TaintNodeUnreachable.

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/api/v1/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/helpers.go
@@ -276,10 +276,10 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
-	podTolerations := pod.Spec.Tolerations
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *PodSpec, toleration *Toleration) (bool, error) {
+	podTolerations := spec.Tolerations
 
 	var newTolerations []Toleration
 	updated := false
@@ -300,8 +300,14 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 		newTolerations = append(newTolerations, *toleration)
 	}
 
-	pod.Spec.Tolerations = newTolerations
+	spec.Tolerations = newTolerations
 	return true, nil
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/util/daemonset_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/util/daemonset_util.go
@@ -31,6 +31,26 @@ import (
 func GetPodTemplateWithGeneration(template v1.PodTemplateSpec, generation int64) v1.PodTemplateSpec {
 	obj, _ := api.Scheme.DeepCopy(template)
 	newTemplate := obj.(v1.PodTemplateSpec)
+	// DaemonSet pods shouldn't be deleted by NodeController in case of node problems.
+	// Add infinite toleration for taint notReady:NoExecute here
+	// to survive taint-based eviction enforced by NodeController
+	// when node turns not ready.
+	v1.AddOrUpdateTolerationInPodSpec(&newTemplate.Spec, &v1.Toleration{
+		Key:      metav1.TaintNodeNotReady,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoExecute,
+	})
+
+	// DaemonSet pods shouldn't be deleted by NodeController in case of node problems.
+	// Add infinite toleration for taint unreachable:NoExecute here
+	// to survive taint-based eviction enforced by NodeController
+	// when node turns unreachable.
+	v1.AddOrUpdateTolerationInPodSpec(&newTemplate.Spec, &v1.Toleration{
+		Key:      metav1.TaintNodeUnreachable,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoExecute,
+	})
+
 	templateGenerationStr := fmt.Sprint(generation)
 	newTemplate.ObjectMeta.Labels = labelsutil.CloneAndAddLabel(
 		template.ObjectMeta.Labels,


### PR DESCRIPTION
@derekwaynecarr 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1459745

I tested this issue in kube upstream and found that it is already fixed in there but the upstream changes can not be directly applied in origin, so had to modify them to fit in origin. Also to keep pkg/api/helpers.go and pkg/api/v1/helpers.go in sync, I made changes in both files, something not done upstream.