### PR TITLE
Restore custom HPA controller setup

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -52,6 +52,10 @@ const (
 	// TemplateInstance backend for most of the heavy lifting.
 	InfraTemplateServiceBrokerServiceAccountName = "template-service-broker"
 	TemplateServiceBrokerControllerRoleName      = "system:openshift:template-service-broker"
+
+	// This is a special constant which maps to the service account name used by the underlying
+	// Kubernetes code, so that we can build out the extra policy required to scale OpenShift resources.
+	InfraHorizontalPodAutoscalerControllerServiceAccountName = "horizontal-pod-autoscaler"
 )
 
 type InfraServiceAccounts struct {

--- a/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
+++ b/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
@@ -94,5 +94,6 @@ func isSystemOnlyRole(role authorizationapi.ClusterRole) bool {
 // to the hide list
 func isControllerRole(role *authorizationapi.ClusterRole) bool {
 	return strings.HasPrefix(role.Name, "system:controller:") ||
-		strings.HasSuffix(role.Name, "-controller")
+		strings.HasSuffix(role.Name, "-controller") ||
+		strings.HasPrefix(role.Name, "system:openshift:controller:")
 }

--- a/pkg/cmd/server/kubernetes/master/controller/config.go
+++ b/pkg/cmd/server/kubernetes/master/controller/config.go
@@ -12,6 +12,8 @@ type KubeControllerConfig struct {
 
 	// TODO the scheduler should move out into its own logical component
 	SchedulerControllerConfig SchedulerControllerConfig
+
+	HeapsterNamespace string
 }
 
 // GetControllerInitializers return the controller initializer functions for kube controllers
@@ -50,6 +52,13 @@ func (c KubeControllerConfig) GetControllerInitializers(cloudProvider cloudprovi
 		CloudProvider: cloudProvider,
 	}
 	ret["service"] = serviceLoadBalancerController.RunController
+
+	// overrides the Kube HPA controller config, so that we can point it at an HTTPS Heapster
+	// in openshift-infra, and pass it a scale client that knows how to scale DCs
+	hpaControllerConfig := HorizontalPodAutoscalerControllerConfig{
+		HeapsterNamespace: c.HeapsterNamespace,
+	}
+	ret["horizontalpodautoscaling"] = hpaControllerConfig.RunController
 
 	return ret, nil
 }

--- a/pkg/cmd/server/kubernetes/master/controller/hpa.go
+++ b/pkg/cmd/server/kubernetes/master/controller/hpa.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	hpacontroller "k8s.io/kubernetes/pkg/controller/podautoscaler"
+	hpametrics "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	clientgoclientset "k8s.io/client-go/kubernetes"
+	kubecontroller "k8s.io/kubernetes/cmd/kube-controller-manager/app"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+)
+
+// NB: this is funky -- it's actually a Kubernetes controller, but we run it as an OpenShift controller in order
+// to get a handle on OpenShift clients, so that our delegating scales getter can work.
+
+type HorizontalPodAutoscalerControllerConfig struct {
+	HeapsterNamespace string
+}
+
+func (c *HorizontalPodAutoscalerControllerConfig) RunController(ctx kubecontroller.ControllerContext) (bool, error) {
+	hpaClientConfig := ctx.ClientBuilder.ConfigOrDie(bootstrappolicy.InfraHorizontalPodAutoscalerControllerServiceAccountName)
+
+	hpaClient, err := kubeclientset.NewForConfig(hpaClientConfig)
+	if err != nil {
+		return false, err
+	}
+
+	// use the Kubernetes config so that the service account is in the same name namespace for both clients
+	hpaOriginClient, err := osclient.New(hpaClientConfig)
+	if err != nil {
+		return false, err
+	}
+
+	hpaEventsClient, err := clientgoclientset.NewForConfig(hpaClientConfig)
+	if err != nil {
+		return false, err
+	}
+
+	metricsClient := hpametrics.NewHeapsterMetricsClient(
+		hpaClient,
+		c.HeapsterNamespace,
+		"https",
+		"heapster",
+		"",
+	)
+	replicaCalc := hpacontroller.NewReplicaCalculator(metricsClient, hpaClient.Core())
+
+	delegatingScalesGetter := osclient.NewDelegatingScaleNamespacer(hpaOriginClient, hpaClient.ExtensionsV1beta1())
+
+	go hpacontroller.NewHorizontalController(
+		hpaEventsClient.Core(),
+		delegatingScalesGetter,
+		hpaClient.Autoscaling(),
+		replicaCalc,
+		ctx.InformerFactory.Autoscaling().V1().HorizontalPodAutoscalers(),
+		ctx.Options.HorizontalPodAutoscalerSyncPeriod.Duration,
+	).Run(ctx.Stop)
+
+	return true, nil
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -570,6 +570,8 @@ func BuildKubeControllerConfig(options configapi.MasterConfig) (*kubecontrollers
 	imageTemplate.Latest = options.ImageConfig.Latest
 	ret.RecyclerImage = imageTemplate.ExpandOrDie("recycler")
 
+	ret.HeapsterNamespace = options.PolicyConfig.OpenShiftInfrastructureNamespace
+
 	return ret, nil
 }
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -905,6 +905,20 @@ items:
   userNames:
   - system:serviceaccount:openshift-infra:resourcequota-controller
 - apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: system:openshift:controller:horizontal-pod-autoscaler
+  roleRef:
+    name: system:openshift:controller:horizontal-pod-autoscaler
+  subjects:
+  - kind: ServiceAccount
+    name: horizontal-pod-autoscaler
+    namespace: kube-system
+  userNames:
+  - system:serviceaccount:kube-system:horizontal-pod-autoscaler
+- apiVersion: v1
   groupNames:
   - system:masters
   kind: ClusterRoleBinding

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3977,6 +3977,23 @@ items:
   metadata:
     annotations:
       authorization.openshift.io/system-only: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:horizontal-pod-autoscaler
+  rules:
+  - apiGroups:
+    - ""
+    - apps.openshift.io
+    attributeRestrictions: null
+    resources:
+    - deploymentconfigs/scale
+    verbs:
+    - get
+    - update
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     labels:


### PR DESCRIPTION
In previous versions, we had custom setup for the HPA controller,
which allowed the HPA controller to scale DCs, and ensured that it
looked for Heapster in the OpenShift infra namespace.  This was
accidentally removed during a rebase.  This commit restores that logic
using the init functions functionality in the Kube controller manager.


This is currently based on top of #14633