### PR TITLE
UPSTREAM: 47270: kubectl drain errors if pod is already deleted

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
@@ -544,7 +544,7 @@ func (o *DrainOptions) deletePods(pods []api.Pod, getPodFn func(namespace, name 
 	}
 	for _, pod := range pods {
 		err := o.deletePod(pod)
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460067

xref https://github.com/kubernetes/kubernetes/pull/47270