### PR TITLE
UPSTREAM: 44115: scheduler should not log an error when no fit

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
@@ -635,7 +635,11 @@ func (factory *ConfigFactory) MakeDefaultErrorFunc(backoff *util.PodBackoff, pod
 		if err == core.ErrNoNodesAvailable {
 			glog.V(4).Infof("Unable to schedule %v %v: no nodes are registered to the cluster; waiting", pod.Namespace, pod.Name)
 		} else {
-			glog.Errorf("Error scheduling %v %v: %v; retrying", pod.Namespace, pod.Name, err)
+			if _, ok := err.(*core.FitError); ok {
+				glog.V(4).Infof("Unable to schedule %v %v: no fit: %v; waiting", pod.Namespace, pod.Name, err)
+			} else {
+				glog.Errorf("Error scheduling %v %v: %v; retrying", pod.Namespace, pod.Name, err)
+			}
 		}
 		backoff.Gc()
 		// Retry asynchronously.


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/pull/44115

related https://bugzilla.redhat.com/show_bug.cgi?id=1462345