### PR TITLE
[1.5] Use GC rather than refcounting for VNID policy rules

### DIFF
--- a/pkg/sdn/plugin/controller.go
+++ b/pkg/sdn/plugin/controller.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,12 +14,14 @@ import (
 	osapi "github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/util/ipcmd"
 	"github.com/openshift/origin/pkg/util/netutils"
+	"github.com/openshift/origin/pkg/util/ovs"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/iptables"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/sysctl"
 	utilwait "k8s.io/kubernetes/pkg/util/wait"
 )
@@ -488,4 +491,67 @@ func generateAddServiceRule(netID uint32, IP string, protocol kapi.Protocol, por
 
 func generateDeleteServiceRule(IP string, protocol kapi.Protocol, port int) string {
 	return generateBaseServiceRule(IP, protocol, port)
+}
+
+// FindUnusedVNIDs returns a list of VNIDs for which there are table 80 "check" rules,
+// but no table 60/70 "load" rules (meaning that there are no longer any pods or services
+// on this node with that VNID). There is no locking with respect to other ovsController
+// actions, but as long the "add a pod" and "add a service" codepaths add the
+// pod/service-specific rules before they call policy.EnsureVNIDRules(), then there is no
+// race condition.
+func (node *OsdnNode) FindUnusedVNIDs() []int {
+	flows, err := node.ovs.DumpFlows()
+	if err != nil {
+		glog.Errorf("FindUnusedVNIDs: could not DumpFlows: %v", err)
+		return nil
+	}
+
+	// inUseVNIDs is the set of VNIDs in use by pods or services on this node.
+	// policyVNIDs is the set of VNIDs that we have rules for delivering to.
+	// VNID 0 is always assumed to be in both sets.
+	inUseVNIDs := sets.NewInt(0)
+	policyVNIDs := sets.NewInt(0)
+	for _, flow := range flows {
+		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flow)
+		if err != nil {
+			glog.Warningf("FindUnusedVNIDs: could not parse flow %q: %v", flow, err)
+			continue
+		}
+
+		// A VNID is in use if there is a table 60 (services) or 70 (pods) flow that
+		// loads that VNID into reg1 for later comparison.
+		if parsed.Table == 60 || parsed.Table == 70 {
+			// Can't use FindAction here since there may be multiple "load"s
+			for _, action := range parsed.Actions {
+				if action.Name != "load" || strings.Index(action.Value, "REG1") == -1 {
+					continue
+				}
+				vnidEnd := strings.Index(action.Value, "->")
+				if vnidEnd == -1 {
+					continue
+				}
+				vnid, err := strconv.ParseInt(action.Value[:vnidEnd], 0, 32)
+				if err != nil {
+					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'load:%s': %v", action.Value, err)
+					continue
+				}
+				inUseVNIDs.Insert(int(vnid))
+				break
+			}
+		}
+
+		// A VNID is checked by policy if there is a table 80 rule comparing reg1 to it.
+		if parsed.Table == 80 {
+			if field, exists := parsed.FindField("reg1"); exists {
+				vnid, err := strconv.ParseInt(field.Value, 0, 32)
+				if err != nil {
+					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'reg1=%s': %v", field.Value, err)
+					continue
+				}
+				policyVNIDs.Insert(int(vnid))
+			}
+		}
+	}
+
+	return policyVNIDs.Difference(inUseVNIDs).UnsortedList()
 }

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -452,7 +452,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (*cnitypes.Result, *runnin
 		return nil, nil, err
 	}
 
-	m.policy.RefVNID(podConfig.vnid)
+	m.policy.EnsureVNIDRules(podConfig.vnid)
 	success = true
 	return ipamResult, &runningPod{activePod: newPod, vnid: podConfig.vnid, ofport: ofport}, nil
 }
@@ -525,10 +525,6 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 			return fmt.Errorf("error running network teardown script: %s", getScriptError(out))
 		} else if err != nil {
 			return err
-		}
-
-		if vnid, err := m.policy.GetVNID(req.PodNamespace); err == nil {
-			m.policy.UnrefVNID(vnid)
 		}
 	}
 

--- a/pkg/sdn/plugin/singletenant.go
+++ b/pkg/sdn/plugin/singletenant.go
@@ -41,8 +41,8 @@ func (sp *singleTenantPlugin) GetMulticastEnabled(vnid uint32) bool {
 	return false
 }
 
-func (sp *singleTenantPlugin) RefVNID(vnid uint32) {
+func (sp *singleTenantPlugin) EnsureVNIDRules(vnid uint32) {
 }
 
-func (sp *singleTenantPlugin) UnrefVNID(vnid uint32) {
+func (sp *singleTenantPlugin) SyncVNIDRules() {
 }

--- a/pkg/util/ovs/parse.go
+++ b/pkg/util/ovs/parse.go
@@ -1,0 +1,352 @@
+package ovs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ovsFlow represents an OVS flow
+type OvsFlow struct {
+	Table    int
+	Priority int
+	Created  time.Time
+	Cookie   string
+	Fields   []OvsField
+	Actions  []OvsField
+}
+
+type OvsField struct {
+	Name  string
+	Value string
+}
+
+const (
+	minPriority     = 0
+	defaultPriority = 32768
+	maxPriority     = 65535
+)
+
+type ParseCmd string
+
+const (
+	ParseForAdd    ParseCmd = "add-flow"
+	ParseForDelete ParseCmd = "del-flows"
+	ParseForDump   ParseCmd = "dump-flows"
+)
+
+func fieldSet(parsed *OvsFlow, field string) bool {
+	for _, f := range parsed.Fields {
+		if f.Name == field {
+			return true
+		}
+	}
+	return false
+}
+
+func checkNotAllowedField(flow string, parsed *OvsFlow, field string, cmd ParseCmd) error {
+	if fieldSet(parsed, field) {
+		return fmt.Errorf("bad flow %q (field %q not allowed in %s)", flow, field, cmd)
+	}
+	return nil
+}
+
+func checkUnimplementedField(flow string, parsed *OvsFlow, field string) error {
+	if fieldSet(parsed, field) {
+		return fmt.Errorf("bad flow %q (field %q not implemented)", flow, field)
+	}
+	return nil
+}
+
+func actionToOvsField(action string) (*OvsField, error) {
+	if action == "" {
+		return nil, fmt.Errorf("cannot make field from empty action")
+	}
+	sep := strings.IndexAny(action, ":(")
+	if sep == -1 {
+		return &OvsField{Name: strings.TrimSpace(action)}, nil
+	} else if sep == len(action)-1 {
+		return nil, fmt.Errorf("action %q has no value", action)
+	}
+	return &OvsField{
+		Name:  strings.TrimSpace(action[:sep]),
+		Value: strings.Trim(action[sep:], ": "),
+	}, nil
+}
+
+func parseActions(actions string) ([]OvsField, error) {
+	fields := make([]OvsField, 0)
+	var parenLevel, braceLevel, idx int
+	origActions := actions
+	for actions != "" {
+		token := strings.IndexAny(actions[idx:], ",([])")
+		if token == -1 {
+			if parenLevel > 0 {
+				return nil, fmt.Errorf("mismatched parentheses in actions %q", origActions)
+			} else if braceLevel > 0 {
+				return nil, fmt.Errorf("mismatched braces in actions %q", origActions)
+			}
+			field, err := actionToOvsField(actions)
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, *field)
+			break
+		}
+		idx += token
+
+		switch actions[idx] {
+		case ',':
+			if parenLevel == 0 && braceLevel == 0 {
+				field, err := actionToOvsField(actions[:idx])
+				if err != nil {
+					return nil, err
+				}
+				fields = append(fields, *field)
+				actions = actions[idx+1:]
+				idx = 0
+			}
+		case '(':
+			parenLevel += 1
+		case '[':
+			braceLevel += 1
+		case ')':
+			parenLevel -= 1
+			if parenLevel < 0 {
+				return nil, fmt.Errorf("mismatched parentheses in actions %q", origActions)
+			}
+		case ']':
+			braceLevel -= 1
+			if braceLevel < 0 {
+				return nil, fmt.Errorf("mismatched braces in actions %q", origActions)
+			}
+		}
+		// Advance past token
+		idx += 1
+	}
+	return fields, nil
+}
+
+func findField(name string, fields *[]OvsField) (*OvsField, bool) {
+	for _, f := range *fields {
+		if f.Name == name {
+			return &f, true
+		}
+	}
+	return nil, false
+}
+
+func (of *OvsFlow) FindField(name string) (*OvsField, bool) {
+	return findField(name, &of.Fields)
+}
+
+func (of *OvsFlow) FindAction(name string) (*OvsField, bool) {
+	return findField(name, &of.Actions)
+}
+
+func (of *OvsFlow) NoteHasPrefix(prefix string) bool {
+	note, ok := of.FindAction("note")
+	return ok && strings.HasPrefix(strings.ToLower(note.Value), strings.ToLower(prefix))
+}
+
+func ParseFlow(cmd ParseCmd, flow string, args ...interface{}) (*OvsFlow, error) {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+
+	// According to the man page, "flow descriptions comprise a series of field=value
+	// assignments, separated by commas or white space." However, you can also have
+	// fields with no value (eg, "ip"), and the "actions" field can also have internal
+	// commas, whitespace, and equals signs (but if it is present, it must be the
+	// last field specified).
+
+	actions := ""
+
+	parsed := &OvsFlow{
+		Table:    0,
+		Priority: defaultPriority,
+		Fields:   make([]OvsField, 0),
+		Actions:  make([]OvsField, 0),
+		Created:  time.Now(),
+		Cookie:   "0",
+	}
+	flow = strings.Trim(flow, " ")
+	origFlow := flow
+	for flow != "" {
+		field := ""
+		value := ""
+
+		end := strings.IndexAny(flow, ", ")
+		if end == -1 {
+			end = len(flow)
+		}
+		eq := strings.Index(flow, "=")
+		if eq == -1 || eq > end {
+			field = flow[:end]
+		} else {
+			field = flow[:eq]
+			if field == "actions" {
+				end = len(flow)
+				value = flow[eq+1:]
+			} else {
+				valueEnd := end - 1
+				for flow[valueEnd] == ' ' || flow[valueEnd] == ',' {
+					valueEnd--
+				}
+				value = strings.Trim(flow[eq+1:end], ", ")
+			}
+			if value == "" {
+				return nil, fmt.Errorf("bad flow definition %q (empty field %q)", origFlow, field)
+			}
+		}
+
+		switch field {
+		case "table":
+			table, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("bad flow %q (bad table number %q)", origFlow, value)
+			} else if table < 0 || table > 255 {
+				return nil, fmt.Errorf("bad flow %q (table number %q out of range)", origFlow, value)
+			}
+			parsed.Table = table
+		case "priority":
+			priority, err := strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("bad flow %q (bad priority %q)", origFlow, value)
+			} else if priority < minPriority || priority > maxPriority {
+				return nil, fmt.Errorf("bad flow %q (priority %q out of range)", origFlow, value)
+			}
+			parsed.Priority = priority
+		case "actions":
+			actions = value
+		case "cookie":
+			parsed.Cookie = value
+		default:
+			parsed.Fields = append(parsed.Fields, OvsField{field, value})
+		}
+
+		for end < len(flow) && (flow[end] == ',' || flow[end] == ' ') {
+			end++
+		}
+		flow = flow[end:]
+	}
+
+	if actions != "" {
+		var err error
+		parsed.Actions, err = parseActions(actions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sanity-checking
+	switch cmd {
+	case ParseForDump:
+		fallthrough
+	case ParseForAdd:
+		if err := checkNotAllowedField(flow, parsed, "out_port", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkNotAllowedField(flow, parsed, "out_group", cmd); err != nil {
+			return nil, err
+		}
+
+		if len(parsed.Actions) == 0 {
+			return nil, fmt.Errorf("bad flow %q (empty actions)", flow)
+		}
+	case ParseForDelete:
+		if err := checkNotAllowedField(flow, parsed, "priority", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkNotAllowedField(flow, parsed, "actions", cmd); err != nil {
+			return nil, err
+		}
+		if err := checkUnimplementedField(flow, parsed, "out_port"); err != nil {
+			return nil, err
+		}
+		if err := checkUnimplementedField(flow, parsed, "out_group"); err != nil {
+			return nil, err
+		}
+	}
+
+	if (fieldSet(parsed, "nw_src") || fieldSet(parsed, "nw_dst")) &&
+		!(fieldSet(parsed, "ip") || fieldSet(parsed, "arp") || fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified nw_src/nw_dst without ip/arp/tcp/udp)", flow)
+	}
+	if (fieldSet(parsed, "arp_spa") || fieldSet(parsed, "arp_tpa") || fieldSet(parsed, "arp_sha") || fieldSet(parsed, "arp_tha")) && !fieldSet(parsed, "arp") {
+		return nil, fmt.Errorf("bad flow %q (specified arp_spa/arp_tpa/arp_sha/arp_tpa without arp)", flow)
+	}
+	if (fieldSet(parsed, "tcp_src") || fieldSet(parsed, "tcp_dst")) && !fieldSet(parsed, "tcp") {
+		return nil, fmt.Errorf("bad flow %q (specified tcp_src/tcp_dst without tcp)", flow)
+	}
+	if (fieldSet(parsed, "udp_src") || fieldSet(parsed, "udp_dst")) && !fieldSet(parsed, "udp") {
+		return nil, fmt.Errorf("bad flow %q (specified udp_src/udp_dst without udp)", flow)
+	}
+	if (fieldSet(parsed, "tp_src") || fieldSet(parsed, "tp_dst")) && !(fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified tp_src/tp_dst without tcp/udp)", flow)
+	}
+	if fieldSet(parsed, "ip_frag") && (fieldSet(parsed, "tcp") || fieldSet(parsed, "udp")) {
+		return nil, fmt.Errorf("bad flow %q (specified ip_frag with tcp/udp)", flow)
+	}
+
+	return parsed, nil
+}
+
+// flowMatches tests if flow matches match. If exact is true, then the table, priority,
+// and all fields much match. If exact is false, then the table and any fields specified
+// in match must match, but priority is not checked, and there can be additional fields
+// in flow that are not in match.
+func FlowMatches(flow, match *OvsFlow, exact bool) bool {
+	if flow.Table != match.Table && (exact || match.Table != 0) {
+		return false
+	}
+	if exact && flow.Priority != match.Priority {
+		return false
+	}
+	if exact && len(flow.Fields) != len(match.Fields) {
+		return false
+	}
+	if match.Cookie != "" && !fieldMatches(flow.Cookie, match.Cookie, exact) {
+		return false
+	}
+	for _, matchField := range match.Fields {
+		var flowValue *string
+		for _, flowField := range flow.Fields {
+			if flowField.Name == matchField.Name {
+				flowValue = &flowField.Value
+				break
+			}
+		}
+		if flowValue == nil || !fieldMatches(*flowValue, matchField.Value, exact) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldMatches(val, match string, exact bool) bool {
+	if val == match {
+		return true
+	}
+	if exact {
+		return false
+	}
+
+	// Handle bitfield/mask matches. (Some other syntax like "10.128.0.0/14" might
+	// get examined here, but it will fail the first ParseUint call and so not
+	// reach the final check.)
+	split := strings.Split(match, "/")
+	if len(split) == 2 {
+		matchNum, err1 := strconv.ParseUint(split[0], 0, 32)
+		mask, err2 := strconv.ParseUint(split[1], 0, 32)
+		valNum, err3 := strconv.ParseUint(val, 0, 32)
+		if err1 == nil && err2 == nil && err3 == nil {
+			if (matchNum & mask) == (valNum & mask) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/ovs/parse_test.go
+++ b/pkg/util/ovs/parse_test.go
@@ -1,0 +1,429 @@
+package ovs
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type flowTest struct {
+	input string
+	match OvsFlow
+}
+
+func TestParseFlows(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			input: "table=10, priority=0, actions=drop",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 0,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+				},
+			},
+		},
+		{
+			input: "table=50, priority=100, arp, nw_dst=10.128.0.0/23, actions=load:0x1234->NXM_NX_TUN_ID[0..31],set_field:172.17.0.2->tun_dst,match:1",
+			match: OvsFlow{
+				Table:    50,
+				Priority: 100,
+				Fields: []OvsField{
+					{Name: "arp", Value: ""},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "load", Value: "0x1234->NXM_NX_TUN_ID[0..31]"},
+					{Name: "set_field", Value: "172.17.0.2->tun_dst"},
+					{Name: "match", Value: "1"},
+				},
+			},
+		},
+		{
+			input: "table=21, priority=100, ip, actions=ct(commit,table=30)",
+			match: OvsFlow{
+				Table:    21,
+				Priority: 100,
+				Fields: []OvsField{
+					{Name: "ip", Value: ""},
+				},
+				Actions: []OvsField{
+					{Name: "ct(commit,table=30)"},
+				},
+			},
+		},
+		{
+			// everything after actions is considered part of actions; this would be a syntax error if we actually parsed actions
+			input: "table=10, priority=0, actions=drop, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 0,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+					{Name: "in_port=1"},
+					{Name: "arp"},
+					{Name: "nw_src=10.128.0.0/14"},
+					{Name: "nw_dst=10.128.0.0/23"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if !FlowMatches(parsed, &test.match, true) {
+			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseFlowsDefaults(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// Default table is 0
+			input: "actions=drop",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 32768,
+				Fields:   []OvsField{},
+				Actions: []OvsField{
+					{Name: "drop"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if !FlowMatches(parsed, &test.match, true) {
+			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseFlowsBad(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// table is empty
+			input: "table=, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table is non-numeric
+			input: "table=foo, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table out of range
+			input: "table=-1, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// table out of range
+			input: "table=1000, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is empty
+			input: "table=0, priority=, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is non-numeric
+			input: "table=0, priority=high, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is out of range
+			input: "table=0, priority=-1, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// priority is out of range
+			input: "table=0, priority=200000, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// field value is empty
+			input: "table=0, priority=200, in_port=, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+		{
+			// actions is empty
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=",
+		},
+		{
+			// actions is empty
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions",
+		},
+		{
+			// nw_src/nw_dst without arp/ip
+			input: "table=0, priority=200, in_port=1, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+		},
+	}
+
+	for i, test := range parseTests {
+		_, err := ParseFlow(ParseForAdd, test.input)
+		if err == nil {
+			t.Fatalf("unexpected lack of error from ParseFlow on %d %q", i, test.input)
+		}
+	}
+}
+
+func TestFlowMatchesBad(t *testing.T) {
+	parseTests := []flowTest{
+		{
+			// Table is wrong
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    10,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// field value is incorrect
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "2"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// present field is matched against empty field
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: ""},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// empty field is matched against present field
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: "jean"},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+		{
+			// match field is not present in input
+			input: "table=0, priority=200, in_port=1, arp, nw_src=10.128.0.0/14, nw_dst=10.128.0.0/23, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: OvsFlow{
+				Table:    0,
+				Priority: 200,
+				Fields: []OvsField{
+					{Name: "in_port", Value: "1"},
+					{Name: "arp", Value: ""},
+					{Name: "nw_src", Value: "10.128.0.0/14"},
+					{Name: "nw_dst", Value: "10.128.0.0/23"},
+					{Name: "today", Value: "wednesday"},
+				},
+				Actions: []OvsField{
+					{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+					{Name: "goto_table", Value: "10"},
+				},
+			},
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := ParseFlow(ParseForAdd, test.input)
+		if err != nil {
+			t.Fatalf("unexpected error from ParseFlow: %v", err)
+		}
+		if FlowMatches(parsed, &test.match, false) {
+			t.Fatalf("parsed flow %d (%#v) unexpectedly matches output (%#v)", i, parsed, &test.match)
+		}
+	}
+}
+
+func TestParseActions(t *testing.T) {
+	parseTests := []struct {
+		input  string
+		match  []OvsField
+		errStr string
+	}{
+		{
+			input: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
+			match: []OvsField{
+				{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+				{Name: "goto_table", Value: "10"},
+			},
+		},
+		{
+			input: "move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],ct(commit,table=30),goto_table:10",
+			match: []OvsField{
+				{Name: "move", Value: "NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[]"},
+				{Name: "ct", Value: "(commit,table=30)"},
+				{Name: "goto_table", Value: "10"},
+			},
+		},
+		{
+			// Test that spaces are stripped from name/value
+			input: "load:4->NXM_NX_REG0[], note:adsfasdfasdf, goto_table:21",
+			match: []OvsField{
+				{Name: "load", Value: "4->NXM_NX_REG0[]"},
+				{Name: "note", Value: "adsfasdfasdf"},
+				{Name: "goto_table", Value: "21"},
+			},
+		},
+		{
+			input: "ct(commit,exec(set_field:1->ct_mark),table=70)",
+			match: []OvsField{
+				{Name: "ct", Value: "(commit,exec(set_field:1->ct_mark),table=70)"},
+			},
+		},
+		{
+			input: "drop",
+			match: []OvsField{
+				{Name: "drop"},
+			},
+		},
+		{
+			input: "goto_table:30",
+			match: []OvsField{
+				{Name: "goto_table", Value: "30"},
+			},
+		},
+		{
+			input:  "move:NXM_NX_TUN_ID[0..31]]]],goto_table:10",
+			errStr: "mismatched braces in actions",
+		},
+		{
+			input:  "move:NXM_NX_TUN_ID[[[[[0..31],goto_table:10",
+			errStr: "mismatched braces in actions",
+		},
+		{
+			input:  "ct(commit,table=30))))),goto_table:10",
+			errStr: "mismatched parentheses in action",
+		},
+		{
+			input:  "ct(((((commit,table=30),goto_table:10",
+			errStr: "mismatched parentheses in action",
+		},
+		{
+			input:  "goto_table:",
+			errStr: "has no value",
+		},
+		{
+			input:  ",,",
+			errStr: "cannot make field from empty action",
+		},
+	}
+
+	for i, test := range parseTests {
+		parsed, err := parseActions(test.input)
+		if err != nil {
+			if test.errStr != "" && !strings.Contains(err.Error(), test.errStr) {
+				t.Fatalf("unexpected error from parseActions: %v", err)
+			}
+		} else if test.errStr != "" {
+			t.Fatalf("expected error %q from parseActions", test.errStr)
+		}
+		if !reflect.DeepEqual(parsed, test.match) {
+			t.Fatalf("parsed action %d (%#v) does not match expected output (%#v)", i, parsed, test.match)
+		}
+	}
+}
+
+func TestMatchNote(t *testing.T) {
+	noteTests := []struct {
+		input   string
+		prefix  string
+		success bool
+		errStr  string
+	}{
+		{
+			// Prefix match
+			input:   "table=10,actions=note:00.33.22.33.00.00.00",
+			prefix:  "00.33.22.33.00",
+			success: true,
+		},
+		{
+			input:   "table=10,actions=note:00.33.22.33.00.00.00",
+			prefix:  "00.bb.dd.ee",
+			success: false,
+		},
+		{
+			// Case insensitive match
+			input:   "table=10,actions=note:00.aA.Aa.bB.Bb.00.00",
+			prefix:  "00.aa.aa.bb.bb.00",
+			success: true,
+		},
+		{
+			// missing note
+			input:   "table=10,actions=goto_table:50",
+			prefix:  "00.aa.aa.bb.bb.00",
+			success: false,
+		},
+	}
+
+	for i, test := range noteTests {
+		flow, err := ParseFlow(ParseForDump, test.input)
+		if err != nil {
+			if test.errStr != "" && !strings.Contains(err.Error(), test.errStr) {
+				t.Fatalf("unexpected error from ParseFlow: %v", err)
+			}
+		} else if test.errStr != "" {
+			t.Fatalf("expected error %q from ParseFlow", test.errStr)
+		}
+		if success := flow.NoteHasPrefix(test.prefix); success != test.success {
+			t.Fatalf("note prefix %d success (%v) does not match expected success (%v)", i, success, test.success)
+		}
+	}
+}


### PR DESCRIPTION
Backport of #14560 (basically just copied from the OCP 3.5 backport).

Fixes #14092