### PR TITLE
Image change trigger must be able to create all build types

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -7,6 +7,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
 
 const saRolePrefix = "system:openshift:controller:"
@@ -165,6 +167,15 @@ func init() {
 			rbac.NewRule("get", "update").Groups(batchGroup).Resources("cronjobs").RuleOrDie(),
 			rbac.NewRule("get", "update").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 			rbac.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs/instantiate").RuleOrDie(),
+			// trigger controller must be able to modify these build types
+			// TODO: move to a new custom binding that can be removed separately from end user access?
+			rbac.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources(
+				authorizationapi.SourceBuildResource,
+				authorizationapi.DockerBuildResource,
+				authorizationapi.OptimizedDockerBuildResource,
+				authorizationapi.JenkinsPipelineBuildResource,
+			).RuleOrDie(),
+
 			eventsRule(),
 		},
 	})

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3495,6 +3495,17 @@ items:
     - create
   - apiGroups:
     - ""
+    - build.openshift.io
+    attributeRestrictions: null
+    resources:
+    - builds/docker
+    - builds/jenkinspipeline
+    - builds/optimizeddocker
+    - builds/source
+    verbs:
+    - create
+  - apiGroups:
+    - ""
     attributeRestrictions: null
     resources:
     - events


### PR DESCRIPTION
Build admission prevents users who don't have access to the synthetic
kinds from mutating builds, which includes the image trigger controller
now that it is not using the privileged loopback client.

Fixes #14725

[test] @bparees

@deads2k we don't want admins to remove this binding, so putting it in the existing bindings for this didn't seem appropriate. If you want this somewhere else let me know.