### PR TITLE
assorted improvements to template service broker

### DIFF
--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -238,6 +238,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 		Verb:      "get",
 		Group:     kapi.GroupName,
 		Resource:  "secrets",
+		Name:      templateInstance.Spec.Secret.Name,
 	}); err != nil {
 		return err
 	}
@@ -271,6 +272,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 		Verb:      "create",
 		Group:     templateapi.GroupName,
 		Resource:  "templateconfigs",
+		Name:      template.Name,
 	}); err != nil {
 		return err
 	}
@@ -288,8 +290,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 	}
 
 	// We add an OwnerReference to all objects we create - this is also needed
-	// by the template service broker for cleanup.  TODO: what about any objects
-	// created by the templateinstance in other namespaces?
+	// by the template service broker for cleanup.
 	for _, obj := range template.Objects {
 		meta, _ := meta.Accessor(obj)
 		ref := meta.GetOwnerReferences()
@@ -328,6 +329,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 				Verb:      "create",
 				Group:     info.Mapping.GroupVersionKind.Group,
 				Resource:  info.Mapping.Resource,
+				Name:      info.Name,
 			}); err != nil {
 				return nil, err
 			}

--- a/pkg/template/servicebroker/bind.go
+++ b/pkg/template/servicebroker/bind.go
@@ -117,6 +117,10 @@ func updateCredentialsForObject(credentials map[string]interface{}, obj runtime.
 		}
 
 		if prefix != "" && len(k) > len(prefix) {
+			if _, exists := credentials[k[len(prefix):]]; exists {
+				return fmt.Errorf("credential with key %q already exists", k[len(prefix):])
+			}
+
 			result, err := evaluateJSONPathExpression(obj, k, v, prefix == templateapi.Base64ExposeAnnotationPrefix)
 			if err != nil {
 				return err
@@ -200,6 +204,7 @@ func (b *Broker) Bind(instanceID, bindingID string, breq *api.BindRequest) *api.
 		Verb:      "get",
 		Group:     templateapi.GroupName,
 		Resource:  "templateinstances",
+		Name:      brokerTemplateInstance.Spec.TemplateInstance.Name,
 	}); err != nil {
 		return api.Forbidden(err)
 	}

--- a/pkg/template/servicebroker/bind_test.go
+++ b/pkg/template/servicebroker/bind_test.go
@@ -2,6 +2,11 @@ package servicebroker
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api"
+
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 func TestEvaluateJSONPathExpression(t *testing.T) {
@@ -122,5 +127,20 @@ func TestEvaluateJSONPathExpression(t *testing.T) {
 		if result != test.expectedResult {
 			t.Errorf("%d: result %q", i, result)
 		}
+	}
+}
+
+func TestDuplicateCredentialKeys(t *testing.T) {
+	credentials := map[string]interface{}{}
+	err := updateCredentialsForObject(credentials, &api.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				templateapi.ExposeAnnotationPrefix + "test":       "",
+				templateapi.Base64ExposeAnnotationPrefix + "test": "",
+			},
+		},
+	})
+	if err.Error() != `credential with key "test" already exists` {
+		t.Errorf("unexpected error %q", err)
 	}
 }

--- a/pkg/template/servicebroker/catalog.go
+++ b/pkg/template/servicebroker/catalog.go
@@ -19,6 +19,8 @@ const (
 	// identity information.
 	requesterUsernameTitle       = "Template service broker: requester username"
 	requesterUsernameDescription = "OpenShift user requesting provision/bind"
+
+	noDescriptionProvided = "No description provided."
 )
 
 // Map OpenShift template annotations to open service broker metadata field
@@ -98,10 +100,15 @@ func serviceFromTemplate(template *templateapi.Template) *api.Service {
 		},
 	}
 
+	description := template.Annotations["description"]
+	if description == "" {
+		description = noDescriptionProvided
+	}
+
 	return &api.Service{
 		Name:        template.Name,
 		ID:          string(template.UID),
-		Description: template.Annotations["description"],
+		Description: description,
 		Tags:        strings.Split(template.Annotations["tags"], ","),
 		Bindable:    true,
 		Metadata:    metadata,

--- a/pkg/template/servicebroker/catalog_test.go
+++ b/pkg/template/servicebroker/catalog_test.go
@@ -131,4 +131,10 @@ func TestServiceFromTemplate(t *testing.T) {
 	if !reflect.DeepEqual(service, expectedService) {
 		t.Error("service did not match expectedService")
 	}
+
+	template.Annotations["description"] = ""
+	service = serviceFromTemplate(template)
+	if service.Description != noDescriptionProvided {
+		t.Errorf("service.Description incorrectly set to %q", service.Description)
+	}
 }

--- a/pkg/template/servicebroker/provision.go
+++ b/pkg/template/servicebroker/provision.go
@@ -38,6 +38,7 @@ func (b *Broker) ensureSecret(u user.Info, namespace string, instanceID string, 
 		Verb:      "create",
 		Group:     kapi.GroupName,
 		Resource:  "secrets",
+		Name:      secret.Name,
 	}); err != nil {
 		return nil, api.Forbidden(err)
 	}
@@ -54,6 +55,7 @@ func (b *Broker) ensureSecret(u user.Info, namespace string, instanceID string, 
 			Verb:      "get",
 			Group:     kapi.GroupName,
 			Resource:  "secrets",
+			Name:      secret.Name,
 		}); err != nil {
 			return nil, api.Forbidden(err)
 		}
@@ -110,6 +112,7 @@ func (b *Broker) ensureTemplateInstance(u user.Info, namespace string, instanceI
 			Verb:      "get",
 			Group:     templateapi.GroupName,
 			Resource:  "templateinstances",
+			Name:      templateInstance.Name,
 		}); err != nil {
 			return nil, api.Forbidden(err)
 		}
@@ -245,6 +248,7 @@ func (b *Broker) Provision(instanceID string, preq *api.ProvisionRequest) *api.R
 			Verb:      "get",
 			Group:     templateapi.GroupName,
 			Resource:  "templates",
+			Name:      template.Name,
 		}); err != nil {
 			return api.Forbidden(err)
 		}
@@ -255,6 +259,7 @@ func (b *Broker) Provision(instanceID string, preq *api.ProvisionRequest) *api.R
 		Verb:      "create",
 		Group:     templateapi.GroupName,
 		Resource:  "templateinstances",
+		Name:      instanceID,
 	}); err != nil {
 		return api.Forbidden(err)
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -96,15 +96,19 @@ func stripNamespace(obj runtime.Object) {
 	if unstruct, ok := obj.(*unstructured.Unstructured); ok && unstruct.Object != nil {
 		if obj, ok := unstruct.Object["metadata"]; ok {
 			if m, ok := obj.(map[string]interface{}); ok {
-				if _, ok := m["namespace"]; ok && !stringParameterExp.MatchString(m["namespace"].(string)) {
-					m["namespace"] = ""
+				if ns, ok := m["namespace"]; ok {
+					if ns, ok := ns.(string); !ok || !stringParameterExp.MatchString(ns) {
+						m["namespace"] = ""
+					}
 				}
 			}
 			return
 		}
-		if _, ok := unstruct.Object["namespace"]; ok && stringParameterExp.MatchString(unstruct.Object["namespace"].(string)) {
-			unstruct.Object["namespace"] = ""
-			return
+		if ns, ok := unstruct.Object["namespace"]; ok {
+			if ns, ok := ns.(string); !ok || !stringParameterExp.MatchString(ns) {
+				unstruct.Object["namespace"] = ""
+				return
+			}
 		}
 	}
 }

--- a/test/extended/templates/templateinstance_cross_namespace.go
+++ b/test/extended/templates/templateinstance_cross_namespace.go
@@ -1,0 +1,139 @@
+package templates
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[templates] templateinstance cross-namespace test", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		cli  = exutil.NewCLI("templates", exutil.KubeConfigPath())
+		cli2 = exutil.NewCLI("templates2", exutil.KubeConfigPath())
+	)
+
+	g.It("should create and delete objects across namespaces", func() {
+		err := cli2.AsAdmin().Run("adm").Args("policy", "add-role-to-user", "admin", cli.Username()).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// parameters for templateinstance
+		_, err = cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Create(&kapiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "secret",
+			},
+			Data: map[string][]byte{
+				"NAMESPACE": []byte(cli2.Namespace()),
+			},
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		templateinstance := &templateapi.TemplateInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "templateinstance",
+			},
+			Spec: templateapi.TemplateInstanceSpec{
+				Template: templateapi.Template{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "template",
+						Namespace: cli.Namespace(),
+					},
+					Parameters: []templateapi.Parameter{
+						{
+							Name: "NAMESPACE",
+						},
+					},
+				},
+				Secret: kapi.LocalObjectReference{
+					Name: "secret",
+				},
+			},
+		}
+
+		err = templateapi.AddObjectsToTemplate(&templateinstance.Spec.Template, []runtime.Object{
+			// secret in the same namespace
+			&kapi.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret1",
+				},
+			},
+			// secret in a different namespace
+			&kapi.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret2",
+					Namespace: "${NAMESPACE}",
+				},
+			},
+		}, latest.Versions...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("creating the templateinstance")
+		_, err = cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstance)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// wait for templateinstance controller to do its thing
+		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			templateinstance, err = cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			for _, c := range templateinstance.Status.Conditions {
+				if c.Reason == "Failed" && c.Status == kapi.ConditionTrue {
+					return false, fmt.Errorf("failed condition: %s", c.Message)
+				}
+				if c.Reason == "Created" && c.Status == kapi.ConditionTrue {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Get("secret1", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		_, err = cli.KubeClient().CoreV1().Secrets(cli2.Namespace()).Get("secret2", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("deleting the templateinstance")
+		err = cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// wait for garbage collector to do its thing
+		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			_, err = cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+			if err == nil || !kerrors.IsNotFound(err) {
+				return false, err
+			}
+
+			_, err = cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Get("secret1", metav1.GetOptions{})
+			if err == nil || !kerrors.IsNotFound(err) {
+				return false, err
+			}
+
+			_, err = cli.KubeClient().CoreV1().Secrets(cli2.Namespace()).Get("secret2", metav1.GetOptions{})
+			if err == nil || !kerrors.IsNotFound(err) {
+				return false, err
+			}
+
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})


### PR DESCRIPTION
- include name of object that fails SAR where appropriate, to improve error message
- prevent bind from working when a given key in credentials is assigned more than once
- in catalog, set description to "No description provided" when no description is provided
- prevent a possible panic in the API controller if a malformed template is passed in
- add a test to ensure templateinstances can be created and deleted with templates with objects in multiple namespaces

Bug 1463570