### PR TITLE
Move deployments to using versioned Kube informers

### DIFF
--- a/pkg/build/admission/buildpodutil.go
+++ b/pkg/build/admission/buildpodutil.go
@@ -7,13 +7,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 // GetBuildFromPod returns a build object encoded in a pod's BUILD environment variable along with
 // its encoding version
-func GetBuildFromPod(pod *kapi.Pod) (*buildapi.Build, schema.GroupVersion, error) {
+func GetBuildFromPod(pod *v1.Pod) (*buildapi.Build, schema.GroupVersion, error) {
 	envVar, err := buildEnvVar(pod)
 	if err != nil {
 		return nil, schema.GroupVersion{}, fmt.Errorf("unable to get build from pod: %v", err)
@@ -30,7 +31,7 @@ func GetBuildFromPod(pod *kapi.Pod) (*buildapi.Build, schema.GroupVersion, error
 }
 
 // SetBuildInPod encodes a build object and sets it in a pod's BUILD environment variable
-func SetBuildInPod(pod *kapi.Pod, build *buildapi.Build, groupVersion schema.GroupVersion) error {
+func SetBuildInPod(pod *v1.Pod, build *buildapi.Build, groupVersion schema.GroupVersion) error {
 	envVar, err := buildEnvVar(pod)
 	if err != nil {
 		return fmt.Errorf("unable to set build in pod: %v", err)
@@ -48,7 +49,7 @@ func SetBuildInPod(pod *kapi.Pod, build *buildapi.Build, groupVersion schema.Gro
 // environment variable may have been set in multiple ways: a default value,
 // by a BuildConfig, or by the BuildDefaults admission plugin. In this method
 // we finally act on the value by injecting it into the Pod.
-func SetPodLogLevelFromBuild(pod *kapi.Pod, build *buildapi.Build) error {
+func SetPodLogLevelFromBuild(pod *v1.Pod, build *buildapi.Build) error {
 	var envs []kapi.EnvVar
 
 	// Check whether the build strategy supports --loglevel parameter.
@@ -75,7 +76,7 @@ func SetPodLogLevelFromBuild(pod *kapi.Pod, build *buildapi.Build) error {
 	return nil
 }
 
-func buildEnvVar(pod *kapi.Pod) (*kapi.EnvVar, error) {
+func buildEnvVar(pod *v1.Pod) (*v1.EnvVar, error) {
 	if len(pod.Spec.Containers) == 0 {
 		return nil, errors.New("pod has no containers")
 	}
@@ -91,12 +92,12 @@ func buildEnvVar(pod *kapi.Pod) (*kapi.EnvVar, error) {
 	return nil, errors.New("pod does not have a BUILD environment variable")
 }
 
-func hasBuildEnvVar(pod *kapi.Pod) bool {
+func hasBuildEnvVar(pod *v1.Pod) bool {
 	_, err := buildEnvVar(pod)
 	return err == nil
 }
 
-func hasBuildAnnotation(pod *kapi.Pod) bool {
+func hasBuildAnnotation(pod *v1.Pod) bool {
 	if pod.Annotations == nil {
 		return false
 	}

--- a/pkg/build/admission/buildpodutil_test.go
+++ b/pkg/build/admission/buildpodutil_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	u "github.com/openshift/origin/pkg/build/admission/testutil"
 )
@@ -15,7 +16,7 @@ func TestGetBuild(t *testing.T) {
 	build := u.Build().WithDockerStrategy()
 	for _, version := range []string{"v1"} {
 		pod := u.Pod().WithBuild(t, build.AsBuild(), version)
-		resultBuild, resultVersion, err := GetBuildFromPod((*kapi.Pod)(pod))
+		resultBuild, resultVersion, err := GetBuildFromPod((*v1.Pod)(pod))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -36,7 +37,7 @@ func TestSetBuild(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		err = SetBuildInPod((*kapi.Pod)(pod), build.AsBuild(), groupVersion)
+		err = SetBuildInPod((*v1.Pod)(pod), build.AsBuild(), groupVersion)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -50,7 +51,7 @@ func TestSetBuild(t *testing.T) {
 func TestSetBuildLogLevel(t *testing.T) {
 	build := u.Build().WithSourceStrategy()
 	pod := u.Pod().WithEnvVar("BUILD", "foo")
-	SetPodLogLevelFromBuild((*kapi.Pod)(pod), build.AsBuild())
+	SetPodLogLevelFromBuild((*v1.Pod)(pod), build.AsBuild())
 
 	if len(pod.Spec.Containers[0].Args) == 0 {
 		t.Errorf("Builds pod loglevel was not set")
@@ -63,7 +64,7 @@ func TestSetBuildLogLevel(t *testing.T) {
 	build = u.Build().WithSourceStrategy()
 	pod = u.Pod().WithEnvVar("BUILD", "foo")
 	build.Spec.Strategy.SourceStrategy.Env = []kapi.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "7", ValueFrom: nil}}
-	SetPodLogLevelFromBuild((*kapi.Pod)(pod), build.AsBuild())
+	SetPodLogLevelFromBuild((*v1.Pod)(pod), build.AsBuild())
 
 	if pod.Spec.Containers[0].Args[0] != "--loglevel=7" {
 		t.Errorf("Build pod loglevel was not transferred from BUILD_LOGLEVEL environment variable: %#v", pod)

--- a/pkg/build/admission/overrides/admission.go
+++ b/pkg/build/admission/overrides/admission.go
@@ -2,7 +2,7 @@ package overrides
 
 import (
 	"github.com/golang/glog"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildadmission "github.com/openshift/origin/pkg/build/admission"
 	overridesapi "github.com/openshift/origin/pkg/build/admission/overrides/api"
@@ -31,7 +31,7 @@ func NewBuildOverrides(pluginConfig map[string]configapi.AdmissionPluginConfig) 
 }
 
 // ApplyOverrides applies configured overrides to a build in a build pod
-func (b BuildOverrides) ApplyOverrides(pod *kapi.Pod) error {
+func (b BuildOverrides) ApplyOverrides(pod *v1.Pod) error {
 	if b.config == nil {
 		return nil
 	}
@@ -87,14 +87,14 @@ func (b BuildOverrides) ApplyOverrides(pod *kapi.Pod) error {
 	return buildadmission.SetBuildInPod(pod, build, version)
 }
 
-func applyForcePullToPod(pod *kapi.Pod) error {
+func applyForcePullToPod(pod *v1.Pod) error {
 	for i := range pod.Spec.InitContainers {
 		glog.V(5).Infof("Setting ImagePullPolicy to PullAlways on init container %s of pod %s/%s", pod.Spec.InitContainers[i].Name, pod.Namespace, pod.Name)
-		pod.Spec.InitContainers[i].ImagePullPolicy = kapi.PullAlways
+		pod.Spec.InitContainers[i].ImagePullPolicy = v1.PullAlways
 	}
 	for i := range pod.Spec.Containers {
 		glog.V(5).Infof("Setting ImagePullPolicy to PullAlways on container %s of pod %s/%s", pod.Spec.Containers[i].Name, pod.Namespace, pod.Name)
-		pod.Spec.Containers[i].ImagePullPolicy = kapi.PullAlways
+		pod.Spec.Containers[i].ImagePullPolicy = v1.PullAlways
 	}
 	return nil
 }

--- a/pkg/build/admission/overrides/admission_test.go
+++ b/pkg/build/admission/overrides/admission_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/admission"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	overridesapi "github.com/openshift/origin/pkg/build/admission/overrides/api"
 	u "github.com/openshift/origin/pkg/build/admission/testutil"
@@ -38,7 +38,7 @@ func TestBuildOverrideForcePull(t *testing.T) {
 		for _, op := range ops {
 			overrides := BuildOverrides{config: &overridesapi.BuildOverridesConfig{ForcePull: true}}
 			pod := u.Pod().WithBuild(t, test.build, "v1")
-			err := overrides.ApplyOverrides((*kapi.Pod)(pod))
+			err := overrides.ApplyOverrides((*v1.Pod)(pod))
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", test.name, err)
 			}
@@ -49,10 +49,10 @@ func TestBuildOverrideForcePull(t *testing.T) {
 				if strategy.CustomStrategy.ForcePull == false {
 					t.Errorf("%s (%s): force pull was false", test.name, op)
 				}
-				if pod.Spec.Containers[0].ImagePullPolicy != kapi.PullAlways {
+				if pod.Spec.Containers[0].ImagePullPolicy != v1.PullAlways {
 					t.Errorf("%s (%s): image pull policy is not PullAlways", test.name, op)
 				}
-				if pod.Spec.InitContainers[0].ImagePullPolicy != kapi.PullAlways {
+				if pod.Spec.InitContainers[0].ImagePullPolicy != v1.PullAlways {
 					t.Errorf("%s (%s): image pull policy is not PullAlways", test.name, op)
 				}
 			case strategy.DockerStrategy != nil:
@@ -186,7 +186,7 @@ func TestLabelOverrides(t *testing.T) {
 
 		admitter := BuildOverrides{overridesConfig}
 		pod := u.Pod().WithBuild(t, u.Build().WithImageLabels(test.buildLabels).AsBuild(), "v1")
-		err := admitter.ApplyOverrides((*kapi.Pod)(pod))
+		err := admitter.ApplyOverrides((*v1.Pod)(pod))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -226,7 +226,7 @@ func TestBuildOverrideNodeSelector(t *testing.T) {
 		// normally the pod will have the nodeselectors from the build, due to the pod creation logic
 		// in the build controller flow. fake it out here.
 		pod.Spec.NodeSelector = test.build.Spec.NodeSelector
-		err := overrides.ApplyOverrides((*kapi.Pod)(pod))
+		err := overrides.ApplyOverrides((*v1.Pod)(pod))
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}
@@ -276,7 +276,7 @@ func TestBuildOverrideAnnotations(t *testing.T) {
 		overrides := BuildOverrides{config: &overridesapi.BuildOverridesConfig{Annotations: test.overrides}}
 		pod := u.Pod().WithBuild(t, test.build, "v1")
 		pod.Annotations = test.annotations
-		err := overrides.ApplyOverrides((*kapi.Pod)(pod))
+		err := overrides.ApplyOverrides((*v1.Pod)(pod))
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}

--- a/pkg/build/admission/testutil/pod.go
+++ b/pkg/build/admission/testutil/pod.go
@@ -7,14 +7,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
-type TestPod kapi.Pod
+type TestPod v1.Pod
 
 func Pod() *TestPod {
-	return (*TestPod)(&kapi.Pod{})
+	return (*TestPod)(&v1.Pod{})
 }
 
 func (p *TestPod) WithAnnotation(name, value string) *TestPod {
@@ -27,13 +28,13 @@ func (p *TestPod) WithAnnotation(name, value string) *TestPod {
 
 func (p *TestPod) WithEnvVar(name, value string) *TestPod {
 	if len(p.Spec.InitContainers) == 0 {
-		p.Spec.InitContainers = append(p.Spec.InitContainers, kapi.Container{})
+		p.Spec.InitContainers = append(p.Spec.InitContainers, v1.Container{})
 	}
 	if len(p.Spec.Containers) == 0 {
-		p.Spec.Containers = append(p.Spec.Containers, kapi.Container{})
+		p.Spec.Containers = append(p.Spec.Containers, v1.Container{})
 	}
-	p.Spec.InitContainers[0].Env = append(p.Spec.InitContainers[0].Env, kapi.EnvVar{Name: name, Value: value})
-	p.Spec.Containers[0].Env = append(p.Spec.Containers[0].Env, kapi.EnvVar{Name: name, Value: value})
+	p.Spec.InitContainers[0].Env = append(p.Spec.InitContainers[0].Env, v1.EnvVar{Name: name, Value: value})
+	p.Spec.Containers[0].Env = append(p.Spec.Containers[0].Env, v1.EnvVar{Name: name, Value: value})
 	return p
 }
 
@@ -87,7 +88,7 @@ func (p *TestPod) GetBuild(t *testing.T) *buildapi.Build {
 }
 
 func (p *TestPod) ToAttributes() admission.Attributes {
-	return admission.NewAttributesRecord((*kapi.Pod)(p),
+	return admission.NewAttributesRecord((*v1.Pod)(p),
 		nil,
 		kapi.Kind("Pod").WithVersion("version"),
 		"default",
@@ -98,6 +99,6 @@ func (p *TestPod) ToAttributes() admission.Attributes {
 		nil)
 }
 
-func (p *TestPod) AsPod() *kapi.Pod {
-	return (*kapi.Pod)(p)
+func (p *TestPod) AsPod() *v1.Pod {
+	return (*v1.Pod)(p)
 }

--- a/pkg/build/controller/build/podcreationstrategy.go
+++ b/pkg/build/controller/build/podcreationstrategy.go
@@ -3,7 +3,7 @@ package build
 import (
 	"fmt"
 
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
@@ -11,7 +11,7 @@ import (
 // buildPodCreationStrategy is used by the build controller to
 // create a build pod based on a build strategy
 type buildPodCreationStrategy interface {
-	CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error)
+	CreateBuildPod(build *buildapi.Build) (*v1.Pod, error)
 }
 
 type typeBasedFactoryStrategy struct {
@@ -20,8 +20,8 @@ type typeBasedFactoryStrategy struct {
 	customBuildStrategy buildPodCreationStrategy
 }
 
-func (f *typeBasedFactoryStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	var pod *kapi.Pod
+func (f *typeBasedFactoryStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, error) {
+	var pod *v1.Pod
 	var err error
 	switch {
 	case build.Spec.Strategy.DockerStrategy != nil:

--- a/pkg/build/controller/build/podcreationstrategy_test.go
+++ b/pkg/build/controller/build/podcreationstrategy_test.go
@@ -4,24 +4,24 @@ import (
 	"fmt"
 	"testing"
 
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 type testPodCreationStrategy struct {
-	pod *kapi.Pod
+	pod *v1.Pod
 	err error
 }
 
-func (s *testPodCreationStrategy) CreateBuildPod(b *buildapi.Build) (*kapi.Pod, error) {
+func (s *testPodCreationStrategy) CreateBuildPod(b *buildapi.Build) (*v1.Pod, error) {
 	return s.pod, s.err
 }
 
 func TestStrategyCreateBuildPod(t *testing.T) {
-	dockerBuildPod := &kapi.Pod{}
-	sourceBuildPod := &kapi.Pod{}
-	customBuildPod := &kapi.Pod{}
+	dockerBuildPod := &v1.Pod{}
+	sourceBuildPod := &v1.Pod{}
+	customBuildPod := &v1.Pod{}
 
 	dockerBuild := &buildapi.Build{}
 	dockerBuild.Spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
@@ -50,7 +50,7 @@ func TestStrategyCreateBuildPod(t *testing.T) {
 	tests := []struct {
 		strategy    buildPodCreationStrategy
 		build       *buildapi.Build
-		expectedPod *kapi.Pod
+		expectedPod *v1.Pod
 		expectError bool
 	}{
 		{

--- a/pkg/build/controller/common/util.go
+++ b/pkg/build/controller/common/util.go
@@ -9,6 +9,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/third_party/forked/golang/expansion"
 
@@ -158,7 +159,7 @@ func (e ErrEnvVarResolver) Error() string {
 // including references to existing environment variables, jsonpath references to
 // the build object, secrets, and configmaps.
 // The build.Strategy.BuildStrategy.Env is replaced with the resolved references.
-func ResolveValueFrom(pod *kapi.Pod, client kclientset.Interface) error {
+func ResolveValueFrom(pod *v1.Pod, client kclientset.Interface) error {
 	var outputEnv []kapi.EnvVar
 	var allErrs []error
 

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -9,8 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 // CustomBuildStrategy creates a build using a custom builder image.
@@ -22,7 +24,7 @@ type CustomBuildStrategy struct {
 }
 
 // CreateBuildPod creates the pod to be used for the Custom build
-func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
+func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, error) {
 	strategy := build.Spec.Strategy.CustomStrategy
 	if strategy == nil {
 		return nil, errors.New("CustomBuildStrategy cannot be executed without CustomStrategy parameters")
@@ -42,7 +44,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		return nil, fmt.Errorf("failed to encode the build: %v", err)
 	}
 
-	containerEnv := []kapi.EnvVar{{Name: "BUILD", Value: string(data)}}
+	containerEnv := []v1.EnvVar{{Name: "BUILD", Value: string(data)}}
 
 	if build.Spec.Source.Git != nil {
 		addSourceEnvVars(build.Spec.Source, &containerEnv)
@@ -61,35 +63,35 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 
 	if len(strategy.Env) > 0 {
-		containerEnv = append(containerEnv, strategy.Env...)
+		containerEnv = append(containerEnv, util.CopyApiEnvVarToV1EnvVar(strategy.Env)...)
 	}
 
 	if strategy.ExposeDockerSocket {
 		glog.V(2).Infof("ExposeDockerSocket is enabled for %s build", build.Name)
-		containerEnv = append(containerEnv, kapi.EnvVar{Name: "DOCKER_SOCKET", Value: dockerSocketPath})
+		containerEnv = append(containerEnv, v1.EnvVar{Name: "DOCKER_SOCKET", Value: dockerSocketPath})
 	}
 
 	privileged := true
-	pod := &kapi.Pod{
+	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildapi.GetBuildPodName(build),
 			Namespace: build.Namespace,
 			Labels:    getPodLabels(build),
 		},
-		Spec: kapi.PodSpec{
+		Spec: v1.PodSpec{
 			ServiceAccountName: build.Spec.ServiceAccount,
-			Containers: []kapi.Container{
+			Containers: []v1.Container{
 				{
 					Name:  "custom-build",
 					Image: strategy.From.Name,
 					Env:   containerEnv,
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
-					SecurityContext: &kapi.SecurityContext{
+					SecurityContext: &v1.SecurityContext{
 						Privileged: &privileged,
 					},
 				},
 			},
-			RestartPolicy: kapi.RestartPolicyNever,
+			RestartPolicy: v1.RestartPolicyNever,
 			NodeSelector:  build.Spec.NodeSelector,
 		},
 	}
@@ -98,12 +100,12 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 
 	if !strategy.ForcePull {
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
+		pod.Spec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
 	} else {
 		glog.V(2).Infof("ForcePull is enabled for %s build", build.Name)
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullAlways
+		pod.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
 	}
-	pod.Spec.Containers[0].Resources = build.Spec.Resources
+	pod.Spec.Containers[0].Resources = util.CopyApiResourcesToV1Resources(&build.Spec.Resources)
 	if build.Spec.Source.Binary != nil {
 		pod.Spec.Containers[0].Stdin = true
 		pod.Spec.Containers[0].StdinOnce = true

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -11,9 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/install"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 func TestCustomCreateBuildPod(t *testing.T) {
@@ -50,10 +52,10 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	if container.Name != "custom-build" {
 		t.Errorf("Expected custom-build, but got %s!", container.Name)
 	}
-	if container.ImagePullPolicy != kapi.PullIfNotPresent {
-		t.Errorf("Expected %v, got %v", kapi.PullIfNotPresent, container.ImagePullPolicy)
+	if container.ImagePullPolicy != v1.PullIfNotPresent {
+		t.Errorf("Expected %v, got %v", v1.PullIfNotPresent, container.ImagePullPolicy)
 	}
-	if actual.Spec.RestartPolicy != kapi.RestartPolicyNever {
+	if actual.Spec.RestartPolicy != v1.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
 	if len(container.VolumeMounts) != 3 {
@@ -67,7 +69,7 @@ func TestCustomCreateBuildPod(t *testing.T) {
 			t.Fatalf("Expected %s in VolumeMount[%d], got %s", expected, i, container.VolumeMounts[i].MountPath)
 		}
 	}
-	if !kapi.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
+	if !kapi.Semantic.DeepEqual(container.Resources, util.CopyApiResourcesToV1Resources(&build.Spec.Resources)) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)
 	}
 	if len(actual.Spec.Volumes) != 3 {
@@ -107,8 +109,8 @@ func TestCustomCreateBuildPodExpectedForcePull(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", fperr)
 	}
 	container := actual.Spec.Containers[0]
-	if container.ImagePullPolicy != kapi.PullAlways {
-		t.Errorf("Expected %v, got %v", kapi.PullAlways, container.ImagePullPolicy)
+	if container.ImagePullPolicy != v1.PullAlways {
+		t.Errorf("Expected %v, got %v", v1.PullAlways, container.ImagePullPolicy)
 	}
 }
 

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -10,9 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/install"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 func TestDockerCreateBuildPod(t *testing.T) {
@@ -44,10 +46,10 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if container.Image != strategy.Image {
 		t.Errorf("Expected %s image, got %s!", container.Image, strategy.Image)
 	}
-	if container.ImagePullPolicy != kapi.PullIfNotPresent {
-		t.Errorf("Expected %v, got %v", kapi.PullIfNotPresent, container.ImagePullPolicy)
+	if container.ImagePullPolicy != v1.PullIfNotPresent {
+		t.Errorf("Expected %v, got %v", v1.PullIfNotPresent, container.ImagePullPolicy)
 	}
-	if actual.Spec.RestartPolicy != kapi.RestartPolicyNever {
+	if actual.Spec.RestartPolicy != v1.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
 	if len(container.Env) != 10 {
@@ -71,7 +73,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if len(actual.Spec.Volumes) != 4 {
 		t.Fatalf("Expected 4 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
-	if !kapi.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
+	if !kapi.Semantic.DeepEqual(container.Resources, util.CopyApiResourcesToV1Resources(&build.Spec.Resources)) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)
 	}
 	found := false

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -12,9 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apiserver/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/install"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 type FakeAdmissionControl struct {
@@ -72,10 +74,10 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	if container.Image != strategy.Image {
 		t.Errorf("Expected %s image, got %s!", container.Image, strategy.Image)
 	}
-	if container.ImagePullPolicy != kapi.PullIfNotPresent {
-		t.Errorf("Expected %v, got %v", kapi.PullIfNotPresent, container.ImagePullPolicy)
+	if container.ImagePullPolicy != v1.PullIfNotPresent {
+		t.Errorf("Expected %v, got %v", v1.PullIfNotPresent, container.ImagePullPolicy)
 	}
-	if actual.Spec.RestartPolicy != kapi.RestartPolicyNever {
+	if actual.Spec.RestartPolicy != v1.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
 
@@ -106,7 +108,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
 	}
-	if !kapi.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
+	if !kapi.Semantic.DeepEqual(container.Resources, util.CopyApiResourcesToV1Resources(&build.Spec.Resources)) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)
 	}
 	found := false

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/golang/glog"
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -52,17 +53,17 @@ func IsFatal(err error) bool {
 }
 
 // setupDockerSocket configures the pod to support the host's Docker socket
-func setupDockerSocket(podSpec *kapi.Pod) {
-	dockerSocketVolume := kapi.Volume{
+func setupDockerSocket(podSpec *v1.Pod) {
+	dockerSocketVolume := v1.Volume{
 		Name: "docker-socket",
-		VolumeSource: kapi.VolumeSource{
-			HostPath: &kapi.HostPathVolumeSource{
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
 				Path: dockerSocketPath,
 			},
 		},
 	}
 
-	dockerSocketVolumeMount := kapi.VolumeMount{
+	dockerSocketVolumeMount := v1.VolumeMount{
 		Name:      "docker-socket",
 		MountPath: dockerSocketPath,
 	}
@@ -76,17 +77,17 @@ func setupDockerSocket(podSpec *kapi.Pod) {
 
 // mountSecretVolume is a helper method responsible for actual mounting secret
 // volumes into a pod.
-func mountSecretVolume(pod *kapi.Pod, secretName, mountPath, volumeSuffix string) {
+func mountSecretVolume(pod *v1.Pod, secretName, mountPath, volumeSuffix string) {
 	volumeName := namer.GetName(secretName, volumeSuffix, kvalidation.DNS1123SubdomainMaxLength)
-	volume := kapi.Volume{
+	volume := v1.Volume{
 		Name: volumeName,
-		VolumeSource: kapi.VolumeSource{
-			Secret: &kapi.SecretVolumeSource{
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
 				SecretName: secretName,
 			},
 		},
 	}
-	volumeMount := kapi.VolumeMount{
+	volumeMount := v1.VolumeMount{
 		Name:      volumeName,
 		MountPath: mountPath,
 		ReadOnly:  true,
@@ -97,10 +98,10 @@ func mountSecretVolume(pod *kapi.Pod, secretName, mountPath, volumeSuffix string
 
 // setupDockerSecrets mounts Docker Registry secrets into Pod running the build,
 // allowing Docker to authenticate against private registries or Docker Hub.
-func setupDockerSecrets(pod *kapi.Pod, pushSecret, pullSecret *kapi.LocalObjectReference, imageSources []buildapi.ImageSource) {
+func setupDockerSecrets(pod *v1.Pod, pushSecret, pullSecret *kapi.LocalObjectReference, imageSources []buildapi.ImageSource) {
 	if pushSecret != nil {
 		mountSecretVolume(pod, pushSecret.Name, DockerPushSecretMountPath, "push")
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []kapi.EnvVar{
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []v1.EnvVar{
 			{Name: dockercfg.PushAuthType, Value: DockerPushSecretMountPath},
 		}...)
 		glog.V(3).Infof("%s will be used for docker push in %s", DockerPushSecretMountPath, pod.Name)
@@ -108,7 +109,7 @@ func setupDockerSecrets(pod *kapi.Pod, pushSecret, pullSecret *kapi.LocalObjectR
 
 	if pullSecret != nil {
 		mountSecretVolume(pod, pullSecret.Name, DockerPullSecretMountPath, "pull")
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []kapi.EnvVar{
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []v1.EnvVar{
 			{Name: dockercfg.PullAuthType, Value: DockerPullSecretMountPath},
 		}...)
 		glog.V(3).Infof("%s will be used for docker pull in %s", DockerPullSecretMountPath, pod.Name)
@@ -120,7 +121,7 @@ func setupDockerSecrets(pod *kapi.Pod, pushSecret, pullSecret *kapi.LocalObjectR
 		}
 		mountPath := filepath.Join(SourceImagePullSecretMountPath, strconv.Itoa(i))
 		mountSecretVolume(pod, imageSource.PullSecret.Name, mountPath, fmt.Sprintf("%s%d", "source-image", i))
-		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []kapi.EnvVar{
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []v1.EnvVar{
 			{Name: fmt.Sprintf("%s%d", dockercfg.PullSourceAuthType, i), Value: mountPath},
 		}...)
 		glog.V(3).Infof("%s will be used for docker pull in %s", mountPath, pod.Name)
@@ -130,14 +131,14 @@ func setupDockerSecrets(pod *kapi.Pod, pushSecret, pullSecret *kapi.LocalObjectR
 
 // setupSourceSecrets mounts SSH key used for accessing private SCM to clone
 // application source code during build.
-func setupSourceSecrets(pod *kapi.Pod, sourceSecret *kapi.LocalObjectReference) {
+func setupSourceSecrets(pod *v1.Pod, sourceSecret *kapi.LocalObjectReference) {
 	if sourceSecret == nil {
 		return
 	}
 
 	mountSecretVolume(pod, sourceSecret.Name, sourceSecretMountPath, "source")
 	glog.V(3).Infof("Installed source secrets in %s, in Pod %s/%s", sourceSecretMountPath, pod.Namespace, pod.Name)
-	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []kapi.EnvVar{
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []v1.EnvVar{
 		{Name: "SOURCE_SECRET_PATH", Value: sourceSecretMountPath},
 	}...)
 }
@@ -145,7 +146,7 @@ func setupSourceSecrets(pod *kapi.Pod, sourceSecret *kapi.LocalObjectReference) 
 // setupSecrets mounts the secrets referenced by the SecretBuildSource
 // into a builder container. It also sets an environment variable that contains
 // a name of the secret and the destination directory.
-func setupSecrets(pod *kapi.Pod, secrets []buildapi.SecretBuildSource) {
+func setupSecrets(pod *v1.Pod, secrets []buildapi.SecretBuildSource) {
 	for _, s := range secrets {
 		mountSecretVolume(pod, s.Secret.Name, filepath.Join(SecretBuildSourceBaseMountPath, s.Secret.Name), "build")
 		glog.V(3).Infof("%s will be used as a build secret in %s", s.Secret.Name, SecretBuildSourceBaseMountPath)
@@ -154,29 +155,29 @@ func setupSecrets(pod *kapi.Pod, secrets []buildapi.SecretBuildSource) {
 
 // addSourceEnvVars adds environment variables related to the source code
 // repository to builder container
-func addSourceEnvVars(source buildapi.BuildSource, output *[]kapi.EnvVar) {
-	sourceVars := []kapi.EnvVar{}
+func addSourceEnvVars(source buildapi.BuildSource, output *[]v1.EnvVar) {
+	sourceVars := []v1.EnvVar{}
 	if source.Git != nil {
-		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_REPOSITORY", Value: source.Git.URI})
-		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_URI", Value: source.Git.URI})
+		sourceVars = append(sourceVars, v1.EnvVar{Name: "SOURCE_REPOSITORY", Value: source.Git.URI})
+		sourceVars = append(sourceVars, v1.EnvVar{Name: "SOURCE_URI", Value: source.Git.URI})
 	}
 	if len(source.ContextDir) > 0 {
-		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_CONTEXT_DIR", Value: source.ContextDir})
+		sourceVars = append(sourceVars, v1.EnvVar{Name: "SOURCE_CONTEXT_DIR", Value: source.ContextDir})
 	}
 	if source.Git != nil && len(source.Git.Ref) > 0 {
-		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_REF", Value: source.Git.Ref})
+		sourceVars = append(sourceVars, v1.EnvVar{Name: "SOURCE_REF", Value: source.Git.Ref})
 	}
 	*output = append(*output, sourceVars...)
 }
 
-func addOriginVersionVar(output *[]kapi.EnvVar) {
-	version := kapi.EnvVar{Name: buildapi.OriginVersion, Value: version.Get().String()}
+func addOriginVersionVar(output *[]v1.EnvVar) {
+	version := v1.EnvVar{Name: buildapi.OriginVersion, Value: version.Get().String()}
 	*output = append(*output, version)
 }
 
 // addOutputEnvVars adds env variables that provide information about the output
 // target for the build
-func addOutputEnvVars(buildOutput *kapi.ObjectReference, output *[]kapi.EnvVar) error {
+func addOutputEnvVars(buildOutput *kapi.ObjectReference, output *[]v1.EnvVar) error {
 	if buildOutput == nil {
 		return nil
 	}
@@ -193,7 +194,7 @@ func addOutputEnvVars(buildOutput *kapi.ObjectReference, output *[]kapi.EnvVar) 
 	ref.Registry = ""
 	image := ref.String()
 
-	outputVars := []kapi.EnvVar{
+	outputVars := []v1.EnvVar{
 		{Name: "OUTPUT_REGISTRY", Value: registry},
 		{Name: "OUTPUT_IMAGE", Value: image},
 	}
@@ -203,7 +204,7 @@ func addOutputEnvVars(buildOutput *kapi.ObjectReference, output *[]kapi.EnvVar) 
 }
 
 // setupAdditionalSecrets creates secret volume mounts in the given pod for the given list of secrets
-func setupAdditionalSecrets(pod *kapi.Pod, secrets []buildapi.SecretSpec) {
+func setupAdditionalSecrets(pod *v1.Pod, secrets []buildapi.SecretSpec) {
 	for _, secretSpec := range secrets {
 		mountSecretVolume(pod, secretSpec.SecretSource.Name, secretSpec.MountPath, "secret")
 		glog.V(3).Infof("Installed additional secret in %s, in Pod %s/%s", secretSpec.MountPath, pod.Namespace, pod.Name)
@@ -211,7 +212,7 @@ func setupAdditionalSecrets(pod *kapi.Pod, secrets []buildapi.SecretSpec) {
 }
 
 // getContainerVerbosity returns the defined BUILD_LOGLEVEL value
-func getContainerVerbosity(containerEnv []kapi.EnvVar) (verbosity string) {
+func getContainerVerbosity(containerEnv []v1.EnvVar) (verbosity string) {
 	for _, env := range containerEnv {
 		if env.Name == "BUILD_LOGLEVEL" {
 			verbosity = env.Value
@@ -226,7 +227,7 @@ func getPodLabels(build *buildapi.Build) map[string]string {
 	return map[string]string{buildapi.BuildLabel: buildapi.LabelValue(build.Name)}
 }
 
-func setOwnerReference(pod *kapi.Pod, build *buildapi.Build) {
+func setOwnerReference(pod *v1.Pod, build *buildapi.Build) {
 	t := true
 	pod.OwnerReferences = []metav1.OwnerReference{
 		{

--- a/pkg/build/controller/strategy/util_test.go
+++ b/pkg/build/controller/strategy/util_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 func TestSetupDockerSocketHostSocket(t *testing.T) {
-	pod := kapi.Pod{
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
 				{},
 			},
 		},
@@ -57,7 +58,7 @@ func TestSetupDockerSocketHostSocket(t *testing.T) {
 	}
 }
 
-func isVolumeSourceEmpty(volumeSource kapi.VolumeSource) bool {
+func isVolumeSourceEmpty(volumeSource v1.VolumeSource) bool {
 	if volumeSource.EmptyDir == nil &&
 		volumeSource.HostPath == nil &&
 		volumeSource.GCEPersistentDisk == nil &&
@@ -69,9 +70,9 @@ func isVolumeSourceEmpty(volumeSource kapi.VolumeSource) bool {
 }
 
 func TestSetupDockerSecrets(t *testing.T) {
-	pod := kapi.Pod{
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
+	pod := v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
 				{},
 			},
 		},

--- a/pkg/build/util/util_test.go
+++ b/pkg/build/util/util_test.go
@@ -8,12 +8,13 @@ import (
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 func TestTrustedMergeEnvWithoutDuplicates(t *testing.T) {
-	input := []kapi.EnvVar{
+	input := []v1.EnvVar{
 		// stripped by whitelist
 		{Name: "foo", Value: "bar"},
 		// stripped by whitelist
@@ -21,7 +22,7 @@ func TestTrustedMergeEnvWithoutDuplicates(t *testing.T) {
 		{Name: "GIT_SSL_NO_VERIFY", Value: "source"},
 		{Name: "BUILD_LOGLEVEL", Value: "source"},
 	}
-	output := []kapi.EnvVar{
+	output := []v1.EnvVar{
 		{Name: "foo", Value: "test"},
 		{Name: "GIT_SSL_NO_VERIFY", Value: "target"},
 	}
@@ -51,7 +52,7 @@ func TestTrustedMergeEnvWithoutDuplicates(t *testing.T) {
 		t.Errorf("Expected output env 'BUILD_LOGLEVEL' to have value 'loglevel', got %+v", output[1])
 	}
 
-	input = []kapi.EnvVar{
+	input = []v1.EnvVar{
 		// stripped by whitelist
 		{Name: "foo", Value: "bar"},
 		// stripped by whitelist
@@ -59,7 +60,7 @@ func TestTrustedMergeEnvWithoutDuplicates(t *testing.T) {
 		{Name: "GIT_SSL_NO_VERIFY", Value: "source"},
 		{Name: "BUILD_LOGLEVEL", Value: "source"},
 	}
-	output = []kapi.EnvVar{
+	output = []v1.EnvVar{
 		{Name: "foo", Value: "test"},
 		{Name: "GIT_SSL_NO_VERIFY", Value: "target"},
 	}

--- a/pkg/client/cache/deploymentconfig.go
+++ b/pkg/client/cache/deploymentconfig.go
@@ -5,7 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
@@ -27,7 +27,7 @@ func (s *StoreToDeploymentConfigLister) List() ([]*deployapi.DeploymentConfig, e
 }
 
 // GetConfigForController returns the managing deployment config for the provided replication controller.
-func (s *StoreToDeploymentConfigLister) GetConfigForController(rc *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
+func (s *StoreToDeploymentConfigLister) GetConfigForController(rc *v1.ReplicationController) (*deployapi.DeploymentConfig, error) {
 	dcName := deployutil.DeploymentConfigNameFor(rc)
 	obj, exists, err := s.Indexer.GetByKey(rc.Namespace + "/" + dcName)
 	if err != nil {
@@ -40,7 +40,7 @@ func (s *StoreToDeploymentConfigLister) GetConfigForController(rc *kapi.Replicat
 }
 
 // GetConfigForPod returns the managing deployment config for the provided pod.
-func (s *StoreToDeploymentConfigLister) GetConfigForPod(pod *kapi.Pod) (*deployapi.DeploymentConfig, error) {
+func (s *StoreToDeploymentConfigLister) GetConfigForPod(pod *v1.Pod) (*deployapi.DeploymentConfig, error) {
 	dcName := deployutil.DeploymentConfigNameFor(pod)
 	obj, exists, err := s.Indexer.GetByKey(pod.Namespace + "/" + dcName)
 	if err != nil {

--- a/pkg/cmd/server/crypto/extensions/serversigning.go
+++ b/pkg/cmd/server/crypto/extensions/serversigning.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 
-	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 )
@@ -24,9 +24,9 @@ var (
 	OpenShiftServerSigningServiceUIDOID = oid(OpenShiftServerSigningServiceOID, 1)
 )
 
-// ServiceServerCertificateExtension returns a CertificateExtensionFunc that will add the
+// ServiceServerCertificateExtensionV1 returns a CertificateExtensionFunc that will add the
 // service UID as an x509 v3 extension to the server certificate.
-func ServiceServerCertificateExtension(svc *kapi.Service) crypto.CertificateExtensionFunc {
+func ServiceServerCertificateExtensionV1(svc *kapiv1.Service) crypto.CertificateExtensionFunc {
 	return func(cert *x509.Certificate) error {
 		uid, err := asn1.Marshal(svc.UID)
 		if err != nil {

--- a/pkg/cmd/server/origin/controller/build.go
+++ b/pkg/cmd/server/origin/controller/build.go
@@ -55,8 +55,8 @@ func (c *BuildControllerConfig) RunController(ctx ControllerContext) (bool, erro
 	buildInformer := ctx.BuildInformers.Build().InternalVersion().Builds()
 	buildConfigInformer := ctx.BuildInformers.Build().InternalVersion().BuildConfigs()
 	imageStreamInformer := ctx.ImageInformers.Image().InternalVersion().ImageStreams()
-	podInformer := ctx.InternalKubeInformers.Core().InternalVersion().Pods()
-	secretInformer := ctx.InternalKubeInformers.Core().InternalVersion().Secrets()
+	podInformer := ctx.ExternalKubeInformers.Core().V1().Pods()
+	secretInformer := ctx.ExternalKubeInformers.Core().V1().Secrets()
 
 	buildControllerParams := &buildcontroller.BuildControllerParams{
 		BuildInformer:       buildInformer,

--- a/pkg/cmd/server/origin/controller/service.go
+++ b/pkg/cmd/server/origin/controller/service.go
@@ -24,18 +24,18 @@ func (c *ServiceServingCertsControllerOptions) RunController(ctx ControllerConte
 	}
 
 	servingCertController := servingcertcontroller.NewServiceServingCertController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Services(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ExternalKubeInformers.Core().V1().Services(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
 		ca,
 		"cluster.local",
 		2*time.Minute,
 	)
 	servingCertUpdateController := servingcertcontroller.NewServiceServingCertUpdateController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Services(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
+		ctx.ExternalKubeInformers.Core().V1().Services(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceServingCertServiceAccountName).Core(),
 		ca,
 		"cluster.local",
 		20*time.Minute,

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -64,24 +64,24 @@ func (c *ServiceAccountTokenControllerOptions) RunController(ctx ControllerConte
 }
 
 func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error) {
-	kc := ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
+	kc := ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
 
 	go serviceaccountcontrollers.NewDockercfgDeletedController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgDeletedControllerOptions{},
 	).Run(ctx.Stop)
 
 	go serviceaccountcontrollers.NewDockercfgTokenDeletedController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgTokenDeletedControllerOptions{},
 	).Run(ctx.Stop)
 
 	dockerURLsInitialized := make(chan struct{})
 	dockercfgController := serviceaccountcontrollers.NewDockercfgController(
-		ctx.InternalKubeInformers.Core().InternalVersion().ServiceAccounts(),
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().ServiceAccounts(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		serviceaccountcontrollers.DockercfgControllerOptions{DockerURLsInitialized: dockerURLsInitialized},
 	)
@@ -94,7 +94,7 @@ func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error)
 		DockerURLsInitialized: dockerURLsInitialized,
 	}
 	go serviceaccountcontrollers.NewDockerRegistryServiceController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Secrets(),
+		ctx.ExternalKubeInformers.Core().V1().Secrets(),
 		kc,
 		dockerRegistryControllerOptions,
 	).Run(10, ctx.Stop)

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -253,8 +253,7 @@ func (c *MasterConfig) RunIngressIPController(internalKubeClientset kclientsetin
 		return
 	}
 	ingressIPController := ingressip.NewIngressIPController(
-		c.InternalKubeInformers.Core().InternalVersion().Services().Informer(),
-		internalKubeClientset,
+		c.ExternalKubeInformers.Core().V1().Services().Informer(),
 		externalKubeClientset,
 		ipNet,
 		defaultIngressIPSyncPeriod,

--- a/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller.go
+++ b/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
-	kcorelisterinternal "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
+	kcorelister "k8s.io/kubernetes/pkg/client/listers/core/v1"
 
 	"github.com/golang/glog"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -36,7 +36,7 @@ type DeploymentTriggerController struct {
 	// dcListerSynced makes sure the dc store is synced before reconcling any deployment config.
 	dcListerSynced func() bool
 	// rcLister provides a local cache for replication controllers.
-	rcLister kcorelisterinternal.ReplicationControllerLister
+	rcLister kcorelister.ReplicationControllerLister
 	// rcListerSynced makes sure the dc store is synced before reconcling any replication controller.
 	rcListerSynced func() bool
 

--- a/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller_test.go
+++ b/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller_test.go
@@ -10,7 +10,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 
 	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"

--- a/pkg/deploy/controller/generictrigger/factory.go
+++ b/pkg/deploy/controller/generictrigger/factory.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	kcorelistersinternal "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
+	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/v1"
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
 	osclient "github.com/openshift/origin/pkg/client"
@@ -54,7 +54,7 @@ func NewDeploymentTriggerController(dcInformer, rcInformer, streamInformer cache
 	c.dcLister.Indexer = dcInformer.GetIndexer()
 	c.dcListerSynced = dcInformer.HasSynced
 
-	c.rcLister = kcorelistersinternal.NewReplicationControllerLister(rcInformer.GetIndexer())
+	c.rcLister = kcorelisters.NewReplicationControllerLister(rcInformer.GetIndexer())
 	c.rcListerSynced = rcInformer.HasSynced
 	return c
 }
@@ -146,7 +146,7 @@ func (c *DeploymentTriggerController) updateDeploymentConfig(old, cur interface{
 	} else {
 		initial, err := deployutil.DecodeDeploymentConfig(latestRc, c.codec)
 		if err != nil {
-			glog.V(2).Infof("Cannot decode dc from replication controller %s: %v", deployutil.LabelForDeployment(latestRc), err)
+			glog.V(2).Infof("Cannot decode dc from replication controller %s: %v", deployutil.LabelForDeploymentV1(latestRc), err)
 			return
 		}
 		shouldInstantiate = !reflect.DeepEqual(newDc.Spec.Template, initial.Spec.Template)

--- a/pkg/deploy/controller/test/fake_deployment_store.go
+++ b/pkg/deploy/controller/test/fake_deployment_store.go
@@ -2,15 +2,15 @@ package test
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type FakeDeploymentStore struct {
-	Deployment *kapi.ReplicationController
+	Deployment *v1.ReplicationController
 	Err        error
 }
 
-func NewFakeDeploymentStore(deployment *kapi.ReplicationController) FakeDeploymentStore {
+func NewFakeDeploymentStore(deployment *v1.ReplicationController) FakeDeploymentStore {
 	return FakeDeploymentStore{Deployment: deployment}
 }
 

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -280,6 +280,9 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 					Volumes: []kapi.Volume{
 						{
 							Name: "volume-2",
+							VolumeSource: kapi.VolumeSource{
+								EmptyDir: &kapi.EmptyDirVolumeSource{},
+							},
 						},
 					},
 					ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
@@ -328,6 +331,7 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 							Name: "secret-1",
 						},
 					},
+					SecurityContext: &kapi.PodSecurityContext{},
 				},
 			},
 		},
@@ -386,6 +390,7 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 							Name: "secret-1",
 						},
 					},
+					SecurityContext: &kapi.PodSecurityContext{},
 				},
 			},
 		},
@@ -446,6 +451,7 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 							Name: "secret-1",
 						},
 					},
+					SecurityContext: &kapi.PodSecurityContext{},
 				},
 			},
 			strategyLabels: map[string]string{
@@ -499,6 +505,7 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 							Name: "secret-1",
 						},
 					},
+					SecurityContext: &kapi.PodSecurityContext{},
 				},
 			},
 		},
@@ -524,7 +531,7 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 		// Copy the ActiveDeadlineSeconds the deployer pod is running for 5 seconds already
 		test.expected.Spec.ActiveDeadlineSeconds = pod.Spec.ActiveDeadlineSeconds
 		if !kapi.Semantic.DeepEqual(pod, test.expected) {
-			t.Errorf("unexpected pod diff: %v", diff.ObjectDiff(pod, test.expected))
+			t.Errorf("unexpected pod diff: %v", diff.ObjectReflectDiff(pod, test.expected))
 		}
 	}
 }

--- a/pkg/service/controller/servingcert/secret_updating_controller_test.go
+++ b/pkg/service/controller/servingcert/secret_updating_controller_test.go
@@ -7,20 +7,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 )
 
 func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 	tests := []struct {
 		name          string
 		primeServices func(cache.Store)
-		secret        *kapi.Secret
+		secret        *v1.Secret
 		expected      bool
 	}{
 		{
 			name:          "no service annotation",
 			primeServices: func(serviceCache cache.Store) {},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{},
@@ -31,7 +31,7 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name:          "missing service",
 			primeServices: func(serviceCache cache.Store) {},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -44,11 +44,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "service-uid-mismatch",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-2"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -62,11 +62,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "service secret name mismatch",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret2"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -80,11 +80,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "no expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -98,11 +98,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "bad expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -117,11 +117,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "expired expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
@@ -136,11 +136,11 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		{
 			name: "distant expiry",
 			primeServices: func(serviceCache cache.Store) {
-				serviceCache.Add(&kapi.Service{
+				serviceCache.Add(&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{ServingCertSecretAnnotation: "mysecret"}},
 				})
 			},
-			secret: &kapi.Secret{
+			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{

--- a/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets_test.go
+++ b/pkg/serviceaccounts/controllers/deleted_dockercfg_secrets_test.go
@@ -9,9 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
-	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
+	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -19,7 +19,7 @@ func TestDockercfgDeletion(t *testing.T) {
 	testcases := map[string]struct {
 		ClientObjects []runtime.Object
 
-		DeletedSecret *api.Secret
+		DeletedSecret *v1.Secret
 
 		ExpectedActions []clientgotesting.Action
 	}{
@@ -27,8 +27,8 @@ func TestDockercfgDeletion(t *testing.T) {
 			DeletedSecret: createdDockercfgSecret(),
 
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 		"deleted dockercfg secret with serviceaccount with reference": {
@@ -36,9 +36,9 @@ func TestDockercfgDeletion(t *testing.T) {
 
 			DeletedSecret: createdDockercfgSecret(),
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 		"deleted dockercfg secret with serviceaccount without reference": {
@@ -46,9 +46,9 @@ func TestDockercfgDeletion(t *testing.T) {
 
 			DeletedSecret: createdDockercfgSecret(),
 			ExpectedActions: []clientgotesting.Action{
-				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", "default"),
-				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
-				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets"}, "default", "token-secret-1"),
+				clientgotesting.NewGetAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", "default"),
+				clientgotesting.NewUpdateAction(schema.GroupVersionResource{Resource: "serviceaccounts", Version: "v1"}, "default", serviceAccount(tokenSecretReferences(), emptyImagePullSecretReferences())),
+				clientgotesting.NewDeleteAction(schema.GroupVersionResource{Resource: "secrets", Version: "v1"}, "default", "token-secret-1"),
 			},
 		},
 	}
@@ -60,7 +60,7 @@ func TestDockercfgDeletion(t *testing.T) {
 		client := fake.NewSimpleClientset(tc.ClientObjects...)
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		controller := NewDockercfgDeletedController(
-			informerFactory.Core().InternalVersion().Secrets(),
+			informerFactory.Core().V1().Secrets(),
 			client,
 			DockercfgDeletedControllerOptions{},
 		)

--- a/pkg/serviceaccounts/util/helpers.go
+++ b/pkg/serviceaccounts/util/helpers.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/util/namer"
 )
@@ -22,5 +23,17 @@ func GetDockercfgSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
 // string.
 // TODO fix the upstream implementation to be more like this.
 func GetTokenSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "token-", maxSecretPrefixNameLength)
+}
+
+func GetDockercfgSecretNamePrefixV1(serviceAccount *v1.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "dockercfg-", maxSecretPrefixNameLength)
+}
+
+// GetTokenSecretNamePrefix creates the prefix used for the generated SA token secret. This is compatible with kube up until
+// long names, at which point we hash the SA name and leave the "token-" intact.  Upstream clips the value and generates a random
+// string.
+// TODO fix the upstream implementation to be more like this.
+func GetTokenSecretNamePrefixV1(serviceAccount *v1.ServiceAccount) string {
 	return namer.GetName(serviceAccount.Name, "token-", maxSecretPrefixNameLength)
 }

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -10,7 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	watchapi "k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/api/v1"
+	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 
 	defaultsapi "github.com/openshift/origin/pkg/build/admission/defaults/api"
 	overridesapi "github.com/openshift/origin/pkg/build/admission/overrides/api"
@@ -123,7 +124,7 @@ func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
 		ForcePull: true,
 	})
 	build, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestCustomBuild())
-	if pod.Spec.Containers[0].ImagePullPolicy != kapi.PullAlways {
+	if pod.Spec.Containers[0].ImagePullPolicy != v1.PullAlways {
 		t.Errorf("Pod ImagePullPolicy is not PullAlways")
 	}
 	if !build.Spec.Strategy.CustomStrategy.ForcePull {
@@ -195,7 +196,7 @@ func buildPodAdmissionTestDockerBuild() *buildapi.Build {
 	return build
 }
 
-func runBuildPodAdmissionTest(t *testing.T, client *client.Client, kclientset kclientset.Interface, build *buildapi.Build) (*buildapi.Build, *kapi.Pod) {
+func runBuildPodAdmissionTest(t *testing.T, client *client.Client, kclientset kclientset.Interface, build *buildapi.Build) (*buildapi.Build, *v1.Pod) {
 
 	ns := testutil.Namespace()
 	_, err := client.Builds(ns).Create(build)
@@ -215,14 +216,14 @@ func runBuildPodAdmissionTest(t *testing.T, client *client.Client, kclientset kc
 	}
 	type resultObjs struct {
 		build *buildapi.Build
-		pod   *kapi.Pod
+		pod   *v1.Pod
 	}
 	result := make(chan resultObjs)
 	defer podWatch.Stop()
 	go func() {
 		for e := range podWatch.ResultChan() {
 			if e.Type == watchapi.Added {
-				pod, ok := e.Object.(*kapi.Pod)
+				pod, ok := e.Object.(*v1.Pod)
 				if !ok {
 					t.Fatalf("unexpected object: %v", e.Object)
 				}
@@ -261,24 +262,32 @@ func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.
 	testutil.RequireEtcd(t)
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
-		t.Fatalf("%v", err)
+		t.Fatal(err)
 	}
 	master.AdmissionConfig.PluginConfig = pluginConfig
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(master)
 	if err != nil {
-		t.Fatalf("%v", err)
+		t.Fatal(err)
 	}
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Fatalf("%v", err)
+		t.Fatal(err)
 	}
-
-	clusterAdminKubeClientset, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	internalClusterAdminKubeClientset, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Fatalf("%v", err)
+		t.Fatal(err)
+	}
+	clientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	_, err = clusterAdminKubeClientset.Core().Namespaces().Create(&kapi.Namespace{
+	clusterAdminKubeClientset, err := kclientset.NewForConfig(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = clusterAdminKubeClientset.Core().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: testutil.Namespace()},
 	})
 	if err != nil {
@@ -286,7 +295,7 @@ func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.
 	}
 
 	err = testserver.WaitForServiceAccounts(
-		clusterAdminKubeClientset,
+		internalClusterAdminKubeClientset,
 		testutil.Namespace(),
 		[]string{
 			bootstrappolicy.BuilderServiceAccountName,


### PR DESCRIPTION
Part of #8229

Switches to the versioned caches and propogates using versioned code throughout deployment for pods and RCs. Leaves a few helpers pointing to internal to reduce test refactoring.

[test]