### PR TITLE
update manage-node to support multiple output formats

### DIFF
--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -66,10 +66,13 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	n.Mapper = mapper
 	n.Typer = typer
 	n.RESTClientFactory = f.ClientForMapping
-	n.Printer = f.Printer
 	n.NodeNames = []string{}
 	n.CmdPrinter = cmdPrinter
 	n.CmdPrinterOutput = false
+
+	n.Printer = func(mapping *meta.RESTMapping, printOptions kprinters.PrintOptions) (kprinters.ResourcePrinter, error) {
+		return f.PrinterForMapping(c, mapping, printOptions.WithNamespace)
+	}
 
 	if output {
 		n.CmdPrinterOutput = true


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14360

Updates `ManageNode` to follow complete,verify,run pattern
Updates `Complete` method of `NodeOptions` to take command printer output format into account

cc @openshift/cli-review  @stevekuznetsov 