### PR TITLE
The hack/common.sh is no more.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ test-extended:
 # Example:
 #   make run
 run: export OS_OUTPUT_BINPATH=$(shell bash -c 'source hack/lib/init.sh; echo $${OS_OUTPUT_BINPATH}')
-run: export PLATFORM=$(shell bash -c 'source hack/common.sh; os::build::host_platform')
+run: export PLATFORM=$(shell bash -c 'source hack/lib/init.sh; os::build::host_platform')
 run: build
 	$(OS_OUTPUT_BINPATH)/$(PLATFORM)/openshift start
 .PHONY: run


### PR DESCRIPTION
It was removed in 56c46b04cca93a6c98a625ad722f6514fd3516bc.

Addressing
```
# make run
hack/build-go.sh
bash: hack/common.sh: No such file or directory
bash: os::build::host_platform: command not found
```