### PR TITLE
UPSTREAM: <drop>: Use internal service/endpoints informers in aggregator

### DIFF
--- a/pkg/cmd/server/origin/aggregator.go
+++ b/pkg/cmd/server/origin/aggregator.go
@@ -69,10 +69,11 @@ func (c *MasterConfig) createAggregatorConfig(kubeAPIServerConfig genericapiserv
 		return nil, err
 	}
 	return &aggregatorapiserver.Config{
-		GenericConfig:       &genericConfig,
-		CoreAPIServerClient: client,
-		ProxyClientCert:     certBytes,
-		ProxyClientKey:      keyBytes,
+		GenericConfig:         &genericConfig,
+		CoreAPIServerClient:   client,
+		ProxyClientCert:       certBytes,
+		ProxyClientKey:        keyBytes,
+		KubeInternalInformers: c.InternalKubeInformers,
 	}, nil
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -26,11 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	v1informers "k8s.io/client-go/informers/core/v1"
-	v1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/kubernetes/pkg/api"
+	internalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion"
+	internallisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	informers "k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion"
@@ -50,7 +50,7 @@ type APIServiceRegistrationController struct {
 	apiServiceSynced cache.InformerSynced
 
 	// serviceLister is used to get the IP to create the transport for
-	serviceLister  v1listers.ServiceLister
+	serviceLister  internallisters.ServiceLister
 	servicesSynced cache.InformerSynced
 
 	// To allow injection for testing.
@@ -59,7 +59,7 @@ type APIServiceRegistrationController struct {
 	queue workqueue.RateLimitingInterface
 }
 
-func NewAPIServiceRegistrationController(apiServiceInformer informers.APIServiceInformer, serviceInformer v1informers.ServiceInformer, apiHandlerManager APIHandlerManager) *APIServiceRegistrationController {
+func NewAPIServiceRegistrationController(apiServiceInformer informers.APIServiceInformer, serviceInformer internalinformers.ServiceInformer, apiHandlerManager APIHandlerManager) *APIServiceRegistrationController {
 	c := &APIServiceRegistrationController{
 		apiHandlerManager: apiHandlerManager,
 		apiServiceLister:  apiServiceInformer.Lister(),
@@ -119,9 +119,9 @@ func (c *APIServiceRegistrationController) getDestinationHost(apiService *apireg
 	}
 	switch {
 	// use IP from a clusterIP for these service types
-	case service.Spec.Type == v1.ServiceTypeClusterIP,
-		service.Spec.Type == v1.ServiceTypeNodePort,
-		service.Spec.Type == v1.ServiceTypeLoadBalancer:
+	case service.Spec.Type == api.ServiceTypeClusterIP,
+		service.Spec.Type == api.ServiceTypeNodePort,
+		service.Spec.Type == api.ServiceTypeLoadBalancer:
 		return service.Spec.ClusterIP
 	}
 
@@ -213,7 +213,7 @@ func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}) {
 }
 
 // there aren't very many apiservices, just check them all.
-func (c *APIServiceRegistrationController) getAPIServicesFor(service *v1.Service) []*apiregistration.APIService {
+func (c *APIServiceRegistrationController) getAPIServicesFor(service *api.Service) []*apiregistration.APIService {
 	var ret []*apiregistration.APIService
 	apiServiceList, _ := c.apiServiceLister.List(labels.Everything())
 	for _, apiService := range apiServiceList {
@@ -231,26 +231,26 @@ func (c *APIServiceRegistrationController) getAPIServicesFor(service *v1.Service
 // TODO, think of a way to avoid checking on every service manipulation
 
 func (c *APIServiceRegistrationController) addService(obj interface{}) {
-	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
+	for _, apiService := range c.getAPIServicesFor(obj.(*api.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
 func (c *APIServiceRegistrationController) updateService(obj, _ interface{}) {
-	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
+	for _, apiService := range c.getAPIServicesFor(obj.(*api.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
 func (c *APIServiceRegistrationController) deleteService(obj interface{}) {
-	castObj, ok := obj.(*v1.Service)
+	castObj, ok := obj.(*api.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			glog.Errorf("Couldn't get object from tombstone %#v", obj)
 			return
 		}
-		castObj, ok = tombstone.Obj.(*v1.Service)
+		castObj, ok = tombstone.Obj.(*api.Service)
 		if !ok {
 			glog.Errorf("Tombstone contained object that is not expected %#v", obj)
 			return

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/pkg/api"
+	internallisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 )
@@ -30,18 +30,18 @@ import (
 func TestGetDestinationHost(t *testing.T) {
 	tests := []struct {
 		name       string
-		services   []*v1.Service
+		services   []*api.Service
 		apiService *apiregistration.APIService
 
 		expected string
 	}{
 		{
 			name: "cluster ip",
-			services: []*v1.Service{
+			services: []*api.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alfa"},
-					Spec: v1.ServiceSpec{
-						Type:      v1.ServiceTypeClusterIP,
+					Spec: api.ServiceSpec{
+						Type:      api.ServiceTypeClusterIP,
 						ClusterIP: "hit",
 					},
 				},
@@ -60,11 +60,11 @@ func TestGetDestinationHost(t *testing.T) {
 		},
 		{
 			name: "loadbalancer",
-			services: []*v1.Service{
+			services: []*api.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alfa"},
-					Spec: v1.ServiceSpec{
-						Type:      v1.ServiceTypeLoadBalancer,
+					Spec: api.ServiceSpec{
+						Type:      api.ServiceTypeLoadBalancer,
 						ClusterIP: "lb",
 					},
 				},
@@ -83,11 +83,11 @@ func TestGetDestinationHost(t *testing.T) {
 		},
 		{
 			name: "node port",
-			services: []*v1.Service{
+			services: []*api.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "alfa"},
-					Spec: v1.ServiceSpec{
-						Type:      v1.ServiceTypeNodePort,
+					Spec: api.ServiceSpec{
+						Type:      api.ServiceTypeNodePort,
 						ClusterIP: "np",
 					},
 				},
@@ -122,7 +122,7 @@ func TestGetDestinationHost(t *testing.T) {
 
 	for _, test := range tests {
 		serviceCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		serviceLister := v1listers.NewServiceLister(serviceCache)
+		serviceLister := internallisters.NewServiceLister(serviceCache)
 		c := &APIServiceRegistrationController{
 			serviceLister: serviceLister,
 		}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -20,27 +20,27 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/pkg/api/v1"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake"
 	listers "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion"
+	"k8s.io/kubernetes/pkg/api"
+	internallisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 )
 
-func newEndpoints(namespace, name string) *v1.Endpoints {
-	return &v1.Endpoints{
+func newEndpoints(namespace, name string) *api.Endpoints {
+	return &api.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
 	}
 }
 
-func newEndpointsWithAddress(namespace, name string) *v1.Endpoints {
-	return &v1.Endpoints{
+func newEndpointsWithAddress(namespace, name string) *api.Endpoints {
+	return &api.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
-		Subsets: []v1.EndpointSubset{
+		Subsets: []api.EndpointSubset{
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []api.EndpointAddress{
 					{
 						IP: "val",
 					},
@@ -50,11 +50,11 @@ func newEndpointsWithAddress(namespace, name string) *v1.Endpoints {
 	}
 }
 
-func newService(namespace, name string) *v1.Service {
-	return &v1.Service{
+func newService(namespace, name string) *api.Service {
+	return &api.Service{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+		Spec: api.ServiceSpec{
+			Type: api.ServiceTypeClusterIP,
 		},
 	}
 }
@@ -83,8 +83,8 @@ func TestSync(t *testing.T) {
 
 		apiServiceName       string
 		apiServices          []*apiregistration.APIService
-		services             []*v1.Service
-		endpoints            []*v1.Endpoints
+		services             []*api.Service
+		endpoints            []*api.Endpoints
 		expectedAvailability apiregistration.APIServiceCondition
 	}{
 		{
@@ -102,7 +102,7 @@ func TestSync(t *testing.T) {
 			name:           "no service",
 			apiServiceName: "remote.group",
 			apiServices:    []*apiregistration.APIService{newRemoteAPIService("remote.group")},
-			services:       []*v1.Service{newService("foo", "not-bar")},
+			services:       []*api.Service{newService("foo", "not-bar")},
 			expectedAvailability: apiregistration.APIServiceCondition{
 				Type:    apiregistration.Available,
 				Status:  apiregistration.ConditionFalse,
@@ -114,7 +114,7 @@ func TestSync(t *testing.T) {
 			name:           "no endpoints",
 			apiServiceName: "remote.group",
 			apiServices:    []*apiregistration.APIService{newRemoteAPIService("remote.group")},
-			services:       []*v1.Service{newService("foo", "bar")},
+			services:       []*api.Service{newService("foo", "bar")},
 			expectedAvailability: apiregistration.APIServiceCondition{
 				Type:    apiregistration.Available,
 				Status:  apiregistration.ConditionFalse,
@@ -126,8 +126,8 @@ func TestSync(t *testing.T) {
 			name:           "missing endpoints",
 			apiServiceName: "remote.group",
 			apiServices:    []*apiregistration.APIService{newRemoteAPIService("remote.group")},
-			services:       []*v1.Service{newService("foo", "bar")},
-			endpoints:      []*v1.Endpoints{newEndpoints("foo", "bar")},
+			services:       []*api.Service{newService("foo", "bar")},
+			endpoints:      []*api.Endpoints{newEndpoints("foo", "bar")},
 			expectedAvailability: apiregistration.APIServiceCondition{
 				Type:    apiregistration.Available,
 				Status:  apiregistration.ConditionFalse,
@@ -139,8 +139,8 @@ func TestSync(t *testing.T) {
 			name:           "remote",
 			apiServiceName: "remote.group",
 			apiServices:    []*apiregistration.APIService{newRemoteAPIService("remote.group")},
-			services:       []*v1.Service{newService("foo", "bar")},
-			endpoints:      []*v1.Endpoints{newEndpointsWithAddress("foo", "bar")},
+			services:       []*api.Service{newService("foo", "bar")},
+			endpoints:      []*api.Endpoints{newEndpointsWithAddress("foo", "bar")},
 			expectedAvailability: apiregistration.APIServiceCondition{
 				// this is different in the 1.7 pull where the check is skipped.
 				Type:    apiregistration.Available,
@@ -169,8 +169,8 @@ func TestSync(t *testing.T) {
 		c := AvailableConditionController{
 			apiServiceClient: fakeClient.Apiregistration(),
 			apiServiceLister: listers.NewAPIServiceLister(apiServiceIndexer),
-			serviceLister:    v1listers.NewServiceLister(serviceIndexer),
-			endpointsLister:  v1listers.NewEndpointsLister(endpointsIndexer),
+			serviceLister:    internallisters.NewServiceLister(serviceIndexer),
+			endpointsLister:  internallisters.NewEndpointsLister(endpointsIndexer),
 		}
 		c.sync(tc.apiServiceName)
 


### PR DESCRIPTION
Until kube-proxy switches to the external endpoints informer (1.7) we
need to use the same one for DNS, which means aggregator does as well.

Can be removed once we move to 1.7

[test] @deads2k close, but no cigar