### PR TITLE
Alter how the new router metrics / health endpoint overrides stats

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -140,10 +140,11 @@ defaults
   {{- end }}
 {{- end }}
 
+{{ if (gt .StatsPort -1) }}
 {{ if (gt .StatsPort 0) }}
-  listen stats :{{.StatsPort}}
+listen stats :{{.StatsPort}}
 {{- else }}
-  listen stats :1936
+listen stats :1936
 {{- end }}
   mode http
   # Health check monitoring uri.
@@ -158,6 +159,7 @@ defaults
   stats uri /
   stats auth {{.StatsUser}}:{{.StatsPassword}}
 {{- end }}
+{{- end }}
 
 {{ if .BindPorts -}}
 frontend public
@@ -165,6 +167,10 @@ frontend public
   mode http
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
+
+  {{- if (eq .StatsPort -1) }}
+  monitor-uri /_______internal_router_healthz
+  {{- end }}
 
   # check if we need to redirect/force using https.
   acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_redirect.map) -m found

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -12,9 +12,11 @@ readonly numeric_re='^[0-9]+$'
 
 function haproxyHealthCheck() {
   local wait_time=${MAX_RELOAD_WAIT_TIME:-$max_wait_time}
-  local port=${STATS_PORT:-"1936"}
+  local port=${ROUTER_SERVICE_HTTP_PORT:-"80"}
+  local url="http://localhost:${port}"
   local retries=0
   local start_ts=$(date +"%s")
+  local proxy_proto="${ROUTER_USE_PROXY_PROTOCOL-}"
 
   if ! [[ $wait_time =~ $numeric_re ]]; then
     echo " - Invalid max reload wait time, using default $max_wait_time ..."
@@ -23,18 +25,39 @@ function haproxyHealthCheck() {
 
   local end_ts=$((start_ts + wait_time))
 
-  local proxy_proto="${ROUTER_USE_PROXY_PROTOCOL:-FALSE}"
-  echo " - Proxy protocol '${proxy_proto}'.  Checking HAProxy /healthz on port $port ..."
-  while true; do
-    local httpcode=$(curl $timeout_opts -s -o /dev/null -I -w "%{http_code}" http://localhost:${port}/healthz)
+  # test with proxy protocol on
+  if [[ "${proxy_proto}" == "TRUE" || "${proxy_proto}" == "true" ]]; then
+    echo " - Proxy protocol on, checking ${url} ..."
+    while true; do
+      local statusline=$(echo $'PROXY UNKNOWN\r\nGET / HTTP/1.1\r\n' | socat tcp-connect:localhost:${port} stdio | head -1)
 
-    if [ "$httpcode" == "200" ]; then
-      echo " - HAProxy port $port health check ok : $retries retry attempt(s)."
+      if [[ "$statusline" == *" 503 "* ]]; then
+        echo " - Health check ok : $retries retry attempt(s)."
+        return 0
+      fi
+
+      if [ $(date +"%s") -ge $end_ts ]; then
+        echo " - Exceeded max wait time ($wait_time) in health check - $retries retry attempt(s)."
+        return 1
+      fi
+
+      sleep 0.5
+      retries=$((retries + 1))
+    done
+    return 0
+  fi
+
+  echo " - Checking ${url} ..."
+  while true; do
+    local httpcode=$(curl $timeout_opts -s -o /dev/null -I -w "%{http_code}" ${url})
+
+    if [ "$httpcode" == "503" ]; then
+      echo " - Health check ok : $retries retry attempt(s)."
       return 0
     fi
 
     if [ $(date +"%s") -ge $end_ts ]; then
-      echo " - Exceeded max wait time ($wait_time) in HAProxy health check - $retries retry attempt(s)."
+      echo " - Exceeded max wait time ($wait_time) in health check - $retries retry attempt(s)."
       return 1
     fi
 

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -682,13 +682,8 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 	}
 	// automatically start the internal metrics agent if we are handling a known type
 	if cfg.Type == "haproxy-router" {
-		env["ROUTER_LISTEN_ADDR"] = fmt.Sprintf("0.0.0.0:%d", defaultStatsPort-1)
+		env["ROUTER_LISTEN_ADDR"] = fmt.Sprintf("0.0.0.0:%d", cfg.StatsPort)
 		env["ROUTER_METRICS_TYPE"] = "haproxy"
-		ports = append(ports, kapi.ContainerPort{
-			Name:          "router-stats",
-			ContainerPort: int32(defaultStatsPort - 1),
-			Protocol:      kapi.ProtocolTCP,
-		})
 	}
 	env.Add(secretEnv)
 	if len(defaultCert) > 0 {
@@ -803,9 +798,9 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 				t.Annotations = make(map[string]string)
 			}
 			t.Annotations["prometheus.io/scrape"] = "true"
-			t.Annotations["prometheus.io/port"] = "1935"
-			t.Annotations["prometheus.io/username"] = cfg.StatsUsername
-			t.Annotations["prometheus.io/password"] = cfg.StatsPassword
+			t.Annotations["prometheus.io/port"] = "1936"
+			t.Annotations["prometheus.openshift.io/username"] = cfg.StatsUsername
+			t.Annotations["prometheus.openshift.io/password"] = cfg.StatsPassword
 			t.Spec.ClusterIP = clusterIP
 			for j, servicePort := range t.Spec.Ports {
 				for _, targetPort := range ports {

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -75,7 +75,7 @@ func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
 	flag.BoolVar(&o.AllowWildcardRoutes, "allow-wildcard-routes", cmdutil.Env("ROUTER_ALLOW_WILDCARD_ROUTES", "") == "true", "Allow wildcard host names for routes")
 	flag.BoolVar(&o.DisableNamespaceOwnershipCheck, "disable-namespace-ownership-check", cmdutil.Env("ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "") == "true", "Disables the namespace ownership checks for a route host with different paths or for overlapping host names in the case of wildcard routes. Please be aware that if namespace ownership checks are disabled, routes in a different namespace can use this mechanism to 'steal' sub-paths for existing domains. This is only safe if route creation privileges are restricted, or if all the users can be trusted.")
 	flag.BoolVar(&o.EnableIngress, "enable-ingress", cmdutil.Env("ROUTER_ENABLE_INGRESS", "") == "true", "Enable configuration via ingress resources")
-	flag.StringVar(&o.ListenAddr, "listen-addr", cmdutil.Env("ROUTER_LISTEN_ADDR", ""), "The name of an interface to listen on to expose metrics and health checking. If not specified, will not listen.")
+	flag.StringVar(&o.ListenAddr, "listen-addr", cmdutil.Env("ROUTER_LISTEN_ADDR", ""), "The name of an interface to listen on to expose metrics and health checking. If not specified, will not listen. Overrides stats port.")
 }
 
 // RouteSelectionFunc returns a func that identifies the host for a route.

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/kubernetes/pkg/probe"
+	probehttp "k8s.io/kubernetes/pkg/probe/http"
+)
+
+var errBackend = fmt.Errorf("backend reported failure")
+
+// HTTPBackendAvailable returns a healthz check that verifies a backend responds to a GET to
+// the provided URL with 2xx or 3xx response.
+func HTTPBackendAvailable(u *url.URL) healthz.HealthzChecker {
+	p := probehttp.New()
+	return healthz.NamedCheck("backend-http", func(r *http.Request) error {
+		result, _, err := p.Probe(u, nil, 2*time.Second)
+		if err != nil {
+			return err
+		}
+		if result != probe.Success {
+			return errBackend
+		}
+		return nil
+	})
+}
+
+// ProxyProtocolHTTPBackendAvailable returns a healthz check that verifies a backend supporting
+// the HAProxy PROXY protocol responds to a GET to the provided URL with 2xx or 3xx response.
+func ProxyProtocolHTTPBackendAvailable(u *url.URL) healthz.HealthzChecker {
+	dialer := &net.Dialer{
+		Timeout:   2 * time.Second,
+		DualStack: true,
+	}
+	return healthz.NamedCheck("backend-proxy-http", func(r *http.Request) error {
+		conn, err := dialer.Dial("tcp", u.Host)
+		if err != nil {
+			return err
+		}
+		conn.SetDeadline(time.Now().Add(2 * time.Second))
+		br := bufio.NewReader(conn)
+		if _, err := conn.Write([]byte("PROXY UNKNOWN\r\n")); err != nil {
+			return err
+		}
+		req := &http.Request{Method: "GET", URL: u, Proto: "HTTP/1.1", ProtoMajor: 1, ProtoMinor: 1}
+		if err := req.Write(conn); err != nil {
+			return err
+		}
+		res, err := http.ReadResponse(br, req)
+		if err != nil {
+			return err
+		}
+
+		// read full body
+		defer res.Body.Close()
+		if _, err := io.Copy(ioutil.Discard, res.Body); err != nil {
+			glog.V(4).Infof("Error discarding probe body contents: %v", err)
+		}
+
+		if res.StatusCode < http.StatusOK && res.StatusCode >= http.StatusBadRequest {
+			glog.V(4).Infof("Probe failed for %s, Response: %v", u.String(), res)
+			return errBackend
+		}
+		glog.V(4).Infof("Probe succeeded for %s, Response: %v", u.String(), res)
+		return nil
+	})
+}

--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -13,10 +13,10 @@ import (
 // Listen starts a server for health, metrics, and profiling on the provided listen port.
 // It will terminate the process if the server fails. Metrics and profiling are only exposed
 // if username and password are provided and the user's input matches.
-func Listen(listenAddr string, username, password string) {
+func Listen(listenAddr string, username, password string, checks ...healthz.HealthzChecker) {
 	go func() {
 		mux := http.NewServeMux()
-		healthz.InstallHandler(mux)
+		healthz.InstallHandler(mux, checks...)
 
 		// TODO: exclude etcd and other unused metrics
 

--- a/test/integration/router_test.go
+++ b/test/integration/router_test.go
@@ -1673,6 +1673,10 @@ func TestRouterBindsPortsAfterSync(t *testing.T) {
 		err := wait.Poll(time.Millisecond*100, time.Duration(reloadInterval)*2*time.Second, func() (bool, error) {
 			_, err := getRoute(routeAddress, routeAddress, scheme, nil, "")
 			lastErr = nil
+
+			if err != nil && strings.Contains(err.Error(), "connection refused") {
+				err = ErrUnavailable
+			}
 			switch err {
 			case ErrUnavailable:
 				return true, nil


### PR DESCRIPTION
When router metrics (new style) are on the stats port is completely disabled and replaced by a healthz endpoint in the openshift-router process. This moves in the direction of having more comprehensive health checking for the router (including the informer) in a backwards compatible fashion. Router templates that wish to preserve the stats port should do so, but will not be able to receive new style metrics.

Health checks are now PROXY aware and tied to the public HTTP port. A router template that has no public HTTP endpoint can still expose their own stats port as needed and customize ROUTER_METRICS_READY_HTTP_URL to point to it.

Fixes #14759

Should be part of 3.6.0 to avoid having to ship double port support.

[test]