### PR TITLE
Fix leader election logging

### DIFF
--- a/pkg/cmd/server/origin/leaderelection.go
+++ b/pkg/cmd/server/origin/leaderelection.go
@@ -133,7 +133,10 @@ func legacyLeaderElectionStart(id, name string, leased *plug.Leased, lock rl.Int
 				leased.Stop(nil)
 				return true, nil
 			}
-			utilruntime.HandleError(fmt.Errorf("unable to confirm %s lease exists: %v", name, err))
+			// NotFound indicates the endpoint is missing and the etcd lease should continue to be held
+			if !kapierrors.IsNotFound(err) {
+				utilruntime.HandleError(fmt.Errorf("unable to confirm %s lease exists: %v", name, err))
+			}
 			return false, nil
 		})
 	}


### PR DESCRIPTION
PR #14094 added support for leader election on endpoints for controllers, but the legacy (etcd) mode was logging NotFound errors, which would be a normal condition when endpoints were not configured. This change ensures that logging only occurs for errors other than NotFound.

Fixes [BZ#1461158](https://bugzilla.redhat.com/show_bug.cgi?id=1461158)