### PR TITLE
Log error verifying state

### DIFF
--- a/pkg/auth/oauth/external/handler.go
+++ b/pkg/auth/oauth/external/handler.go
@@ -161,14 +161,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// Validate state before making any server-to-server calls
 	ok, err := h.state.Check(authData.State, req)
-	if !ok {
-		glog.V(4).Infof("State is invalid")
-		err := errors.New("State is invalid")
+	if err != nil {
+		glog.V(4).Infof("Error verifying state: %v", err)
 		h.handleError(err, w, req)
 		return
 	}
-	if err != nil {
-		glog.V(4).Infof("Error verifying state: %v", err)
+	if !ok {
+		glog.V(4).Infof("State is invalid")
+		err := errors.New("State is invalid")
 		h.handleError(err, w, req)
 		return
 	}


### PR DESCRIPTION
If there's an error verifying the state, we should log it. the diff is ugly, but it's just flipping the order we log in.

https://bugzilla.redhat.com/show_bug.cgi?id=1455650