### PR TITLE
Copy labels when creating a tag

### DIFF
--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -34,6 +34,7 @@ type TagOptions struct {
 	insecureTag  bool
 	referenceTag bool
 	namespace    string
+	labels       map[string]string
 
 	referencePolicy string
 
@@ -249,6 +250,7 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 				ref.Tag = ""
 				sourceKind = "ImageStreamImage"
 			}
+			o.labels = is.Labels
 		}
 
 		args = args[1:]
@@ -419,6 +421,7 @@ func (o TagOptions) Run() error {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      destNameAndTag,
 					Namespace: o.destNamespace[i],
+					Labels:    o.labels,
 				},
 				Tag: &imageapi.TagReference{
 					Reference: o.referenceTag,

--- a/test/cmd/images_tests.sh
+++ b/test/cmd/images_tests.sh
@@ -181,6 +181,10 @@ os::cmd::expect_success_and_text "oc get is/mysql --template='{{(index .spec.tag
 
 os::cmd::expect_failure_and_text 'oc tag mysql:latest tagtest:tag1 --alias' 'cannot set alias across'
 
+# tag labeled image
+os::cmd::expect_success 'oc label is/mysql labelA=value'
+os::cmd::expect_success 'oc tag mysql:latest mysql:labeled'
+os::cmd::expect_success_and_text "oc get istag/mysql:labeled -o jsonpath='{.metadata.labels.labelA}'" 'value'
 # test copying tags
 os::cmd::expect_success 'oc tag registry-1.docker.io/openshift/origin:v1.0.4 newrepo:latest'
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}'" 'DockerImage'


### PR DESCRIPTION
Fixes #14409

@smarterclayton ptal, although this uncovered one interesting thing. When I'm running test-cmd tests, [this line](https://github.com/openshift/origin/blob/8c00852590400f0cc851b6935865430ca8936c7a/test/cmd/images_tests.sh#L189) fails with error similar to the one from the original issue. The reason why for that is that [this get](https://github.com/openshift/origin/blob/8c00852590400f0cc851b6935865430ca8936c7a/pkg/image/registry/imagestreamtag/rest.go#L174) is returning older (sic!) version of IS (the one before label was added to IS). Running `oc get is` clearly shows me the labels are there, but the internal registry get does not sees them. Any ideas?
@deads2k ^ or you might know something about this

@bparees @gabemontero fyi