### PR TITLE
Change the MAC addresses to be generated based on IP

### DIFF
--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -268,12 +268,15 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 		if err != nil {
 			return fmt.Errorf("failed to create container veth: %v", err)
 		}
+		// Force a consistent MAC address based on the IP address
+		if err := ip.SetHWAddrByIP(podInterfaceName, podIP, nil); err != nil {
+			return fmt.Errorf("failed to set pod interface MAC address: %v", err)
+		}
 		// refetch to get hardware address and other properties
 		contVeth, err = netlink.LinkByIndex(contVeth.Attrs().Index)
 		if err != nil {
 			return fmt.Errorf("failed to fetch container veth: %v", err)
 		}
-
 		// Clear out gateway to prevent ConfigureIface from adding the cluster
 		// subnet via the gateway
 		ipamResult.IP4.Gateway = nil


### PR DESCRIPTION
The ARP cache seems to misbehave in some clusters and if an IP address
is reused then the MAC address can get out of sync (he root cause has
not been identified).  When that happens the target pod looks at the
MAC address and drops the packets on the floor despite the IP address
being correct.

This patch changes the code to generate the MAC address based on the
IP address so that when an IP is reused, it will have the same MAC
address and the packets will flow.

This behavior is consistent with what Docker does when allocating MACs
and what Kubenet does too.  It may change in the future, but this
fixes our CNI plugin now.

Fixes bug 1451854 (https://bugzilla.redhat.com/show_bug.cgi?id=1451854)