### PR TITLE
Split controller config out from api server config

### DIFF
--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -136,7 +136,7 @@ func (g *configRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) 
 			return generic.UndecoratedStorage(copier, storageConfig, capacity, objectType, resourcePrefix, keyFunc, newListFn, getAttrsFunc, triggerFn)
 		}
 
-		glog.V(5).Infof("using watch cache storage (capacity=%v, quorum=%t) for %s %#v", *capacity, storageConfig.Quorum, resource.String(), storageConfig)
+		glog.V(5).Infof("using cached watch storage (capacity=%v, quorum=%t) for %s %#v", *capacity, storageConfig.Quorum, resource.String(), storageConfig)
 		return storageWithCacher(copier, storageConfig, capacity, objectType, resourcePrefix, keyFunc, newListFn, getAttrsFunc, triggerFn)
 	}
 


### PR DESCRIPTION
During startup of the controller, do not start RESTConfigs for master processes by splitting the config path when running in "controller only" mode. Avoids keeping a large chunk of things in memory that have no business being in memory (6 rest storage, which bring along caches)

@deads2k @liggitt [test]