### PR TITLE
Bump namespace workers to 10 to potentially fix some flakes

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config_test.go
+++ b/pkg/cmd/server/kubernetes/master/master_config_test.go
@@ -190,7 +190,7 @@ func TestCMServerDefaults(t *testing.T) {
 			ConcurrentJobSyncs:                5,
 			ConcurrentResourceQuotaSyncs:      5,
 			ConcurrentDeploymentSyncs:         5,
-			ConcurrentNamespaceSyncs:          5,
+			ConcurrentNamespaceSyncs:          10,
 			ConcurrentSATokenSyncs:            5,
 			ConcurrentServiceSyncs:            1,
 			ConcurrentGCSyncs:                 20,

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
@@ -66,7 +66,7 @@ func NewCMServer() *CMServer {
 			ConcurrentJobSyncs:                5,
 			ConcurrentResourceQuotaSyncs:      5,
 			ConcurrentDeploymentSyncs:         5,
-			ConcurrentNamespaceSyncs:          5,
+			ConcurrentNamespaceSyncs:          10,
 			ConcurrentSATokenSyncs:            5,
 			LookupCacheSizeForRC:              4096,
 			LookupCacheSizeForRS:              4096,


### PR DESCRIPTION
1.7 kube ships with 10, it has minor impact, but we think this may also
fix some namespace flakes like #12487

[severity:blocker][merge] @liggitt