### PR TITLE
UPSTREAM: 47537: Fix typo in secretbox transformer prefix

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -37,7 +37,7 @@ import (
 const (
 	aesCBCTransformerPrefixV1    = "k8s:enc:aescbc:v1:"
 	aesGCMTransformerPrefixV1    = "k8s:enc:aesgcm:v1:"
-	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1"
+	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1:"
 )
 
 // GetTransformerOverrides returns the transformer overrides by reading and parsing the encryption provider configuration file


### PR DESCRIPTION
As a follow-up to https://github.com/openshift/origin/pull/14517: backport of https://github.com/kubernetes/kubernetes/pull/47537

PTAL @smarterclayton @mfojtik 