### PR TITLE
Migrate controllers to external secrets, services, and service accounts

### DIFF
--- a/pkg/cmd/server/crypto/extensions/serversigning.go
+++ b/pkg/cmd/server/crypto/extensions/serversigning.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 
-	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 )
@@ -24,9 +24,9 @@ var (
 	OpenShiftServerSigningServiceUIDOID = oid(OpenShiftServerSigningServiceOID, 1)
 )
 
-// ServiceServerCertificateExtension returns a CertificateExtensionFunc that will add the
+// ServiceServerCertificateExtensionV1 returns a CertificateExtensionFunc that will add the
 // service UID as an x509 v3 extension to the server certificate.
-func ServiceServerCertificateExtension(svc *kapi.Service) crypto.CertificateExtensionFunc {
+func ServiceServerCertificateExtensionV1(svc *kapiv1.Service) crypto.CertificateExtensionFunc {
 	return func(cert *x509.Certificate) error {
 		uid, err := asn1.Marshal(svc.UID)
 		if err != nil {

--- a/pkg/cmd/server/origin/controller/service.go
+++ b/pkg/cmd/server/origin/controller/service.go
@@ -24,18 +24,18 @@ func (c *ServiceServingCertsControllerOptions) RunController(ctx ControllerConte
 	}
 
 	servingCertController := servingcertcontroller.NewServiceServingCertController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Services(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ExternalKubeInformers.Core().V1().Services(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
 		ca,
 		"cluster.local",
 		2*time.Minute,
 	)
 	servingCertUpdateController := servingcertcontroller.NewServiceServingCertUpdateController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Services(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ExternalKubeInformers.Core().V1().Services(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
 		ca,
 		"cluster.local",
 		20*time.Minute,

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -64,24 +64,24 @@ func (c *ServiceAccountTokenControllerOptions) RunController(ctx ControllerConte
 }
 
 func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error) {
-	kc := ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
+	kc := ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
 
 	go serviceaccountcontrollers.NewDockercfgDeletedController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgDeletedControllerOptions{},
 	).Run(ctx.Stop)
 
 	go serviceaccountcontrollers.NewDockercfgTokenDeletedController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgTokenDeletedControllerOptions{},
 	).Run(ctx.Stop)
 
 	dockerURLsInitialized := make(chan struct{})
 	dockercfgController := serviceaccountcontrollers.NewDockercfgController(
-		ctx.InternalKubeInformers.Core().InternalVersion().ServiceAccounts(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().ServiceAccounts(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgControllerOptions{DockerURLsInitialized: dockerURLsInitialized},
 	)
@@ -94,7 +94,7 @@ func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error)
 		DockerURLsInitialized: dockerURLsInitialized,
 	}
 	go serviceaccountcontrollers.NewDockerRegistryServiceController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		dockerRegistryControllerOptions,
 	).Run(10, ctx.Stop)

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -253,8 +253,7 @@ func (c *MasterConfig) RunIngressIPController(internalKubeClientset kclientsetin
 		return
 	}
 	ingressIPController := ingressip.NewIngressIPController(
-		c.InternalKubeInformers.Core().InternalVersion().Services().Informer(),
-		internalKubeClientset,
+		c.ExternalKubeInformers.Core().V1().Services().Informer(),
 		externalKubeClientset,
 		ipNet,
 		defaultIngressIPSyncPeriod,

--- a/pkg/service/controller/servingcert/secret_updating_controller_test.go
+++ b/pkg/service/controller/servingcert/secret_updating_controller_test.go
@@ -7,20 +7,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 )
 
 func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 	tests := []struct {
 		name          string
 		primeServices func(cache.Store)
-		secret        *kapi.Secret
+		secret        *v1.Secret
 		expected      bool
 	}{
 		{
 			name:          "no service annotation",
 			primeServices: func(serviceCache cache.Store) {},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{},
@@ -31,7 +31,7 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name:          "missing service",
 			primeServices: func(serviceCache cache.Store) {},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -44,11 +44,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "service-uid-mismatch",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-2"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -62,11 +62,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "service secret name mismatch",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret2"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -80,11 +80,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "no expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -98,11 +98,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "bad expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -117,11 +117,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "expired expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -136,11 +136,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "distant expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{

--- a/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets_test.go
+++ b/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets_test.go
@@ -9,9 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
-	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
+	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -19,7 +19,7 @@ func TestDockercfgDeletion(t *testing.T) {
 	testcases := map[string]struct {
 		ClientObjects []runtime.Object
 
-		DeletedSecret *api.Secret
+		DeletedSecret *v1.Secret
 
 		ExpectedActions []clientgotesting.Action
 	}{
@@ -27,8 +27,8 @@ func TestDockercfgDeletion(t *testing.T) {
 			DeletedSecret: createdDockercfgSecret(),
 
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 		"deleted dockercfg secret with serviceaccount with reference": {
@@ -36,9 +36,9 @@ func TestDockercfgDeletion(t *testing.T) {
 
 			DeletedSecret: createdDockercfgSecret(),
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 		"deleted dockercfg secret with serviceaccount without reference": {
@@ -46,9 +46,9 @@ func TestDockercfgDeletion(t *testing.T) {
 
 			DeletedSecret: createdDockercfgSecret(),
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 	}
@@ -60,7 +60,7 @@ func TestDockercfgDeletion(t *testing.T) {
 		client := fake.NewSimpleClientset(tc.ClientObjects...)
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		controller := NewDockercfgDeletedController(
-			informerFactory.Core().InternalVersion().Secrets(),
+			informerFactory.Core().V1().Secrets(),
 			client,
 			DockercfgDeletedControllerOptions{},
 		)

--- a/pkg/serviceaccounts/util/helpers.go
+++ b/pkg/serviceaccounts/util/helpers.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/util/namer"
 )
@@ -22,5 +23,17 @@ func GetDockercfgSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
 // string.
 // TODO fix the upstream implementation to be more like this.
 func GetTokenSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "token-", maxSecretPrefixNameLength)
+}
+
+func GetDockercfgSecretNamePrefixV1(serviceAccount *v1.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "dockercfg-", maxSecretPrefixNameLength)
+}
+
+// GetTokenSecretNamePrefix creates the prefix used for the generated SA token secret. This is compatible with kube up until
+// long names, at which point we hash the SA name and leave the "token-" intact.  Upstream clips the value and generates a random
+// string.
+// TODO fix the upstream implementation to be more like this.
+func GetTokenSecretNamePrefixV1(serviceAccount *v1.ServiceAccount) string {
 	return namer.GetName(serviceAccount.Name, "token-", maxSecretPrefixNameLength)
 }


### PR DESCRIPTION
Goal of eliminating duplicate internal and external caches when running
in the controller by itself.

[test]