### PR TITLE
Remove last uses of internal namespaces in controller

### DIFF
--- a/pkg/cmd/server/origin/controller/project.go
+++ b/pkg/cmd/server/origin/controller/project.go
@@ -7,8 +7,8 @@ import (
 
 func RunOriginNamespaceController(ctx ControllerContext) (bool, error) {
 	controller := projectcontroller.NewProjectFinalizerController(
-		ctx.InternalKubeInformers.Core().InternalVersion().Namespaces(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraOriginNamespaceServiceAccountName),
+		ctx.ExternalKubeInformers.Core().V1().Namespaces(),
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraOriginNamespaceServiceAccountName),
 	)
 	go controller.Run(ctx.Stop, 5)
 	return true, nil

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -1078,8 +1078,8 @@ func (c *MasterConfig) DeploymentLogClient() kclientsetinternal.Interface {
 }
 
 // SecurityAllocationControllerClient returns the security allocation controller client object
-func (c *MasterConfig) SecurityAllocationControllerClient() kclientsetinternal.Interface {
-	return c.PrivilegedLoopbackKubernetesClientsetInternal
+func (c *MasterConfig) SecurityAllocationControllerClient() kclientsetexternal.Interface {
+	return c.PrivilegedLoopbackKubernetesClientsetExternal
 }
 
 // SDNControllerClients returns the SDN controller client objects

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -287,7 +287,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	}
 	groupCache := usercache.NewGroupCache(groupregistry.NewRegistry(groupStorage))
 	projectCache := projectcache.NewProjectCache(internalKubeInformerFactory.Core().InternalVersion().Namespaces().Informer(), privilegedLoopbackKubeClientsetInternal.Core().Namespaces(), options.ProjectConfig.DefaultNodeSelector)
-	clusterQuotaMappingController := clusterquotamapping.NewClusterQuotaMappingController(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformers.Quota().InternalVersion().ClusterResourceQuotas())
+	clusterQuotaMappingController := clusterquotamapping.NewClusterQuotaMappingControllerInternal(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformers.Quota().InternalVersion().ClusterResourceQuotas())
 
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -100,7 +100,7 @@ func fakeMasterConfig() *MasterConfig {
 		InternalKubeInformers:                         internalKubeInformerFactory,
 		AuthorizationInformers:                        authorizationInformerFactory,
 		QuotaInformers:                                quotaInformerFactory,
-		ClusterQuotaMappingController:                 clusterquotamapping.NewClusterQuotaMappingController(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
+		ClusterQuotaMappingController:                 clusterquotamapping.NewClusterQuotaMappingControllerInternal(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
 		PrivilegedLoopbackKubernetesClientsetInternal: &kclientsetinternal.Clientset{},
 		PrivilegedLoopbackKubernetesClientsetExternal: &kclientsetexternal.Clientset{},
 	}
@@ -124,7 +124,7 @@ func fakeOpenshiftAPIServerConfig() *OpenshiftAPIConfig {
 		QuotaInformers:                quotaInformerFactory,
 		EnableBuilds:                  true,
 		EnableTemplateServiceBroker:   false,
-		ClusterQuotaMappingController: clusterquotamapping.NewClusterQuotaMappingController(internalkubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
+		ClusterQuotaMappingController: clusterquotamapping.NewClusterQuotaMappingControllerInternal(internalkubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
 	}
 	return ret
 }

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -169,7 +169,7 @@ func (c *MasterConfig) RunSecurityAllocationController() {
 	}
 
 	controller := securitycontroller.NewNamespaceSecurityDefaultsController(
-		c.InternalKubeInformers.Core().InternalVersion().Namespaces(),
+		c.ExternalKubeInformers.Core().V1().Namespaces(),
 		kclient.Core().Namespaces(),
 		uidAllocator,
 		securitycontroller.DefaultMCSAllocation(uidRange, mcsRange, alloc.MCSLabelsPerProject),

--- a/pkg/project/controller/project_finalizer_controller_test.go
+++ b/pkg/project/controller/project_finalizer_controller_test.go
@@ -6,10 +6,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
-	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 
-	"github.com/openshift/origin/pkg/project/api"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	projectapiv1 "github.com/openshift/origin/pkg/project/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 )
 
 func TestSyncNamespaceThatIsTerminating(t *testing.T) {
@@ -18,17 +18,17 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 		client: mockKubeClient,
 	}
 	now := metav1.Now()
-	testNamespace := &kapi.Namespace{
+	testNamespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test",
 			ResourceVersion:   "1",
 			DeletionTimestamp: &now,
 		},
-		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
+		Spec: v1.NamespaceSpec{
+			Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes, projectapiv1.FinalizerOrigin},
 		},
-		Status: kapi.NamespaceStatus{
-			Phase: kapi.NamespaceTerminating,
+		Status: v1.NamespaceStatus{
+			Phase: v1.NamespaceTerminating,
 		},
 	}
 	err := nm.finalize(testNamespace)
@@ -55,16 +55,16 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 	nm := &ProjectFinalizerController{
 		client: mockKubeClient,
 	}
-	testNamespace := &kapi.Namespace{
+	testNamespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test",
 			ResourceVersion: "1",
 		},
-		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
+		Spec: v1.NamespaceSpec{
+			Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes, projectapiv1.FinalizerOrigin},
 		},
-		Status: kapi.NamespaceStatus{
-			Phase: kapi.NamespaceActive,
+		Status: v1.NamespaceStatus{
+			Phase: v1.NamespaceActive,
 		},
 	}
 	err := nm.finalize(testNamespace)

--- a/pkg/quota/api/helpers.go
+++ b/pkg/quota/api/helpers.go
@@ -54,3 +54,42 @@ func GetMatcher(selector ClusterResourceQuotaSelector) (func(obj runtime.Object)
 		return true, nil
 	}, nil
 }
+
+func GetObjectMatcher(selector ClusterResourceQuotaSelector) (func(obj metav1.Object) (bool, error), error) {
+	var labelSelector labels.Selector
+	if selector.LabelSelector != nil {
+		var err error
+		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var annotationSelector map[string]string
+	if len(selector.AnnotationSelector) > 0 {
+		// ensure our matcher has a stable copy of the map
+		annotationSelector = make(map[string]string, len(selector.AnnotationSelector))
+		for k, v := range selector.AnnotationSelector {
+			annotationSelector[k] = v
+		}
+	}
+
+	return func(obj metav1.Object) (bool, error) {
+		if labelSelector != nil {
+			if !labelSelector.Matches(labels.Set(obj.GetLabels())) {
+				return false, nil
+			}
+		}
+
+		if annotationSelector != nil {
+			objAnnotations := obj.GetAnnotations()
+			for k, v := range annotationSelector {
+				if objValue, exists := objAnnotations[k]; !exists || objValue != v {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	}, nil
+}

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
@@ -8,14 +8,18 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kcoreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion"
-	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
+	"k8s.io/kubernetes/pkg/api/v1"
+	kcoreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions/core/v1"
+	kcoreinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion"
+	kcoreinternallisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
+	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/v1"
 	"k8s.io/kubernetes/pkg/controller"
 
 	quotaapi "github.com/openshift/origin/pkg/quota/api"
@@ -50,21 +54,76 @@ import (
 
 // NewClusterQuotaMappingController builds a mapping between namespaces and clusterresourcequotas
 func NewClusterQuotaMappingController(namespaceInformer kcoreinformers.NamespaceInformer, quotaInformer quotainformer.ClusterResourceQuotaInformer) *ClusterQuotaMappingController {
+	c := newClusterQuotaMappingController(namespaceInformer.Informer(), quotaInformer)
+	c.namespaceLister = v1NamespaceLister{lister: namespaceInformer.Lister()}
+	return c
+}
+
+// NewClusterQuotaMappingControllerInternal provides an adapter for listing internal resources. This
+// method may be removed in the future.
+func NewClusterQuotaMappingControllerInternal(namespaceInformer kcoreinternalinformers.NamespaceInformer, quotaInformer quotainformer.ClusterResourceQuotaInformer) *ClusterQuotaMappingController {
+	c := newClusterQuotaMappingController(namespaceInformer.Informer(), quotaInformer)
+	c.namespaceLister = internalNamespaceLister{lister: namespaceInformer.Lister()}
+	return c
+}
+
+type namespaceLister interface {
+	Each(label labels.Selector, fn func(metav1.Object) bool) error
+	Get(name string) (metav1.Object, error)
+}
+
+type v1NamespaceLister struct {
+	lister kcorelisters.NamespaceLister
+}
+
+func (l v1NamespaceLister) Each(label labels.Selector, fn func(metav1.Object) bool) error {
+	results, err := l.lister.List(label)
+	if err != nil {
+		return err
+	}
+	for i := range results {
+		if !fn(results[i]) {
+			return nil
+		}
+	}
+	return nil
+}
+func (l v1NamespaceLister) Get(name string) (metav1.Object, error) {
+	return l.lister.Get(name)
+}
+
+type internalNamespaceLister struct {
+	lister kcoreinternallisters.NamespaceLister
+}
+
+func (l internalNamespaceLister) Each(label labels.Selector, fn func(metav1.Object) bool) error {
+	results, err := l.lister.List(label)
+	if err != nil {
+		return err
+	}
+	for i := range results {
+		if !fn(results[i]) {
+			return nil
+		}
+	}
+	return nil
+}
+func (l internalNamespaceLister) Get(name string) (metav1.Object, error) {
+	return l.lister.Get(name)
+}
+
+func newClusterQuotaMappingController(namespaceInformer cache.SharedIndexInformer, quotaInformer quotainformer.ClusterResourceQuotaInformer) *ClusterQuotaMappingController {
 	c := &ClusterQuotaMappingController{
-		namespaceQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controller_clusterquotamappingcontroller_namespaces"),
-
-		quotaQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controller_clusterquotamappingcontroller_clusterquotas"),
-
+		namespaceQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controller_clusterquotamappingcontroller_namespaces"),
+		quotaQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controller_clusterquotamappingcontroller_clusterquotas"),
 		clusterQuotaMapper: NewClusterQuotaMapper(),
 	}
-
-	namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addNamespace,
 		UpdateFunc: c.updateNamespace,
 		DeleteFunc: c.deleteNamespace,
 	})
-	c.namespaceLister = namespaceInformer.Lister()
-	c.namespacesSynced = namespaceInformer.Informer().HasSynced
+	c.namespacesSynced = namespaceInformer.HasSynced
 
 	quotaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addQuota,
@@ -79,7 +138,7 @@ func NewClusterQuotaMappingController(namespaceInformer kcoreinformers.Namespace
 
 type ClusterQuotaMappingController struct {
 	namespaceQueue   workqueue.RateLimitingInterface
-	namespaceLister  kcorelisters.NamespaceLister
+	namespaceLister  namespaceLister
 	namespacesSynced func() bool
 
 	quotaQueue   workqueue.RateLimitingInterface
@@ -116,27 +175,21 @@ func (c *ClusterQuotaMappingController) Run(workers int, stopCh <-chan struct{})
 }
 
 func (c *ClusterQuotaMappingController) syncQuota(quota *quotaapi.ClusterResourceQuota) error {
-	matcherFunc, err := quotaapi.GetMatcher(quota.Spec.Selector)
+	matcherFunc, err := quotaapi.GetObjectMatcher(quota.Spec.Selector)
 	if err != nil {
 		return err
 	}
 
-	allNamespaces, err := c.namespaceLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	for i := range allNamespaces {
-		namespace := allNamespaces[i]
-
+	if err := c.namespaceLister.Each(labels.Everything(), func(obj metav1.Object) bool {
 		// attempt to set the mapping. The quotas never collide with each other (same quota is never processed twice in parallel)
 		// so this means that the project we have is out of date, pull a more recent copy from the cache and retest
 		for {
-			matches, err := matcherFunc(namespace)
+			matches, err := matcherFunc(obj)
 			if err != nil {
 				utilruntime.HandleError(err)
 				break
 			}
-			success, quotaMatches, _ := c.clusterQuotaMapper.setMapping(quota, namespace, !matches)
+			success, quotaMatches, _ := c.clusterQuotaMapper.setMapping(quota, obj, !matches)
 			if success {
 				break
 			}
@@ -145,9 +198,9 @@ func (c *ClusterQuotaMappingController) syncQuota(quota *quotaapi.ClusterResourc
 			// if we've been updated, we'll be rekicked, if we've been deleted we should stop.  Either way, this
 			// execution is finished
 			if !quotaMatches {
-				return nil
+				return false
 			}
-			ns, err := c.namespaceLister.Get(namespace.Name)
+			newer, err := c.namespaceLister.Get(obj.GetName())
 			if kapierrors.IsNotFound(err) {
 				// if the namespace is gone, then the deleteNamespace path will be called, just continue
 				break
@@ -156,16 +209,18 @@ func (c *ClusterQuotaMappingController) syncQuota(quota *quotaapi.ClusterResourc
 				utilruntime.HandleError(err)
 				break
 			}
-			namespace = ns
+			obj = newer
 		}
-
+		return true
+	}); err != nil {
+		return err
 	}
 
 	c.clusterQuotaMapper.completeQuota(quota)
 	return nil
 }
 
-func (c *ClusterQuotaMappingController) syncNamespace(namespace *kapi.Namespace) error {
+func (c *ClusterQuotaMappingController) syncNamespace(namespace metav1.Object) error {
 	allQuotas, err1 := c.quotaLister.List(labels.Everything())
 	if err1 != nil {
 		return err1
@@ -174,7 +229,7 @@ func (c *ClusterQuotaMappingController) syncNamespace(namespace *kapi.Namespace)
 		quota := allQuotas[i]
 
 		for {
-			matcherFunc, err := quotaapi.GetMatcher(quota.Spec.Selector)
+			matcherFunc, err := quotaapi.GetObjectMatcher(quota.Spec.Selector)
 			if err != nil {
 				utilruntime.HandleError(err)
 				break
@@ -300,21 +355,27 @@ func (c *ClusterQuotaMappingController) namespaceWorker() {
 }
 
 func (c *ClusterQuotaMappingController) deleteNamespace(obj interface{}) {
-	ns, ok1 := obj.(*kapi.Namespace)
-	if !ok1 {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %v", obj))
+	var name string
+	switch ns := obj.(type) {
+	case cache.DeletedFinalStateUnknown:
+		switch nested := ns.Obj.(type) {
+		case *v1.Namespace:
+			name = nested.Name
+		case *kapi.Namespace:
+			name = nested.Name
+		default:
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace %T", ns.Obj))
 			return
 		}
-		ns, ok = tombstone.Obj.(*kapi.Namespace)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace %v", obj))
-			return
-		}
+	case *v1.Namespace:
+		name = ns.Name
+	case *kapi.Namespace:
+		name = ns.Name
+	default:
+		utilruntime.HandleError(fmt.Errorf("not a Namespace %v", obj))
+		return
 	}
-
-	c.clusterQuotaMapper.removeNamespace(ns.Name)
+	c.clusterQuotaMapper.removeNamespace(name)
 }
 
 func (c *ClusterQuotaMappingController) addNamespace(cur interface{}) {
@@ -324,16 +385,28 @@ func (c *ClusterQuotaMappingController) updateNamespace(old, cur interface{}) {
 	c.enqueueNamespace(cur)
 }
 func (c *ClusterQuotaMappingController) enqueueNamespace(obj interface{}) {
-	ns, ok := obj.(*kapi.Namespace)
-	if !ok {
+	switch ns := obj.(type) {
+	case *v1.Namespace:
+		if !c.clusterQuotaMapper.requireNamespace(ns) {
+			return
+		}
+	case *kapi.Namespace:
+		adaptedNs := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        ns.Name,
+				Labels:      ns.Labels,
+				Annotations: ns.Annotations,
+			},
+		}
+		if !c.clusterQuotaMapper.requireNamespace(adaptedNs) {
+			return
+		}
+	default:
 		utilruntime.HandleError(fmt.Errorf("not a Namespace %v", obj))
 		return
 	}
-	if !c.clusterQuotaMapper.requireNamespace(ns) {
-		return
-	}
 
-	key, err := controller.KeyFunc(ns)
+	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
@@ -68,7 +68,7 @@ func runFuzzer(t *testing.T) {
 	quotaClient := quotaclient.NewSimpleClientset(startingQuotas...)
 	quotaClient.PrependWatchReactor("clusterresourcequotas", clientgotesting.DefaultWatchReactor(quotaWatch, nil))
 	quotaFactory := quotainformer.NewSharedInformerFactory(quotaClient, 0)
-	controller := NewClusterQuotaMappingController(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaFactory.Quota().InternalVersion().ClusterResourceQuotas())
+	controller := NewClusterQuotaMappingControllerInternal(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaFactory.Quota().InternalVersion().ClusterResourceQuotas())
 	go controller.Run(5, stopCh)
 	quotaFactory.Start(stopCh)
 	internalKubeInformerFactory.Start(stopCh)

--- a/pkg/security/controller/repair.go
+++ b/pkg/security/controller/repair.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
 	"k8s.io/kubernetes/pkg/registry/core/rangeallocation"
 
 	"github.com/openshift/origin/pkg/security"

--- a/pkg/security/controller/repair_test.go
+++ b/pkg/security/controller/repair_test.go
@@ -8,7 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 
 	"github.com/openshift/origin/pkg/security"
 	"github.com/openshift/origin/pkg/security/uid"
@@ -33,8 +34,8 @@ func (r *fakeRange) CreateOrUpdate(update *kapi.RangeAllocation) error {
 func TestRepair(t *testing.T) {
 	client := &fake.Clientset{}
 	client.AddReactor("*", "*", func(a clientgotesting.Action) (bool, runtime.Object, error) {
-		list := &kapi.NamespaceList{
-			Items: []kapi.Namespace{
+		list := &v1.NamespaceList{
+			Items: []v1.Namespace{
 				{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 			},
 		}
@@ -66,8 +67,8 @@ func TestRepair(t *testing.T) {
 func TestRepairIgnoresMismatch(t *testing.T) {
 	client := &fake.Clientset{}
 	client.AddReactor("*", "*", func(a clientgotesting.Action) (bool, runtime.Object, error) {
-		list := &kapi.NamespaceList{
-			Items: []kapi.Namespace{
+		list := &v1.NamespaceList{
+			Items: []v1.Namespace{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "default",


### PR DESCRIPTION
Only the last commit is new, part of #8229. ClusterQuotaMapping is the most changed - it now deals generically with either an internal or external lister to avoid having to perform expensive copies on large sets. Should be no more expensive than before.

[test] @deads2k

After this, controller manager only starts 48 reflectors, with no duplication, no rest cache storage loaded, and no accidental caching.  The controller manager will effectively be minimal.

Fixes #8229