### PR TITLE
When OPENSHIFT_PROFILE is set, add an additional signal (SIGUSR1)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -18,7 +18,7 @@ To build the base and release images, run:
 
     $ hack/build-base-images.sh
 
-Today, all of our container image builds require 
+Today, all of our container image builds require
 [imagebuilder](https://github.com/openshift/imagebuilder).
 
 Once a release has been created, it can be pushed:
@@ -709,6 +709,9 @@ and `OPENSHIFT_PROFILE_PORT=` to change default ip `127.0.0.1` and default port 
 In order to start the server in CPU profiling mode, run:
 
     $ OPENSHIFT_PROFILE=cpu sudo ./_output/local/bin/linux/amd64/openshift start
+
+When you're done, you can use the SIGUSR1 signal to kill the openshift process
+and ensure the profile logs are flushed to disk.
 
 Or, if running OpenShift under systemd, append this to
 `/etc/sysconfig/atomic-openshift-{master,node}`

--- a/pkg/cmd/util/serviceability/serviceability.go
+++ b/pkg/cmd/util/serviceability/serviceability.go
@@ -37,7 +37,7 @@ func Profile(mode string) Stop {
 func profileOnExit(s Stop) Stop {
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+		signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
 		<-c
 		// Programs with more sophisticated signal handling
 		// should ensure the Stop() function returned from


### PR DESCRIPTION
When OPENSHIFT_PROFILE is set, add an additional signal (SIGUSR1) that kills the openshift process and ensures the profile logs are flushed to disk.