### PR TITLE
oc new-app display correct error on missing context directory

### DIFF
--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -259,6 +259,9 @@ func (r *SourceRepository) LocalPath() (string, error) {
 			return "", err
 		}
 	}
+	if _, err := os.Stat(r.localDir); os.IsNotExist(err) {
+		return "", fmt.Errorf("supplied context directory '%s' does not exist in '%s'", r.contextDir, r.url.String())
+	}
 	return r.localDir, nil
 }
 


### PR DESCRIPTION
Adds additional check for existence of supplied context directory
and displays correct error
Also added test for the correct error

Previously a missing context directory would display an error
about a missing Dockerfile (when using the docker strategy)

Fixes #14298