### PR TITLE
System containers: add bind mount for /etc/pki

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -463,6 +463,15 @@
 	    ]
         },
 	{
+	    "type": "bind",
+	    "source": "/etc/pki",
+	    "destination": "/etc/pki",
+	    "options": [
+		"bind",
+		"ro"
+	    ]
+	},
+	{
 	    "destination": "/tmp",
 	    "type": "tmpfs",
 	    "source": "tmpfs",

--- a/images/origin/system-container/config.json.template
+++ b/images/origin/system-container/config.json.template
@@ -159,6 +159,15 @@
 	},
 	{
 	    "type": "bind",
+	    "source": "/etc/pki",
+	    "destination": "/etc/pki",
+	    "options": [
+		"bind",
+		"ro"
+	    ]
+	},
+	{
+	    "type": "bind",
 	    "source": "$ORIGIN_DATA_DIR",
 	    "destination": "/var/lib/origin",
 	    "options": [


### PR DESCRIPTION
Ensures that pki trust store from the host is propagated into master and node images

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1460626
