### PR TITLE
Skip valueFrom tests if provider is gce

### DIFF
--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -50,6 +50,8 @@ var _ = g.Describe("[builds][Conformance][valueFrom] process valueFrom in build 
 
 	g.It("should successfully resolve valueFrom in s2i build environment variables", func() {
 
+		framework.SkipIfProviderIs("gce")
+
 		g.By("creating test successful build config")
 		err := oc.Run("create").Args("-f", successfulSTIBuildValueFrom).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -73,6 +75,7 @@ var _ = g.Describe("[builds][Conformance][valueFrom] process valueFrom in build 
 	g.It("should successfully resolve valueFrom in docker build environment variables", func() {
 
 		framework.SkipIfProviderIs("gce")
+
 		g.By("creating test successful build config")
 		err := oc.Run("create").Args("-f", successfulDockerBuildValueFrom).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -95,6 +98,8 @@ var _ = g.Describe("[builds][Conformance][valueFrom] process valueFrom in build 
 
 	g.It("should fail resolving unresolvable valueFrom in sti build environment variable references", func() {
 
+		framework.SkipIfProviderIs("gce")
+
 		g.By("creating test build config")
 		err := oc.Run("create").Args("-f", failedSTIBuildValueFrom).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -111,6 +116,8 @@ var _ = g.Describe("[builds][Conformance][valueFrom] process valueFrom in build 
 	})
 
 	g.It("should fail resolving unresolvable valueFrom in docker build environment variable references", func() {
+
+		framework.SkipIfProviderIs("gce")
 
 		g.By("creating test build config")
 		err := oc.Run("create").Args("-f", failedDockerBuildValueFrom).Execute()


### PR DESCRIPTION
GCE does not use new builder images for tests, so skipping valueFrom
tests until new images are pushed