### PR TITLE
NetworkCheck diagnostic: create projects with empty nodeselector

### DIFF
--- a/pkg/diagnostics/network/setup.go
+++ b/pkg/diagnostics/network/setup.go
@@ -35,7 +35,7 @@ func (d *NetworkDiagnostic) TestSetup() error {
 
 	for _, name := range nsList {
 		// Create a new namespace for network diagnostics
-		ns := &kapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		ns := &kapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: map[string]string{"openshift.io/node-selector": ""}}}
 		if _, err := d.KubeClient.Core().Namespaces().Create(ns); err != nil {
 			return fmt.Errorf("Creating namespace %q failed: %v", name, err)
 		}


### PR DESCRIPTION
fix bug 1431588 https://bugzilla.redhat.com/show_bug.cgi?id=1431588
fix bug 1459241 https://bugzilla.redhat.com/show_bug.cgi?id=1459241

When creating the projects in which the test pods will deploy, create
them with an empty node selector so that they can run on any nodes, not
just nodes with the cluster default node selector.