### PR TITLE
minor efficiency improvements in pkg/authorization

### DIFF
--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -99,11 +99,9 @@ func Convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRu
 
 	out.APIGroups = in.APIGroups
 
-	out.Resources = sets.String{}
-	out.Resources.Insert(in.Resources...)
+	out.Resources = sets.NewString(in.Resources...)
 
-	out.Verbs = sets.String{}
-	out.Verbs.Insert(in.Verbs...)
+	out.Verbs = sets.NewString(in.Verbs...)
 
 	out.ResourceNames = sets.NewString(in.ResourceNames...)
 
@@ -119,14 +117,11 @@ func Convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRu
 
 	out.APIGroups = in.APIGroups
 
-	out.Resources = []string{}
-	out.Resources = append(out.Resources, in.Resources.List()...)
+	out.Resources = in.Resources.List()
 
-	out.Verbs = []string{}
-	out.Verbs = append(out.Verbs, in.Verbs.List()...)
+	out.Verbs = in.Verbs.List()
 
 	out.ResourceNames = in.ResourceNames.List()
-
 	out.NonResourceURLsSlice = in.NonResourceURLs.List()
 
 	return nil

--- a/pkg/authorization/rulevalidation/policy_comparator.go
+++ b/pkg/authorization/rulevalidation/policy_comparator.go
@@ -104,16 +104,16 @@ func ruleCovers(ownerRule, subrule authorizationapi.PolicyRule) bool {
 	allResources := authorizationapi.NormalizeResources(ownerRule.Resources)
 
 	ownerGroups := sets.NewString(ownerRule.APIGroups...)
-	groupMatches := ownerGroups.Has(authorizationapi.APIGroupAll) || ownerGroups.HasAll(subrule.APIGroups...) || (len(ownerRule.APIGroups) == 0 && len(subrule.APIGroups) == 0)
+	groupMatches := ownerGroups.Has(authorizationapi.APIGroupAll) || ownerGroups.HasAll(subrule.APIGroups...)
 
-	verbMatches := ownerRule.Verbs.Has(authorizationapi.VerbAll) || ownerRule.Verbs.HasAll(subrule.Verbs.List()...)
-	resourceMatches := ownerRule.Resources.Has(authorizationapi.ResourceAll) || allResources.HasAll(subrule.Resources.List()...)
+	verbMatches := ownerRule.Verbs.Has(authorizationapi.VerbAll) || ownerRule.Verbs.IsSuperset(subrule.Verbs)
+	resourceMatches := ownerRule.Resources.Has(authorizationapi.ResourceAll) || allResources.IsSuperset(subrule.Resources)
 	resourceNameMatches := false
 
 	if len(subrule.ResourceNames) == 0 {
 		resourceNameMatches = (len(ownerRule.ResourceNames) == 0)
 	} else {
-		resourceNameMatches = (len(ownerRule.ResourceNames) == 0) || ownerRule.ResourceNames.HasAll(subrule.ResourceNames.List()...)
+		resourceNameMatches = (len(ownerRule.ResourceNames) == 0) || ownerRule.ResourceNames.IsSuperset(subrule.ResourceNames)
 	}
 
 	nonResourceCovers := nonResourceRuleCovers(ownerRule.NonResourceURLs, subrule.NonResourceURLs)


### PR DESCRIPTION
1. don't do append([]string{}, sets.String.List()...) - needless double copy
2. do x.IsSuperset(y) instead of x.HasAll(y.List()...) - saves bit shuffling