### PR TITLE
Add ROUTER_LISTEN_ADDRESS_* for multi homed setup

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -161,7 +161,7 @@ defaults
 
 {{ if .BindPorts -}}
 frontend public
-  bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80" }} v4v6 {{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
+  bind {{env "ROUTER_LISTEN_ADDRESS_HTTP" "::"}}:{{env "ROUTER_SERVICE_HTTP_PORT" "80" }} v4v6 {{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
   mode http
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
@@ -186,7 +186,7 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
-  bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v4v6 {{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
+  bind {{env "ROUTER_LISTEN_ADDRESS_HTTPS" "::"}}:{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v4v6 {{ if matchPattern "true|TRUE" (env "ROUTER_USE_PROXY_PROTOCOL" "") }} accept-proxy{{ end }}
   tcp-request  inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
 


### PR DESCRIPTION
To be able to use a multi homed setup you will need to specify the address on which the router (haproxy) should listen.

The format for this Variable is documented at the haproxy doc.
http://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4-bind