### PR TITLE
WIP - Standalone registry PoC

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -78,6 +78,8 @@ func Execute(configFile io.Reader) {
 			Logger:           context.GetLogger(ctx),
 			SafeClientConfig: registryClient.SafeClientConfig(),
 		}
+	} else {
+		ctx = server.WithAuthSkipped(ctx)
 	}
 
 	app := handlers.NewApp(ctx, dockerConfig)

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -79,7 +79,7 @@ func Execute(configFile io.Reader) {
 			SafeClientConfig: registryClient.SafeClientConfig(),
 		}
 	} else {
-		ctx = server.WithAuthSkipped(ctx)
+		ctx = server.WithStandalone(ctx)
 	}
 
 	app := handlers.NewApp(ctx, dockerConfig)

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -136,6 +136,7 @@ var (
 	ErrNamespaceRequired   = errors.New("repository namespace required")
 	ErrUnsupportedAction   = errors.New("unsupported action")
 	ErrUnsupportedResource = errors.New("unsupported resource")
+	ErrStandalone          = errors.New("standalone registry")
 )
 
 // TokenRealm returns the template URL to use as the token realm redirect.
@@ -295,6 +296,9 @@ func (ac *AccessController) wrapErr(ctx context.Context, err error) error {
 //   origin/pkg/cmd/dockerregistry/dockerregistry.go#Execute
 //   docker/distribution/registry/handlers/app.go#appendAccessRecords
 func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...registryauth.Access) (context.Context, error) {
+	if standalone(ctx) {
+		return nil, ErrStandalone
+	}
 	req, err := context.GetRequest(ctx)
 	if err != nil {
 		return nil, ac.wrapErr(ctx, err)

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -54,6 +54,9 @@ type blobDescriptorService struct {
 // a proper repository object to be set on given context by upper openshift middleware wrappers.
 func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	context.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: starting with digest=%s", dgst.String())
+	if standalone(ctx) {
+		return dockerRegistry.BlobStatter().Stat(ctx, dgst)
+	}
 	repo, found := repositoryFrom(ctx)
 	if !found || repo == nil {
 		err := fmt.Errorf("failed to retrieve repository from context")
@@ -99,6 +102,9 @@ func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (
 }
 
 func (bs *blobDescriptorService) Clear(ctx context.Context, dgst digest.Digest) error {
+	if standalone(ctx) {
+		return bs.BlobDescriptorService.Clear(ctx, dgst)
+	}
 	repo, found := repositoryFrom(ctx)
 	if !found || repo == nil {
 		err := fmt.Errorf("failed to retrieve repository from context")

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -28,6 +28,10 @@ const (
 	// performed in Contexts.
 	authPerformedKey contextKey = "authPerformed"
 
+	// authSkippedKey is the key to indicate that authentication was
+	// skipped
+	authSkippedKey contextKey = "authSkipped"
+
 	// deferredErrorsKey is the key for deferred errors in Contexts.
 	deferredErrorsKey contextKey = "deferredErrors"
 
@@ -94,6 +98,19 @@ func withAuthPerformed(parent context.Context) context.Context {
 func authPerformed(ctx context.Context) bool {
 	authPerformed, ok := ctx.Value(authPerformedKey).(bool)
 	return ok && authPerformed
+}
+
+// withAuthSkipped returns a new Context with indication that authentication
+// is skipped
+func WithAuthSkipped(parent context.Context) context.Context {
+	return context.WithValue(parent, authSkippedKey, true)
+}
+
+// authskipped reports whether ctx has indication that authentication was
+// skipped
+func authSkipped(ctx context.Context) bool {
+	authSkipped, ok := ctx.Value(authSkippedKey).(bool)
+	return ok && authSkipped
 }
 
 // withDeferredErrors returns a new Context that carries deferred errors.

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -28,9 +28,8 @@ const (
 	// performed in Contexts.
 	authPerformedKey contextKey = "authPerformed"
 
-	// authSkippedKey is the key to indicate that authentication was
-	// skipped
-	authSkippedKey contextKey = "authSkipped"
+	// standaloneKey is the key to indicate that registry is running standalone
+	standaloneKey contextKey = "standalone"
 
 	// deferredErrorsKey is the key for deferred errors in Contexts.
 	deferredErrorsKey contextKey = "deferredErrors"
@@ -100,17 +99,15 @@ func authPerformed(ctx context.Context) bool {
 	return ok && authPerformed
 }
 
-// withAuthSkipped returns a new Context with indication that authentication
-// is skipped
-func WithAuthSkipped(parent context.Context) context.Context {
-	return context.WithValue(parent, authSkippedKey, true)
+// standalone returns a new Context with indication that registry is running standalone
+func WithStandalone(parent context.Context) context.Context {
+	return context.WithValue(parent, standaloneKey, true)
 }
 
-// authskipped reports whether ctx has indication that authentication was
-// skipped
-func authSkipped(ctx context.Context) bool {
-	authSkipped, ok := ctx.Value(authSkippedKey).(bool)
-	return ok && authSkipped
+// standalone reports whether ctx has indication that registry is running standalone
+func standalone(ctx context.Context) bool {
+	standalone, ok := ctx.Value(standaloneKey).(bool)
+	return ok && standalone
 }
 
 // withDeferredErrors returns a new Context that carries deferred errors.

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -56,7 +56,7 @@ func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options .
 		Name:      m.repo.name,
 		Registry:  m.repo.registryAddr,
 	}
-	if isImageManaged(image) {
+	if !standalone(ctx) && isImageManaged(image) {
 		// Reference without a registry part refers to repository containing locally managed images.
 		// Such an entry is retrieved, checked and set by blobDescriptorService operating only on local blobs.
 		ref.Registry = ""

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -514,7 +514,7 @@ func (r *repository) checkPendingErrors(ctx context.Context) error {
 }
 
 func checkPendingErrors(ctx context.Context, logger context.Logger, namespace, name string) error {
-	if !authPerformed(ctx) {
+	if !authSkipped(ctx) && !authPerformed(ctx) {
 		return fmt.Errorf("openshift.auth.completed missing from context")
 	}
 

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -104,7 +104,9 @@ func init() {
 			if dockerStorageDriver == nil {
 				panic(fmt.Sprintf("Configuration error: OpenShift storage driver middleware not activated"))
 			}
-
+			if standalone(ctx) {
+				return repo, nil
+			}
 			registryOSClient, kCoreClient, errClients := RegistryClientFrom(ctx).Clients()
 			if errClients != nil {
 				return nil, errClients
@@ -166,7 +168,7 @@ func newRepositoryWithClient(
 	options map[string]interface{},
 ) (distribution.Repository, error) {
 	registryAddr := os.Getenv(DockerRegistryURLEnvVar)
-	if len(registryAddr) == 0 {
+	if !standalone(ctx) && len(registryAddr) == 0 {
 		return nil, fmt.Errorf("%s is required", DockerRegistryURLEnvVar)
 	}
 
@@ -514,7 +516,7 @@ func (r *repository) checkPendingErrors(ctx context.Context) error {
 }
 
 func checkPendingErrors(ctx context.Context, logger context.Logger, namespace, name string) error {
-	if !authSkipped(ctx) && !authPerformed(ctx) {
+	if !standalone(ctx) && !authPerformed(ctx) {
 		return fmt.Errorf("openshift.auth.completed missing from context")
 	}
 


### PR DESCRIPTION
This is still in proof-of-concept stage. Experimenting with running registry in "standalone" mode when openshift specific configuration sections are omitted. This appears to be working for basic docker push/pull.

 * add "standalone" flag to ctx if openshift configuration is not in config
 * disable image streams in standalone, instead write manifests locally