### PR TITLE
Change git command for description extraction

### DIFF
--- a/tools/rebasehelpers/commitchecker/commitchecker.go
+++ b/tools/rebasehelpers/commitchecker/commitchecker.go
@@ -30,7 +30,10 @@ func main() {
 	// TODO: ...along with subtree merges.
 	nonbumpCommits := []util.Commit{}
 	for _, commit := range commits {
-		lastDescriptionLine := commit.Description[len(commit.Description)-1]
+		var lastDescriptionLine string
+		if descriptionLen := len(commit.Description); descriptionLen > 0 {
+			lastDescriptionLine = commit.Description[descriptionLen-1]
+		}
 		if !strings.HasPrefix(commit.Summary, "bump(") && !strings.HasPrefix(lastDescriptionLine, "git-subtree-split:") {
 			nonbumpCommits = append(nonbumpCommits, commit)
 		}

--- a/tools/rebasehelpers/util/git.go
+++ b/tools/rebasehelpers/util/git.go
@@ -343,7 +343,7 @@ func filesInCommit(sha string) ([]File, error) {
 
 func descriptionInCommit(sha string) ([]string, error) {
 	descriptionLines := []string{}
-	stdout, stderr, err := run("git", "show", "--quiet", sha)
+	stdout, stderr, err := run("git", "log", "--pretty=%b", "-1", sha)
 	if err != nil {
 		return descriptionLines, fmt.Errorf("%s: %s", stderr, err)
 	}
@@ -352,7 +352,7 @@ func descriptionInCommit(sha string) ([]string, error) {
 		if len(commitLine) == 0 {
 			continue
 		}
-		descriptionLines = append(descriptionLines, strings.Trim(commitLine, " "))
+		descriptionLines = append(descriptionLines, commitLine)
 	}
 	return descriptionLines, nil
 }


### PR DESCRIPTION
This code seems to perform slightly better and only retrieves the actual
body/description of the commit with no additional whitespace.

@stevekuznetsov